### PR TITLE
Install GOV.UK Template with NPM

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "GOV.UK Notify admin frontend",
-  "version": "0.0.1",
-  "dependencies": {
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.16.0/jinja_govuk_template-0.16.0.tgz"
-  }
-}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,11 +23,11 @@ var gulp = require('gulp'),
 
 // Move GOV.UK template resources
 
-gulp.task('copy:govuk_template:template', () => gulp.src('bower_components/govuk_template/views/layouts/govuk_template.html')
+gulp.task('copy:govuk_template:template', () => gulp.src(paths.npm + '/govuk_template_jinja/views/layouts/govuk_template.html')
   .pipe(gulp.dest(paths.templates))
 );
 
-gulp.task('copy:govuk_template:assets', () => gulp.src('bower_components/govuk_template/assets/**/*')
+gulp.task('copy:govuk_template:assets', () => gulp.src(paths.npm + '/govuk_template_jinja/assets/**/*')
   .pipe(gulp.dest(paths.dist))
 );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "test": "gulp lint",
-    "postinstall": "./node_modules/bower/bin/bower install",
     "build": "gulp",
     "watch": "gulp watch"
   },
@@ -21,9 +20,9 @@
   "dependencies": {
     "babel-core": "6.3.26",
     "babel-preset-es2015": "6.3.13",
-    "bower": "1.7.1",
     "govuk-elements-sass": "1.1.1",
     "govuk_frontend_toolkit": "4.6.0",
+    "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.16.4/jinja_govuk_template-0.16.4.tgz",
     "gulp": "3.9.0",
     "gulp-add-src": "0.2.0",
     "gulp-babel": "6.1.1",


### PR DESCRIPTION
Since https://github.com/alphagov/govuk_template/pull/193 the Jinja version of the GOV.UK Template is published with a `package.json`. This means
- we can consume it via NPM
- so we can get rid of Bower :tada: 

Which is what this commit does.