### PR TITLE
Change activity to view to request a week of data

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -27,7 +27,8 @@ class NotificationApiClient(BaseAPIClient):
                                       template_type=None,
                                       status=None,
                                       page=None,
-                                      page_size=None):
+                                      page_size=None,
+                                      limit_days=None):
         params = {}
         if page is not None:
             params['page'] = page
@@ -43,6 +44,9 @@ class NotificationApiClient(BaseAPIClient):
                 params=params
             )
         else:
+            if limit_days is not None:
+                params['limit_days'] = limit_days
+
             return self.get(
                 url='/service/{}/notifications'.format(service_id),
                 params=params

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -4,7 +4,7 @@
   </h2>
   <ul>
   {% if current_user.has_permissions(['view_activity'], admin_override=True) %}
-    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='delivered,failed') }}">Activity</a></li>
+    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='delivered,failed', template_type='email,sms') }}">Activity</a></li>
   {% endif %}
   {% if current_user.has_permissions(['view_activity', 'manage_templates', 'manage_api_keys'], admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='email') }}">Email templates</a></li>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -45,7 +45,7 @@
     {%- endif -%}
 
   </h1>
-  
+
   <div class='grid-row bottom-gutter'>
     <div class='column-half'>
       {{ pill(

--- a/config.py
+++ b/config.py
@@ -40,6 +40,7 @@ class Config(object):
     DESKPRO_API_KEY = os.environ['DESKPRO_API_KEY']
     DESKPRO_PERSON_EMAIL = os.environ['DESKPRO_PERSON_EMAIL']
     DESKPRO_TEAM_ID = os.environ['DESKPRO_TEAM_ID']
+    ACTIVITY_STATS_LIMIT_DAYS = 7
 
     EMAIL_DOMAIN_REGEXES = [
         "gov\.uk",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -691,7 +691,8 @@ def mock_get_notifications(mocker):
                            page=1,
                            page_size=50,
                            template_type=None,
-                           status=None):
+                           status=None,
+                           limit_days=None):
         return notification_json(service_id)
     return mocker.patch(
         'app.notification_api_client.get_notifications_for_service',
@@ -705,7 +706,8 @@ def mock_get_notifications_with_previous_next(mocker):
                            job_id=None,
                            page=1,
                            template_type=None,
-                           status=None):
+                           status=None,
+                           limit_days=None):
         return notification_json(service_id, with_links=True)
     return mocker.patch(
         'app.notification_api_client.get_notifications_for_service',


### PR DESCRIPTION
Cleaned up filters a bit so that if you want both templates email and sms is passed. 

Added mock assertion to tests.

There is pr on api to filter by a day limit. The default with be a week + today (8 days)

https://github.com/alphagov/notifications-api/pull/274