### PR TITLE
Fix exception on email job page

### DIFF
--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -25,8 +25,8 @@
       {{ email_message(
         template.subject,
         template.formatted_as_markup,
-        from_address='{}@notifications.service.gov.uk'.format(service.email_from),
-        from_name=service.name
+        from_address='{}@notifications.service.gov.uk'.format(current_service.email_from),
+        from_name=current_service.name
       )}}
     {% endif %}
 


### PR DESCRIPTION
For email jobs, the template needed to look up the service to work out the email_from and from_name.

`service` used to be a variable passed through to the view. Now every view gets `current_service` instead.

This is a quick fix to make things work.