### PR TITLE
Fix 500 on job page when notifications are sending

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -28,7 +28,7 @@
           align='right',
           status='error' if item.status == 'Failed' else 'default'
         ) %}
-          {{ item.status|format_notification_status }} at {{ item.updated_at|format_time }}
+          {{ item.status|format_notification_status }} at {{ (item.updated_at or item.created_at)|format_time }}
         {% endcall %}
       {% endcall %}
     {% else %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -94,7 +94,7 @@
     {{ text_field(item.status|format_notification_status) }}
 
     {% call field(align='right') %}
-      {{ item.updated_at|format_datetime_short }}
+      {{ (item.updated_at or item.created_at)|format_datetime_short }}
     {% endcall %}
   {% endcall %}
 


### PR DESCRIPTION
Sending notifications don’t have an `updated_at`. This causes the time formatting to throw a wobly, because it doesn’t expect `None`.

This commit changes the template to also look for the `created_at`, which all notifications have.