### PR TITLE
Fix the big numbers on the dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -57,6 +57,7 @@ def service_dashboard(service_id):
 
 @main.route("/services/<service_id>/dashboard.json")
 @login_required
+@user_has_permissions('view_activity', admin_override=True)
 def service_dashboard_updates(service_id):
     return jsonify(**{
         'today': render_template(

--- a/app/notify_client/statistics_api_client.py
+++ b/app/notify_client/statistics_api_client.py
@@ -18,4 +18,5 @@ class StatisticsApiClient(BaseAPIClient):
             params['limit_days'] = limit_days
         return self.get(
             url='/service/{}/notifications-statistics'.format(service_id),
+            params=params
         )

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -1,6 +1,10 @@
 {% macro big_number(number, label) %}
-  <div class="big-number">
-    {{ number }}
+  <div class="big-number{% if right_aligned %}-right-aligned{% endif %}">
+    {% if number is number %}
+      {{ "{:,}".format(number) }}
+    {% else %}
+      {{ number }}
+    {% endif %}
     <span class="big-number-label">{{ label }}</span>
   </div>
 {% endmacro %}
@@ -13,10 +17,10 @@
       {% if failures %}
         {% if failure_link %}
           <a href="{{ failure_link }}">
-            {{ failures }} failed – {{ failure_percentage }}%
+            {{ "{:,}".format(failures) }} failed – {{ failure_percentage }}%
           </a>
         {% else %}
-          {{ failures }} failed – {{ failure_percentage }}%
+          {{ "{:,}".format(failures) }} failed – {{ failure_percentage }}%
         {% endif %}
       {% else %}
         No failures

--- a/tests/app/main/notify_client/test_statistics_client.py
+++ b/tests/app/main/notify_client/test_statistics_client.py
@@ -14,4 +14,18 @@ def test_notifications_statistics_client_calls_correct_api_endpoint(mocker, api_
 
     client.get_statistics_for_service(some_service_id)
 
-    mock_get.assert_called_once_with(url=expected_url)
+    mock_get.assert_called_once_with(url=expected_url, params={})
+
+
+def test_notifications_statistics_client_calls_correct_api_endpoint_with_params(mocker, api_user_active):
+
+    some_service_id = uuid.uuid4()
+    expected_url = '/service/{}/notifications-statistics'.format(some_service_id)
+
+    client = StatisticsApiClient()
+
+    mock_get = mocker.patch('app.notify_client.statistics_api_client.StatisticsApiClient.get')
+
+    client.get_statistics_for_service(some_service_id, limit_days=99)
+
+    mock_get.assert_called_once_with(url=expected_url, params={'limit_days': 99})


### PR DESCRIPTION
## Make sure the stats client passes params through
This was the cause of the dashboard showing statistics from all time instead of the last 7 days.

## Separate thousands with comma for big numbers
Makes it easier to see just how big the numbers are.

![image](https://cloud.githubusercontent.com/assets/355079/14781353/e9b18158-0ad9-11e6-8ff1-810a339e4520.png)
