### PR TITLE
Fix incorrect width on empty tables

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -41,7 +41,10 @@
     </p>
   {% endif %}
 
-  <div class='dashboard-table'>
+
+  {% if notifications %}
+    <div class='dashboard-table'>
+  {% endif %}
     {% call(item, row_number) list_table(
       notifications,
       caption="Recent activity",
@@ -74,7 +77,9 @@
       {% endcall %}
 
     {% endcall %}
-  </div>
+  {% if notifications %}
+    </div>
+  {% endif %}
 
   {{ previous_next_navigation(prev_page, next_page) }}
 


### PR DESCRIPTION
Empty tables shouldn’t have `table-display: fixed` because it stops them filling the width of their container.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/16073810/9f1fb938-32df-11e6-819e-cdb3168634e9.png)

## After

![image](https://cloud.githubusercontent.com/assets/355079/16073818/a77a6eb6-32df-11e6-91d5-f587b4b482bd.png)
