### PR TITLE
Update Slack link to point at channel, not archive

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -79,7 +79,7 @@
           <h2>Contact</h2>
           <ul>
             <li><a href="{{ url_for('main.feedback') }}">Support and feedback</a></li>
-            <li><a href="https://ukgovernmentdigital.slack.com/archives/govuk-notify">Chat with the Notify team</a></li>
+            <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Chat with the Notify team</a></li>
           </ul>
         </div>
         <div class="column-one-third">


### PR DESCRIPTION
https://ukgovernmentdigital.slack.com/messages/govuk-notify/

not

https://ukgovernmentdigital.slack.com/archive/govuk-notify/