### PR TITLE
Redirect to dashboard if this isn't the first service

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -43,7 +43,12 @@ def add_service():
                                                        user_id=session['user_id'],
                                                        email_from=email_from)
         session['service_id'] = service_id
-        return redirect(url_for('main.tour', page=1))
+
+        services = service_api_client.get_services({'user_id': session['user_id']}).get('data', [])
+        if (len(services) > 1):
+            return redirect(url_for('main.service_dashboard', service_id=service_id))
+        else:
+            return redirect(url_for('main.tour', page=1))
     else:
         return render_template(
             'views/add-service.html',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,18 @@ def mock_get_services(mocker, fake_uuid, user=None):
 
 
 @pytest.fixture(scope='function')
+def mock_get_services_with_no_services(mocker, fake_uuid, user=None):
+    if user is None:
+        user = active_user_with_permissions(fake_uuid)
+
+    def _create(user_id=None):
+        return {'data': []}
+
+    return mocker.patch(
+        'app.service_api_client.get_services', side_effect=_create)
+
+
+@pytest.fixture(scope='function')
 def mock_get_services_with_one_service(mocker, fake_uuid, user=None):
     if user is None:
         user = api_user_active(fake_uuid)


### PR DESCRIPTION
There's no need to show the tour again if the user has previously created a service so just redirect to the dashboard instead.

https://www.pivotaltracker.com/story/show/116960671