### PR TITLE
Make ‘edit template’ textboxes the same width

### DIFF
--- a/app/assets/javascripts/highlightTags.js
+++ b/app/assets/javascripts/highlightTags.js
@@ -23,6 +23,10 @@
         .on("input", this.update)
         .on("scroll", this.maintainScrollParity);
 
+      this.$backgroundMaskForeground.width(
+        this.$textbox.width()
+      );
+
       this.$textbox
         .trigger("input");
 

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -18,11 +18,10 @@
     display: block;
     box-sizing: border-box;
     position: relative;
-    width: 500px;
-    height: 200px;
     margin: 0;
     padding: 4px;
     overflow: hidden;
+    height: 200px;
   }
 
   &-background,


### PR DESCRIPTION
This involves:
- removing the hard coded width on any textbox that does placeholder
  highlighting
- adding JS to make sure that the extra layers on top of the textbox inherit
  the width of the textbox that the user types in (so the layers don’t get
  misaligned)

Keeping the textboxes at ⅔<sup>rd</sup> width for consistency with how wide the messages are on the ‘manage templates’ page.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/12883094/ab574122-ce4d-11e5-8a29-d09f85b11478.png) | ![image](https://cloud.githubusercontent.com/assets/355079/12883085/9cace64a-ce4d-11e5-90d0-08418577af73.png)