### PR TITLE
Page for adding a new service

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -5,3 +5,7 @@
 .column-three-quarters {
   @include grid-column(3/4);
 }
+
+.bottom-gutter {
+  margin-bottom: $gutter;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -161,8 +161,12 @@ class AddServiceForm(Form):
         self.service_names = service_names
         super(AddServiceForm, self).__init__(*args, **kwargs)
 
-    service_name = StringField(validators=[
-        DataRequired(message='Service name can not be empty')])
+    service_name = StringField(
+        'Service name',
+        validators=[
+            DataRequired(message='Service name can not be empty')
+        ]
+    )
 
     def validate_service_name(self, a):
         if self.service_name.data in self.service_names:

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,4 +1,4 @@
-from flask import render_template, jsonify, redirect, session, url_for
+from flask import request, render_template, jsonify, redirect, session, url_for, abort
 from flask_login import login_required
 from app.main import main
 from app.main.dao import services_dao, users_dao
@@ -6,13 +6,25 @@ from app.main.forms import AddServiceForm
 
 
 @main.route("/add-service", methods=['GET', 'POST'])
+@main.route("/add-service/<string:first>", methods=['GET', 'POST'])
 @login_required
-def add_service():
+def add_service(first=False):
+    if first:
+        if first == 'first':
+            heading = 'Set up notifications for your service'
+        else:
+            abort(404)
+    else:
+        heading = 'Add a new service'
+
     form = AddServiceForm(services_dao.find_all_service_names())
     if form.validate_on_submit():
-
         user = users_dao.get_user_by_id(session['user_id'])
         services_dao.insert_new_service(form.service_name.data, user)
         return redirect(url_for('.dashboard', service_id=123))
     else:
-        return render_template('views/add-service.html', form=form)
+        return render_template(
+            'views/add-service.html',
+            form=form,
+            heading=heading
+        )

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -20,5 +20,5 @@ def verify():
         verify_codes_dao.use_code_for_user_and_type(user_id=user.id, code_type='sms')
         users_dao.activate_user(user.id)
         login_user(user)
-        return redirect(url_for('.add_service'))
+        return redirect(url_for('.add_service', first='first'))
     return render_template('views/verify.html', form=form)

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -56,7 +56,7 @@
               Service name
             </div>
             <a href="#">Switch to A N Other service</a>
-            <a href="#">Add a new service to Notify…</a>
+            <a href="{{ url_for('.add_service') }}">Add a new service to GOV.UK Notify</a>
           </div>
         </div>
         <div class="column-half management-navigation-account">

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -1,5 +1,6 @@
 {% extends "admin_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
 GOV.UK Notify | Set up service
@@ -8,24 +9,34 @@ GOV.UK Notify | Set up service
 {% block fullwidth_content %}
 
 <div class="grid-row">
-	<div class="column-two-thirds">
-		<h1 class="heading-xlarge">Set up notifications for your service</h1>
+  <div class="column-two-thirds">
 
-		<p>Users will see your service name:</p>
-			<ul class="list-bullet">
-				<li>at the start of every text message, eg 'Vehicle tax: we received your payment, thank you'</li>
-				<li>as your email sender name</li>
-			</ul>
+    <h1 class="heading-xlarge">
+      {{ heading }}
+    </h1>
 
-		<form autocomplete="off" method="post">
-			{{ textbox(form.service_name) }}
+    <p>
+      Users will see your service name:
+    </p>
 
-			<p>
-			<button class="button" href="dashboard" role="button">Continue</button>
-			</p>
-		</form>
-		</div>
-	</div>
+    <ul class="list-bullet bottom-gutter">
+      <li>
+        at the start of every text message, eg ‘Vehicle tax: we received your
+        payment, thank you’
+      </li>
+      <li>
+        as your email sender name
+      </li>
+    </ul>
+
+    <form autocomplete="off" method="post">
+      {{ textbox(form.service_name) }}
+      {{ page_footer(
+        'Continue'
+      ) }}
+    </form>
+
+  </div>
 </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -1,3 +1,4 @@
+from flask import url_for
 from app.main.dao import verify_codes_dao, services_dao
 from tests.app.main import create_test_user
 
@@ -8,8 +9,8 @@ def test_get_should_render_add_service_template(notifications_admin, notificatio
             user = create_test_user('active')
             client.login(user)
             verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='sms')
-            client.post('/two-factor', data={'sms_code': '12345'})
-            response = client.get('/add-service')
+            client.post(url_for('.two_factor'), data={'sms_code': '12345'})
+            response = client.get(url_for('.add_service', first='first'))
             assert response.status_code == 200
             assert 'Set up notifications for your service' in response.get_data(as_text=True)
 
@@ -20,10 +21,13 @@ def test_should_add_service_and_redirect_to_next_page(notifications_admin, notif
             user = create_test_user('active')
             client.login(user)
             verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='sms')
-            client.post('/two-factor', data={'sms_code': '12345'})
-            response = client.post('/add-service', data={'service_name': 'testing the post'})
+            client.post(url_for('.two_factor'), data={'sms_code': '12345'})
+            response = client.post(
+                url_for('.add_service', first='first'),
+                data={'service_name': 'testing the post'}
+            )
             assert response.status_code == 302
-            assert response.location == 'http://localhost/services/123/dashboard'
+            assert response.location == url_for('.dashboard', service_id=123, _external=True)
             saved_service = services_dao.find_service_by_service_name('testing the post')
             assert saved_service is not None
 
@@ -36,7 +40,19 @@ def test_should_return_form_errors_when_service_name_is_empty(notifications_admi
             user = create_test_user('active')
             client.login(user)
             verify_codes_dao.add_code(user_id=user.id, code='12345', code_type='sms')
-            client.post('/two-factor', data={'sms_code': '12345'})
-            response = client.post('/add-service', data={})
+            client.post(url_for('.two_factor'), data={'sms_code': '12345'})
+            response = client.post(url_for('.add_service', first='first'), data={})
             assert response.status_code == 200
             assert 'Service name can not be empty' in response.get_data(as_text=True)
+
+
+def test_should_show_page_for_adding_another_service(notifications_admin,
+                                                     notifications_admin_db,
+                                                     notify_db_session):
+    with notifications_admin.test_request_context():
+        with notifications_admin.test_client() as client:
+            user = create_test_user('active')
+            client.login(user)
+            response = client.get(url_for('.add_service'))
+            assert response.status_code == 200
+            assert 'Add a new service' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -32,7 +32,7 @@ def test_should_redirect_to_add_service_when_code_are_correct(notifications_admi
                                    data={'sms_code': '12345',
                                          'email_code': '23456'})
             assert response.status_code == 302
-            assert response.location == url_for('main.add_service', _external=True)
+            assert response.location == url_for('main.add_service', first='first', _external=True)
 
 
 def test_should_activate_user_after_verify(notifications_admin, notifications_admin_db, notify_db_session):


### PR DESCRIPTION
This page is exactly the same as the page for adding your first service, save the heading text.

![image](https://cloud.githubusercontent.com/assets/355079/12389779/ea83ca86-bdd2-11e5-8443-75eec57c857d.png)

So all this commit does is:
- set up two routes (`/add-service`, `/add-service/first`) for each of the two journeys and change the existing journeys to use the `/add-service/first` route
- add logic to show different heading text depending on the journey
- add a link to the new (`/add-service`) route in the service chooser dropdown