### PR TITLE
Use correct API endpoint in docs

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -161,7 +161,7 @@
         <h2 class="heading-medium">API endpoint</h2>
 
         <p>
-            https://www.notify.works/api/endpoint
+            https://api.notify.works
         </p>
 
         <p>


### PR DESCRIPTION
This has confused people, should change it before the site visits next week.