### PR TITLE
Show email subject on choose template page

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -4,7 +4,7 @@
 <div class="column-two-thirds">
   {% if 'email' == template.template_type %}
     {{ email_message(
-      None,
+      template.formatted_subject_as_markup,
       template.formatted_as_markup,
       name=template.name if show_title else None
     ) }}


### PR DESCRIPTION
Removed this before as part of truncating email previews in
https://github.com/alphagov/notifications-admin/commit/3a5b76ce2a672ba5d42b4013a0274f64742eb5d7#diff-b5f54dc364655c298fd119e3bc148cc6R45

But actually trying to use the app it’s a weird inconsistency to not have the subject show everywhere.

So this commit reinstates it.

***

![image](https://cloud.githubusercontent.com/assets/355079/14532085/b9c71258-0257-11e6-98f5-4cf5924ccd9e.png)
