### PR TITLE
New script to run db updates so can be done by ubuntu user

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -13,6 +13,10 @@ hooks:
       location: scripts/aws_change_ownership.sh
       runas: root
       timeout: 300
+    -
+      location: scripts/aws_db_updates.sh
+      runas: ubuntu
+      timeout: 300
   ApplicationStart: 
     - 
       location: scripts/aws_start_app.sh

--- a/scripts/aws_db_updates.sh
+++ b/scripts/aws_db_updates.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 db.py db upgrade


### PR DESCRIPTION
DB updates on a new build ran by root, which meant the app counldn't start as is run as ubuntu.

- this moves the db upgrade into it's own file and the appspec file will run it as ubuntu