### PR TITLE
Record start of request so we can time all requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,12 +11,15 @@ from flask import (
     render_template,
     make_response,
     current_app,
-    request)
+    request,
+    g)
 from flask._compat import string_types
 from flask.globals import _lookup_req_object
 from flask_login import LoginManager
 from flask_wtf import CsrfProtect
 from functools import partial
+
+from monotonic import monotonic
 from notifications_python_client.errors import HTTPError
 from notifications_utils import logging
 from notifications_utils.recipients import validate_phone_number, InvalidPhoneError
@@ -141,6 +144,11 @@ def init_csrf(application):
 
 
 def init_app(application):
+
+    @application.before_request
+    def record_start_time():
+        g.start = monotonic()
+
     @application.context_processor
     def inject_global_template_variables():
         return {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ monotonic==0.3
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@5.2.0#egg=notifications-utils==5.2.0
+git+https://github.com/alphagov/notifications-utils.git@5.2.3#egg=notifications-utils==5.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ boto3==1.3.0
 Pygments==2.0.2
 py-gfm==0.1.2
 blinker==1.4
+monotonic==0.3
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 


### PR DESCRIPTION
Records the start time as a monotic on the global, to be read and used as part of request logging