### PR TITLE
Fix create SMS template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -31,7 +31,11 @@ def add_service_template(service_id, template_type):
 
     if form.validate_on_submit():
         tdao.insert_service_template(
-            form.name.data, template_type, form.template_content.data, service_id, form.subject.data or None
+            form.name.data,
+            template_type,
+            form.template_content.data,
+            service_id,
+            form.subject.data if hasattr(form, 'subject') else None
         )
         return redirect(
             url_for('.choose_template', service_id=service_id, template_type=template_type)

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -14,12 +14,8 @@
       <div class="grid-row">
         <div class="column-two-thirds">
           {{ textbox(form.name, width='1-1') }}
-          {% if 'email' == template_type %}
-            {{ textbox(form.subject, width='1-1') }}
-          {% endif %}
+          {{ textbox(form.subject, width='1-1') }}
         </div>
-      </div>
-      <div class="grid-row">
         <div class="column-two-thirds">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1') }}
         </div>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -14,12 +14,7 @@
       <div class="grid-row">
         <div class="column-two-thirds">
           {{ textbox(form.name, width='1-1') }}
-          {% if 'email' == template_type %}
-            {{ textbox(form.subject, width='1-1') }}
-          {% endif %}
         </div>
-      </div>
-      <div class="grid-row">
         <div class="column-two-thirds">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1') }}
         </div>


### PR DESCRIPTION
When creating an SMS template the form validation was looking for a subject.

SMS messages don’t have a subject.