### PR TITLE
Use different colours for each environment

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,7 +100,10 @@ def init_app(app, config_overrides):
 
     @app.context_processor
     def inject_global_template_variables():
-        return {'asset_path': '/static/'}
+        return {
+            'asset_path': '/static/',
+            'header_colour': app.config['HEADER_COLOUR']
+        }
 
 
 def convert_to_boolean(value):

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -5,6 +5,9 @@
   <!--[if gt IE 8]><!-->
   <link rel="stylesheet" media="screen" href="{{ asset_path }}stylesheets/main.css" />
   <!--<![endif]-->
+  <style>
+    #global-header-bar { background-color: {{header_colour}} }
+  </style>
   <!--[if IE 6]>
   <link rel="stylesheet" media="screen" href="{{ asset_path }}/stylesheets/main-ie6.css" />
   <![endif]-->

--- a/config.py
+++ b/config.py
@@ -39,6 +39,8 @@ class Config(object):
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10mb
     UPLOAD_FOLDER = '/tmp'
 
+    HEADER_COLOUR = '#FFBF47'  # $yellow
+
 
 class Development(Config):
     DEBUG = True
@@ -53,10 +55,19 @@ class Test(Development):
     WTF_CSRF_ENABLED = False
 
 
-class Live(Config):
+class Preview(Config):
     DEBUG = False
     HTTP_PROTOCOL = 'https'
     SESSION_COOKIE_SECURE = True
+    HEADER_COLOUR = '#F47738'  # $orange
+
+
+class Staging(Preview):
+    pass
+
+
+class Live(Staging):
+    HEADER_COLOUR = '#B10E1E'  # $red
 
 
 configs = {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/112786779

> There's an emerging convention on admin apps, to have a red strip atop the page, also to have a different colour for preview environment... so let's adopt that and see how it feels. Red for prod and gold for preview.

This commit adds config so that the strip below the header is:
- yellow locally
- orange on preview and staging
- red on live

<img width="1087" alt="screen shot 2016-02-01 at 15 34 02" src="https://cloud.githubusercontent.com/assets/355079/12721758/422c8454-c8f9-11e5-8953-27641e24c91e.png">
<img width="1089" alt="screen shot 2016-02-01 at 15 26 46" src="https://cloud.githubusercontent.com/assets/355079/12721759/422d33a4-c8f9-11e5-9903-7ae74951855b.png">
<img width="1087" alt="screen shot 2016-02-01 at 15 25 14" src="https://cloud.githubusercontent.com/assets/355079/12721760/42358d2e-c8f9-11e5-9928-e1f0dc8c3c2a.png">

It will not actually work until each AWS environment uses the right config, but can be tested locally by setting the environment variable manually, eg: `export HEADER_COLOUR='#F47738'`