### PR TITLE
Remove email from address on the job page

### DIFF
--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -24,9 +24,7 @@
     {% elif 'email' == template.template_type %}
       {{ email_message(
         template.formatted_subject_as_markup,
-        template.formatted_as_markup,
-        from_address='{}@notifications.service.gov.uk'.format(current_service.email_from),
-        from_name=current_service.name
+        template.formatted_as_markup
       )}}
     {% endif %}
 


### PR DESCRIPTION
- it’s just taking up space
- it’s too late to change it if it’s wrong
- it’s not accurate if you’ve changed your service name since creating the job