### PR TITLE
Fix innacurate error message on CSV check

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -79,9 +79,9 @@ def get_errors_for_csv(recipients, template_type):
     if recipients.rows_with_missing_data:
         number_of_rows_with_missing_data = len(list(recipients.rows_with_missing_data))
         if 1 == number_of_rows_with_missing_data:
-            errors.append("fill in 1 empty cell")
+            errors.append("enter missing data in 1 row")
         else:
-            errors.append("fill in {} empty cells".format(number_of_rows_with_missing_data))
+            errors.append("enter missing data in {} rows".format(number_of_rows_with_missing_data))
 
     return errors
 

--- a/tests/app/main/test_errors_for_csv.py
+++ b/tests/app/main/test_errors_for_csv.py
@@ -49,7 +49,7 @@ MockRecipients = namedtuple(
             [
                 'add a column called ‘name’',
                 'fix 1 phone number',
-                'fill in 1 empty cell'
+                'enter missing data in 1 row'
             ]
         ),
         (
@@ -63,7 +63,7 @@ MockRecipients = namedtuple(
             [
                 'add columns called ‘name’, ‘date’, and ‘time’',
                 'fix 4 phone numbers',
-                'fill in 4 empty cells'
+                'enter missing data in 4 rows'
             ]
         )
     ]


### PR DESCRIPTION
We only know if a row contains missing cell(s), not how many cells are missing data, eg

![image](https://cloud.githubusercontent.com/assets/355079/14601201/b7c3ef36-0558-11e6-8296-e09f18a2c88a.png)


This commit changes the error message to be more accurate.