### PR TITLE
Put app environment in support tickets

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -16,10 +16,12 @@ def feedback():
             'person_email': current_app.config.get('DESKPRO_PERSON_EMAIL'),
             'department_id': current_app.config.get('DESKPRO_TEAM_ID'),
             'subject': 'Notify feedback',
-            'message': '{}\n{}\n{}'.format(
+            'message': 'Environment: {}\n\n{}\n{}\n{}'.format(
+                url_for('main.index', _external=True),
                 form.name.data,
                 form.email_address.data,
-                form.feedback.data)
+                form.feedback.data
+            )
         }
         headers = {
             "X-DeskPRO-API-Key": current_app.config.get('DESKPRO_API_KEY'),

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -102,7 +102,7 @@ def service_request_to_go_live(service_id):
                 current_user.name,
                 current_user.email_address,
                 current_service['name'],
-                current_service['id'],
+                url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 form.usage.data
             )
         }

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -49,7 +49,7 @@ def test_post_feedback_with_no_name_email(app_, mocker):
                 data={
                     'department_id': ANY,
                     'subject': 'Notify feedback',
-                    'message': '\n\nblah',
+                    'message': 'Environment: http://localhost/\n\n\n\nblah',
                     'person_email': ANY},
                 headers=ANY)
 
@@ -69,7 +69,7 @@ def test_post_feedback_with_name_email(app_, mocker):
                 data={
                     'subject': 'Notify feedback',
                     'department_id': ANY,
-                    'message': 'Steve Irwin\nrip@gmail.com\nblah',
+                    'message': 'Environment: http://localhost/\n\nSteve Irwin\nrip@gmail.com\nblah',
                     'person_email': ANY},
                 headers=ANY)
 
@@ -94,7 +94,7 @@ def test_log_error_on_post(app_, mocker):
                 data={
                     'subject': 'Notify feedback',
                     'department_id': ANY,
-                    'message': 'Steve Irwin\nrip@gmail.com\nblah',
+                    'message': 'Environment: http://localhost/\n\nSteve Irwin\nrip@gmail.com\nblah',
                     'person_email': ANY},
                 headers=ANY)
             mock_logger.assert_called_with(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -239,7 +239,7 @@ def test_should_redirect_after_request_to_go_live(
                 data={
                     'subject': 'Request to go live',
                     'department_id': ANY,
-                    'message': 'From Test User <test@user.gov.uk> on behalf of Test Service (6ce466d0-fd6a-11e5-82f5-e0accb9d11a6)\n\nUsage estimate\n---\n\nOne million messages',  # noqa
+                    'message': 'From Test User <test@user.gov.uk> on behalf of Test Service (http://localhost/services/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/dashboard)\n\nUsage estimate\n---\n\nOne million messages',  # noqa
                     'person_email': ANY
                 },
                 headers=ANY


### PR DESCRIPTION
## Put URL to service in request to go live ticket

So that:
- we know what environment the request has come from
- a platform admin user can jump straight to that service to check it out

## Put environment URL in feedback tickets

So that:
- we know what environment a request has been sent from