### PR TITLE
Change banners on home page if no permissions

### DIFF
--- a/app/templates/views/choose-template.html
+++ b/app/templates/views/choose-template.html
@@ -16,8 +16,9 @@
 
     {% if current_user.has_permissions(permissions=['manage_templates'], any_=True) %}
        <p class="bottom-gutter">
-         You need a template before you can send
-         {{ 'emails' if 'email' == template_type else 'text messages' }}
+         There are no
+         {{ 'email' if 'email' == template_type else 'text message' }}
+         templates
        </p>
       <a href="{{ url_for('.add_service_template', service_id=current_service.id, template_type=template_type) }}" class="button">Add a new template</a>
     {% else %}

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -8,10 +8,14 @@
 
     {% if not templates and current_user.has_permissions(['send_texts', 'send_emails', 'send_letters'], any_=True) %}
       {% include 'views/dashboard/get-started.html' %}
-    {% elif current_service.restricted %}
-      <div class="dashboard">
+    {% elif current_user.has_permissions([
+      'manage_templates', 'manage_api_keys', 'manage_users', 'manage_settings
+    '], any_=True, admin_override=True) %}
+      {% if current_service.restricted %}
         {% include 'views/dashboard/trial-mode-banner.html' %}
-      </div>
+      {% endif %}
+    {% else %}
+      {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 
       <div

--- a/app/templates/views/dashboard/no-permissions-banner.html
+++ b/app/templates/views/dashboard/no-permissions-banner.html
@@ -1,0 +1,5 @@
+{% from "components/banner.html" import banner_wrapper %}
+
+{% call banner_wrapper(type="mode") %}
+  You only have permission to view this service
+{% endcall %}


### PR DESCRIPTION
## Change banners on home page if no permissions

(except view activity, natch)

> No permissions – Remove trial mode banner

> No permissions – Add blue banner saying 'You only have permission to view this service'

## Shorten empty message on choose template

You may have permission to add templates but not to send messages. The previous error message was misleading.