### PR TITLE
Wrap long words in SMS template previews

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -10,6 +10,7 @@
   white-space: normal;
   margin: 0 0 $gutter 0;
   clear: both;
+  word-wrap: break-word;
 
   p {
     margin: 0;


### PR DESCRIPTION
If you put, for example, a URL in an SMS template it can be very long. This can cause it to overflow its container. This commit forces it to wrap instead.

Related: https://github.com/alphagov/notifications-admin/pull/439

![image](https://cloud.githubusercontent.com/assets/355079/14564138/1e6d0d00-031d-11e6-87da-e2df94d513c0.png)
