### PR TITLE
Make activity consistent

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -43,12 +43,15 @@ def _parse_filter_args(filter_dict):
 
 
 def _set_status_filters(filter_args):
+    all_failure_statuses = ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
+    all_statuses = ['sending', 'delivered'] + all_failure_statuses
     if filter_args.get('status'):
-        if 'failed' in filter_args.get('status'):
-            filter_args['status'].extend(['temporary-failure', 'permanent-failure', 'technical-failure'])
+        if 'processed' in filter_args.get('status'):
+            filter_args['status'] = all_statuses
+        elif 'failed' in filter_args.get('status'):
+            filter_args['status'].extend(all_failure_statuses[1:])
     else:
-        # default to everything
-        filter_args['status'] = ['delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
+        filter_args['status'] = all_statuses
 
 
 @main.route("/services/<service_id>/jobs")
@@ -232,9 +235,10 @@ def view_notifications(service_id, message_type):
                 message_type=message_type,
                 status=item[1]
             )] for item in [
-                ['Successful', 'delivered'],
+                ['Processed', 'sending,delivered,failed'],
+                ['Sending', 'sending'],
+                ['Delivered', 'delivered'],
                 ['Failed', 'failed'],
-                ['', 'delivered,failed']
             ]
         ]
     )

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -19,7 +19,7 @@
         statistics.get('emails_failure_rate', 0.0),
         statistics.get('emails_failure_rate', 0)|float > 3,
         failure_link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='failed'),
-        label_link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='delivered,failed')
+        label_link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='sending,delivered,failed')
       ) }}
     </div>
     <div class="column-half">
@@ -30,7 +30,7 @@
         statistics.get('sms_failure_rate', 0.0),
         statistics.get('sms_failure_rate', 0)|float > 3,
         failure_link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='failed'),
-        label_link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='delivered,failed')
+        label_link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='sending,delivered,failed')
       ) }}
     </div>
     <div class="column-whole">

--- a/app/templates/views/dashboard/today.html
+++ b/app/templates/views/dashboard/today.html
@@ -18,8 +18,8 @@
         statistics.emails_failed,
         statistics.get('emails_failure_rate', 0.0),
         statistics.get('emails_failure_rate', 0)|float > 3,
-        failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='email', status='failed'),
-        label_link=url_for(".view_notifications", service_id=current_service.id, template_type='email', status='delivered,failed')
+        failure_link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='failed'),
+        label_link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='delivered,failed')
       ) }}
     </div>
     <div class="column-half">
@@ -29,8 +29,8 @@
         statistics.sms_failed,
         statistics.get('sms_failure_rate', 0.0),
         statistics.get('sms_failure_rate', 0)|float > 3,
-        failure_link=url_for(".view_notifications", service_id=current_service.id, template_type='sms', status='failed'),
-        label_link=url_for(".view_notifications", service_id=current_service.id, template_type='sms', status='delivered,failed')
+        failure_link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='failed'),
+        label_link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='delivered,failed')
       ) }}
     </div>
     <div class="column-whole">

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -35,7 +35,7 @@
 
   {% if notifications %}
     <p class="bottom-gutter">
-      <a href="{{ request.url }}&amp;download=csv" download class="heading-small">Download as a CSV file</a>
+      <a href="{{ download_link }}" download="download" class="heading-small">Download as a CSV file</a>
       &emsp;
       Delivery information is available for 7 days
     </p>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -3,60 +3,34 @@
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/pill.html" import pill %}
+{% from "components/message-count-label.html" import message_count_label %}
 
 {% block page_title %}
-  Activity – GOV.UK Notify
+  {{ message_count_label(99, message_type, suffix='') | capitalize }} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    {%- if (request_args.get('template_type', 'email,sms') == 'email,sms') and (request_args.get('status', 'delivered,failed') == 'delivered,failed') -%}
 
-      Activity
-
-    {%- else -%}
-
+    <span class="visually-hidden">
       {%- if request_args.get('status') != 'delivered,failed' -%}
         {%- for label, option, _ in status_filters -%}
           {%- if request_args.get('status', 'delivered,failed') == option -%}{{label}} {% endif -%}
         {%- endfor -%}
       {%- endif -%}
+    </span>
 
-      {%- if request_args.get('template_type', 'email,sms') == 'email,sms' %} emails and text messages
-      {%- else -%}
-
-        {%- for template_label, template_option, _ in type_filters -%}
-          {%- if request_args.get('template_type') == template_option -%}
-            {%- if request_args.get('status', 'delivered,failed') == 'delivered,failed' -%}
-              {{ template_label }}
-            {%- else -%}
-              {{ template_label | lower }}
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor -%}
-
-      {%- endif -%}
-
-    {%- endif -%}
+    {{- message_count_label(99, message_type, suffix='') | capitalize }}
 
   </h1>
 
-  <div class='grid-row bottom-gutter'>
-    <div class='column-half'>
-      {{ pill(
-        'Status',
-        status_filters,
-        request_args.get('status', '')
-      ) }}
-    </div>
-    <div class='column-half'>
-      {{ pill(
-        'Type',
-        type_filters,
-        request_args.get('template_type', '')
-      ) }}
-    </div>
+  <div class='bottom-gutter'>
+    {{ pill(
+      'Status',
+      status_filters,
+      request_args.get('status', '')
+    ) }}
   </div>
 
   {% if notifications %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -175,7 +175,6 @@ def test_menu_send_messages(mocker,
             'main.choose_template',
             service_id=service_one['id'],
             template_type='sms')in page
-        assert url_for('main.view_notifications', service_id=service_one['id']) in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
         assert url_for('main.documentation') in page
 
@@ -209,7 +208,6 @@ def test_menu_manage_service(mocker,
             'main.choose_template',
             service_id=service_one['id'],
             template_type='sms') in page
-        assert url_for('main.view_notifications', service_id=service_one['id']) in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
         assert url_for('main.service_settings', service_id=service_one['id']) in page
         assert url_for('main.documentation') in page
@@ -242,7 +240,6 @@ def test_menu_manage_api_keys(mocker,
             'main.choose_template',
             service_id=service_one['id'],
             template_type='sms') in page
-        assert url_for('main.view_notifications', service_id=service_one['id']) in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
         assert url_for('main.service_settings', service_id=service_one['id']) not in page
         assert url_for('main.show_all_services') not in page
@@ -270,7 +267,8 @@ def test_menu_all_services_for_platform_admin_user(mocker,
         assert url_for('main.choose_template', service_id=service_one['id'], template_type='email') in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
         assert url_for('main.service_settings', service_id=service_one['id']) in page
-        assert url_for('main.view_notifications', service_id=service_one['id']) in page
+        assert url_for('main.view_notifications', service_id=service_one['id'], message_type='email') in page
+        assert url_for('main.view_notifications', service_id=service_one['id'], message_type='sms') in page
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
 
         # Should this be here??

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -88,16 +88,20 @@ def test_should_show_updates_for_one_job_as_json(
 @pytest.mark.parametrize(
     "status_argument, expected_api_call", [
         (
+            'processed',
+            ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
+        ),
+        (
+            'sending',
+            ['sending']
+        ),
+        (
             'delivered',
             ['delivered']
         ),
         (
             'failed',
             ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
-        ),
-        (
-            'delivered,failed',
-            ['delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
         )
     ]
 )

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -101,7 +101,7 @@ def test_should_show_updates_for_one_job_as_json(
         )
     ]
 )
-def test_can_see_sms(
+def test_can_show_notifications(
     app_,
     service_one,
     active_user_with_permissions,
@@ -140,86 +140,18 @@ def test_can_see_sms(
             template_type=[message_type]
         )
 
-
-def test_can_see_emails(
-    app_,
-    service_one,
-    active_user_with_permissions,
-    mock_get_notifications,
-    mocker
-):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.view_notifications',
-                service_id=service_one['id'],
-                status='delivered,failed',
-                message_type='email'))
-        assert response.status_code == 200
-        content = response.get_data(as_text=True)
-
-        notifications = notification_json(service_one['id'])
-        notification = notifications['notifications'][0]
-        assert notification['to'] in content
-        assert notification['status'] in content
-        assert notification['template']['name'] in content
-        assert 'csv' in content
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.text.strip() == 'Emails'
-
-        mock_get_notifications.assert_called_with(limit_days=7, page=1, service_id=service_one['id'], status=['delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure'], template_type=['email'])  # noqa
-
-
-def test_can_view_failed_emails(
-    app_,
-    service_one,
-    active_user_with_permissions,
-    mock_get_notifications,
-    mocker
-):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.view_notifications',
-                service_id=service_one['id'],
-                message_type='email',
-                status='failed'))
-        assert response.status_code == 200
-        content = response.get_data(as_text=True)
-        notifications = notification_json(service_one['id'])
-        notification = notifications['notifications'][0]
-        assert notification['to'] in content
-        assert notification['status'] in content
-        assert notification['template']['name'] in content
-        assert 'csv' in content
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.text.strip() == 'Failed Emails'
-
-        mock_get_notifications.assert_called_with(limit_days=7, page=1, service_id=service_one['id'], status=['failed', 'temporary-failure', 'permanent-failure', 'technical-failure'], template_type=['email'])  # noqa
-
-
-def test_can_view_failed_sms_messages(
-    app_,
-    service_one,
-    active_user_with_permissions,
-    mock_get_notifications,
-    mocker
-):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.view_notifications',
-                service_id=service_one['id'],
-                status='failed',
-                message_type='sms'))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.text.strip() == 'Failed Text messages'
-
-        mock_get_notifications.assert_called_with(limit_days=7, page=1, service_id=service_one['id'], status=['failed', 'temporary-failure', 'permanent-failure', 'technical-failure'], template_type=['sms'])  # noqa
+        csv_response = client.get(url_for(
+            'main.view_notifications',
+            service_id=service_one['id'],
+            message_type='email',
+            download='csv'
+        ))
+        csv_content = generate_notifications_csv(
+            mock_get_notifications(service_one['id'])['notifications']
+        )
+        assert csv_response.status_code == 200
+        assert csv_response.get_data(as_text=True) == csv_content
+        assert 'text/csv' in csv_response.headers['Content-Type']
 
 
 def test_should_show_notifications_for_a_service_with_next_previous(app_,
@@ -242,27 +174,6 @@ def test_should_show_notifications_for_a_service_with_next_previous(app_,
         assert url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=1) in content
         assert 'Previous page' in content
         assert 'Next page' in content
-
-
-def test_should_download_notifications_for_a_service(app_,
-                                                     service_one,
-                                                     active_user_with_permissions,
-                                                     mock_get_service_template,
-                                                     mock_get_notifications,
-                                                     mocker):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.view_notifications',
-                service_id=service_one['id'],
-                message_type='email',
-                download='csv'))
-        csv_content = generate_notifications_csv(
-            mock_get_notifications(service_one['id'])['notifications'])
-        assert response.status_code == 200
-        assert response.get_data(as_text=True) == csv_content
-        assert 'text/csv' in response.headers['Content-Type']
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -131,6 +131,12 @@ def test_can_show_notifications(
         assert 'csv' in content
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
         assert page_title in page.h1.text.strip()
+        assert url_for(
+            '.view_notifications_csv',
+            service_id=service_one['id'],
+            message_type=message_type,
+            status=status_argument
+        ) == page.findAll("a", {"download": "download"})[0]['href']
 
         mock_get_notifications.assert_called_with(
             limit_days=7,
@@ -141,7 +147,7 @@ def test_can_show_notifications(
         )
 
         csv_response = client.get(url_for(
-            'main.view_notifications',
+            'main.view_notifications_csv',
             service_id=service_one['id'],
             message_type='email',
             download='csv'
@@ -190,12 +196,13 @@ def test_should_download_notifications_for_a_job(app_,
         with app_.test_client() as client:
             client.login(api_user_active)
             response = client.get(url_for(
-                'main.view_job',
+                'main.view_job_csv',
                 service_id=fake_uuid,
                 job_id=fake_uuid,
-                download='csv'))
+            ))
         csv_content = generate_notifications_csv(
-            mock_get_notifications(fake_uuid, job_id=fake_uuid)['notifications'])
+            mock_get_notifications(fake_uuid, job_id=fake_uuid)['notifications']
+        )
         assert response.status_code == 200
         assert response.get_data(as_text=True) == csv_content
         assert 'text/csv' in response.headers['Content-Type']


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/15864295/7061d6c4-2cce-11e6-9f2d-9a8223431b7e.png)

***

_This pull request does a fair bit of refactoring (in separate commits) but the main functional changes are:_

## Remove template type filter from activity

This commit splits the activity page into two pages, one for emails and one for SMS.

Technically this means moving from having template type in the querystring and putting in it the URL, eg:

Before | After
--- | ---
`/services/abc/notifications/?template_type=sms` | `/services/abc/notifications/sms`

## 	Add filters for ‘processed’ and sending states  …

- _Processed_ is all the notifications that we know about, ie sending, failed and delivered (can come up with a better word for this later)

- _Sending_ is notifications that we have either put into a queue or are waiting to hear back from the provider about.

The big numbers on the dashboard are a count of all the messages we’ve processed. So when you click them, the table of notifications you see on the dashboard should contain that number of notifications.

This also gets the activity page one step closer to being like the job page:

         | Before                     | After
---------|----------------------------|---------------------------------
Activity | Sending, failed, both      | Processed, sending, failed, delivered
Job page | Sending, failed, delivered | Sending, failed, delivered

***

_Also, here’s how to make sure you’re writing nice atomic commits:_

![image](https://cloud.githubusercontent.com/assets/355079/15858227/62addc74-2cb7-11e6-8772-74e8ff8c47d3.png)
