### PR TITLE
Make URLs service-specific

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,4 +1,4 @@
-from flask import render_template, jsonify, redirect, session
+from flask import render_template, jsonify, redirect, session, url_for
 from flask_login import login_required
 from app.main import main
 from app.main.dao import services_dao, users_dao
@@ -13,6 +13,6 @@ def add_service():
 
         user = users_dao.get_user_by_id(session['user_id'])
         services_dao.insert_new_service(form.service_name.data, user)
-        return redirect('/dashboard')
+        return redirect(url_for('.dashboard', service_id=123))
     else:
         return render_template('views/add-service.html', form=form)

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -6,7 +6,7 @@ from app.main import main
 from ._jobs import jobs
 
 
-@main.route("/<int:service_id>/dashboard")
+@main.route("/services/<int:service_id>/dashboard")
 @login_required
 def dashboard(service_id):
     return render_template(

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -6,12 +6,13 @@ from app.main import main
 from ._jobs import jobs
 
 
-@main.route("/dashboard")
+@main.route("/<int:service_id>/dashboard")
 @login_required
-def dashboard():
+def dashboard(service_id):
     return render_template(
         'views/dashboard.html',
         jobs=jobs,
         free_text_messages_remaining=560,
-        spent_this_month='0.00'
+        spent_this_month='0.00',
+        service_id=service_id
     )

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -20,25 +20,25 @@ def verifymobile():
     return render_template('views/verify-mobile.html')
 
 
-@main.route("/<int:service_id>/send-email")
+@main.route("/services/<int:service_id>/send-email")
 @login_required
 def sendemail(service_id):
     return render_template('views/send-email.html')
 
 
-@main.route("/<int:service_id>/check-email")
+@main.route("/services/<int:service_id>/check-email")
 @login_required
 def checkemail(service_id):
     return render_template('views/check-email.html')
 
 
-@main.route("/<int:service_id>/manage-users")
+@main.route("/services/<int:service_id>/manage-users")
 @login_required
 def manageusers(service_id):
     return render_template('views/manage-users.html', service_id=service_id)
 
 
-@main.route("/<int:service_id>/api-keys")
+@main.route("/services/<int:service_id>/api-keys")
 @login_required
 def apikeys(service_id):
     return render_template('views/api-keys.html', service_id=service_id)

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -20,25 +20,25 @@ def verifymobile():
     return render_template('views/verify-mobile.html')
 
 
-@main.route("/send-email")
+@main.route("/<int:service_id>/send-email")
 @login_required
-def sendemail():
+def sendemail(service_id):
     return render_template('views/send-email.html')
 
 
-@main.route("/check-email")
+@main.route("/<int:service_id>/check-email")
 @login_required
-def checkemail():
+def checkemail(service_id):
     return render_template('views/check-email.html')
 
 
-@main.route("/manage-users")
+@main.route("/<int:service_id>/manage-users")
 @login_required
-def manageusers():
-    return render_template('views/manage-users.html')
+def manageusers(service_id):
+    return render_template('views/manage-users.html', service_id=service_id)
 
 
-@main.route("/api-keys")
+@main.route("/<int:service_id>/api-keys")
 @login_required
-def apikeys():
-    return render_template('views/api-keys.html')
+def apikeys(service_id):
+    return render_template('views/api-keys.html', service_id=service_id)

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -52,9 +52,9 @@ def showjobs(service_id):
     )
 
 
-@main.route("/<int:service_id>/jobs/job")
+@main.route("/<int:service_id>/jobs/<job_id>")
 @login_required
-def showjob(service_id):
+def showjob(service_id, job_id):
     return render_template(
         'views/job.html',
         messages=messages,
@@ -76,9 +76,9 @@ def showjob(service_id):
     )
 
 
-@main.route("/<int:service_id>/jobs/job/notification/<string:notification_id>")
+@main.route("/<int:service_id>/jobs/<job_id>/notification/<string:notification_id>")
 @login_required
-def shownotification(service_id, notification_id):
+def shownotification(service_id, job_id, notification_id):
     return render_template(
         'views/notification.html',
         message=[
@@ -86,5 +86,6 @@ def shownotification(service_id, notification_id):
         ][0],
         delivered_at=now,
         uploaded_at=now,
-        service_id=service_id
+        service_id=service_id,
+        job_id=job_id
     )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -42,18 +42,19 @@ messages = [
 ]
 
 
-@main.route("/jobs")
+@main.route("/<int:service_id>/jobs")
 @login_required
-def showjobs():
+def showjobs(service_id):
     return render_template(
         'views/jobs.html',
-        jobs=jobs
+        jobs=jobs,
+        service_id=service_id
     )
 
 
-@main.route("/jobs/job")
+@main.route("/<int:service_id>/jobs/job")
 @login_required
-def showjob():
+def showjob(service_id):
     return render_template(
         'views/job.html',
         messages=messages,
@@ -70,18 +71,20 @@ def showjob():
         uploaded_file_name='dispatch_20151114.csv',
         uploaded_file_time=now,
         template_used='Test message 1',
-        flash_message=u'We’ve started sending your messages'
+        flash_message=u'We’ve started sending your messages',
+        service_id=service_id
     )
 
 
-@main.route("/jobs/job/notification/<string:notification_id>")
+@main.route("/<int:service_id>/jobs/job/notification/<string:notification_id>")
 @login_required
-def shownotification(notification_id):
+def shownotification(service_id, notification_id):
     return render_template(
         'views/notification.html',
         message=[
             message for message in messages if message['id'] == notification_id
         ][0],
         delivered_at=now,
-        uploaded_at=now
+        uploaded_at=now,
+        service_id=service_id
     )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -42,7 +42,7 @@ messages = [
 ]
 
 
-@main.route("/<int:service_id>/jobs")
+@main.route("/services/<int:service_id>/jobs")
 @login_required
 def showjobs(service_id):
     return render_template(
@@ -52,7 +52,7 @@ def showjobs(service_id):
     )
 
 
-@main.route("/<int:service_id>/jobs/<job_id>")
+@main.route("/services/<int:service_id>/jobs/<job_id>")
 @login_required
 def showjob(service_id, job_id):
     return render_template(
@@ -76,7 +76,7 @@ def showjob(service_id, job_id):
     )
 
 
-@main.route("/<int:service_id>/jobs/<job_id>/notification/<string:notification_id>")
+@main.route("/services/<int:service_id>/jobs/<job_id>/notification/<string:notification_id>")
 @login_required
 def shownotification(service_id, job_id, notification_id):
     return render_template(

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -11,18 +11,19 @@ service = {
 }
 
 
-@main.route("/service-settings")
+@main.route("/<int:service_id>/service-settings")
 @login_required
-def service_settings():
+def service_settings(service_id):
     return render_template(
         'views/service-settings.html',
-        service=service
+        service=service,
+        service_id=service_id
     )
 
 
-@main.route("/service-settings/name", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/name", methods=['GET', 'POST'])
 @login_required
-def name():
+def name(service_id):
 
     form = ServiceNameForm()
     form.service_name.data = 'Service name'
@@ -31,15 +32,16 @@ def name():
         return render_template(
             'views/service-settings/name.html',
             service=service,
-            form=form
+            form=form,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.confirm_name_change'))
+        return redirect(url_for('.confirm_name_change', service_id=service_id))
 
 
-@main.route("/service-settings/name/confirm", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @login_required
-def confirm_name_change():
+def confirm_name_change(service_id):
 
     form = ConfirmPasswordForm()
 
@@ -47,39 +49,42 @@ def confirm_name_change():
         return render_template(
             'views/service-settings/confirm.html',
             heading='Change your service name',
-            form=form
+            form=form,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.service_settings'))
+        return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/service-settings/request-to-go-live", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/request-to-go-live", methods=['GET', 'POST'])
 @login_required
-def request_to_go_live():
+def request_to_go_live(service_id):
     if request.method == 'GET':
         return render_template(
             'views/service-settings/request-to-go-live.html',
-            service=service
+            service=service,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.service_settings'))
+        return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/service-settings/status", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/status", methods=['GET', 'POST'])
 @login_required
-def status():
+def status(service_id):
     if request.method == 'GET':
         return render_template(
             'views/service-settings/status.html',
-            service=service
+            service=service,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.confirm_status_change'))
+        return redirect(url_for('.confirm_status_change', service_id=service_id))
 
 
-@main.route("/service-settings/status/confirm", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/status/confirm", methods=['GET', 'POST'])
 @login_required
-def confirm_status_change():
+def confirm_status_change(service_id):
 
     form = ConfirmPasswordForm()
 
@@ -88,27 +93,29 @@ def confirm_status_change():
             'views/service-settings/confirm.html',
             heading='Turn off all outgoing notifications',
             destructive=True,
-            form=form
+            form=form,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.service_settings'))
+        return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/service-settings/delete", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/delete", methods=['GET', 'POST'])
 @login_required
-def delete():
+def delete(service_id):
     if request.method == 'GET':
         return render_template(
             'views/service-settings/delete.html',
-            service=service
+            service=service,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.confirm_delete'))
+        return redirect(url_for('.confirm_delete', service_id=service_id))
 
 
-@main.route("/service-settings/delete/confirm", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/service-settings/delete/confirm", methods=['GET', 'POST'])
 @login_required
-def confirm_delete():
+def confirm_delete(service_id):
 
     form = ConfirmPasswordForm()
 
@@ -117,7 +124,8 @@ def confirm_delete():
             'views/service-settings/confirm.html',
             heading='Delete this service from Notify',
             destructive=True,
-            form=form
+            form=form,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.dashboard'))
+        return redirect(url_for('.dashboard', service_id=service_id))

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -11,7 +11,7 @@ service = {
 }
 
 
-@main.route("/<int:service_id>/service-settings")
+@main.route("/services/<int:service_id>/service-settings")
 @login_required
 def service_settings(service_id):
     return render_template(
@@ -21,7 +21,7 @@ def service_settings(service_id):
     )
 
 
-@main.route("/<int:service_id>/service-settings/name", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/name", methods=['GET', 'POST'])
 @login_required
 def name(service_id):
 
@@ -39,7 +39,7 @@ def name(service_id):
         return redirect(url_for('.confirm_name_change', service_id=service_id))
 
 
-@main.route("/<int:service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @login_required
 def confirm_name_change(service_id):
 
@@ -56,7 +56,7 @@ def confirm_name_change(service_id):
         return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/<int:service_id>/service-settings/request-to-go-live", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/request-to-go-live", methods=['GET', 'POST'])
 @login_required
 def request_to_go_live(service_id):
     if request.method == 'GET':
@@ -69,7 +69,7 @@ def request_to_go_live(service_id):
         return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/<int:service_id>/service-settings/status", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/status", methods=['GET', 'POST'])
 @login_required
 def status(service_id):
     if request.method == 'GET':
@@ -82,7 +82,7 @@ def status(service_id):
         return redirect(url_for('.confirm_status_change', service_id=service_id))
 
 
-@main.route("/<int:service_id>/service-settings/status/confirm", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/status/confirm", methods=['GET', 'POST'])
 @login_required
 def confirm_status_change(service_id):
 
@@ -100,7 +100,7 @@ def confirm_status_change(service_id):
         return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/<int:service_id>/service-settings/delete", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/delete", methods=['GET', 'POST'])
 @login_required
 def delete(service_id):
     if request.method == 'GET':
@@ -113,7 +113,7 @@ def delete(service_id):
         return redirect(url_for('.confirm_delete', service_id=service_id))
 
 
-@main.route("/<int:service_id>/service-settings/delete/confirm", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/service-settings/delete/confirm", methods=['GET', 'POST'])
 @login_required
 def confirm_delete(service_id):
 

--- a/app/main/views/sms.py
+++ b/app/main/views/sms.py
@@ -83,7 +83,7 @@ def checksms(service_id):
             service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.showjob', service_id=service_id))
+        return redirect(url_for('.showjob', service_id=service_id, job_id=456))
 
 
 def _build_upload_result(csv_file):

--- a/app/main/views/sms.py
+++ b/app/main/views/sms.py
@@ -35,9 +35,9 @@ message_templates = [
 ]
 
 
-@main.route("/sms/send", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/sms/send", methods=['GET', 'POST'])
 @login_required
-def sendsms():
+def sendsms(service_id):
     form = CsvUploadForm()
     if form.validate_on_submit():
         csv_file = form.file.data
@@ -49,24 +49,25 @@ def sendsms():
             message = 'There was a problem with the file: {}'.format(
                       csv_file.filename)
             flash(message)
-            return redirect(url_for('.sendsms'))
+            return redirect(url_for('.sendsms', service_id=service_id))
 
         if not results['valid'] and not results['rejects']:
             message = "The file {} contained no data".format(csv_file.filename)
             flash(message, 'error')
-            return redirect(url_for('.sendsms'))
+            return redirect(url_for('.sendsms', service_id=service_id))
 
         session[csv_file.filename] = results
-        return redirect(url_for('.checksms', recipients=csv_file.filename))
+        return redirect(url_for('.checksms', service_id=service_id, recipients=csv_file.filename))
 
     return render_template('views/send-sms.html',
                            message_templates=message_templates,
-                           form=form)
+                           form=form,
+                           service_id=service_id)
 
 
-@main.route("/sms/check", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/sms/check", methods=['GET', 'POST'])
 @login_required
-def checksms():
+def checksms(service_id):
     if request.method == 'GET':
 
         recipients_filename = request.args.get('recipients')
@@ -78,10 +79,11 @@ def checksms():
         return render_template(
             'views/check-sms.html',
             upload_result=upload_result,
-            message_template=message_templates[0]['body']
+            message_template=message_templates[0]['body'],
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.showjob'))
+        return redirect(url_for('.showjob', service_id=service_id))
 
 
 def _build_upload_result(csv_file):

--- a/app/main/views/sms.py
+++ b/app/main/views/sms.py
@@ -35,7 +35,7 @@ message_templates = [
 ]
 
 
-@main.route("/<int:service_id>/sms/send", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/sms/send", methods=['GET', 'POST'])
 @login_required
 def sendsms(service_id):
     form = CsvUploadForm()
@@ -65,7 +65,7 @@ def sendsms(service_id):
                            service_id=service_id)
 
 
-@main.route("/<int:service_id>/sms/check", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/sms/check", methods=['GET', 'POST'])
 @login_required
 def checksms(service_id):
     if request.method == 'GET':

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -5,7 +5,7 @@ from app.main import main
 from app.main.forms import TemplateForm
 
 
-@main.route("/<int:service_id>/templates")
+@main.route("/services/<int:service_id>/templates")
 @login_required
 def manage_templates(service_id):
     return render_template(
@@ -14,7 +14,7 @@ def manage_templates(service_id):
     )
 
 
-@main.route("/<int:service_id>/templates/template", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/templates/template", methods=['GET', 'POST'])
 @login_required
 def add_template(service_id):
 
@@ -34,7 +34,7 @@ def add_template(service_id):
         return redirect(url_for('.manage_templates', service_id=service_id))
 
 
-@main.route("/<int:service_id>/templates/template/add", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/templates/template/add", methods=['GET', 'POST'])
 @login_required
 def edit_template(service_id):
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -14,9 +14,26 @@ def manage_templates(service_id):
     )
 
 
-@main.route("/services/<int:service_id>/templates/template", methods=['GET', 'POST'])
+@main.route("/services/<int:service_id>/templates/add", methods=['GET', 'POST'])
 @login_required
 def add_template(service_id):
+
+    form = TemplateForm()
+
+    if request.method == 'GET':
+        return render_template(
+            'views/edit-template.html',
+            h1='Add template',
+            form=form,
+            service_id=service_id
+        )
+    elif request.method == 'POST':
+        return redirect(url_for('.manage_templates', service_id=service_id))
+
+
+@main.route("/services/<int:service_id>/templates/<template_id>", methods=['GET', 'POST'])
+@login_required
+def edit_template(service_id, template_id):
 
     form = TemplateForm()
 
@@ -27,23 +44,6 @@ def add_template(service_id):
         return render_template(
             'views/edit-template.html',
             h1='Edit template',
-            form=form,
-            service_id=service_id
-        )
-    elif request.method == 'POST':
-        return redirect(url_for('.manage_templates', service_id=service_id))
-
-
-@main.route("/services/<int:service_id>/templates/template/add", methods=['GET', 'POST'])
-@login_required
-def edit_template(service_id):
-
-    form = TemplateForm()
-
-    if request.method == 'GET':
-        return render_template(
-            'views/edit-template.html',
-            h1='Add template',
             form=form,
             service_id=service_id
         )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -5,15 +5,18 @@ from app.main import main
 from app.main.forms import TemplateForm
 
 
-@main.route("/templates")
+@main.route("/<int:service_id>/templates")
 @login_required
-def manage_templates():
-    return render_template('views/manage-templates.html')
+def manage_templates(service_id):
+    return render_template(
+        'views/manage-templates.html',
+        service_id=service_id
+    )
 
 
-@main.route("/templates/template", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/templates/template", methods=['GET', 'POST'])
 @login_required
-def add_template():
+def add_template(service_id):
 
     form = TemplateForm()
 
@@ -24,15 +27,16 @@ def add_template():
         return render_template(
             'views/edit-template.html',
             h1='Edit template',
-            form=form
+            form=form,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.manage_templates'))
+        return redirect(url_for('.manage_templates', service_id=service_id))
 
 
-@main.route("/templates/template/add", methods=['GET', 'POST'])
+@main.route("/<int:service_id>/templates/template/add", methods=['GET', 'POST'])
 @login_required
-def edit_template():
+def edit_template(service_id):
 
     form = TemplateForm()
 
@@ -40,7 +44,8 @@ def edit_template():
         return render_template(
             'views/edit-template.html',
             h1='Add template',
-            form=form
+            form=form,
+            service_id=service_id
         )
     elif request.method == 'POST':
-        return redirect(url_for('.manage_templates'))
+        return redirect(url_for('.manage_templates', service_id=service_id))

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -19,6 +19,6 @@ def two_factor():
     if form.validate_on_submit():
         verify_codes_dao.use_code_for_user_and_type(user_id=user.id, code_type='sms')
         login_user(user)
-        return redirect(url_for('.dashboard'))
+        return redirect(url_for('.dashboard', service_id=123))
 
     return render_template('views/two-factor.html', form=form)

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -42,7 +42,7 @@
 {% if not current_user.is_authenticated() %}
     {% set homepage_url = url_for('main.index') %}
 {% else %}
-    {% set homepage_url = url_for('main.dashboard') %}
+    {% set homepage_url = url_for('main.dashboard', service_id=123) %}
 {% endif %}
 
 {% block content %}
@@ -60,7 +60,7 @@
           </div>
         </div>
         <div class="column-half management-navigation-account">
-          <a href="{{ url_for('.userprofile') }}">{{ current_user.name }}</a>
+          <a href="{{ url_for('main.userprofile') }}">{{ current_user.name }}</a>
           <a href="{{ url_for('main.sign_out')}}">Sign out</a>
         </div>
       </div>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -1,17 +1,17 @@
 <nav class="navigation">
   <ul>
-    <li><a href="{{ url_for('.dashboard') }}">Dashboard</a></li>
+    <li><a href="{{ url_for('.dashboard', service_id=123) }}">Dashboard</a></li>
   </ul>
   <ul>
-    <li><a href="{{ url_for('.sendsms') }}">Send text messages</a></li>
-    <li><a href="{{ url_for('.sendemail') }}">Send emails</a></li>
-    <li><a href="{{ url_for('.showjobs') }}">Activity</a></li>
+    <li><a href="{{ url_for('.sendsms', service_id=123) }}">Send text messages</a></li>
+    <li><a href="{{ url_for('.sendemail', service_id=123) }}">Send emails</a></li>
+    <li><a href="{{ url_for('.showjobs', service_id=123) }}">Activity</a></li>
   </ul>
   <ul>
-    <li><a href="{{ url_for('.apikeys') }}">API keys and documentation</a></li>
+    <li><a href="{{ url_for('.apikeys', service_id=123) }}">API keys and documentation</a></li>
   </ul>
   <ul>
-    <li><a href="{{ url_for('.manageusers') }}">Manage users</a></li>
-    <li><a href="{{ url_for('.service_settings') }}">Service settings</a></li>
+    <li><a href="{{ url_for('.manageusers', service_id=123) }}">Manage users</a></li>
+    <li><a href="{{ url_for('.service_settings', service_id=123) }}">Service settings</a></li>
   </ul>
 </nav>

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -7,13 +7,13 @@ GOV.UK Notify | API keys and documentation
 
 {% block maincolumn_content %}
 
-		<h1 class="heading-xlarge">API keys and documentation</h1>
+    <h1 class="heading-xlarge">API keys and documentation</h1>
 
-		<p>Here's where developers can access information about the API and access keys</p>
+    <p>Here's where developers can access information about the API and access keys</p>
 
-		{{ page_footer(
-			back_link=url_for('.dashboard'),
-			back_link_text='Back to dashboard'
-		) }}
+    {{ page_footer(
+      back_link=url_for('.dashboard', service_id=service_id),
+      back_link_text='Back to dashboard'
+    ) }}
 
 {% endblock %}

--- a/app/templates/views/check-sms.html
+++ b/app/templates/views/check-sms.html
@@ -17,7 +17,7 @@
 		{% for rejected in upload_result.rejects %}
 			<p>Line {{rejected.line_number}}: {{rejected.phone }}</a>
 		{% endfor %}
-		<p><a href="{{url_for('.sendsms')}}" class="button">Go back and resolve errors</a></p>
+		<p><a href="{{url_for('.sendsms', service_id=service_id)}}" class="button">Go back and resolve errors</a></p>
 
 	{% else %}
 
@@ -26,7 +26,7 @@
 
 			{{ page_footer(
 					button_text = "Send {} text messages".format(upload_result.valid|count),
-					back_link = url_for(".sendsms")
+					back_link = url_for(".sendsms", service_id=service_id)
 			)}}
 
 			{% if upload_result.valid | count > 6 %}
@@ -56,7 +56,7 @@
 
 			{{ page_footer(
 					button_text = "Send {} text messages".format(upload_result.valid|count),
-					back_link = url_for(".sendsms")
+					back_link = url_for(".sendsms", service_id=service_id)
 			)}}
 
 		</form>

--- a/app/templates/views/dashboard.html
+++ b/app/templates/views/dashboard.html
@@ -30,10 +30,10 @@
       field_headings=['Job', 'File', 'Time', 'Status']
     ) %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.file }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id, job_id=456) }}">{{ item.file }}</a>
 			{% endcall %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.job }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id, job_id=456) }}">{{ item.job }}</a>
 			{% endcall %}
 			{% call field() %}
 				{{ item.time }}

--- a/app/templates/views/dashboard.html
+++ b/app/templates/views/dashboard.html
@@ -30,10 +30,10 @@
       field_headings=['Job', 'File', 'Time', 'Status']
     ) %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob') }}">{{ item.file }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.file }}</a>
 			{% endcall %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob') }}">{{ item.job }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.job }}</a>
 			{% endcall %}
 			{% call field() %}
 				{{ item.time }}
@@ -43,7 +43,7 @@
 			{% endcall %}
     {% endcall %}
     <p>
-      <a href={{ url_for('.showjobs') }}>See all notifications activity</a>
+      <a href={{ url_for('.showjobs', service_id=service_id) }}>See all notifications activity</a>
     </p>
 
 

--- a/app/templates/views/edit-template.html
+++ b/app/templates/views/edit-template.html
@@ -15,7 +15,7 @@ GOV.UK Notify | Edit template
 			{{ textbox(form.template_body, highlight_tags=True) }}
 			{{ page_footer(
 				'Save and continue',
-				back_link=url_for('.dashboard'),
+				back_link=url_for('.dashboard', service_id=service_id),
 				back_link_text='Back to manage templates'
 			) }}
 		</form>

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -38,7 +38,7 @@ GOV.UK Notify | Notifications activity
 		</ul>
 
     <p>
-      Sent with template <a href="{{ url_for('.edit_template') }}">{{ template_used }}</a> at {{ uploaded_file_time }}
+      Sent with template <a href="{{ url_for('.edit_template', service_id=service_id) }}">{{ template_used }}</a> at {{ uploaded_file_time }}
     </p>
 
     {% call(item) list_table(
@@ -52,10 +52,10 @@ GOV.UK Notify | Notifications activity
       ]
     ) %}
       {% call field() %}
-        <a href="{{ url_for('.shownotification', notification_id=item.id) }}">{{item.phone}}</a>
+        <a href="{{ url_for('.shownotification', service_id=service_id, notification_id=item.id) }}">{{item.phone}}</a>
       {% endcall %}
       {% call field() %}
-        <a href="{{ url_for('.shownotification', notification_id=item.id) }}">{{item.message[:50]}}…</a>
+        <a href="{{ url_for('.shownotification', service_id=service_id, notification_id=item.id) }}">{{item.message[:50]}}…</a>
       {% endcall %}
       {% call field(
         align='right',

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -38,7 +38,7 @@ GOV.UK Notify | Notifications activity
 		</ul>
 
     <p>
-      Sent with template <a href="{{ url_for('.edit_template', service_id=service_id) }}">{{ template_used }}</a> at {{ uploaded_file_time }}
+      Sent with template <a href="{{ url_for('.edit_template', service_id=service_id, template_id=1) }}">{{ template_used }}</a> at {{ uploaded_file_time }}
     </p>
 
     {% call(item) list_table(

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -52,10 +52,10 @@ GOV.UK Notify | Notifications activity
       ]
     ) %}
       {% call field() %}
-        <a href="{{ url_for('.shownotification', service_id=service_id, notification_id=item.id) }}">{{item.phone}}</a>
+        <a href="{{ url_for('.shownotification', service_id=service_id, job_id=456, notification_id=item.id) }}">{{item.phone}}</a>
       {% endcall %}
       {% call field() %}
-        <a href="{{ url_for('.shownotification', service_id=service_id, notification_id=item.id) }}">{{item.message[:50]}}…</a>
+        <a href="{{ url_for('.shownotification', service_id=service_id, job_id=456, notification_id=item.id) }}">{{item.message[:50]}}…</a>
       {% endcall %}
       {% call field(
         align='right',

--- a/app/templates/views/jobs.html
+++ b/app/templates/views/jobs.html
@@ -16,10 +16,10 @@ GOV.UK Notify | Notifications activity
 			field_headings=['Job', 'File', 'Time', 'Status']
 		) %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob') }}">{{ item.file }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.file }}</a>
 			{% endcall %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob') }}">{{ item.job }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.job }}</a>
 			{% endcall %}
 			{% call field() %}
 				{{ item.time }}

--- a/app/templates/views/jobs.html
+++ b/app/templates/views/jobs.html
@@ -16,10 +16,10 @@ GOV.UK Notify | Notifications activity
 			field_headings=['Job', 'File', 'Time', 'Status']
 		) %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.file }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id, job_id=456) }}">{{ item.file }}</a>
 			{% endcall %}
 			{% call field() %}
-				<a href="{{ url_for('.showjob', service_id=service_id) }}">{{ item.job }}</a>
+				<a href="{{ url_for('.showjob', service_id=service_id, job_id=456) }}">{{ item.job }}</a>
 			{% endcall %}
 			{% call field() %}
 				{{ item.time }}

--- a/app/templates/views/manage-templates.html
+++ b/app/templates/views/manage-templates.html
@@ -12,11 +12,11 @@ GOV.UK Notify | Manage templates
     <p>Here's where you can view templates, choose to add one, or edit/delete one.</p>
 
     <p>
-      <a href="{{ url_for('.edit_template', service_id=service_id) }}">Here is my first template</a>
+      <a href="{{ url_for('.edit_template', service_id=service_id, template_id=1) }}">Here is my first template</a>
     </p>
 
     <p>
-      <a class="button" href="{{ url_for('.edit_template', service_id=service_id) }}" role="button">Add a new message template</a>
+      <a class="button" href="{{ url_for('.add_template', service_id=service_id) }}" role="button">Add a new message template</a>
     </p>
 
 

--- a/app/templates/views/manage-templates.html
+++ b/app/templates/views/manage-templates.html
@@ -12,11 +12,11 @@ GOV.UK Notify | Manage templates
     <p>Here's where you can view templates, choose to add one, or edit/delete one.</p>
 
     <p>
-      <a href="{{ url_for('.edit_template') }}">Here is my first template</a>
+      <a href="{{ url_for('.edit_template', service_id=service_id) }}">Here is my first template</a>
     </p>
 
     <p>
-      <a class="button" href="{{ url_for('.edit_template') }}" role="button">Add a new message template</a>
+      <a class="button" href="{{ url_for('.edit_template', service_id=service_id) }}" role="button">Add a new message template</a>
     </p>
 
 

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -12,7 +12,7 @@ GOV.UK Notify | Manage users
 		<p>Here's where you can add or remove users of a service.</p>
 
 		{{ page_footer(
-			back_link = url_for('.dashboard'),
+			back_link = url_for('.dashboard', service_id=service_id),
 			back_link_text = 'Back to dashboard'
 		) }}
 

--- a/app/templates/views/notification.html
+++ b/app/templates/views/notification.html
@@ -26,7 +26,7 @@ GOV.UK Notify | Notifications activity
 		</div>
 
 		{{ page_footer(
-			back_link = url_for('.showjob', service_id=service_id),
+			back_link = url_for('.showjob', service_id=service_id, job_id=job_id),
 			back_link_text = 'View other messages in this job'
 		) }}
 

--- a/app/templates/views/notification.html
+++ b/app/templates/views/notification.html
@@ -26,7 +26,7 @@ GOV.UK Notify | Notifications activity
 		</div>
 
 		{{ page_footer(
-			back_link = url_for('.showjob'),
+			back_link = url_for('.showjob', service_id=service_id),
 			back_link_text = 'View other messages in this job'
 		) }}
 

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -26,7 +26,7 @@
 				{% endfor %}
 
 				<p>
-					or <a href="{{ url_for(".add_template") }}">create a new template</a>
+					or <a href="{{ url_for(".add_template", service_id=service_id) }}">create a new template</a>
 				</p>
 
 				<h2 class="heading-medium">2. Add recipients</h2>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -12,26 +12,26 @@
     {{ browse_list([
       {
         'title': 'Change your service name',
-        'link': url_for('.name'),
+        'link': url_for('.name', service_id=service_id),
         'hint': 'Your service name ({}) is included in every sent notification'.format(service.name)
       },
       {
         'title': 'Request to go live and turn off sending restrictions',
-        'link': url_for('.request_to_go_live'),
+        'link': url_for('.request_to_go_live', service_id=service_id),
         'hint': 'A live service can send notifications to any phone number or email address',
       } if not service.live else {
       },
       {
         'title': 'Turn off all outgoing notifications',
-        'link': url_for('.status'),
+        'link': url_for('.status', service_id=service_id),
         'destructive': True
       } if service.active else {
         'title': 'Restart sending notifications',
-        'link': url_for('.status')
+        'link': url_for('.status', service_id=service_id)
       },
       {
         'title': 'Delete this service from Notify',
-        'link': url_for('.delete'),
+        'link': url_for('.delete', service_id=service_id),
         'destructive': True
       },
     ]) }}

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -18,7 +18,7 @@ GOV.UK Notify | Service settings
       {{ page_footer(
         'Confirm',
         destructive=destructive,
-        back_link=url_for('.service_settings')
+        back_link=url_for('.service_settings', service_id=service_id)
       ) }}
     </form>
     </div>

--- a/app/templates/views/service-settings/delete.html
+++ b/app/templates/views/service-settings/delete.html
@@ -35,7 +35,7 @@
         {{ page_footer(
           'Yes, delete ‘{}’'.format(service.name),
           destructive=True,
-          back_link=url_for('.service_settings')
+          back_link=url_for('.service_settings', service_id=service_id)
         ) }}
       </form>
 

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -24,7 +24,7 @@ GOV.UK Notify | Service settings
         {{ textbox(form.service_name) }}
         {{ page_footer(
           'Save',
-          back_link=url_for('.service_settings')
+          back_link=url_for('.service_settings', service_id=service_id)
         ) }}
       </form>
     </div>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -39,7 +39,7 @@
       <form method="post">
         {{ page_footer(
           'Send request',
-          back_link=url_for('.service_settings')
+          back_link=url_for('.service_settings', service_id=service_id)
         ) }}
       </form>
 

--- a/app/templates/views/service-settings/status.html
+++ b/app/templates/views/service-settings/status.html
@@ -25,7 +25,7 @@ GOV.UK Notify | Service settings
         {{ page_footer(
           'Turn off all outgoing notifications',
           destructive=True,
-          back_link=url_for('.service_settings')
+          back_link=url_for('.service_settings', service_id=service_id)
         ) }}
       </form>
 

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -1,11 +1,11 @@
-{% extends "withnav_template.html" %}
+{% extends "admin_template.html" %}
 {% from "components/table.html" import list_table, row, field %}
 
 {% block page_title %}
   GOV.UK Notify | Your profile
 {% endblock %}
 
-{% block maincolumn_content %}
+{% block fullwidth_content %}
 
   <h1 class="heading-xlarge">Your profile</h1>
 

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -1,4 +1,4 @@
-{% extends "withnav_template.html" %}
+{% extends "admin_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block maincolumn_content %}
+{% block fullwidth_content %}
 
   <h1 class="heading-xlarge">Change your {{ thing }}</h1>
 

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -1,4 +1,4 @@
-{% extends "withnav_template.html" %}
+{% extends "admin_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block maincolumn_content %}
+{% block fullwidth_content %}
 
   <h1 class="heading-xlarge">Change your password</h1>
 

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -1,4 +1,4 @@
-{% extends "withnav_template.html" %}
+{% extends "admin_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block maincolumn_content %}
+{% block fullwidth_content %}
 
   <h1 class="heading-xlarge">Change your {{ thing }}</h1>
 

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -1,4 +1,4 @@
-{% extends "withnav_template.html" %}
+{% extends "admin_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block maincolumn_content %}
+{% block fullwidth_content %}
 
   <h1 class="heading-xlarge">Change your {{ thing }}</h1>
 
@@ -20,7 +20,7 @@ GOV.UK Notify | Service settings
         {{ page_footer(
           'Confirm',
           destructive=destructive,
-          back_link=url_for('.service_settings')
+          back_link=url_for('.userprofile')
         ) }}
       </form>
     </div>

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -23,7 +23,7 @@ def test_should_add_service_and_redirect_to_next_page(notifications_admin, notif
             client.post('/two-factor', data={'sms_code': '12345'})
             response = client.post('/add-service', data={'service_name': 'testing the post'})
             assert response.status_code == 302
-            assert response.location == 'http://localhost/dashboard'
+            assert response.location == 'http://localhost/123/dashboard'
             saved_service = services_dao.find_service_by_service_name('testing the post')
             assert saved_service is not None
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -23,7 +23,7 @@ def test_should_add_service_and_redirect_to_next_page(notifications_admin, notif
             client.post('/two-factor', data={'sms_code': '12345'})
             response = client.post('/add-service', data={'service_name': 'testing the post'})
             assert response.status_code == 302
-            assert response.location == 'http://localhost/123/dashboard'
+            assert response.location == 'http://localhost/services/123/dashboard'
             saved_service = services_dao.find_service_by_service_name('testing the post')
             assert saved_service is not None
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -9,7 +9,7 @@ def test_should_show_recent_jobs_on_dashboard(notifications_admin,
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/dashboard')
+            response = client.get('/services/123/dashboard')
 
         assert response.status_code == 200
         assert 'Test message 1' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -9,7 +9,7 @@ def test_should_show_recent_jobs_on_dashboard(notifications_admin,
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get(url_for('main.dashboard'))
+            response = client.get('/123/dashboard')
 
         assert response.status_code == 200
         assert 'Test message 1' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -6,7 +6,7 @@ def test_should_return_list_of_all_jobs(notifications_admin, notifications_admin
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/jobs')
+            response = client.get('/services/123/jobs')
 
         assert response.status_code == 200
         assert 'Test message 1' in response.get_data(as_text=True)
@@ -18,7 +18,7 @@ def test_should_show_page_for_one_job(notifications_admin, notifications_admin_d
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/jobs/456')
+            response = client.get('/services/123/jobs/456')
 
         assert response.status_code == 200
         assert 'dispatch_20151114.csv' in response.get_data(as_text=True)
@@ -30,7 +30,7 @@ def test_should_show_page_for_one_notification(notifications_admin, notification
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/jobs/456/notification/3')
+            response = client.get('/services/123/jobs/456/notification/3')
 
         assert response.status_code == 200
         assert 'Text message' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -6,7 +6,7 @@ def test_should_return_list_of_all_jobs(notifications_admin, notifications_admin
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/jobs')
+            response = client.get('/123/jobs')
 
         assert response.status_code == 200
         assert 'Test message 1' in response.get_data(as_text=True)
@@ -18,7 +18,7 @@ def test_should_show_page_for_one_job(notifications_admin, notifications_admin_d
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/jobs/job')
+            response = client.get('/123/jobs/job')
 
         assert response.status_code == 200
         assert 'dispatch_20151114.csv' in response.get_data(as_text=True)
@@ -30,7 +30,7 @@ def test_should_show_page_for_one_notification(notifications_admin, notification
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/jobs/job/notification/3')
+            response = client.get('/123/jobs/job/notification/3')
 
         assert response.status_code == 200
         assert 'Text message' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -18,7 +18,7 @@ def test_should_show_page_for_one_job(notifications_admin, notifications_admin_d
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/jobs/job')
+            response = client.get('/123/jobs/456')
 
         assert response.status_code == 200
         assert 'dispatch_20151114.csv' in response.get_data(as_text=True)
@@ -30,7 +30,7 @@ def test_should_show_page_for_one_notification(notifications_admin, notification
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/jobs/job/notification/3')
+            response = client.get('/123/jobs/456/notification/3')
 
         assert response.status_code == 200
         assert 'Text message' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -6,7 +6,7 @@ def test_should_show_overview(notifications_admin, notifications_admin_db, notif
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings')
+            response = client.get('/services/123/service-settings')
         assert response.status_code == 200
         assert 'Service settings' in response.get_data(as_text=True)
 
@@ -16,7 +16,7 @@ def test_should_show_service_name(notifications_admin, notifications_admin_db, n
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/name')
+            response = client.get('/services/123/service-settings/name')
         assert response.status_code == 200
         assert 'Change your service name' in response.get_data(as_text=True)
 
@@ -26,10 +26,10 @@ def test_should_redirect_after_change_service_name(notifications_admin, notifica
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/request-to-go-live')
+            response = client.post('/services/123/service-settings/request-to-go-live')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/service-settings' == response.location
+    assert 'http://localhost/services/123/service-settings' == response.location
 
 
 def test_should_show_service_name_confirmation(notifications_admin, notifications_admin_db, notify_db_session):
@@ -37,7 +37,7 @@ def test_should_show_service_name_confirmation(notifications_admin, notification
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/name/confirm')
+            response = client.get('/services/123/service-settings/name/confirm')
 
     assert response.status_code == 200
     assert 'Change your service name' in response.get_data(as_text=True)
@@ -49,10 +49,10 @@ def test_should_redirect_after_service_name_confirmation(notifications_admin, no
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/name/confirm')
+            response = client.post('/services/123/service-settings/name/confirm')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/service-settings' == response.location
+    assert 'http://localhost/services/123/service-settings' == response.location
 
 
 def test_should_show_request_to_go_live(notifications_admin, notifications_admin_db, notify_db_session):
@@ -60,7 +60,7 @@ def test_should_show_request_to_go_live(notifications_admin, notifications_admin
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/request-to-go-live')
+            response = client.get('/services/123/service-settings/request-to-go-live')
 
     assert response.status_code == 200
     assert 'Request to go live' in response.get_data(as_text=True)
@@ -71,10 +71,10 @@ def test_should_redirect_after_request_to_go_live(notifications_admin, notificat
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/request-to-go-live')
+            response = client.post('/services/123/service-settings/request-to-go-live')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/service-settings' == response.location
+    assert 'http://localhost/services/123/service-settings' == response.location
 
 
 def test_should_show_status_page(notifications_admin, notifications_admin_db, notify_db_session):
@@ -82,7 +82,7 @@ def test_should_show_status_page(notifications_admin, notifications_admin_db, no
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/status')
+            response = client.get('/services/123/service-settings/status')
 
     assert response.status_code == 200
     assert 'Turn off all outgoing notifications' in response.get_data(as_text=True)
@@ -93,10 +93,10 @@ def test_should_show_redirect_after_status_change(notifications_admin, notificat
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/status')
+            response = client.post('/services/123/service-settings/status')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/service-settings/status/confirm' == response.location
+    assert 'http://localhost/services/123/service-settings/status/confirm' == response.location
 
 
 def test_should_show_status_confirmation(notifications_admin, notifications_admin_db, notify_db_session):
@@ -104,7 +104,7 @@ def test_should_show_status_confirmation(notifications_admin, notifications_admi
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/status/confirm')
+            response = client.get('/services/123/service-settings/status/confirm')
 
     assert response.status_code == 200
     assert 'Turn off all outgoing notifications' in response.get_data(as_text=True)
@@ -115,10 +115,10 @@ def test_should_redirect_after_status_confirmation(notifications_admin, notifica
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/status/confirm')
+            response = client.post('/services/123/service-settings/status/confirm')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/service-settings' == response.location
+    assert 'http://localhost/services/123/service-settings' == response.location
 
 
 def test_should_show_delete_page(notifications_admin, notifications_admin_db, notify_db_session):
@@ -126,7 +126,7 @@ def test_should_show_delete_page(notifications_admin, notifications_admin_db, no
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/delete')
+            response = client.get('/services/123/service-settings/delete')
 
     assert response.status_code == 200
     assert 'Delete this service from Notify' in response.get_data(as_text=True)
@@ -137,10 +137,10 @@ def test_should_show_redirect_after_deleting_service(notifications_admin, notifi
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/delete')
+            response = client.post('/services/123/service-settings/delete')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/service-settings/delete/confirm' == response.location
+    assert 'http://localhost/services/123/service-settings/delete/confirm' == response.location
 
 
 def test_should_show_delete_confirmation(notifications_admin, notifications_admin_db, notify_db_session):
@@ -148,7 +148,7 @@ def test_should_show_delete_confirmation(notifications_admin, notifications_admi
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/service-settings/delete/confirm')
+            response = client.get('/services/123/service-settings/delete/confirm')
 
     assert response.status_code == 200
     assert 'Delete this service from Notify' in response.get_data(as_text=True)
@@ -159,7 +159,7 @@ def test_should_redirect_delete_confirmation(notifications_admin, notifications_
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/service-settings/delete/confirm')
+            response = client.post('/services/123/service-settings/delete/confirm')
 
     assert response.status_code == 302
-    assert 'http://localhost/123/dashboard' == response.location
+    assert 'http://localhost/services/123/dashboard' == response.location

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -6,7 +6,7 @@ def test_should_show_overview(notifications_admin, notifications_admin_db, notif
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings')
+            response = client.get('/123/service-settings')
         assert response.status_code == 200
         assert 'Service settings' in response.get_data(as_text=True)
 
@@ -16,7 +16,7 @@ def test_should_show_service_name(notifications_admin, notifications_admin_db, n
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/name')
+            response = client.get('/123/service-settings/name')
         assert response.status_code == 200
         assert 'Change your service name' in response.get_data(as_text=True)
 
@@ -26,10 +26,10 @@ def test_should_redirect_after_change_service_name(notifications_admin, notifica
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/request-to-go-live')
+            response = client.post('/123/service-settings/request-to-go-live')
 
     assert response.status_code == 302
-    assert 'http://localhost/service-settings' == response.location
+    assert 'http://localhost/123/service-settings' == response.location
 
 
 def test_should_show_service_name_confirmation(notifications_admin, notifications_admin_db, notify_db_session):
@@ -37,7 +37,7 @@ def test_should_show_service_name_confirmation(notifications_admin, notification
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/name/confirm')
+            response = client.get('/123/service-settings/name/confirm')
 
     assert response.status_code == 200
     assert 'Change your service name' in response.get_data(as_text=True)
@@ -49,10 +49,10 @@ def test_should_redirect_after_service_name_confirmation(notifications_admin, no
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/name/confirm')
+            response = client.post('/123/service-settings/name/confirm')
 
     assert response.status_code == 302
-    assert 'http://localhost/service-settings' == response.location
+    assert 'http://localhost/123/service-settings' == response.location
 
 
 def test_should_show_request_to_go_live(notifications_admin, notifications_admin_db, notify_db_session):
@@ -60,7 +60,7 @@ def test_should_show_request_to_go_live(notifications_admin, notifications_admin
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/request-to-go-live')
+            response = client.get('/123/service-settings/request-to-go-live')
 
     assert response.status_code == 200
     assert 'Request to go live' in response.get_data(as_text=True)
@@ -71,10 +71,10 @@ def test_should_redirect_after_request_to_go_live(notifications_admin, notificat
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/request-to-go-live')
+            response = client.post('/123/service-settings/request-to-go-live')
 
     assert response.status_code == 302
-    assert 'http://localhost/service-settings' == response.location
+    assert 'http://localhost/123/service-settings' == response.location
 
 
 def test_should_show_status_page(notifications_admin, notifications_admin_db, notify_db_session):
@@ -82,7 +82,7 @@ def test_should_show_status_page(notifications_admin, notifications_admin_db, no
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/status')
+            response = client.get('/123/service-settings/status')
 
     assert response.status_code == 200
     assert 'Turn off all outgoing notifications' in response.get_data(as_text=True)
@@ -93,10 +93,10 @@ def test_should_show_redirect_after_status_change(notifications_admin, notificat
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/status')
+            response = client.post('/123/service-settings/status')
 
     assert response.status_code == 302
-    assert 'http://localhost/service-settings/status/confirm' == response.location
+    assert 'http://localhost/123/service-settings/status/confirm' == response.location
 
 
 def test_should_show_status_confirmation(notifications_admin, notifications_admin_db, notify_db_session):
@@ -104,7 +104,7 @@ def test_should_show_status_confirmation(notifications_admin, notifications_admi
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/status/confirm')
+            response = client.get('/123/service-settings/status/confirm')
 
     assert response.status_code == 200
     assert 'Turn off all outgoing notifications' in response.get_data(as_text=True)
@@ -115,10 +115,10 @@ def test_should_redirect_after_status_confirmation(notifications_admin, notifica
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/status/confirm')
+            response = client.post('/123/service-settings/status/confirm')
 
     assert response.status_code == 302
-    assert 'http://localhost/service-settings' == response.location
+    assert 'http://localhost/123/service-settings' == response.location
 
 
 def test_should_show_delete_page(notifications_admin, notifications_admin_db, notify_db_session):
@@ -126,7 +126,7 @@ def test_should_show_delete_page(notifications_admin, notifications_admin_db, no
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/delete')
+            response = client.get('/123/service-settings/delete')
 
     assert response.status_code == 200
     assert 'Delete this service from Notify' in response.get_data(as_text=True)
@@ -137,10 +137,10 @@ def test_should_show_redirect_after_deleting_service(notifications_admin, notifi
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/delete')
+            response = client.post('/123/service-settings/delete')
 
     assert response.status_code == 302
-    assert 'http://localhost/service-settings/delete/confirm' == response.location
+    assert 'http://localhost/123/service-settings/delete/confirm' == response.location
 
 
 def test_should_show_delete_confirmation(notifications_admin, notifications_admin_db, notify_db_session):
@@ -148,7 +148,7 @@ def test_should_show_delete_confirmation(notifications_admin, notifications_admi
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/service-settings/delete/confirm')
+            response = client.get('/123/service-settings/delete/confirm')
 
     assert response.status_code == 200
     assert 'Delete this service from Notify' in response.get_data(as_text=True)
@@ -159,7 +159,7 @@ def test_should_redirect_delete_confirmation(notifications_admin, notifications_
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/service-settings/delete/confirm')
+            response = client.post('/123/service-settings/delete/confirm')
 
     assert response.status_code == 302
-    assert 'http://localhost/dashboard' == response.location
+    assert 'http://localhost/123/dashboard' == response.location

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -34,7 +34,7 @@ def test_sign_out_user(notifications_admin,
         with notifications_admin.test_client() as client:
             client.login(user)
             # Check we are logged in
-            response = client.get('/123/dashboard')
+            response = client.get('/services/123/dashboard')
             assert response.status_code == 200
             response = client.get(url_for('main.sign_out'))
             assert response.status_code == 302

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -34,8 +34,7 @@ def test_sign_out_user(notifications_admin,
         with notifications_admin.test_client() as client:
             client.login(user)
             # Check we are logged in
-            response = client.get(
-                url_for('main.dashboard'))
+            response = client.get('/123/dashboard')
             assert response.status_code == 200
             response = client.get(url_for('main.sign_out'))
             assert response.status_code == 302

--- a/tests/app/main/views/test_sms.py
+++ b/tests/app/main/views/test_sms.py
@@ -9,7 +9,7 @@ def test_upload_empty_csvfile_returns_to_upload_page(notifications_admin, notifi
             client.login(user)
 
             upload_data = {'file': (BytesIO(''.encode('utf-8')), 'emtpy.csv')}
-            response = client.post('/sms/send', data=upload_data,
+            response = client.post('/123/sms/send', data=upload_data,
                                    follow_redirects=True)
 
         assert response.status_code == 200
@@ -27,7 +27,7 @@ def test_upload_csvfile_with_invalid_phone_shows_check_page_with_errors(
 
             file_contents = 'phone\n+44 123\n+44 456'.encode('utf-8')
             upload_data = {'file': (BytesIO(file_contents), 'invalid.csv')}
-            response = client.post('/sms/send', data=upload_data,
+            response = client.post('/123/sms/send', data=upload_data,
                                    follow_redirects=True)
         assert response.status_code == 200
         content = response.get_data(as_text=True)
@@ -48,7 +48,7 @@ def test_upload_csvfile_with_valid_phone_shows_first3_and_last3_numbers(
             file_contents = 'phone\n+44 7700 900981\n+44 7700 900982\n+44 7700 900983\n+44 7700 900984\n+44 7700 900985\n+44 7700 900986\n+44 7700 900987\n+44 7700 900988\n+44 7700 900989'.encode('utf-8')  # noqa
 
             upload_data = {'file': (BytesIO(file_contents), 'valid.csv')}
-            response = client.post('/sms/send', data=upload_data,
+            response = client.post('/123/sms/send', data=upload_data,
                                    follow_redirects=True)
 
         content = response.get_data(as_text=True)
@@ -79,7 +79,7 @@ def test_upload_csvfile_with_valid_phone_shows_all_if_6_or_less_numbers(
             file_contents = 'phone\n+44 7700 900981\n+44 7700 900982\n+44 7700 900983\n+44 7700 900984\n+44 7700 900985\n+44 7700 900986'.encode('utf-8')  # noqa
 
             upload_data = {'file': (BytesIO(file_contents), 'valid.csv')}
-            response = client.post('/sms/send', data=upload_data,
+            response = client.post('/123/sms/send', data=upload_data,
                                    follow_redirects=True)
 
         content = response.get_data(as_text=True)
@@ -102,7 +102,7 @@ def test_should_redirect_to_job(notifications_admin, notifications_admin_db,
             user = create_test_user('active')
             client.login(user)
 
-        response = client.post('/sms/check')
+        response = client.post('/123/sms/check')
 
         assert response.status_code == 302
-        assert response.location == 'http://localhost/jobs/job'
+        assert response.location == 'http://localhost/123/jobs/job'

--- a/tests/app/main/views/test_sms.py
+++ b/tests/app/main/views/test_sms.py
@@ -9,7 +9,7 @@ def test_upload_empty_csvfile_returns_to_upload_page(notifications_admin, notifi
             client.login(user)
 
             upload_data = {'file': (BytesIO(''.encode('utf-8')), 'emtpy.csv')}
-            response = client.post('/123/sms/send', data=upload_data,
+            response = client.post('/services/123/sms/send', data=upload_data,
                                    follow_redirects=True)
 
         assert response.status_code == 200
@@ -27,7 +27,7 @@ def test_upload_csvfile_with_invalid_phone_shows_check_page_with_errors(
 
             file_contents = 'phone\n+44 123\n+44 456'.encode('utf-8')
             upload_data = {'file': (BytesIO(file_contents), 'invalid.csv')}
-            response = client.post('/123/sms/send', data=upload_data,
+            response = client.post('/services/123/sms/send', data=upload_data,
                                    follow_redirects=True)
         assert response.status_code == 200
         content = response.get_data(as_text=True)
@@ -48,7 +48,7 @@ def test_upload_csvfile_with_valid_phone_shows_first3_and_last3_numbers(
             file_contents = 'phone\n+44 7700 900981\n+44 7700 900982\n+44 7700 900983\n+44 7700 900984\n+44 7700 900985\n+44 7700 900986\n+44 7700 900987\n+44 7700 900988\n+44 7700 900989'.encode('utf-8')  # noqa
 
             upload_data = {'file': (BytesIO(file_contents), 'valid.csv')}
-            response = client.post('/123/sms/send', data=upload_data,
+            response = client.post('/services/123/sms/send', data=upload_data,
                                    follow_redirects=True)
 
         content = response.get_data(as_text=True)
@@ -79,7 +79,7 @@ def test_upload_csvfile_with_valid_phone_shows_all_if_6_or_less_numbers(
             file_contents = 'phone\n+44 7700 900981\n+44 7700 900982\n+44 7700 900983\n+44 7700 900984\n+44 7700 900985\n+44 7700 900986'.encode('utf-8')  # noqa
 
             upload_data = {'file': (BytesIO(file_contents), 'valid.csv')}
-            response = client.post('/123/sms/send', data=upload_data,
+            response = client.post('/services/123/sms/send', data=upload_data,
                                    follow_redirects=True)
 
         content = response.get_data(as_text=True)
@@ -102,7 +102,7 @@ def test_should_redirect_to_job(notifications_admin, notifications_admin_db,
             user = create_test_user('active')
             client.login(user)
 
-        response = client.post('/123/sms/check')
+        response = client.post('/services/123/sms/check')
 
         assert response.status_code == 302
-        assert response.location == 'http://localhost/123/jobs/456'
+        assert response.location == 'http://localhost/services/123/jobs/456'

--- a/tests/app/main/views/test_sms.py
+++ b/tests/app/main/views/test_sms.py
@@ -105,4 +105,4 @@ def test_should_redirect_to_job(notifications_admin, notifications_admin_db,
         response = client.post('/123/sms/check')
 
         assert response.status_code == 302
-        assert response.location == 'http://localhost/123/jobs/job'
+        assert response.location == 'http://localhost/123/jobs/456'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -6,7 +6,7 @@ def test_should_return_list_of_all_templates(notifications_admin, notifications_
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/templates')
+            response = client.get('/123/templates')
 
     assert response.status_code == 200
 
@@ -16,7 +16,7 @@ def test_should_show_page_for_one_templates(notifications_admin, notifications_a
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/templates/template')
+            response = client.get('/123/templates/template')
 
     assert response.status_code == 200
 
@@ -26,7 +26,7 @@ def test_should_redirect_when_saving_a_template(notifications_admin, notificatio
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/templates/template')
+            response = client.post('/123/templates/template')
 
     assert response.status_code == 302
-    assert response.location == 'http://localhost/templates'
+    assert response.location == 'http://localhost/123/templates'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -6,7 +6,7 @@ def test_should_return_list_of_all_templates(notifications_admin, notifications_
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/templates')
+            response = client.get('/services/123/templates')
 
     assert response.status_code == 200
 
@@ -16,7 +16,7 @@ def test_should_show_page_for_one_templates(notifications_admin, notifications_a
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.get('/123/templates/template')
+            response = client.get('/services/123/templates/template')
 
     assert response.status_code == 200
 
@@ -26,7 +26,7 @@ def test_should_redirect_when_saving_a_template(notifications_admin, notificatio
         with notifications_admin.test_client() as client:
             user = create_test_user('active')
             client.login(user)
-            response = client.post('/123/templates/template')
+            response = client.post('/services/123/templates/template')
 
     assert response.status_code == 302
-    assert response.location == 'http://localhost/123/templates'
+    assert response.location == 'http://localhost/services/123/templates'

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -28,7 +28,7 @@ def test_should_login_user_and_redirect_to_dashboard(notifications_admin, notifi
                                    data={'sms_code': '12345'})
 
             assert response.status_code == 302
-            assert response.location == url_for('main.dashboard', _external=True)
+            assert response.location == url_for('main.dashboard', service_id=123, _external=True)
 
 
 def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(notifications_admin,


### PR DESCRIPTION
# TL;DR

Before | After
--- | ---
/dashboard | /services/123/dashboard
/templates/template | /services/123/templates/456
/user-profile | /user-profile

## Add mocked service ID to all service-specific pages

We’ve decided that the URL (as opposed to something session-y) is the best place to communicate the current service to the views.


## Add stubbed `job_id` and `template_id`

So that we can get a better sense of what the URLs look like.

Leaving unsigned for now because we don’t know if the ID will be a `string` or `int` or…


## Add /services prefix to all service-related URLs

The URLs will be easier to parse if the parts are clearly labelled.

This is a precursor to making a blueprint for all service-related URLs.