### PR TITLE
Don’t allow commas in placeholders

### DIFF
--- a/app/assets/javascripts/highlightTags.js
+++ b/app/assets/javascripts/highlightTags.js
@@ -46,9 +46,10 @@
 
       this.initialHeight = this.$textbox.height();
 
-      this.$backgroundMaskForeground.width(
-        this.$textbox.width()
-      );
+      this.$backgroundMaskForeground.css({
+        'width': this.$textbox.width(),
+        'border-width': this.$textbox.css('border-width')
+      });
 
       this.$textbox
         .trigger("input");

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -15,7 +15,7 @@ from wtforms import (
 from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import (DataRequired, Email, Length, Regexp)
 
-from app.main.validators import (Blacklist, CsvFileValidator, ValidEmailDomainRegex)
+from app.main.validators import (Blacklist, CsvFileValidator, ValidEmailDomainRegex, NoCommasInPlaceHolders)
 
 
 def email_address(label='Email address'):
@@ -203,7 +203,11 @@ class SMSTemplateForm(Form):
 
     template_content = TextAreaField(
         u'Message content',
-        validators=[DataRequired(message="Can’t be empty")])
+        validators=[
+            DataRequired(message="Can’t be empty"),
+            NoCommasInPlaceHolders()
+        ]
+    )
 
 
 class EmailTemplateForm(SMSTemplateForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -2,6 +2,7 @@ import re
 from wtforms import ValidationError
 from datetime import datetime
 from app.main.encryption import check_hash
+from utils.template import Template
 
 
 class Blacklist(object):
@@ -38,3 +39,13 @@ class ValidEmailDomainRegex(object):
         email_regex = "[^\@^\s]+@([^@^\\.^\\s]+\.)*({})$".format("|".join(valid_domains))
         if not re.match(email_regex, field.data.lower()):
             raise ValidationError(message)
+
+
+class NoCommasInPlaceHolders():
+
+    def __init__(self, message='You can’t have commas in your fields'):
+        self.message = message
+
+    def __call__(self, form, field):
+        if ',' in ''.join(Template({'content': field.data}).placeholders):
+            raise ValidationError(self.message)

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -1,6 +1,6 @@
 import pytest
 from app.main.forms import RegisterUserForm
-from app.main.validators import ValidEmailDomainRegex
+from app.main.validators import ValidEmailDomainRegex, NoCommasInPlaceHolders
 from wtforms import ValidationError
 from unittest.mock import Mock
 
@@ -112,3 +112,11 @@ def test_invalid_list_of_white_list_email_domains(app_, email):
         email_domain_validators = ValidEmailDomainRegex()
         with pytest.raises(ValidationError):
             email_domain_validators(None, _gen_mock_field(email))
+
+
+def test_for_commas_in_placeholders(app_):
+    with app_.test_request_context():
+        with pytest.raises(ValidationError) as error:
+            NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name,date))'))
+        assert str(error.value) == 'You can’t have commas in your fields'
+        NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name))'))


### PR DESCRIPTION
## Don’t allow commas in placeholders

> If a user tries to save a template containing something like ((name,date)) we should give a validation error.

This is because it causes havoc with the column headers in CSV files.

https://www.pivotaltracker.com/story/show/117043389

![image](https://cloud.githubusercontent.com/assets/355079/14356098/5ff6e7ac-fcdb-11e5-8d79-893b1e0aff1e.png)


## Make border width of field layers match textbox

We put a border on text boxes that have errors. This means that they take up more space than the layers above them which don’t have borders.

This makes the layers that highlight the fields in a template misalign.

This commit adds a line to make the borders match, which fixes this.

![image](https://cloud.githubusercontent.com/assets/355079/14356116/7893154c-fcdb-11e5-8487-f489957ffbde.png)
