### PR TITLE
Add context to trial mode link for screen readers

### DIFF
--- a/app/templates/views/dashboard/trial-mode-banner.html
+++ b/app/templates/views/dashboard/trial-mode-banner.html
@@ -7,7 +7,7 @@
       Your service is in trial mode
     </div>
     <div class="column-one-half">
-        <a href="{{ url_for(".trial_mode") }}" class="banner-mode-action">Find out more</a>
+        <a href="{{ url_for(".trial_mode") }}" class="banner-mode-action">Find out more<span class="visuallyhidden"> about trial mode</span></a>
     </div>
   </div>
 {% endcall %}


### PR DESCRIPTION
Screen reader users have the option to navigate by jumping between anchor tags and reading out the content. "Find out more" does not provide a lot of context about what the link does.

This commit adds some visually hidden text which screen readers will still read that makes the link work without the visual context.