### PR TITLE
Swap order of fields of three factor page

### DIFF
--- a/app/templates/views/verify.html
+++ b/app/templates/views/verify.html
@@ -16,16 +16,16 @@
     </p>
     <form autocomplete="off" method="post">
       {{ textbox(
-        form.email_code,
-        width='5em',
-        help_link=url_for('.check_and_resend_email_code'),
-        help_link_text='I haven’t received an email'
-      ) }}
-      {{ textbox(
         form.sms_code,
         width='5em',
         help_link=url_for('.check_and_resend_text_code'),
         help_link_text='I haven’t received a text message'
+      ) }}
+      {{ textbox(
+        form.email_code,
+        width='5em',
+        help_link=url_for('.check_and_resend_email_code'),
+        help_link_text='I haven’t received an email'
       ) }}
       {{ page_footer("Continue") }}
     </form>


### PR DESCRIPTION
Most people seem to get the text message before the email, so it makes sense for this to be the first field on the page.