### PR TITLE
Don’t package raw front end assets for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ deploy:
   region: eu-west-1
   on: *2
 before_deploy:
+- rm -rf notifications-admin/node_modules notifications-admin/bower_components notifications-admin/app/assets
 - zip -r notifications-admin *
 - mkdir -p dpl_cd_upload
 - mv notifications-admin.zip dpl_cd_upload/notifications-admin.zip


### PR DESCRIPTION
None of these files are used by the app when it’s running them.

Having them in the deployed blob only makes the deploy slower and the logs massive:

![image](https://cloud.githubusercontent.com/assets/355079/12169922/4c3719a6-b534-11e5-9db4-5b3783d744cd.png)
