### PR TITLE
Fixed the title tag on the help page

### DIFF
--- a/app/templates/views/help.html
+++ b/app/templates/views/help.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
-  Cookies – GOV.UK Notify
+  Help – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
It was showing Cookies.