### PR TITLE
Show sent, not pending numbers on the dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -99,14 +99,19 @@ def add_rates_to(delivery_statistics):
         delivery_statistics
     )
 
+    sum_of_statistics.update({
+        'emails_sent': sum_of_statistics['emails_failed'] + sum_of_statistics['emails_delivered'],
+        'sms_sent': sum_of_statistics['sms_failed'] + sum_of_statistics['sms_delivered']
+    })
+
     return dict(
         emails_failure_rate=(
-            "{0:.1f}".format((float(sum_of_statistics['emails_failed']) / sum_of_statistics['emails_requested'] * 100))
-            if sum_of_statistics.get('emails_requested') else 0
+            "{0:.1f}".format((float(sum_of_statistics['emails_failed']) / sum_of_statistics['emails_sent'] * 100))
+            if sum_of_statistics.get('emails_sent') else 0
         ),
         sms_failure_rate=(
-            "{0:.1f}".format((float(sum_of_statistics['sms_failed']) / sum_of_statistics['sms_requested'] * 100))
-            if sum_of_statistics.get('sms_requested') else 0
+            "{0:.1f}".format((float(sum_of_statistics['sms_failed']) / sum_of_statistics['sms_sent'] * 100))
+            if sum_of_statistics.get('sms_sent') else 0
         ),
         **sum_of_statistics
     )

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -13,9 +13,9 @@
   <div class="grid-row bottom-gutter">
     <div class="column-half">
       {{ big_number_with_status(
-        statistics.get('emails_delivered', 0),
-        'email' if statistics.get('emails_delivered') == 1 else 'emails',
-        statistics.get('emails_failed'),
+        statistics.emails_sent,
+        'email' if statistics.emails_sent == 1 else 'emails',
+        statistics.emails_failed,
         statistics.get('emails_failure_rate', 0.0),
         statistics.get('emails_failure_rate', 0)|float > 3,
         failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='email', status='failed')
@@ -23,9 +23,9 @@
     </div>
     <div class="column-half">
       {{ big_number_with_status(
-        statistics.get('sms_requested', 0),
-        'text message' if statistics.get('sms_requested') == 1 else 'text messages',
-        statistics.get('sms_failed'),
+        statistics.sms_sent,
+        'text message' if statistics.sms_sent == 1 else 'text messages',
+        statistics.sms_failed,
         statistics.get('sms_failure_rate', 0.0),
         statistics.get('sms_failure_rate', 0)|float > 3,
         failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='sms', status='failed')


### PR DESCRIPTION
The dashboard should only talk about notifications that are *successful* or *failed*. It should not count notifications that are still queued.

This will stop:
- a situation like ‘0 emails, 14.1% failed’
- the big numbers and the template statistics numbers not adding up to the same total