### PR TITLE
Upgrade GOV.UK template to 0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-preset-es2015": "6.3.13",
     "govuk-elements-sass": "1.1.1",
     "govuk_frontend_toolkit": "4.6.0",
-    "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.16.4/jinja_govuk_template-0.16.4.tgz",
+    "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.17.1/jinja_govuk_template-0.17.1.tgz",
     "gulp": "3.9.0",
     "gulp-add-src": "0.2.0",
     "gulp-babel": "6.1.1",


### PR DESCRIPTION
Makes the size of the HTML file slightly smaller

Full changelog:

> # 0.17.1
>
> - Reduce file size of template: removes HTML comments, `type` attributes
>   on scripts, and uses HTML5 charset declaration. #208
> - Switch external link media query to be mobile first #205
> - Sass file cleanups
> - Replace old grid mixins with newer grid from frontend toolkit #134
> - Remove duplicate grey variables #201
>
> # 0.17.0
>
> - Add CSS hook (`.js-hidden`) for hiding content when JS is  enabled.
>   Some apps have an equivalent hook, which can be removed once
>   upgraded to this version