### PR TITLE
Remove ‘show more’ from big number pattern

### DIFF
--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -31,9 +31,7 @@
   failure_percentage,
   danger_zone=False,
   failure_link=None,
-  link=None,
-  show_more_link=None,
-  show_more_text=''
+  link=None
 ) %}
   <div class="big-number-with-status">
     {{ big_number(number, label, link=link) }}
@@ -51,7 +49,4 @@
       {% endif %}
     </div>
   </div>
-  {% if show_more_link and show_more_text %}
-    <a href="{{ show_more_link }}" class="big-number-with-status-show-more-link">{{ show_more_text }}</a>
-  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This isn’t used anywhere.