### PR TITLE
Hide ‘created at…’ on the templates page

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -79,7 +79,7 @@
     &:hover {
       text-decoration: underline;
     }
-    
+
   }
 
   .primary {
@@ -90,7 +90,7 @@
 
 .sms-message-use-links-with-title {
   @extend %sms-message-use-links;
-  margin-top: 95px;
+  margin-top: 50px;
 }
 
 .sms-message-from {

--- a/app/templates/components/email-message.html
+++ b/app/templates/components/email-message.html
@@ -7,7 +7,6 @@
   from_address=None,
   recipient=None,
   id=None,
-  created_at=None,
   updated_at=None,
   versions_url=None,
   version=1,
@@ -26,10 +25,6 @@
   {% if version > 1 %}
     {% if updated_at %}
       <p class="email-message-updated-at">Last updated on {{ updated_at|format_date_normal }} <a href="{{ versions_url }}">see earlier versions</a></p>
-    {% endif %}
-  {% else %}
-    {% if created_at %}
-      <p class="email-message-updated-at">Created on {{ created_at|format_date_normal }}</p>
     {% endif %}
   {% endif %}
   <div class="email-message">

--- a/app/templates/components/sms-message.html
+++ b/app/templates/components/sms-message.html
@@ -6,7 +6,6 @@
   edit_link=None,
   from=None,
   version=1,
-  created_at=None,
   updated_at=None,
   versions_url=None,
   show_placeholder_for_recipient=False,
@@ -25,14 +24,10 @@
     {% if updated_at %}
       <p class="sms-message-updated-at">Last updated on {{ updated_at|format_date_normal }} <a href="{{ versions_url }}">see earlier versions</a></p>
     {% endif %}
-  {% else %}
-    {% if created_at %}
-      <p class="sms-message-updated-at">Created on {{ created_at|format_date_normal }}</p>
-    {% endif %}
   {% endif %}
   {% if recipient is not none %}
     <p class="sms-message-recipient">
-      To: 
+      To:
       {% if show_placeholder_for_recipient %}
         <span class="placeholder">
           phone number

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -9,7 +9,6 @@
       template.formatted_as_markup,
       name=template.name if show_title else None,
       id=template.id,
-      created_at=template.get_raw('created_at', None),
       updated_at=template.get_raw('updated_at', None),
       version=template.get_raw('version', 1),
       versions_url=url_for('.view_template_versions', service_id=current_service.id, template_id=template.id)
@@ -19,7 +18,6 @@
       template.formatted_as_markup,
       name=template.name if show_title else None,
       id=template.id,
-      created_at=template.get_raw('created_at', None),
       updated_at=template.get_raw('updated_at', None),
       version=template.get_raw('version', 1),
       versions_url=url_for('.view_template_versions', service_id=current_service.id, template_id=template.id)


### PR DESCRIPTION
I don’t think that if there’s only one version of the template that it’s useful to see the created at date.

The auditing stuff only becomes relevant once someone a template has been changed.