### PR TITLE
Added content security policy header.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -123,6 +123,8 @@ def useful_headers_after_request(response):
     response.headers.add('X-Frame-Options', 'deny')
     response.headers.add('X-Content-Type-Options', 'nosniff')
     response.headers.add('X-XSS-Protection', '1; mode=block')
+    response.headers.add('Content-Security-Policy',
+                         "default-src 'self' 'unsafe-inline'")
     return response
 
 

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -6,3 +6,4 @@ def test_owasp_useful_headers_set(notifications_admin):
     assert response.headers['X-Frame-Options'] == 'deny'
     assert response.headers['X-Content-Type-Options'] == 'nosniff'
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
+    assert response.headers['Content-Security-Policy'] == "default-src 'self' 'unsafe-inline'"  # noqa


### PR DESCRIPTION
unsafe-inline exception added to allow inline js scripts
we have in base govuk_template.