### PR TITLE
caching in travis for pip and npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: python
+cache:
+  pip: true
+  directories:
+  - node_modules
 python:
 - '3.5'
 env:


### PR DESCRIPTION
similar to https://github.com/alphagov/notifications-api/pull/368 but also cache the `node_modules` directory

before:
![image](https://cloud.githubusercontent.com/assets/5020841/15742796/012ae5d4-28b9-11e6-8704-5e1f3bf11c7f.png)


after:
![image](https://cloud.githubusercontent.com/assets/5020841/15742785/e9986bb2-28b8-11e6-9cde-03b74d9afc1d.png)
