### PR TITLE
Make activity page use new nomenclature for status

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -119,7 +119,7 @@ def view_notifications(service_id):
         service_id=service_id,
         page=page,
         template_type=filter_args.getlist('template_type') if 'template_type' in filter_args else None,
-        status=filter_args.getlist('status') if 'status' in filter_args else None)
+        status=filter_args.getlist('status') if 'status' in filter_args else ['delivered', 'failed'])
     view_dict = MultiDict(request.args)
     prev_page = None
     if notifications['links'].get('prev', None):
@@ -157,7 +157,7 @@ def view_notifications(service_id):
                 '.view_notifications',
                 service_id=current_service['id'],
                 template_type=item[1],
-                status=request.args.get('status', '')
+                status=request.args.get('status', 'delivered,failed')
             )] for item in [
                 ['Emails', 'email'],
                 ['Text messages', 'sms'],
@@ -171,9 +171,9 @@ def view_notifications(service_id):
                 template_type=request.args.get('template_type', ''),
                 status=item[1]
             )] for item in [
-                ['Successful', 'sent,delivered'],
-                ['Failed', 'failed,complaint,bounce'],
-                ['Both', '']
+                ['Successful', 'delivered'],
+                ['Failed', 'failed'],
+                ['Both', 'delivered,failed']
             ]
         ]
     )

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -4,7 +4,7 @@
   </h2>
   <ul>
   {% if current_user.has_permissions(['view_activity'], admin_override=True) %}
-    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, page=1) }}">Activity</a></li>
+    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='delivered,failed') }}">Activity</a></li>
   {% endif %}
   {% if current_user.has_permissions(['view_activity', 'manage_templates', 'manage_api_keys'], admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='sms') }}">Text message templates</a></li>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -12,13 +12,13 @@
 
   <h1 class="heading-large">
 
-    {%- if (request_args.get('template_type', '') == '') and (request_args.get('status', '') == '') -%}
+    {%- if (request_args.get('template_type', '') == '') and (request_args.get('status', 'delivered,failed') == 'delivered,failed') -%}
 
       Activity
 
     {%- else -%}
 
-      {% if request_args.get('status') != '' %}
+      {% if request_args.get('status') != 'delivered,failed' %}
         {% for label, option, _ in status_filters %}
           {% if request_args.get('status') == option %}
             {{ label }}
@@ -32,7 +32,7 @@
 
         {% for template_label, template_option, _ in type_filters %}
           {% if request_args.get('template_type') == template_option %}
-            {% if request_args.get('status', '') == '' %}
+            {% if request_args.get('status', 'delivered,failed') == 'delivered,failed' %}
               {{ template_label }}
             {% else %}
               {{ template_label | lower }}


### PR DESCRIPTION
Statuses used to be:
- failed
- complaint
- bounce
- sent
- delivered

Now they are:
- sent
- sending
- delivered

This change broke the notifications page on the admin app.

It also made me realise that we should be ignoring ‘sending’ messages in the history page—it should only show messages we’ve tried to deliver.

The code for this is a bit of a bodge, but it will get things working again for now.