### PR TITLE
Fix get started banner on dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -50,6 +50,7 @@ def service_dashboard(service_id):
     return render_template(
         'views/dashboard/dashboard.html',
         updates_url=url_for(".service_dashboard_updates", service_id=service_id),
+        templates=service_api_client.get_service_templates(service_id)['data'],
         partials=get_dashboard_partials(service_id)
     )
 

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -15,7 +15,6 @@
   <div class="dashboard">
 
     <h1 class="visuallyhidden">Dashboard</h1>
-
     {% if current_user.has_permissions(['manage_templates'], admin_override=True) %}
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}

--- a/app/templates/views/dashboard/write-first-messages.html
+++ b/app/templates/views/dashboard/write-first-messages.html
@@ -10,7 +10,7 @@
     </div>
     <div class="column-half">
       {% call banner_wrapper(type="mode") %}
-        <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='email') }}">Write a text message</a>
+        <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type='sms') }}">Write a text message</a>
       {% endcall %}
     </div>
   </nav>

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -56,6 +56,63 @@ stub_template_stats = [
 ]
 
 
+def test_get_started(
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_service,
+    mock_get_service_templates_when_no_templates_exist,
+    mock_get_service_statistics,
+    mock_get_aggregate_service_statistics,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_usage
+):
+
+    mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
+                                       return_value=copy.deepcopy(stub_template_stats))
+
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(api_user_active)
+        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+
+    # mock_get_service_templates_when_no_templates_exist.assert_called_once_with(SERVICE_ONE_ID)
+    print(response.get_data(as_text=True))
+    assert response.status_code == 200
+    assert 'Get started' in response.get_data(as_text=True)
+
+
+def test_get_started_is_hidden_once_templates_exist(
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_service,
+    mock_get_service_templates,
+    mock_get_service_statistics,
+    mock_get_aggregate_service_statistics,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_usage
+):
+
+    mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
+                                       return_value=copy.deepcopy(stub_template_stats))
+
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(api_user_active)
+        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+
+    # mock_get_service_templates.assert_called_once_with(SERVICE_ONE_ID)
+    assert response.status_code == 200
+    assert 'Get started' not in response.get_data(as_text=True)
+
+
 def test_should_show_recent_templates_on_dashboard(app_,
                                                    mocker,
                                                    api_user_active,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,6 +425,17 @@ def mock_get_service_templates(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_service_templates_when_no_templates_exist(mocker):
+
+    def _create(service_id):
+        return {'data': []}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_templates',
+        side_effect=_create)
+
+
+@pytest.fixture(scope='function')
 def mock_delete_service_template(mocker):
     def _delete(service_id, template_id):
         template = template_json(


### PR DESCRIPTION
This banner was always being shown because the template was never getting sent the service’s templates from the API.

This commit fixes this to only show the banner when a service has no templates, and adds some tests to make sure it doesn’t happen again.

Also fixes the link that took you to the email page instead of the text message page.