### PR TITLE
Fix 500 being thrown when uploading large files

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -158,7 +158,7 @@ class Spreadsheet():
 
     @staticmethod
     def normalise_newlines(file_content):
-        return '\r\n'.join(file_content.getvalue().decode('utf-8').splitlines())
+        return '\r\n'.join(file_content.read().decode('utf-8').splitlines())
 
     @classmethod
     def from_rows(cls, rows, filename=''):


### PR DESCRIPTION
This is re-fixing a bug which was re-introduced when adding the `Spreadsheet` class in 1409ca36ca5a97ed4a1a80160913ad40fd85f50e.

It was previously fixed in 19662d8329c622f7600eee982313dee52703c479:

>  Fix bug with large file uploads
>
>  Depending on the size of the uploaded file, Flask will temporarily store it in different ways. This means that it comes back as a `TempFile` if the file is roughly <500k and as `BytesIO` if the file is larger.
>
>  `TempFile` supports the `.getvalue()` method, but `BytesIO` does not. Both support the `.read()` method, so this commit changes to use that instead.