### PR TITLE
Make job page more realistic for demo

### DIFF
--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -29,12 +29,12 @@
     <ul class="grid-row job-totals">
       <li class="column-one-quarter">
         {{ big_number(
-          1, 'queued'
+          0, 'queued'
         )}}
       </li>
       <li class="column-one-quarter">
         {{ big_number(
-          0, 'sent'
+          1, 'sent'
         )}}
       </li>
       <li class="column-one-quarter">

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -52,19 +52,23 @@
 
     {% call(item) list_table(
       [
-        {'phone': '+447700 900995', 'template': template['name'], 'status': 'queued'}
+        {'row': 1, 'phone': '+447700 900995', 'template': template['name'], 'status': 'queued'}
       ],
       caption=uploaded_file_name,
       caption_visible=False,
       empty_message="Messages go here",
       field_headings=[
+        'Row',
         'Recipient',
         'Template',
         right_aligned_field_heading('Status')
       ]
     ) %}
       {% call field() %}
-        {{item.phone}}
+        {{ item.row }}.
+      {% endcall %}
+      {% call field() %}
+        {{item.phone[:3]}} •••• ••••••
       {% endcall %}
       {% call field() %}
         {{item.template}}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/12943746/24372a92-cfdb-11e5-8803-3153f7ba3901.png)

## Mask phone number on jobs page 

The phone number on the job page is hard-coded at the moment. This is not good for the consistency of the demo, and showing it is probably not good because we don’t want to be storing it forever. So this commit:

- masks it out with bullets • because they’re nicer than asteriks
- adds a ‘row number’ column, which I think is good for users uploading CSVs to reconcile the job run with their data (if we’re not showing the data any more)

## Make message sent, not queued, for realism