### PR TITLE
Show subject line with placeholders replaced

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -46,7 +46,7 @@
 
   {% if 'email' == template.template_type %}
     {{ email_message(
-      template.formatted_subject_as_markup,
+      template.formatted_subject_as_markup if errors else template.replaced_subject,
       template.formatted_as_markup if errors else template.replaced,
       from_address='{}@notifications.service.gov.uk'.format(current_service.email_from),
       from_name=current_service.name


### PR DESCRIPTION
On the check page, we show what the message will look like with the data from the first row of the CSV, if the CSV contains all the required data.

We should do the same for the subject line.

![image](https://cloud.githubusercontent.com/assets/355079/14702694/aa103384-07a3-11e6-87b0-78dbb48f268c.png)

![image](https://cloud.githubusercontent.com/assets/355079/14702716/b93c31be-07a3-11e6-9fa1-ae3041073693.png)
