### PR TITLE
Make registration and forgot password pages better

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -9,6 +9,7 @@ from wtforms import (
     FileField,
     RadioField
 )
+from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import DataRequired, Email, Length, Regexp
 
 from app.main.validators import Blacklist, CsvFileValidator
@@ -23,14 +24,14 @@ from app.main.utils import (
 def email_address():
     gov_uk_email \
         = "(^[^@^\\s]+@[^@^\\.^\\s]+(\\.[^@^\\.^\\s]*)*.gov.uk)"
-    return StringField('Email address', validators=[
+    return EmailField('Email address', validators=[
         Length(min=5, max=255),
         DataRequired(message='Email cannot be empty'),
         Email(message='Enter a valid email address'),
         Regexp(regex=gov_uk_email, message='Enter a gov.uk email address')])
 
 
-class UKMobileNumber(StringField):
+class UKMobileNumber(TelField):
 
     def pre_validate(self, form):
         try:

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -15,6 +15,7 @@ def forgot_password():
             users_dao.request_password_reset(user)
             send_change_password_email(form.email_address.data)
             return render_template('views/password-reset-sent.html')
-        flash('There was an error processing your request')
+        else:
+            return render_template('views/password-reset-sent.html')
 
     return render_template('views/forgot-password.html', form=form)

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -14,7 +14,7 @@ Create an account – GOV.UK Notify
 
     <p>If you've used GOV.UK Notify before, <a href="{{ url_for('.sign_in') }}">sign in to your account</a>.</p>
 
-    <form autocomplete="off" action="" method="post">
+    <form method="post" autocomplete="nope">
       {{ textbox(form.name, width='3-4') }}
       {{ textbox(form.email_address, hint="Your email address must end in .gov.uk", width='3-4') }}
       {{ textbox(form.mobile_number, width='3-4') }}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -12,7 +12,7 @@ Create an account – GOV.UK Notify
   <div class="column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
 
-    <p>If you've used GOV.UK Notify before, <a href="{{ url_for('.sign_in') }}">sign in to your account</a>.</p>
+    <p>If you’ve used GOV.UK Notify before, <a href="{{ url_for('.sign_in') }}">sign in to your account</a>.</p>
 
     <form method="post" autocomplete="nope">
       {{ textbox(form.name, width='3-4') }}

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -14,7 +14,7 @@
 
     <p>If you do not have an account, you can <a href="register">register for one now</a>.</p>
 
-    <form autocomplete="off" method="post">
+    <form method="post" autocomplete="nope">
       {{ textbox(form.email_address) }}
       {{ textbox(form.password) }}
       {{ page_footer("Continue", secondary_link=url_for('.forgot_password'), secondary_link_text="Forgotten password?") }}

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -9,11 +9,13 @@ def test_should_render_forgot_password(app_):
                in response.get_data(as_text=True)
 
 
-def test_should_redirect_to_password_reset_sent_and_state_updated(app_,
-                                                                  api_user_active,
-                                                                  mock_get_user_by_email,
-                                                                  mock_update_user,
-                                                                  mock_send_email):
+def test_should_redirect_to_password_reset_sent_and_state_updated(
+    app_,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_update_user,
+    mock_send_email
+):
     with app_.test_request_context():
         response = app_.test_client().post(
             url_for('.forgot_password'),
@@ -22,3 +24,23 @@ def test_should_redirect_to_password_reset_sent_and_state_updated(app_,
         assert (
             'You have been sent an email containing a link'
             ' to reset your password.') in response.get_data(as_text=True)
+        assert mock_send_email.call_count == 1
+
+
+def test_should_redirect_to_password_reset_sent_for_non_existant_email_address(
+    app_,
+    api_user_active,
+    mock_dont_get_user_by_email,
+    mock_update_user,
+    mock_send_email
+):
+    with app_.test_request_context():
+        response = app_.test_client().post(
+            url_for('.forgot_password'),
+            data={'email_address': 'nope@example.gov.uk'})
+        assert response.status_code == 200
+        assert (
+            'You have been sent an email containing a link'
+            ' to reset your password.') in response.get_data(as_text=True)
+        mock_dont_get_user_by_email.assert_called_once_with('nope@example.gov.uk')
+        assert not mock_send_email.called

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def mock_send_sms(request, mocker):
 
 @pytest.fixture(scope='function')
 def mock_send_email(request, mocker):
-    return mocker.patch("app.notifications_api_client.send_email")
+    return mocker.patch("app.notifications_api_client.send_email", autospec=True)
 
 
 @pytest.fixture(scope='function')
@@ -285,6 +285,18 @@ def mock_get_user_by_email(mocker, api_user_active):
         api_user_active._email_address = email_address
         return api_user_active
     return mocker.patch('app.user_api_client.get_user_by_email', side_effect=_get_user)
+
+
+@pytest.fixture(scope='function')
+def mock_dont_get_user_by_email(mocker):
+
+    def _get_user(email_address):
+        return None
+    return mocker.patch(
+        'app.user_api_client.get_user_by_email',
+        side_effect=_get_user,
+        autospec=True
+    )
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Don’t allow autocomplete on register page
This is a potential attack vector which was highlighted by the pen test.

Setting autocomplete to `nope` (or any random string) is the most comprehensive way of telling browsers not to autocomplete a form according to: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

## Use correct HTML 5 input types 

These give devices a hint (although don’t mandate them) to use a numeric keypad, or a keypad with the `@` symbol visible when entering phone numbers or email addresses.

## Use typographic quotes

http://smartquotesforsmartpeople.com

## Stop enumeration of email addresses via forgot password

https://www.pivotaltracker.com/story/show/113840073

Previously the forgot password page would give an error if you entered an email address which didn’t belong to an account.

This would allow a potential attacker to know which email addresses were registered.

This commit changes the response to always be the same, whether or not the email address exists.

Also, this is a good read about the dangers of asserting whether a mocked method
was called: http://engineeringblog.yelp.com/2015/02/assert_called_once-threat-or-menace.html