### PR TITLE
Improve csv examples

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -158,7 +158,10 @@ def get_example_csv(service_id, template_id, number_of_rows=2):
             ] +
             get_example_csv_rows(template, number_of_rows=number_of_rows)
         )
-        return output.getvalue(), 200, {'Content-Type': 'text/csv; charset=utf-8'}
+        return output.getvalue(), 200, {
+            'Content-Type': 'text/csv; charset=utf-8',
+            'Content-Disposition': 'inline; filename="{}.csv"'.format(template.name)
+        }
 
 
 @main.route("/services/<service_id>/send/<template_id>/to-self", methods=['GET'])

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -3,7 +3,7 @@
 {% from "components/email-message.html" import email_message %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/table.html" import list_table, field %}
+{% from "components/table.html" import list_table, text_field %}
 
 {% block page_title %}
   Send text messages – GOV.UK Notify
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Send from a CSV file</h1>
+  <h1 class="heading-large">Send a batch</h1>
 
   {% if 'sms' == template.template_type %}
     <div class="grid-row">
@@ -28,27 +28,32 @@
     ) }}
   {% endif %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <p>
-        You need
-        {{ template.placeholders|length + 1 }}
-        {% if template.placeholders %}
-          columns
-        {% else %}
-          column
-        {% endif %}
-        in your file:
-      </p>
-      <p class="bottom-gutter-2-3">
-        <span class='placeholder'>{{ recipient_column }}</span>
-        {{ template.placeholders_as_markup|join(" ") }}
-      </p>
-      <p>
-        <a href="{{ url_for('.get_example_csv', service_id=service_id, template_id=template.id) }}">Download an example</a>
-      </p>
-    </div>
-  </div>
+  <p>
+    You need
+    {{ template.placeholders|length + 1 }}
+    {% if template.placeholders %}
+      columns
+    {% else %}
+      column
+    {% endif %}
+    in your file, like this:
+  </p>
+
+  {% call(item) list_table(
+    example,
+    caption="Example",
+    caption_visible=False,
+    field_headings=[recipient_column] + template.placeholders|list
+  ) %}
+    {% for column in item %}
+      {{ text_field(column) }}
+    {% endfor %}
+  {% endcall %}
+
+  <p class="bottom-gutter">
+    <a href="{{ url_for('.get_example_csv', service_id=service_id, template_id=template.id) }}">Download this example</a>
+  </p>
+
 
   {{file_upload(form.file, button_text='Upload your CSV file')}}
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -129,7 +129,7 @@ def test_download_example_csv(
                 follow_redirects=True
             )
         assert response.status_code == 200
-        assert response.get_data(as_text=True) == 'phone number\r\n+4412341234\r\n'
+        assert response.get_data(as_text=True) == 'phone number\r\n+4412341234\r\n+4412341234\r\n'
         assert 'text/csv' in response.headers['Content-Type']
 
 


### PR DESCRIPTION
## Put two rows in example CSV file

We reckon that this will help people understand that the first row is headers and the subsequent rows are the users’ data.

## Use context managers for StringIO

It’s possible that leaving a StringIO stream open could cause a memory leak. Using a context manager closes it automatically when it’s finished with.

## Show an example of a CSV on the ‘send’ page

![image](https://cloud.githubusercontent.com/assets/355079/14243173/dc815d62-fa4b-11e5-8919-7be89fd76e0f.png)

This should help:
- understanding of what the CSV should contain
- understanding what ‘download example’ will do

## Use template name as file name for example CSV

`11.csv` or `9a1d8a7f-c202-43b9-9239-68939d34fec6.csv` is not very friendly.

`Two week reminder.csv` is much nicer.