### PR TITLE
Fix error message spacing on yes/no pattern

### DIFF
--- a/app/assets/stylesheets/components/yes-no.scss
+++ b/app/assets/stylesheets/components/yes-no.scss
@@ -9,8 +9,14 @@
   padding: 10px 0;
 
   &-label {
+
     padding-top: 19px;
     float: left;
+
+    &.error {
+      padding-top: 5px;
+    }
+
   }
 
   &-fields {

--- a/app/templates/components/yes-no.html
+++ b/app/templates/components/yes-no.html
@@ -1,6 +1,6 @@
 {% macro yes_no(field, current_value=None) %}
-  <fieldset class='yes-no {% if field.errors %} error{% endif %}'>
-    <legend class='yes-no-label'>
+  <fieldset class='yes-no'>
+    <legend class='yes-no-label{% if field.errors %} error{% endif %}'>
       {{ field.label }}
        {% if field.errors %}
         <span class="error-message">


### PR DESCRIPTION
Error messages were added to the yes/no fields on the invite user page in https://github.com/alphagov/notifications-admin/commit/4c323a9a9918f6a6959a0153950b0bb5eec38cea

This commit fixes the margins and padding on these fields so they look consistent with how we do validation errors elsewhere.

Before | After 
--- | ---
<img width="497" alt="screen shot 2016-03-14 at 09 15 21" src="https://cloud.githubusercontent.com/assets/355079/13739853/710ce830-e9c5-11e5-8bee-7d0c36ac51fa.png"> | <img width="498" alt="screen shot 2016-03-14 at 09 15 04" src="https://cloud.githubusercontent.com/assets/355079/13739854/710d2fb6-e9c5-11e5-9f4e-0a0e83362736.png">