### PR TITLE
Blacklist password

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2,6 +2,8 @@ from flask_wtf import Form
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Email, Length, Regexp
 
+from app.main.validators import Blacklist
+
 
 class LoginForm(Form):
     email_address = StringField('Email address', validators=[
@@ -32,4 +34,5 @@ class RegisterUserForm(Form):
                                             Regexp(regex=mobile_number, message='Please enter a +44 mobile number')])
     password = PasswordField('Password',
                              validators=[DataRequired(message='Please enter your password'),
-                                         Length(10, 255, message='Password must be at least 10 characters')])
+                                         Length(10, 255, message='Password must be at least 10 characters'),
+                                         Blacklist(message='That password is blacklisted, too common')])

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,0 +1,12 @@
+from wtforms import ValidationError
+
+
+class Blacklist(object):
+    def __init__(self, message=None):
+        if not message:
+            message = 'Password is blacklisted.'
+        self.message = message
+
+    def __call__(self, form, field):
+        if field.data in ['password1234', 'passw0rd1234']:
+            raise ValidationError(self.message)

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from flask import render_template, redirect, jsonify
+from flask_login import login_user
 
 from app.main import main
 from app.main.dao import users_dao
@@ -26,6 +27,7 @@ def process_register():
                     role_id=1)
         try:
             users_dao.insert_user(user)
+            login_user(user)
             return redirect('/two-factor')
         except Exception as e:
             return jsonify(database_error=e.message), 400

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -28,6 +28,6 @@ def process_register():
             users_dao.insert_user(user)
             return redirect('/two-factor')
         except Exception as e:
-            return jsonify(database_error='encountered database error'), 400
+            return jsonify(database_error=e.message), 400
     else:
         return jsonify(form.errors), 400

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -1,0 +1,17 @@
+from pytest import fail
+
+from app.main.forms import RegisterUserForm
+
+
+def test_should_raise_validation_error_for_password(notifications_admin):
+    form = RegisterUserForm()
+    form.name.data = 'test'
+    form.email_address.data = 'teset@example.gov.uk'
+    form.mobile_number.data = '+441231231231'
+    form.password.data = 'password1234'
+
+    try:
+        form.validate()
+        fail()
+    except:
+        assert 'That password is blacklisted, too common' in form.errors['password']

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -44,7 +44,7 @@ def test_should_return_400_if_password_is_blacklisted(notifications_admin, notif
                                                       data={'name': 'Bad Mobile',
                                                             'email_address': 'bad_mobile@example.not.right',
                                                             'mobile_number': '+44123412345',
-                                                            'password': 'password'})
+                                                            'password': 'password1234'})
 
     response.status_code == 400
     assert 'That password is blacklisted, too common' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -37,3 +37,14 @@ def test_should_return_400_when_email_is_not_gov_uk(notifications_admin, notific
 
     assert response.status_code == 400
     assert 'Please enter a gov.uk email address' in response.get_data(as_text=True)
+
+
+def test_should_return_400_if_password_is_blacklisted(notifications_admin, notifications_admin_db):
+    response = notifications_admin.test_client().post('/register',
+                                                      data={'name': 'Bad Mobile',
+                                                            'email_address': 'bad_mobile@example.not.right',
+                                                            'mobile_number': '+44123412345',
+                                                            'password': 'password'})
+
+    response.status_code == 400
+    assert 'That password is blacklisted, too common' in response.get_data(as_text=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.monkeypatch import monkeypatch
 from sqlalchemy.schema import MetaData, DropConstraint
 
 from app import create_app, db


### PR DESCRIPTION
Create a validator to blacklist passwords.
Interesting to note that most of the common passwords on blacklists are under 10 characters, password must be at least 10 characters.