### PR TITLE
Link back to all template versions from 1 version

### DIFF
--- a/app/templates/views/templates/template_history.html
+++ b/app/templates/views/templates/template_history.html
@@ -19,4 +19,9 @@
     {% endwith %}
   </div>
 
+  {{ page_footer(
+    secondary_link=url_for('.view_template_versions', service_id=current_service.id, template_id=template.id),
+    secondary_link_text='See all versions of this template'
+  ) }}
+
 {% endblock %}

--- a/tests/app/main/views/test_template_history.py
+++ b/tests/app/main/views/test_template_history.py
@@ -17,6 +17,11 @@ def test_view_template_version(app_,
             service_id = fake_uuid
             template_id = fake_uuid
             version = 1
+            all_versions_link = url_for(
+                'main.view_template_versions',
+                service_id=service_id,
+                template_id=template_id
+            )
             resp = client.get(url_for(
                 '.view_template_version',
                 service_id=service_id,
@@ -28,6 +33,7 @@ def test_view_template_version(app_,
     template = mock_get_template_version(service_id, template_id, version)
     assert api_user_active.name in resp_data
     assert template['data']['content'] in resp_data
+    assert all_versions_link in resp_data
     mock_get_template_version.assert_called_with(
         service_id,
         template_id,


### PR DESCRIPTION
If you get linked to a single version of a template, you’re at a dead end. Let’s add a link to go back up a level to where you can understand the current version in context.

![image](https://cloud.githubusercontent.com/assets/355079/15999998/583b891a-3141-11e6-8c8a-0d05e1173d88.png)
