### PR TITLE
Make ‘Too many recipients’ error lower priority

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -13,31 +13,20 @@
 
 {% block maincolumn_content %}
 
-  {% if count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0)) %}
+  {% if not recipients.allowed_to_send_to and not recipients.missing_column_headers %}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         <h1 class='banner-title'>
-          Too many recipients
-        </h1>
-        {% if statistics.emails_requested or statistics.sms_requested %}
-          <p>
-            You can only send {{ current_service.message_limit }}
-            messages per day
-            {%- if current_service.restricted %}
-              in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
-            {%- endif -%}
-            .
-          </p>
-        {% endif %}
-        <p>
-          You can still send
-          {{ current_service.message_limit - statistics.emails_requested - statistics.sms_requested }}
-          messages today, but
-          ‘{{ original_file_name }}’ contains
-          {{ count_of_recipients }} {{ recipients.recipient_column_header }}
+          You can’t send to
+          {{ 'this' if count_of_recipients == 1 else 'these' }}
+          {{ recipients.recipient_column_header }}
           {%- if count_of_recipients != 1 -%}
             {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
-          {%- endif -%}.
+          {%- endif %}
+        </h1>
+        <p>
+          In <a href="{{ url_for('.trial_mode') }}">trial mode</a> you can only
+          send to yourself and members of your team
         </p>
       {% endcall %}
     </div>
@@ -64,6 +53,34 @@
             {% endfor %}
           </ul>
         {% endif %}
+      {% endcall %}
+    </div>
+  {% elif count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0)) %}
+    <div class="bottom-gutter">
+      {% call banner_wrapper(type='dangerous') %}
+        <h1 class='banner-title'>
+          Too many recipients
+        </h1>
+        {% if statistics.emails_requested or statistics.sms_requested %}
+          <p>
+            You can only send {{ current_service.message_limit }}
+            messages per day
+            {%- if current_service.restricted %}
+              in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
+            {%- endif -%}
+            .
+          </p>
+        {% endif %}
+        <p>
+          You can still send
+          {{ current_service.message_limit - statistics.emails_requested - statistics.sms_requested }}
+          messages today, but
+          ‘{{ original_file_name }}’ contains
+          {{ count_of_recipients }} {{ recipients.recipient_column_header }}
+          {%- if count_of_recipients != 1 -%}
+            {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
+          {%- endif -%}.
+        </p>
       {% endcall %}
     </div>
   {% else %}
@@ -95,7 +112,7 @@
 
   {% if (
     errors or
-    count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0)) 
+    count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0))
   ) %}
     {% if request.args.from_test %}
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@5.2.5#egg=notifications-utils==5.2.5
+git+https://github.com/alphagov/notifications-utils.git@5.3.0#egg=notifications-utils==5.3.0


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/15326822/4ed72bb8-1c47-11e6-8492-4c7bb82e1970.png)



This commit makes two main changes to what happens when a user is in trial mode and they upload some email addresses belonging to other people.

1. Add a specific banner error telling the user about trial mode

2. Make this error higher priority, eg it will show up before the  error about having too many recipients in your file

This means making some changes to the tests so that the example CSV files include the user’s phone number, then making them invalid by omitting data required by the templates.

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/34