### PR TITLE
Start to remove the dao layer

### DIFF
--- a/app/main/dao/services_dao.py
+++ b/app/main/dao/services_dao.py
@@ -3,13 +3,6 @@ from app import notifications_api_client
 from app.utils import BrowsableItem
 
 
-def insert_new_service(service_name, user_id):
-    resp = notifications_api_client.create_service(
-        service_name, False, current_app.config['DEFAULT_SERVICE_LIMIT'], True, user_id)
-
-    return resp['data']['id']
-
-
 def update_service(service):
     return notifications_api_client.update_service(
         service['id'],

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -2,8 +2,8 @@ from flask import (
     render_template,
     redirect,
     session,
-    url_for
-)
+    url_for,
+    current_app)
 
 from flask_login import login_required
 
@@ -14,8 +14,8 @@ from app.notify_client.models import InvitedUser
 
 from app import (
     invite_api_client,
-    user_api_client
-)
+    user_api_client,
+    notifications_api_client)
 
 
 @main.route("/add-service", methods=['GET', 'POST'])
@@ -36,8 +36,9 @@ def add_service():
     heading = 'Which service do you want to set up notifications for?'
     if form.validate_on_submit():
         session['service_name'] = form.name.data
-        user = users_dao.get_user_by_id(session['user_id'])
-        service_id = services_dao.insert_new_service(session['service_name'], user.id)
+        service_id = notifications_api_client.create_service(
+            session['service_name'], False, current_app.config['DEFAULT_SERVICE_LIMIT'], True, session['user_id'])
+
         return redirect(url_for('main.service_dashboard', service_id=service_id))
     else:
         return render_template(

--- a/app/notify_client/api_client.py
+++ b/app/notify_client/api_client.py
@@ -27,7 +27,7 @@ class NotificationsAdminAPIClient(NotificationsAPIClient):
             "user_id": user_id,
             "restricted": restricted
         }
-        return self.post("/service", data)
+        return self.post("/service", data)['data']['id']
 
     def delete_service(self, service_id):
         """

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -7,7 +7,6 @@ def test_get_should_render_add_service_template(app_,
                                                 mock_login,
                                                 mock_get_service,
                                                 mock_get_services,
-                                                mock_get_user,
                                                 mock_get_user_by_email):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -21,9 +20,7 @@ def test_should_add_service_and_redirect_to_next_page(app_,
                                                       mock_login,
                                                       mock_create_service,
                                                       mock_get_services,
-                                                      api_user_active,
-                                                      mock_get_user,
-                                                      mock_get_user_by_email):
+                                                      api_user_active):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -32,7 +29,9 @@ def test_should_add_service_and_redirect_to_next_page(app_,
                 data={'name': 'testing the post'})
             assert response.status_code == 302
             assert response.location == url_for('main.service_dashboard', service_id=101, _external=True)
-            assert mock_create_service.called
+            mock_create_service.asset_called_once_with('testing the post', False,
+                                                       app_.config['DEFAULT_SERVICE_LIMIT'],
+                                                       True, api_user_active.id)
 
 
 def test_should_return_form_errors_when_service_name_is_empty(app_,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def mock_create_service(mocker):
         service = service_json(
             101, service_name, [user_id], limit=limit,
             active=active, restricted=restricted)
-        return {'data': service}
+        return service['id']
 
     return mocker.patch(
         'app.notifications_api_client.create_service', side_effect=_create)


### PR DESCRIPTION
There is no real need for the dao layer. This pull request is the first in a series to remove that layer.

- Remove services_dao.insert_new_service.
- Update api_client.create_service to return the service id.
- Fix unit tests.