### PR TITLE
Use tabular numbers for all big numbers

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -4,7 +4,7 @@
   display: block;
 
   &-number {
-    @include bold-48;
+    @include bold-48($tabular-numbers: true);
     display: block;
   }
 
@@ -21,7 +21,7 @@
   @extend %big-number;
 
   .big-number-number {
-    @include bold-36();
+    @include bold-36($tabular-numbers: true);
   }
 
 }
@@ -31,7 +31,7 @@
   @extend %big-number;
 
   .big-number-number {
-    @include bold-24();
+    @include bold-24($tabular-numbers: true);
   }
 
 }


### PR DESCRIPTION
Reimplements https://github.com/alphagov/notifications-admin/pull/169

> Tabular numbers have numerals of a standard fixed width. As all
> numbers have the same width, sets of numbers may be more easily
> compared. We recommend using them where different numbers are likely
> to be compared, or where different numbers should line up with each
> other, eg in tables.

— https://github.com/alphagov/govuk_frontend_toolkit/blob/5f38012f94dc2dcf676b565204126d056b794e90/docs/mixins.md#tabular-numbers

![image](https://cloud.githubusercontent.com/assets/355079/16260594/0688337c-3860-11e6-958b-88e8f5fdb38c.png)

![image](https://cloud.githubusercontent.com/assets/355079/16260609/1a9731e2-3860-11e6-9881-30bccafa912b.png)
