### PR TITLE
Redirect to the templates page after the tour

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -92,10 +92,6 @@ def view_job(service_id, job_id):
             job.get('notifications_failed', 0)
         ) == 0),
         uploaded_file_name=job['original_file_name'],
-        first_email_template=[
-            template for template in service_api_client.get_service_templates(service_id)['data']
-            if template['template_type'] == 'email'
-        ][0] if request.args.get('help') else None,
         template=Template(
             template,
             prefix=current_service['name']

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -33,11 +33,11 @@
           </p>
           {% if request.args['help'] == '3' %}
             {% if first_email_template %}
-              <a href='{{ url_for(".edit_service_template", service_id=current_service.id, template_id=first_email_template.id) }}'>
+              <a href='{{ url_for(".choose_template", service_id=current_service.id, template_type="email") }}'>
                 Write an email
               </a>
             {% endif %}
-            <a href='{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}'>
+            <a href='{{ url_for(".choose_template", service_id=current_service.id, template_type="sms") }}'>
               Write a text message
             </a>
           {% endif %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -32,11 +32,9 @@
             Now try it with your own message
           </p>
           {% if request.args['help'] == '3' %}
-            {% if first_email_template %}
-              <a href='{{ url_for(".choose_template", service_id=current_service.id, template_type="email") }}'>
-                Write an email
-              </a>
-            {% endif %}
+            <a href='{{ url_for(".choose_template", service_id=current_service.id, template_type="email") }}'>
+              Write an email
+            </a>
             <a href='{{ url_for(".choose_template", service_id=current_service.id, template_type="sms") }}'>
               Write a text message
             </a>


### PR DESCRIPTION
When you’re dropped straight into the ‘edit template’ page it’s still a bit confusing what the thing you’re typing is—the mental model isn’t quite there yet.

I think it will help (rather than redirect to the dashboard) to redirect to the choose template page. You can then choose to edit the example or add your own template.

This should help people understand that the example is one of a number of templates that you create.