### PR TITLE
Resend verification code

### DIFF
--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -1,7 +1,7 @@
 from flask import render_template, redirect, jsonify, session
 
 from app.main import main
-from app.main.dao import users_dao, verify_codes_dao
+from app.main.dao import users_dao
 from app.main.forms import EmailNotReceivedForm, TextNotReceivedForm
 from app.main.views import send_sms_code, send_email_code
 
@@ -39,3 +39,15 @@ def check_and_resend_text_code():
         send_sms_code(user_id=user.id, mobile_number=user.mobile_number)
         return redirect('/verify')
     return jsonify(form.errors), 400
+
+
+@main.route('/verification-not-received', methods=['GET'])
+def verification_code_not_received():
+    return render_template('views/verification-not-received.html')
+
+
+@main.route('/verification-not-received', methods=['POST'])
+def check_and_resend_verification_code():
+    user = users_dao.get_user_by_id(session['user_id'])
+    send_sms_code(user.id, user.mobile_number)
+    return redirect('/two-factor')

--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -46,7 +46,7 @@ def verification_code_not_received():
     return render_template('views/verification-not-received.html')
 
 
-@main.route('/verification-not-received', methods=['POST'])
+@main.route('/send-new-code', methods=['GET'])
 def check_and_resend_verification_code():
     user = users_dao.get_user_by_id(session['user_id'])
     send_sms_code(user.id, user.mobile_number)

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -16,7 +16,7 @@ GOV.UK Notify
 
 
       <p>
-      <a class="button" href="two-factor" role="button">Resend verification code</a>
+      <a class="button" href="send-new-code" role="button">Resend verification code</a>
       </p>
   </div>
 </div>

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -41,7 +41,7 @@ def test_should_render_text_code_not_received_template(notifications_admin,
             _set_up_mocker(mocker)
             user = create_test_user('pending')
             session['user_id'] = user.id
-            verify_codes_dao.add_code(user.id, code='12345', code_type='email')
+            verify_codes_dao.add_code(user.id, code='12345', code_type='sms')
         response = client.get('/text-not-received')
         assert response.status_code == 200
         assert 'Check your mobile phone number is correct and then resend the confirmation code.' \
@@ -70,17 +70,17 @@ def test_should_update_email_address_resend_code(notifications_admin,
                                                  notify_db_session,
                                                  mocker):
     with notifications_admin.test_client() as client:
-            with client.session_transaction() as session:
-                _set_up_mocker(mocker)
-                user = create_test_user('pending')
-                session['user_id'] = user.id
-                verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='email')
-            response = client.post('/email-not-received',
-                                   data={'email_address': 'new@address.gov.uk'})
-            assert response.status_code == 302
-            assert response.location == 'http://localhost/verify'
-            updated_user = users_dao.get_user_by_id(user.id)
-            assert updated_user.email_address == 'new@address.gov.uk'
+        with client.session_transaction() as session:
+            _set_up_mocker(mocker)
+            user = create_test_user('pending')
+            session['user_id'] = user.id
+            verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='email')
+        response = client.post('/email-not-received',
+                               data={'email_address': 'new@address.gov.uk'})
+        assert response.status_code == 302
+        assert response.location == 'http://localhost/verify'
+        updated_user = users_dao.get_user_by_id(user.id)
+        assert updated_user.email_address == 'new@address.gov.uk'
 
 
 def test_should_update_mobile_number_resend_code(notifications_admin,
@@ -88,17 +88,45 @@ def test_should_update_mobile_number_resend_code(notifications_admin,
                                                  notify_db_session,
                                                  mocker):
     with notifications_admin.test_client() as client:
-            with client.session_transaction() as session:
-                _set_up_mocker(mocker)
-                user = create_test_user('pending')
-                session['user_id'] = user.id
-                verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='sms')
-            response = client.post('/text-not-received',
-                                   data={'mobile_number': '+443456789012'})
-            assert response.status_code == 302
-            assert response.location == 'http://localhost/verify'
-            updated_user = users_dao.get_user_by_id(user.id)
-            assert updated_user.mobile_number == '+443456789012'
+        with client.session_transaction() as session:
+            _set_up_mocker(mocker)
+            user = create_test_user('pending')
+            session['user_id'] = user.id
+            verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='sms')
+        response = client.post('/text-not-received',
+                               data={'mobile_number': '+443456789012'})
+        assert response.status_code == 302
+        assert response.location == 'http://localhost/verify'
+        updated_user = users_dao.get_user_by_id(user.id)
+        assert updated_user.mobile_number == '+443456789012'
+
+
+def test_should_render_verification_code_not_received(notifications_admin,
+                                                      notifications_admin_db,
+                                                      notify_db_session):
+    with notifications_admin.test_client() as client:
+        with client.session_transaction() as session:
+            user = create_test_user('active')
+            session['user_id'] = user.id
+        response = client.get('/verification-not-received')
+        assert response.status_code == 200
+        assert 'Resend verification code' in response.get_data(as_text=True)
+        assert 'If you no longer have access to the phone with the number you registered for this service, ' \
+               'speak to your service manager to reset the number.' in response.get_data(as_text=True)
+
+
+def test_check_and_redirect_to_two_factor(notifications_admin,
+                                          notifications_admin_db,
+                                          notify_db_session,
+                                          mocker):
+    with notifications_admin.test_client() as client:
+        with client.session_transaction() as session:
+            user = create_test_user('active')
+            session['user_id'] = user.id
+            _set_up_mocker(mocker)
+        response = client.post('/verification-not-received')
+        assert response.status_code == 302
+        assert response.location == 'http://localhost/two-factor'
 
 
 def _set_up_mocker(mocker):

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -35,3 +35,23 @@ def test_should_return_400_with_sms_code_error_when_sms_code_is_wrong(notificati
                                data={'sms_code': '23456'})
         assert response.status_code == 400
         assert {'sms_code': ['Code does not match']} == json.loads(response.get_data(as_text=True))
+
+
+def test_should_login_user_when_multiple_valid_codes_exist(notifications_admin,
+                                                           notifications_admin_db,
+                                                           notify_db_session):
+    with notifications_admin.test_client() as client:
+        with client.session_transaction() as session:
+            user = create_test_user('active')
+            session['user_id'] = user.id
+            verify_codes_dao.add_code(user_id=user.id, code='23456', code_type='sms')
+            verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='sms')
+            verify_codes_dao.add_code(user_id=user.id, code='34567', code_type='sms')
+        assert len(verify_codes_dao.get_codes(user_id=user.id, code_type='sms')) == 3
+        response = client.post('/two-factor',
+                               data={'sms_code': '23456'})
+        assert response.status_code == 302
+        print(user.id)
+        codes = verify_codes_dao.get_codes(user_id=user.id, code_type='sms')
+        # query will only return codes where code_used == False
+        assert len(codes) == 0


### PR DESCRIPTION
This pull request implements the 'I haven't received a text' link on the'/two-factor' page. The /send-new-code endpoint will create and send a new verification code via text to the user. All verification codes created during this sign in step are valid until one is used and then they are all marked as used.