### PR TITLE
Update pip to latest version before Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
 - npm install
 - npm rebuild node-sass
+- pip install --upgrade pip setuptools
 - pip install -r requirements_for_test.txt
 after_success:
 - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pyexcel-xls==0.1.0
 pyexcel-xlsx==0.1.0
 pyexcel-ods3==0.1.1
 pytz==2016.4
+html5lib==0.9999999
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 


### PR DESCRIPTION
Getting this error on Travis:

```
html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 12.0.5)
```

To stop this happening again, we should make sure our version of pip and setuptools is always up to date.