### PR TITLE
If not logged in, go to homepage when clicking GOV.UK 

### DIFF
--- a/app/main/views/choose_service.py
+++ b/app/main/views/choose_service.py
@@ -16,8 +16,11 @@ def choose_service():
 
 
 @main.route("/services-or-dashboard")
-@login_required
 def show_all_services_or_dashboard():
+
+    if not current_user.is_authenticated():
+        return redirect(url_for('.index'))
+
     services = service_api_client.get_services({'user_id': current_user.id})['data']
 
     if 1 == len(services):

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -1,4 +1,4 @@
-from flask import url_for
+from flask import url_for, session
 
 
 def test_should_show_choose_services_page(app_,
@@ -52,6 +52,29 @@ def test_redirect_if_multiple_services(
 
         assert response.status_code == 302
         assert response.location == url_for('main.choose_service', _external=True)
+
+
+def test_redirect_if_service_in_session(
+    app_,
+    mock_login,
+    mock_get_user,
+    api_user_active,
+    mock_get_services,
+    mock_get_service
+):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            with client.session_transaction() as session:
+                session['service_id'] = '147ad62a-2951-4fa1-9ca0-093cd1a52c52'
+            response = client.get(url_for('main.show_all_services_or_dashboard'))
+
+        assert response.status_code == 302
+        assert response.location == url_for(
+            'main.service_dashboard',
+            service_id='147ad62a-2951-4fa1-9ca0-093cd1a52c52',
+            _external=True
+        )
 
 
 def test_should_redirect_if_not_logged_in(app_):

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -59,7 +59,7 @@ def test_should_redirect_if_not_logged_in(app_):
         with app_.test_client() as client:
             response = client.get(url_for('main.show_all_services_or_dashboard'))
             assert response.status_code == 302
-            assert url_for('main.sign_in', _external=True) in response.location
+            assert url_for('main.index', _external=True) in response.location
 
 
 def test_should_show_all_services_for_platform_admin_user(app_,


### PR DESCRIPTION
It’s a bit of a weird experience to be taken to the sign in screen when you click GOV.UK in the header. It’s doubly weird if you take the tour before creating an account, and at the end of the tour you get prompted
to sign in.

This commit adds some extra logic to take you to the homepage instead, which I think is more what you’d expect.

### Also, add test for redirecting to your last-used service

If you click GOV.UK and have:
- multiple services
- a service in your session

…we take you to the dashboard for that service. This works great, but wasn’t tested. This commit adds a test for it.