### PR TITLE
Whitelisting Salesforce for account creation

### DIFF
--- a/config.py
+++ b/config.py
@@ -52,7 +52,8 @@ class Config(object):
         "parliament\.uk",
         "nhs\.uk",
         "nhs\.net",
-        "police\.uk"]
+        "police\.uk",
+        "salesforce\.com"]
 
 
 class Development(Config):


### PR DESCRIPTION
This is ahead of a story to move the domain whitelisting into the platform admin app