### PR TITLE
Fix for duplicate email registration

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -35,6 +35,7 @@ def register():
             return redirect(url_for('main.verify'))
         else:
             flash('There was an error registering your account')
+            return render_template('views/register.html', form=form), 400
 
     return render_template('views/register.html', form=form)
 

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -30,9 +30,13 @@ def register():
 
     form = RegisterUserForm()
     if form.validate_on_submit():
-        return _do_registration(form)
-    else:
-        return render_template('views/register.html', form=form)
+        registered = _do_registration(form)
+        if registered:
+            return redirect(url_for('main.verify'))
+        else:
+            flash('There was an error registering your account')
+
+    return render_template('views/register.html', form=form)
 
 
 @main.route('/register-from-invite', methods=['GET', 'POST'])
@@ -46,7 +50,11 @@ def register_from_invite():
     if form.validate_on_submit():
         if form.service.data != invited_user['service'] or form.email_address.data != invited_user['email_address']:
             abort(400)
-        return _do_registration(form)
+        registered = _do_registration(form)
+        if registered:
+            return redirect(url_for('main.verify'))
+        else:
+            flash('There was an error registering your account')
 
     form.service.data = invited_user['service']
     form.email_address.data = invited_user['email_address']
@@ -77,6 +85,6 @@ def _do_registration(form, service=None):
         users_dao.send_verify_code(user.id, 'email', user.email_address)
         session['expiry_date'] = str(datetime.now() + timedelta(hours=1))
         session['user_details'] = {"email": user.email_address, "id": user.id}
-        return redirect(url_for('main.verify'))
+        return True
     else:
-        flash('There was an error registering your account')
+        return False

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -122,7 +122,7 @@ def test_register_with_existing_email_returns_error(app_,
     with app_.test_request_context():
         response = app_.test_client().post(url_for('main.register'),
                                            data=user_data)
-        assert response.status_code == 200
+        assert response.status_code == 400
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
         element = page.find('h1')
         assert element.text == 'Create an account'


### PR DESCRIPTION
 That front end got stack trace and not flash error as expected.

The error message does not specify the error is a duplicate email
address so as not to reveal which emails are current user accounts.