### PR TITLE
Give the <code> example in docs better CSS

### DIFF
--- a/app/assets/stylesheets/views/documenation.scss
+++ b/app/assets/stylesheets/views/documenation.scss
@@ -57,9 +57,19 @@
     margin: 0 0 20px 0;
   }
 
+  pre,
+  code {
+    font-size: 16px;
+  }
+
+  code {
+    background: $highlight-colour;
+    padding: 2px 5px;
+  }
+
   .highlight {
     margin: 0 0 20px 0;
-    background: #F8F8F8;
+    background: $highlight-colour;
   }
 
   strong,


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/355079/15211911/e0859e3e-1835-11e6-9110-d6773d89181e.png)

***


- adds a background colour, to words wrapped in `<code>` tags, like we
  have for whole snippets of code
- reduces the font size of all code blocks
  a) to differentiate them further
  b) to fit more on the screen