### PR TITLE
Tweak some wording

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -29,18 +29,6 @@ from app import (job_api_client, service_api_client)
 from app.utils import user_has_permissions, get_errors_for_csv
 
 
-send_messages_page_headings = {
-    'email': 'Send emails',
-    'sms': 'Send text messages'
-}
-
-
-manage_templates_page_headings = {
-    'email': 'Email templates',
-    'sms': 'Text message templates'
-}
-
-
 def get_send_button_text(template_type, number_of_messages):
     if 1 == number_of_messages:
         return {
@@ -55,11 +43,10 @@ def get_send_button_text(template_type, number_of_messages):
 
 
 def get_page_headings(template_type):
-    # User has manage_service role
-    if current_user.has_permissions(['send_texts', 'send_emails', 'send_letters']):
-        return send_messages_page_headings[template_type]
-    else:
-        return manage_templates_page_headings[template_type]
+    return {
+        'email': 'Email templates',
+        'sms': 'Text message templates'
+    }[template_type]
 
 
 @main.route("/services/<service_id>/send/<template_type>", methods=['GET'])

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -4,15 +4,10 @@
   </h2>
   {% if current_user.has_permissions(['view_activity'], admin_override=True) %}
   <ul>
-    <li><a href="{{ url_for('.view_notifications', service_id=service_id) }}">View activity</a></li>
+    <li><a href="{{ url_for('.view_notifications', service_id=service_id) }}">History</a></li>
   </ul>
   {% endif %}
-  {% if current_user.has_permissions(['send_texts', 'send_emails', 'send_letters']) %}
-  <ul>
-    <li><a href="{{ url_for('.choose_template', service_id=service_id, template_type='sms') }}">Send text messages</a></li>
-    <li><a href="{{ url_for('.choose_template', service_id=service_id, template_type='email') }}">Send emails</a></li>
-  </ul>
-  {% elif current_user.has_permissions(['view_activity', 'manage_templates','manage_api_keys'], admin_override=True, any_=True) %}
+  {% if current_user.has_permissions(['view_activity', 'manage_templates', 'manage_api_keys'], admin_override=True, any_=True) %}
   <ul>
     <li><a href="{{ url_for('.choose_template', service_id=service_id, template_type='sms') }}">Text message templates</a></li>
     <li><a href="{{ url_for('.choose_template', service_id=service_id, template_type='email') }}">Email templates</a></li>
@@ -20,17 +15,17 @@
   {% endif %}
   {% if current_user.has_permissions(['manage_users', 'manage_settings'], admin_override=True) %}
   <ul>
-    <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Manage team</a></li>
-    <li><a href="{{ url_for('.service_settings', service_id=service_id) }}">Manage settings</a></li>
+    <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Team members</a></li>
+    <li><a href="{{ url_for('.service_settings', service_id=service_id) }}">Settings</a></li>
   </ul>
   {% elif current_user.has_permissions(['view_activity']) %}
   <ul>
-    <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">View team members</a></li>
+    <li><a href="{{ url_for('.manage_users', service_id=service_id) }}">Team members</a></li>
   </ul>
   {% endif %}
   {% if current_user.has_permissions(['manage_api_keys']) %}
   <ul>
-    <li><a href="{{ url_for('.api_keys', service_id=service_id) }}">Manage API keys</a></li>
+    <li><a href="{{ url_for('.api_keys', service_id=service_id) }}">API keys</a></li>
   </ul>
   {% endif %}
   {% if current_user.has_permissions(admin_override=True) %}

--- a/app/templates/views/choose-template.html
+++ b/app/templates/views/choose-template.html
@@ -77,7 +77,7 @@
         <div class="column-one-third">
           <div class="sms-message-use-links">
             {% if current_user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']) %}
-              <a href="{{ url_for(".send_messages", service_id=service_id, template_id=template.id) }}">Send a batch</a>
+              <a href="{{ url_for(".send_messages", service_id=service_id, template_id=template.id) }}">Send from a CSV file</a>
               <a href="{{ url_for(".send_message_to_self", service_id=service_id, template_id=template.id) }}">Send yourself a test</a>
             {% endif %}
             {% if current_user.has_permissions(permissions=['manage_api_keys']) %}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -15,7 +15,7 @@
     <form method="post">
       <div class="grid-row">
         <div class="column-two-thirds">
-          {{ textbox(form.name, width='1-1') }}
+          {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this') }}
           {{ textbox(form.subject, width='1-1') }}
         </div>
         <div class="column-two-thirds">

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -15,7 +15,7 @@
     <form method="post">
       <div class="grid-row">
         <div class="column-two-thirds">
-          {{ textbox(form.name, width='1-1') }}
+          {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this') }}
         </div>
         <div class="column-two-thirds">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1') }}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -19,11 +19,7 @@ Manage users – GOV.UK Notify
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        {% if current_user.has_permissions(['manage_users']) %}
-          Manage team
-        {% else %}
-          View team members
-        {% endif %}
+        Team members
       </h1>
     </div>
     {% if current_user.has_permissions(['manage_users']) %}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Send a batch</h1>
+  <h1 class="heading-large">Send from a CSV file</h1>
 
   {% if 'sms' == template.template_type %}
     <div class="grid-row">
@@ -31,13 +31,14 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <p>
-        Add recipients by uploading a .csv file with
+        You need
         {{ template.placeholders|length + 1 }}
         {% if template.placeholders %}
-          columns:
+          columns
         {% else %}
-          column:
+          column
         {% endif %}
+        in your file:
       </p>
       <p class="bottom-gutter-2-3">
         <span class='placeholder'>{{ recipient_column }}</span>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">Manage settings</h1>
+    <h1 class="heading-large">Settings</h1>
 
     {{ browse_list([
       {

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -18,7 +18,7 @@ def test_should_show_overview_page(
             mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
             response = client.get(url_for('main.manage_users', service_id=service['id']))
 
-        assert 'Manage team' in response.get_data(as_text=True)
+        assert 'Team members' in response.get_data(as_text=True)
         assert response.status_code == 200
         app.user_api_client.get_users_for_service.assert_called_once_with(service_id=service['id'])
 
@@ -158,7 +158,7 @@ def test_invite_user(
 
         assert response.status_code == 200
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.string.strip() == 'Manage team'
+        assert page.h1.string.strip() == 'Team members'
         flash_banner = page.find('div', class_='banner-default-with-tick').string.strip()
         assert flash_banner == 'Invite sent to test@example.gov.uk'
         excpected_permissions = 'manage_api_keys,manage_service,send_messages,view_activity'
@@ -203,7 +203,7 @@ def test_manage_users_shows_invited_user(app_,
 
             assert response.status_code == 200
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'Manage team'
+            assert page.h1.string.strip() == 'Team members'
             invites_table = page.find_all('table')[1]
             cols = invites_table.find_all('td')
             assert cols[0].text.strip() == 'invited_user@test.gov.uk'
@@ -231,7 +231,7 @@ def test_manage_users_does_not_show_accepted_invite(app_,
 
             assert response.status_code == 200
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'Manage team'
+            assert page.h1.string.strip() == 'Team members'
             tables = page.find_all('table')
             assert len(tables) == 1
             assert not page.find(text='invited_user@test.gov.uk')
@@ -275,7 +275,7 @@ def test_no_permission_manage_users_page(app_,
             resp_text = response.get_data(as_text=True)
             assert url_for('.invite_user', service_id=service_one['id']) not in resp_text
             assert "Edit permission" not in resp_text
-            assert "Manage team" not in resp_text
+            assert "Team members" not in resp_text
 
 
 def test_get_remove_user_from_service(app_,


### PR DESCRIPTION
## Remove the verbs from the navigation

Because ‘Send text messages’ isn’t very helpful if you’re looking to edit a template.

It also helps front-load the navigation, ie ‘Team’ is the first word, rather than the more generic ‘Manage’.

## Add a hint to ‘Template name’ text input

> Your recipients won’t see this

We’ve seen lots of users unsure what the ‘template name’ field is for, especially on first use. Is it the subject line of the text message? Will it be who the message comes from? Answer: neither.

So this commit adds a hint to make that clearer.

## Replace ‘send a batch’ with ‘send from a CSV file’ 

This is better. Not done enough testing to know if it’s the best, but let’s try it.
