### PR TITLE
Add information about cookies, add a help page

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -30,3 +30,19 @@
   padding-left: 2px;
   padding-right: 2px;
 }
+
+.global-cookie-message {
+  p {
+    @extend %site-width-container;
+  }
+}
+
+.footer-nav {
+  @include copy-16;
+  margin-bottom: $gutter-two-thirds;
+
+  a {
+    display: inline-block;
+    margin-right: $gutter-half;
+  }
+}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -80,3 +80,11 @@ a {
   }
 
 }
+
+td {
+  vertical-align: top;
+}
+
+.heading-xlarge {
+  margin-bottom: 20px;
+}

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -112,7 +112,7 @@
   margin-top: $gutter;
 
   .heading-medium {
-    margin-top: 0;
+    margin: 0 0 10px 0;
   }
 
   a {
@@ -125,6 +125,16 @@
     &:hover,
     &:active {
       color: $light-blue-25;
+    }
+
+  }
+
+  .big-number {
+
+    margin-top: 10px;
+
+    &-label {
+      padding-bottom: 0;
     }
 
   }

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -16,3 +16,8 @@ def index():
 @login_required
 def verify_mobile():
     return render_template('views/verify-mobile.html')
+
+
+@main.route('/cookies')
+def cookies():
+    return render_template('views/cookies.html')

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -21,3 +21,8 @@ def verify_mobile():
 @main.route('/cookies')
 def cookies():
     return render_template('views/cookies.html')
+
+
+@main.route('/help')
+def help():
+    return render_template('views/help.html')

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -24,6 +24,10 @@
 {% endblock %}
 
 {% block cookie_message %}
+  <p>
+    GOV.UK Notify uses cookies to make the site simpler.
+    <a href="{{ url_for("main.cookies") }}">Find out more about cookies</a>
+  </p>
 {% endblock %}
 
 {% block inside_header %}
@@ -66,6 +70,14 @@
   <div id="content">
     {% block fullwidth_content %}{% endblock %}
   </div>
+{% endblock %}
+
+{% block footer_support_links %}
+  <nav class="footer-nav">
+    <a href="https://docs.google.com/forms/d/1AL8U-xJX_HAFEiQiJszGQw0PcEaEUnYATSntEghNDGo/viewform">Support and feedback</a>
+    <a href="{{ url_for("main.cookies") }}">Cookies</a>
+    Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+  </nav>
 {% endblock %}
 
 {% block body_end %}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -74,6 +74,7 @@
 
 {% block footer_support_links %}
   <nav class="footer-nav">
+    <a href="{{ url_for("main.help") }}">Help</a>
     <a href="https://docs.google.com/forms/d/1AL8U-xJX_HAFEiQiJszGQw0PcEaEUnYATSntEghNDGo/viewform">Support and feedback</a>
     <a href="{{ url_for("main.cookies") }}">Cookies</a>
     Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -1,0 +1,81 @@
+{% extends "withoutnav_template.html" %}
+
+{% block page_title %}
+  Cookies – GOV.UK Notify
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge">Cookies</h1>
+    <p class="summary">
+        GOV.UK Notify puts small files (known as ‘cookies’)
+        on to your computer.
+    </p>
+    <p>These cookies are used to remember you once you’ve logged in</p>
+    <p>
+        Find out <a href="http://www.aboutcookies.org/">how to manage cookies</a>.
+    </p>
+
+    <h2 class="heading-medium">Session cookies</h2>
+    <p>
+        We store session cookies on your computer to help keep your information
+        secure while you use the service.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Purpose</th>
+                <th>Expires</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                  notify_admin_session
+                </td>
+                <td width="50%">
+                  Used to keep you logged in
+                </td>
+                <td>
+                  1 hour
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2 class="heading-medium">Introductory message cookie</h2>
+    <p>
+        When you first use the service, you may see a pop-up ‘welcome’ message.
+        Once you’ve seen the message, we store a cookie on your computer so it
+        knows not to show it again.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Purpose</th>
+                <th>Expires</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                  seen_cookie_message
+                </td>
+                <td width="50%">
+                    Saves a message to let us know that you have seen our cookie
+                    message
+                </td>
+                <td>
+                  1 month
+                </td>
+            </tr>
+        </tbody>
+    </table>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/views/dashboard/trial-mode-banner.html
+++ b/app/templates/views/dashboard/trial-mode-banner.html
@@ -3,12 +3,13 @@
 
 {% call banner_wrapper(type="mode") %}
 
+  <h2 class="heading-medium">Trial mode</h2>
   <div class="grid-row">
     <div class="column-one-half">
-      <h2 class="heading-medium">Trial mode</h2>
       <p>
         We’ll only deliver messages to you and members of your team
-
+        <br>
+        <a href="{{ url_for(".help", _anchor="trial-mode") }}">Find out more</a>
       </p>
     </div>
     <div class="column-one-sixth">

--- a/app/templates/views/help.html
+++ b/app/templates/views/help.html
@@ -10,7 +10,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-xlarge">Help</h1>
 
-    <h2 class="heading-large">Trial mode</h2>
+    <h2 class="heading-large" id="trial-mode">Trial mode</h2>
 
     <p>
       When you create a service on GOV.UK&nbsp;Notify, you start off in trial

--- a/app/templates/views/help.html
+++ b/app/templates/views/help.html
@@ -1,0 +1,79 @@
+{% extends "withoutnav_template.html" %}
+
+{% block page_title %}
+  Cookies – GOV.UK Notify
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-xlarge">Help</h1>
+
+    <h2 class="heading-large">Trial mode</h2>
+
+    <p>
+      When you create a service on GOV.UK&nbsp;Notify, you start off in trial
+      mode. This means:
+    </p>
+    <ul class="list list-bullet">
+      <li>
+        you can only send messages to yourself and your team members
+      </li>
+      <li>
+        you can only send 50 messages per day
+      </li>
+    </ul>
+
+    <p>
+      Anyone working in central government can create an account on
+      GOV.UK&nbsp;Notify and try it out. So it’s important that you start off
+      with some restrictions in place.
+    </p>
+
+    <h3 class="heading-medium">To remove these restrictions</h3>
+
+    <p>
+      You need to request to go live:
+    </p>
+    <ul class="list list-bullet">
+      <li>
+        You’ll need to agree to our terms of use
+      </li>
+      <li>
+        If you plan to send more than 250,000 text messages per year, you’ll
+        need to agree to pay for what you use – take a look at our pricing
+      </li>
+      <li>
+        We’ll check your templates to make sure they’re consistent with our
+        design patterns, style guide and information security principles
+      </li>
+    </ul>
+
+    <h3 class="heading-medium">
+      All other aspects of GOV.UK&nbsp;Notify are exactly the same
+    </h2>
+
+    <p>
+      You can still:
+    </p>
+    <ul class="list list-bullet">
+      <li>
+        upload a batch of recipients
+      </li>
+      <li>
+        do an API integration
+      </li>
+    </ul>
+
+    <p>
+      We’ll send the messages you have permission to send. The messages you
+      don’t have permission to send will still be listed on your
+      GOV.UK&nbsp;Notify dashboard but won’t actually get sent. This means you
+      can check that everything is fully working without accidentally sending
+      hundreds of text messages or emails.
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -175,7 +175,7 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(app_,
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
             assert page.h1.string.strip() == 'Create an account'
 
-            email_in_page = page.find('p')
+            email_in_page = page.find('main').find('p')
             assert email_in_page.text.strip() == 'Your account will be created with this email: invited_user@test.gov.uk'  # noqa
 
             form = page.find('form')


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/13810299/0b41980e-eb67-11e5-9327-1e1baefd1257.png)
***
![image](https://cloud.githubusercontent.com/assets/355079/13810304/138b2f20-eb67-11e5-9b36-028cce21ff9e.png)

> Let’s start the footer links with the cookie page.
> Banner to say: "GOV.UK Notify uses cookies to make the site simpler. Find out
> more about cookies"
> Standard style one... see
> https://www.registertovote.service.gov.uk/register-to-vote/cookies or
> https://www.digitalmarketplace.service.gov.uk/cookies
>
> Let's link to the feedback form too...
> https://docs.google.com/forms/d/1AL8U-xJX_HAFEiQiJszGQw0PcEaEUnYATSntEghNDGo/viewform
> Call it Support and feedback

https://www.pivotaltracker.com/story/show/115483375