### PR TITLE
Add test for template page repopulation

### DIFF
--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -38,6 +38,8 @@ def test_should_show_page_for_one_templates(app_,
                 template_id=template_id))
 
     assert response.status_code == 200
+    assert "Two week reminder" in response.get_data(as_text=True)
+    assert "Your vehicle tax is about to expire" in response.get_data(as_text=True)
     mock_get_service_template.assert_called_with(
         service_id, template_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,7 @@ def mock_delete_service(mocker, mock_get_service):
 def mock_get_service_template(mocker):
     def _create(service_id, template_id):
         template = template_json(
-            template_id, "Template Name", "sms", "template content", service_id)
+            template_id, "Two week reminder", "sms", "Your vehicle tax is about to expire", service_id)
         return {'data': template}
 
     return mocker.patch(


### PR DESCRIPTION
A bug was found whereby the body of a template was not being shown in the on the page when returning to edit an existing template. This bug was caused by renaming the field in some places, but not in the `Form` class.

This bug has since been fixed, but this commit adds to the tests to make sure that it doesn’t happen again.