### PR TITLE
Temporarily remove SASS linting

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -103,10 +103,11 @@ gulp.task('watchForChanges', function() {
 });
 
 gulp.task('lint:sass', () => gulp
-  .src(paths.src + 'stylesheets/**/*.scss')
-    .pipe(plugins.sassLint())
-    .pipe(plugins.sassLint.format(stylish))
-    .pipe(plugins.sassLint.failOnError())
+// Removed until gulp-sass-lint installs cleanly
+//  .src(paths.src + 'stylesheets/**/*.scss')
+//    .pipe(plugins.sassLint())
+//    .pipe(plugins.sassLint.format(stylish))
+//    .pipe(plugins.sassLint.failOnError())
 );
 
 gulp.task('lint:js', () => gulp

--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
     "gulp-base64": "0.1.3",
     "gulp-concat": "2.6.0",
     "gulp-include": "2.1.0",
-    "gulp-jquery": "1.1.1",
     "gulp-load-plugins": "1.1.0",
-    "gulp-sass": "2.1.1",
+    "gulp-sass": "2.2.0",
     "gulp-uglify": "1.5.1",
     "jquery": "1.11.2",
     "query-command-supported": "1.0.0"
@@ -39,7 +38,6 @@
   "devDependencies": {
     "gulp-css-url-adjuster": "0.2.3",
     "gulp-jshint": "2.0.0",
-    "gulp-sass-lint": "1.1.1",
     "jshint": "2.9.1",
     "jshint-stylish": "2.1.0"
   }


### PR DESCRIPTION
Trying to install gulp-sass-lint fails because some of its dependencies are not met:
> npm install gulp-sass-lint
> npm ERR! Darwin 15.3.0
> npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "gulp-sass-lint"
> npm ERR! node v5.7.0
> npm ERR! npm  v3.7.5
>
> npm ERR! No compatible version found: lodash.upperfirst@^3.0.0
> npm ERR! Valid install targets:
> npm ERR! 4.1.2, 4.1.1, 4.1.0, 4.0.2, 4.0.1, 4.0.0
> npm ERR!

This commit removes it until we can work out what the problem is.