### PR TITLE
Only collapse email templates if they’re long

### DIFF
--- a/app/assets/javascripts/expandCollapse.js
+++ b/app/assets/javascripts/expandCollapse.js
@@ -5,7 +5,11 @@
 
     this.start = function(component) {
 
-      this.$component = $(component)
+      this.$component = $(component);
+
+      if (this.$component.height() < this.$component.data('max-height')) return;
+
+      this.$component      
         .append(`
           <div class='toggle' tabindex='0'>...<span class='visually-hidden'>show full email</span></div>
         `)

--- a/app/templates/components/email-message.html
+++ b/app/templates/components/email-message.html
@@ -31,7 +31,7 @@
         </tbody>
       </table>
     {% endif %}
-    <div class="email-message-body" data-module="expand-collapse">
+    <div class="email-message-body" data-module="expand-collapse" data-max-height="200">
       <div class="email-message-body-wrapper">
       {{ body|nl2br }}
       </div>


### PR DESCRIPTION
It’s a bit silly to have email templates expandable if you’re only going
to reveal a couple more lines.

This commit adds a data attribute which specifies how high (in pixels)
the email template can be before it gets truncated. It then changes the
script to only truncate emails which are naturally taller than this
height.

Currently the cut off is at 200px, which is approximately 8 lines of
text: `200px / (font-size: 19px * line-height: 1.31) = 8.03`