### PR TITLE
Add restricted mode warning

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -28,6 +28,12 @@
 
 }
 
+.banner-info {
+  @extend .banner;
+  background: $govuk-blue;
+  color: $white;
+}
+
 .banner-dangerous {
 
   @extend .banner;

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -1,5 +1,5 @@
-{% macro banner(body, with_tick=False) %}
-  <div class='banner{% if with_tick %}-with-tick{% endif %}'>
+{% macro banner(body, type=None, with_tick=False) %}
+  <div class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'>
     {{ body }}
   </div>
 {% endmacro %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -1,13 +1,17 @@
 {% extends "admin_template.html" %}
-{% from "main_nav.html" import main_nav with context %}
+{% from "components/banner.html" import banner %}
 
 {% block fullwidth_content %}
-	<div class="grid-row">
-	  <div class="column-one-quarter">
-	    {% include "main_nav.html" %}
-	  </div>
-	  <div class="column-three-quarters">
-	    {% block maincolumn_content %}{% endblock %}
-	  </div>
-	</div>
+  <div class="grid-row">
+    <div class="column-one-quarter">
+      {% include "main_nav.html" %}
+    </div>
+    <div class="column-three-quarters">
+      {{ banner(
+        'You are in restricted mode. You can only send notifications to yourself.',
+        'info'
+      ) }}
+      {% block maincolumn_content %}{% endblock %}
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
For the hack day, we should only let developers use the platform in restricted mode. This commit adds a banner telling them this.

Can’t get the app running locally, so fingers crossed it actually looks how I imagine it’s going to look…

:tada: :100: :tada: 