### PR TITLE
Prefil placeholders

### DIFF
--- a/app/main/views/sms.py
+++ b/app/main/views/sms.py
@@ -70,19 +70,10 @@ def send_sms(service_id, template_id):
         templates_dao.get_service_template_or_404(service_id, template_id)['data']
     )
 
-    example_data = [dict(
-        phone=current_user.mobile_number,
-        **{
-            header: "test {}".format(header) for header in template.placeholders
-        }
-    )]
-
     return render_template(
         'views/send-sms.html',
         template=template,
         column_headers=['phone'] + template.placeholders_as_markup,
-        placeholders=template.placeholders,
-        example_data=example_data,
         form=form,
         service_id=service_id
     )

--- a/app/main/views/sms.py
+++ b/app/main/views/sms.py
@@ -104,10 +104,12 @@ def get_example_csv(service_id, template_id):
 @main.route("/services/<service_id>/sms/send/<template_id>/to-self", methods=['GET'])
 @login_required
 def send_sms_to_self(service_id, template_id):
+    template = templates_dao.get_service_template_or_404(service_id, template_id)['data']
+    placeholders = list(Template(template).placeholders)
     output = io.StringIO()
     writer = csv.writer(output)
-    writer.writerow(['phone'])
-    writer.writerow([current_user.mobile_number])
+    writer.writerow(['phone'] + placeholders)
+    writer.writerow([current_user.mobile_number] + ["test {}".format(header) for header in placeholders])
     filedata = {
         'file_name': 'Test run',
         'data': output.getvalue().splitlines()

--- a/app/templates/views/send-sms.html
+++ b/app/templates/views/send-sms.html
@@ -22,32 +22,14 @@
 
     {{file_upload(form.file, button_text='Choose a CSV file')}}
 
+    <p>
+      <a href="{{ url_for('.get_example_csv', service_id=service_id, template_id=template.id) }}">Download an example CSV file</a>
+    </p>
+
     {{ page_footer(
       "Continue to preview"
     ) }}
 
-    {% if column_headers %}
-      {% call(item) list_table(
-        example_data,
-        caption='Example',
-        field_headings=column_headers,
-        field_headings_visible=True,
-        caption_visible=True,
-        empty_message="Your data here"
-      ) %}
-        {% call field() %}
-          {{ item.phone }}
-        {% endcall %}
-        {% for column in template.placeholders %}
-          {% call field() %}
-            {{ item.get(column) }}
-          {% endcall %}
-        {% endfor %}
-      {% endcall %}
-    {% endif %}
-    <p class="table-show-more-link">
-      <a href="{{ url_for('.get_example_csv', service_id=service_id, template_id=template.id) }}">Download this CSV file</a>
-    </p>
 
   </form>
 {% endblock %}


### PR DESCRIPTION
## Prefill placeholders for test message

If you want to send yourself a test message from a template that has placeholders you can’t, at the moment.

Rather than forcing you to upload a CSV, we should prefil the data, and then you only need to upload a CSV if you want to customise it.

![image](https://cloud.githubusercontent.com/assets/355079/13152226/05f89020-d666-11e5-8138-753b30963acc.png)

## Remove the weird table from the send SMS page

It was weird.

Before | After 
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/13152261/38324ebe-d666-11e5-8aea-5e4ddf2377ba.png) | ![image](https://cloud.githubusercontent.com/assets/355079/13152240/112475f4-d666-11e5-90d5-f06e30f4599d.png)

