### PR TITLE
Tidy up ‘change service name’ page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -168,7 +168,7 @@ class ServiceNameForm(Form):
         super(ServiceNameForm, self).__init__(*args, **kwargs)
 
     name = StringField(
-        u'New name',
+        u'Service name',
         validators=[
             DataRequired(message='Can’t be empty')
         ])

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -42,6 +42,9 @@ def service_settings(service_id):
 def service_name_change(service_id):
     form = ServiceNameForm(service_api_client.find_all_service_email_from)
 
+    if request.method == 'GET':
+        form.name.data = current_service.get('name')
+
     if form.validate_on_submit():
         session['service_name_change'] = form.name.data
         return redirect(url_for('.service_name_change_confirm', service_id=service_id))

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -13,12 +13,13 @@
   <div class="grid-row">
     <div class="column-three-quarters">
 
-      <p>Users will see your service name:</p>
-
-      <ul class="list-bullet">
-        <li>at the start of every text message, eg ‘Vehicle tax: we received your payment, thank you’</li>
-        <li>as your email sender name</li>
-      </ul>
+      <div class="form-group">
+        <p>Users will see your service name:</p>
+        <ul class="list-bullet">
+          <li>at the start of every text message, eg ‘Vehicle tax: we received your payment, thank you’</li>
+          <li>as your email sender name</li>
+        </ul>
+      </div>
 
       <form method="post">
         {{ textbox(form.name) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -34,8 +34,9 @@ def test_should_show_service_name(app_,
             response = client.get(url_for(
                 'main.service_name_change', service_id=service_one['id']))
         assert response.status_code == 200
-        resp_data = response.get_data(as_text=True)
-        assert 'Change your service name' in resp_data
+        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+        assert page.find('h1').text == 'Change your service name'
+        assert page.find('input', attrs={"type": "text"})['value'] == 'service one'
         app.service_api_client.get_service.assert_called_with(service_one['id'])
 
 


### PR DESCRIPTION
- Make service name repopulate in textbox
- More spacing between sections of the page

Before | After 
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/16194330/f1243028-36eb-11e6-8cde-96e5089264dd.png) | ![image](https://cloud.githubusercontent.com/assets/355079/16194317/e00f0740-36eb-11e6-942a-37b7c5ed0611.png)
