### PR TITLE
Add code coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 - npm rebuild node-sass
 - pip install -r requirements_for_test.txt
 after_success:
+- coveralls
 - ./scripts/trigger-dependent-build.sh
 script:
 - npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/alphagov/notifications-admin.svg)](https://travis-ci.org/alphagov/notifications-admin)
 [![Requirements Status](https://requires.io/github/alphagov/notifications-admin/requirements.svg?branch=master)](https://requires.io/github/alphagov/notifications-admin/requirements/?branch=master)
+[![Coverage Status](https://coveralls.io/repos/alphagov/notifications-admin/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/notifications-admin?branch=master)
 
 
 [![Deploy to staging](https://notify-build-monitor.herokuapp.com/deploys/notifications-admin/master...staging.svg?prefix=Deploy%20to)](https://github.com/alphagov/notifications-admin/compare/staging...master?expand=1&title=Deploy%20to%20staging) [![Deploy to live](https://notify-build-monitor.herokuapp.com/deploys/notifications-admin/staging...live.svg?prefix=Deploy%20to)](https://github.com/alphagov/notifications-admin/compare/live...staging?expand=1&title=Deploy%20to%20live)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,6 +2,8 @@
 pep8==1.5.7
 pytest==2.8.1
 pytest-mock==0.8.1
+pytest-cov==2.2.1
+coveralls==1.1
 moto==0.4.19
 httpretty==0.8.10
 beautifulsoup4==4.4.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -31,8 +31,8 @@ npm test
 display_result $? 2 "Front end code style check"
 
 ## Code coverage
-#py.test --cov=app tests/
-#display_result $? 3 "Code coverage"
+py.test --cov=app --cov-report=term-missing tests/
+display_result $? 3 "Code coverage"
 
 export NOTIFY_ADMIN_ENVIRONMENT='config.Test'
 py.test -v


### PR DESCRIPTION
- generates a code coverage report
- triggers Coveralls on every Travis build
- adds a badge to the README

[![Coverage Status](https://coveralls.io/repos/alphagov/notifications-admin/badge.svg?branch=code-coverage&service=github)](https://coveralls.io/github/alphagov/notifications-admin?branch=code-coverage)