### PR TITLE
Fix broken link on dashboard

### DIFF
--- a/app/templates/views/service_dashboard.html
+++ b/app/templates/views/service_dashboard.html
@@ -35,7 +35,7 @@
             </li>
           </ol>
         """.format(
-          url_for(".add_service_template", service_id=service_id),
+          url_for(".add_service_template", service_id=service_id, template_type="sms"),
           url_for(".choose_template", service_id=service_id, template_type="sms")
         )|safe,
         subhead='Get started',


### PR DESCRIPTION
The link in the yellow box for adding a template was missing the parameter specifying what type of template should be created.