### PR TITLE
Bring back SASS lint

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -103,11 +103,10 @@ gulp.task('watchForChanges', function() {
 });
 
 gulp.task('lint:sass', () => gulp
-// Removed until gulp-sass-lint installs cleanly
-//  .src(paths.src + 'stylesheets/**/*.scss')
-//    .pipe(plugins.sassLint())
-//    .pipe(plugins.sassLint.format(stylish))
-//    .pipe(plugins.sassLint.failOnError())
+  .src(paths.src + 'stylesheets/**/*.scss')
+    .pipe(plugins.sassLint())
+    .pipe(plugins.sassLint.format(stylish))
+    .pipe(plugins.sassLint.failOnError())
 );
 
 gulp.task('lint:js', () => gulp

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "gulp-css-url-adjuster": "0.2.3",
     "gulp-jshint": "2.0.0",
+    "gulp-sass-lint": "1.1.1",
     "jshint": "2.9.1",
     "jshint-stylish": "2.1.0"
   }


### PR DESCRIPTION
The problem with SASS lint that we found in https://github.com/alphagov/notifications-admin/pull/202 has been fixed (see https://github.com/sasstools/sass-lint/pull/550).

This commit reverts #202, re-enabling linting of SASS files.