### PR TITLE
mmg rates set to 1.65p

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -178,7 +178,10 @@ def get_dashboard_partials(service_id):
     }
 
 
-def calculate_usage(usage, sms_free_allowance=250000, sms_rate=0.018):
+def calculate_usage(usage):
+    # TODO: Don't hardcode these - get em from the API
+    sms_free_allowance = 250000
+    sms_rate = 0.0165
 
     sms_sent = usage.get('sms_count', 0)
     emails_sent = usage.get('email_count', 0)

--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -26,7 +26,7 @@
         <li>Up to 306 characters = 2 text messages</li>
         <li>Up to 459 characters = 3 text messages</li>
       </ul></li>
-      <li>Standard text message rate: 1.8p + VAT</li>
+      <li>Standard text message rate: 1.65p + VAT</li>
     </ul>
 
     <p>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -34,7 +34,7 @@
           {% if sms_chargeable %}
             {{ big_number(
               sms_chargeable,
-              'at {:.1f}p per message'.format(sms_rate * 100),
+              'at {:.2f}p per message'.format(sms_rate * 100),
               smaller=True
             ) }}
           {% endif %}


### PR DESCRIPTION
also moved a default parameter to a plain ol' local variable to reduce ambiguity about whether it is overriden by any callers (it's not)