### PR TITLE
Link up the last 7 days

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -16,13 +16,38 @@
   @extend %big-number;
   background: $text-colour;
   color: $white;
+  position: relative;
 
   .big-number {
     padding: 15px;
+    position: relative;
+  }
+
+  .big-number-overlay-link {
+
+    background: transparent;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: transparent;
+    width: 100%;
+    height: 100%;
+
+    &:hover {
+      background: rgba($text-colour, 0.2);
+    }
+
   }
 
   .big-number-label {
+
     padding-bottom: 0;
+
+    &:link,
+    &:visited {
+      color: $white;
+    }
+
   }
 
   %big-number-status,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -82,20 +82,24 @@ def template_history(service_id):
 
 def add_rates_to(delivery_statistics):
 
+    keys = [
+        'emails_delivered',
+        'emails_requested',
+        'emails_failed',
+        'sms_requested',
+        'sms_delivered',
+        'sms_failed'
+    ]
+
     if not delivery_statistics or not delivery_statistics[0]:
-        return {}
+        return {
+            key: 0 for key in keys
+        }
 
     sum_of_statistics = reduce(
         lambda x, y: {
             key: x.get(key, 0) + y.get(key, 0)
-            for key in [
-                'emails_delivered',
-                'emails_requested',
-                'emails_failed',
-                'sms_requested',
-                'sms_delivered',
-                'sms_failed'
-            ]
+            for key in keys
         },
         delivery_statistics
     )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -116,6 +116,8 @@ def view_notifications(service_id):
 
     filter_args = _parse_filter_args(request.args)
 
+    print(filter_args)
+
     notifications = notification_api_client.get_notifications_for_service(
         service_id=service_id,
         page=page,
@@ -147,8 +149,8 @@ def view_notifications(service_id):
                 service_id=service_id,
                 page=page,
                 page_size=notifications['total'],
-                template_type=filter_args.getlist('template_type') if 'template_type' in filter_args else None,
-                status=filter_args.getlist('status')
+                template_type=filter_args.get('template_type') if 'template_type' in filter_args else ['email', 'sms'],
+                status=filter_args.get('status')
                 if 'status' in filter_args else ['delivered', 'failed'],
                 limit_days=current_app.config['ACTIVITY_STATS_LIMIT_DAYS'])['notifications'])
         return csv_content, 200, {

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -1,18 +1,31 @@
-{% macro big_number(number, label) %}
+{% macro big_number(number, label, label_link=None) %}
   <div class="big-number{% if right_aligned %}-right-aligned{% endif %}">
     {% if number is number %}
       {{ "{:,}".format(number) }}
     {% else %}
       {{ number }}
     {% endif %}
-    <span class="big-number-label">{{ label }}</span>
+    {% if label_link %}
+      <a class="big-number-label" href="{{ label_link }}">{{ label }}</a>
+      <a class="big-number-overlay-link" href="{{ label_link }}" aria-hidden="true"></a>
+    {% else %}
+      <span class="big-number-label">{{ label }}</span>
+    {% endif %}
   </div>
 {% endmacro %}
 
 
-{% macro big_number_with_status(number, label, failures, failure_percentage, danger_zone=False, failure_link=None) %}
+{% macro big_number_with_status(
+  number,
+  label,
+  failures,
+  failure_percentage,
+  danger_zone=False,
+  failure_link=None,
+  label_link=None
+) %}
   <div class="big-number-with-status">
-    {{ big_number(number, label) }}
+    {{ big_number(number, label, label_link) }}
     <div class="big-number-status{% if danger_zone %}-failing{% endif %}">
       {% if failures %}
         {% if failure_link %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -3,9 +3,6 @@
     <a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">{{ current_service.name }}</a>
   </h2>
   <ul>
-  {% if current_user.has_permissions(['view_activity'], admin_override=True) %}
-    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='delivered,failed', template_type='email,sms') }}">Activity</a></li>
-  {% endif %}
   {% if current_user.has_permissions(['view_activity', 'manage_templates', 'manage_api_keys'], admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='email') }}">Email templates</a></li>
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='sms') }}">Text message templates</a></li>

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -18,7 +18,8 @@
         statistics.emails_failed,
         statistics.get('emails_failure_rate', 0.0),
         statistics.get('emails_failure_rate', 0)|float > 3,
-        failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='email', status='failed')
+        failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='email', status='failed'),
+        label_link=url_for(".view_notifications", service_id=current_service.id, template_type='email', status='delivered,failed')
       ) }}
     </div>
     <div class="column-half">
@@ -28,7 +29,8 @@
         statistics.sms_failed,
         statistics.get('sms_failure_rate', 0.0),
         statistics.get('sms_failure_rate', 0)|float > 3,
-        failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='sms', status='failed')
+        failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='sms', status='failed'),
+        label_link=url_for(".view_notifications", service_id=current_service.id, template_type='sms', status='delivered,failed')
       ) }}
     </div>
   </div>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -11,36 +11,32 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-
-    {%- if (request_args.get('template_type', '') == '') and (request_args.get('status', 'delivered,failed') == 'delivered,failed') -%}
+    {%- if (request_args.get('template_type', 'email,sms') == 'email,sms') and (request_args.get('status', 'delivered,failed') == 'delivered,failed') -%}
 
       Activity
 
     {%- else -%}
 
-      {% if request_args.get('status') != 'delivered,failed' %}
-        {% for label, option, _ in status_filters %}
-          {% if request_args.get('status') == option %}
-            {{ label }}
-          {% endif %}
-        {% endfor %}
-      {% endif %}
+      {%- if request_args.get('status') != 'delivered,failed' -%}
+        {%- for label, option, _ in status_filters -%}
+          {%- if request_args.get('status', 'delivered,failed') == option -%}{{label}} {% endif -%}
+        {%- endfor -%}
+      {%- endif -%}
 
-      {% if request_args.get('template_type') == '' %}
-        emails and text messages
-      {% else %}
+      {%- if request_args.get('template_type', 'email,sms') == 'email,sms' %} emails and text messages
+      {%- else -%}
 
-        {% for template_label, template_option, _ in type_filters %}
-          {% if request_args.get('template_type') == template_option %}
-            {% if request_args.get('status', 'delivered,failed') == 'delivered,failed' %}
+        {%- for template_label, template_option, _ in type_filters -%}
+          {%- if request_args.get('template_type') == template_option -%}
+            {%- if request_args.get('status', 'delivered,failed') == 'delivered,failed' -%}
               {{ template_label }}
-            {% else %}
+            {%- else -%}
               {{ template_label | lower }}
-            {% endif %}
-          {% endif %}
-        {% endfor %}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endfor -%}
 
-      {% endif %}
+      {%- endif -%}
 
     {%- endif -%}
 


### PR DESCRIPTION
## Make big numbers on the homepage linkable

The big numbers on the homepage relate directly to the notifications on the notification page. So let’s link them. With a _hyper_ link.

This commit actually adds two links, one of which is semantically correct, and one of which is visually correct, ie makes the whole black area of the box clickable/hoverable.

## Fix page titles on activity page

We were getting some weirdness like ‘Failed both’.

This commit fixes the problem, and adds some tests for the page headings to make sure they don’t break again.

***

![big-clicks](https://cloud.githubusercontent.com/assets/355079/14920054/8a3c70d2-0e23-11e6-8024-f10bc26557f0.gif)

## Remove activity from the nav

We saw lots of people in the lab clicking activity hoping for… something. But it’s not really where you go to do a thing, so they weren’t finding what they were looking for.

Since you can now get to the activity from the dashboard, let’s remove the link in the nav, to make thing less ambiguous.

![image](https://cloud.githubusercontent.com/assets/355079/14921574/d0fb18e6-0e2a-11e6-949d-a3c2d7ad77e2.png)
