### PR TITLE
Remove human-friendly timestamps from activity page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,6 @@ from pygments import highlight
 from pygments.lexers import JavascriptLexer
 from pygments.formatters import HtmlFormatter
 from werkzeug.exceptions import abort
-import humanize
 
 from app.notify_client.api_client import ServiceAPIClient
 from app.notify_client.api_key_api_client import ApiKeyApiClient
@@ -97,12 +96,12 @@ def create_app():
 
     application.add_template_filter(nl2br)
     application.add_template_filter(format_datetime)
+    application.add_template_filter(format_datetime_short)
     application.add_template_filter(format_time)
     application.add_template_filter(syntax_highlight_json)
     application.add_template_filter(valid_phone_number)
     application.add_template_filter(linkable_name)
     application.add_template_filter(format_date)
-    application.add_template_filter(format_delta)
 
     application.after_request(useful_headers_after_request)
     application.after_request(save_service_after_request)
@@ -177,6 +176,12 @@ def format_datetime(date):
     return native.strftime('%A %d %B %Y at %H:%M')
 
 
+def format_datetime_short(date):
+    date = dateutil.parser.parse(date)
+    native = date.replace(tzinfo=None)
+    return native.strftime('%d %B at %H:%M')
+
+
 def format_time(date):
     date = dateutil.parser.parse(date)
     native = date.replace(tzinfo=None)
@@ -186,15 +191,6 @@ def format_time(date):
 def format_date(date):
     date = dateutil.parser.parse(date)
     return date.strftime('%A %d %B %Y')
-
-
-def format_delta(date):
-    date = dateutil.parser.parse(date)
-    native = date.replace(tzinfo=None)
-    difference = datetime.datetime.now() - native
-    return humanize.naturaltime(
-        datetime.timedelta(seconds=difference.total_seconds())
-    )
 
 
 def valid_phone_number(phone_number):

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -96,7 +96,7 @@
     {{ text_field(item.status|capitalize) }}
 
     {% call field(align='right') %}
-      {{ item.created_at|format_delta|capitalize }}
+      {{ item.created_at|format_datetime_short }}
     {% endcall %}
   {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ Flask-Bcrypt==0.6.2
 credstash==1.8.0
 boto3==1.2.3
 Pygments==2.0.2
-humanize==0.5.1
 
 git+https://github.com/alphagov/notifications-python-client.git@0.3.1#egg=notifications-python-client==0.3.1
 


### PR DESCRIPTION
The fix introduced by e6490e1 did not fix anything.

So lets remove the ‘3 days ago’ thing completely and just say the date and time instead.

![image](https://cloud.githubusercontent.com/assets/355079/14528155/0d69f64e-0246-11e6-9da7-f1cb0772506c.png)
