### PR TITLE
Make page titles consistent

### DIFF
--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Set up service
+  {{heading}} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -2,7 +2,7 @@
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
 
 {% block page_title %}
-  GOV.UK Notify | API keys and documentation
+  API keys – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/api-keys/create.html
+++ b/app/templates/views/api-keys/create.html
@@ -3,7 +3,7 @@
 {% from "components/textbox.html" import textbox %}
 
 {% block page_title %}
-  GOV.UK Notify | API keys and documentation
+  Add a new API key – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/api-keys/revoke.html
+++ b/app/templates/views/api-keys/revoke.html
@@ -3,7 +3,7 @@
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
-  GOV.UK Notify | API keys and documentation
+  Revoke API key – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/api-keys/show.html
+++ b/app/templates/views/api-keys/show.html
@@ -3,7 +3,7 @@
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
-  GOV.UK Notify | API keys and documentation
+  New API key – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/check-email.html
+++ b/app/templates/views/check-email.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify | Send email
+  Send email – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/check-sms.html
+++ b/app/templates/views/check-sms.html
@@ -5,7 +5,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-  GOV.UK Notify | Send text messages
+  Check and confirm – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/choose-service.html
+++ b/app/templates/views/choose-service.html
@@ -2,7 +2,7 @@
 {% from "components/browse-list.html" import browse_list %}
 
 {% block page_title %}
-  GOV.UK Notify | Dashboard
+  Choose service – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/choose-sms-template.html
+++ b/app/templates/views/choose-sms-template.html
@@ -4,7 +4,7 @@
 {% from "components/textbox.html" import textbox %}
 
 {% block page_title %}
-  GOV.UK Notify | Send text messages
+  Send text messages – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -3,7 +3,7 @@
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
-GOV.UK Notify | API keys and documentation
+  Developer documentation – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/edit-template.html
+++ b/app/templates/views/edit-template.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Edit template
+  {{ h1 }} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify
+  Check your email address – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify
+Create a new password – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -5,7 +5,7 @@
 {% from "components/sms-message.html" import sms_message %}
 
 {% block page_title %}
-  GOV.UK Notify | Notifications activity
+  {{ uploaded_file_name }} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/jobs.html
+++ b/app/templates/views/jobs.html
@@ -2,7 +2,7 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
 {% block page_title %}
-GOV.UK Notify | Notifications activity
+  Notifications activity – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/manage-templates.html
+++ b/app/templates/views/manage-templates.html
@@ -4,12 +4,12 @@
 {% from "components/browse-list.html" import browse_list %}
 
 {% block page_title %}
-GOV.UK Notify | Manage templates
+Manage templates – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">Templates</h1>
+    <h1 class="heading-large">Manage templates</h1>
 
 
     {% if not has_jobs %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Manage users
+Manage users – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/new-password.html
+++ b/app/templates/views/new-password.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify
+  Create a new password – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/notification.html
+++ b/app/templates/views/notification.html
@@ -4,7 +4,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Notifications activity
+  Text message – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/password-reset-sent.html
+++ b/app/templates/views/password-reset-sent.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify |
+GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify | Create a user account
+Create an account – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Create an account
+Create an account – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/send-email.html
+++ b/app/templates/views/send-email.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify | Send email
+Send email – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -4,7 +4,7 @@
 {% from "components/file-upload.html" import file_upload %}
 
 {% block page_title %}
-  GOV.UK Notify | Send text messages
+  Send text messages – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -2,7 +2,7 @@
 {% from "components/browse-list.html" import browse_list %}
 
 {% block page_title %}
-  GOV.UK Notify | Service settings
+  Service settings – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Service settings
+  {{ heading }} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings/delete.html
+++ b/app/templates/views/service-settings/delete.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-  GOV.UK Notify | Service settings
+  Delete service – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Service settings
+  Change your service name – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-  GOV.UK Notify | Service settings
+  Request to go live – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings/status.html
+++ b/app/templates/views/service-settings/status.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Service settings
+  Temporrily suspend API keys – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service_dashboard.html
+++ b/app/templates/views/service_dashboard.html
@@ -3,7 +3,7 @@
 {% from "components/big-number.html" import big_number %}
 
 {% block page_title %}
-  GOV.UK Notify | Dashboard
+  {{ session.get('service_name', 'Dashboard') }} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify | Get started
+  GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-Sign in
+  Sign in – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/text-not-received-2.html
+++ b/app/templates/views/text-not-received-2.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify
+Check your mobile number – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify
+Check your mobile number – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Text verification
+  Text verification – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -2,7 +2,7 @@
 {% from "components/table.html" import list_table, row, field %}
 
 {% block page_title %}
-  GOV.UK Notify | Your profile
+  Your profile – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify
+  Resend verification code – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/verify-mobile.html
+++ b/app/templates/views/verify-mobile.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-GOV.UK Notify | Confirm mobile number
+Confirm your  mobile number – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block page_title %}
-GOV.UK Notify | Confirm email address and mobile number
+  Enter the codes we’ve sent you – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
This commit modifies the HTML `<title>` tags for all the pages. It makes two main changes:
- make the title tag match the `<h1>` of the page, for better or worse
- put the service name after the page title, seperated by an en dash, as per GOV.UK