### PR TITLE
Add page to choose services

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -5,5 +5,5 @@ main = Blueprint('main', __name__)
 from app.main.views import (
     index, sign_in, sign_out, register, two_factor, verify, sms, add_service,
     code_not_received, jobs, dashboard, templates, service_settings, forgot_password,
-    new_password, styleguide, user_profile
+    new_password, styleguide, user_profile, choose_service
 )

--- a/app/main/views/choose_service.py
+++ b/app/main/views/choose_service.py
@@ -5,5 +5,5 @@ from app.main import main
 
 @main.route("/services")
 @login_required
-def chooseservice():
+def choose_service():
     return render_template('views/choose-service.html')

--- a/app/main/views/choose_service.py
+++ b/app/main/views/choose_service.py
@@ -1,0 +1,9 @@
+from flask import render_template
+from flask_login import login_required
+from app.main import main
+
+
+@main.route("/services")
+@login_required
+def chooseservice():
+    return render_template('views/choose-service.html')

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -19,6 +19,6 @@ def two_factor():
     if form.validate_on_submit():
         verify_codes_dao.use_code_for_user_and_type(user_id=user.id, code_type='sms')
         login_user(user)
-        return redirect(url_for('.dashboard', service_id=123))
+        return redirect(url_for('.chooseservice'))
 
     return render_template('views/two-factor.html', form=form)

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -19,6 +19,6 @@ def two_factor():
     if form.validate_on_submit():
         verify_codes_dao.use_code_for_user_and_type(user_id=user.id, code_type='sms')
         login_user(user)
-        return redirect(url_for('.chooseservice'))
+        return redirect(url_for('.choose_service'))
 
     return render_template('views/two-factor.html', form=form)

--- a/app/templates/views/choose-service.html
+++ b/app/templates/views/choose-service.html
@@ -1,0 +1,31 @@
+{% extends "withnav_template.html" %}
+{% from "components/browse-list.html" import browse_list %}
+
+{% block page_title %}
+  GOV.UK Notify | Dashboard
+{% endblock %}
+
+{% block fullwidth_content %}
+
+  <h1 class="heading-xlarge">
+    Choose service
+  </h1>
+
+  {{ browse_list([
+    {
+      'title': 'MOT Reminders',
+      'link': url_for('.dashboard', service_id=123)
+    },
+    {
+      'title': 'Vehicle Tax',
+      'link': url_for('.dashboard', service_id=123)
+    },
+  ]) }}
+  {{ browse_list([
+    {
+      'title': 'Add a new service…',
+      'link': url_for('.add_service')
+    },
+  ]) }}
+
+{% endblock %}

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -1,0 +1,15 @@
+from tests.app.main import create_test_user
+from flask import url_for
+
+
+def test_should_show_choose_services_page(notifications_admin,
+                                          notifications_admin_db,
+                                          notify_db_session):
+    with notifications_admin.test_request_context():
+        with notifications_admin.test_client() as client:
+            user = create_test_user('active')
+            client.login(user)
+            response = client.get('/services')
+
+        assert response.status_code == 200
+        assert 'Choose service' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -28,7 +28,7 @@ def test_should_login_user_and_redirect_to_dashboard(notifications_admin, notifi
                                    data={'sms_code': '12345'})
 
             assert response.status_code == 302
-            assert response.location == url_for('main.dashboard', service_id=123, _external=True)
+            assert response.location == 'http://localhost/services'
 
 
 def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(notifications_admin,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -28,7 +28,7 @@ def test_should_login_user_and_redirect_to_dashboard(notifications_admin, notifi
                                    data={'sms_code': '12345'})
 
             assert response.status_code == 302
-            assert response.location == 'http://localhost/services'
+            assert response.location == url_for('main.choose_service', _external=True)
 
 
 def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(notifications_admin,


### PR DESCRIPTION
Because a user can have multiple services, they need a way to navigate between them. Normally they can use the ▶ Switcher to do this, except when:

- they first sign in
- they are on a page which isn’t associated with a service (eg user profile) in which case we can’t use the switcher because it won’t know what the ‘current’ service is

So this commit adds a new page with a (fake) list of services.

***

![image](https://cloud.githubusercontent.com/assets/355079/12297450/2858821a-ba05-11e5-937e-3f68002cc981.png)
