### PR TITLE
Make it easier to deal with phone numbers in spreadsheets

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -73,6 +73,10 @@
 
   }
 
+  &-index {
+    width: 15px;
+  }
+
 }
 
 .table-field-heading {

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -18,7 +18,7 @@ from flask import (
 
 from flask_login import login_required, current_user
 from utils.template import Template
-from utils.recipients import RecipientCSV, first_column_heading
+from utils.recipients import RecipientCSV, first_column_heading, validate_and_format_phone_number
 
 from app.main import main
 from app.main.forms import CsvUploadForm
@@ -55,7 +55,9 @@ def get_example_csv_rows(template, number_of_rows=2):
         [
             {
                 'email': current_user.email_address,
-                'sms': current_user.mobile_number
+                'sms': validate_and_format_phone_number(
+                    current_user.mobile_number, human_readable=True
+                )
             }[template.template_type]
         ] + [
             "{} {}".format(header, i) for header in template.placeholders

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -29,7 +29,7 @@
   {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible) %}
     {% for item in items %}
       {% call row() %}
-        {{ parent_caller(item) }}
+        {{ parent_caller(item, loop.index + 1) }}
       {% endcall %}
     {% endfor %}
     {% if not items %}
@@ -52,6 +52,12 @@
 {% macro field(align='left', status='') -%}
   <td class="table-field{% if align == 'right' %}-right-aligned{% endif %}">
     <span class="{{ 'table-field-status-' + status if status }}">{{ caller() }}</span>
+  </td>
+{%- endmacro %}
+
+{% macro index_field(text) -%}
+  <td class="table-field-index">
+    <span>{{ text }}</span>
   </td>
 {%- endmacro %}
 

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,6 +1,6 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
-{% call(item) list_table(
+{% call(item, row_number) list_table(
   notifications,
   caption=uploaded_file_name,
   caption_visible=False,

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -29,7 +29,7 @@
     {{ current_service.id }}
   </p>
 
-  {% call(item) list_table(
+  {% call(item, row_number) list_table(
     keys,
     empty_message="You haven’t created any API keys yet",
     caption="API keys",

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -2,7 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/email-message.html" import email_message %}
 {% from "components/sms-message.html" import sms_message %}
-{% from "components/table.html" import list_table, field, text_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/placeholder.html" import placeholder %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-footer.html" import page_footer %}
@@ -71,14 +71,12 @@
     </form>
   {% endif %}
 
-  {% call(item) list_table(
+  {% call(item, row_number) list_table(
     recipients.initial_annotated_rows_with_errors if rows_have_errors else recipients.initial_annotated_rows,
     caption=original_file_name,
     field_headings=['1'] + recipients.column_headers_with_placeholders_highlighted
   ) %}
-    {% call field() %}
-      {{ item.index + 2 }}
-    {% endcall %}
+    {{ index_field(item.index + 2) }}
     {% for column in recipients.column_headers %}
       {% if item[column].error %}
         {% call field() %}

--- a/app/templates/views/dashboard/jobs.html
+++ b/app/templates/views/dashboard/jobs.html
@@ -1,6 +1,6 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, hidden_field_heading %}
 
-{% call(item) list_table(
+{% call(item, row_number) list_table(
   jobs,
   caption="Recent batch jobs",
   empty_message='You haven’t sent any batch messages yet',

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -1,5 +1,5 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading %}
-{% call(item) list_table(
+{% call(item, row_number) list_table(
   template_statistics,
   caption="Recent templates used",
   empty_message='You haven’t sent any batch messages yet',

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -19,7 +19,7 @@
       <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, status=['sent', 'delivered'], page=1) }}">Successful messages</a>&emsp;
       <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, status=['failed', 'complaint', 'bounce'], page=1) }}">Failed messages</a>
     </p>
-    {% call(item) list_table(
+    {% call(item, row_number) list_table(
       jobs,
       caption="Recent activity",
       caption_visible=False,

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -29,7 +29,7 @@ Manage users – GOV.UK Notify
     {% endif %}
   </div>
 
-  {% call(item) list_table(
+  {% call(item, row_number) list_table(
     users, caption='Active', **table_options
   ) %}
     {% call field() %}
@@ -48,7 +48,7 @@ Manage users – GOV.UK Notify
   {% endcall %}
 
   {% if invited_users %}
-    {% call(item) list_table(
+    {% call(item, row_number) list_table(
       invited_users, caption='Invited', **table_options
     ) %}
       {% call field() %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -20,7 +20,7 @@
       <a href="{{ url_for(".view_notifications", service_id=current_service.id, status=['sent', 'delivered'], page=1) }}">Successful messages</a>&emsp;
       <a href="{{ url_for(".view_notifications", service_id=current_service.id, status=['failed', 'complaint', 'bounce'], page=1) }}">Failed messages</a>
     </p>
-    {% call(item) list_table(
+    {% call(item, row_number) list_table(
       notifications,
       caption="Recent activity",
       caption_visible=False,

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -3,7 +3,7 @@
 {% from "components/email-message.html" import email_message %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/table.html" import list_table, text_field %}
+{% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
 
 {% block page_title %}
   Send text messages – GOV.UK Notify
@@ -39,12 +39,13 @@
     in your file, like this:
   </p>
 
-  {% call(item) list_table(
+  {% call(item, row_number) list_table(
     example,
     caption="Example",
     caption_visible=False,
-    field_headings=[recipient_column] + template.placeholders|list
+    field_headings=['1'] + [recipient_column] + template.placeholders|list
   ) %}
+    {{ index_field(row_number) }}
     {% for column in item %}
       {{ text_field(column) }}
     {% endfor %}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -178,7 +178,7 @@
         {% endcall %}
       {% endcall %}
 
-      {% call(item) list_table(
+      {% call(item, row_number) list_table(
         [
           {
             'file': 'dispatch_20151114.csv', 'status': 'Queued'
@@ -206,7 +206,7 @@
         {% endcall %}
       {% endcall %}
 
-      {% call(item) list_table(
+      {% call(item, row_number) list_table(
         [],
         caption='Jobs',
         field_headings=['Job', 'Time'],

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -9,7 +9,7 @@
 
   <h1 class="heading-large">Your profile</h1>
 
-  {% call(item) list_table(
+  {% call(item, row_number) list_table(
     [
       {'label': 'Name', 'value': current_user.name, 'url': url_for('.user_profile_name')},
       {'label': 'Email address', 'value': current_user.email_address, 'url': url_for('.user_profile_email')},

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ Pygments==2.0.2
 
 git+https://github.com/alphagov/notifications-python-client.git@0.3.1#egg=notifications-python-client==0.3.1
 
-git+https://github.com/alphagov/notifications-utils.git@3.2.1#egg=notifications-utils==3.2.1
+git+https://github.com/alphagov/notifications-utils.git@3.3.0#egg=notifications-utils==3.3.0

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -60,7 +60,7 @@ def test_send_test_sms_message_to_self(
     mock_get_users_by_service
 ):
 
-    expected_data = {'data': 'phone number\r\n07700 900762\r\n', 'file_name': 'Test run'}
+    expected_data = {'data': 'phone number\r\n07700 900 762\r\n', 'file_name': 'Test run'}
     mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')
 
     with app_.test_request_context():
@@ -139,7 +139,7 @@ def test_download_example_csv(
                 follow_redirects=True
             )
         assert response.status_code == 200
-        assert response.get_data(as_text=True) == 'phone number\r\n07700 900762\r\n07700 900762\r\n'
+        assert response.get_data(as_text=True) == 'phone number\r\n07700 900 762\r\n07700 900 762\r\n'
         assert 'text/csv' in response.headers['Content-Type']
 
 


### PR DESCRIPTION
## Make phone numbers human readable
- in the example table on the ‘send’ page
- in the example CSV files

Implements: alphagov/notifications-utils#18

## Add row numbers to tables

When a table is showing the contents of a CSV file, it should look something like a spreadsheet.

The minimally skeuomorphic way to do this is by adding row numbers.

![image](https://cloud.githubusercontent.com/assets/355079/14311600/0e610086-fbe0-11e5-9c70-ee22b3e8c41e.png)

This commit doesn’t
- make the row numbers monospace (it’s barely noticeable and doesn’t reflect what actual spreadsheets do)
- make the first column heading ‘Row’ (again, doesn’t reflect how actual spreadsheets work, and takes up more valuable space)

https://www.pivotaltracker.com/story/show/116966855