### PR TITLE
Remove hint from choose service page

### DIFF
--- a/app/main/dao/services_dao.py
+++ b/app/main/dao/services_dao.py
@@ -93,4 +93,4 @@ class ServicesBrowsableItem(BrowsableItem):
 
     @property
     def hint(self):
-        return "Some service hint here"
+        return None


### PR DESCRIPTION
We might want this one day, but for now nothing is better than non-real-looking text.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/12588343/2c6daf7e-c450-11e5-86e0-6c3bf9aac803.png) | ![image](https://cloud.githubusercontent.com/assets/355079/12588362/39b4e1e8-c450-11e5-9eb1-5a51c7fa52cb.png)
