### PR TITLE
Put real data on job page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,6 +73,7 @@ def create_app(config_name, config_overrides=None):
 
     application.add_template_filter(nl2br)
     application.add_template_filter(format_datetime)
+    application.add_template_filter(format_time)
     application.add_template_filter(syntax_highlight_json)
     application.add_template_filter(valid_phone_number)
 
@@ -147,6 +148,12 @@ def format_datetime(date):
     date = dateutil.parser.parse(date)
     native = date.replace(tzinfo=None)
     return native.strftime('%A %d %B %Y at %H:%M')
+
+
+def format_time(date):
+    date = dateutil.parser.parse(date)
+    native = date.replace(tzinfo=None)
+    return native.strftime('%H:%M')
 
 
 def valid_phone_number(phone_number):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,7 @@ from app.notify_client.api_client import NotificationsAdminAPIClient
 from app.notify_client.api_key_api_client import ApiKeyApiClient
 from app.notify_client.user_api_client import UserApiClient
 from app.notify_client.job_api_client import JobApiClient
+from app.notify_client.notification_api_client import NotificationApiClient
 from app.notify_client.status_api_client import StatusApiClient
 from app.notify_client.permission_api_client import PermissionApiClient
 from app.notify_client.invite_api_client import InviteApiClient
@@ -31,6 +32,7 @@ notifications_api_client = NotificationsAdminAPIClient()
 user_api_client = UserApiClient()
 api_key_api_client = ApiKeyApiClient()
 job_api_client = JobApiClient()
+notification_api_client = NotificationApiClient()
 status_api_client = StatusApiClient()
 invite_api_client = InviteApiClient()
 asset_fingerprinter = AssetFingerprinter()
@@ -50,6 +52,7 @@ def create_app(config_name, config_overrides=None):
     user_api_client.init_app(application)
     api_key_api_client.init_app(application)
     job_api_client.init_app(application)
+    notification_api_client.init_app(application)
     status_api_client.init_app(application)
     permission_api_client.init_app(application)
     invite_api_client.init_app(application)

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -10,7 +10,7 @@ from flask_login import login_required
 from notifications_python_client.errors import HTTPError
 from utils.template import Template
 
-from app import job_api_client
+from app import job_api_client, notification_api_client
 from app.main import main
 from app.main.dao import templates_dao
 from app.main.dao import services_dao
@@ -41,18 +41,14 @@ def view_job(service_id, job_id):
     service = services_dao.get_service_by_id_or_404(service_id)
     try:
         job = job_api_client.get_job(service_id, job_id)['data']
-        messages = []
+        notifications = notification_api_client.get_notifications_for_service(service_id, job_id)
         return render_template(
             'views/job.html',
-            messages=messages,
+            notifications=notifications['notifications'],
             counts={
-                'total': len(messages),
-                'delivered': len([
-                    message for message in messages if message['status'] == 'Delivered'
-                ]),
-                'failed': len([
-                    message for message in messages if message['status'] == 'Failed'
-                ])
+                'total': len(notifications),
+                'delivered': len(notifications),
+                'failed': 0
             },
             cost=u'£0.00',
             uploaded_file_name=job['original_file_name'],

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -1,0 +1,37 @@
+from notifications_python_client.base import BaseAPIClient
+
+
+class NotificationApiClient(BaseAPIClient):
+    def __init__(self, base_url=None, client_id=None, secret=None):
+        super(self.__class__, self).__init__(base_url=base_url or 'base_url',
+                                             client_id=client_id or 'client_id',
+                                             secret=secret or 'secret')
+
+    def init_app(self, app):
+        self.base_url = app.config['API_HOST_NAME']
+        self.client_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.secret = app.config['ADMIN_CLIENT_SECRET']
+
+    def get_all_notifications(self, page=None):
+        params = {}
+        if page is not None:
+            params['page'] = page
+        return self.get(
+            url='/notifications',
+            params=params
+        )
+
+    def get_notifications_for_service(self, service_id, job_id=None, page=None):
+        params = {}
+        if page is not None:
+            params['page'] = page
+        if job_id:
+            return self.get(
+                url='/service/{}/job/{}/notifications'.format(service_id, job_id),
+                params=params
+            )
+        else:
+            return self.get(
+                url='/service/{}/notifications'.format(service_id),
+                params=params
+            )

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -28,23 +28,29 @@
         template.subject,
         template,
         from_address='{}@notifications.service.gov.uk'.format(service.email_from),
-        from_name=service.name
+        from_name=from_name
       )}}
     {% endif %}
 
-    <p class='heading-small'>
-      Started {{ uploaded_file_time|format_datetime }}
-    </p>
+    {% if finished_at %}
+      <p class='heading-small'>
+        Finished {{ finished_at|format_datetime }}
+      </p>
+    {% else %}
+      <p class='heading-small'>
+        Started {{ uploaded_at|format_datetime }}
+      </p>
+    {% endif %}
 
     <ul class="grid-row job-totals">
       <li class="column-one-quarter">
         {{ big_number(
-          0, 'queued'
+          counts.queued, 'queued'
         )}}
       </li>
       <li class="column-one-quarter">
         {{ big_number(
-          1, 'sent'
+          counts.sent, 'sent'
         )}}
       </li>
       <li class="column-one-quarter">
@@ -60,26 +66,32 @@
       </li>
     </ul>
 
-    {% call(item) list_table(
-      notifications,
-      caption=uploaded_file_name,
-      caption_visible=False,
-      empty_message="Messages go here",
-      field_headings=[
-        'Recipient',
-        'Template',
-        right_aligned_field_heading('Status')
-      ]
-    ) %}
-      {% call field() %}
-        {{ item.to }}
-      {% endcall %}
-      {% call field(
-        align='right',
-        status='error' if item.status == 'Failed' else 'default'
+
+    {% if notifications %}
+      {% call(item) list_table(
+        notifications,
+        caption=uploaded_file_name,
+        caption_visible=False,
+        empty_message="Messages go here",
+        field_headings=[
+          'Recipient',
+          right_aligned_field_heading('Status')
+        ]
       ) %}
-        {{ item.status }}
+        {% call field() %}
+          {{ item.to }}
+        {% endcall %}
+        {% call field(
+          align='right',
+          status='error' if item.status == 'Failed' else 'default'
+        ) %}
+          {{ item.status|title }} at {{ item.sent_at|format_time }}
+        {% endcall %}
       {% endcall %}
-    {% endcall %}
+    {% else %}
+      <p>
+        <a href="{{ url_for(".view_job", service_id=service_id, job_id=job_id) }}">Refresh</a>
+      </p>
+    {% endif %}
 
 {% endblock %}

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -61,24 +61,18 @@
     </ul>
 
     {% call(item) list_table(
-      [
-        {'row': 1, 'phone': '+447700 900995', 'template': template['name'], 'status': 'sent'}
-      ],
+      notifications,
       caption=uploaded_file_name,
       caption_visible=False,
       empty_message="Messages go here",
       field_headings=[
-        'Row',
         'Recipient',
         'Template',
         right_aligned_field_heading('Status')
       ]
     ) %}
       {% call field() %}
-        {{ item.row }}.
-      {% endcall %}
-      {% call field() %}
-        {{item.phone[:3]}} •••• ••••••
+        {{ item.to }}
       {% endcall %}
       {% call field() %}
         {{item.template}}

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -19,7 +19,7 @@
       <div class="grid-row">
         <div class="column-two-thirds">
           {{ sms_message(
-            template,
+            template.formatted_as_markup,
           )}}
         </div>
       </div>

--- a/app/templates/views/job.html
+++ b/app/templates/views/job.html
@@ -74,9 +74,6 @@
       {% call field() %}
         {{ item.to }}
       {% endcall %}
-      {% call field() %}
-        {{item.template}}
-      {% endcall %}
       {% call field(
         align='right',
         status='error' if item.status == 'Failed' else 'default'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -109,6 +109,18 @@ def job_json():
         'bucket_name': 'service-1-{}-notify'.format(job_id),
         'file_name': '{}.csv'.format(job_id),
         'created_at': created_at,
-        'notification_count': 1
+        'notification_count': 1,
+        'status': ''
         }
+    return data
+
+
+def notification_json():
+    import datetime
+    data = {
+        'notifications': [{
+            'sent_at': str(datetime.datetime.now().time())
+        } for i in range(5)],
+        'links': {}
+    }
     return data

--- a/tests/app/main/notify_client/test_notification_client.py
+++ b/tests/app/main/notify_client/test_notification_client.py
@@ -1,0 +1,41 @@
+import pytest
+from app.notify_client.notification_api_client import NotificationApiClient
+
+
+def test_client_gets_notifications(mocker):
+
+    mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
+    NotificationApiClient().get_all_notifications()
+    mock_get.assert_called_once_with(url='/notifications', params={})
+
+
+def test_client_gets_notifications_with_page(mocker):
+
+    mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
+    NotificationApiClient().get_all_notifications(page=99)
+    mock_get.assert_called_once_with(url='/notifications', params={'page': 99})
+
+
+@pytest.mark.parametrize("arguments,expected_call", [
+    (
+        {},
+        {'url': '/service/abcd1234/notifications', 'params': {}}
+    ),
+    (
+        {'page': 99},
+        {'url': '/service/abcd1234/notifications', 'params': {'page': 99}}
+    ),
+    (
+        {'job_id': 'efgh5678'},
+        {'url': '/service/abcd1234/job/efgh5678/notifications', 'params': {}}
+    ),
+    (
+        {'job_id': 'efgh5678', 'page': 48},
+        {'url': '/service/abcd1234/job/efgh5678/notifications', 'params': {'page': 48}}
+    )
+])
+def test_client_gets_notifications_for_service_and_job_by_page(mocker, arguments, expected_call):
+
+    mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
+    NotificationApiClient().get_notifications_for_service('abcd1234', **arguments)
+    mock_get.assert_called_once_with(**expected_call)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -41,4 +41,6 @@ def test_should_show_page_for_one_job(app_,
             response = client.get(url_for('main.view_job', service_id=service_id, job_id=job_id))
 
         assert response.status_code == 200
-        assert file_name in response.get_data(as_text=True)
+        content = response.get_data(as_text=True)
+        assert "Test Service: Your vehicle tax is about to expire" in content
+        assert file_name in content

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -30,7 +30,8 @@ def test_should_show_page_for_one_job(app_,
                                       mock_get_service,
                                       mock_get_service_template,
                                       job_data,
-                                      mock_get_job):
+                                      mock_get_job,
+                                      mock_get_notifications):
     service_id = job_data['service']
     job_id = job_data['id']
     file_name = job_data['original_file_name']

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -242,6 +242,7 @@ def test_create_job_should_call_api(
     job_data,
     mock_create_job,
     mock_get_job,
+    mock_get_notifications,
     mock_get_service,
     mock_get_service_template,
     mock_has_permissions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from . import (
     template_json,
     api_key_json,
     job_json,
+    notification_json,
     invite_json
 )
 from app.notify_client.models import (
@@ -539,6 +540,16 @@ def mock_get_jobs(mocker):
             data.append(job_data)
         return {"data": data}
     return mocker.patch('app.job_api_client.get_job', side_effect=_get_jobs)
+
+
+@pytest.fixture(scope='function')
+def mock_get_notifications(mocker):
+    def _get_notifications(service_id, job_id):
+        return notification_json()
+    return mocker.patch(
+        'app.notification_api_client.get_notifications_for_service',
+        side_effect=_get_notifications
+    )
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Make the template preview work

The template was displaying raw, eg ‘Hello ((name))’

This commit changes it to use the `.formatted_as_markup` property so the template is rendered with:
- the placeholders as blue lozenges
- the service name prefixing the message

## Add API client for notifications and put real notifications on job page

Adds an API client for the notifications endpoints added in: alphagov/notifications-api#113

## Remove ‘template’ column from notifications table

As one of our user research participants pointed out, this column is redundant because we’re showing the template on the page already.

## Put data from job on job page

The main change is showing the finished time if the job is finished, rather than the start time.

