### PR TITLE
Make placeholder hint work for SMS messages

### DIFF
--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -26,8 +26,8 @@
           ) }}
         </div>
         <div class="column-one-third">
-          <label for='template_content' class='placeholder-hint'>
-            <div class="banner-mode" id="placeholder-hint" aria-live="polite">
+          <label for='template_content' class='placeholder-hint banner-mode' data-module='placeholder-hint' data-textboxes-selector='#template_content' data-target-textbox-selector="#template_content">
+            <div class="" id="placeholder-hint" aria-live="polite">
               <p>Add fields using ((double brackets))</p>
             </div>
           </label>


### PR DESCRIPTION
The changes introduced in 54e42a2021e26785f892a10dcdb0accca4185c4f didn’t get applied to the add/edit SMS template page. This commit fixes that.