### PR TITLE
Reorder the breaking change page

### DIFF
--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -25,6 +25,18 @@
     {% endif %}
   </div>
 
+  <form method="post">
+    <input type="hidden" name="name" value="{{ new_template.name }}" />
+    <input type="hidden" name="subject" value="{{ new_template.subject or '' }}" />
+    <input type="hidden" name="template_content" value="{{ new_template.content }}" />
+    <input type="hidden" name="confirm" value="true" />
+    {{ page_footer(
+      'Save changes to template',
+      back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id),
+      back_link_text="Back"
+    ) }}
+  </form>
+
   <p>
     When you send messages using this template you’ll need
     {{ new_template.placeholders|length + 1 }} columns of data:
@@ -49,17 +61,5 @@
   </div>
 
   <p>Developers, you’ll need to update your API calls</p>
-
-  <form method="post">
-    <input type="hidden" name="name" value="{{ new_template.name }}" />
-    <input type="hidden" name="subject" value="{{ new_template.subject or '' }}" />
-    <input type="hidden" name="template_content" value="{{ new_template.content }}" />
-    <input type="hidden" name="confirm" value="true" />
-    {{ page_footer(
-      'Save changes to template',
-      back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id),
-      back_link_text="Back"
-    ) }}
-  </form>
 
 {% endblock %}


### PR DESCRIPTION
The table on this page looked too much like something you were supposed to interact with. To understand what’s expected of you from this page, you need to know:

- what you’ve done to make this page happen (you changed some stuff)
- what actions are available now (confirm, back)

The rest of the information is supplementary—it helps you make a decision, but it’s not key to understanding what the decision _is_.

This also matches what we do on the upload file page, where the non-essential example is under the button.

***

![image](https://cloud.githubusercontent.com/assets/355079/16152029/ac203ff4-3497-11e6-8bcf-5d1f7e2895fe.png)
