### PR TITLE
Count only requested and failed messages on dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -99,19 +99,14 @@ def add_rates_to(delivery_statistics):
         delivery_statistics
     )
 
-    sum_of_statistics.update({
-        'emails_sent': sum_of_statistics['emails_failed'] + sum_of_statistics['emails_delivered'],
-        'sms_sent': sum_of_statistics['sms_failed'] + sum_of_statistics['sms_delivered']
-    })
-
     return dict(
         emails_failure_rate=(
-            "{0:.1f}".format((float(sum_of_statistics['emails_failed']) / sum_of_statistics['emails_sent'] * 100))
-            if sum_of_statistics.get('emails_sent') else 0
+            "{0:.1f}".format((float(sum_of_statistics['emails_failed']) / sum_of_statistics['emails_requested'] * 100))
+            if sum_of_statistics['emails_requested'] else 0
         ),
         sms_failure_rate=(
-            "{0:.1f}".format((float(sum_of_statistics['sms_failed']) / sum_of_statistics['sms_sent'] * 100))
-            if sum_of_statistics.get('sms_sent') else 0
+            "{0:.1f}".format((float(sum_of_statistics['sms_failed']) / sum_of_statistics['sms_requested'] * 100))
+            if sum_of_statistics['sms_requested'] else 0
         ),
         **sum_of_statistics
     )

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -13,8 +13,8 @@
   <div class="grid-row bottom-gutter">
     <div class="column-half">
       {{ big_number_with_status(
-        statistics.emails_sent,
-        'email' if statistics.emails_sent == 1 else 'emails',
+        statistics.emails_requested,
+        'email' if statistics.emails_requested == 1 else 'emails',
         statistics.emails_failed,
         statistics.get('emails_failure_rate', 0.0),
         statistics.get('emails_failure_rate', 0)|float > 3,
@@ -23,8 +23,8 @@
     </div>
     <div class="column-half">
       {{ big_number_with_status(
-        statistics.sms_sent,
-        'text message' if statistics.sms_sent == 1 else 'text messages',
+        statistics.sms_requested,
+        'text message' if statistics.sms_requested == 1 else 'text messages',
         statistics.sms_failed,
         statistics.get('sms_failure_rate', 0.0),
         statistics.get('sms_failure_rate', 0)|float > 3,


### PR DESCRIPTION
Requested, delivered and failed are the three states stored in the notification statistics table. They are not discrete, eg a message can be counted in delivered and failed.

`requested` is incremented **when a notification is created**, and has no chance of being incremented twice for the same notification.

The template statistics are incremented **when a notification is created only**.

Therefore the only way to make the numbers line up is to count:
- messages sent as being `requested`
- failure rate being `failed`/`requested` **not** `failed`/`failed`+`delivered`