### PR TITLE
Limit number of jobs on dashboard to 5

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -60,3 +60,10 @@
   border-bottom: 1px solid $border-colour;
   padding: 0.75em 0 0.5625em 0;
 }
+
+.table-show-more-link {
+  margin-top: -20px;
+  border-bottom: 1px solid $border-colour;
+  padding-bottom: 10px;
+  @include bold-16;
+}

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -28,7 +28,8 @@ def service_dashboard(service_id):
             raise e
     return render_template(
         'views/service_dashboard.html',
-        jobs=list(reversed(jobs)),
+        jobs=list(reversed(jobs))[:5],
+        more_jobs_to_show=(len(jobs) > 5),
         free_text_messages_remaining='250,000',
         spent_this_month='0.00',
         template_count=len(templates),

--- a/app/templates/views/jobs.html
+++ b/app/templates/views/jobs.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
 {% block page_title %}
 GOV.UK Notify | Notifications activity
@@ -14,18 +14,15 @@ GOV.UK Notify | Notifications activity
       caption="Recent activity",
       caption_visible=False,
       empty_message='You haven’t sent any notifications yet',
-      field_headings=['Job', 'File', 'Time', 'Status']
+      field_headings=['Job', 'Time', right_aligned_field_heading('Status')]
     ) %}
-      {% call field() %}
-        <a href="{{ url_for('.view_job', service_id=service_id, job_id=item.id) }}">{{ item.id }}</a>
-      {% endcall %}
       {% call field() %}
         <a href="{{ url_for('.view_job', service_id=service_id, job_id=item.id) }}">{{ item.original_file_name }}</a>
       {% endcall %}
       {% call field() %}
         {{ item.created_at | format_datetime}}
       {% endcall %}
-      {% call field() %}
+      {% call field(align='right') %}
         {{ item.status }}
       {% endcall %}
     {% endcall %}

--- a/app/templates/views/service_dashboard.html
+++ b/app/templates/views/service_dashboard.html
@@ -58,6 +58,11 @@
           {{ item.status }}
         {% endcall %}
       {% endcall %}
+      {% if more_jobs_to_show %}
+        <p class="table-show-more-link">
+          <a href="{{ url_for('.view_jobs', service_id=service_id) }}">See all sent text messages</a>
+        </p>
+      {% endif %}
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Limit number of jobs on dashboard to 5
…and add a link to view the rest of the jobs if there are more than 5.

![image](https://cloud.githubusercontent.com/assets/355079/12823570/a8d82cfe-cb64-11e5-8a71-16bf881fd4a0.png)

## Remove job ID from jobs table 

Don’t think it’s something we need to surface to users.