### PR TITLE
Reword homepage

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -10,7 +10,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-xlarge">GOV.UK Notify</h1>
     <p>
-      Making it easy to send text messages, emails, and letters to your users.
+      Making it easy to send text messages and emails to your users.
     </p>
     <p>
       If you work for a UK government department or agency you can try it now.

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -9,21 +9,17 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-xlarge">GOV.UK Notify</h1>
-
     <p>
-      Use GOV.UK Notify to send notifications by text message, email and letter.
+      Making it easy to send text messages, emails, and letters to your users.
     </p>
     <p>
-      We're making it easy to keep your users informed.
-    </p>
-    <p>
-      If you work for a UK government department or agency you can set up a test account now.
+      If you work for a UK government department or agency you can try it now.
     </p>
     <p>
       <a class="button" href="{{ url_for('.register' )}}" role="button">Set up an account</a>
     </p>
     <p>
-      If you've used GOV.UK Notify before, <a href="{{ url_for('.sign_in' )}}">sign in to your account</a>.
+      If you’ve used GOV.UK Notify before, <a href="{{ url_for('.sign_in' )}}">sign in to your account</a>.
     </p>
 
   </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/14776848/02ec2c9a-0ac1-11e6-8dc4-035f27b27254.png)

## Remove some words from the home page
So that the proposition is clearer.

## Don’t talk about letters on the homepage

We don’t have letters yet. No point in someone setting up an account hoping they can send letters.