### PR TITLE
Put uploaded files on the dashboard

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -202,7 +202,7 @@ def format_datetime_normal(date):
 
 
 def format_datetime_short(date):
-    return gmt_timezones(date).strftime('%d %B at %H:%M')
+    return gmt_timezones(date).strftime('%d %B at %H:%M').lstrip('0')
 
 
 def format_time(date):

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -1,6 +1,16 @@
 .dashboard {
-  table th {
-    font-size: 0;
+
+  table {
+    th {
+      @include core-16;
+      padding-top: 0;
+      border: 0;
+    }
+
+    td {
+      @include core-19;
+      border: 0;
+    }
   }
 }
 
@@ -15,11 +25,8 @@
   box-sizing: border-box;
   display: block;
   width: 100%;
-  text-align: right;
   margin-bottom: $gutter-half;
   height: $gutter-half;
-  color: $govuk-blue;
-  text-align: left;
   color: $govuk-blue;
 
   span {
@@ -44,6 +51,20 @@
     max-width: 100%;
     background: $white;
     margin-bottom: $gutter;
+  }
+
+}
+
+.file-list {
+
+  &-filename {
+    @include bold-19;
+  }
+
+  &-hint {
+    @include core-16;
+    display: block;
+    color: $secondary-text-colour;
   }
 
 }

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -16,6 +16,7 @@ from flask_login import login_required
 
 from app.main import main
 from app import (
+    job_api_client,
     statistics_api_client,
     service_api_client,
     template_statistics_client
@@ -218,4 +219,5 @@ def get_dashboard_statistics_for_service(service_id):
         'sms_allowance_remaining': max(0, (sms_free_allowance - sms_sent)),
         'sms_chargeable': max(0, sms_sent - sms_free_allowance),
         'sms_rate': sms_rate,
+        'jobs': job_api_client.get_job(service_id)['data']
     }

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -14,7 +14,7 @@
     {% if label_link %}
       <a class="big-number-label" href="{{ label_link }}">{{ label }}</a>
       <a class="big-number-overlay-link" href="{{ label_link }}" aria-hidden="true"></a>
-    {% else %}
+    {% elif label %}
       <span class="big-number-label">{{ label }}</span>
     {% endif %}
   </div>

--- a/app/templates/partials/jobs/count.html
+++ b/app/templates/partials/jobs/count.html
@@ -1,9 +1,9 @@
 {% from "components/big-number.html" import big_number %}
 
 <div
-  {% if not finished_at %}
+  {% if not finished %}
     data-module="update-content"
-    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job_id)}}"
+    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job.id)}}"
     data-key="counts"
     aria-live="polite"
   {% endif %}
@@ -12,12 +12,17 @@
   <ul class="grid-row job-totals">
     <li class="column-one-quarter">
       {{ big_number(
-        counts.queued, 'queued'
+        job.get('notifications_sent', 0) - job.get('notifications_delivered', 0) - job.get('notifications_failed', 0), 'sending'
       )}}
     </li>
     <li class="column-one-quarter">
       {{ big_number(
-        counts.sent, 'processed'
+        job.get('notifications_delivered', 0), 'delivered'
+      )}}
+    </li>
+    <li class="column-one-quarter">
+      {{ big_number(
+        job.notifications_failed, 'failed'
       )}}
     </li>
   </ul>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,9 +1,9 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
 <div
-  {% if not finished_at %}
+  {% if not finished %}
     data-module="update-content"
-    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job_id)}}"
+    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job.id)}}"
     data-key="notifications"
     aria-live="polite"
   {% endif %}

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,20 +1,12 @@
 <div
-  {% if not finished_at %}
+  {% if not finished %}
     data-module="update-content"
-    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job_id)}}"
+    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job.id)}}"
     data-key="status"
     aria-live="polite"
   {% endif %}
 >
-
-  {% if finished_at %}
-    <p class='heading-small'>
-      Finished {{ finished_at|format_datetime }}
-    </p>
-  {% else %}
-    <p class='heading-small'>
-      Started {{ uploaded_at|format_datetime }}
-    </p>
-  {% endif %}
-  Uploaded by {{ created_by }}
+  <p class='heading-small'>
+    Uploaded by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
+  </p>
 </div>

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -1,0 +1,35 @@
+{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
+{% from "components/big-number.html" import big_number %}
+
+{% call(item, row_number) list_table(
+  jobs,
+  caption="Recent batch jobs",
+  caption_visible=False,
+  empty_message='You haven’t sent any batch messages yet',
+  field_headings=[
+    'File',
+    right_aligned_field_heading('Sending'),
+    right_aligned_field_heading('Delivered'),
+    right_aligned_field_heading('Failed')
+  ],
+  field_headings_visible=True
+) %}
+  {% call field() %}
+    <div class="file-list">
+      <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+      <span class="file-list-hint">Uploaded {{ item.created_at|format_datetime_short }}</span>
+    </div
+  {% endcall %}
+  {% call field(align='right') %}
+    {{ big_number(
+      item.get('notifications_sent', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0),
+      smaller=True
+    ) }}
+  {% endcall %}
+  {% call field(align='right') %}
+    {{ big_number(item.get('notifications_delivered', 0), smaller=True) }}
+  {% endcall %}
+  {% call field(align='right', status='error' if 0 else '') %}
+    {{ big_number(item.get('notifications_failed', 0), smaller=True) }}
+  {% endcall %}
+{% endcall %}

--- a/app/templates/views/dashboard/jobs.html
+++ b/app/templates/views/dashboard/jobs.html
@@ -8,9 +8,10 @@
 ) %}
   {% call field() %}
     <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+    {{ item.created_at|format_datetime }}
   {% endcall %}
   {% call field() %}
-    {{ item.created_at|format_datetime }}
+    
   {% endcall %}
   {% call field(align='right') %}
     {{ item.notification_count }}

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -1,6 +1,7 @@
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/show-more.html" import show_more %}
 {% from "components/message-count-label.html" import message_count_label %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, hidden_field_heading %}
 
 <div
   data-module="update-content"
@@ -39,7 +40,7 @@
       ) }}
     </div>
   </div>
-  
+
   {% if template_statistics|length %}
     {% include 'views/dashboard/template-statistics.html' %}
     {{ show_more(
@@ -48,8 +49,16 @@
     ) }}
   {% endif %}
 
+  {% if jobs %}
+    {% include 'views/dashboard/_jobs.html' %}
+    {{ show_more(
+      url_for('.view_jobs', service_id=current_service.id),
+      'See all uploaded files'
+    ) }}
+  {% endif %}
+
   {% if current_user.has_permissions(['manage_settings'], admin_override=True) %}
-    <h2 class='heading-medium'>This year</h2>   
+    <h2 class='heading-medium'>This year</h2>
 
     <div class='grid-row'>
       <div class='column-half'>

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -1,44 +1,12 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
 {% block page_title %}
   Notifications activity – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}
-
-    <h1 class="heading-large">Notifications activity</h1>
-    <p>
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, page=1) }}">All messages</a>
-    </p>
-    <p>
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, type="sms", page=1) }}">Text messages</a>&emsp;
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, type="email", page=1) }}">Email messages</a>
-    </p>
-    <p>
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, status=['sent', 'delivered'], page=1) }}">Successful messages</a>&emsp;
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, status=['failed', 'complaint', 'bounce'], page=1) }}">Failed messages</a>
-    </p>
-    {% call(item, row_number) list_table(
-      jobs,
-      caption="Recent activity",
-      caption_visible=False,
-      empty_message='You haven’t sent any notifications yet',
-      field_headings=['Job', 'Time', 'Uploaded by', right_aligned_field_heading('Status')]
-    ) %}
-      {% call field() %}
-        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
-      {% endcall %}
-      {% call field() %}
-        {{ item.created_at | format_datetime}}
-      {% endcall %}
-      {% call field() %}
-        {{ item.created_by.name }}
-      {% endcall %}
-      {% call field(align='right') %}
-        {{ item.status }}
-      {% endcall %}
-    {% endcall %}
-
-
+    <h1 class="heading-large">Uploaded files</h1>
+    <div class="dashboard">
+      {% include 'views/dashboard/_jobs.html' %}
+    </div>
 {% endblock %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -20,7 +20,7 @@ def test_should_return_list_of_all_jobs(app_,
 
         assert response.status_code == 200
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.string == 'Notifications activity'
+        assert page.h1.string == 'Uploaded files'
         jobs = page.tbody.find_all('tr')
         assert len(jobs) == 5
 
@@ -50,10 +50,12 @@ def test_should_show_page_for_one_job(
         assert "Delivered at 11:10" in content
 
 
+@freeze_time("2016-01-01 11:09:00.061258")
 def test_should_show_updates_for_one_job_as_json(
     app_,
     service_one,
     active_user_with_permissions,
+    mock_get_jobs,
     mock_get_notifications,
     mocker
 ):
@@ -67,12 +69,14 @@ def test_should_show_updates_for_one_job_as_json(
 
         assert response.status_code == 200
         content = json.loads(response.get_data(as_text=True))
-        assert 'processed' in content['counts']
-        assert 'queued' in content['counts']
+        assert 'sending' in content['counts']
+        assert 'delivered' in content['counts']
+        assert 'failed' in content['counts']
         assert 'Recipient' in content['notifications']
+        assert '07123456789' in content['notifications']
         assert 'Status' in content['notifications']
-        assert 'Started' in content['status']
-        assert 'Uploaded by Test User' in content['status']
+        assert 'Delivered at 11:10' in content['notifications']
+        assert 'Uploaded by Test User on 1 January at 11:09' in content['status']
 
 
 def test_should_show_notifications_for_a_service(app_,
@@ -288,4 +292,4 @@ def test_should_download_notifications_for_a_job(app_,
         assert response.status_code == 200
         assert response.get_data(as_text=True) == csv_content
         assert 'text/csv' in response.headers['Content-Type']
-        assert 'sample template - 01 January at 11:09.csv"' in response.headers['Content-Disposition']
+        assert 'sample template - 1 January at 11:09.csv"' in response.headers['Content-Disposition']


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/15511365/1fd48748-21d3-11e6-8f4e-3bc38edf1bd0.png)

This commit depends on and uses the data returned by:
- [x] https://github.com/alphagov/notifications-api/pull/345
- [ ] a pull request which will allow us to limit this data to the last 7 days

It puts the jobs on the dashboard.

It also:
- links to the jobs page
- makes the numbers on the jobs page consistent with the dashboard
- makes the numbers on an individual job consistent with the appearance of the dashboard