### PR TITLE
Restore template content when deleting template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -92,6 +92,7 @@ def delete_service_template(service_id, template_id):
         else:
             raise e
 
+    template['template_content'] = template['content']
     form = TemplateForm(**template)
 
     if request.method == 'POST':

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -95,8 +95,11 @@ def test_should_show_delete_template_page(app_,
                 service_id=service_id,
                 template_id=template_id))
 
+    content = response.get_data(as_text=True)
     assert response.status_code == 200
-    assert 'Are you sure' in response.get_data(as_text=True)
+    assert 'Are you sure' in content
+    assert 'Two week reminder' in content
+    assert 'Your vehicle tax is about to expire' in content
     mock_get_service_template.assert_called_with(
         service_id, template_id)
 


### PR DESCRIPTION
When the template content was renamed in 9ee8610da0704215d96602e34ac77b998e055373 I missed doing the same change for the delete template route.

This commit does the same fix, so that template content is still visible when you’re about to delete a template (so you can make sure it’s the right one).

![image](https://cloud.githubusercontent.com/assets/355079/12885766/5d3895b4-ce60-11e5-9bc9-85594fc70367.png)
