### PR TITLE
Show all links in side navigation again

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -1,5 +1,6 @@
 %banner,
-.banner {
+.banner,
+.banner-default {
 
   @include core-19;
   background: $turquoise;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -56,6 +56,7 @@
 .table-empty-message {
   @include core-16;
   color: $secondary-text-colour;
+  border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
-  padding: 5px 0 8px 0;
+  padding: 0.75em 0 0.5625em 0;
 }

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -51,5 +51,5 @@ def revoke_api_key(service_id, key_id):
         )
     elif request.method == 'POST':
         api_key_api_client.revoke_api_key(service_id=service_id, key_id=key_id)
-        flash('‘{}’ was revoked'.format(key_name))
+        flash('‘{}’ was revoked'.format(key_name), 'default')
         return redirect(url_for('.api_keys', service_id=service_id))

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -73,7 +73,11 @@
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           {% for category, message in messages %}
-            {{ banner(message, 'dangerous', delete_button="Yes, delete this template" if 'delete' == category else None)}}
+            {{ banner(
+              message,
+              'default' if category == 'default' else 'dangerous',
+              delete_button="Yes, delete this template" if 'delete' == category else None
+            )}}
           {% endfor %}
         {% endif %}
       {% endwith %}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -72,19 +72,9 @@
   <main id="content" role="main" class="page-container">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-          <ul class="banner-dangerous">
-            {% for category, message in messages %}
-              <li class="flash-message">
-                {{ message }}
-                {% if 'delete' == category %}
-                  <form method='post'>
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                    <input type="submit" class="button" name="delete" value="Yes, delete this template" />
-                  </form>
-                {% endif %}
-              </li>
-            {% endfor %}
-          </ul>
+          {% for category, message in messages %}
+            {{ banner(message, 'dangerous', delete_button="Yes, delete this template" if 'delete' == category else None)}}
+          {% endfor %}
         {% endif %}
       {% endwith %}
       {% block fullwidth_content %}{% endblock %}

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -1,5 +1,11 @@
-{% macro banner(body, type=None, with_tick=False) %}
+{% macro banner(body, type=None, with_tick=False, delete_button=None) %}
   <div class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'>
     {{ body }}
+    {% if delete_button %}
+      <form method='post'>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="submit" class="button" name="delete" value="{{ delete_button }}" />
+      </form>
+    {% endif %}
   </div>
 {% endmacro %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -3,9 +3,9 @@
     <li><a href="{{ url_for('.service_dashboard', service_id=service_id) }}">Dashboard</a></li>
   </ul>
   <ul>
-    <!--<li><a href="{{ url_for('.send_sms', service_id=service_id) }}">Send text messages</a></li>-->
-    <!--<li><a href="{{ url_for('.send_email', service_id=service_id) }}">Send emails</a></li>-->
-    <!--<li><a href="{{ url_for('.view_jobs', service_id=service_id) }}">Activity</a></li>-->
+    <li><a href="{{ url_for('.send_sms', service_id=service_id) }}">Send text messages</a></li>
+    <li><a href="{{ url_for('.send_email', service_id=service_id) }}">Send emails</a></li>
+    <li><a href="{{ url_for('.view_jobs', service_id=service_id) }}">Activity</a></li>
     <li><a href="{{ url_for('.manage_service_templates', service_id=service_id) }}">Templates</a></li>
   </ul>
   <ul>
@@ -13,7 +13,7 @@
     <li><a href="{{ url_for('.api_keys', service_id=service_id) }}">API keys</a></li>
   </ul>
   <ul>
-    <!--<li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Manage users</a></li>-->
+    <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Manage users</a></li>
     <li><a href="{{ url_for('.service_settings', service_id=service_id) }}">Service settings</a></li>
   </ul>
 </nav>

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -22,13 +22,24 @@
   <p><a href="https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/styleguide.html">View source</a></p>
 
   <h2 class="heading-large">Banner</h2>
-  <p>Used to show the result of a user’s action.</p>
-  {{ banner("This is a banner", with_tick=True) }}
+  <p>Used to show the status of a thing or action.</p>
+
+  {{ banner("You sent 1,234 text messages", with_tick=True) }}
+
   <div class="grid-row">
     <div class="column-one-third">
       {{ banner("Delivered 10:20") }}
     </div>
   </div>
+
+  {{ banner(
+    'Your service is in restricted mode. You can only send notifications to yourself.',
+    'info'
+  ) }}
+
+  {{ banner('You’re not allowed to do this', 'dangerous')}}
+
+  {{ banner('Are you sure you want to delete?', 'dangerous', delete_button="Yes, delete this thing")}}
 
   <h2 class="heading-large">Big number</h2>
 


### PR DESCRIPTION
These were temporarily hidden for hack day, to not distract participants.

Also:
- update [styleguide](https://www.notify.works/_styleguide) with better banner examples
- use green banner for ‘API key was revoked’ flash message