### PR TITLE
Convert uploaded Excel files to CSV

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,6 +1,7 @@
 import re
 from wtforms import ValidationError
 from notifications_utils.template import Template
+from app.utils import Spreadsheet
 
 
 class Blacklist(object):
@@ -20,8 +21,8 @@ class CsvFileValidator(object):
         self.message = message
 
     def __call__(self, form, field):
-        if not field.data.filename.lower().endswith('.csv'):
-            raise ValidationError("{} is not a CSV file".format(field.data.filename))
+        if not Spreadsheet.can_handle(field.data.filename):
+            raise ValidationError("{} is not a spreadsheet file".format(field.data.filename))
 
 
 class ValidEmailDomainRegex(object):

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -100,6 +100,7 @@ def choose_template(service_id, template_type):
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def send_messages(service_id, template_id):
+
     template = Template(
         service_api_client.get_service_template(service_id, template_id)['data'],
         prefix=current_service['name']
@@ -108,13 +109,6 @@ def send_messages(service_id, template_id):
     form = CsvUploadForm()
     if form.validate_on_submit():
 
-        if form.file.data.filename.lower().endswith('.xlsx'):
-            contents = Spreadsheet.from_xlsx(form.file.data).as_csv
-        elif form.file.data.filename.lower().endswith('.xls'):
-            contents = Spreadsheet.from_xls(form.file.data).as_csv
-        else:
-            contents = Spreadsheet(form.file.data).as_csv
-
         try:
             upload_id = str(uuid.uuid4())
             s3upload(
@@ -122,7 +116,7 @@ def send_messages(service_id, template_id):
                 service_id,
                 {
                     'file_name': form.file.data.filename,
-                    'data': contents
+                    'data': Spreadsheet.from_file(form.file.data.filename, form.file.data).as_csv_data
                 },
                 current_app.config['AWS_REGION']
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ boto3==1.3.0
 Pygments==2.0.2
 py-gfm==0.1.2
 blinker==1.4
+openpyxl==2.4.0-a1
 monotonic==0.3
+xlrd==0.9.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,11 @@ blinker==1.4
 openpyxl==2.4.0-a1
 monotonic==0.3
 xlrd==0.9.4
+pyexcel==0.2.1
+pyexcel-io==0.1.0
+pyexcel-xls==0.1.0
+pyexcel-xlsx==0.1.0
+pyexcel-ods3==0.1.1
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -74,7 +74,8 @@ def test_upload_csv_invalid_extension(app_,
             )
 
         assert resp.status_code == 200
-        assert "{} is not a CSV file".format(filename) in resp.get_data(as_text=True)
+        print(resp.get_data(as_text=True))
+        assert "{} is not a spreadsheet file".format(filename) in resp.get_data(as_text=True)
 
 
 def test_send_test_sms_message(


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/15046787/7e3ef858-12d9-11e6-8ddd-8b558f4e6628.png)

We require users to export their spreadsheets as CSV files before uploading them. But this seems like the sort of thing a computer should be able to do.

So this commit adds a wrapper which:
- takes a .xlsx or .xls file
- uses an appropriate library to parse the proprietary soup
- gives the data back in CSV format

We can upload the resultant CSV just like normal, and process it for errors like normal.

Important notes
---

1. It may be worth looking at https://github.com/pyexcel/pyexcel instead (says that it can handle lots of formats, and detect them automatically)

2. This is a bit of a spike. There are no unit tests. Merge at your own risk, I’ll be in 🇮🇹 😎 

3. This doesn’t change the UI (ie we’re not telling anyone we can do this yet)

***

![steve-ballmer-o](https://cloud.githubusercontent.com/assets/355079/15046766/6890ab64-12d9-11e6-9000-88e70cdc7791.gif)
