### PR TITLE
Use correct port to connect to API

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ class Config(object):
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SECURE = True
 
-    NOTIFY_DATA_API_URL = os.getenv('NOTIFY_API_URL', "http://localhost:6001")
+    NOTIFY_DATA_API_URL = os.getenv('NOTIFY_API_URL', "http://localhost:6011")
     NOTIFY_DATA_API_AUTH_TOKEN = os.getenv('NOTIFY_API_TOKEN', "dev-token")
 
     WTF_CSRF_ENABLED = True


### PR DESCRIPTION
The API runs on port `6011`, as set here:
https://github.com/alphagov/notifications-api/blob/761e7b4444f45948182e9fa6a14e01955188786a/application.py#L11