### PR TITLE
Revert the disabled email field on the register-invited-user page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -104,7 +104,7 @@ class RegisterUserFromInviteForm(Form):
     mobile_number = mobile_number()
     password = password()
     service = HiddenField('service')
-    email_address = email_address()
+    email_address = HiddenField('email_address')
 
 
 class InviteUserForm(Form):

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -12,12 +12,12 @@ Create an account – GOV.UK Notify
   <div class="column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     <form method="post" autocomplete="nope">
-      {{ textbox(form.email_address, width='3-4', disabled=True ) }}
       {{ textbox(form.name, width='3-4') }}
       {{ textbox(form.mobile_number, width='3-4') }}
       {{ textbox(form.password, hint="Your password must have at least 10 characters", width='3-4') }}
       {{ page_footer("Continue") }}
       {{form.service}}
+      {{form.email_address}}
     </form>
   </div>
 </div>

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -101,13 +101,13 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(app_,
             assert page.h1.string.strip() == 'Create an account'
 
             form = page.find('form')
-            email = form.find('input', id='email_address')
             name = form.find('input', id='name')
             password = form.find('input', id='password')
             service = form.find('input', type='hidden', id='service')
+            email = form.find('input', type='hidden', id='email_address')
 
             assert email
-            assert email.attrs['disabled']
+            assert email.attrs['value'] == 'invited_user@test.gov.uk'
             assert name
             assert password
             assert service


### PR DESCRIPTION
The email address is not being submitted on the form when registering causing the registration to fail