### PR TITLE
Remove ‘register account’ language

### DIFF
--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -12,7 +12,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large">Sign in</h1>
 
-    <p>If you do not have an account, you can <a href="register">register for one now</a>.</p>
+    <p>If you do not have an account, you can <a href="register">create one now</a>.</p>
 
     <form method="post" autocomplete="nope">
       {{ textbox(form.email_address) }}


### PR DESCRIPTION
We always call it ‘create account’.