### PR TITLE
Add a ‘dashboard’ link to the navigation

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -1,16 +1,16 @@
 .navigation {
 
-  padding: $gutter-two-thirds $gutter-half 0 0;
+  padding: 0 $gutter 0 0;
 
-  h2,
   li {
     @include core-19;
-    margin: 10px 20px 0 0;
+    margin: 10px 0 0 0;
     list-style-type: none;
   }
 
   h2 {
     @include bold-19;
+    margin: $gutter 0 0 0;
   }
 
   a {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -2,20 +2,15 @@
 
   padding: $gutter-two-thirds $gutter-half 0 0;
 
-  ul,
-  h2 {
+  h2,
+  li {
     @include core-19;
-    margin: 10px 20px 15px 0;
+    margin: 10px 20px 0 0;
     list-style-type: none;
   }
 
   h2 {
-    font-weight: bold;
-    margin-bottom: 10px;
-  }
-
-  li {
-    margin: 10px 0 0 0;
+    @include bold-19;
   }
 
   a {

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -46,9 +46,10 @@
 {% else %}
 <nav class="navigation">
   <h2 class="navigation-service-name">
-    <a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">{{ current_service.name }}</a>
+    {{ current_service.name }}
   </h2>
   <ul>
+    <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
   {% if current_user.has_permissions(['view_activity', 'manage_templates', 'manage_api_keys'], admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='email') }}">Email templates</a></li>
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='sms') }}">Text message templates</a></li>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/16259874/a128132e-385c-11e6-9f15-43c7811d1e46.png)

![image](https://cloud.githubusercontent.com/assets/355079/16259865/926d9700-385c-11e6-83de-8558847e2a39.png)

It’s been unclear that:

- the dashboard exists
- that you click the name of the service to get back to it

So this commit:

- takes the link off the service name
- adds a link labelled ‘Dashboard’ to the navigation