### PR TITLE
Remove placeholder logs of notifications sent

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -41,3 +41,10 @@
   @extend .table-field;
   text-align: right;
 }
+
+.table-empty-message {
+  @include core-16;
+  color: $secondary-text-colour;
+  border-bottom: 1px solid $border-colour;
+  padding: 5px 0 8px 0;
+}

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -19,6 +19,6 @@ def service_dashboard(service_id):
     return render_template(
         'views/service_dashboard.html',
         jobs=jobs,
-        free_text_messages_remaining=560,
+        free_text_messages_remaining='25,000',
         spent_this_month='0.00',
         service_id=service_id)

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -50,7 +50,7 @@ messages = [
 def view_jobs(service_id):
     return render_template(
         'views/jobs.html',
-        jobs=jobs,
+        jobs=[],  # use `jobs` for placeholder data
         service_id=service_id
     )
 

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -23,20 +23,21 @@
 {%- endmacro %}
 
 {% macro list_table(items, caption='', empty_message='', field_headings=[], field_headings_visible=True, caption_visible=True) -%}
-  {% if items %}
-    {% set parent_caller = caller %}
-    {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible) %}
-      {% for item in items %}
-        {% call row() %}
-          {{ parent_caller(item) }}
-        {% endcall %}
-      {% endfor %}
-    {%- endcall %}
-  {% else %}
-    <p class="summary-item-no-content">
+
+  {% set parent_caller = caller %}
+  {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible) %}
+    {% for item in items %}
+      {% call row() %}
+        {{ parent_caller(item) }}
+      {% endcall %}
+    {% endfor %}
+  {%- endcall %}
+  {% if not items %}
+    <p class="table-empty-message">
       {{ empty_message }}
     </p>
   {% endif %}
+
 {%- endmacro %}
 
 {% macro row() -%}

--- a/app/templates/views/jobs.html
+++ b/app/templates/views/jobs.html
@@ -13,6 +13,7 @@ GOV.UK Notify | Notifications activity
 			jobs,
 			caption="Recent activity",
 			caption_visible=False,
+			empty_message='You haven’t sent any notifications yet',
 			field_headings=['Job', 'File', 'Time', 'Status']
 		) %}
 			{% call field() %}

--- a/app/templates/views/service_dashboard.html
+++ b/app/templates/views/service_dashboard.html
@@ -24,9 +24,9 @@
 		</ul>
 
     {% call(item) list_table(
-      jobs[:3],
+      [],
       caption="Recent text messages",
-			empty_message="No recent text messages",
+			empty_message='You haven’t sent any text messages yet',
       field_headings=['Job', 'File', 'Time', 'Status']
     ) %}
 			{% call field() %}
@@ -42,9 +42,5 @@
 				{{ item.status }}
 			{% endcall %}
     {% endcall %}
-    <p>
-      <a href={{ url_for('.view_jobs', service_id=service_id) }}>See all notifications activity</a>
-    </p>
-
 
 {% endblock %}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -148,6 +148,21 @@
     {% endcall %}
   {% endcall %}
 
+  {% call(item) list_table(
+    [],
+    caption='Jobs',
+    field_headings=['Job', 'Time'],
+    caption_visible=True,
+    empty_message='You haven’t scheduled any jobs yet'
+  ) %}
+    {% call field() %}
+      {{ item.job }}
+    {% endcall %}
+    {% call field() %}
+      {{ item.time }}
+    {% endcall %}
+  {% endcall %}
+
   <h2 class="heading-large">Textbox</h2>
   {{ textbox(form.username) }}
   {{ textbox(form.password) }}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -13,5 +13,4 @@ def test_should_show_recent_jobs_on_dashboard(app_,
             response = client.get(url_for('main.service_dashboard', service_id=123))
 
         assert response.status_code == 200
-        assert 'Test message 1' in response.get_data(as_text=True)
-        assert 'Asdfgg' in response.get_data(as_text=True)
+        assert 'You haven’t sent any text messages yet' in response.get_data(as_text=True)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -11,8 +11,7 @@ def test_should_return_list_of_all_jobs(app_, db_, db_session, service_one):
             response = client.get(url_for('main.view_jobs', service_id=101))
 
         assert response.status_code == 200
-        assert 'Test message 1' in response.get_data(as_text=True)
-        assert 'Final reminder' in response.get_data(as_text=True)
+        assert 'You haven’t sent any notifications yet' in response.get_data(as_text=True)
 
 
 def test_should_show_page_for_one_job(app_, db_, db_session, service_one):


### PR DESCRIPTION
From the:

## Dashboard
![image](https://cloud.githubusercontent.com/assets/355079/12417291/f014a34a-be9e-11e5-8750-234509c38384.png)

## Activity page
![image](https://cloud.githubusercontent.com/assets/355079/12417295/fb60788c-be9e-11e5-9505-798983ef0273.png)

This info will be confusing for users at the hack day, because it will say they’ve already sent messages when they first sign up.

This involved changing the table macro to have a nice ‘no rows’ message.