### PR TITLE
Get users for service

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -29,10 +29,11 @@ fake_users = [
 @main.route("/services/<service_id>/users")
 @login_required
 def manage_users(service_id):
+    users = user_api_client.get_users_for_service(service_id=service_id)
     return render_template(
         'views/manage-users.html',
         service_id=service_id,
-        users=fake_users,
+        users=users,
         current_user=current_user,
         invited_users=[]
     )

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -81,6 +81,11 @@ class UserApiClient(BaseAPIClient):
                     return False, 'Code not found'
             raise e
 
+    def get_users_for_service(self, service_id):
+        endpoint = '/service/{}/users'.format(service_id)
+        resp = self.get(endpoint)
+        return resp['data']
+
 
 class User(UserMixin):
     def __init__(self, fields, max_failed_login_count=3):

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -26,13 +26,13 @@ Manage users – GOV.UK Notify
     users, caption='Active', **table_options
   ) %}
     {% call field() %}
-      {{ current_user.name }}
+      {{ item.name }}
     {% endcall %}
     {{ boolean_field(item.permission_send_messages) }}
     {{ boolean_field(item.permission_manage_service) }}
     {{ boolean_field(item.permission_manage_api_keys) }}
     {% call field(align='right') %}
-      <a href="{{ url_for('.edit_user', service_id=service_id, user_id=0)}}">Change</a>
+      <a href="{{ url_for('.edit_user', service_id=service_id, user_id=item.id)}}">Change</a>
     {% endcall %}
   {% endcall %}
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -6,7 +6,8 @@ def test_should_show_overview_page(
     app_,
     api_user_active,
     mock_login,
-    mock_get_service
+    mock_get_service,
+    mock_get_users_by_service
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -35,7 +36,8 @@ def test_redirect_after_saving_user(
     app_,
     api_user_active,
     mock_login,
-    mock_get_service
+    mock_get_service,
+    mock_get_users_by_service
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -69,7 +71,8 @@ def test_invite_user(
     app_,
     api_user_active,
     mock_login,
-    mock_get_service
+    mock_get_service,
+    mock_get_users_by_service
 ):
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -16,6 +16,7 @@ def test_should_show_overview_page(
 
         assert 'Manage team' in response.get_data(as_text=True)
         assert response.status_code == 200
+        mock_get_users_by_service.assert_called_once_with(service_id='55555')
 
 
 def test_should_show_page_for_one_user(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -525,4 +525,4 @@ def mock_get_users_by_service(mocker):
                  'email_address': 'notify@digital.cabinet-office.gov.uk',
                  'failed_login_count': 0}]
         return data
-    return mocker.patch('app.user_api_client.get_users_for_service', side_effect=_get_users_for_service)
+    return mocker.patch('app.user_api_client.get_users_for_service', side_effect=_get_users_for_service, autospec=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -510,3 +510,19 @@ def mock_get_jobs(mocker):
             data.append(job_data)
         return {"data": data}
     return mocker.patch('app.job_api_client.get_job', side_effect=_get_jobs)
+
+
+@pytest.fixture(scope='function')
+def mock_get_users_by_service(mocker):
+    def _get_users_for_service(service_id):
+        data = [{'id': 1,
+                 'logged_in_at': None,
+                 'mobile_number': '+447700900986',
+                 'permissions': [],
+                 'state': 'active',
+                 'password_changed_at': None,
+                 'name': 'Test User',
+                 'email_address': 'notify@digital.cabinet-office.gov.uk',
+                 'failed_login_count': 0}]
+        return data
+    return mocker.patch('app.user_api_client.get_users_for_service', side_effect=_get_users_for_service)


### PR DESCRIPTION
- Get users for service to show on the manage team page.
- Calls api endpoint /service/<service_id>/users to retrieve all users associated with the service

https://www.pivotaltracker.com/story/show/114295337