### PR TITLE
Hide download CSV link when in the tour

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -28,6 +28,7 @@ from app.utils import (
     user_has_permissions,
     generate_notifications_csv)
 from app.statistics_utils import sum_of_statistics, statistics_by_state, add_rate_to_jobs
+from app.utils import get_help_argument
 
 
 def _parse_filter_args(filter_dict):
@@ -98,7 +99,8 @@ def view_job(service_id, job_id):
             job_id=job['id'],
             status=request.args.get('status', '')
         ),
-        partials=get_job_partials(job)
+        partials=get_job_partials(job),
+        help=get_help_argument()
     )
 
 
@@ -311,7 +313,8 @@ def get_job_partials(job):
             notifications=notification_api_client.get_notifications_for_service(
                 job['service'], job['id'], status=filter_args.get('status')
             )['notifications'],
-            status=request.args.get('status', '')
+            status=request.args.get('status', ''),
+            help=get_help_argument()
         ),
         'status': render_template(
             'partials/jobs/status.html',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -29,7 +29,7 @@ from app.main.uploader import (
     s3download
 )
 from app import job_api_client, service_api_client, current_service, user_api_client, statistics_api_client
-from app.utils import user_has_permissions, get_errors_for_csv, Spreadsheet
+from app.utils import user_has_permissions, get_errors_for_csv, Spreadsheet, get_help_argument
 
 
 def get_page_headings(template_type):
@@ -181,7 +181,8 @@ def send_test(service_id, template_id):
         'views/send-test.html',
         template=template,
         recipient_column=first_column_heading[template.template_type],
-        example=[get_example_csv_rows(template, use_example_as_example=False)]
+        example=[get_example_csv_rows(template, use_example_as_example=False)],
+        help=get_help_argument()
     )
 
 
@@ -278,7 +279,8 @@ def check_messages(service_id, template_type, upload_id):
         upload_id=upload_id,
         form=CsvUploadForm(),
         statistics=statistics,
-        back_link=back_link
+        back_link=back_link,
+        help=get_help_argument()
     )
 
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -1,9 +1,9 @@
 {% from "components/banner.html" import banner_wrapper %}
 
-{% if request.args['help'] and request.args['help'] != '0' %}
+{% if help %}
   {% call banner_wrapper(type='tour') %}
       <p class="heading-medium">Try this example</p>
-      <div class="grid-row bottom-gutter" {% if request.args['help'] != '1' %}style="opacity: 0.6"{% endif %}>
+      <div class="grid-row bottom-gutter" {% if help != '1' %}style="opacity: 0.6"{% endif %}>
         <div class="column-one-sixth">
           <p class="heading-large" style="float: left;">1.</p>
         </div>
@@ -13,7 +13,7 @@
           </p>
         </div>
       </div>
-      <div class="grid-row bottom-gutter" {% if request.args['help'] != '2' %}style="opacity: 0.6"{% endif %}>
+      <div class="grid-row bottom-gutter" {% if help != '2' %}style="opacity: 0.6"{% endif %}>
         <div class="column-one-sixth">
           <p class="heading-large">2.</p>
         </div>
@@ -23,7 +23,7 @@
           </p>
         </div>
       </div>
-      <div class="grid-row bottom-gutter" {% if request.args['help'] != '3' %}style="opacity: 0.6"{% endif %}>
+      <div class="grid-row bottom-gutter" {% if help != '3' %}style="opacity: 0.6"{% endif %}>
         <div class="column-one-sixth">
           <p class="heading-large">3.</p>
         </div>
@@ -31,7 +31,7 @@
           <p>
             Notify delivers the message
           </p>
-          {% if request.args['help'] == '3' %}
+          {% if help == '3' %}
             <a href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
               Now go to your dashboard
             </a>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -4,7 +4,7 @@
   <div class="dashboard-table">
 {% endif %}
 
-  {% if notifications %}
+  {% if notifications and request.args.get('help', '0') == '0' %}
     <p class="bottom-gutter">
       <a href="{{ url_for('.view_job_csv', service_id=current_service.id, job_id=job.id, status=status) }}" download="download" class="heading-small">Download as a CSV file</a>
       &emsp;

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -4,7 +4,7 @@
   <div class="dashboard-table">
 {% endif %}
 
-  {% if notifications and request.args.get('help', '0') == '0' %}
+  {% if notifications and not help %}
     <p class="bottom-gutter">
       <a href="{{ url_for('.view_job_csv', service_id=current_service.id, job_id=job.id, status=status) }}" download="download" class="heading-small">Download as a CSV file</a>
       &emsp;

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -174,7 +174,7 @@
   {% else %}
     <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id)}}" class='page-footer'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <input type="hidden" name="help" value="{{ '3' if request.args['help'] == '2' else 0 }}" />
+      <input type="hidden" name="help" value="{{ '3' if help else 0 }}" />
       <input type="submit" class="button" value="Send {{ count_of_recipients }} {{ message_count_label(count_of_recipients, template.template_type, suffix='') }}" />
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
     </form>

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -55,7 +55,7 @@
     {% endcall %}
 
     {{ page_footer("Preview", back_link=(
-      url_for('.choose_template', service_id=current_service.id, template_type=template.template_type)) if not request.args['help'] else None
+      url_for('.send_messages', service_id=current_service.id, template_id=template.id)) if not help else None
     ) }}
   </form>
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -186,3 +186,7 @@ class Spreadsheet():
             file_type=extension,
             file_content=file_content.getvalue()
         ).to_array(), filename)
+
+
+def get_help_argument():
+    return request.args.get('help') if request.args.get('help') in ('1', '2', '3') else None

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -99,6 +99,34 @@ def test_should_show_page_for_one_job(
         )
 
 
+def test_should_show_not_show_csv_download_in_tour(
+    app_,
+    service_one,
+    active_user_with_permissions,
+    mock_get_service_template,
+    mock_get_service_statistics,
+    mock_get_job,
+    mocker,
+    mock_get_notifications,
+    fake_uuid
+):
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(active_user_with_permissions, mocker, service_one)
+        response = client.get(url_for(
+            'main.view_job',
+            service_id=service_one['id'],
+            job_id=fake_uuid,
+            help=3
+        ))
+
+        assert response.status_code == 200
+        assert url_for(
+            'main.view_job_csv',
+            service_id=service_one['id'],
+            job_id=fake_uuid
+        ) not in response.get_data(as_text=True)
+
+
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_show_updates_for_one_job_as_json(
     app_,


### PR DESCRIPTION
There is really no point to downloading the CSV file of delivery info when you’re in the tour. It’s just distracting at this point.