### PR TITLE
Make tests run faster by using multiple CPU cores

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,6 +3,7 @@ pep8==1.7.0
 pytest==2.9.1
 pytest-mock==0.11.0
 pytest-cov==2.2.1
+pytest-xdist==1.14
 coveralls==1.1
 moto==0.4.23
 httpretty==0.8.14

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -33,7 +33,7 @@ display_result $? 2 "Front end code style check"
 export NOTIFY_ADMIN_ENVIRONMENT='config.Test'
 
 ## Code coverage
-py.test --cov=app --cov-report=term-missing tests/
+py.test -n2 --cov=app --cov-report=term-missing tests/
 display_result $? 3 "Code coverage"
 
 #py.test -v

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,6 +35,3 @@ export NOTIFY_ADMIN_ENVIRONMENT='config.Test'
 ## Code coverage
 py.test -n2 --cov=app --cov-report=term-missing tests/
 display_result $? 3 "Code coverage"
-
-#py.test -v
-#display_result $? 4 "Unit tests


### PR DESCRIPTION
We can make the tests run slightly faster by parallelizing them across multiple CPU cores:

- from some casual testing locally, 2 cores gives the optimum speedup
- Travis container-based builds [have 2 CPU cores available](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments)
- the net gain is about 20%, or 2 seconds
- unfortunately we can’t do this on the API because each test is still using the same instance of the database

This pull request also tidies up the `run_tests.sh` script a little.