### PR TITLE
Fix hidden trial mode link

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -71,7 +71,27 @@
   }
 
   &-action {
+    
+    display: block;
     text-align: right;
+    float: right;
+
+    &:link,
+    &:visited {
+      color: $white;
+    }
+
+    &:hover,
+    &:active {
+      color: $light-blue-25;
+    }
+
+    &:active,
+    &:focus {
+      background-color: $yellow;
+      color: $govuk-blue;
+    }
+
   }
 
 }


### PR DESCRIPTION
This link wasn’t styled, therefore it had, by default, the same colour as its background (blue).

This commit explicitly sets it to be white, so it is visible against its background.

***

![image](https://cloud.githubusercontent.com/assets/355079/14282150/00ed0cac-fb35-11e5-863c-dbbd3c5f3605.png)
