### PR TITLE
Forgot password

### DIFF
--- a/app/main/dao/users_dao.py
+++ b/app/main/dao/users_dao.py
@@ -64,11 +64,6 @@ def is_email_unique(email_address):
             raise ex
 
 
-def request_password_reset(user):
-    user.state = 'request_password_reset'
-    user_api_client.update_user(user)
-
-
 def send_verify_code(user_id, code_type, to):
     return user_api_client.send_verify_code(user_id, code_type, to)
 

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -1,25 +1,22 @@
 from flask import (
     render_template,
-    flash
 )
+from notifications_python_client.errors import HTTPError
 
 from app.main import main
-from app.main.dao import users_dao
 from app.main.forms import ForgotPasswordForm
-from app.notify_client.sender import send_change_password_email
+from app import user_api_client
 
 
 @main.route('/forgot-password', methods=['GET', 'POST'])
 def forgot_password():
-
     form = ForgotPasswordForm()
     if form.validate_on_submit():
-        if not users_dao.is_email_unique(form.email_address.data):
-            user = users_dao.get_user_by_email(form.email_address.data)
-            users_dao.request_password_reset(user)
-            send_change_password_email(form.email_address.data)
-            return render_template('views/password-reset-sent.html')
-        else:
-            return render_template('views/password-reset-sent.html')
+        try:
+            user_api_client.send_reset_password_url(form.email_address.data)
+        except HTTPError as e:
+            if e.status_code != 404:
+                raise e
+        return render_template('views/password-reset-sent.html')
 
     return render_template('views/forgot-password.html', form=form)

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -1,22 +1,33 @@
-from flask import (render_template, url_for, redirect, flash, session)
+import json
+
+from flask import (render_template, url_for, redirect, flash, session, current_app, abort)
+from itsdangerous import SignatureExpired
 
 from app.main import main
 from app.main.dao import users_dao
 from app.main.forms import NewPasswordForm
-from app.notify_client.sender import check_token
+from datetime import datetime
 
 
 @main.route('/new-password/<path:token>', methods=['GET', 'POST'])
 def new_password(token):
-    email_address = check_token(token)
-    if not email_address:
+    from utils.url_safe_token import check_token
+    try:
+        token_data = check_token(token, current_app.config['SECRET_KEY'], current_app.config['DANGEROUS_SALT'],
+                                 current_app.config['TOKEN_MAX_AGE_SECONDS'])
+    except SignatureExpired:
         flash('The link in the email we sent you has expired. Enter your email address to resend.')
         return redirect(url_for('.forgot_password'))
 
+    email_address = json.loads(token_data)['email']
     user = users_dao.get_user_by_email(email_address=email_address)
-    if user and user.state != 'request_password_reset':
-        flash('The link in the email we sent you has already been used.')
-        return redirect(url_for('.index'))
+    # TODO: what should this be??
+    if not user:
+        abort(404, 'user not found')
+    if user.password_changed_at and datetime.strptime(user.password_changed_at, '%Y-%m-%d %H:%M:%S.%f') > \
+            datetime.strptime(json.loads(token_data)['created_at'], '%Y-%m-%d %H:%M:%S.%f'):
+        flash('The link in the email has already been used')
+        return redirect(url_for('main.index'))
 
     form = NewPasswordForm()
 
@@ -26,7 +37,6 @@ def new_password(token):
             'id': user.id,
             'email': user.email_address,
             'password': form.new_password.data}
-        users_dao.activate_user(user)
         return redirect(url_for('main.two_factor'))
     else:
         return render_template('views/new-password.html', token=token, form=form, user=user)

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -1,6 +1,6 @@
 
 from flask import (
-    render_template, redirect, jsonify, session, url_for)
+    render_template, redirect, session, url_for)
 
 from flask_login import login_user
 
@@ -33,7 +33,7 @@ def two_factor():
             login_user(user, remember=form.remember_me.data if form.remember_me.data else False)
         finally:
             del session['user_details']
-        if (len(services) == 1):
+        if len(services) == 1:
             return redirect(url_for('main.service_dashboard', service_id=services[0]['id']))
         else:
             return redirect(url_for('main.choose_service'))

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -102,4 +102,9 @@ class UserApiClient(BaseAPIClient):
     def set_user_permissions(self, user_id, service_id, permissions):
         data = [{'permission': x} for x in permissions]
         endpoint = '/user/{}/service/{}/permission'.format(user_id, service_id)
-        resp = self.post(endpoint, data=data)
+        self.post(endpoint, data=data)
+
+    def send_reset_password_url(self, email_address):
+        endpoint = '/user/reset-password'
+        data = {'email': email_address}
+        self.post(endpoint, data=data)

--- a/config.py
+++ b/config.py
@@ -39,9 +39,9 @@ class Config(object):
     ADMIN_CLIENT_SECRET = os.getenv('ADMIN_CLIENT_SECRET')
 
     WTF_CSRF_ENABLED = True
-    SECRET_KEY = 'secret-key'
+    SECRET_KEY = 'dev-notify-secret-key'
     HTTP_PROTOCOL = 'http'
-    DANGEROUS_SALT = 'itsdangeroussalt'
+    DANGEROUS_SALT = 'dev-notify-salt'
     TOKEN_MAX_AGE_SECONDS = 3600
 
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10mb

--- a/config.py
+++ b/config.py
@@ -39,9 +39,9 @@ class Config(object):
     ADMIN_CLIENT_SECRET = os.getenv('ADMIN_CLIENT_SECRET')
 
     WTF_CSRF_ENABLED = True
-    SECRET_KEY = 'dev-notify-secret-key'
+    SECRET_KEY = 'secret-key'
     HTTP_PROTOCOL = 'http'
-    DANGEROUS_SALT = 'dev-notify-salt'
+    DANGEROUS_SALT = 'itsdangeroussalt'
     TOKEN_MAX_AGE_SECONDS = 3600
 
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10mb

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -9,13 +9,10 @@ def test_should_render_forgot_password(app_):
                in response.get_data(as_text=True)
 
 
-def test_should_redirect_to_password_reset_sent_and_state_updated(
-    app_,
-    api_user_active,
-    mock_get_user_by_email,
-    mock_update_user,
-    mock_send_email
-):
+def test_should_redirect_to_password_reset_sent_for_valid_email(
+        app_,
+        api_user_active,
+        mock_reset_user_password):
     with app_.test_request_context():
         response = app_.test_client().post(
             url_for('.forgot_password'),
@@ -24,23 +21,4 @@ def test_should_redirect_to_password_reset_sent_and_state_updated(
         assert (
             'You have been sent an email containing a link'
             ' to reset your password.') in response.get_data(as_text=True)
-        assert mock_send_email.call_count == 1
-
-
-def test_should_redirect_to_password_reset_sent_for_non_existant_email_address(
-    app_,
-    api_user_active,
-    mock_dont_get_user_by_email,
-    mock_update_user,
-    mock_send_email
-):
-    with app_.test_request_context():
-        response = app_.test_client().post(
-            url_for('.forgot_password'),
-            data={'email_address': 'nope@example.gov.uk'})
-        assert response.status_code == 200
-        assert (
-            'You have been sent an email containing a link'
-            ' to reset your password.') in response.get_data(as_text=True)
-        mock_dont_get_user_by_email.assert_called_once_with('nope@example.gov.uk')
-        assert not mock_send_email.called
+        mock_reset_user_password.assert_called_once_with(api_user_active.email_address)

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -1,5 +1,7 @@
 from flask import url_for
 
+import app
+
 
 def test_should_render_forgot_password(app_):
     with app_.test_request_context():
@@ -12,8 +14,9 @@ def test_should_render_forgot_password(app_):
 def test_should_redirect_to_password_reset_sent_for_valid_email(
         app_,
         api_user_active,
-        mock_reset_user_password):
+        mocker):
     with app_.test_request_context():
+        mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
         response = app_.test_client().post(
             url_for('.forgot_password'),
             data={'email_address': api_user_active.email_address})
@@ -21,4 +24,4 @@ def test_should_redirect_to_password_reset_sent_for_valid_email(
         assert (
             'You have been sent an email containing a link'
             ' to reset your password.') in response.get_data(as_text=True)
-        mock_reset_user_password.assert_called_once_with(api_user_active.email_address)
+        app.user_api_client.send_reset_password_url.assert_called_once_with(api_user_active.email_address)

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from flask import url_for
 from utils.url_safe_token import generate_token
-import pytest
 
 
 def test_should_render_new_password_template(app_,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -1,4 +1,5 @@
 from flask import url_for
+from tests.conftest import SERVICE_ONE_ID
 
 
 def test_should_render_two_factor_page(app_,
@@ -31,11 +32,10 @@ def test_should_login_user_and_redirect_to_service_dashboard(app_,
                     'email': api_user_active.email_address}
             response = client.post(url_for('main.two_factor'),
                                    data={'sms_code': '12345'})
-
             assert response.status_code == 302
             assert response.location == url_for(
                 'main.service_dashboard',
-                service_id="596364a0-858e-42c8-9062-a8fe822260eb",
+                service_id=SERVICE_ONE_ID,
                 _external=True
             )
 
@@ -125,11 +125,10 @@ def test_two_factor_should_set_password_when_new_password_exists_in_session(app_
 
             response = client.post(url_for('main.two_factor'),
                                    data={'sms_code': '12345'})
-
             assert response.status_code == 302
             assert response.location == url_for(
                 'main.service_dashboard',
-                service_id="596364a0-858e-42c8-9062-a8fe822260eb",
+                service_id=SERVICE_ONE_ID,
                 _external=True
             )
             api_user_active.password = 'changedpassword'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,17 +90,20 @@ def mock_update_service(mocker):
         'app.notifications_api_client.update_service', side_effect=_update)
 
 
+SERVICE_ONE_ID = "596364a0-858e-42c8-9062-a8fe822260eb"
+SERVICE_TWO_ID = "147ad62a-2951-4fa1-9ca0-093cd1a52c52"
+
+
 @pytest.fixture(scope='function')
 def mock_get_services(mocker, user=None):
     if user is None:
         user = api_user_active()
 
     def _create(user_id=None):
-        import uuid
         service_one = service_json(
-            "596364a0-858e-42c8-9062-a8fe822260eb", "service_one", [user.id], 1000, True, False)
+            SERVICE_ONE_ID, "service_one", [user.id], 1000, True, False)
         service_two = service_json(
-            "147ad62a-2951-4fa1-9ca0-093cd1a52c52", "service_two", [user.id], 1000, True, False)
+            SERVICE_TWO_ID, "service_two", [user.id], 1000, True, False)
         return {'data': [service_one, service_two]}
 
     return mocker.patch(
@@ -113,9 +116,8 @@ def mock_get_services_with_one_service(mocker, user=None):
         user = api_user_active()
 
     def _create(user_id=None):
-        import uuid
         return {'data': [service_json(
-            "596364a0-858e-42c8-9062-a8fe822260eb", "service_one", [user.id], 1000, True, False
+            SERVICE_ONE_ID, "service_one", [user.id], 1000, True, False
         )]}
 
     return mocker.patch(
@@ -669,8 +671,3 @@ def mock_add_user_to_service(mocker, service_one, api_user_active):
 @pytest.fixture(scope='function')
 def mock_set_user_permissions(mocker):
     return mocker.patch('app.user_api_client.set_user_permissions', return_value=None)
-
-
-@pytest.fixture(scope='function')
-def mock_reset_user_password(mocker):
-    return mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)


### PR DESCRIPTION
story: https://www.pivotaltracker.com/story/show/114940405

The password reset functionality was broken when the notifications-python-client stopped taking content as an option in the send_email method. The forgot-password endpoint will call the newly created /user/reset-password api endpoint to send an email contain the forgot password url. Updates to new-password were also required to make this work. 
