### PR TITLE
Add a ‘private’ preview email template endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -291,8 +291,13 @@ def useful_headers_after_request(response):
     response.headers.add('X-Frame-Options', 'deny')
     response.headers.add('X-Content-Type-Options', 'nosniff')
     response.headers.add('X-XSS-Protection', '1; mode=block')
-    response.headers.add('Content-Security-Policy',
-                         "default-src 'self' 'unsafe-inline'; script-src 'self' *.google-analytics.com 'unsafe-inline' data:; object-src 'self'; font-src 'self' data:; img-src 'self' *.google-analytics.com data:;")  # noqa
+    response.headers.add('Content-Security-Policy', (
+        "default-src 'self' 'unsafe-inline';"
+        "script-src 'self' *.google-analytics.com 'unsafe-inline' data:;"
+        "object-src 'self';"
+        "font-src 'self' data:;"
+        "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
+    ))
     if 'Cache-Control' in response.headers:
         del response.headers['Cache-Control']
     response.headers.add(

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,11 +1,14 @@
 import markdown
 import os
-from flask import (render_template, url_for, redirect, Markup)
+from flask import (render_template, url_for, redirect, Markup, request)
 from app.main import main
+from app import convert_to_boolean
 from flask_login import login_required
 
 from flask.ext.login import current_user
 from mdx_gfm import GithubFlavoredMarkdownExtension
+
+from notifications_utils.renderers import HTMLEmail
 
 
 @main.route('/')
@@ -44,6 +47,42 @@ def terms():
 @main.route('/delivery-and-failure')
 def delivery_and_failure():
     return render_template('views/delivery-and-failure.html')
+
+
+@main.route('/_email')
+def email_template():
+    return HTMLEmail(
+        govuk_banner=convert_to_boolean(request.args.get('govuk_banner', True))
+    )(
+        'Lorem Ipsum is simply dummy text of the printing and typesetting '
+        'industry.\n\nLorem Ipsum has been the industry’s standard dummy '
+        'text ever since the 1500s, when an unknown printer took a galley '
+        'of type and scrambled it to make a type specimen book. '
+        '\n\n'
+        '# History'
+        '\n\n'
+        'It has '
+        'survived not only'
+        '\n'
+        '*five centuries'
+        '\n'
+        '* but also the leap into electronic typesetting'
+        '\n\n'
+        'It was '
+        'popularised in the 1960s with the release of Letraset sheets '
+        'containing Lorem Ipsum passages, and more recently with desktop '
+        'publishing software like Aldus PageMaker including versions of '
+        'Lorem Ipsum.'
+        '\n\n'
+        '^ It is a long established fact that a reader will be distracted '
+        'by the readable content of a page when looking at its layout.'
+        '\n\n'
+        'The point of using Lorem Ipsum is that it has a more-or-less '
+        'normal distribution of letters, as opposed to using ‘Content '
+        'here, content here’, making it look like readable English.'
+        '\n\n\n'
+        'This is an example of an email sent using GOV.UK Notify.'
+    )
 
 
 @main.route('/documentation')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@6.2.0#egg=notifications-utils==6.2.0
+git+https://github.com/alphagov/notifications-utils.git@8.3.0#egg=notifications-utils==8.3.0

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -1,0 +1,23 @@
+import pytest
+from flask import url_for
+
+
+@pytest.mark.parametrize(
+    "query_args, params", [
+        ({}, {'govuk_banner': True}),
+        ({'govuk_banner': 'false'}, {'govuk_banner': False})
+    ]
+)
+def test_renders(app_, mocker, query_args, params):
+    with app_.test_request_context(), app_.test_client() as client:
+
+        mock_html_email = mocker.patch(
+            'app.main.views.index.HTMLEmail',
+            return_value=lambda x: 'rendered'
+        )
+
+        response = client.get(url_for('main.email_template', **query_args))
+
+        assert response.status_code == 200
+        assert response.get_data(as_text=True) == 'rendered'
+        mock_html_email.assert_called_once_with(**params)

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -6,4 +6,10 @@ def test_owasp_useful_headers_set(app_):
     assert response.headers['X-Frame-Options'] == 'deny'
     assert response.headers['X-Content-Type-Options'] == 'nosniff'
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
-    assert response.headers['Content-Security-Policy'] == "default-src 'self' 'unsafe-inline'; script-src 'self' *.google-analytics.com 'unsafe-inline' data:; object-src 'self'; font-src 'self' data:; img-src 'self' *.google-analytics.com data:;"  # noqa
+    assert response.headers['Content-Security-Policy'] == (
+        "default-src 'self' 'unsafe-inline';"
+        "script-src 'self' *.google-analytics.com 'unsafe-inline' data:;"
+        "object-src 'self';"
+        "font-src 'self' data:;"
+        "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
+    )


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/45
- [x] https://github.com/alphagov/notifications-utils/pull/47
- [x] https://github.com/alphagov/notifications-utils/pull/48
- [x] https://github.com/alphagov/notifications-utils/pull/50

***

This will make working on the email template easier.

![image](https://cloud.githubusercontent.com/assets/355079/16575354/86b3aa80-427f-11e6-9d3c-59503b388390.png)

![image](https://cloud.githubusercontent.com/assets/355079/16565373/b4d724da-4204-11e6-9e92-0589de620fc2.png)

