### PR TITLE
Fix re-uploading of CSV files

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -252,6 +252,17 @@ def check_messages(service_id, template_type, upload_id):
     )
 
 
+@main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['POST'])
+@login_required
+@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+def recheck_messages(service_id, template_type, upload_id):
+
+    if not session.get('upload_data'):
+        return redirect(url_for('main.choose_template', service_id=service_id, template_type=template_type))
+
+    return send_messages(service_id, session['upload_data'].get('template_id'))
+
+
 @main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')


### PR DESCRIPTION
The problem
---

1. Upload a CSV with problems
2. See the validation errors on the page
3. Try to re-upload the file
4. Get this error:

> Method Not Allowed
> The method is not allowed for the requested URL.

https://www.pivotaltracker.com/story/show/116882241

The cause
---
The `POST` route for the check page (where you see errors in your files)
was removed here: https://github.com/alphagov/notifications-admin/commit/f3fd5f6b15b9841111819d9526cf80b20b6ababd#diff-1dd8b3bf53dfd9382c7721051f3d930dR280

The fix
---
This commit adds:
- a simple route which re-calls the initial ‘I have uploaded a file’ route
- a test to make sure that both of these routes are `POST`ed to