### PR TITLE
Improve the ‘download a CSV’ from the job page

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -18,7 +18,8 @@ from app import (
     job_api_client,
     notification_api_client,
     service_api_client,
-    current_service)
+    current_service,
+    format_datetime_short)
 from app.main import main
 from app.utils import (
     get_page_from_request,
@@ -81,7 +82,10 @@ def view_job(service_id, job_id):
             notification_api_client.get_notifications_for_service(service_id, job_id)['notifications'])
         return csv_content, 200, {
             'Content-Type': 'text/csv; charset=utf-8',
-            'Content-Disposition': 'inline; filename="job_notifications.csv"'
+            'Content-Disposition': 'inline; filename="{} - {}.csv"'.format(
+                template['name'],
+                format_datetime_short(job['created_at'])
+            )
         }
     return render_template(
         'views/jobs/job.html',

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -30,16 +30,14 @@
       )}}
     {% endif %}
 
-    <p class="bottom-gutter">
-      <a href="{{ request.url }}?&amp;download=csv" download class="heading-small">Download as a CSV file</a>
-      &emsp;
-      Delivery information is available for 7 days
-    </p>
-
     {% include 'partials/jobs/status.html' %}
 
     {% include 'partials/jobs/count.html' %}
 
     {% include 'partials/jobs/notifications.html' %}
+
+    <p class="table-show-more-link">
+      <a href="{{ request.url }}?&amp;download=csv" download>Download as a CSV file</a>
+    </p>
 
 {% endblock %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -248,6 +248,7 @@ def test_should_show_notifications_for_a_service_with_next_previous(app_,
 def test_should_download_notifications_for_a_service(app_,
                                                      service_one,
                                                      active_user_with_permissions,
+                                                     mock_get_service_template,
                                                      mock_get_notifications,
                                                      mocker):
     with app_.test_request_context():
@@ -264,6 +265,7 @@ def test_should_download_notifications_for_a_service(app_,
         assert 'text/csv' in response.headers['Content-Type']
 
 
+@freeze_time("2016-01-01 11:09:00.061258")
 def test_should_download_notifications_for_a_job(app_,
                                                  api_user_active,
                                                  mock_login,
@@ -286,3 +288,4 @@ def test_should_download_notifications_for_a_job(app_,
         assert response.status_code == 200
         assert response.get_data(as_text=True) == csv_content
         assert 'text/csv' in response.headers['Content-Type']
+        assert 'sample template - 01 January at 11:09.csv"' in response.headers['Content-Disposition']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -793,6 +793,7 @@ def mock_get_job(mocker, job_data):
     def _get_job(service_id, job_id):
         job_data['id'] = job_id
         job_data['service'] = service_id
+        job_data['created_at'] = str(datetime.utcnow())
         return {"data": job_data}
 
     return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)


### PR DESCRIPTION
## Put ‘download CSV’ on job in logical place

![image](https://cloud.githubusercontent.com/assets/355079/15498079/cf2aab16-2195-11e6-8e98-bc6983fa467d.png)

## Give the job CSV a helpful filename

If you’re downloading a bunch of reports from your jobs then it’s useful to be able to differentiate between them. This commit makes it easy to do so by naming the file with:
- the name of the template
- when the job was created