### PR TITLE
Put a link to the tour in the footer

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -43,7 +43,7 @@ def add_service():
                                                        user_id=session['user_id'],
                                                        email_from=email_from)
 
-        return redirect(url_for('main.tour', service_id=service_id, page=1))
+        return redirect(url_for('main.tour', page=1))
     else:
         return render_template(
             'views/add-service.html',

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -42,7 +42,7 @@ def add_service():
                                                        restricted=True,
                                                        user_id=session['user_id'],
                                                        email_from=email_from)
-
+        session['service_id'] = service_id
         return redirect(url_for('main.tour', page=1))
     else:
         return render_template(

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -34,7 +34,7 @@ def service_dashboard(service_id):
 
     if session.get('invited_user'):
         session.pop('invited_user', None)
-        return redirect(url_for("main.tour", service_id=service_id, page=1))
+        return redirect(url_for("main.tour", page=1))
 
     statistics = statistics_api_client.get_statistics_for_service(service_id)['data']
     template_statistics = aggregate_usage(template_statistics_client.get_template_statistics_for_service(service_id))

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -34,6 +34,7 @@ def service_dashboard(service_id):
 
     if session.get('invited_user'):
         session.pop('invited_user', None)
+        session['service_id'] = service_id
         return redirect(url_for("main.tour", page=1))
 
     statistics = statistics_api_client.get_statistics_for_service(service_id)['data']

--- a/app/main/views/tour.py
+++ b/app/main/views/tour.py
@@ -12,9 +12,8 @@ headings = [
 ]
 
 
-@main.route("/services/<service_id>/tour/<int:page>")
-@login_required
-def tour(service_id, page):
+@main.route("/tour/<int:page>")
+def tour(page):
     return render_template(
         'views/tour/{}.html'.format(page),
         current_page=page,

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -91,8 +91,11 @@
           </ul>
         </div>
         <div class="column-one-third">
-          <h2>Developers</h2>
-          <a href="{{ url_for('main.documentation') }}">API documentation</a>
+          <h2>Documentation</h2>
+          <ul>
+            <li><a href="{{ url_for('main.tour', page=1) }}">Take the tour</a></li>
+            <li><a href="{{ url_for('main.documentation') }}">API documentation</a></li>
+          </ul>
         </div>
       </div>
     </div>

--- a/app/templates/views/tour/1.html
+++ b/app/templates/views/tour/1.html
@@ -17,7 +17,7 @@
 	<p>
 		We can remove these restrictions when you’re ready.
 	</p>
-    <a href='{{ url_for('.tour', service_id=current_service.id, page=next_page) }}'>
+    <a href='{{ url_for('.tour', page=next_page) }}'>
       Next
     </a>
   {% endcall %}

--- a/app/templates/views/tour/2.html
+++ b/app/templates/views/tour/2.html
@@ -29,7 +29,7 @@
 		  >
 		</picture>
 	</p>
-    <a href='{{ url_for('.tour', service_id=current_service.id, page=next_page) }}'>
+    <a href='{{ url_for('.tour', page=next_page) }}'>
       Next
     </a>
   {% endcall %}

--- a/app/templates/views/tour/3.html
+++ b/app/templates/views/tour/3.html
@@ -32,7 +32,7 @@
 	<p>
 		Developers, you can add data automatically using an API
 	</p>
-    <a href='{{ url_for('.tour', service_id=current_service.id, page=next_page) }}'>
+    <a href='{{ url_for('.tour', page=next_page) }}'>
       Next
     </a>
   {% endcall %}

--- a/app/templates/views/tour/4.html
+++ b/app/templates/views/tour/4.html
@@ -14,7 +14,7 @@
 	<p>
 		Notify merges your data with the template and sends the messages
 	</p>
-	<a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">
+	<a href="{{ url_for('.show_all_services_or_dashboard') }}">
       Next
     </a>
     <picture class="banner-tour-image-flush-bottom">

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -1,4 +1,4 @@
-from flask import url_for
+from flask import url_for, session
 
 from bs4 import BeautifulSoup
 
@@ -372,8 +372,8 @@ def test_new_invited_user_verifies_and_added_to_service(app_,
                 mock_add_user_to_service.assert_called_with(data['service'], new_user_id, expected_permissions)
                 mock_accept_invite.assert_called_with(data['service'], sample_invite['id'])
                 mock_check_verify_code.assert_called_once_with(new_user_id, '12345', 'sms')
+                assert service_one['id'] == session['service_id']
 
             raw_html = response.data.decode('utf-8')
             page = BeautifulSoup(raw_html, 'html.parser')
             element = page.find('h2').text == 'Trial mode'
-            assert service_one['id'] in raw_html

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -26,7 +26,7 @@ def test_should_add_service_and_redirect_to_next_page(app_,
                 url_for('main.add_service'),
                 data={'name': 'testing the post'})
             assert response.status_code == 302
-            assert response.location == url_for('main.tour', service_id=101, page=1, _external=True)
+            assert response.location == url_for('main.tour', page=1, _external=True)
             assert mock_get_services.called
             mock_create_service.asset_called_once_with(service_name='testing the post',
                                                        active=False,

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -1,4 +1,4 @@
-from flask import url_for
+from flask import url_for, session
 
 import app
 
@@ -25,15 +25,18 @@ def test_should_add_service_and_redirect_to_next_page(app_,
             response = client.post(
                 url_for('main.add_service'),
                 data={'name': 'testing the post'})
+            assert mock_get_services.called
+            mock_create_service.assert_called_once_with(
+                service_name='testing the post',
+                active=False,
+                message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
+                restricted=True,
+                user_id=api_user_active.id,
+                email_from='testing.the.post'
+            )
+            assert session['service_id'] == 101
             assert response.status_code == 302
             assert response.location == url_for('main.tour', page=1, _external=True)
-            assert mock_get_services.called
-            mock_create_service.asset_called_once_with(service_name='testing the post',
-                                                       active=False,
-                                                       limit=app_.config['DEFAULT_SERVICE_LIMIT'],
-                                                       restricted=True,
-                                                       user_id=api_user_active.id,
-                                                       email_from='testing.the.post')
 
 
 def test_should_return_form_errors_when_service_name_is_empty(app_,

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -14,7 +14,6 @@ def test_should_render_tour_pages(
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
-            client.login(api_user_active, mocker)
-            response = client.get(url_for('main.tour', service_id=101, page=page))
+            response = client.get(url_for('main.tour', page=page))
             assert response.status_code == 200
             assert 'Next' in response.get_data(as_text=True)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/116960703

## Make tour work for non-logged-in users

There’s no content in the tour that’s specific to a service, and we have no good reason to only restrict these pages to users with accounts.

## Make new service the current service on first use

When you add a new service, it’s probably the one you want to do stuff with.

When you get invited, the service you’ve been invited to is probably the one you want to use.

## Put a link to the tour in the footer

So you can:
- see it again
- see it if you don’t have an account yet

***

![image](https://cloud.githubusercontent.com/assets/355079/14635545/add5d96e-061e-11e6-8597-cda32049686f.png)
