### PR TITLE
Explain why we need your phone number

### DIFF
--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -17,7 +17,7 @@ Create an account – GOV.UK Notify
     <form method="post" autocomplete="nope">
       {{ textbox(form.name, width='3-4') }}
       {{ textbox(form.email_address, hint="Must be from a central government organisation", width='3-4', safe_error_message=True) }}
-      {{ textbox(form.mobile_number, width='3-4', hint='You’ll need this phone to hand') }}
+      {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a verification code by text message') }}
       {{ textbox(form.password, hint="At least 10 characters", width='3-4') }}
       {{ page_footer("Continue") }}
     </form>


### PR DESCRIPTION
The previous hint text was sort of half way there. Told you that you’d need your phone handy, but not _why_. This came up multiple times in user research. Also, the term ‘handy’ is not as familiar to users as
I anticipated.

This commit changes the message to explain exactly what we use your phone number for.

***

![image](https://cloud.githubusercontent.com/assets/355079/15433594/e2da0082-1eaa-11e6-8d83-5eb0ff1d9be5.png)
