### PR TITLE
Fix flakiness with Gulp + Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,14 @@ before_install:
 - nvm install 5.0.0
 install:
 - npm install
+- npm rebuild node-sass
 - pip install -r requirements_for_test.txt
 before_script:
 - psql -c 'create database test_notifications_admin;' -U postgres
 after_success:
 - ./scripts/trigger-dependent-build.sh
 script:
+- npm run build
 - ./scripts/run_tests.sh
 notifications:
   slack:

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ n is a tool for managing different versions of node. The following installs n an
     npm install -g n
     n latest
     npm rebuild node-sass
- 
+
 Most of the frontend dependencies are managed using Git Submodules. Some are
 managed with NPM and Bower. To install or update *all the things*, run
 ```shell
-    git submodule init 
+    git submodule init
     git submodule update
     npm install
+    npm run build
 ```
 
 If you want the front end assets to re-compile on changes, leave this running

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -29,23 +29,8 @@ gulp.task('copy:govuk_template:assets', () => gulp.src('bower_components/govuk_t
   .pipe(gulp.dest(paths.dist))
 );
 
-
-// Concatenate and minify
-
-gulp.task('jquery', () => plugins.jquery.src({
-    release: 1,
-    flags: [
-      '-ajax', '-ajax/jsonp', '-ajax/load', '-ajax/parseJSON',
-      '-ajax/parseXML', '-ajax/script', '-ajax/var/nonce',
-      '-ajax/var/rquery', '-ajax/xhr', '-manipulation/_evalUrl',
-      '-deprecated', '-effects', '-effects/Tween',
-      '-effects/animatedSelector', '-effects/support', '-event-alias'
-    ]
-  })
-  .pipe(gulp.dest(paths.dist + 'javascripts/'))
-);
-
-gulp.task('javascripts', ['jquery'], () => gulp.src([
+gulp.task('javascripts', () => gulp
+  .src([
     paths.src + 'govuk_frontend_toolkit/javascripts/govuk/modules.js',
     paths.src + 'javascripts/highlightTags.js',
     paths.src + 'javascripts/dropdown.js',
@@ -54,15 +39,16 @@ gulp.task('javascripts', ['jquery'], () => gulp.src([
   .pipe(plugins.babel({
     presets: ['es2015']
   }))
-  .pipe(plugins.addSrc.prepend(
-    paths.dist + 'javascripts/jquery.custom.js'
-  ))
   .pipe(plugins.uglify())
+  .pipe(plugins.addSrc.prepend(
+    './node_modules/jquery/dist/jquery.min.js'
+  ))
   .pipe(plugins.concat('all.js'))
   .pipe(gulp.dest(paths.dist + 'javascripts/'))
 );
 
-gulp.task('sass', () => gulp.src(paths.src + '/stylesheets/main*.scss')
+gulp.task('sass', () => gulp
+  .src(paths.src + '/stylesheets/main*.scss')
   .pipe(plugins.sass({outputStyle: 'compressed'}))
   .pipe(gulp.dest(paths.dist + '/stylesheets'))
 );
@@ -70,7 +56,8 @@ gulp.task('sass', () => gulp.src(paths.src + '/stylesheets/main*.scss')
 
 // Copy images
 
-gulp.task('images', () => gulp.src(paths.src + 'images/**/*')
+gulp.task('images', () => gulp
+  .src(paths.src + 'images/**/*')
   .pipe(gulp.dest(paths.dist + '/images'))
 );
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./node_modules/bower/bin/bower install && npm run build",
-    "build": "./node_modules/gulp/bin/gulp.js",
-    "watch": "./node_modules/gulp/bin/gulp.js watch"
+    "postinstall": "./node_modules/bower/bin/bower install",
+    "build": "gulp",
+    "watch": "gulp watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Gulp was failing silently on Travis. I tracked this down to the task that builds a custom, slimmed-down version of jQuery from source.

To fix this I’ve removed the task and replaced it with just `src`ing the minified version of jQuery from `node_modules`.

Cons:
- A few more kb of JS

Pros:
- Less random, afternoon-chewing complexity