### PR TITLE
Add flow for sending yourself a text message

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -36,7 +36,20 @@
   z-index: 50;
 }
 
-.sms-message-use-link {
-  @include bold-19;
-  margin-top: 70px;
+.sms-message-use-links {
+
+  @include copy-19;
+  margin-top: 55px;
+
+  a {
+
+    display: block;
+    margin-bottom: 5px;
+
+    &:first-child {
+      @include bold-19;
+    }
+
+  }
+
 }

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -48,7 +48,7 @@ def add_service_template(service_id):
 
     if form.validate_on_submit():
         tdao.insert_service_template(
-            form.name.data, form.template_content.data, service_id)
+            form.name.data, 'sms', form.template_content.data, service_id)
         return redirect(url_for(
             '.manage_service_templates', service_id=service_id))
     return render_template(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -48,7 +48,7 @@ def add_service_template(service_id):
 
     if form.validate_on_submit():
         tdao.insert_service_template(
-            form.name.data, 'sms', form.template_content.data, service_id)
+            form.name.data, form.template_content.data, service_id)
         return redirect(url_for(
             '.manage_service_templates', service_id=service_id))
     return render_template(

--- a/app/templates/views/choose-sms-template.html
+++ b/app/templates/views/choose-sms-template.html
@@ -20,8 +20,9 @@
             {{ sms_message(template.formatted_as_markup, name=template.name) }}
           </div>
           <div class="column-one-third">
-            <div class="sms-message-use-link">
-              <a href="{{ url_for(".send_sms", service_id=service_id, template_id=template.id) }}">Use this template</a>
+            <div class="sms-message-use-links">
+              <a href="{{ url_for(".send_sms", service_id=service_id, template_id=template.id) }}">Add recipients</a>
+              <a href="{{ url_for(".send_sms_to_self", service_id=service_id, template_id=template.id) }}">Send yourself a test</a>
             </div>
           </div>
         {% endfor %}

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -52,7 +52,7 @@
 
     {% call(item) list_table(
       [
-        {'row': 1, 'phone': '+447700 900995', 'template': template['name'], 'status': 'queued'}
+        {'row': 1, 'phone': '+447700 900995', 'template': template['name'], 'status': 'sent'}
       ],
       caption=uploaded_file_name,
       caption_visible=False,

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Send text messages</h1>
+  <h1 class="heading-large">Add recipients</h1>
 
   <form method="POST" enctype="multipart/form-data">
 

--- a/tests/app/main/views/test_sms.py
+++ b/tests/app/main/views/test_sms.py
@@ -70,6 +70,53 @@ def test_upload_csvfile_with_invalid_phone_shows_check_page_with_errors(app_,
 
 
 @moto.mock_s3
+def test_send_test_message_to_self(
+    app_,
+    mocker,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_get_service_template
+):
+
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            response = client.get(
+                url_for('main.send_sms_to_self', service_id=12345, template_id=54321),
+                follow_redirects=True
+            )
+        assert response.status_code == 200
+        content = response.get_data(as_text=True)
+        assert 'Test run' in content
+        assert '+4412341234' in content
+
+
+@moto.mock_s3
+def test_download_example_csv(
+    app_,
+    mocker,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_get_service_template
+):
+
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            response = client.get(
+                url_for('main.get_example_csv', service_id=12345, template_id=54321),
+                follow_redirects=True
+            )
+        assert response.status_code == 200
+        assert response.get_data(as_text=True) == 'phone\r\n+4412341234\r\n'
+        assert 'text/csv' in response.headers['Content-Type']
+
+
+@moto.mock_s3
 def test_upload_csvfile_with_valid_phone_shows_all_numbers(app_,
                                                            mocker,
                                                            api_user_active,


### PR DESCRIPTION
This commit adds a shortcut, which (in the background) does the creation and uploading of a CSV file for you.

This enables users to send themselves a test message without having to fiddle about with CSV files.

***

![image](https://cloud.githubusercontent.com/assets/355079/13117640/bdcfa0fe-d598-11e5-8eb5-a921ae26e799.png)

***

![image](https://cloud.githubusercontent.com/assets/355079/13117650/c92fdcca-d598-11e5-880d-a9966e568483.png)