### PR TITLE
Fix logic around team on navigation

### DIFF
--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -23,8 +23,7 @@
     <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Manage team</a></li>
     <li><a href="{{ url_for('.service_settings', service_id=service_id) }}">Manage settings</a></li>
   </ul>
-  {% endif %}
-  {% if current_user.has_permissions(['view_activity']) %}
+  {% elif current_user.has_permissions(['view_activity']) %}
   <ul>
     <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">View team members</a></li>
   </ul>


### PR DESCRIPTION
In the navigation you should see either:
- manage team
- view team members

This depends on which permissions you have. You shouldn’t see both at once. There was a bug which meant you could see both. This commit fixes that bug.

https://www.pivotaltracker.com/story/show/116608291