### PR TITLE
Updated the api_client call to send_verify_code

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -65,10 +65,8 @@ class UserApiClient(BaseAPIClient):
         return None
 
     def send_verify_code(self, user_id, code_type, to=None):
-        data = {'code_type': code_type}
-        if to:
-            data['to'] = to
-        endpoint = '/user/{}/code'.format(user_id)
+        data = {'to': to} if to else {}
+        endpoint = '/user/{0}/{1}-code'.format(user_id, code_type)
         resp = self.post(endpoint, data=data)
 
     def check_verify_code(self, user_id, code, code_type):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ credstash==1.8.0
 boto3==1.2.3
 Pygments==2.0.2
 
-git+https://github.com/alphagov/notifications-python-client.git@0.2.5#egg=notifications-python-client==0.2.5
+git+https://github.com/alphagov/notifications-python-client.git@0.2.5#egg=notifications-python-client==0.2.7
 
 git+https://github.com/alphagov/notifications-utils.git@0.1.0#egg=notifications-utils==0.1.0


### PR DESCRIPTION
The api has now has an user/<user_id>/email-code and user/<user_id>/sms-code
This commit requires the https://github.com/alphagov/notifications-api/pull/84 to be merge and deployed first.
This commit requires an update to the python-client. Make sure the PR for that version has been merged first and the tag push using scripts/push_tag.sh
