### PR TITLE
API keys page improvements

### DIFF
--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -33,8 +33,6 @@
             key = $component.data('key'),
             thing = $component.data('thing');
 
-      console.log(thing)
-
       $component
         .html(states.keyVisible(key, thing))
         .attr('aria-live', 'polite')

--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -33,6 +33,8 @@
             key = $component.data('key'),
             thing = $component.data('thing');
 
+      console.log(thing)
+
       $component
         .html(states.keyVisible(key, thing))
         .attr('aria-live', 'polite')

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -20,8 +20,12 @@
   </div>
 
   <p>
-    To connect to the API you will need to create an API Key. Each service can have multiple API Keys to allow
-    for test and live environments.
+    To connect to the API you need to create an API Key.
+  </p>
+  <p>
+    Each service can have multiple API Keys. This allows you to integrate a
+    number of systems, each with its own key. You can also have separate
+    keys for your development and test environments.
   </p>
 
   <p>

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
+{% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
   API keys – GOV.UK Notify
@@ -22,17 +23,11 @@
     developer documentation</a>.
   </p>
 
-  <h2 class="heading-medium">
-    Service ID
-  </h2>
-  <p class="api-key-key">
-    {{ current_service.id }}
-  </p>
-
   {% call(item, row_number) list_table(
     keys,
     empty_message="You haven’t created any API keys yet",
     caption="API keys",
+    caption_visible=False,
     field_headings=['Key name', hidden_field_heading('Action')]
   ) %}
     {% call field() %}
@@ -52,5 +47,7 @@
   <p class='table-show-more-link'>
     <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}">Create a new API key</a>
   </p>
+
+  {{ api_key(current_service.id, "Service ID", thing="service ID") }}
 
 {% endblock %}

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -8,9 +8,16 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    API keys
-  </h1>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        API keys
+      </h1>
+    </div>
+    <div class="column-one-third">
+      <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}" class="button align-with-heading">Create new API key</a>
+    </div>
+  </div>
 
   <p>
     To connect to the API you will need to create an API Key. Each service can have multiple API Keys to allow
@@ -43,10 +50,6 @@
       {% endcall %}
     {% endif %}
   {% endcall %}
-
-  <p class='table-show-more-link'>
-    <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}">Create a new API key</a>
-  </p>
 
   {{ api_key(current_service.id, "Service ID", thing="service ID") }}
 

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -34,7 +34,7 @@ def test_should_show_empty_api_keys_page(app_,
 
         assert response.status_code == 200
         assert 'You haven’t created any API keys yet' in response.get_data(as_text=True)
-        assert 'Create a new API key' in response.get_data(as_text=True)
+        assert 'Create new API key' in response.get_data(as_text=True)
         mock_get_no_api_keys.assert_called_once_with(service_id=service_id)
 
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/14778578/a7cad900-0acb-11e6-844b-16f0ec9e13a3.png)

## Use the API key pattern for showing service ID

When we show an identifier, like an ID or a key, we have a pattern which adds a ‘copy to clipboard’ button. We weren’t using this pattern for service ID.

This commit also moves service ID underneath the table, so hopefully people will be less likely to confuse the service ID for an API key when scanning down the page.

## Use the same pattern as elsewhere for ‘new thing’

On the team and templates pages we have a pattern for adding a new ‘thing’, which is a green button in the top right.

This commit changes the API key page to follow the same pattern.