### PR TITLE
Reverse the order of the filters on activity page

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -49,16 +49,16 @@
   <div class='grid-row bottom-gutter'>
     <div class='column-half'>
       {{ pill(
-        'Type',
-        type_filters,
-        request_args.get('template_type', '')
+        'Status',
+        status_filters,
+        request_args.get('status', '')
       ) }}
     </div>
     <div class='column-half'>
       {{ pill(
-        'Status',
-        status_filters,
-        request_args.get('status', '')
+        'Type',
+        type_filters,
+        request_args.get('template_type', '')
       ) }}
     </div>
   </div>


### PR DESCRIPTION
So that they match the order of the page title, eg ‘Failed text messages’

![image](https://cloud.githubusercontent.com/assets/355079/14562207/4a6c140a-0313-11e6-87d4-61ad43b67188.png)
