### PR TITLE
Doc integrate info

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,9 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 If you code in one of the languages in the table below, you can use one a client library provided by GOV.UK Notify to intergrate the API into your service:
 
+
+Lanuguage | Library
+--- | --- 
 Lanuguage | Library
 Python | [Link to coding examples](https://github.com/alphagov/notifications-python-client)
 PHP | [Link to coding examples](https://github.com/alphagov/notifications-php-client)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,13 +54,14 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 <h2 id="integrate_Notify">Integrate the GOV.UK Notify API into your service</h2>
 
-There are 2 ways to integrate the API into your service:
+If you code in one of the languages in the table below, you can use one a client library provided by GOV.UK Notify to intergrate the API into your service:
 
-* use one of the client libraries provided by GOV.UK Notify (see the Usage section in the Readme files):
-      * [Python library](https://github.com/alphagov/notifications-python-client)
-      * [PHP library](https://github.com/alphagov/notifications-php-client)
-      * [Java library](https://github.com/alphagov/notifications-java-client)
-* develop your own integration to produce requests in the correct format
+Lanuguage | Library |
+Python | [Link to coding examples](https://github.com/alphagov/notifications-python-client)
+PHP | [Link to coding examples](https://github.com/alphagov/notifications-php-client)
+Jave | [Link to coding examples](https://github.com/alphagov/notifications-java-client)
+
+If you code in a different language you need to develop your own integration to produce requests in the correct format.
 
 <h3 id="AuthRequests">Authenticate requests</h3>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -304,6 +304,7 @@ where:
 * `links`:
     * `last` is the URL of the last page of notifications
     * `next` is the URL of the next page of notifications
+  
   These URLs accept the following query string parameters:
   * `template_type`
   * `status`

--- a/docs/index.md
+++ b/docs/index.md
@@ -308,7 +308,7 @@ where:
 
 The above fields are populated once the message has been processed; initially you get back the [response](#coderesponse) indicated above.
 
-You can adapt the ``GET /notifications`` command with the following query string parameters:
+The ``GET /notifications`` request accepts the following query string parameters:
   * `template_type` - `sms` or `email` (you can enter `template_type` twice)
   * `status` - `sending`, `delivered`, or `failed`
   * `page` - page number

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,9 +57,11 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 There are 2 ways to integrate the API into your service:
 
 * use one of the client libraries provided by GOV.UK Notify:
-      * Python library - [link to coding examples](https://github.com/alphagov/notifications-python-client/blob/master/README.md#usage)
-      * PHP library [link to coding examples](https://github.com/alphagov/notifications-php-client/blob/master/README.md#usage)
+      
+      * [Python library](https://github.com/alphagov/notifications-python-client/blob/master/README.md#usage)
+      * [PHP library](https://github.com/alphagov/notifications-php-client/blob/master/README.md#usage)
       * [Java library](https://github.com/alphagov/notifications-java-client)
+
 * develop your own integration to produce requests in the correct format
 
 <h3 id="AuthRequests">Authenticate requests</h3>

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 <h2 id="integrate_Notify">Integrate the GOV.UK Notify API into your service</h2>
 
-If you code in one of the languages listed below, you can use a client library provided by GOV.UK Notify to intergrate the GOV.UK Notify API into your service:
+If you code in one of the languages listed below, you can use a client library provided by GOV.UK Notify to integrate the GOV.UK Notify API into your service:
 
 
 Language | Library
@@ -63,7 +63,7 @@ Python | [Link to Python library coding examples](https://github.com/alphagov/no
 PHP | [Link to PHP library coding examples](https://github.com/alphagov/notifications-php-client)
 Java | [Link to Java library coding examples](https://github.com/alphagov/notifications-java-client)
 
-If you code in a different language you need to develop your own integration to produce requests in the correct format.
+If you code in a different language, you need to develop your own integration to produce requests in the correct format.
 
 <h3 id="AuthRequests">Authenticate requests</h3>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -305,12 +305,12 @@ where:
     * `last` is the URL of the last page of notifications
     * `next` is the URL of the next page of notifications
   
-  These URLs accept the following query string parameters:
-  * `template_type`
-  * `status`
-  * `page`
-  * `page_size`
-  * `limit_days`
+    These URLs accept the following query string parameters:
+    * `template_type`
+    * `status`
+    * `page`
+    * `page_size`
+    * `limit_days`
 * `total` is the total number of notifications sent by the service using the given template type
 * `page_size` is an optional integer indicating the number of notifications per page; if not provided, defaults to 50
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,9 +56,9 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 There are 2 ways to integrate the API into your service:
 
-* use one of the client libraries provided by GOV.UK Notify (see the Usage section in the Readme files):
-      * [Python library](https://github.com/alphagov/notifications-python-client/blob/master/README.md#usage)
-      * [PHP library](https://github.com/alphagov/notifications-php-client/blob/master/README.md#usage)
+* use one of the client libraries provided by GOV.UK Notify:
+      * Python library - [link to coding examples](https://github.com/alphagov/notifications-python-client/blob/master/README.md#usage)
+      * PHP library [link to coding examples](https://github.com/alphagov/notifications-php-client/blob/master/README.md#usage)
       * [Java library](https://github.com/alphagov/notifications-java-client)
 * develop your own integration to produce requests in the correct format
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -306,8 +306,6 @@ where:
 * `total` is the total number of notifications sent by the service using the given template type
 * `page_size` is an optional integer indicating the number of notifications per page; if not provided, defaults to 50
 
-The above fields are populated once the message has been processed; initially you get back the [response](#coderesponse) indicated above.
-
 The ``GET /notifications`` request accepts the following query string parameters:
   * `template_type` - `sms` or `email` (you can enter `template_type` twice)
   * `status` - `sending`, `delivered`, or `failed`

--- a/docs/index.md
+++ b/docs/index.md
@@ -306,11 +306,11 @@ where:
     * `next` is the URL of the next page of notifications
   
     These URLs accept the following query string parameters:
-    * `template_type`
-    * `status`
-    * `page`
+    * `template_type` - `sms` or `email` (you can enter both)
+    * `status` - `sending`, `delivered`, or `failed`
+    * `page` - page number
     * `page_size`
-    * `limit_days`
+    * `limit_days` - defaults to 7
 * `total` is the total number of notifications sent by the service using the given template type
 * `page_size` is an optional integer indicating the number of notifications per page; if not provided, defaults to 50
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 If you code in one of the languages in the table below, you can use one a client library provided by GOV.UK Notify to intergrate the API into your service:
 
-Lanuguage | Library |
+Lanuguage | Library
 Python | [Link to coding examples](https://github.com/alphagov/notifications-python-client)
 PHP | [Link to coding examples](https://github.com/alphagov/notifications-php-client)
 Jave | [Link to coding examples](https://github.com/alphagov/notifications-java-client)

--- a/docs/index.md
+++ b/docs/index.md
@@ -309,8 +309,8 @@ where:
     * `template_type` - `sms` or `email` (you can enter both)
     * `status` - `sending`, `delivered`, or `failed`
     * `page` - page number
-    * `page_size`
-    * `limit_days` - defaults to 7
+    * `page_size` - number of notifications per page; defaults to 50
+    * `limit_days` - number of days; defaults to 7
 * `total` is the total number of notifications sent by the service using the given template type
 * `page_size` is an optional integer indicating the number of notifications per page; if not provided, defaults to 50
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 If you code in one of the languages listed below, you can use a client library provided by GOV.UK Notify to intergrate the GOV.UK Notify API into your service:
 
 
-Lanuguage | Library
+Language | Library
 --- | --- 
 Python | [Link to Python library coding examples](https://github.com/alphagov/notifications-python-client)
 PHP | [Link to PHP library coding examples](https://github.com/alphagov/notifications-php-client)

--- a/docs/index.md
+++ b/docs/index.md
@@ -306,7 +306,7 @@ where:
     * `next` is the URL of the next page of notifications
   
     These URLs accept the following query string parameters:
-    * `template_type` - `sms` or `email` (you can enter both)
+    * `template_type` - `sms` or `email` (you can enter `template_type` twice)
     * `status` - `sending`, `delivered`, or `failed`
     * `page` - page number
     * `page_size` - number of notifications per page; defaults to 50

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 <h2 id="integrate_Notify">Integrate the GOV.UK Notify API into your service</h2>
 
-If you code in one of the languages in the table below, you can use one a client library provided by GOV.UK Notify to intergrate the API into your service:
+If you code in one of the languages listed below, you can use one a client library provided by GOV.UK Notify to intergrate the API into your service:
 
 
 Lanuguage | Library

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 <h2 id="integrate_Notify">Integrate the GOV.UK Notify API into your service</h2>
 
-If you code in one of the languages listed below, you can use one a client library provided by GOV.UK Notify to intergrate the API into your service:
+If you code in one of the languages listed below, you can use one a client library provided by GOV.UK Notify to intergrate the GOV.UK Notify API into your service:
 
 
 Lanuguage | Library

--- a/docs/index.md
+++ b/docs/index.md
@@ -302,8 +302,14 @@ where:
 * `reference` is used in the Notifications API so you can ignore it (populated for email notifications only)
 * `sent_by` is the name of the provider
 * `links`:
-    * `last` is the url of the last page of notifications
-    * `next` is the url of the next page of notifications
+    * `last` is the URL of the last page of notifications
+    * `next` is the URL of the next page of notifications
+  These URLs accept the following query string parameters:
+  * `template_type`
+  * `status`
+  * `page`
+  * `page_size`
+  * `limit_days`
 * `total` is the total number of notifications sent by the service using the given template type
 * `page_size` is an optional integer indicating the number of notifications per page; if not provided, defaults to 50
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 There are 2 ways to integrate the API into your service:
 
 * use one of the client libraries provided by GOV.UK Notify (see the Usage section in the Readme files):
-      * [Python library](https://github.com/alphagov/nnotifications-python-client/blob/master/README.md#usage)
+      * [Python library](https://github.com/alphagov/notifications-python-client/blob/master/README.md#usage)
       * [PHP library](https://github.com/alphagov/notifications-php-client/blob/master/README.md#usage)
       * [Java library](https://github.com/alphagov/notifications-java-client)
 * develop your own integration to produce requests in the correct format

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,10 +59,9 @@ If you code in one of the languages in the table below, you can use one a client
 
 Lanuguage | Library
 --- | --- 
-Lanuguage | Library
-Python | [Link to coding examples](https://github.com/alphagov/notifications-python-client)
-PHP | [Link to coding examples](https://github.com/alphagov/notifications-php-client)
-Jave | [Link to coding examples](https://github.com/alphagov/notifications-java-client)
+Python | [Link to Python library coding examples](https://github.com/alphagov/notifications-python-client)
+PHP | [Link to PHP library coding examples](https://github.com/alphagov/notifications-php-client)
+Java | [Link to Java library coding examples](https://github.com/alphagov/notifications-java-client)
 
 If you code in a different language you need to develop your own integration to produce requests in the correct format.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 <h2 id="integrate_Notify">Integrate the GOV.UK Notify API into your service</h2>
 
-If you code in one of the languages listed below, you can use one a client library provided by GOV.UK Notify to intergrate the GOV.UK Notify API into your service:
+If you code in one of the languages listed below, you can use a client library provided by GOV.UK Notify to intergrate the GOV.UK Notify API into your service:
 
 
 Lanuguage | Library

--- a/docs/index.md
+++ b/docs/index.md
@@ -308,7 +308,7 @@ where:
 
 The above fields are populated once the message has been processed; initially you get back the [response](#coderesponse) indicated above.
 
-You can adapt the ``GET/notifications`` command with the following query string parameters:
+You can adapt the ``GET /notifications`` command with the following query string parameters:
   * `template_type` - `sms` or `email` (you can enter `template_type` twice)
   * `status` - `sending`, `delivered`, or `failed`
   * `page` - page number

--- a/docs/index.md
+++ b/docs/index.md
@@ -303,23 +303,25 @@ where:
 * `links`:
     * `last` is the URL of the last page of notifications
     * `next` is the URL of the next page of notifications
-  
-    These URLs accept the following query string parameters:
-    * `template_type` - `sms` or `email` (you can enter `template_type` twice)
-    * `status` - `sending`, `delivered`, or `failed`
-    * `page` - page number
-    * `page_size` - number of notifications per page; defaults to 50
-    * `limit_days` - number of days; defaults to 7
 * `total` is the total number of notifications sent by the service using the given template type
 * `page_size` is an optional integer indicating the number of notifications per page; if not provided, defaults to 50
 
 The above fields are populated once the message has been processed; initially you get back the [response](#coderesponse) indicated above.
 
-This list is split into pages. To scroll through the pages run:
+You can adapt the ``GET/notifications`` command with the following query string parameters:
+  * `template_type` - `sms` or `email` (you can enter `template_type` twice)
+  * `status` - `sending`, `delivered`, or `failed`
+  * `page` - page number
+  * `page_size` - number of notifications per page; defaults to 50
+  * `limit_days` - number of days; defaults to 7
+
+
+For example, to scroll through the pages in the list, run:
 
 ```
-GET /notifications?&page=2
+GET /notifications?page=2
 ```
+
 
 <h3 id="autherror_code">Authorisation error messages</h3>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,16 +54,13 @@ To find out more about GOV.UK Notify, see the [Government as a Platform](https:/
 
 <h2 id="integrate_Notify">Integrate the GOV.UK Notify API into your service</h2>
 
-If you code in one of the languages listed below, you can use a client library provided by GOV.UK Notify to integrate the GOV.UK Notify API into your service:
+There are 2 ways to integrate the API into your service:
 
-
-Language | Library
---- | --- 
-Python | [Link to Python library coding examples](https://github.com/alphagov/notifications-python-client)
-PHP | [Link to PHP library coding examples](https://github.com/alphagov/notifications-php-client)
-Java | [Link to Java library coding examples](https://github.com/alphagov/notifications-java-client)
-
-If you code in a different language, you need to develop your own integration to produce requests in the correct format.
+* use one of the client libraries provided by GOV.UK Notify (see the Usage section in the Readme files):
+      * [Python library](https://github.com/alphagov/nnotifications-python-client/blob/master/README.md#usage)
+      * [PHP library](https://github.com/alphagov/notifications-php-client/blob/master/README.md#usage)
+      * [Java library](https://github.com/alphagov/notifications-java-client)
+* develop your own integration to produce requests in the correct format
 
 <h3 id="AuthRequests">Authenticate requests</h3>
 


### PR DESCRIPTION
Add list of query string parameters for GET /notifications request
Link directly to Usage sections in Python and PHP readme files
Add space to list of libraries (Integrate section) for readability