### PR TITLE
Use real API endpoints in documentation

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -209,7 +209,6 @@ def send_from_api(service_id, template_id):
         'views/send-from-api.html',
         template=template,
         payload=json.dumps(payload, indent=4),
-        api_host=current_app.config['API_HOST_NAME'],
         service_id=service_id
     )
 

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -161,7 +161,7 @@
         <h2 class="heading-medium">API endpoint</h2>
 
         <p>
-            https://api.notify.works
+            https://api.notifications.service.gov.uk/
         </p>
 
     </div>

--- a/app/templates/views/send-from-api.html
+++ b/app/templates/views/send-from-api.html
@@ -3,7 +3,7 @@
 {% from "components/sms-message.html" import sms_message %}
 
 {% block page_title %}
-  Developer documentation – GOV.UK Notify
+  API integration – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -48,15 +48,14 @@
 
   <div class="highlight" style="background: #f8f8f8">
     <pre style="line-height: 125%">
-      {{- 'POST {}/notifications/{}'.format(
-        api_host,
+      {{- 'POST https://api.notifications.service.gov.uk/notifications/{}'.format(
         template.template_type
       ) -}}
     </pre>
   </div>
 
   <p>
-    <br />See the <a href="#">developer documentation</a> for full details.
+    <br />See the <a href="{{ url_for(".documentation") }}">developer documentation</a> for full details.
   </p>
 
 {% endblock %}


### PR DESCRIPTION
There is no need to make the API endpoints environment-specific. But it is still useful to know what the endpoint is.

Also fixes a broken link on the integration page.