### PR TITLE
Resend verification code

### DIFF
--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -22,18 +22,19 @@ def resend_email_verification():
 def check_and_resend_text_code():
     # TODO there needs to be a way to regenerate a session id
     user = user_api_client.get_user_by_email(session['user_details']['email'])
+
+    if user.state == 'active':
+        # this is a verified user and therefore redirect to page to request resend without edit mobile
+        return render_template('views/verification-not-received.html')
+
     form = TextNotReceivedForm(mobile_number=user.mobile_number)
     if form.validate_on_submit():
         user_api_client.send_verify_code(user.id, 'sms', to=form.mobile_number.data)
         user.mobile_number = form.mobile_number.data
         user_api_client.update_user(user)
         return redirect(url_for('.verify'))
+
     return render_template('views/text-not-received.html', form=form)
-
-
-@main.route('/verification-not-received', methods=['GET'])
-def verification_code_not_received():
-    return render_template('views/verification-not-received.html')
 
 
 @main.route('/send-new-code', methods=['GET'])

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -23,7 +23,7 @@
       ) }}
       {{ page_footer(
         "Continue",
-        secondary_link=url_for('.verification_code_not_received'),
+        secondary_link=url_for('main.check_and_resend_text_code'),
         secondary_link_text='Not received a text message?'
       ) }}
     </form>

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -4,7 +4,7 @@ from flask import url_for
 from bs4 import BeautifulSoup
 
 
-def test_should_render_email_verification_resent_show_email_address_and_resend_verify_email(app_,
+def test_should_render_email_verification_resend_show_email_address_and_resend_verify_email(app_,
                                                                                             mocker,
                                                                                             api_user_active,
                                                                                             mock_get_user_by_email,
@@ -29,10 +29,10 @@ def test_should_render_email_verification_resent_show_email_address_and_resend_v
             mock_send_verify_email.assert_called_with(api_user_active.id, api_user_active.email_address)
 
 
-def test_should_render_text_code_not_received_template(app_,
-                                                       api_user_active,
-                                                       mock_get_user_by_email,
-                                                       mock_send_verify_code):
+def test_should_render_correct_resend_template_for_active_user(app_,
+                                                               api_user_active,
+                                                               mock_get_user_by_email,
+                                                               mock_send_verify_code):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -41,60 +41,59 @@ def test_should_render_text_code_not_received_template(app_,
                     'email': api_user_active.email_address}
             response = client.get(url_for('main.check_and_resend_text_code'))
             assert response.status_code == 200
-            assert 'Check your mobile phone number is correct and then resend the confirmation code.' \
-                   in response.get_data(as_text=True)
-            assert 'value="+441234123412"'
+
+            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+            assert page.h1.string == 'Resend verification code'
+            # there shouldn't be a form for updating mobile number
+            assert page.find('form') is None
 
 
-def test_should_check_and_redirect_to_verify(app_,
-                                             api_user_active,
-                                             mock_get_user_by_email,
-                                             mock_update_user,
-                                             mock_send_verify_code):
+def test_should_render_correct_resend_template_for_pending_user(app_,
+                                                                mocker,
+                                                                api_user_pending,
+                                                                mock_send_verify_code):
+
+    mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
+
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
                 session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.check_and_resend_text_code'),
-                                   data={'mobile_number': '+447700900460'})
-            assert response.status_code == 302
-            assert response.location == url_for('main.verify', _external=True)
-
-
-def test_should_update_mobile_number_resend_code(app_,
-                                                 api_user_active,
-                                                 mock_get_user_by_email,
-                                                 mock_update_user,
-                                                 mock_send_verify_code):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.check_and_resend_text_code'),
-                                   data={'mobile_number': '+447700900460'})
-            assert response.status_code == 302
-            assert response.location == url_for('main.verify', _external=True)
-            api_user_active.mobile_number = '+447700900460'
-
-
-def test_should_render_verification_code_not_received(app_,
-                                                      api_user_active,
-                                                      mock_send_verify_code):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.get(url_for('main.verification_code_not_received'))
+                    'id': api_user_pending.id,
+                    'email': api_user_pending.email_address}
+            response = client.get(url_for('main.check_and_resend_text_code'))
             assert response.status_code == 200
-            assert 'Resend verification code' in response.get_data(as_text=True)
-            assert 'If you no longer have access to the phone with the number you registered for this service, ' \
-                   'speak to your service manager to reset the number.' in response.get_data(as_text=True)
+
+            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+            assert page.h1.string == 'Check your mobile number'
+
+            expected = 'Check your mobile phone number is correct and then resend the confirmation code.'
+            message = page.find_all('p')[1].text
+            assert message == expected
+            assert page.find('form').input['value'] == api_user_pending.mobile_number
+
+
+def test_should_resend_verify_code_and_update_mobile_for_pending_user(app_,
+                                                                      mocker,
+                                                                      api_user_pending,
+                                                                      mock_update_user,
+                                                                      mock_send_verify_code):
+
+    mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
+
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            with client.session_transaction() as session:
+                session['user_details'] = {
+                    'id': api_user_pending.id,
+                    'email': api_user_pending.email_address}
+            response = client.post(url_for('main.check_and_resend_text_code'),
+                                   data={'mobile_number': '+447700900460'})
+            assert response.status_code == 302
+            assert response.location == url_for('main.verify', _external=True)
+
+            mock_update_user.assert_called_once_with(api_user_pending)
+            mock_send_verify_code.assert_called_once_with(api_user_pending.id, 'sms', to='+447700900460')
 
 
 def test_check_and_redirect_to_two_factor_if_user_active(app_,
@@ -129,18 +128,3 @@ def test_check_and_redirect_to_verify_if_user_pending(app_,
             response = client.get(url_for('main.check_and_resend_verification_code'))
             assert response.status_code == 302
             assert response.location == url_for('main.verify', _external=True)
-
-
-def test_should_create_new_code_for_user(app_,
-                                         api_user_active,
-                                         mock_get_user_by_email,
-                                         mock_send_verify_code):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.get(url_for('main.check_and_resend_verification_code'))
-            assert response.status_code == 302
-            assert response.location == url_for('main.two_factor', _external=True)


### PR DESCRIPTION
This PR relates to https://www.pivotaltracker.com/story/show/120370831

Requesting a resend of verify code for a user that has not completed registration will allow user to check and modify mobile number.

Registered (active) users will only be able to request resend to their existing registered number.