### PR TITLE
Start aligning Admin app with config styles used elsewhere

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,12 +39,12 @@ invite_api_client = InviteApiClient()
 asset_fingerprinter = AssetFingerprinter()
 
 
-def create_app(config_name, config_overrides=None):
+def create_app():
     application = Flask(__name__)
 
-    application.config['NOTIFY_ADMIN_ENVIRONMENT'] = config_name
-    application.config.from_object(configs[config_name])
-    init_app(application, config_overrides)
+    application.config.from_object(os.environ['NOTIFY_ADMIN_ENVIRONMENT'])
+
+    init_app(application)
     logging.init_app(application)
     init_csrf(application)
 
@@ -101,22 +101,12 @@ def init_csrf(application):
         abort(400, reason)
 
 
-def init_app(app, config_overrides):
-
-    if config_overrides:
-        for key in app.config.keys():
-            if key in config_overrides:
-                    app.config[key] = config_overrides[key]
-
-    for key, value in app.config.items():
-        if key in os.environ:
-            app.config[key] = convert_to_boolean(os.environ[key])
-
-    @app.context_processor
+def init_app(application):
+    @application.context_processor
     def inject_global_template_variables():
         return {
             'asset_path': '/static/',
-            'header_colour': app.config['HEADER_COLOUR'],
+            'header_colour': application.config['HEADER_COLOUR'],
             'asset_url': asset_fingerprinter.get_url
         }
 

--- a/config.py
+++ b/config.py
@@ -72,18 +72,10 @@ class Preview(Config):
     HEADER_COLOUR = '#F47738'  # $orange
 
 
-class Staging(Preview):
-    SHOW_STYLEGUIDE = False
-
-
-class Live(Staging):
-    HEADER_COLOUR = '#B10E1E'  # $red
-
-
 configs = {
-    'development': Development,
-    'test': Test,
-    'preview': Preview,
-    'staging': Staging,
-    'live': Live
+    'development': 'config.Development',
+    'test': 'config.Test',
+    'preview': 'config.Preview',
+    'staging': 'config_staging.Staging',
+    'live': 'config_live.Live'
 }

--- a/config_live.py
+++ b/config_live.py
@@ -1,0 +1,15 @@
+import os
+from config import Config
+
+
+class Live(Config):
+    SHOW_STYLEGUIDE = False
+    HEADER_COLOUR = '#B10E1E'  # $red
+    HTTP_PROTOCOL = 'https'
+    API_HOST_NAME = os.getenv('LIVE_API_HOST_NAME')
+    NOTIFY_API_SECRET = os.getenv('LIVE_NOTIFY_API_SECRET', "dev-secret")
+    NOTIFY_API_CLIENT = os.getenv('LIVE_NOTIFY_API_CLIENT', "admin")
+    ADMIN_CLIENT_USER_NAME = os.getenv('LIVE_ADMIN_CLIENT_USER_NAME')
+    ADMIN_CLIENT_SECRET = os.getenv('LIVE_ADMIN_CLIENT_SECRET')
+    SECRET_KEY = os.getenv('LIVE_SECRET_KEY')
+    DANGEROUS_SALT = os.getenv('LIVE_DANGEROUS_SALT')

--- a/config_staging.py
+++ b/config_staging.py
@@ -1,0 +1,14 @@
+import os
+from config import Config
+
+
+class Staging(Config):
+    SHOW_STYLEGUIDE = False
+    HTTP_PROTOCOL = 'https'
+    API_HOST_NAME = os.getenv('STAGING_API_HOST_NAME')
+    NOTIFY_API_SECRET = os.getenv('STAGING_NOTIFY_API_SECRET', "dev-secret")
+    NOTIFY_API_CLIENT = os.getenv('STAGING_NOTIFY_API_CLIENT', "admin")
+    ADMIN_CLIENT_USER_NAME = os.getenv('STAGING_ADMIN_CLIENT_USER_NAME')
+    ADMIN_CLIENT_SECRET = os.getenv('STAGING_ADMIN_CLIENT_SECRET')
+    SECRET_KEY = os.getenv('STAGING_SECRET_KEY')
+    DANGEROUS_SALT = os.getenv('STAGING_DANGEROUS_SALT')

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export NOTIFY_ADMIN_ENVIRONMENT='config.Development'
 python3 app.py runserver

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -32,5 +32,6 @@ display_result $? 2 "Front end code style check"
 #py.test --cov=app tests/
 #display_result $? 3 "Code coverage"
 
+export NOTIFY_ADMIN_ENVIRONMENT='config.Test'
 py.test -v
 display_result $? 4 "Unit tests"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from notifications_python_client.errors import HTTPError
 
 @pytest.fixture(scope='session')
 def app_(request):
-    app = create_app('test')
+    app = create_app()
 
     ctx = app.app_context()
     ctx.push()

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,16 +2,22 @@ from app import create_app
 from credstash import getAllSecrets
 import os
 
-config = 'live'
 default_env_file = '/home/ubuntu/environment'
+environment = 'live'
 
 if os.path.isfile(default_env_file):
-        environment = open(default_env_file, 'r')
-        config = environment.readline().strip()
+    with open(default_env_file, 'r') as environment_file:
+        environment = environment_file.readline().strip()
 
-secrets = getAllSecrets(region="eu-west-1")
 
-application = create_app(config, secrets)
+# on aws get secrets and export to env
+os.environ.update(getAllSecrets(region="eu-west-1"))
+
+from config import configs
+
+os.environ['NOTIFY_ADMIN_ENVIRONMENT'] = configs[environment]
+
+application = create_app()
 
 if __name__ == "__main__":
         application.run()


### PR DESCRIPTION
- no config overrides - now all set in environment
- use different files for staging and live too allow for differently named env variables
- updates to run_app and run_tests scripts to set correct environment (test/development) so correct config picked up
- use environment file on deployed environments to pick correct config