### PR TITLE
Fix 403s when viewing a job as platform admin

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -111,7 +111,7 @@ def view_job(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>.json")
 @login_required
-@user_has_permissions('view_activity')
+@user_has_permissions('view_activity', admin_override=True)
 def view_job_updates(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     notifications = notification_api_client.get_notifications_for_service(service_id, job_id)


### PR DESCRIPTION
While battling the bank holiday traffic on my way home this evening I realised why looking at the job page was causing lots of 403 errors in the Chrome console (a spike which was reflected on the Graphite screen).

There is a separate `.json` endpoint for getting updates to a job. This endpoint did not have the `admin=True` option set in its permissions decorator. So when viewing a service as a platform admin you could see the page, but not receive any AJAX-powered updates to it.