### PR TITLE
Two factor page bug

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -19,7 +19,7 @@ def two_factor():
     try:
         user_id = session['user_details']['id']
     except KeyError:
-        return redirect('main.sign_in')
+        return redirect(url_for('main.sign_in'))
 
     def _check_code(code):
         return user_api_client.check_verify_code(user_id, code, "sms")

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -210,3 +210,15 @@ def test_two_factor_reset_login_count_called(app_,
             api_user_locked.reset_failed_login_count()
             api_user_locked.password = new_password
             mock_update_user.assert_called_with(api_user_locked)
+
+
+def test_two_factor_should_redirect_to_sign_in_if_user_not_in_session(app_,
+                                                                      api_user_active,
+                                                                      mock_get_user):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+
+            response = client.post(url_for('main.two_factor'),
+                                   data={'sms_code': '12345'})
+            assert response.status_code == 302
+            assert response.location == url_for('main.sign_in', _external=True)


### PR DESCRIPTION
In case user details were not in session the redirect did not use url_for to redirect to sign in.

This fixes: https://www.pivotaltracker.com/story/show/120823303