### PR TITLE
Skip ‘choose service’ page if user has one service

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -5,7 +5,7 @@ from flask import (
 from flask_login import login_user
 
 from app.main import main
-from app.main.dao import users_dao
+from app.main.dao import users_dao, services_dao
 from app.main.forms import TwoFactorForm
 
 
@@ -22,6 +22,7 @@ def two_factor():
     if form.validate_on_submit():
         try:
             user = users_dao.get_user_by_id(user_id)
+            services = services_dao.get_services(user_id).get('data', [])
             # Check if coming from new password page
             if 'password' in session['user_details']:
                 user.set_password(session['user_details']['password'])
@@ -29,6 +30,9 @@ def two_factor():
             login_user(user)
         finally:
             del session['user_details']
-        return redirect(url_for('main.choose_service'))
+        if (len(services) == 1):
+            return redirect(url_for('main.service_dashboard', service_id=services[0]['id']))
+        else:
+            return redirect(url_for('main.choose_service'))
 
     return render_template('views/two-factor.html', form=form)

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -4,11 +4,11 @@ from app.main.dao import services_dao
 
 def test_get_should_render_add_service_template(app_,
                                                 api_user_active,
+                                                mock_login,
                                                 mock_get_service,
                                                 mock_get_services,
                                                 mock_get_user,
-                                                mock_get_user_by_email,
-                                                mock_login):
+                                                mock_get_user_by_email):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -18,12 +18,12 @@ def test_get_should_render_add_service_template(app_,
 
 
 def test_should_add_service_and_redirect_to_next_page(app_,
+                                                      mock_login,
                                                       mock_create_service,
                                                       mock_get_services,
                                                       api_user_active,
                                                       mock_get_user,
-                                                      mock_get_user_by_email,
-                                                      mock_login):
+                                                      mock_get_user_by_email):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -52,11 +52,11 @@ def test_should_return_form_errors_when_service_name_is_empty(app_,
 
 
 def test_should_return_form_errors_with_duplicate_service_name(app_,
+                                                               mock_login,
                                                                mock_get_services,
                                                                mock_get_user,
                                                                api_user_active,
-                                                               mock_get_user_by_email,
-                                                               mock_login):
+                                                               mock_get_user_by_email):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -4,10 +4,10 @@ import pytest
 
 
 def test_should_show_choose_services_page(app_,
+                                          mock_login,
                                           mock_get_user,
                                           api_user_active,
-                                          mock_get_services,
-                                          mock_login):
+                                          mock_get_services):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)

--- a/tests/app/main/views/test_sms.py
+++ b/tests/app/main/views/test_sms.py
@@ -6,6 +6,7 @@ import moto
 
 def test_choose_sms_template(app_,
                              api_user_active,
+                             mock_login,
                              mock_get_user,
                              mock_get_service_templates,
                              mock_check_verify_code,
@@ -25,6 +26,7 @@ def test_choose_sms_template(app_,
 
 def test_upload_empty_csvfile_returns_to_upload_page(app_,
                                                      api_user_active,
+                                                     mock_login,
                                                      mock_get_user,
                                                      mock_get_service_templates,
                                                      mock_check_verify_code,
@@ -45,9 +47,9 @@ def test_upload_empty_csvfile_returns_to_upload_page(app_,
 def test_upload_csvfile_with_invalid_phone_shows_check_page_with_errors(app_,
                                                                         mocker,
                                                                         api_user_active,
+                                                                        mock_login,
                                                                         mock_get_user,
                                                                         mock_get_user_by_email,
-                                                                        mock_login,
                                                                         mock_get_service_template):
 
     contents = 'phone\n+44 123\n+44 456'
@@ -72,9 +74,9 @@ def test_upload_csvfile_with_invalid_phone_shows_check_page_with_errors(app_,
 def test_upload_csvfile_with_valid_phone_shows_all_numbers(app_,
                                                            mocker,
                                                            api_user_active,
+                                                           mock_login,
                                                            mock_get_user,
                                                            mock_get_user_by_email,
-                                                           mock_login,
                                                            mock_get_service_template):
 
     contents = 'phone\n+44 7700 900981\n+44 7700 900982\n+44 7700 900983\n+44 7700 900984\n+44 7700 900985\n+44 7700 900986'  # noqa

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -19,11 +19,35 @@ def test_should_render_two_factor_page(app_,
         assert '''We've sent you a text message with a verification code.''' in response.get_data(as_text=True)
 
 
-def test_should_login_user_and_redirect_to_dashboard(app_,
-                                                     api_user_active,
-                                                     mock_get_user,
-                                                     mock_get_user_by_email,
-                                                     mock_check_verify_code):
+def test_should_login_user_and_redirect_to_service_dashboard(app_,
+                                                             api_user_active,
+                                                             mock_get_user,
+                                                             mock_get_user_by_email,
+                                                             mock_check_verify_code,
+                                                             mock_get_services_with_one_service):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            with client.session_transaction() as session:
+                session['user_details'] = {
+                    'id': api_user_active.id,
+                    'email': api_user_active.email_address}
+            response = client.post(url_for('main.two_factor'),
+                                   data={'sms_code': '12345'})
+
+            assert response.status_code == 302
+            assert response.location == url_for(
+                'main.service_dashboard',
+                service_id="596364a0-858e-42c8-9062-a8fe822260eb",
+                _external=True
+            )
+
+
+def test_should_login_user_and_redirect_to_choose_services(app_,
+                                                           api_user_active,
+                                                           mock_get_user,
+                                                           mock_get_user_by_email,
+                                                           mock_check_verify_code,
+                                                           mock_get_services):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -57,7 +81,8 @@ def test_should_login_user_when_multiple_valid_codes_exist(app_,
                                                            api_user_active,
                                                            mock_get_user,
                                                            mock_get_user_by_email,
-                                                           mock_check_verify_code):
+                                                           mock_check_verify_code,
+                                                           mock_get_services_with_one_service):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,11 +398,23 @@ def mock_get_no_api_keys(mocker):
 
 @pytest.fixture(scope='function')
 def mock_login(mocker, mock_get_user, mock_update_user):
+
     def _verify_code(user_id, code, code_type):
         return True, ''
-    return mocker.patch(
-        'app.user_api_client.check_verify_code',
-        side_effect=_verify_code)
+
+    def _no_services(user_id=None):
+        return {'data': []}
+
+    return (
+        mocker.patch(
+            'app.user_api_client.check_verify_code',
+            side_effect=_verify_code
+        ),
+        mocker.patch(
+            'app.notifications_api_client.get_services',
+            side_effect=_no_services
+        )
+    )
 
 
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,10 +92,25 @@ def mock_get_services(mocker, user=None):
     def _create(user_id=None):
         import uuid
         service_one = service_json(
-            uuid.uuid4(), "service_one", [user.id], 1000, True, False)
+            "596364a0-858e-42c8-9062-a8fe822260eb", "service_one", [user.id], 1000, True, False)
         service_two = service_json(
-            uuid.uuid4(), "service_two", [user.id], 1000, True, False)
+            "147ad62a-2951-4fa1-9ca0-093cd1a52c52", "service_two", [user.id], 1000, True, False)
         return {'data': [service_one, service_two]}
+
+    return mocker.patch(
+        'app.notifications_api_client.get_services', side_effect=_create)
+
+
+@pytest.fixture(scope='function')
+def mock_get_services_with_one_service(mocker, user=None):
+    if user is None:
+        user = api_user_active()
+
+    def _create(user_id=None):
+        import uuid
+        return {'data': [service_json(
+            "596364a0-858e-42c8-9062-a8fe822260eb", "service_one", [user.id], 1000, True, False
+        )]}
 
     return mocker.patch(
         'app.notifications_api_client.get_services', side_effect=_create)


### PR DESCRIPTION
We used to do this by redirecting on the choose service page. However when we lost the dropdown and this page also became the page for adding a new service (in 3617f2e936aadbdf71d582e58d88a16629ee5ca2) the redirect was removed.

This commit re-adds the redirect on the two factor page, so that it only happens on first login.

So the flows are:

**Multiple services**
`Sign in` → `Enter two factor code` → `Choose service` → `Service dashboard`

**One service**
`Sign in` → `Enter two factor code` → `Service dashboard`

**No services (you’ve deleted all your services)**
`Sign in` → `Enter two factor code` → `Choose service` → `Add new service`
