### PR TITLE
Clearer verify page

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -30,3 +30,11 @@
 a:visited {
   color: $link-colour;
 }
+
+.form-control-5em {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 5em;
+  }
+}

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -81,3 +81,7 @@
 
 
 }
+
+.textbox-help-link {
+  margin: 5px 0 0 0;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -62,7 +62,7 @@ def password(label='Create a password'):
 
 def sms_code():
     verify_code = '^\d{5}$'
-    return StringField('Text message confirmation code',
+    return StringField('Text message code',
                        validators=[DataRequired(message='Text message confirmation code can not be empty'),
                                    Regexp(regex=verify_code,
                                           message='Text message confirmation code must be 5 digits')])
@@ -70,7 +70,7 @@ def sms_code():
 
 def email_code():
     verify_code = '^\d{5}$'
-    return StringField("Email confirmation code",
+    return StringField("Email code",
                        validators=[DataRequired(message='Email confirmation code can not be empty'),
                                    Regexp(regex=verify_code, message='Email confirmation code must be 5 digits')])
 

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -1,4 +1,4 @@
-{% macro textbox(field, hint=False, highlight_tags=False) %}
+{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None) %}
   <div class="form-group{% if field.errors %} error{% endif %}">
     <label class="form-label" for="{{ field.name }}">
       {{ field.label }}
@@ -17,5 +17,10 @@
       'class': 'form-control textbox-highlight-textbox' if highlight_tags else 'form-control',
       'data-module': 'highlight-tags' if highlight_tags else ''
     }) }}
+    {% if help_link and help_link_text %}
+      <p class="textbox-help-link">
+        <a href='{{ help_link }}'>{{ help_link_text }}</a>
+      </p>
+    {% endif %}
   </div>
 {% endmacro %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -1,4 +1,4 @@
-{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None) %}
+{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None, width='2-3') %}
   <div class="form-group{% if field.errors %} error{% endif %}">
     <label class="form-label" for="{{ field.name }}">
       {{ field.label }}
@@ -14,7 +14,7 @@
       {% endif %}
     </label>
     {{ field(**{
-      'class': 'form-control textbox-highlight-textbox' if highlight_tags else 'form-control',
+      'class': 'form-control form-control-{} textbox-highlight-textbox'.format(width) if highlight_tags else 'form-control form-control-{}'.format(width),
       'data-module': 'highlight-tags' if highlight_tags else ''
     }) }}
     {% if help_link and help_link_text %}

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -15,14 +15,16 @@ GOV.UK Notify | Confirm email address and mobile number
     <p>We’ve sent you confirmation codes by email and text message. You need to enter both codes here.</p>
 
     <form autocomplete="off" method="post">
-      {{ textbox(form.email_code) }}
-      <p>
-        <a href="{{ url_for('.check_and_resend_email_code')}}">I haven’t received an email</a>
-      </p>
-      {{ textbox(form.sms_code) }}
-      <p>
-        <a href="{{ url_for('.check_and_resend_text_code') }}">I haven’t received a text</a></span>
-      </p>
+      {{ textbox(
+        form.email_code,
+        help_link=url_for('.check_and_resend_email_code'),
+        help_link_text='I haven’t received an email'
+      ) }}
+      {{ textbox(
+        form.sms_code,
+        help_link=url_for('.check_and_resend_text_code'),
+        help_link_text='I haven’t received a text'
+      ) }}
       {{ page_footer("Continue") }}
     </form>
   </div>

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -10,10 +10,10 @@ GOV.UK Notify | Confirm email address and mobile number
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">Activate your account</h1>
-
-    <p>We’ve sent you confirmation codes by email and text message. You need to enter both codes here.</p>
-
+    <h1 class="heading-large">Enter the codes we’ve sent you</h1>
+    <p>
+      We’ve sent you confirmation codes by email and text message.
+    </p>
     <form autocomplete="off" method="post">
       {{ textbox(
         form.email_code,
@@ -25,7 +25,7 @@ GOV.UK Notify | Confirm email address and mobile number
         form.sms_code,
         width='5em',
         help_link=url_for('.check_and_resend_text_code'),
-        help_link_text='I haven’t received a text'
+        help_link_text='I haven’t received a text message'
       ) }}
       {{ page_footer("Continue") }}
     </form>

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -17,11 +17,13 @@ GOV.UK Notify | Confirm email address and mobile number
     <form autocomplete="off" method="post">
       {{ textbox(
         form.email_code,
+        width='5em',
         help_link=url_for('.check_and_resend_email_code'),
         help_link_text='I haven’t received an email'
       ) }}
       {{ textbox(
         form.sms_code,
+        width='5em',
         help_link=url_for('.check_and_resend_text_code'),
         help_link_text='I haven’t received a text'
       ) }}

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -18,7 +18,7 @@ def test_should_return_verify_template(app_,
             assert response.status_code == 200
             assert (
                 "We’ve sent you confirmation codes by email and text message."
-                " You need to enter both codes here.") in response.get_data(as_text=True)
+            ) in response.get_data(as_text=True)
 
 
 def test_should_redirect_to_add_service_when_code_are_correct(app_,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/112891755

***

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/12755056/c4a8024c-c9c5-11e5-924a-c233d3bb77df.png) | ![image](https://cloud.githubusercontent.com/assets/355079/12755036/b449dc90-c9c5-11e5-91f1-8a0c1fe45389.png)

## Reduce spacing between textbox and ‘I haven’t received…’ links

The grouping on this page was weird because these links were two far away from the associated textbox, and too close to the next textbox.

This commit adds them as parameters to the textbox macro, which means their relative spacing can be controlled exactly, and thus reduced.

## Allow textboxes to have width set, default to 2/3

For entering 2 or 3fa codes, we want a textbox that’s just over 6 characters wide.

To do this, a width can now be passed to the textbox macro. The possible widths are the same as those provided by GOV.UK Elements, and in the same format (eg 1-4, 1-2, 2-3…)

This commit also adds a new width (5em) which is suitable for 3fa codes, and adds it to the verify page.