### PR TITLE
When a user accepts an invite, show them the tour

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -2,6 +2,8 @@ from datetime import date
 
 from flask import (
     render_template,
+    redirect,
+    url_for,
     session,
     flash,
     jsonify
@@ -30,9 +32,7 @@ def service_dashboard(service_id):
 
     if session.get('invited_user'):
         session.pop('invited_user', None)
-        message = 'You have successfully accepted your invitation and been added to {}'.format(
-            current_service['name'])
-        flash(message, 'default_with_tick')
+        return redirect(url_for("main.tour", service_id=service_id, page=1))
 
     statistics = statistics_api_client.get_statistics_for_service(service_id)['data']
     template_statistics = template_statistics_client.get_template_statistics_for_service(service_id)

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -370,11 +370,7 @@ def test_new_invited_user_verifies_and_added_to_service(app_,
                 mock_accept_invite.assert_called_with(data['service'], sample_invite['id'])
                 mock_check_verify_code.assert_called_once_with(new_user_id, '12345', 'sms')
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            element = page.find('h2', class_='navigation-service-name').find('a')
-            assert element.text == 'Test Service'
-            service_link = element.attrs['href']
-            assert service_link == '/services/{}/dashboard'.format(service_one['id'])
-
-            flash_banner = page.find('div', class_='banner-default-with-tick').string.strip()
-            assert flash_banner == 'You have successfully accepted your invitation and been added to Test Service'
+            raw_html = response.data.decode('utf-8')
+            page = BeautifulSoup(raw_html, 'html.parser')
+            element = page.find('h2').text == 'Trial mode'
+            assert service_one['id'] in raw_html


### PR DESCRIPTION
It’s jarring to be sent right into the dashboard.

We think the tour makes things less jarring.