### PR TITLE
Various fixes

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -19,7 +19,7 @@
 .sms-message-recipient {
   @include copy-19;
   color: $secondary-text-colour;
-  margin: -$gutter-half 0 $gutter 0;
+  margin: -20px 0 $gutter 0;
 }
 
 .sms-message-name {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -194,7 +194,7 @@ class TemplateForm(Form):
         u'Template name',
         validators=[DataRequired(message="Template name cannot be empty")])
     template_type = SelectField(u'Template type', choices=[('sms', 'SMS')])
-    content = TextAreaField(
+    template_content = TextAreaField(
         u'Message',
         validators=[DataRequired(message="Template content cannot be empty")])
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -7,7 +7,7 @@ from wtforms import (
     ValidationError,
     TextAreaField,
     FileField,
-    SelectField
+    RadioField
 )
 from wtforms.validators import DataRequired, Email, Length, Regexp
 
@@ -193,7 +193,8 @@ class TemplateForm(Form):
     name = StringField(
         u'Template name',
         validators=[DataRequired(message="Template name cannot be empty")])
-    template_type = SelectField(u'Template type', choices=[('sms', 'SMS')])
+    template_type = RadioField(u'Template type', choices=[('sms', 'SMS')])
+
     template_content = TextAreaField(
         u'Message',
         validators=[DataRequired(message="Template content cannot be empty")])

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -40,7 +40,7 @@ def add_service_template(service_id):
 
     if form.validate_on_submit():
         tdao.insert_service_template(
-            form.name.data, form.template_type.data, form.content.data, service_id)
+            form.name.data, form.template_type.data, form.template_content.data, service_id)
         return redirect(url_for(
             '.manage_service_templates', service_id=service_id))
     return render_template(
@@ -60,12 +60,14 @@ def edit_service_template(service_id, template_id):
             abort(404)
         else:
             raise e
+
+    template['template_content'] = template['content']
     form = TemplateForm(**template)
 
     if form.validate_on_submit():
         tdao.update_service_template(
             template_id, form.name.data, form.template_type.data,
-            form.content.data, service_id)
+            form.template_content.data, service_id)
         return redirect(url_for('.manage_service_templates', service_id=service_id))
 
     return render_template(

--- a/app/templates/components/sms-message.html
+++ b/app/templates/components/sms-message.html
@@ -6,7 +6,6 @@
   {% endif %}
   {% if name %}
     <h3 class="sms-message-name">
-      ID: {{ id }}
       {% if edit_link %}
         <a href="{{ edit_link }}">{{ name }}</a>
       {% else %}
@@ -23,6 +22,11 @@
   {% if recipient %}
     <p class="sms-message-recipient">
       {{ recipient }}
+    </p>
+  {% endif %}
+  {% if id %}
+    <p class="sms-message-recipient">
+      Template ID: {{ id }}
     </p>
   {% endif %}
   {% if input_name %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -25,14 +25,15 @@
 {% macro list_table(items, caption='', empty_message='', field_headings=[], field_headings_visible=True, caption_visible=True) -%}
 
   {% set parent_caller = caller %}
-  {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible) %}
-    {% for item in items %}
-      {% call row() %}
-        {{ parent_caller(item) }}
-      {% endcall %}
-    {% endfor %}
-  {%- endcall %}
-  {% if not items %}
+  {% if items %}
+    {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible) %}
+      {% for item in items %}
+        {% call row() %}
+          {{ parent_caller(item) }}
+        {% endcall %}
+      {% endfor %}
+    {%- endcall %}
+  {% else %}
     <p class="table-empty-message">
       {{ empty_message }}
     </p>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -9,11 +9,11 @@
     <li><a href="{{ url_for('.manage_service_templates', service_id=service_id) }}">Templates</a></li>
   </ul>
   <ul>
-    <li><a href="{{ url_for('.api_keys', service_id=service_id) }}">API keys</a></li>
     <li><a href="{{ url_for('.documentation', service_id=service_id) }}">Developer documentation</a></li>
+    <li><a href="{{ url_for('.api_keys', service_id=service_id) }}">API keys</a></li>
   </ul>
   <ul>
-    <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Manage users</a></li>
+    <!--<li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Manage users</a></li>-->
     <li><a href="{{ url_for('.service_settings', service_id=service_id) }}">Service settings</a></li>
   </ul>
 </nav>

--- a/app/templates/views/edit-template.html
+++ b/app/templates/views/edit-template.html
@@ -13,7 +13,7 @@ GOV.UK Notify | Edit template
 		<form method="post">
 			{{ textbox(form.name) }}
 			{{ textbox(form.template_type) }}
-			{{ textbox(form.content, highlight_tags=True) }}
+			{{ textbox(form.template_content, highlight_tags=True) }}
 			{{ page_footer(
 				'Save',
 				delete_link=url_for('.delete_service_template', service_id=service_id, template_id=template_id) if template_id or None,

--- a/app/templates/views/edit-template.html
+++ b/app/templates/views/edit-template.html
@@ -18,13 +18,14 @@ GOV.UK Notify | Edit template
 				</legend>
 				<label class="block-label" for="template_type">
 					<input type="radio" name="template_type" id="template_type" checked="checked" value="sms" />
-					SMS
+					Text message
 				</label>
 			</fieldset>
 			{{ textbox(form.template_content, highlight_tags=True) }}
 			{{ page_footer(
 				'Save',
 				delete_link=url_for('.delete_service_template', service_id=service_id, template_id=template_id) if template_id or None,
+				delete_link_text='delete this template',
 				back_link=url_for('.manage_service_templates', service_id=service_id),
 				back_link_text='Back to templates'
 			) }}

--- a/app/templates/views/edit-template.html
+++ b/app/templates/views/edit-template.html
@@ -12,7 +12,15 @@ GOV.UK Notify | Edit template
 
 		<form method="post">
 			{{ textbox(form.name) }}
-			{{ textbox(form.template_type) }}
+			<fieldset class="form-group">
+				<legend class="form-label">
+					Template type
+				</legend>
+				<label class="block-label" for="template_type">
+					<input type="radio" name="template_type" id="template_type" checked="checked" value="sms" />
+					SMS
+				</label>
+			</fieldset>
 			{{ textbox(form.template_content, highlight_tags=True) }}
 			{{ page_footer(
 				'Save',

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -12,8 +12,7 @@
     {{ browse_list([
       {
         'title': 'Change your service name',
-        'link': url_for('.service_name_change', service_id=service_id),
-        'hint': 'Your service name ({}) is included in every sent notification'.format(service.name)
+        'link': url_for('.service_name_change', service_id=service_id)
       },
       {
         'title': 'Request to go live and turn off sending restrictions',
@@ -22,15 +21,15 @@
       } if not service.live else {
       },
       {
-        'title': 'Turn off all outgoing notifications',
+        'title': 'Temporarily suspend API keys',
         'link': url_for('.service_status_change', service_id=service_id),
         'destructive': True
       } if service.active else {
-        'title': 'Restart sending notifications',
+        'title': 'Reactivate API keys',
         'link': url_for('.service_status_change', service_id=service_id)
       },
       {
-        'title': 'Delete this service from Notify',
+        'title': 'Delete this service from GOV.UK Notify',
         'link': url_for('.service_delete', service_id=service_id),
         'destructive': True
       },

--- a/app/templates/views/service-settings/delete.html
+++ b/app/templates/views/service-settings/delete.html
@@ -7,10 +7,12 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-xlarge">Delete this service from Notify</h1>
+
 
   <div class="grid-row">
     <div class="column-three-quarters">
+
+      <h1 class="heading-xlarge">Delete this service from GOV.UK Notify</h1>
 
       <p>
         This can’t be undone. You will lose:
@@ -24,7 +26,7 @@
           any templates you’ve created
         </li>
         <li>
-          the history of
+          the history of notifications you’ve sent
         </li>
         <li>
           API keys

--- a/app/templates/views/service-settings/status.html
+++ b/app/templates/views/service-settings/status.html
@@ -7,7 +7,7 @@ GOV.UK Notify | Service settings
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-xlarge">Turn off all outgoing notifications</h1>
+  <h1 class="heading-xlarge">Temporarily suspend API keys</h1>
 
   <div class="grid-row">
     <div class="column-three-quarters">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -10,15 +10,22 @@ GOV.UK Notify | Get started
 	<div class="column-two-thirds">
 		<h1 class="heading-xlarge">GOV.UK Notify</h1>
 
-		<p>Use GOV.UK Notify to send notifications by text message, email and letter.</p>
-		<p>We're making it easy to keep your users informed.</p>
-		<p>If you work for a UK government department or agency you can set up a test account now.</p>
+		<p>
+			Use GOV.UK Notify to send notifications by text message, email and letter.
+		</p>
+		<p>
+			We're making it easy to keep your users informed.
+		</p>
+		<p>
+			If you work for a UK government department or agency you can set up a test account now.
+		</p>
+		<p>
+			<a class="button" href="{{ url_for('.register' )}}" role="button">Set up an account</a>
+		</p>
+		<p>
+			If you've used GOV.UK Notify before, <a href="{{ url_for('.sign_in' )}}">sign in to your account</a>.
+		</p>
 
-		<a class="button" href="register" role="button">Set up an account</a>
-
-		<!-- <h2 class="heading-large">Used GOV.UK Notify before?</h2> -->
-
-		<p>If you've used GOV.UK Notify before, <a href="sign-in">sign in to your account</a>.</p>
 	</div>
 </div>
 

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -8,7 +8,7 @@
     </div>
     <div class="column-three-quarters">
       {{ banner(
-        'You are in restricted mode. You can only send notifications to yourself.',
+        'Your service is in restricted mode. You can only send notifications to yourself.',
         'info'
       ) }}
       {% block maincolumn_content %}{% endblock %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -13,7 +13,6 @@ def test_should_show_overview(app_, db_, db_session, mock_api_user, mock_get_ser
         resp_data = response.get_data(as_text=True)
         assert 'Service settings' in resp_data
         service = mock_get_service.side_effect(service_id)['data']
-        assert service['name'] in resp_data
         assert mock_get_service.called
 
 
@@ -217,7 +216,7 @@ def test_should_show_delete_page(app_, db_, db_session, mock_api_user, mock_get_
                 'main.service_delete', service_id=service_id))
 
         assert response.status_code == 200
-        assert 'Delete this service from Notify' in response.get_data(as_text=True)
+        assert 'Delete this service from GOV.UK Notify' in response.get_data(as_text=True)
         assert mock_get_service.called
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -62,7 +62,7 @@ def test_should_redirect_when_saving_a_template(app_,
                 'id': template_id,
                 'name': name,
                 'template_type': type_,
-                "content": content,
+                "template_content": content,
                 "service": service_id
             }
             response = client.post(url_for(


### PR DESCRIPTION
- Fix spacing on empty table
- Fix banner copy (your service is restricted, not you)

## Rename `content` form field to `template_content`

WTForms sets the `id` of a `textarea` element to the variable name to which the form control is assigned.

This conflicts with the page container, which is styled by targeting `#content`.

## Make ‘template type’ radio buttons not `<select>` 

Because [burn your select tags](https://www.youtube.com/watch?v=CUkMCQR4TpY).

This commit hard codes the markup for the time being until I can work out how to get WTForms outputting the markup I want.

## SKIRMISH MODE

![image](https://cloud.githubusercontent.com/assets/355079/12513528/209cee22-c116-11e5-97a0-aeef8ebd1f73.png)
