### PR TITLE
Revert questionable design decisions in send messages flow

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -29,10 +29,6 @@
 
     }
 
-    .primary {
-      @include bold-19;
-    }
-
   }
 
 }

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -242,11 +242,16 @@ def check_messages(service_id, template_type, upload_id):
         ) if current_service['restricted'] else None
     )
 
-    if request.args.get('from_test') and len(template.placeholders):
+    if request.args.get('from_test'):
         extra_args = {'help': 1} if request.args.get('help', '0') != '0' else {}
-        back_link = url_for(
-            '.send_test', service_id=service_id, template_id=template.id, **extra_args
-        )
+        if len(template.placeholders):
+            back_link = url_for(
+                '.send_test', service_id=service_id, template_id=template.id, **extra_args
+            )
+        else:
+            back_link = url_for(
+                '.choose_template', service_id=service_id, template_type=template.template_type, **extra_args
+            )
     else:
         back_link = url_for('.send_messages', service_id=service_id, template_id=template.id)
 

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -9,7 +9,7 @@
 {% from "components/message-count-label.html" import message_count_label %}
 
 {% block page_title %}
-  {{ "Error" if errors else "Check and confirm" }} – GOV.UK Notify
+  {{ "Error" if errors else "Preview" }} – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -136,7 +136,7 @@
   {% else %}
 
     <h1 class="heading-large">
-      Check and confirm
+      Preview
     </h1>
 
   {% endif %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -14,7 +14,7 @@
   {% if request.args['help'] %}
     <h1 class="heading-large">Example text message</h1>
   {% else %}
-    <h1 class="heading-large">Send a test</h1>
+    <h1 class="heading-large">Send yourself a test</h1>
   {% endif %}
 
   {% if 'sms' == template.template_type %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -54,7 +54,7 @@
       {% endfor %}
     {% endcall %}
 
-    {{ page_footer("Check and confirm", back_link=(
+    {{ page_footer("Preview", back_link=(
       url_for('.send_messages', service_id=current_service.id, template_id=template.id)) if not request.args['help'] else None
     ) }}
   </form>

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -55,7 +55,7 @@
     {% endcall %}
 
     {{ page_footer("Preview", back_link=(
-      url_for('.send_messages', service_id=current_service.id, template_id=template.id)) if not request.args['help'] else None
+      url_for('.choose_template', service_id=current_service.id, template_type=template.template_type)) if not request.args['help'] else None
     ) }}
   </form>
 

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Send {{ 'text messages' if 'sms' == template.template_type else 'emails' }}</h1>
+  <h1 class="heading-large">Upload recipients</h1>
 
   {% if 'sms' == template.template_type %}
     <div class="grid-row">
@@ -35,7 +35,7 @@
   <div class="page-footer bottom-gutter">
     {{file_upload(
       form.file,
-      button_text='Upload a file of recipients'
+      button_text='Choose a file'
     )}}
   </div>
 

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -39,36 +39,30 @@
     )}}
   </div>
 
-  <details role="group">
-    <summary role="button" aria-controls="how-to-format-your-file" aria-expanded="false">
-      <span class="summary">See an example</span>
-    </summary>
+  <h2 class="heading-medium">Your file needs to look like this example</h2>
+  <div class="spreadsheet">
+    {% call(item, row_number) list_table(
+      example,
+      caption="Example",
+      caption_visible=False,
+      field_headings=[''] + column_headings
+    ) %}
+      {{ index_field(row_number - 1) }}
+      {% for column in item %}
+        {{ text_field(column) }}
+      {% endfor %}
+    {% endcall %}
+  </div>
+  <p class="table-show-more-link">
+    <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}">Download this example</a>
+  </p>
 
-    <div id="how-to-format-your-file" aria-hidden="true">
-      <div class="spreadsheet">
-        {% call(item, row_number) list_table(
-          example,
-          caption="Example",
-          caption_visible=False,
-          field_headings=[''] + column_headings
-        ) %}
-          {{ index_field(row_number - 1) }}
-          {% for column in item %}
-            {{ text_field(column) }}
-          {% endfor %}
-        {% endcall %}
-      </div>
-      <p class="table-show-more-link">
-        <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}">Download this example</a>
-      </p>
-      <p>Save the file as</p>
-      <ul class="list list-bullet">
-        <li>.<acronym title="Comma Separated Values">csv</acronym></li>
-        <li>.<acronym title="Comma Separated Values">tsv</acronym></li>
-        <li>Open Document Spreadsheet (.ods)</li>
-        <li>or Microsoft Excel (.xls, .xlsx, .xlsm)</li>
-      </p>
-    </div>
-  </details>
+  <h2 class="heading-medium">Accepted file formats</h2>
+  <ul class="list list-bullet">
+    <li>.<acronym title="Comma Separated Values">csv</acronym></li>
+    <li>.<acronym title="Comma Separated Values">tsv</acronym></li>
+    <li>Open Document Spreadsheet (.ods)</li>
+    <li>Microsoft Excel (.xls, .xlsx, .xlsm)</li>
+  </p>
 
 {% endblock %}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -35,9 +35,7 @@
   <div class="page-footer bottom-gutter">
     {{file_upload(
       form.file,
-      button_text='Upload a file of recipients',
-      alternate_link=url_for(".send_test", service_id=current_service.id, template_id=template.id),
-      alternate_link_text='send yourself a test'
+      button_text='Upload a file of recipients'
     )}}
   </div>
 

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -26,7 +26,10 @@
         <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="primary">
           Send {{ 'text messages' if 'sms' == template.template_type else 'emails' }}
         </a>
-      {% endif %}
+      <a href="{{ url_for(".send_test", service_id=current_service.id, template_id=template.id) }}">
+        Send yourself a test
+      </a>
+    {% endif %}
       {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
          <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}">Edit template</a>
       {% endif %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -24,7 +24,7 @@
     <div class="message-use-links{% if show_title %}-with-title{% endif %}">
       {% if current_user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']) %}
         <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="primary">
-          Send {{ 'text messages' if 'sms' == template.template_type else 'emails' }}
+          Upload recipients
         </a>
       <a href="{{ url_for(".send_test", service_id=current_service.id, template_id=template.id) }}">
         Send yourself a test

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -694,7 +694,7 @@ def test_send_and_check_page_renders_if_no_statistics(
             today = datetime.today().date().strftime('%Y-%m-%d')
             assert resp.status_code == 200
             page = BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
-            assert page.h1.text.strip() == 'Check and confirm'
+            assert page.h1.text.strip() == 'Preview'
             mock_get_stats.assert_called_once_with(fake_uuid, today)
 
 


### PR DESCRIPTION
## Move ‘send test’ link back to template page and reword ‘send emails’ to ‘upload recipients’

![image](https://cloud.githubusercontent.com/assets/355079/16516375/a7ae6210-3f6f-11e6-998e-7472f8908c8a.png)
![image](https://cloud.githubusercontent.com/assets/355079/16516490/47b3be72-3f70-11e6-8fbd-d271ec23f2a9.png)

This changes it back to how it was when we first introduced this feature: #181

It’s kind of lost on the page where you upload a file, which is a shame because it’s a good learning opportunity.

‘Send emails’ doesn’t speak to you if you already have the idea of a file or address book in mind. ‘Upload’ better describes what you’re going to do on the next page.

Also makes all the links regular weight, because having the first one bold looked like a heading.

## Don’t hide the example on the send page

![image](https://cloud.githubusercontent.com/assets/355079/16516424/eb2a2d8a-3f6f-11e6-93db-23b0242f7a24.png)

People missed this example because it was hidden in a `<details>` element. Perhaps the wording of the link wasn’t ideal, but we’ve tried two different variations of it (#640).

Better not to hide things than try to think of some text which will make people want to show them.

Also adds some headings to chunk up this page a bit.

## Rename check and confirm to preview

![image](https://cloud.githubusercontent.com/assets/355079/16516445/0b5b5dc2-3f70-11e6-9380-d1b98594ab91.png)

We’ve seen people land on this page and expect the message to be on their phone already.

‘Check and confirm’ sounds a lot like ‘check your phone’, which is language that we use earlier on when we _have_ sent a message.

Hopefully ‘preview’ is a better indication that it’s not sent yet.