### PR TITLE
API keys and documentation page

### DIFF
--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -1,0 +1,58 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.ApiKey = function() {
+
+    const states = {
+      'initial': `
+        <input type='button' class='api-key-button-show' value='Show API key' />
+      `,
+      'keyVisibleBasic': key => `
+        <span class="api-key-key">${key}</span>
+      `,
+      'keyVisible': key => `
+        <span class="api-key-key">${key}</span>
+        <input type='button' class='api-key-button-copy' value='Copy API key to clipboard' />
+      `,
+      'keyCopied': `
+        <span class="api-key-key">Copied to clipboard</span>
+        <input type='button' class='api-key-button-show' value='Show API key' />
+      `
+    };
+
+    this.copyKey = function(keyElement, callback) {
+      var selection = window.getSelection ? window.getSelection() : document.selection,
+          range = document.createRange();
+      selection.removeAllRanges();
+      range.selectNodeContents(keyElement);
+      selection.addRange(range);
+      document.execCommand('copy');
+      selection.removeAllRanges();
+      callback();
+    };
+
+    this.start = function(component) {
+
+      const $component = $(component).html(states.initial).attr('aria-live', 'polite'),
+            key = $component.data('key');
+
+      $component
+        .on(
+          'click', '.api-key-button-show', () =>
+            $component.html(
+              document.queryCommandSupported('copy') ?
+                states.keyVisible(key) : states.keyVisibleBasic(key)
+            )
+        )
+        .on(
+          'click', '.api-key-button-copy', () =>
+            this.copyKey(
+              $('.api-key-key', component)[0], () =>
+                $component.html(states.keyCopied)
+            )
+        );
+
+    };
+  };
+
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/components/api-key.scss
+++ b/app/assets/stylesheets/components/api-key.scss
@@ -1,0 +1,17 @@
+.api-key {
+
+  &-key {
+    font-family: monospace;
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  &-button-show {
+    @include button($grey-3);
+  }
+
+  &-button-copy {
+    @include button($grey-3);
+  }
+
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -45,6 +45,7 @@
 @import 'components/management-navigation';
 @import 'components/dropdown';
 @import 'components/email-message';
+@import 'components/api-key';
 
 @import 'views/job';
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -5,5 +5,5 @@ main = Blueprint('main', __name__)
 from app.main.views import (
     index, sign_in, sign_out, register, two_factor, verify, sms, add_service,
     code_not_received, jobs, dashboard, templates, service_settings, forgot_password,
-    new_password, styleguide, user_profile, choose_service
+    new_password, styleguide, user_profile, choose_service, api_keys
 )

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -1,0 +1,9 @@
+from flask import render_template
+from flask_login import login_required
+from app.main import main
+
+
+@main.route("/services/<int:service_id>/api-keys")
+@login_required
+def api_keys(service_id):
+    return render_template('views/api-keys.html', service_id=service_id)

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -36,9 +36,3 @@ def checkemail(service_id):
 @login_required
 def manageusers(service_id):
     return render_template('views/manage-users.html', service_id=service_id)
-
-
-@main.route("/services/<int:service_id>/api-keys")
-@login_required
-def apikeys(service_id):
-    return render_template('views/api-keys.html', service_id=service_id)

--- a/app/templates/components/api-key.html
+++ b/app/templates/components/api-key.html
@@ -1,0 +1,5 @@
+{% macro api_key(key) %}
+  <div data-module="api-key" data-key="{{ key }}">
+    <span class="api-key-key">{{ key }}</span>
+  </div>
+{% endmacro %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -9,7 +9,7 @@
     <li><a href="{{ url_for('.manage_templates', service_id=123) }}">Templates</a></li>
   </ul>
   <ul>
-    <li><a href="{{ url_for('.apikeys', service_id=123) }}">API keys and documentation</a></li>
+    <li><a href="{{ url_for('.api_keys', service_id=123) }}">API keys and documentation</a></li>
   </ul>
   <ul>
     <li><a href="{{ url_for('.manageusers', service_id=123) }}">Manage users</a></li>

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -7,9 +7,58 @@ GOV.UK Notify | API keys and documentation
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-xlarge">API keys and documentation</h1>
+    <h1 class="heading-xlarge">API documentation and key</h1>
 
-    <p>Here's where developers can access information about the API and access keys</p>
+    <h2 class="heading-medium">How to integrate Notify into your service</h2>
+
+    <p>blah blah blah this is where we tell you how the API works</p>
+
+    <h2 class="heading-medium">Repositories</h2>
+
+    <p><a href="https://github.com/alphagov/notify-api">https://github.com/alphagov/notify-api</a><br>
+    Notify API</p>
+
+    <p><a href="https://github.com/alphagov/notify-api-client">A python api client for Notify</a></p>
+
+
+    <h2 class="heading-medium">Python client</h2>
+
+    <p>blah blah blah this is what to do for Python</p>
+
+    <div style="width: 80%; border: 1px solid #BFC1C3;">
+    <p style="font-size: 16px; font-family: monospace; white-space: pre;">
+    here is;
+    some() {
+    	code.stuff();
+    }
+    </p>
+    </div>
+
+    <p></p>
+
+    <div style="border-top: 1px solid #BFC1C3;"></div>
+
+    <h2 class="heading-medium">API key for [service name]</h2>
+
+    <p>API endpoint: https://www.notify.works/api/endpoint</p>
+
+	<div id="api-button">
+    <p><a class="button" type="submit" onclick="document.getElementById('api-key').style.display='block'; document.getElementById('api-button').style.display='none'; ">Show API key</a></p>
+    </div>
+
+    <div id="api-key" style="display: none;">
+    <p>API key: hh234hsdf9234sdflwerk234ksdflmwer0234welkfj</p>
+    <p><a class="button" type="submit" onclick="document.getElementById('api-key-copied').style.display='block'; document.getElementById('api-key').style.display='none'; ">Copy API key to clipboard</a></p>
+    </div>
+
+	<div id="api-key-copied" style="display: none;">
+    <p>API key copied to clipboard</p>
+
+    <p><a class="button" type="submit" onclick="document.getElementById('api-key').style.display='block'; document.getElementById('api-key-copied').style.display='none'; ">Show API key</a></p>
+    </div>
+
+
+    <div style="border-top: 1px solid #BFC1C3;"></div>
 
     {{ page_footer(
       back_link=url_for('.dashboard', service_id=service_id),

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
 GOV.UK Notify | API keys and documentation
@@ -9,16 +10,16 @@ GOV.UK Notify | API keys and documentation
 
     <h1 class="heading-xlarge">API documentation and key</h1>
 
-    <h2 class="heading-medium">How to integrate Notify into your service</h2>
+    <h2 class="heading-medium">How to integrate GOV.UK Notify into your service</h2>
 
     <p>blah blah blah this is where we tell you how the API works</p>
 
     <h2 class="heading-medium">Repositories</h2>
 
-    <p><a href="https://github.com/alphagov/notify-api">https://github.com/alphagov/notify-api</a><br>
-    Notify API</p>
+    <p><a href="https://github.com/alphagov/notifications-api">https://github.com/alphagov/notifications-api</a><br>
+    GOV.UK Notify API</p>
 
-    <p><a href="https://github.com/alphagov/notify-api-client">A python api client for Notify</a></p>
+    <p><a href="https://github.com/alphagov/notify-api-client">A python api client for GOV.UK Notify</a></p>
 
 
     <h2 class="heading-medium">Python client</h2>
@@ -42,23 +43,7 @@ GOV.UK Notify | API keys and documentation
 
     <p>API endpoint: https://www.notify.works/api/endpoint</p>
 
-	<div id="api-button">
-    <p><a class="button" type="submit" onclick="document.getElementById('api-key').style.display='block'; document.getElementById('api-button').style.display='none'; ">Show API key</a></p>
-    </div>
-
-    <div id="api-key" style="display: none;">
-    <p>API key: hh234hsdf9234sdflwerk234ksdflmwer0234welkfj</p>
-    <p><a class="button" type="submit" onclick="document.getElementById('api-key-copied').style.display='block'; document.getElementById('api-key').style.display='none'; ">Copy API key to clipboard</a></p>
-    </div>
-
-	<div id="api-key-copied" style="display: none;">
-    <p>API key copied to clipboard</p>
-
-    <p><a class="button" type="submit" onclick="document.getElementById('api-key').style.display='block'; document.getElementById('api-key-copied').style.display='none'; ">Show API key</a></p>
-    </div>
-
-
-    <div style="border-top: 1px solid #BFC1C3;"></div>
+    {{ api_key('d30512af92e1386d63b90e5973b49a10') }}
 
     {{ page_footer(
       back_link=url_for('.dashboard', service_id=service_id),

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -3,47 +3,50 @@
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
-GOV.UK Notify | API keys and documentation
+  GOV.UK Notify | API keys and documentation
 {% endblock %}
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-xlarge">API documentation and key</h1>
+    <div class="grid-row">
+      <div class="column-two-thirds">
 
-    <h2 class="heading-medium">How to integrate GOV.UK Notify into your service</h2>
+        <h1 class="heading-xlarge">
+          API keys and documentation
+        </h1>
 
-    <p>blah blah blah this is where we tell you how the API works</p>
+        <h2 class="heading-medium">
+          How to integrate GOV.UK Notify into your service
+        </h2>
 
-    <h2 class="heading-medium">Repositories</h2>
+        <p>
+          blah blah blah this is where we tell you how the API works
+        </p>
 
-    <p><a href="https://github.com/alphagov/notifications-api">https://github.com/alphagov/notifications-api</a><br>
-    GOV.UK Notify API</p>
-
-    <p><a href="https://github.com/alphagov/notify-api-client">A python api client for GOV.UK Notify</a></p>
+        <h2 class="heading-medium">Repositories</h2>
 
 
-    <h2 class="heading-medium">Python client</h2>
 
-    <p>blah blah blah this is what to do for Python</p>
+        <p>
+          <a href="https://github.com/alphagov/notifications-api">GOV.UK Notify API</a>
+        </p>
 
-    <div style="width: 80%; border: 1px solid #BFC1C3;">
-    <p style="font-size: 16px; font-family: monospace; white-space: pre;">
-    here is;
-    some() {
-    	code.stuff();
-    }
-    </p>
+        <p>
+          <a href="https://github.com/alphagov/notify-api-client">GOV.UK Notify Python client</a>
+        </p>
+
+        <h2 class="heading-medium">API key for [service name]</h2>
+
+        {{ api_key('d30512af92e1386d63b90e5973b49a10') }}
+
+        <h2 class="heading-medium">API endpoint</h2>
+
+        <p>
+          https://www.notify.works/api/endpoint
+        </p>
+
+      </div>
     </div>
-
-    <p></p>
-
-    <div style="border-top: 1px solid #BFC1C3;"></div>
-
-    <h2 class="heading-medium">API key for [service name]</h2>
-
-    <p>API endpoint: https://www.notify.works/api/endpoint</p>
-
-    {{ api_key('d30512af92e1386d63b90e5973b49a10') }}
 
     {{ page_footer(
       back_link=url_for('.dashboard', service_id=service_id),

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -7,6 +7,7 @@
 {% from "components/sms-message.html" import sms_message %}
 {% from "components/table.html" import mapping_table, list_table, row, field %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
   Styleguide – GOV.UK Notify
@@ -151,5 +152,9 @@
   {{ textbox(form.username) }}
   {{ textbox(form.password) }}
   {{ textbox(form.message, highlight_tags=True) }}
+
+  <h2 class="heading-large">API key</h2>
+
+  {{ api_key('d30512af92e1386d63b90e5973b49a10') }}
 
 {% endblock %}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -34,17 +34,19 @@ gulp.task('javascripts', () => gulp
   .src([
     paths.npm + 'govuk_frontend_toolkit/javascripts/govuk/modules.js',
     paths.npm + 'govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js',
-    paths.src + 'javascripts/highlightTags.js',
+    paths.src + 'javascripts/apiKey.js',
     paths.src + 'javascripts/dropdown.js',
+    paths.src + 'javascripts/highlightTags.js',
     paths.src + 'javascripts/main.js'
   ])
   .pipe(plugins.babel({
     presets: ['es2015']
   }))
   .pipe(plugins.uglify())
-  .pipe(plugins.addSrc.prepend(
-    './node_modules/jquery/dist/jquery.min.js'
-  ))
+  .pipe(plugins.addSrc.prepend([
+    paths.npm + 'jquery/dist/jquery.min.js',
+    paths.npm + 'query-command-supported/dist/queryCommandSupported.min.js'
+  ]))
   .pipe(plugins.concat('all.js'))
   .pipe(gulp.dest(paths.dist + 'javascripts/'))
 );

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-load-plugins": "1.1.0",
     "gulp-sass": "2.1.1",
     "gulp-uglify": "1.5.1",
-    "jquery": "1.11.2"
+    "jquery": "1.11.2",
+    "query-command-supported": "1.0.0"
   }
 }

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -1,0 +1,14 @@
+from tests.app.main import create_test_user
+from flask import url_for
+
+
+def test_should_show_api_keys_and_documentation_page(notifications_admin,
+                                                     notifications_admin_db,
+                                                     notify_db_session):
+    with notifications_admin.test_request_context():
+        with notifications_admin.test_client() as client:
+            user = create_test_user('active')
+            client.login(user)
+            response = client.get(url_for('.api_keys', service_id=123))
+
+        assert response.status_code == 200


### PR DESCRIPTION
![screencapture-localhost-6012-services-123-api-keys-1453107984332 copy](https://cloud.githubusercontent.com/assets/355079/12387234/0074b482-bdc3-11e5-85c8-234affcd2fa5.png)

***
# The API key component

This commit adds a component for showing an API key. Usage:

```jinja
{{ from 'components/api-key.html' import api_key }}
{{ api_key('e1b0751388f3cd0fc9982c701acdb3c2') }}
```

Depending on the user’s browser, it works in three different ways.

## No Javascript
The API key is shown on the page.

## Older browsers with Javascript
The API key is hidden, and users can click a button to reveal it.

## Newer browsers that support copying to clipboard without Flash
As above, but when the key is shown there is a button which copies it to the clipboard. This is acheived by using [this polyfill](https://www.npmjs.com/package/query-command-supported) to reliably detect browser support for the ‘copy’ command.

![api-key-2](https://cloud.githubusercontent.com/assets/355079/12387258/3043b1f4-bdc3-11e5-8a57-b18e37122482.gif)

***

The styling of the component is a bit different to the initial sketch. I think a grey button works better than green. Green feels like it’s going to take you somewhere else.