### PR TITLE
Make preview of uploaded CSV files clearer

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -222,7 +222,8 @@ def check_messages(service_id, upload_id):
         contents,
         template_type=template.template_type,
         placeholders=template.placeholders,
-        max_initial_rows_shown=5
+        max_initial_rows_shown=15,
+        max_errors_shown=15
     )
 
     with suppress(StopIteration):
@@ -237,8 +238,13 @@ def check_messages(service_id, upload_id):
         template=template,
         page_heading=get_page_headings(template.template_type),
         errors=get_errors_for_csv(recipients, template.template_type),
+        rows_have_errors=any(recipients.rows_with_errors),
         count_of_recipients=session['upload_data']['notification_count'],
-        count_of_displayed_recipients=len(list(recipients.rows_annotated_and_truncated)),
+        count_of_displayed_recipients=(
+            len(list(recipients.initial_annotated_rows_with_errors))
+            if any(recipients.rows_with_errors) else
+            len(list(recipients.initial_annotated_rows))
+        ),
         original_file_name=session['upload_data'].get('original_file_name'),
         send_button_text=get_send_button_text(template.template_type, session['upload_data']['notification_count']),
         service_id=service_id,

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -74,10 +74,10 @@
   {% call(item) list_table(
     recipients.rows_annotated_and_truncated,
     caption=original_file_name,
-    field_headings=['Row'] + recipients.column_headers_with_placeholders_highlighted
+    field_headings=['1'] + recipients.column_headers_with_placeholders_highlighted
   ) %}
     {% call field() %}
-      {{ item.index + 1 }}
+      {{ item.index + 2 }}
     {% endcall %}
     {% for column in recipients.column_headers %}
       {% if item[column].error %}

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -72,7 +72,7 @@
   {% endif %}
 
   {% call(item) list_table(
-    recipients.rows_annotated_and_truncated,
+    recipients.initial_annotated_rows_with_errors if rows_have_errors else recipients.initial_annotated_rows,
     caption=original_file_name,
     field_headings=['1'] + recipients.column_headers_with_placeholders_highlighted
   ) %}
@@ -99,7 +99,7 @@
 
   {% if count_of_displayed_recipients < count_of_recipients %}
     <p class="table-show-more-link">
-      {{ count_of_recipients - count_of_displayed_recipients }} more {{ "row" if 1 == (count_of_recipients - count_of_displayed_recipients) else "rows"}} not shown
+      {{ count_of_recipients - count_of_displayed_recipients }} {{ "row" if 1 == (count_of_recipients - count_of_displayed_recipients) else "rows"}} not shown
     </p>
   {% endif %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ Pygments==2.0.2
 
 git+https://github.com/alphagov/notifications-python-client.git@0.3.1#egg=notifications-python-client==0.3.1
 
-git+https://github.com/alphagov/notifications-utils.git@2.0.0#egg=notifications-utils==2.0.0
+git+https://github.com/alphagov/notifications-utils.git@3.0.0#egg=notifications-utils==3.0.0


### PR DESCRIPTION
Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/13697672/ee6f3136-e766-11e5-8111-6014d02e52ed.png) | <img width="697" alt="screen shot 2016-03-11 at 08 53 41" src="https://cloud.githubusercontent.com/assets/355079/13697676/f7d370d4-e766-11e5-8dbd-c74e2ec19713.png"> ![image](https://cloud.githubusercontent.com/assets/355079/13697781/a958914a-e767-11e5-9d55-092e0f38d0f2.png)


## Start row numbers from 2
Because row 1 will be the column headers when you look at a CSV file in Excel.

## Don’t mix errors with valid rows

Brings in (and depends on): https://github.com/alphagov/notifications-utils/pull/11

Changes the number of rows shown to be at most 15 (either 15 rows with errors or 15 valid rows).
