### PR TITLE
Fix wonky tables on dashboard and activity page

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -21,6 +21,10 @@
     }
   }
 
+  .table-field-heading-first {
+    width: 52.5%
+  }
+
   .table-row {
     th {
       display: table-cell;


### PR DESCRIPTION
Tables with a `layout` of `fixed` determine column widths from the width of the column headings.

We weren’t setting the width of the first column heading, so our tables were getting out of alignment.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/16810348/7aa7c29c-491b-11e6-8a90-64be72f4bb3c.png)

## After

![image](https://cloud.githubusercontent.com/assets/355079/16810373/8952fdde-491b-11e6-87d2-b095e99aae07.png)
