### PR TITLE
Redirect to single template view after edit

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -154,9 +154,9 @@ def edit_service_template(service_id, template_id):
                 raise e
         else:
             return redirect(url_for(
-                '.choose_template',
+                '.view_template',
                 service_id=service_id,
-                template_type=template['template_type']
+                template_id=template_id
             ))
     return render_template(
         'views/edit-{}-template.html'.format(template['template_type']),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -63,7 +63,7 @@ def test_should_redirect_when_saving_a_template(app_,
 
             assert response.status_code == 302
             assert response.location == url_for(
-                '.choose_template', service_id=service_id, template_type='sms', _external=True)
+                '.view_template', service_id=service_id, template_id=template_id, _external=True)
             mock_update_service_template.assert_called_with(
                 template_id, name, 'sms', content, service_id, None)
 
@@ -210,9 +210,9 @@ def test_should_redirect_when_saving_a_template_email(app_,
                 template_id=template_id), data=data)
             assert response.status_code == 302
             assert response.location == url_for(
-                '.choose_template',
+                '.view_template',
                 service_id=service_id,
-                template_type='email',
+                template_id=template_id,
                 _external=True)
             mock_update_service_template.assert_called_with(
                 template_id, name, 'email', content, service_id, subject)


### PR DESCRIPTION
When you edit a template, you’re probably going to do something with it straight afterwards, eg send yourself a test.

We could make it easy to find the template you’ve just saved by putting it at the top of the pile, but this gets confusing for other reasons (order of templates will constantly shift about).

So this commit changes the flow to take you to the single page for the template you’ve just edited.