### PR TITLE
Don’t show send/edit links for deleted template

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -16,15 +16,21 @@
   {% endif %}
 </div>
 <div class="column-one-third">
-  <div class="message-use-links{% if show_title %}-with-title{% endif %}">
-    {% if current_user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']) %}
-      <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="primary">
-        Send {{ 'text messages' if 'sms' == template.template_type else 'emails' }}
-      </a>
-    {% endif %}
-    {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
-       <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}">Edit template</a>
-    {% endif %}
-    <a href="{{ url_for(".send_from_api", service_id=current_service.id, template_id=template.id) }}">API info</a>
-  </div>
+  {% if template._template.archived %}
+    <div class="message-updated-at">
+      This template was deleted<br/>{{ template._template.updated_at|format_date_normal }}
+    </div>
+  {% else %}
+    <div class="message-use-links{% if show_title %}-with-title{% endif %}">
+      {% if current_user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']) %}
+        <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="primary">
+          Send {{ 'text messages' if 'sms' == template.template_type else 'emails' }}
+        </a>
+      {% endif %}
+      {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
+         <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}">Edit template</a>
+      {% endif %}
+      <a href="{{ url_for(".send_from_api", service_id=current_service.id, template_id=template.id) }}">API info</a>
+    </div>
+  {% endif %}
 </div>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -68,14 +68,17 @@ def template_json(service_id,
                   type_="sms",
                   content="template content",
                   subject=None,
-                  version=1):
+                  version=1,
+                  archived=False):
     template = {
         'id': id_,
         'name': name,
         'template_type': type_,
         'content': content,
         'service': service_id,
-        'version': version
+        'version': version,
+        'updated_at': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f'),
+        'archived': archived
     }
     if subject is not None:
         template['subject'] = subject

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,27 @@ def mock_get_service_template(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_deleted_template(mocker):
+    def _get(service_id, template_id, version=None):
+        template = template_json(
+            service_id,
+            template_id,
+            "Two week reminder",
+            "sms",
+            "Your vehicle tax is about to expire",
+            archived=True
+        )
+        if version:
+            template.update({'version': version})
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template',
+        side_effect=_get
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_template_version(mocker, fake_uuid, user=None):
     if user is None:
         user = api_user_active(fake_uuid)


### PR DESCRIPTION
Since you can’t really send or edit a deleted template we should show a message telling you that the template has been deleted.

This is important because deleted templates still show up in the template statistics.

![image](https://cloud.githubusercontent.com/assets/355079/16521743/db8bb8fa-3f90-11e6-8d03-b1355c247de6.png)
