### PR TITLE
Increase daily message limit for unrestricted services

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -148,7 +148,7 @@ def service_switch_live(service_id):
         current_service['active'],
         # TODO This limit should be set depending on the agreement signed by
         # with Notify.
-        25000 if current_service['restricted'] else 50,
+        250000 if current_service['restricted'] else 50,
         False if current_service['restricted'] else True,
         current_service['users'],
         current_service['email_from'])

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -80,7 +80,7 @@ def test_switch_service_to_live(app_,
         assert response.location == url_for(
             'main.service_settings',
             service_id=service_one['id'], _external=True)
-        mock_update_service.assert_called_with(ANY, ANY, ANY, 25000, False, ANY, ANY)
+        mock_update_service.assert_called_with(ANY, ANY, ANY, 250000, False, ANY, ANY)
 
 
 def test_switch_service_to_restricted(app_,


### PR DESCRIPTION
Set daily message limit for live services to 250,000

This pr is for https://www.pivotaltracker.com/story/show/126230157