### PR TITLE
Add live/trial flag on platform-admin page

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -45,7 +45,8 @@
   .big-number {
     padding: $gutter-half;
     position: relative;
-    cursor: pointer;
+    background: $black;
+    color: $white;
   }
 
   .big-number-label {
@@ -69,12 +70,22 @@
     margin-bottom: 5px;
 
     &:hover {
+
       color: $light-blue-25;
+
+      .big-number {
+        color: $light-blue-25;
+      }
+
     }
 
     &:active,
     &:focus {
       outline: 3px solid $yellow;
+    }
+
+    .big-number {
+      background: transparent;
     }
 
     .big-number-label {

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -42,7 +42,8 @@ def format_stats_by_service(all_stats, services):
                 (stats['emails_requested'] - stats['emails_delivered'] - stats['emails_failed'])
             ),
             'delivered': stats['sms_delivered'] + stats['emails_delivered'],
-            'failed': stats['sms_failed'] + stats['emails_failed']
+            'failed': stats['sms_failed'] + stats['emails_failed'],
+            'restricted': services[stats['service']]['restricted']
         }
         for stats in all_stats
     ]

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -60,6 +60,9 @@
     {% call field() %}
       <div>
         <a href="{{ url_for('main.service_dashboard', service_id=item['id']) }}" class="browse-list-link">{{ item['name'] }}</a>
+        <span class="file-list-hint">
+          {{ 'Trial' if item['restricted'] else 'Live' }}
+        </span>
       </div>
     {% endcall %}
     {% call field(align='right') %}

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -22,8 +22,8 @@
   ]) }}
 
 
-  <h2 class='heading-medium'>Today's statistics</h2>
-  <div class="grid-row">
+  <h2 class='heading-medium'>Today</h2>
+  <div class="grid-row bottom-gutter">
     <div class="column-half">
       {{ big_number_with_status(
         global_stats.emails_delivered,

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -2,7 +2,7 @@
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
 {% from "components/browse-list.html" import browse_list %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, hidden_field_heading %}
 
 {% block page_title %}
   Platform admin – GOV.UK Notify
@@ -44,13 +44,14 @@
     </div>
   </div>
 
-  <h2 class='heading-medium'>Services</h2>
+  <h2 class='heading-medium visually-hidden'>Services</h2>
   {% call(item, row_number) list_table(
     service_stats,
     caption="All services",
     caption_visible=False,
     field_headings=[
       'Service',
+      hidden_field_heading('Status'),
       right_aligned_field_heading('Sending'),
       right_aligned_field_heading('Delivered'),
       right_aligned_field_heading('Failed')
@@ -60,10 +61,12 @@
     {% call field() %}
       <div>
         <a href="{{ url_for('main.service_dashboard', service_id=item['id']) }}" class="browse-list-link">{{ item['name'] }}</a>
-        <span class="file-list-hint">
-          {{ 'Trial' if item['restricted'] else 'Live' }}
-        </span>
       </div>
+    {% endcall %}
+    {% call field(status='error') %}
+      <span class="heading-medium">
+      {{ '' if item['restricted'] else 'Live' }}
+      </span>
     {% endcall %}
     {% call field(align='right') %}
       {{ big_number(item['sending'], smaller=True) }}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -43,7 +43,7 @@ def test_should_render_platform_admin_page(
             assert response.status_code == 200
             resp_data = response.get_data(as_text=True)
             assert 'Platform admin' in resp_data
-            assert 'Today\'s statistics' in resp_data
+            assert 'Today' in resp_data
             assert 'Services' in resp_data
 
 

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -87,8 +87,8 @@ def create_stats(
 
 def test_format_stats_by_service_gets_correct_stats_for_each_service():
     services = [
-        {'name': 'a', 'id': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
-        {'name': 'b', 'id': 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'}
+        {'name': 'a', 'id': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'restricted': False},
+        {'name': 'b', 'id': 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'restricted': True}
     ]
     all_stats = [
         create_stats('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', emails_requested=1),
@@ -102,16 +102,18 @@ def test_format_stats_by_service_gets_correct_stats_for_each_service():
     assert ret[0]['sending'] == 1
     assert ret[0]['delivered'] == 0
     assert ret[0]['failed'] == 0
+    assert ret[0]['restricted'] is False
 
     assert ret[1]['name'] == 'b'
     assert ret[1]['sending'] == 2
     assert ret[1]['delivered'] == 0
     assert ret[1]['failed'] == 0
+    assert ret[1]['restricted'] is True
 
 
 def test_format_stats_by_service_sums_values_for_sending():
     services = [
-        {'name': 'a', 'id': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
+        {'name': 'a', 'id': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'restricted': False},
     ]
     all_stats = [
         create_stats(


### PR DESCRIPTION
Show 'Live' or 'Trial' under each service to easily identify services

![image](https://cloud.githubusercontent.com/assets/5020841/16226906/8d193258-37a5-11e6-9193-b849e48dcb00.png)
