### PR TITLE
Removed download link

### DIFF
--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -36,8 +36,5 @@
 
     {% include 'partials/jobs/notifications.html' %}
 
-    <p class="table-show-more-link">
-      <a href="{{ request.url }}?&amp;download=csv" download>Download as a CSV file</a>
-    </p>
 
 {% endblock %}


### PR DESCRIPTION
Download link had a bug where it downloaded the HTML of the page not the CSV on the jobs page.

As @quis is refactoring this page now, I've removed the link rather than fix the bug ahead of his work shipping.