### PR TITLE
[WIP] Add a 'get started' banner message to the dashboard

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -51,3 +51,19 @@
   }
 
 }
+
+.banner-tip {
+
+  @extend .banner;
+  background: $yellow;
+  color: $text-colour;
+  text-align: left;
+  border: 5px solid $text-colour;
+  font-weight: bold;
+
+  a:link, a:visited {
+    color: $text-colour;
+    text-decoration: underline;
+  }
+
+}

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -2,6 +2,7 @@ from flask import (abort, render_template, session)
 from flask_login import login_required
 from app.main import main
 from app.main.dao.services_dao import get_service_by_id
+from app.main.dao import templates_dao
 from client.errors import HTTPError
 from ._jobs import jobs
 
@@ -9,6 +10,13 @@ from ._jobs import jobs
 @main.route("/services/<int:service_id>/dashboard")
 @login_required
 def service_dashboard(service_id):
+    try:
+        templates = templates_dao.get_service_templates(service_id)['data']
+    except HTTPError as e:
+        if e.status_code == 404:
+            abort(404)
+        else:
+            raise e
     try:
         service = get_service_by_id(service_id)
         session['service_name'] = service['data']['name']
@@ -22,4 +30,5 @@ def service_dashboard(service_id):
         jobs=jobs,
         free_text_messages_remaining='25,000',
         spent_this_month='0.00',
+        has_templates=bool(len(templates)),
         service_id=service_id)

--- a/app/templates/views/manage-templates.html
+++ b/app/templates/views/manage-templates.html
@@ -15,7 +15,7 @@ GOV.UK Notify | Manage templates
         <h1 class="heading-xlarge">Templates</h1>
 
         <p>
-          <a href="{{ url_for('.add_service_template', service_id=service_id) }}">Create new template</a>
+          <a href="{{ url_for('.add_service_template', service_id=service_id) }}">Add new template</a>
 
         {% for template in templates %}
           {% if template.get_field('template_type') == 'sms' %}

--- a/app/templates/views/service_dashboard.html
+++ b/app/templates/views/service_dashboard.html
@@ -8,6 +8,15 @@
 
 {% block maincolumn_content %}
 
+    {% if not has_templates %}
+      {{ banner(
+        '<a href="{}">Add a template</a> to start sending notifications'.format(
+          url_for(".add_service_template", service_id=service_id)
+        )|safe,
+        type="tip"
+      )}}
+    {% endif %}
+
     <ul class="grid-row job-totals">
       <li class="column-half">
         {{ big_number(

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -19,7 +19,9 @@
     Styleguide
   </h1>
 
-  <p><a href="https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/styleguide.html">View source</a></p>
+  <p>
+    <a href="https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/styleguide.html">View source</a>
+  </p>
 
   <h2 class="heading-large">Banner</h2>
   <p>Used to show the status of a thing or action.</p>
@@ -40,6 +42,8 @@
   {{ banner('You’re not allowed to do this', 'dangerous')}}
 
   {{ banner('Are you sure you want to delete?', 'dangerous', delete_button="Yes, delete this thing")}}
+
+  {{ banner('<a href="#">Send your first message</a>'|safe, 'tip')}}
 
   <h2 class="heading-large">Big number</h2>
 
@@ -90,8 +94,14 @@
   </p>
 
   {{ page_footer(
-    button_text='Save and continue'
+    button_text='Next step'
   ) }}
+
+  {{ page_footer(
+    button_text='Save',
+    delete_link='http://example.com',
+    delete_link_text='delete this thing'
+  )}}
 
   {{ page_footer(
     button_text='Delete', destructive=True
@@ -112,6 +122,11 @@
       {{ sms_message(
         "Your vehicle tax for registration number is due on date. Renew online at www.gov.uk/vehicle-tax",
         "+44 7700 900 306"
+      ) }}
+      {{ sms_message(
+        "Your vehicle tax for ((registration number)) is due on ((date)). Renew online at www.gov.uk/vehicle-tax",
+        name='Two week reminder',
+        edit_link='#'
       ) }}
       {{ sms_message(
         "Your vehicle tax for ((registration number)) is due on ((date)). Renew online at www.gov.uk/vehicle-tax",

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -4,6 +4,7 @@ from flask import url_for, session
 def test_should_show_recent_jobs_on_dashboard(app_,
                                               api_user_active,
                                               mock_get_service,
+                                              mock_get_service_templates,
                                               mock_get_user,
                                               mock_get_user_by_email,
                                               mock_login):

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -17,6 +17,7 @@ def test_sign_out_user(app_,
                        api_user_active,
                        mock_get_user,
                        mock_get_user_by_email,
+                       mock_get_service_templates,
                        mock_login):
     with app_.test_request_context():
         email = 'valid@example.gov.uk'


### PR DESCRIPTION
## Add a new style of banner—‘tip’

This banner is meant for onboarding users and giving them prompts about what they should do next.

![image](https://cloud.githubusercontent.com/assets/355079/12745644/555523e4-c992-11e5-801b-ab8ca445122d.png)
_this one ↑_


## Add banner to prompt user to add first template to dashboard

![image](https://cloud.githubusercontent.com/assets/355079/12745759/f1aaa0e8-c992-11e5-994a-2c4bcc5d8950.png)

> As you need to have templates to send any notifications, we should be nudging people to do that when they sign in.
>
> This should be in the dashboard, with a link to manage templates.
>
> Should be bright and shiny and only show if the service has no templates.

—https://www.pivotaltracker.com/story/show/112814667

This commit adds the above.

It also rationalises the language (some places used ‘create template’, others used ‘add template’, this changes everything to the latter).