### PR TITLE
Play back the user’s email address

### DIFF
--- a/app/templates/views/registration-continue.html
+++ b/app/templates/views/registration-continue.html
@@ -6,11 +6,8 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-large">​Now check your email​</h1>
-    <p>Click the link in the email we’ve sent you to continue your registration</p>
-  </div>
-</div>
+  <h1 class="heading-large">​Now check your email​</h1>
+  <p>We’ve sent an email to {{ session['user_details']['email'] }}.</p>
+  <p>Click the link in the email to continue your registration.</p>
 
 {% endblock %}


### PR DESCRIPTION
<img width="1064" alt="screen shot 2016-06-23 at 15 42 45" src="https://cloud.githubusercontent.com/assets/355079/16307548/8e21e162-3959-11e6-97a0-06ab98170f83.png">

When you register you type in your email address. If you don’t get the email there’s no way of knowing it’s because you’ve mistyped it.

If we play back the email address, you can double check it.

This commit also removes the ⅔ column on this page to make sure a long email address doesn’t wrap.