### PR TITLE
Split ‘send SMS’ page into two pages

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -33,6 +33,16 @@
   @extend .banner;
   background: $govuk-blue;
   color: $white;
+
+  a:link, a:visited {
+    color: $white;
+    text-decoration: underline;
+  }
+
+  a:hover {
+    color: $light-blue-25;
+  }
+
 }
 
 .banner-dangerous {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -217,7 +217,7 @@ class ChangePasswordForm(Form):
 
 
 class CsvUploadForm(Form):
-    file = FileField('File to upload', validators=[DataRequired(
+    file = FileField('Upload a CSV file to add your recipients’ details', validators=[DataRequired(
                      message='Please pick a file'), CsvFileValidator()])
 
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -3,7 +3,7 @@
     <a href="{{ url_for('.service_dashboard', service_id=service_id) }}">{{ session.get('service_name', 'Service') }}</a>
   </h2>
   <ul>
-    <li><a href="{{ url_for('.send_sms', service_id=service_id) }}">Send text messages</a></li>
+    <li><a href="{{ url_for('.choose_sms_template', service_id=service_id) }}">Send text messages</a></li>
     <li><a href="{{ url_for('.send_email', service_id=service_id) }}">Send emails</a></li>
     <li><a href="{{ url_for('.view_jobs', service_id=service_id) }}">Activity</a></li>
     <li><a href="{{ url_for('.manage_service_templates', service_id=service_id) }}">Templates</a></li>

--- a/app/templates/views/check-sms.html
+++ b/app/templates/views/check-sms.html
@@ -17,7 +17,7 @@
     {% for rejected in upload_result.rejects %}
       <p>Line {{rejected.line_number}}: {{rejected.phone }}</a>
     {% endfor %}
-    <p><a href="{{url_for('.send_sms', service_id=service_id)}}" class="button">Go back and resolve errors</a></p>
+    <p><a href="{{url_for('.send_sms', service_id=service_id, template_id=template_id)}}" class="button">Go back and resolve errors</a></p>
 
   {% else %}
 
@@ -26,7 +26,7 @@
 
       {{ page_footer(
           button_text = "Send {} text messages".format(upload_result.valid|count),
-          back_link = url_for(".send_sms", service_id=service_id)
+          back_link = url_for(".send_sms", service_id=service_id, template_id=template_id)
       )}}
 
       {% if upload_result.valid | count > 6 %}
@@ -56,7 +56,7 @@
 
       {{ page_footer(
           button_text = "Send {} text messages".format(upload_result.valid|count),
-          back_link = url_for(".send_sms", service_id=service_id)
+          back_link = url_for(".send_sms", service_id=service_id, template_id=template_id)
       )}}
 
     </form>

--- a/app/templates/views/choose-sms-template.html
+++ b/app/templates/views/choose-sms-template.html
@@ -1,0 +1,26 @@
+{% extends "withnav_template.html" %}
+{% from "components/sms-message.html" import sms_message %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/textbox.html" import textbox %}
+
+{% block page_title %}
+  GOV.UK Notify | Send text messages
+{% endblock %}
+
+{% block maincolumn_content %}
+  <form method="POST" enctype="multipart/form-data">
+
+    <h1 class="heading-large">Send text messages</h1>
+
+    <fieldset class='form-group'>
+      {% for template in templates %}
+        {{ sms_message(
+          template.content, name=template.name, input_name='template', input_index=template.id
+        ) }}
+      {% endfor %}
+    </fieldset>
+
+    {{ page_footer("Continue") }}
+
+  </form>
+{% endblock %}

--- a/app/templates/views/choose-sms-template.html
+++ b/app/templates/views/choose-sms-template.html
@@ -12,15 +12,23 @@
 
     <h1 class="heading-large">Send text messages</h1>
 
-    <fieldset class='form-group'>
-      {% for template in templates %}
-        {{ sms_message(
-          template.content, name=template.name, input_name='template', input_index=template.id
-        ) }}
-      {% endfor %}
-    </fieldset>
-
-    {{ page_footer("Continue") }}
+    {% if templates %}
+      <fieldset class='form-group'>
+        {% for template in templates %}
+          {{ sms_message(
+            template.content, name=template.name, input_name='template', input_index=template.id
+          ) }}
+        {% endfor %}
+      </fieldset>
+      {{ page_footer("Continue") }}
+    {% else %}
+      {{ banner(
+        '<a href="{}">Add a text message template</a> to start sending messages'.format(
+          url_for(".add_service_template", service_id=service_id)
+        )|safe,
+        type="tip"
+      )}}
+    {% endif %}
 
   </form>
 {% endblock %}

--- a/app/templates/views/manage-templates.html
+++ b/app/templates/views/manage-templates.html
@@ -13,7 +13,7 @@ GOV.UK Notify | Manage templates
 
     {{ banner(
       '<a href="{}">Try sending a text message</a>'.format(
-        url_for(".send_sms", service_id=service_id)
+        url_for(".choose_sms_template", service_id=service_id)
       )|safe,
       subhead='Next step',
       type="tip"

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -10,34 +10,31 @@
 {% block maincolumn_content %}
   <form method="POST" enctype="multipart/form-data">
 
-        <h1 class="heading-large">Send text messages</h1>
+    <h1 class="heading-large">Send text messages</h1>
 
-    <fieldset class='form-group'>
-      <legend class="heading-medium">1. Choose text message template</legend>
-      {% for template in templates %}
-        {{ sms_message(
-          template.content, name=template.name, input_name='template', input_index=template.id
-        ) }}
-      {% endfor %}
-    </fieldset>
-
-    <h2 class="heading-medium">2. Add recipients</h2>
     {{ banner(
       'You can only send notifications to yourself',
       subhead='Trial mode',
       type='info'
     ) }}
-    <p>
-      Upload a CSV file to add your recipients’ details.
-    </p>
-    <p>
-      You can also <a href="#">download an example CSV</a>.
-    </p>
+
+    {{ sms_message(
+      template.content, name='Preview'
+    ) }}
+
     <p>
       {{textbox(form.file)}}
     </p>
 
-    {{ page_footer("Continue") }}
+    <p>
+      <a href="#">Download an example CSV</a> to test with.
+    </p>
+
+    {{ page_footer(
+      "Continue",
+      back_link=url_for(".choose_sms_template", service_id=service_id),
+      back_link_text="Back to templates"
+    ) }}
 
   </form>
 {% endblock %}

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -12,14 +12,15 @@
 
     <h1 class="heading-large">Send text messages</h1>
 
-    {{ banner(
-      'You can only send notifications to yourself',
-      subhead='Trial mode',
-      type='info'
-    ) }}
-
     {{ sms_message(
       template.content, name='Preview'
+    ) }}
+
+    {{ banner(
+      'You can only send messages to yourself until you <a href="{}">request to go live</a>'.format(
+        url_for('.service_request_to_go_live', service_id=service_id)
+      )|safe,
+      type='info'
     ) }}
 
     <p>

--- a/app/templates/views/service_dashboard.html
+++ b/app/templates/views/service_dashboard.html
@@ -34,7 +34,7 @@
     {% else %}
       {{ banner(
         '<a href="{}">Try sending a text message</a>'.format(
-          url_for(".send_sms", service_id=service_id)
+          url_for(".choose_sms_template", service_id=service_id)
         )|safe,
         subhead='Next step',
         type="tip"

--- a/tests/app/main/views/test_sms.py
+++ b/tests/app/main/views/test_sms.py
@@ -4,16 +4,54 @@ from flask import url_for
 import moto
 
 
+def test_choose_sms_template(app_,
+                             api_user_active,
+                             mock_get_user,
+                             mock_get_service_templates,
+                             mock_check_verify_code,
+                             mock_get_service_template):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            response = client.get(url_for('main.choose_sms_template', service_id=12345))
+
+        assert response.status_code == 200
+        content = response.get_data(as_text=True)
+        assert 'template_one' in content
+        assert 'template one content' in content
+        assert 'template_two' in content
+        assert 'template two content' in content
+
+
+def test_choose_sms_template_redirects(app_,
+                                       api_user_active,
+                                       mock_get_user,
+                                       mock_get_service_templates,
+                                       mock_check_verify_code,
+                                       mock_get_service_template):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            response = client.post(
+                url_for('main.choose_sms_template', service_id=12345),
+                data={'template': '54321'}
+            )
+
+        assert response.status_code == 302
+        assert response.location == url_for('main.send_sms', service_id=12345, template_id=54321, _external=True)
+
+
 def test_upload_empty_csvfile_returns_to_upload_page(app_,
                                                      api_user_active,
                                                      mock_get_user,
                                                      mock_get_service_templates,
-                                                     mock_check_verify_code):
+                                                     mock_check_verify_code,
+                                                     mock_get_service_template):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
             upload_data = {'file': (BytesIO(''.encode('utf-8')), 'emtpy.csv')}
-            response = client.post(url_for('main.send_sms', service_id=123),
+            response = client.post(url_for('main.send_sms', service_id=12345, template_id=54321),
                                    data=upload_data, follow_redirects=True)
 
         assert response.status_code == 200
@@ -37,7 +75,7 @@ def test_upload_csvfile_with_invalid_phone_shows_check_page_with_errors(app_,
         with app_.test_client() as client:
             client.login(api_user_active)
             upload_data = {'file': file_data}
-            response = client.post(url_for('main.send_sms', service_id=123),
+            response = client.post(url_for('main.send_sms', service_id=12345, template_id=54321),
                                    data=upload_data,
                                    follow_redirects=True)
         assert response.status_code == 200
@@ -64,7 +102,7 @@ def test_upload_csvfile_with_valid_phone_shows_first3_and_last3_numbers(app_,
         with app_.test_client() as client:
             client.login(api_user_active)
             upload_data = {'file': file_data}
-            response = client.post(url_for('main.send_sms', service_id=123),
+            response = client.post(url_for('main.send_sms', service_id=12345, template_id=54321),
                                    data=upload_data,
                                    follow_redirects=True)
 
@@ -102,7 +140,7 @@ def test_upload_csvfile_with_valid_phone_shows_all_if_6_or_less_numbers(app_,
         with app_.test_client() as client:
             client.login(api_user_active)
             upload_data = {'file': file_data}
-            response = client.post(url_for('main.send_sms', service_id=123),
+            response = client.post(url_for('main.send_sms', service_id=12345, template_id=54321),
                                    data=upload_data,
                                    follow_redirects=True)
 


### PR DESCRIPTION
This pull request just splits the existing page into two. It doesn’t do any substantive changes to how the two parts of the page work.

It also changes the wording on the blue banner—we can ignore any mention of trial/test/mode if we just talk about ‘not live’. It also feels sensible to link through to the page where you can make that
change, rather than dig through the navigation.

![image](https://cloud.githubusercontent.com/assets/355079/12780887/b02826aa-ca68-11e5-9094-786b4e0b939a.png)

![image](https://cloud.githubusercontent.com/assets/355079/12780899/bbc627a0-ca68-11e5-88e0-0f1c9b32d792.png)

