### PR TITLE
After send sms or email to self or batch back button bug

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -98,6 +98,12 @@ def choose_template(service_id, template_type):
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def send_messages(service_id, template_id):
 
+    service = services_dao.get_service_by_id_or_404(service_id)
+    template = Template(
+        templates_dao.get_service_template_or_404(service_id, template_id)['data'],
+        prefix=service['name']
+    )
+
     form = CsvUploadForm()
     if form.validate_on_submit():
         try:
@@ -117,17 +123,12 @@ def send_messages(service_id, template_id):
             }
             return redirect(url_for('.check_messages',
                                     service_id=service_id,
-                                    upload_id=upload_id))
+                                    upload_id=upload_id,
+                                    template_type=template.template_type))
         except ValueError as e:
             flash('There was a problem uploading: {}'.format(form.file.data.filename))
             flash(str(e))
             return redirect(url_for('.send_messages', service_id=service_id, template_id=template_id))
-
-    service = services_dao.get_service_by_id_or_404(service_id)
-    template = Template(
-        templates_dao.get_service_template_or_404(service_id, template_id)['data'],
-        prefix=service['name']
-    )
 
     return render_template(
         'views/send.html',
@@ -184,12 +185,14 @@ def send_message_to_self(service_id, template_id):
         'data': output.getvalue()
     }
     upload_id = str(uuid.uuid4())
+
     s3upload(upload_id, service_id, filedata, current_app.config['AWS_REGION'])
     session['upload_data'] = {"template_id": template_id, "original_file_name": filedata['file_name']}
 
     return redirect(url_for('.check_messages',
                             service_id=service_id,
-                            upload_id=upload_id))
+                            upload_id=upload_id,
+                            template_type=template.template_type))
 
 
 @main.route("/services/<service_id>/send/<template_id>/from-api", methods=['GET'])
@@ -214,10 +217,13 @@ def send_from_api(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/check/<upload_id>", methods=['GET'])
+@main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['GET'])
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
-def check_messages(service_id, upload_id):
+def check_messages(service_id, template_type, upload_id):
+
+    if not session.get('upload_data'):
+        return redirect(url_for('main.choose_template', service_id=service_id, template_type=template_type))
 
     service = services_dao.get_service_by_id_or_404(service_id)
 
@@ -266,11 +272,12 @@ def check_messages(service_id, upload_id):
         send_button_text=get_send_button_text(template.template_type, session['upload_data']['notification_count']),
         service_id=service_id,
         service=service,
+        upload_id=upload_id,
         form=CsvUploadForm()
     )
 
 
-@main.route("/services/<service_id>/check/<upload_id>", methods=['POST'])
+@main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def start_job(service_id, upload_id):

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -26,8 +26,10 @@ from app.main.uploader import (
     s3download
 )
 from app.main.dao import templates_dao
-from app.main.dao import services_dao
-from app import job_api_client
+from app import (
+    job_api_client,
+    service_api_client
+)
 from app.utils import user_has_permissions, get_errors_for_csv
 
 
@@ -70,7 +72,7 @@ def get_page_headings(template_type):
                       admin_override=True, or_=True)
 def choose_template(service_id, template_type):
 
-    service = services_dao.get_service_by_id_or_404(service_id)
+    service = service_api_client.get_service(service_id)['data']
 
     if template_type not in ['email', 'sms']:
         abort(404)
@@ -98,7 +100,7 @@ def choose_template(service_id, template_type):
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def send_messages(service_id, template_id):
 
-    service = services_dao.get_service_by_id_or_404(service_id)
+    service = service_api_client.get_service(service_id)['data']
     template = Template(
         templates_dao.get_service_template_or_404(service_id, template_id)['data'],
         prefix=service['name']
@@ -225,7 +227,7 @@ def check_messages(service_id, template_type, upload_id):
     if not session.get('upload_data'):
         return redirect(url_for('main.choose_template', service_id=service_id, template_type=template_type))
 
-    service = services_dao.get_service_by_id_or_404(service_id)
+    service = service_api_client.get_service(service_id)['data']
 
     contents = s3download(service_id, upload_id)
     if not contents:
@@ -283,7 +285,7 @@ def check_messages(service_id, template_type, upload_id):
 def start_job(service_id, upload_id):
 
     upload_data = session['upload_data']
-    services_dao.get_service_by_id_or_404(service_id)
+    service = service_api_client.get_service(service_id)['data']
 
     if request.files or not upload_data.get('valid'):
         # The csv was invalid, validate the csv again

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -64,7 +64,7 @@
   {% if errors %}
     {{file_upload(form.file, button_text='Re-upload your file')}}
   {% else %}
-    <form method="post" enctype="multipart/form-data">
+    <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=service_id, upload_id=upload_id)}}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="submit" class="button" value="{{ send_button_text }}" />
       <a href="{{url_for('.send_messages', service_id=service_id, template_id=template.id)}}" class="page-footer-back-link">Back</a>

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -46,31 +46,6 @@ def test_send_test_message_to_self(
     api_user_active,
     mock_login,
     mock_get_service,
-    mock_get_service_template,
-    mock_s3_upload,
-    mock_has_permissions
-):
-
-    expected_data = {'data': ['phone number', '+4412341234'], 'file_name': 'Test run'}
-    mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')
-
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(
-                url_for('main.send_message_to_self', service_id=12345, template_id=54321),
-                follow_redirects=True
-            )
-        assert response.status_code == 200
-        mock_s3_upload.assert_called_with(ANY, '12345', expected_data, 'eu-west-1')
-
-
-def test_send_test_message_to_self(
-    app_,
-    mocker,
-    api_user_active,
-    mock_login,
-    mock_get_service,
     mock_get_service_email_template,
     mock_s3_upload,
     mock_has_permissions
@@ -260,7 +235,7 @@ def test_check_messages_should_revalidate_file_when_uploading_file(
                                           'notification_count': job_data['notification_count'],
                                           'valid': True}
             response = client.post(
-                url_for('main.check_messages', service_id=service_id, upload_id=job_data['id']),
+                url_for('main.start_job', service_id=service_id, upload_id=job_data['id']),
                 data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
                 content_type='multipart/form-data',
                 follow_redirects=True

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -40,7 +40,32 @@ def test_upload_csvfile_with_errors_shows_check_page_with_errors(
         assert 'Re-upload your file' in content
 
 
-def test_send_test_message_to_self(
+def test_send_test_sms_message_to_self(
+    app_,
+    mocker,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template,
+    mock_s3_upload,
+    mock_has_permissions
+):
+
+    expected_data = {'data': 'phone number\r\n+4412341234\r\n', 'file_name': 'Test run'}
+    mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')
+
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            response = client.get(
+                url_for('main.send_message_to_self', service_id=12345, template_id=54321),
+                follow_redirects=True
+            )
+        assert response.status_code == 200
+        mock_s3_upload.assert_called_with(ANY, '12345', expected_data, 'eu-west-1')
+
+
+def test_send_test_email_message_to_self(
     app_,
     mocker,
     api_user_active,


### PR DESCRIPTION
The back button to check and confirm page returns error as session data no longer available.

Now going back from sent page does not take user to check, but rather the start of sending
either sms or email.