### PR TITLE
Simplify JWT

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,6 @@ import os
 import re
 
 import dateutil
-import datetime
 import urllib
 from flask import (
     Flask,
@@ -16,10 +15,10 @@ from flask import (
 from flask._compat import string_types
 from flask_login import LoginManager
 from flask_wtf import CsrfProtect
-from notifications_python_client import HTTPError
+from notifications_python_client.errors import HTTPError
 from pygments import highlight
-from pygments.lexers import JavascriptLexer
-from pygments.formatters import HtmlFormatter
+from pygments.formatters.html import HtmlFormatter
+from pygments.lexers.javascript import JavascriptLexer
 from werkzeug.exceptions import abort
 
 from app.notify_client.api_client import ServiceAPIClient

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -7,9 +7,6 @@ from flask import (
     abort
 )
 
-
-from notifications_python_client.errors import HTTPError
-
 from app.main import main
 
 from app import (

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -14,7 +14,7 @@ from flask_login import (
     current_user
 )
 
-from notifications_python_client import HTTPError
+from notifications_python_client.errors import HTTPError
 from app.main import main
 from app.main.forms import (
     InviteUserForm,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -11,7 +11,7 @@ from flask_login import (
     login_required,
     current_user
 )
-from notifications_python_client import HTTPError
+from notifications_python_client.errors import HTTPError
 
 from app import service_api_client
 from app.main import main

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -14,7 +14,6 @@ from itsdangerous import SignatureExpired
 
 from flask_login import login_user
 
-from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import check_token
 
 from app.main import main

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -1,7 +1,7 @@
 from flask import jsonify, request
 from app import (version, status_api_client)
 from app.status import status
-from notifications_python_client import HTTPError
+from notifications_python_client.errors import HTTPError
 
 
 @status.route('/_status', methods=['GET'])

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -48,26 +48,10 @@
 {
   iss: 'string', // service id
   iat: 0, // creation time in  epoch seconds (UTC)
-  req: 'string', // signed request
-  pay: 'string', // signed payload (POST requests only)
 }
         """|syntax_highlight_json}}
 <div class="grid-row">
     <div class="column-three-quarters">
-        <p>Notify API tokens sign both the request being made, and for POST requests, the payload.</p>
-
-        <p>
-            The signing algorithm is HMAC signature, using provided key SHA256 hashing algorithm.
-        </p>
-
-        <p>Request signing is of the form HTTP METHOD PATH.</p>
-
-        {{ "GET /notification/1234"|syntax_highlight_json }}
-
-        <p></p>
-
-        <p>Payload signing requires the actual payload to be signed, NOT the JSON object. Serialize the object first
-            then sign the serialized object.</p>
 
         <h3 class="heading-medium">
             API endpoints

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,8 +75,6 @@ For examples of how to encode and decode JSON Web Tokens, see [authentication.py
 A JSON Web Token contains, in encrypted format:
 * your service ID - identifies your service
 * your API key (in JSON Web Token terms this is called the client ID) - used to sign tokens during requests for API resources
-* an indication of what you're trying to do - GET, POST, etc.
-* the endpoint you're trying to access
 
 Use the [GOV.UK Notify](https://www.notifications.service.gov.uk/) web application to find your service ID and create API keys. 
 
@@ -100,23 +98,10 @@ GOV.UK Notify application-specific claims:
 {
   iss: 'string', // service id
   iat: 0, // creation time in  epoch seconds (UTC)
-  req: 'string', // signed request
-  pay: 'string', // signed payload (POST requests only)
 }
 ```
 
-The GOV.UK Notify API tokens sign the:
-* request being made
-* payload (for POST requests)
-
 The signing algorithm is the HMAC signature, using the provided key SHA256 hashing algorithm.
-
-Request signing is of the form HTTP METHOD PATH:
-```
-GET /notification/1234
-```
-
-Payload signing requires the actual payload to be signed, not the JSON object. Make sure you serialize the object first, then sign the serialized object.
 
 API client libraries
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ credstash==1.8.0
 boto3==1.2.3
 Pygments==2.0.2
 
-git+https://github.com/alphagov/notifications-python-client.git@0.3.1#egg=notifications-python-client==0.3.1
+git+https://github.com/alphagov/notifications-python-client.git@0.5.0#egg=notifications-python-client==0.5.0
 
 git+https://github.com/alphagov/notifications-utils.git@4.1.3#egg=notifications-utils==4.1.3


### PR DESCRIPTION
This pull request removes the need for the req and pay in the claims JWT.

Use the new version of the notifications-python-client. This version no longer adds the req and pay to the claims of the jwt.

The change is backward compatible so an older client that sends a JWT with the extra claims will pass authentication.
Once all the clients have been updated to not include the extra claims some updates to exclude them from the method signatures will happen as well.

The documentation has been updated to reflect this change.

https://www.pivotaltracker.com/story/show/116971293