### PR TITLE
send key_type = normal when creating api keys

### DIFF
--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -2,6 +2,11 @@ from notifications_python_client.base import BaseAPIClient
 from app.notify_client import _attach_current_user
 
 
+# must match key types in notifications-api/app/models.py
+KEY_TYPE_NORMAL = 'normal'
+KEY_TYPE_TEAM = 'team'
+
+
 class ApiKeyApiClient(BaseAPIClient):
     def __init__(self, base_url=None, client_id=None, secret=None):
         super(self.__class__, self).__init__(base_url=base_url or 'base_url',
@@ -13,19 +18,22 @@ class ApiKeyApiClient(BaseAPIClient):
         self.client_id = app.config['ADMIN_CLIENT_USER_NAME']
         self.secret = app.config['ADMIN_CLIENT_SECRET']
 
-    def get_api_keys(self, service_id, key_id=None, *params):
+    def get_api_keys(self, service_id, key_id=None):
         if key_id:
             return self.get(url='/service/{}/api-keys/{}'.format(service_id, key_id))
         else:
             return self.get(url='/service/{}/api-keys'.format(service_id))
 
-    def create_api_key(self, service_id, key_name, *params):
-        data = {"name": key_name}
+    def create_api_key(self, service_id, key_name):
+        data = {
+            'name': key_name,
+            'key_type': KEY_TYPE_NORMAL
+        }
         _attach_current_user(data)
         key = self.post(url='/service/{}/api-key'.format(service_id), data=data)
         return key['data']
 
-    def revoke_api_key(self, service_id, key_id, *params):
+    def revoke_api_key(self, service_id, key_id):
         data = _attach_current_user({})
         return self.post(
             url='/service/{0}/api-key/revoke/{1}'.format(service_id, key_id),

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -1,28 +1,13 @@
 import uuid
-from datetime import date
+
 from flask import url_for
+
 from tests import validate_route_permission
-
-
-def test_should_show_api_keys_and_documentation_page(app_,
-                                                     api_user_active,
-                                                     mock_login,
-                                                     mock_get_user,
-                                                     mock_get_user_by_email,
-                                                     mock_get_service):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.documentation', service_id=uuid.uuid4()))
-
-        assert response.status_code == 200
 
 
 def test_should_show_empty_api_keys_page(app_,
                                          api_user_active,
-                                         mock_get_user,
                                          mock_login,
-                                         mock_get_user_by_email,
                                          mock_get_no_api_keys,
                                          mock_get_service,
                                          mock_has_permissions):
@@ -41,8 +26,6 @@ def test_should_show_empty_api_keys_page(app_,
 def test_should_show_api_keys_page(app_,
                                    api_user_active,
                                    mock_login,
-                                   mock_get_user,
-                                   mock_get_user_by_email,
                                    mock_get_api_keys,
                                    mock_get_service,
                                    mock_has_permissions,
@@ -60,15 +43,13 @@ def test_should_show_api_keys_page(app_,
         mock_get_api_keys.assert_called_once_with(service_id=fake_uuid)
 
 
-def test_should_show_name_api_key_page(app_,
-                                       api_user_active,
-                                       mock_login,
-                                       mock_get_user,
-                                       mock_get_user_by_email,
-                                       mock_get_api_keys,
-                                       mock_get_service,
-                                       mock_has_permissions,
-                                       fake_uuid):
+def test_should_show_create_api_key_page(app_,
+                                         api_user_active,
+                                         mock_login,
+                                         mock_get_api_keys,
+                                         mock_get_service,
+                                         mock_has_permissions,
+                                         fake_uuid):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -78,32 +59,34 @@ def test_should_show_name_api_key_page(app_,
         assert response.status_code == 200
 
 
-def test_should_render_show_api_key(app_,
-                                    api_user_active,
-                                    mock_login,
-                                    mock_get_user,
-                                    mock_get_user_by_email,
-                                    mock_create_api_key,
-                                    mock_get_api_keys,
-                                    mock_get_service,
-                                    mock_has_permissions):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = str(uuid.uuid4())
-            response = client.post(url_for('main.create_api_key', service_id=service_id),
-                                   data={'key_name': 'some default key name'})
+def test_should_create_api_key_with_type_normal(app_,
+                                                api_user_active,
+                                                mock_login,
+                                                mock_get_api_keys,
+                                                mock_get_service,
+                                                mock_has_permissions,
+                                                fake_uuid,
+                                                mocker):
+    post = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.post', return_value={'data': fake_uuid})
+    service_id = str(uuid.uuid4())
 
-        assert response.status_code == 200
-        assert 'some default key name' in response.get_data(as_text=True)
-        mock_create_api_key.assert_called_once_with(service_id=service_id, key_name='some default key name')
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(api_user_active)
+        response = client.post(url_for('main.create_api_key', service_id=service_id),
+                               data={'key_name': 'some default key name'})
+
+    assert response.status_code == 200
+    assert 'some default key name' in response.get_data(as_text=True)
+    post.assert_called_once_with(url='/service/{}/api-key'.format(service_id), data={
+        'name': 'some default key name',
+        'key_type': 'normal',
+        'created_by': api_user_active.id
+    })
 
 
 def test_should_show_confirm_revoke_api_key(app_,
                                             api_user_active,
                                             mock_login,
-                                            mock_get_user,
-                                            mock_get_user_by_email,
                                             mock_get_api_keys,
                                             mock_get_service,
                                             mock_has_permissions,
@@ -121,8 +104,6 @@ def test_should_show_confirm_revoke_api_key(app_,
 def test_should_redirect_after_revoking_api_key(app_,
                                                 api_user_active,
                                                 mock_login,
-                                                mock_get_user,
-                                                mock_get_user_by_email,
                                                 mock_revoke_api_key,
                                                 mock_get_api_keys,
                                                 mock_get_service,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -701,8 +701,7 @@ def mock_get_all_users_from_api(mocker):
 @pytest.fixture(scope='function')
 def mock_create_api_key(mocker):
     def _create(service_id, key_name):
-        import uuid
-        return {'data': str(generate_uuid())}
+        return str(generate_uuid())
 
     return mocker.patch('app.api_key_api_client.create_api_key', side_effect=_create)
 


### PR DESCRIPTION
~~depends on https://github.com/alphagov/notifications-api/pull/473~~

also cleaned up the test_api_keys file a little - removed a couple of unnecessary fixtures