### PR TITLE
Api key types

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -111,7 +111,12 @@
 
 }
 
-.table-field-heading {
+.table-field-headings,
+.table-field-headings-visible {
+
+  th {
+    @include bold-19;
+  }
 
   .dashboard-table &-first {
     width: 52.5%;

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -19,6 +19,7 @@ from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import (DataRequired, Email, Length, Regexp)
 
 from app.main.validators import (Blacklist, CsvFileValidator, ValidEmailDomainRegex, NoCommasInPlaceHolders)
+from app.notify_client.api_key_api_client import KEY_TYPE_NORMAL, KEY_TYPE_TEST, KEY_TYPE_TEAM
 
 
 def email_address(label='Email address'):
@@ -295,9 +296,9 @@ class CreateKeyForm(Form):
     key_type = RadioField(
         'What should Notify do when you use this key?',
         choices=[
-            ('normal', 'Send messages to anyone'),
-            ('test', 'Simulate sending messages to anyone'),
-            ('team', 'Only send messages to members of your team')
+            (KEY_TYPE_NORMAL, 'Send messages to anyone'),
+            (KEY_TYPE_TEST, 'Simulate sending messages to anyone'),
+            (KEY_TYPE_TEAM, 'Only send messages to members of your team')
         ],
         validators=[
             DataRequired()

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -12,7 +12,8 @@ from wtforms import (
     FileField,
     BooleanField,
     HiddenField,
-    IntegerField
+    IntegerField,
+    RadioField
 )
 from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import (DataRequired, Email, Length, Regexp)
@@ -290,6 +291,18 @@ class CreateKeyForm(Form):
     def __init__(self, existing_key_names=[], *args, **kwargs):
         self.existing_key_names = [x.lower() for x in existing_key_names]
         super(CreateKeyForm, self).__init__(*args, **kwargs)
+
+    key_type = RadioField(
+        'What should Notify do when you use this key?',
+        choices=[
+            ('normal', 'Send messages to anyone'),
+            ('test', 'Simulate sending messages to anyone'),
+            ('team', 'Only send messages to members of your team')
+        ],
+        validators=[
+            DataRequired()
+        ]
+    )
 
     key_name = StringField(u'Description of key', validators=[
         DataRequired(message='You need to give the key a name')

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -25,7 +25,11 @@ def create_api_key(service_id):
     ]
     form = CreateKeyForm(key_names)
     if form.validate_on_submit():
-        secret = api_key_api_client.create_api_key(service_id=service_id, key_name=form.key_name.data)
+        secret = api_key_api_client.create_api_key(
+            service_id=service_id,
+            key_name=form.key_name.data,
+            key_type=form.key_type.data
+        )
         return render_template('views/api-keys/show.html', secret=secret,
                                key_name=form.key_name.data)
     return render_template(

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -30,7 +30,7 @@ def create_api_key(service_id):
                                key_name=form.key_name.data)
     return render_template(
         'views/api-keys/create.html',
-        key_name=form.key_name
+        form=form
     )
 
 

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -5,6 +5,7 @@ from app.notify_client import _attach_current_user
 # must match key types in notifications-api/app/models.py
 KEY_TYPE_NORMAL = 'normal'
 KEY_TYPE_TEAM = 'team'
+KEY_TYPE_TEST = 'test'
 
 
 class ApiKeyApiClient(BaseAPIClient):
@@ -24,10 +25,10 @@ class ApiKeyApiClient(BaseAPIClient):
         else:
             return self.get(url='/service/{}/api-keys'.format(service_id))
 
-    def create_api_key(self, service_id, key_name):
+    def create_api_key(self, service_id, key_name, key_type):
         data = {
             'name': key_name,
-            'key_type': KEY_TYPE_NORMAL
+            'key_type': key_type
         }
         _attach_current_user(data)
         key = self.post(url='/service/{}/api-key'.format(service_id), data=data)

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -1,0 +1,23 @@
+{% macro radios(
+  field,
+  hint=None
+) %}
+  <div class="form-group {% if field.errors %} error{% endif %}">
+    <fieldset>
+      <legend class="form-label">
+        {{ field.label }}
+        {% if field.errors %}
+          <span class="error-message">
+            {{ field.errors[0] }}
+          </span>
+        {% endif %}
+      </legend>
+      {% for option in field %}
+        <label class="block-label" for="{{ option.id }}">
+          {{ option }}
+          {{ option.label.text }}
+        </label>
+      {% endfor %}
+    </fieldset>
+  </div>
+{% endmacro %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -58,7 +58,7 @@
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
   {% if current_user.has_permissions(['manage_api_keys']) %}
-    <li><a href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a></li>
+    <li><a href="{{ url_for('.api_keys', service_id=current_service.id) }}">API integration</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -11,7 +11,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        API keys
+        API integration
       </h1>
     </div>
     <div class="column-one-third">
@@ -23,8 +23,8 @@
     keys,
     empty_message="You haven’t created any API keys yet",
     caption="API keys",
-    caption_visible=False,
-    field_headings=['Key name', hidden_field_heading('Action')]
+    caption_visible=false,
+    field_headings=['API keys', hidden_field_heading('Action')],
   ) %}
     {% call field() %}
       {{ item.name }}

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -26,24 +26,25 @@
     caption_visible=false,
     field_headings=[
       'API keys',
-      hidden_field_heading('Key type'),
       hidden_field_heading('Action')
     ],
   ) %}
     {% call field() %}
-      {{ item.name }}
-    {% endcall %}
-    {% call field(status='default') %}
-      {% if item.key_type == 'normal' %}
-        <span class="visually-hidden">Normal</span>
-      {% elif item.key_type == 'team' %}
-        Only sends to team members
-      {% elif item.key_type == 'test' %}
-        Simulates sending messages
-      {% endif %}
+      <div class="file-list">
+        {{ item.name }}
+        <span class="file-list-hint">
+          {% if item.key_type == 'normal' %}
+            <span class="visually-hidden">Normal</span>
+          {% elif item.key_type == 'team' %}
+            Only sends to team members
+          {% elif item.key_type == 'test' %}
+            Simulates sending messages
+          {% endif %}
+        </span>
+      </div>
     {% endcall %}
     {% if item.expiry_date %}
-      {% call field(align='right', status='default') %}
+      {% call field(align='right') %}
         Revoked {{ item.expiry_date|format_datetime }}
       {% endcall %}
     {% else %}

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -24,10 +24,23 @@
     empty_message="You haven’t created any API keys yet",
     caption="API keys",
     caption_visible=false,
-    field_headings=['API keys', hidden_field_heading('Action')],
+    field_headings=[
+      'API keys',
+      hidden_field_heading('Key type'),
+      hidden_field_heading('Action')
+    ],
   ) %}
     {% call field() %}
       {{ item.name }}
+    {% endcall %}
+    {% call field(status='default') %}
+      {% if item.key_type == 'normal' %}
+        <span class="visually-hidden">Normal</span>
+      {% elif item.key_type == 'team' %}
+        Only sends to team members
+      {% elif item.key_type == 'test' %}
+        Simulates sending messages
+      {% endif %}
     {% endcall %}
     {% if item.expiry_date %}
       {% call field(align='right', status='default') %}

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -57,10 +57,11 @@
     {{ api_key(current_service.id, "Service ID", thing="service ID") }}
   </div>
 
+  <h2 class="heading-small">Documentation</h2>
   <p>
-    API usage is described in the
-    <a href="{{ url_for('.documentation', service_id=current_service.id) }}">
-    API documentation</a>.
+    See the
+    <a href="{{ url_for('.documentation') }}">
+    API documentation</a> for clients and specfications.
   </p>
 
 {% endblock %}

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -45,7 +45,7 @@
     {% endcall %}
     {% if item.expiry_date %}
       {% call field(align='right') %}
-        Revoked {{ item.expiry_date|format_datetime }}
+        Revoked {{ item.expiry_date|format_datetime_short }}
       {% endcall %}
     {% else %}
       {% call field(align='right', status='error') %}

--- a/app/templates/views/api-keys/create.html
+++ b/app/templates/views/api-keys/create.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/radios.html" import radios %}
 
 {% block page_title %}
   Add a new API key – GOV.UK Notify
@@ -13,7 +14,8 @@
   </h1>
 
   <form method="post">
-    {{ textbox(key_name, hint='eg CRM application') }}
+    {{ radios(form.key_type) }}
+    {{ textbox(form.key_name, label='Name for this key') }}
     {{ page_footer('Continue') }}
   </form>
 

--- a/app/templates/views/api-keys/create.html
+++ b/app/templates/views/api-keys/create.html
@@ -9,7 +9,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    Add a new API key
+    Create an API key
   </h1>
 
   <form method="post">

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -1,3 +1,5 @@
+import pytest
+
 from werkzeug.datastructures import MultiDict
 
 from app.main.forms import CreateKeyForm
@@ -11,4 +13,20 @@ def test_return_validation_error_when_key_name_exists(app_):
         form = CreateKeyForm(_get_names(),
                              formdata=MultiDict([('key_name', 'Some key')]))
         form.validate()
-        assert {'key_name': ['A key with this name already exists']} == form.errors
+        assert form.errors['key_name'] == ['A key with this name already exists']
+
+
+@pytest.mark.parametrize(
+    'key_type, expected_error', [
+        ('', 'This field is required.'),
+        ('invalid', 'Not a valid choice')
+    ]
+)
+def test_return_validation_error_when_key_type_not_chosen(app_, key_type, expected_error):
+
+    with app_.test_request_context():
+        form = CreateKeyForm(
+            [],
+            formdata=MultiDict([('key_name', 'Some key'), ('key_type', key_type)]))
+        form.validate()
+        assert form.errors['key_type'] == [expected_error]

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -39,7 +39,7 @@ def test_should_show_api_keys_page(app_,
         resp_data = response.get_data(as_text=True)
         assert 'some key name' in resp_data
         assert 'another key name' in resp_data
-        assert 'Revoked Thursday 01 January 1970 at 01:00' in resp_data
+        assert 'Revoked 1 January at 01:00' in resp_data
         mock_get_api_keys.assert_called_once_with(service_id=fake_uuid)
 
 

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -72,8 +72,13 @@ def test_should_create_api_key_with_type_normal(app_,
 
     with app_.test_request_context(), app_.test_client() as client:
         client.login(api_user_active)
-        response = client.post(url_for('main.create_api_key', service_id=service_id),
-                               data={'key_name': 'some default key name'})
+        response = client.post(
+            url_for('main.create_api_key', service_id=service_id),
+            data={
+                'key_name': 'some default key name',
+                'key_type': 'normal'
+            }
+        )
 
     assert response.status_code == 200
     assert 'some default key name' in response.get_data(as_text=True)


### PR DESCRIPTION
Can now set api keys on the front end. Tada! 🎉  🎉  🎉 

![image](https://cloud.githubusercontent.com/assets/5020841/16620952/5ad0bbca-438c-11e6-88cd-274bbf8fb5c2.png)

![image](https://cloud.githubusercontent.com/assets/5020841/16620942/52a8bdf8-438c-11e6-8198-692c55fdb62c.png)


@quis - revoking a key leaves you with two columns of quite long content  - do we want to look at that or is that fine? 