### PR TITLE
Email flow fixes

### DIFF
--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -17,6 +17,7 @@
       @include core-19;
       border-bottom: 0;
       border-top: 1px solid $border-colour;
+      vertical-align: top;
     }
 
     th {

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -40,6 +40,7 @@ def view_job(service_id, job_id):
     service = services_dao.get_service_by_id_or_404(service_id)
     try:
         job = job_api_client.get_job(service_id, job_id)['data']
+        template = templates_dao.get_service_template_or_404(service_id, job['template'])['data']
         notifications = notification_api_client.get_notifications_for_service(service_id, job_id)
         finished = job['status'] == 'finished'
         return render_template(
@@ -55,11 +56,11 @@ def view_job(service_id, job_id):
             finished_at=job['updated_at'] if finished else None,
             uploaded_file_name=job['original_file_name'],
             template=Template(
-                templates_dao.get_service_template_or_404(service_id, job['template'])['data'],
-                prefix=service['name']
+                template,
+                prefix=service['name'] if template['template_type'] == 'sms' else ''
             ),
             service_id=service_id,
-            from_name=service['name'],
+            service=service,
             job_id=job_id
         )
     except HTTPError as e:

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -203,12 +203,14 @@ def check_messages(service_id, upload_id):
     if not contents:
         flash('There was a problem reading your upload file')
 
+    template = templates_dao.get_service_template_or_404(
+        service_id,
+        session['upload_data'].get('template_id')
+    )['data']
+
     template = Template(
-        templates_dao.get_service_template_or_404(
-            service_id,
-            session['upload_data'].get('template_id')
-        )['data'],
-        prefix=service['name']
+        template,
+        prefix=service['name'] if template['template_type'] == 'sms' else ''
     )
 
     recipients = RecipientCSV(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -43,6 +43,19 @@ manage_templates_page_headings = {
 }
 
 
+def get_send_button_text(template_type, number_of_messages):
+    if 1 == number_of_messages:
+        return {
+            'email': 'Send 1 email',
+            'sms': 'Send 1 text message'
+        }[template_type]
+    else:
+        return {
+            'email': 'Send {} emails',
+            'sms': 'Send {} text messages'
+        }[template_type].format(number_of_messages)
+
+
 def get_page_headings(template_type):
     # User has manage_service role
     if current_user.has_permissions(['send_texts', 'send_emails', 'send_letters']):
@@ -235,6 +248,7 @@ def check_messages(service_id, upload_id):
         count_of_recipients=session['upload_data']['notification_count'],
         count_of_displayed_recipients=len(list(recipients.rows_annotated_and_truncated)),
         original_file_name=session['upload_data'].get('original_file_name'),
+        send_button_text=get_send_button_text(template.template_type, session['upload_data']['notification_count']),
         service_id=service_id,
         service=service,
         form=CsvUploadForm()

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -66,7 +66,7 @@
   {% else %}
     <form method="post" enctype="multipart/form-data">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <input type="submit" class="button" value="{{ "Send {} message{}".format(count_of_recipients, '' if count_of_recipients == 1 else 's') }}" />
+      <input type="submit" class="button" value="{{ send_button_text }}" />
       <a href="{{url_for('.send_messages', service_id=service_id, template_id=template.id)}}" class="page-footer-back-link">Back</a>
     </form>
   {% endif %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -24,9 +24,9 @@
     {% elif 'email' == template.template_type %}
       {{ email_message(
         template.subject,
-        template,
+        template.formatted_as_markup,
         from_address='{}@notifications.service.gov.uk'.format(service.email_from),
-        from_name=from_name
+        from_name=service.name
       )}}
     {% endif %}
 


### PR DESCRIPTION
## Fix bug which prevented viewing an email job

![image](https://cloud.githubusercontent.com/assets/355079/13635321/edddfec0-e5f2-11e5-8caa-d8f84612426e.png)

The template for viewing a job was not getting all the variables it needed in order to display an email template. Hadn’t noticed this before, because email templates require more variables than SMS templates.

This commit fixes that bug.

## Make text of ‘send’ button say ‘email’ or ‘text…’

![image](https://cloud.githubusercontent.com/assets/355079/13635313/e06205f2-e5f2-11e5-9302-ed42a39b0602.png)

Previously the send button on the ‘Check and confirm’ page always said ‘Send x messages’, irrespective of whether you were sending emails or text messages.

This commit makes it say one of
- Send 1 email
- Send 29 emails
- Send 1 text message
- Send 999 text messages

***

[#115326437](https://www.pivotaltracker.com/story/show/115326437)