### PR TITLE
Download csv for job added.

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -76,6 +76,13 @@ def view_job(service_id, job_id):
                                                        version=job['template_version'])['data']
     notifications = notification_api_client.get_notifications_for_service(service_id, job_id)
     finished = job['status'] == 'finished'
+    if 'download' in request.args and request.args['download'] == 'csv':
+        csv_content = generate_notifications_csv(
+            notification_api_client.get_notifications_for_service(service_id, job_id)['notifications'])
+        return csv_content, 200, {
+            'Content-Type': 'text/csv; charset=utf-8',
+            'Content-Disposition': 'inline; filename="job_notifications.csv"'
+        }
     return render_template(
         'views/jobs/job.html',
         notifications=notifications['notifications'],

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -30,6 +30,12 @@
       )}}
     {% endif %}
 
+    <p class="bottom-gutter">
+      <a href="{{ request.url }}?&amp;download=csv" download class="heading-small">Download as a CSV file</a>
+      &emsp;
+      Delivery information is available for 7 days
+    </p>
+
     {% include 'partials/jobs/status.html' %}
 
     {% include 'partials/jobs/count.html' %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -262,3 +262,27 @@ def test_should_download_notifications_for_a_service(app_,
         assert response.status_code == 200
         assert response.get_data(as_text=True) == csv_content
         assert 'text/csv' in response.headers['Content-Type']
+
+
+def test_should_download_notifications_for_a_job(app_,
+                                                 api_user_active,
+                                                 mock_login,
+                                                 mock_get_service,
+                                                 mock_get_job,
+                                                 mock_get_notifications,
+                                                 mock_get_template_version,
+                                                 mock_has_permissions,
+                                                 fake_uuid):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            client.login(api_user_active)
+            response = client.get(url_for(
+                'main.view_job',
+                service_id=fake_uuid,
+                job_id=fake_uuid,
+                download='csv'))
+        csv_content = generate_notifications_csv(
+            mock_get_notifications(fake_uuid, job_id=fake_uuid)['notifications'])
+        assert response.status_code == 200
+        assert response.get_data(as_text=True) == csv_content
+        assert 'text/csv' in response.headers['Content-Type']


### PR DESCRIPTION
Download button now available on the job page.
Allows you to only download notifications for that job.