### PR TITLE
Remove ‘delete this service’ link

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -27,12 +27,7 @@
       } if not service.active else {
         'title': 'Reactivate API keys',
         'link': url_for('.service_status_change', service_id=service_id)
-      },
-      {
-        'title': 'Delete this service from GOV.UK Notify',
-        'link': url_for('.service_delete', service_id=service_id),
-        'destructive': True
-      },
+      }
     ]) }}
 
 {% endblock %}


### PR DESCRIPTION
> We have an option to delete a service, which looks good, but then doesn't delete the service.
>
> Until we have the ability to delete, let's get rid of the link.

https://www.pivotaltracker.com/story/show/115775329