### PR TITLE
Visually align headings inside grid rows

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -26,7 +26,7 @@
 .align-with-heading {
   display: block;
   text-align: center;
-  margin-top: 45px;
+  margin-top: 35px;
   padding-left: 2px;
   padding-right: 2px;
 }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -60,6 +60,14 @@ a {
     margin-top: $gutter;
   }
 
+  > .grid-row  {
+    
+    .heading-large {
+      margin-top: $gutter;
+    }
+    
+  }
+
 }
 
 .highlight {


### PR DESCRIPTION
When the first heading on the page is inside a grid row, it doesn’t vertically align properly with the navigation. This is because it isn’t targeted by the selector that does this for pages without an initial grid row.

This commit:
- adds an extra selector to target these headings
- makes the ‘add new thing’ buttons maintain their alignment with the page heading

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/14113243/f8841134-f5c9-11e5-9bec-08de05140e1d.png) | ![image](https://cloud.githubusercontent.com/assets/355079/14113215/dc0f7c8c-f5c9-11e5-9c2a-d1987baa7c98.png)
