### PR TITLE
Expand permissions before post to api

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -99,7 +99,8 @@ class UserApiClient(BaseAPIClient):
 
     def add_user_to_service(self, service_id, user_id, permissions):
         endpoint = '/service/{}/users/{}'.format(service_id, user_id)
-        resp = self.post(endpoint, data={'permissions': permissions})
+        data = [{'permission': x} for x in permissions]
+        resp = self.post(endpoint, data=data)
         return User(resp['data'], max_failed_login_count=self.max_failed_login_count)
 
     def set_user_permissions(self, user_id, service_id, permissions):

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -160,11 +160,13 @@ def test_invite_user(
         assert page.h1.string.strip() == 'Team members'
         flash_banner = page.find('div', class_='banner-default-with-tick').string.strip()
         assert flash_banner == 'Invite sent to test@example.gov.uk'
-        excpected_permissions = 'manage_api_keys,manage_service,send_messages,view_activity'
+
+        expected_permissions = 'manage_api_keys,manage_settings,manage_templates,manage_users,send_emails,send_letters,send_texts,view_activity'  # noqa
+
         app.invite_api_client.create_invite.assert_called_once_with(sample_invite['from_user'],
                                                                     sample_invite['service'],
                                                                     email_address,
-                                                                    excpected_permissions)
+                                                                    expected_permissions)
 
 
 def test_cancel_invited_user_cancels_user_invitations(app_,


### PR DESCRIPTION
Expand permissions to all possible values on admin before posting to api. 

For example instead of posting 'send_messages' to be stored against invited user, post 'send_emails', 'send_texts', 'send_letters'. 

As the latter values are save from the outset against the invite user, then when the user is created, no mapping needs to be done.

This makes admin template work for both existing and invited users without change.

This fixes:
https://www.pivotaltracker.com/story/show/120829927

This PR will enable this following on API.
https://github.com/alphagov/notifications-api/pull/384