### PR TITLE
Use <main> element in semantically appropriate way

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -63,9 +63,9 @@
 {% endif %}
 
 {% block content %}
-  <main id="content" role="main" class="page-container">
+  <div id="content">
     {% block fullwidth_content %}{% endblock %}
-  </main>
+  </div>
 {% endblock %}
 
 {% block body_end %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -5,9 +5,9 @@
     <div class="column-one-third">
       {% include "main_nav.html" %}
     </div>
-    <div class="column-two-thirds column-main">
+    <main role="main" class="column-two-thirds column-main">
       {% include 'flash_messages.html' %}
       {% block maincolumn_content %}{% endblock %}
-    </div>
+    </main>
   </div>
 {% endblock %}

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -1,6 +1,8 @@
 {% extends "admin_template.html" %}
 
 {% block fullwidth_content %}
-  {% include 'flash_messages.html' %}
-  {% block maincolumn_content %}{% endblock %}
+  <main role="main">
+    {% include 'flash_messages.html' %}
+    {% block maincolumn_content %}{% endblock %}
+  </main>
 {% endblock %}


### PR DESCRIPTION
_Not needed for the Sprint demo_

***

Assistive technologies use the `<main>` element to navigate around a document. In `<main>` their users expect to find:

> [content] unique to the document, excluding any content that is repeated across a set of documents such as sidebars, navigation links, copyright information, site logos, and search forms…

—https://developer.mozilla.org/en/docs/Web/HTML/Element/main

Previously, the `<main>` element also wrapped the sidebar navigation. This commit moves the `<main>` element to only wrap the content of the page when the page has a navigation sidebar.

This commit also removes the `page-container` class which wasn’t being used for anything.