### PR TITLE
Autofocus two factor

### DIFF
--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -1,0 +1,12 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.Autofocus = function() {
+    this.start = function(component) {
+
+      $('input, textarea, select', component).eq(0).trigger('focus');
+
+    };
+  };
+
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -30,3 +30,11 @@
 a:visited {
   color: $link-colour;
 }
+
+.form-control-5em {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 5em;
+  }
+}

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -81,3 +81,7 @@
 
 
 }
+
+.textbox-help-link {
+  margin: 5px 0 0 0;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -62,7 +62,7 @@ def password(label='Create a password'):
 
 def sms_code():
     verify_code = '^\d{5}$'
-    return StringField('Text message confirmation code',
+    return StringField('Text message code',
                        validators=[DataRequired(message='Text message confirmation code can not be empty'),
                                    Regexp(regex=verify_code,
                                           message='Text message confirmation code must be 5 digits')])
@@ -70,7 +70,7 @@ def sms_code():
 
 def email_code():
     verify_code = '^\d{5}$'
-    return StringField("Email confirmation code",
+    return StringField("Email code",
                        validators=[DataRequired(message='Email confirmation code can not be empty'),
                                    Regexp(regex=verify_code, message='Email confirmation code must be 5 digits')])
 

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -1,4 +1,4 @@
-{% macro textbox(field, hint=False, highlight_tags=False) %}
+{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None) %}
   <div class="form-group{% if field.errors %} error{% endif %}">
     <label class="form-label" for="{{ field.name }}">
       {{ field.label }}
@@ -17,5 +17,10 @@
       'class': 'form-control textbox-highlight-textbox' if highlight_tags else 'form-control',
       'data-module': 'highlight-tags' if highlight_tags else ''
     }) }}
+    {% if help_link and help_link_text %}
+      <p class="textbox-help-link">
+        <a href='{{ help_link }}'>{{ help_link_text }}</a>
+      </p>
+    {% endif %}
   </div>
 {% endmacro %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -1,4 +1,4 @@
-{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None) %}
+{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None, width='2-3') %}
   <div class="form-group{% if field.errors %} error{% endif %}">
     <label class="form-label" for="{{ field.name }}">
       {{ field.label }}
@@ -14,7 +14,7 @@
       {% endif %}
     </label>
     {{ field(**{
-      'class': 'form-control textbox-highlight-textbox' if highlight_tags else 'form-control',
+      'class': 'form-control form-control-{} textbox-highlight-textbox'.format(width) if highlight_tags else 'form-control form-control-{}'.format(width),
       'data-module': 'highlight-tags' if highlight_tags else ''
     }) }}
     {% if help_link and help_link_text %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -1,5 +1,13 @@
-{% macro textbox(field, hint=False, highlight_tags=False, help_link=None, help_link_text=None, width='2-3') %}
-  <div class="form-group{% if field.errors %} error{% endif %}">
+{% macro textbox(
+  field,
+  hint=False,
+  highlight_tags=False,
+  autofocus=False,
+  help_link=None,
+  help_link_text=None,
+  width='2-3'
+) %}
+  <div class="form-group{% if field.errors %} error{% endif %}" {% if autofocus %}data-module="autofocus"{% endif %}>
     <label class="form-label" for="{{ field.name }}">
       {{ field.label }}
       {% if hint %}

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -15,11 +15,14 @@ GOV.UK Notify | Text verification
     <p>We've sent you a text message with a verification code.</p>
 
     <form autocomplete="off" method="post">
-      {{ textbox(form.sms_code) }}
+      {{ textbox(
+        form.sms_code,
+        width='5em',
+        help_link=url_for('.verification_code_not_received'),
+        help_link_text='I haven’t received a text message'
+      ) }}
       {{ page_footer(
-        "Continue",
-        back_link=url_for('.verification_code_not_received'),
-        back_link_text='I haven’t received a text'
+        "Continue"
       ) }}
     </form>
   </div>

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -18,6 +18,7 @@ GOV.UK Notify | Text verification
       {{ textbox(
         form.sms_code,
         width='5em',
+        autofocus=True,
         help_link=url_for('.verification_code_not_received'),
         help_link_text='I haven’t received a text message'
       ) }}

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -15,14 +15,16 @@ GOV.UK Notify | Confirm email address and mobile number
     <p>We’ve sent you confirmation codes by email and text message. You need to enter both codes here.</p>
 
     <form autocomplete="off" method="post">
-      {{ textbox(form.email_code) }}
-      <p>
-        <a href="{{ url_for('.check_and_resend_email_code')}}">I haven’t received an email</a>
-      </p>
-      {{ textbox(form.sms_code) }}
-      <p>
-        <a href="{{ url_for('.check_and_resend_text_code') }}">I haven’t received a text</a></span>
-      </p>
+      {{ textbox(
+        form.email_code,
+        help_link=url_for('.check_and_resend_email_code'),
+        help_link_text='I haven’t received an email'
+      ) }}
+      {{ textbox(
+        form.sms_code,
+        help_link=url_for('.check_and_resend_text_code'),
+        help_link_text='I haven’t received a text'
+      ) }}
       {{ page_footer("Continue") }}
     </form>
   </div>

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -10,10 +10,10 @@ GOV.UK Notify | Confirm email address and mobile number
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">Activate your account</h1>
-
-    <p>We’ve sent you confirmation codes by email and text message. You need to enter both codes here.</p>
-
+    <h1 class="heading-large">Enter the codes we’ve sent you</h1>
+    <p>
+      We’ve sent you confirmation codes by email and text message.
+    </p>
     <form autocomplete="off" method="post">
       {{ textbox(
         form.email_code,
@@ -25,7 +25,7 @@ GOV.UK Notify | Confirm email address and mobile number
         form.sms_code,
         width='5em',
         help_link=url_for('.check_and_resend_text_code'),
-        help_link_text='I haven’t received a text'
+        help_link_text='I haven’t received a text message'
       ) }}
       {{ page_footer("Continue") }}
     </form>

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -17,11 +17,13 @@ GOV.UK Notify | Confirm email address and mobile number
     <form autocomplete="off" method="post">
       {{ textbox(
         form.email_code,
+        width='5em',
         help_link=url_for('.check_and_resend_email_code'),
         help_link_text='I haven’t received an email'
       ) }}
       {{ textbox(
         form.sms_code,
+        width='5em',
         help_link=url_for('.check_and_resend_text_code'),
         help_link_text='I haven’t received a text'
       ) }}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -35,6 +35,7 @@ gulp.task('javascripts', () => gulp
     paths.npm + 'govuk_frontend_toolkit/javascripts/govuk/modules.js',
     paths.npm + 'govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js',
     paths.src + 'javascripts/apiKey.js',
+    paths.src + 'javascripts/autofocus.js',
     paths.src + 'javascripts/highlightTags.js',
     paths.src + 'javascripts/main.js'
   ])

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -18,7 +18,7 @@ def test_should_return_verify_template(app_,
             assert response.status_code == 200
             assert (
                 "We’ve sent you confirmation codes by email and text message."
-                " You need to enter both codes here.") in response.get_data(as_text=True)
+            ) in response.get_data(as_text=True)
 
 
 def test_should_redirect_to_add_service_when_code_are_correct(app_,


### PR DESCRIPTION
_Rebased on top of https://github.com/alphagov/notifications-admin/pull/142 which should be merged first_

***

_https://www.pivotaltracker.com/story/show/112433857_

***

## Make two factor textbox consistent with verify textboxes
- make the field the same width (5em to match length of code)
- move ‘haven’t received…’ link underneath the textbox instead of underneath the button

## Make autofocus textbox module

This commit adds a very small Javascript module to autofocus a textbox on page load. It should only be used once per page.

It also adds a parameter to the textbox macro which adds the attribute to trigger autofocus.

## Add autofocus module to two factor page

![autofocus](https://cloud.githubusercontent.com/assets/355079/12756519/fefd1ef4-c9cb-11e5-9d6a-b5c3e2b029a0.gif)