### PR TITLE
Use correct key to set team in DeskPro

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -11,7 +11,7 @@ def feedback():
         data = {
             'person_email': current_app.config.get('DESKPRO_PERSON_EMAIL'),
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
-            'assigned_agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
+            'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Notify feedback',
             'message': 'Environment: {}\n\n{}\n{}\n{}'.format(
                 url_for('main.index', _external=True),
@@ -35,7 +35,7 @@ def feedback():
                     resp.json())
                 )
             abort(500, "Feedback submission failed")
-        flash("Thanks, we've received your feedback", 'default_with_tick')
+        flash("Thanks, we’ve received your feedback", 'default_with_tick')
         return redirect(url_for('.feedback'))
 
     return render_template('views/feedback.html', form=form)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -102,7 +102,7 @@ def service_request_to_go_live(service_id):
         data = {
             'person_email': current_app.config.get('DESKPRO_PERSON_EMAIL'),
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
-            'assigned_agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
+            'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live',
             'message': "From {} <{}> on behalf of {} ({})\n\nUsage estimate\n---\n\n{}".format(
                 current_user.name,

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -48,7 +48,7 @@ def test_post_feedback_with_no_name_email(app_, mocker):
                 ANY,
                 data={
                     'department_id': ANY,
-                    'assigned_agent_team_id': ANY,
+                    'agent_team_id': ANY,
                     'subject': 'Notify feedback',
                     'message': 'Environment: http://localhost/\n\n\n\nblah',
                     'person_email': ANY},
@@ -70,7 +70,7 @@ def test_post_feedback_with_name_email(app_, mocker):
                 data={
                     'subject': 'Notify feedback',
                     'department_id': ANY,
-                    'assigned_agent_team_id': ANY,
+                    'agent_team_id': ANY,
                     'message': 'Environment: http://localhost/\n\nSteve Irwin\nrip@gmail.com\nblah',
                     'person_email': ANY},
                 headers=ANY)
@@ -96,7 +96,7 @@ def test_log_error_on_post(app_, mocker):
                 data={
                     'subject': 'Notify feedback',
                     'department_id': ANY,
-                    'assigned_agent_team_id': ANY,
+                    'agent_team_id': ANY,
                     'message': 'Environment: http://localhost/\n\nSteve Irwin\nrip@gmail.com\nblah',
                     'person_email': ANY},
                 headers=ANY)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -239,7 +239,7 @@ def test_should_redirect_after_request_to_go_live(
                 data={
                     'subject': 'Request to go live',
                     'department_id': ANY,
-                    'assigned_agent_team_id': ANY,
+                    'agent_team_id': ANY,
                     'message': 'From Test User <test@user.gov.uk> on behalf of Test Service (http://localhost/services/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/dashboard)\n\nUsage estimate\n---\n\nOne million messages',  # noqa
                     'person_email': ANY
                 },


### PR DESCRIPTION
For the `POST` ticket endpoint, the parameter is `agent_team_id`:

https://manuals.deskpro.com/html/developer-apps/api/api-tickets.html#id2

***

We should also rename the Credstash key… _later_.