### PR TITLE
Put uploaded files on the dashboard

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -202,7 +202,7 @@ def format_datetime_normal(date):
 
 
 def format_datetime_short(date):
-    return gmt_timezones(date).strftime('%d %B at %H:%M')
+    return gmt_timezones(date).strftime('%d %B at %H:%M').lstrip('0')
 
 
 def format_time(date):

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -1,6 +1,16 @@
 .dashboard {
-  table th {
-    font-size: 0;
+
+  table {
+    th {
+      @include core-16;
+      padding-top: 0;
+      border: 0;
+    }
+
+    td {
+      @include core-19;
+      border: 0;
+    }
   }
 }
 
@@ -15,11 +25,8 @@
   box-sizing: border-box;
   display: block;
   width: 100%;
-  text-align: right;
   margin-bottom: $gutter-half;
   height: $gutter-half;
-  color: $govuk-blue;
-  text-align: left;
   color: $govuk-blue;
 
   span {
@@ -44,6 +51,20 @@
     max-width: 100%;
     background: $white;
     margin-bottom: $gutter;
+  }
+
+}
+
+.file-list {
+
+  &-filename {
+    @include bold-19;
+  }
+
+  &-hint {
+    @include core-16;
+    display: block;
+    color: $secondary-text-colour;
   }
 
 }

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -16,6 +16,7 @@ from flask_login import login_required
 
 from app.main import main
 from app import (
+    job_api_client,
     statistics_api_client,
     service_api_client,
     template_statistics_client
@@ -217,4 +218,5 @@ def get_dashboard_statistics_for_service(service_id):
         'sms_allowance_remaining': max(0, (sms_free_allowance - sms_sent)),
         'sms_chargeable': max(0, sms_sent - sms_free_allowance),
         'sms_rate': sms_rate,
+        'jobs': job_api_client.get_job(service_id, limit_days=7)['data']
     }

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -90,12 +90,13 @@ def view_job(service_id, job_id):
     return render_template(
         'views/jobs/job.html',
         notifications=notifications['notifications'],
-        counts={
-            'queued': 0 if finished else job['notification_count'],
-            'sent': job['notification_count'] if finished else 0
-        },
+        job=job,
         uploaded_at=job['created_at'],
-        finished_at=job['updated_at'] if finished else None,
+        finished=job.get('notifications_sent', 0) and ((
+            job.get('notifications_sent', 0) -
+            job.get('notifications_delivered', 0) -
+            job.get('notifications_failed', 0)
+        ) == 0),
         uploaded_file_name=job['original_file_name'],
         first_email_template=[
             template for template in service_api_client.get_service_templates(service_id)['data']
@@ -104,9 +105,7 @@ def view_job(service_id, job_id):
         template=Template(
             template,
             prefix=current_service['name']
-        ),
-        job_id=job_id,
-        created_by=job['created_by']['name']
+        )
     )
 
 
@@ -116,24 +115,27 @@ def view_job(service_id, job_id):
 def view_job_updates(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     notifications = notification_api_client.get_notifications_for_service(service_id, job_id)
-    finished = job['status'] == 'finished'
+    finished = (
+        job.get('notifications_sent', 0) -
+        job.get('notifications_delivered', 0) -
+        job.get('notifications_failed', 0)
+    ) == 0
     return jsonify(**{
         'counts': render_template(
             'partials/jobs/count.html',
-            counts={
-                'queued': 0 if finished else job['notification_count'],
-                'sent': job['notification_count'] if finished else 0
-            }
+            job=job,
+            finished=finished
         ),
         'notifications': render_template(
             'partials/jobs/notifications.html',
-            notifications=notifications['notifications']
+            job=job,
+            notifications=notifications['notifications'],
+            finished=finished
         ),
         'status': render_template(
             'partials/jobs/status.html',
-            uploaded_at=job['created_at'],
-            finished_at=job['updated_at'] if finished else None,
-            created_by=job['created_by']['name']
+            job=job,
+            finished=finished
         ),
     })
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -20,8 +20,7 @@ class JobApiClient(BaseAPIClient):
         params = {}
         if limit_days is not None:
             params['limit_days'] = limit_days
-        else:
-            return self.get(url='/service/{}/job'.format(service_id), params=params)
+        return self.get(url='/service/{}/job'.format(service_id), params=params)
 
     def create_job(self, job_id, service_id, template_id, original_file_name, notification_count):
         data = {

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -14,7 +14,7 @@
     {% if label_link %}
       <a class="big-number-label" href="{{ label_link }}">{{ label }}</a>
       <a class="big-number-overlay-link" href="{{ label_link }}" aria-hidden="true"></a>
-    {% else %}
+    {% elif label %}
       <span class="big-number-label">{{ label }}</span>
     {% endif %}
   </div>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -1,6 +1,6 @@
 {% from "components/banner.html" import banner_wrapper %}
 
-{% if request.args['help'] %}
+{% if request.args['help'] and request.args['help'] != '0' %}
   {% call banner_wrapper(type='tour') %}
       <p class="heading-medium">Get started</p>
       <div class="grid-row bottom-gutter" {% if request.args['help'] != '1' %}style="opacity: 0.6"{% endif %}>

--- a/app/templates/partials/jobs/count.html
+++ b/app/templates/partials/jobs/count.html
@@ -1,9 +1,9 @@
 {% from "components/big-number.html" import big_number %}
 
 <div
-  {% if not finished_at %}
+  {% if not finished %}
     data-module="update-content"
-    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job_id)}}"
+    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job.id)}}"
     data-key="counts"
     aria-live="polite"
   {% endif %}
@@ -12,12 +12,17 @@
   <ul class="grid-row job-totals">
     <li class="column-one-quarter">
       {{ big_number(
-        counts.queued, 'queued'
+        job.get('notifications_sent', 0) - job.get('notifications_delivered', 0) - job.get('notifications_failed', 0), 'sending'
       )}}
     </li>
     <li class="column-one-quarter">
       {{ big_number(
-        counts.sent, 'processed'
+        job.get('notifications_delivered', 0), 'delivered'
+      )}}
+    </li>
+    <li class="column-one-quarter">
+      {{ big_number(
+        job.notifications_failed, 'failed'
       )}}
     </li>
   </ul>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,9 +1,9 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
 <div
-  {% if not finished_at %}
+  {% if not finished %}
     data-module="update-content"
-    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job_id)}}"
+    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job.id)}}"
     data-key="notifications"
     aria-live="polite"
   {% endif %}

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,12 +1,12 @@
 <div
-  {% if not finished_at %}
+  {% if not finished %}
     data-module="update-content"
-    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job_id)}}"
+    data-resource="{{url_for(".view_job_updates", service_id=current_service.id, job_id=job.id)}}"
     data-key="status"
     aria-live="polite"
   {% endif %}
 >
   <p class='heading-small'>
-    Sent by {{ created_by }} on {{ uploaded_at|format_datetime_short }}
+    Uploaded by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
   </p>
 </div>

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -1,0 +1,35 @@
+{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
+{% from "components/big-number.html" import big_number %}
+
+{% call(item, row_number) list_table(
+  jobs,
+  caption="Recent batch jobs",
+  caption_visible=False,
+  empty_message='You haven’t sent any batch messages yet',
+  field_headings=[
+    'File',
+    right_aligned_field_heading('Sending'),
+    right_aligned_field_heading('Delivered'),
+    right_aligned_field_heading('Failed')
+  ],
+  field_headings_visible=True
+) %}
+  {% call field() %}
+    <div class="file-list">
+      <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+      <span class="file-list-hint">Uploaded {{ item.created_at|format_datetime_short }}</span>
+    </div
+  {% endcall %}
+  {% call field(align='right') %}
+    {{ big_number(
+      item.get('notifications_sent', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0),
+      smaller=True
+    ) }}
+  {% endcall %}
+  {% call field(align='right') %}
+    {{ big_number(item.get('notifications_delivered', 0), smaller=True) }}
+  {% endcall %}
+  {% call field(align='right', status='error' if 0 else '') %}
+    {{ big_number(item.get('notifications_failed', 0), smaller=True) }}
+  {% endcall %}
+{% endcall %}

--- a/app/templates/views/dashboard/jobs.html
+++ b/app/templates/views/dashboard/jobs.html
@@ -8,9 +8,10 @@
 ) %}
   {% call field() %}
     <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+    {{ item.created_at|format_datetime }}
   {% endcall %}
   {% call field() %}
-    {{ item.created_at|format_datetime }}
+    
   {% endcall %}
   {% call field(align='right') %}
     {{ item.notification_count }}

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -1,6 +1,7 @@
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/show-more.html" import show_more %}
 {% from "components/message-count-label.html" import message_count_label %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, hidden_field_heading %}
 
 <div
   data-module="update-content"
@@ -39,7 +40,7 @@
       ) }}
     </div>
   </div>
-  
+
   {% if template_statistics|length %}
     {% include 'views/dashboard/template-statistics.html' %}
     {{ show_more(
@@ -48,8 +49,16 @@
     ) }}
   {% endif %}
 
+  {% if jobs %}
+    {% include 'views/dashboard/_jobs.html' %}
+    {{ show_more(
+      url_for('.view_jobs', service_id=current_service.id),
+      'See all uploaded files'
+    ) }}
+  {% endif %}
+
   {% if current_user.has_permissions(['manage_settings'], admin_override=True) %}
-    <h2 class='heading-medium'>This year</h2>   
+    <h2 class='heading-medium'>This year</h2>
 
     <div class='grid-row'>
       <div class='column-half'>

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -1,44 +1,12 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
 
 {% block page_title %}
   Notifications activity – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}
-
-    <h1 class="heading-large">Notifications activity</h1>
-    <p>
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, page=1) }}">All messages</a>
-    </p>
-    <p>
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, type="sms", page=1) }}">Text messages</a>&emsp;
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, type="email", page=1) }}">Email messages</a>
-    </p>
-    <p>
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, status=['sent', 'delivered'], page=1) }}">Successful messages</a>&emsp;
-      <a href="{{ url_for(".view_notifications", service_id=current_service.id, job_id=job_id, status=['failed', 'complaint', 'bounce'], page=1) }}">Failed messages</a>
-    </p>
-    {% call(item, row_number) list_table(
-      jobs,
-      caption="Recent activity",
-      caption_visible=False,
-      empty_message='You haven’t sent any notifications yet',
-      field_headings=['Job', 'Time', 'Uploaded by', right_aligned_field_heading('Status')]
-    ) %}
-      {% call field() %}
-        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
-      {% endcall %}
-      {% call field() %}
-        {{ item.created_at | format_datetime}}
-      {% endcall %}
-      {% call field() %}
-        {{ item.created_by.name }}
-      {% endcall %}
-      {% call field(align='right') %}
-        {{ item.status }}
-      {% endcall %}
-    {% endcall %}
-
-
+    <h1 class="heading-large">Uploaded files</h1>
+    <div class="dashboard">
+      {% include 'views/dashboard/_jobs.html' %}
+    </div>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -794,7 +794,7 @@ def mock_get_job(mocker, api_user_active):
 
 @pytest.fixture(scope='function')
 def mock_get_jobs(mocker, api_user_active):
-    def _get_jobs(service_id):
+    def _get_jobs(service_id, limit_days=None):
         data = []
         for i in range(5):
             job_data = job_json(service_id, api_user_active)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/15511365/1fd48748-21d3-11e6-8f4e-3bc38edf1bd0.png)

This commit depends on and uses the data returned by:
- [x] alphagov/notifications-api#345
- [x] alphagov/notifications-api#347
- [x] #612

It:
- puts jobs from the last 7 days on the dashboard
- links to the jobs page
- makes the numbers on the jobs page consistent with the dashboard
- makes the numbers on an individual job consistent with the appearance of the dashboard