### PR TITLE
File uploader

### DIFF
--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -1,0 +1,27 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.FileUpload = function() {
+
+    let $field, $button, $filename;
+
+    this.update = function() {
+
+      $filename.text($field.val().split('\\').pop());
+
+    };
+
+    this.start = function(component) {
+
+      $field = $('.file-upload-field', component);
+      $button = $('.file-upload-button', component);
+      $filename = $('.file-upload-filename', component);
+
+      // Need to put the event on the container, not the input for it to work properly
+      $(component).on('change', '.file-upload-field', this.update);
+
+    };
+
+  };
+
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -1,0 +1,36 @@
+.js-enabled {
+
+  .file-upload {
+
+    &-label {
+      @include bold-19;
+      display: block;
+      margin: 0 0 10px 0;
+    }
+
+    &-field {
+      width: 0.1px;
+      height: 0.1px;
+      opacity: 0;
+      overflow: hidden;
+      position: absolute;
+      z-index: -1;
+    }
+
+    &-field:focus + .file-upload-button {
+      outline: 3px solid $yellow;
+    }
+
+    &-button {
+      @include button($panel-colour);
+      display: inline-block;
+    }
+
+    &-filename {
+      display: inline-block;
+      padding-left: $gutter-half;
+    }
+
+  }
+
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -40,6 +40,7 @@
 @import 'components/big-number';
 @import 'components/banner';
 @import 'components/textbox';
+@import 'components/file-upload';
 @import 'components/browse-list';
 @import 'components/email-message';
 @import 'components/api-key';

--- a/app/main/views/styleguide.py
+++ b/app/main/views/styleguide.py
@@ -1,6 +1,6 @@
 from flask import render_template
 from flask_wtf import Form
-from wtforms import StringField, PasswordField, TextAreaField, validators
+from wtforms import StringField, PasswordField, TextAreaField, FileField, validators
 from app.main import main
 
 
@@ -11,6 +11,7 @@ def styleguide():
         username = StringField(u'Username')
         password = PasswordField(u'Password', [validators.required()])
         message = TextAreaField(u'Message')
+        file_upload = FileField('Upload a CSV file to add your recipients’ details')
 
     form = FormExamples()
 

--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -1,0 +1,24 @@
+{% macro file_upload(field) %}
+  <div class="form-group{% if field.errors %} error{% endif %}" data-module="file-upload">
+    <label class="file-upload-label" for="{{ field.name }}">
+      {{ field.label }}
+      {% if hint %}
+        <span class="form-hint">
+          {{ hint }}
+        </span>
+      {% endif %}
+      {% if field.errors %}
+        <span class="error-message">
+          {{ field.errors[0] }}
+        </span>
+      {% endif %}
+    </label>
+    {{ field(**{
+      'class': 'file-upload-field'
+    }) }}
+    <label class="file-upload-button" for="{{ field.name }}">
+      Choose file
+    </label>
+    <label class="file-upload-filename" for="{{ field.name }}"></label>
+  </div>
+{% endmacro %}

--- a/app/templates/views/choose-sms-template.html
+++ b/app/templates/views/choose-sms-template.html
@@ -20,7 +20,8 @@
           ) }}
         {% endfor %}
       </fieldset>
-      {{ page_footer("Continue") }}
+
+    {{ page_footer("Continue") }}
     {% else %}
       {{ banner(
         '<a href="{}">Add a text message template</a> to start sending messages'.format(

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/sms-message.html" import sms_message %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/textbox.html" import textbox %}
+{% from "components/file-upload.html" import file_upload %}
 
 {% block page_title %}
   GOV.UK Notify | Send text messages
@@ -29,9 +29,7 @@
       type='info'
     ) }}
 
-    <p>
-      {{textbox(form.file)}}
-    </p>
+    {{file_upload(form.file)}}
 
     <p>
       <a href="#">Download an example CSV</a> to test with.

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -12,6 +12,12 @@
 
     <h1 class="heading-large">Send text messages</h1>
 
+    {{ banner(
+      'You can only send notifications to yourself',
+      subhead='Trial mode',
+      type='info'
+    ) }}
+
     {{ sms_message(
       template.content, name='Preview'
     ) }}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -7,6 +7,7 @@
 {% from "components/sms-message.html" import sms_message %}
 {% from "components/table.html" import mapping_table, list_table, row, field %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/file-upload.html" import file_upload %}
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
@@ -204,6 +205,9 @@
   {{ textbox(form.username) }}
   {{ textbox(form.password) }}
   {{ textbox(form.message, highlight_tags=True) }}
+
+  <h2 class="heading-large">File upload</h2>
+  {{ file_upload(form.file_upload) }}
 
   <h2 class="heading-large">API key</h2>
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -37,6 +37,7 @@ gulp.task('javascripts', () => gulp
     paths.src + 'javascripts/apiKey.js',
     paths.src + 'javascripts/autofocus.js',
     paths.src + 'javascripts/highlightTags.js',
+    paths.src + 'javascripts/fileUpload.js',
     paths.src + 'javascripts/main.js'
   ])
   .pipe(plugins.babel({


### PR DESCRIPTION
_Rebased on top of https://github.com/alphagov/notifications-admin/pull/147, which should be merged first_

***

## Add custom file upload component

The default browser file upload control is difficult to style, but looks totally out of place.

This commit replaces it with one that has a GOV.UK style button, as a first step.

Based heavily on this example:
http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/

## Add custom file upload to the send SMS page

This is the only place we’re doing file upload at the moment.

![file](https://cloud.githubusercontent.com/assets/355079/12783060/1c246b26-ca77-11e5-85f0-0638c7b20651.gif)
