### PR TITLE
Use tablular numbers for ‘big number’ pattern

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -1,6 +1,6 @@
 .big-number {
 
-  @include bold-48;
+  @include bold-48($tabular-numbers: true);
 
   &-label {
     @include core-19;

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -62,7 +62,12 @@
       {{ big_number("567") }}
     </div>
     <div class="column-one-third">
-      {{ big_number("2", "Messages delivered") }}
+      {{ big_number("£2.19", "Final cost") }}
+    </div>
+  </div>
+  <div class="grid-row">
+    <div class="column-one-third">
+      {{ big_number("711", "Queued") }}
     </div>
   </div>
 


### PR DESCRIPTION
> Tabular numbers have numerals of a standard fixed width. As all numbers have the same width, sets of numbers may be more easily compared. We recommend using them where different numbers are likely to be compared, or where different numbers should line up with each other, eg in tables.

The big number pattern is good candidate for tabular numbers, especially if we ever have these numbers update dynamically (in that case tabular numbers won’t jump around like lining ones would).

![screen-shot-2016-02-10-at-10 54 50](https://cloud.githubusercontent.com/assets/355079/12945668/f618aee0-cfe6-11e5-8de5-7a4cd74b074e.png)
