### PR TITLE
Wrap long words in email template previews

### DIFF
--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -45,6 +45,7 @@
     border-top: 1px solid $border-colour;
     border-bottom: 1px solid $border-colour;
     position: relative;
+    word-wrap: break-word;
 
     &-wrapper {
 


### PR DESCRIPTION
If you put, for example, a URL in an email template it can be very long.
This can cause it to overflow its container. This commit forces it to
wrap instead.

Before | After 
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/14495820/f599c174-0188-11e6-99d1-7ea6cc9591bb.png) | ![image](https://cloud.githubusercontent.com/assets/355079/14495805/e7bba8ce-0188-11e6-8c36-b45cf71cc177.png)


https://www.pivotaltracker.com/story/show/117233785