### PR TITLE
Set service name on session

### DIFF
--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -8,5 +8,7 @@ from app.main import main
 @main.route('/sign-out', methods=(['GET']))
 @login_required
 def sign_out():
+    if session.get('service_name', None):
+        session.pop('service_name')
     logout_user()
     return redirect(url_for('main.index'))

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -48,17 +48,17 @@
 
 {% block content %}
 
-  {% if current_user.is_authenticated() %}
+  {% if current_user.is_authenticated() and session['service_name'] != None %}
     <nav class="management-navigation">
       <div class="grid-row">
         <div class="column-half">
           <details class="dropdown">
             <summary class="dropdown-toggle">
-              {{ session['service_name'] }}
+              {{ session.get('service_name', 'Choose service') }}
             </summary>
             <div>
               <a href="{{ url_for('main.choose_service') }}">Switch service</a>
-              <a href="{{ url_for('.add_service') }}">Add a new service to GOV.UK Notify</a>
+              <a href="{{ url_for('main.add_service') }}">Add a new service to GOV.UK Notify</a>
             </div>
           </details>
         </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/111589704
- Pop service name off the session on sign out.
- Default service name if service name is not set on the session.