### PR TITLE
Fix bug with large file uploads

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -110,7 +110,7 @@ def send_messages(service_id, template_id):
                 service_id,
                 {
                     'file_name': form.file.data.filename,
-                    'data': form.file.data.getvalue().decode('utf-8')
+                    'data': form.file.data.read().decode('utf-8')
                 },
                 current_app.config['AWS_REGION']
             )


### PR DESCRIPTION
Depending on the size of the uploaded file, Flask will temporarily store it in different ways. This means that it comes back as a `TempFile` if the file is roughly <500k and as `BytesIO` if the file is larger.

`TempFile` supports the `.getvalue()` method, but `BytesIO` does not, which means that with a large file you get the following error:
```
AttributeError: '_io.BufferedRandom' object has no attribute 'getvalue'
```

Both support the `.read()` method, so this commit changes to use that instead.

![image](https://cloud.githubusercontent.com/assets/355079/14778002/6b4ba494-0ac8-11e6-9339-a1bd39864124.png)
