### PR TITLE
Fix bug with ‘ghost’ links in template textbox

### DIFF
--- a/app/assets/javascripts/highlightTags.js
+++ b/app/assets/javascripts/highlightTags.js
@@ -33,7 +33,7 @@
     };
 
     this.update = () => this.$backgroundMaskForeground.html(
-      this.$textbox.val().replace(
+      $('<div/>').text(this.$textbox.val()).html().replace(
         tagPattern, match => `<span class='tag'>${match}</span>`
       )
     );


### PR DESCRIPTION
This is a bug with the code that highlights placeholders.

It was:

1. taking the value of the textbox
2. copying it straight into the HTML of the layer that contains the blue lozenges

This meant that any HTML that the user typed into the textbox was rendered by the browser.

This commit fixes the bug by:

1. taking the contents of the textbox
2. copying it to the _text_ (not inner HTML) of a temporary `<div>`
3. taking the inner HTML of that `<div>` (whose text has been encoded with HTML entities in step 2., eg `>` becomes `&gt;`)
4. using that for the HTML content of the layer with the blue lozenges

Before | After
--- | ---
<img width="446" alt="screen shot 2016-03-09 at 16 52 11" src="https://cloud.githubusercontent.com/assets/355079/13643644/c48d47ac-e619-11e5-9b21-043c5b603c89.png"> | <img width="450" alt="screen shot 2016-03-09 at 16 52 46" src="https://cloud.githubusercontent.com/assets/355079/13643655/ca99686a-e619-11e5-997a-bc986e509a51.png">
