### PR TITLE
Show error if you try to send too many messages

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -56,6 +56,19 @@
     margin-top: 10px;
   }
 
+  a {
+
+    &:link,
+    &:visited {
+      color: $error-colour;
+    }
+
+    &:hover {
+      color: $mellow-red;
+    }
+
+  }
+
 }
 
 .banner-mode {

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -26,7 +26,7 @@ from app.main.uploader import (
     s3upload,
     s3download
 )
-from app import job_api_client, service_api_client, current_service, user_api_client
+from app import job_api_client, service_api_client, current_service, user_api_client, statistics_api_client
 from app.utils import user_has_permissions, get_errors_for_csv
 
 
@@ -204,6 +204,8 @@ def check_messages(service_id, template_type, upload_id):
         return redirect(url_for('main.choose_template', service_id=service_id, template_type=template_type))
 
     users = user_api_client.get_users_for_service(service_id=service_id)
+    statistics = statistics_api_client.get_statistics_for_service(service_id, limit_days=1)['data']
+    statistics = statistics[0] if statistics else {}
 
     contents = s3download(service_id, upload_id)
     if not contents:
@@ -252,7 +254,8 @@ def check_messages(service_id, template_type, upload_id):
         original_file_name=session['upload_data'].get('original_file_name'),
         send_button_text=get_send_button_text(template.template_type, session['upload_data']['notification_count']),
         upload_id=upload_id,
-        form=CsvUploadForm()
+        form=CsvUploadForm(),
+        statistics=statistics
     )
 
 

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -22,7 +22,11 @@
         {% if statistics.emails_requested or statistics.sms_requested %}
           <p>
             You can only send {{ current_service.message_limit }}
-            messages per day in <a href="{{ url_for('.trial_mode')}}">trial mode</a>.
+            messages per day
+            {%- if current_service.restricted %}
+              in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
+            {%- endif -%}
+            .
           </p>
         {% endif %}
         <p>

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -13,7 +13,31 @@
 
 {% block maincolumn_content %}
 
-  {% if errors %}
+  {% if count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0)) %}
+    <div class="bottom-gutter">
+      {% call banner_wrapper(type='dangerous') %}
+        <h1 class='banner-title'>
+          Too many recipients
+        </h1>
+        {% if statistics.emails_requested or statistics.sms_requested %}
+          <p>
+            You can only send {{ current_service.message_limit }}
+            messages per day in <a href="{{ url_for('.trial_mode')}}">trial mode</a>.
+          </p>
+        {% endif %}
+        <p>
+          You can still send
+          {{ current_service.message_limit - statistics.emails_requested - statistics.sms_requested }}
+          messages today, but
+          ‘{{ original_file_name }}’ contains
+          {{ count_of_recipients }} {{ recipients.recipient_column_header }}
+          {%- if count_of_recipients != 1 -%}
+            {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
+          {%- endif -%}.
+        </p>
+      {% endcall %}
+    </div>
+  {% elif errors %}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% if errors|length == 1 %}
@@ -61,7 +85,10 @@
     </div>
   {% endif %}
 
-  {% if errors %}
+  {% if (
+    errors or
+    count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0)) 
+  ) %}
     {{file_upload(form.file, button_text='Re-upload your file')}}
   {% else %}
     <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id)}}">

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -19,6 +19,7 @@ def test_upload_csvfile_with_errors_shows_check_page_with_errors(
     mock_s3_upload,
     mock_has_permissions,
     mock_get_users_by_service,
+    mock_get_service_statistics,
     fake_uuid
 ):
 
@@ -60,6 +61,7 @@ def test_send_test_sms_message_to_self(
     mock_s3_upload,
     mock_has_permissions,
     mock_get_users_by_service,
+    mock_get_service_statistics,
     fake_uuid
 ):
 
@@ -87,6 +89,7 @@ def test_send_test_email_message_to_self(
     mock_s3_upload,
     mock_has_permissions,
     mock_get_users_by_service,
+    mock_get_service_statistics,
     fake_uuid
 ):
 
@@ -159,6 +162,7 @@ def test_upload_csvfile_with_valid_phone_shows_all_numbers(
     mock_s3_upload,
     mock_has_permissions,
     mock_get_users_by_service,
+    mock_get_service_statistics,
     fake_uuid
 ):
 
@@ -239,6 +243,7 @@ def test_check_messages_should_revalidate_file_when_uploading_file(
     mock_s3_upload,
     mocker,
     mock_has_permissions,
+    mock_get_service_statistics,
     mock_get_users_by_service
 ):
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/14736304/375a0ec0-086e-11e6-9075-5bbabc1a5abd.png)

***

https://www.pivotaltracker.com/story/show/117630691

There is a limit of 50 messages per day in trial mode. Right now, we don’t tell you this, we just start failing your messages.

This commit adds an error message if you upload a CSV file that has too many rows in it.