### PR TITLE
Give users better guidance about CSV files

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -15,3 +15,7 @@
   margin-bottom: $gutter;
   clear: both;
 }
+
+.bottom-gutter-2-3 {
+  margin-bottom: $gutter * 2/3;
+}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -30,19 +30,25 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      {{ banner(
-        'You can upload real data, but we’ll only send to your mobile number until you <a href="{}">request to go live</a>'.format(
-          url_for('.service_request_to_go_live', service_id=service_id)
-        )|safe,
-        'info'
-      )}}
+      <p>
+        Add recipients by uploading a .csv file with
+        {{ template.placeholders|length + 1 }}
+        {% if template.placeholders %}
+          columns:
+        {% else %}
+          column:
+        {% endif %}
+      </p>
+      <p class="bottom-gutter-2-3">
+        <span class='placeholder'>to</span>
+        {{ template.placeholders_as_markup|join(" ") }}
+      </p>
+      <p>
+        <a href="{{ url_for('.get_example_csv', service_id=service_id, template_id=template.id) }}">Download an example</a>
+      </p>
     </div>
   </div>
 
-  {{file_upload(form.file, button_text='Upload a CSV file')}}
-
-  <p>
-    <a href="{{ url_for('.get_example_csv', service_id=service_id, template_id=template.id) }}">Download an example CSV file</a>
-  </p>
+  {{file_upload(form.file, button_text='Upload your CSV file')}}
 
 {% endblock %}


### PR DESCRIPTION
This commit adds some guidance on the ‘Add recipients’ page about what should be in the CSV file. The guidance is contextual to the template, and based on the problems that we saw users having in the lab on wednesday.

![image](https://cloud.githubusercontent.com/assets/355079/13358202/0122f9f0-dca6-11e5-933e-2709085b8dd1.png)
![image](https://cloud.githubusercontent.com/assets/355079/13358242/2f6bd7fa-dca6-11e5-8432-53602c7a820e.png)

At the moment, this uses ‘to’ as the recipient column. We should change this so that the column is called ‘mobile number’ for text messages and ‘email address’ for emails. This is a wider change though, so not in this pull request.