### PR TITLE
Added error message if no permissions chosen

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -98,13 +98,26 @@ class RegisterUserFromInviteForm(Form):
     email_address = HiddenField('email_address')
 
 
+# WTF forms does not give a handy way to customise error messages for
+# radio button fields so just overriding the default here for use
+# in permissions form.
+class CustomRadioField(RadioField):
+
+    def pre_validate(self, form):
+        for v, _ in self.choices:
+            if self.data == v:
+                break
+        else:
+            raise ValueError(self.gettext('Choose yes or no'))
+
+
 class PermisisonsForm(Form):
 
     # TODO fix this Radio field so we are not having to test for yes or no rather
     # use operator equality.
-    send_messages = RadioField("Send messages", choices=[('yes', 'yes'), ('no', 'no')])
-    manage_service = RadioField("Manage service", choices=[('yes', 'yes'), ('no', 'no')])
-    manage_api_keys = RadioField("Manage API keys", choices=[('yes', 'yes'), ('no', 'no')])
+    send_messages = CustomRadioField("Send messages", choices=[('yes', 'yes'), ('no', 'no')])
+    manage_service = CustomRadioField("Manage service", choices=[('yes', 'yes'), ('no', 'no')])
+    manage_api_keys = CustomRadioField("Manage API keys", choices=[('yes', 'yes'), ('no', 'no')])
 
 
 class InviteUserForm(PermisisonsForm):

--- a/app/main/views/styleguide.py
+++ b/app/main/views/styleguide.py
@@ -1,6 +1,7 @@
 from flask import render_template, current_app, abort
 from flask_wtf import Form
 from wtforms import StringField, PasswordField, TextAreaField, FileField, validators
+from app.main.forms import CustomRadioField
 from utils.template import Template
 from app.main import main
 
@@ -17,11 +18,14 @@ def styleguide():
         code = StringField('Enter code')
         message = TextAreaField(u'Message')
         file_upload = FileField('Upload a CSV file to add your recipients’ details')
+        manage_service = CustomRadioField('Manage service', choices=[('yes', 'yes'), ('no', 'no')])
+        manage_templates = CustomRadioField('Manage templates', choices=[('yes', 'yes'), ('no', 'no')])
 
     sms = "Your vehicle tax for ((registration number)) is due on ((date)). Renew online at www.gov.uk/vehicle-tax"
 
     form = FormExamples()
     form.message.data = sms
+    form.manage_service.data = 'yes'
     form.validate()
 
     template = Template({'content': sms})

--- a/app/templates/components/yes-no.html
+++ b/app/templates/components/yes-no.html
@@ -1,15 +1,20 @@
-{% macro yes_no(name, label, current_value=None) %}
-  <fieldset class='yes-no'>
+{% macro yes_no(field, current_value=None) %}
+  <fieldset class='yes-no {% if field.errors %} error{% endif %}'>
     <legend class='yes-no-label'>
-      {{ label }}
+      {{ field.label }}
+       {% if field.errors %}
+        <span class="error-message">
+          {{ field.errors[0] }}
+        </span>
+      {% endif %}
     </legend>
     <div class='yes-no-fields inline'>
       <label class='block-label'>
-        <input type='radio' name='{{ name }}' value='yes' {% if current_value == 'yes' %}checked{% endif %} />
+        <input type='radio' name='{{ field.name }}' value='yes' {% if current_value == 'yes' %}checked{% endif %} />
         Yes
       </label>
       <label class='block-label'>
-        <input type='radio' name='{{ name }}' value='no' {% if current_value == 'no' %}checked{% endif %} />
+        <input type='radio' name='{{ field.name }}' value='no' {% if current_value == 'no' %}checked{% endif %} />
         No
       </label>
     </div>

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -21,9 +21,9 @@ Manage users – GOV.UK Notify
           Permissions
         </legend>
         <span class="form-hint">All team members can see message history</span>
-        {{ yes_no(form.send_messages.name, form.send_messages.label, form.send_messages.data) }}
-        {{ yes_no(form.manage_service.name, form.manage_service.label, form.manage_service.data) }}
-        {{ yes_no(form.manage_api_keys.name, form.manage_api_keys.label, form.manage_api_keys.data) }}
+        {{ yes_no(form.send_messages, form.send_messages.data) }}
+        {{ yes_no(form.manage_service, form.manage_service.data) }}
+        {{ yes_no(form.manage_api_keys, form.manage_api_keys.data) }}
       </fieldset>
 
       {{ page_footer(

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -23,9 +23,9 @@ Manage users – GOV.UK Notify
           Permissions
         </legend>
         <span class="form-hint">All team members can see message history</span>
-        {{ yes_no(form.send_messages.name, form.send_messages.label, form.send_messages.data) }}
-        {{ yes_no(form.manage_service.name, form.manage_service.label, form.manage_service.data) }}
-        {{ yes_no(form.manage_api_keys.name, form.manage_api_keys.label, form.manage_api_keys.data) }}
+        {{ yes_no(form.send_messages, form.send_messages.data) }}
+        {{ yes_no(form.manage_service, form.manage_service.data) }}
+        {{ yes_no(form.manage_api_keys, form.manage_api_keys.data) }}
       </fieldset>
 
       {{ page_footer('Send invitation email') }}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -247,8 +247,8 @@
   <div class="grid-row">
     <div class='column-half'>
       <fieldset class='yes-no-wrapper'>
-        {{ yes_no('manage_service', 'Manage service', True) }}
-        {{ yes_no('templates', 'Create templates', True) }}
+        {{ yes_no(form.manage_service, form.manage_service.data) }}
+        {{ yes_no(form.manage_templates, form.manage_templates.data) }}
       </fieldset>
     </div>
   </div>


### PR DESCRIPTION
If no permissions chosen in invite, render validation errors.

Custom error message to over ride that from WTF forms radio field required creation of a custom field.