### PR TITLE
Reword ‘recent templates’ section of dashboard

### DIFF
--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -1,9 +1,9 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
+{% from "components/table.html" import list_table, field, hidden_field_heading, right_aligned_field_heading %}
 {% call(item, row_number) list_table(
   template_statistics,
-  caption="Recent templates – last 7 days",
-  empty_message='You haven’t sent any batch messages yet',
-  field_headings=['Template', 'Type', right_aligned_field_heading('Usage')]
+  caption="In the last 7 days",
+  empty_message='You haven’t set up any templates yet',
+  field_headings=['Template', hidden_field_heading('Type'), right_aligned_field_heading('Messages sent')]
 ) %}
   {% call field() %}
     <a href="{{ url_for('.edit_service_template', service_id=current_service.id, template_id=item.template.id) }}">
@@ -11,7 +11,7 @@
     </a>
   {% endcall %}
   {% call field() %}
-    {{item.template.template_type}}
+    {{'Text message' if 'sms' == item.template.template_type else 'Email'}}
   {% endcall %}
   {% call field(align='right') %}
     {{ item.usage_count }}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -85,7 +85,7 @@ def test_should_show_recent_templates_on_dashboard(app_,
         assert 'Test Service' in headers
         assert 'Sent today' in headers
         template_usage_headers = [th.text.strip() for th in page.thead.find_all('th')]
-        for th in ['Template', 'Type', 'Usage']:
+        for th in ['Template', 'Type', 'Messages sent']:
             assert th in template_usage_headers
         table_rows = page.tbody.find_all('tr')
 


### PR DESCRIPTION
## Before

![image](https://cloud.githubusercontent.com/assets/355079/14421961/2d4116e0-ffcc-11e5-8dfd-958d3ac2ddb5.png)

## After

![image](https://cloud.githubusercontent.com/assets/355079/14421949/184a9392-ffcc-11e5-83b0-be0145705584.png)
