### PR TITLE
Use a different module for doing nice timestamps

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,7 @@ from pygments import highlight
 from pygments.lexers import JavascriptLexer
 from pygments.formatters import HtmlFormatter
 from werkzeug.exceptions import abort
-from babel.dates import format_timedelta
+import humanize
 
 from app.notify_client.api_client import ServiceAPIClient
 from app.notify_client.api_key_api_client import ApiKeyApiClient
@@ -191,11 +191,9 @@ def format_date(date):
 def format_delta(date):
     date = dateutil.parser.parse(date)
     native = date.replace(tzinfo=None)
-    difference = native - datetime.datetime.now()
-    return format_timedelta(
-        datetime.timedelta(seconds=difference.total_seconds()),
-        add_direction=True,
-        format='short'
+    difference = datetime.datetime.now() - native
+    return humanize.naturaltime(
+        datetime.timedelta(seconds=difference.total_seconds())
     )
 
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -93,10 +93,10 @@
       </p>
     {% endcall %}
 
-    {{ text_field(item.status|title) }}
+    {{ text_field(item.status|capitalize) }}
 
     {% call field(align='right') %}
-      {{ item.created_at|format_delta }}
+      {{ item.created_at|format_delta|capitalize }}
     {% endcall %}
   {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Flask-Bcrypt==0.6.2
 credstash==1.8.0
 boto3==1.2.3
 Pygments==2.0.2
-Babel==2.3.3
+humanize==0.5.1
 
 git+https://github.com/alphagov/notifications-python-client.git@0.3.1#egg=notifications-python-client==0.3.1
 


### PR DESCRIPTION
There is a bug in Babel[1] which means that it throws an exception if it can’t find the locale it wants to use.

This is not a problem when developing locally, because OS X comes with lots of locales. The AWS machines, however, only have one locale, which is not the one that Babel is looking for. Hence the ‘Activity’ page doesn’t work.

This commit changes to using Humanize[2] instead, which is much less vast and hopefully less hungry in its requirements.

That’s a morning we won’t get back…

1. https://github.com/python-babel/babel/issues/137
2. https://pypi.python.org/pypi/humanize