### PR TITLE
Make ‘Available for…’ text on job page relative

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -320,19 +320,23 @@ def get_job_partials(job):
                 status=request.args.get('status', '')
             ),
             help=get_help_argument(),
-            time_left=ago.human(
-                (
-                    datetime.now(timezone.utc).replace(hour=23, minute=59, second=59)
-                ) - (
-                    dateutil.parser.parse(job['created_at']) + timedelta(days=8)
-                ),
-                future_tense='Data available for {}',
-                past_tense='Was available {} ago',  # No-one should ever see this
-                precision=1
-            )
+            time_left=get_time_left(job['created_at'])
         ),
         'status': render_template(
             'partials/jobs/status.html',
             job=job
         ),
     }
+
+
+def get_time_left(job_created_at):
+    return ago.human(
+        (
+            datetime.now(timezone.utc).replace(hour=23, minute=59, second=59)
+        ) - (
+            dateutil.parser.parse(job_created_at) + timedelta(days=8)
+        ),
+        future_tense='Data available for {}',
+        past_tense='Data no longer available',  # No-one should ever see this
+        precision=1
+    )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -299,7 +299,6 @@ def get_job_partials(job):
 
     filter_args = _parse_filter_args(request.args)
     _set_status_filters(filter_args)
-
     return {
         'counts': render_template(
             'partials/jobs/count.html',
@@ -309,11 +308,15 @@ def get_job_partials(job):
         ),
         'notifications': render_template(
             'partials/jobs/notifications.html',
-            job=job,
             notifications=notification_api_client.get_notifications_for_service(
                 job['service'], job['id'], status=filter_args.get('status')
             )['notifications'],
-            status=request.args.get('status', ''),
+            download_link=url_for(
+                '.view_job_csv',
+                service_id=current_service['id'],
+                job_id=job['id'],
+                status=request.args.get('status', '')
+            ),
             help=get_help_argument()
         ),
         'status': render_template(

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import time
+import dateutil
+from datetime import datetime, timedelta, timezone
+import ago
 
 from flask import (
     render_template,
@@ -296,7 +299,6 @@ def _get_job_counts(job, help_argument):
 
 
 def get_job_partials(job):
-
     filter_args = _parse_filter_args(request.args)
     _set_status_filters(filter_args)
     return {
@@ -317,7 +319,17 @@ def get_job_partials(job):
                 job_id=job['id'],
                 status=request.args.get('status', '')
             ),
-            help=get_help_argument()
+            help=get_help_argument(),
+            time_left=ago.human(
+                (
+                    datetime.now(timezone.utc).replace(hour=23, minute=59, second=59)
+                ) - (
+                    dateutil.parser.parse(job['created_at']) + timedelta(days=8)
+                ),
+                future_tense='Data available for {}',
+                past_tense='Was available {} ago',  # No-one should ever see this
+                precision=1
+            )
         ),
         'status': render_template(
             'partials/jobs/status.html',

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -8,7 +8,7 @@
     <p class="bottom-gutter">
       <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
-      <span id="time-left">Available for 7 days</span>
+      <span id="time-left">{{ time_left }}</span>
     </p>
   {% endif %}
 

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -8,7 +8,7 @@
     <p class="bottom-gutter">
       <a href="{{ url_for('.view_job_csv', service_id=current_service.id, job_id=job.id, status=status) }}" download="download" class="heading-small">Download this report</a>
       &emsp;
-      Available for 7 days
+      <span id="time-left">Available for 7 days</span>
     </p>
   {% endif %}
 

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -6,7 +6,7 @@
 
   {% if notifications and not help %}
     <p class="bottom-gutter">
-      <a href="{{ url_for('.view_job_csv', service_id=current_service.id, job_id=job.id, status=status) }}" download="download" class="heading-small">Download this report</a>
+      <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
       <span id="time-left">Available for 7 days</span>
     </p>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -6,9 +6,9 @@
 
   {% if notifications and not help %}
     <p class="bottom-gutter">
-      <a href="{{ url_for('.view_job_csv', service_id=current_service.id, job_id=job.id, status=status) }}" download="download" class="heading-small">Download as a CSV file</a>
+      <a href="{{ url_for('.view_job_csv', service_id=current_service.id, job_id=job.id, status=status) }}" download="download" class="heading-small">Download this report</a>
       &emsp;
-      Delivery information is available for 7 days
+      Available for 7 days
     </p>
   {% endif %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ago==0.0.8
 Flask==0.10.1
 Flask-Script==2.0.5
 Flask-WTF==0.11

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import pytest
 import uuid
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta, date, timezone
 from flask.testing import FlaskClient
 from flask import url_for
 from flask_login import login_user
@@ -155,7 +155,7 @@ def job_json(service_id,
     if template_id is None:
         template_id = str(generate_uuid())
     if created_at is None:
-        created_at = str(datetime.utcnow().time())
+        created_at = str(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z'))
     if status is None:
         status = 'Delivered'
     data = {

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -90,12 +90,14 @@ def test_should_show_page_for_one_job(
             job_id=fake_uuid,
             status=status_argument,
         )
-        assert page.find('a', {'download': 'download'})['href'] == url_for(
+        csv_link = page.find('a', {'download': 'download'})
+        assert csv_link['href'] == url_for(
             'main.view_job_csv',
             service_id=service_one['id'],
             job_id=fake_uuid,
             status=status_argument
         )
+        assert csv_link.text == 'Download this report'
         mock_get_notifications.assert_called_with(
             service_one['id'],
             fake_uuid,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -65,15 +65,14 @@ def test_should_show_page_for_one_job(
     expected_api_call
 ):
     file_name = mock_get_job(service_one['id'], fake_uuid)['data']['original_file_name']
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.view_job',
-                service_id=service_one['id'],
-                job_id=fake_uuid,
-                status=status_argument
-            ))
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(active_user_with_permissions, mocker, service_one)
+        response = client.get(url_for(
+            'main.view_job',
+            service_id=service_one['id'],
+            job_id=fake_uuid,
+            status=status_argument
+        ))
 
         assert response.status_code == 200
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -97,7 +97,7 @@ def test_should_show_page_for_one_job(
             status=status_argument
         )
         assert csv_link.text == 'Download this report'
-        assert page.find('span', {'id': 'time-left'}).text == 'Available for 7 days'
+        assert page.find('span', {'id': 'time-left'}).text == 'Data available for 7 days'
         mock_get_notifications.assert_called_with(
             service_one['id'],
             fake_uuid,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -98,6 +98,7 @@ def test_should_show_page_for_one_job(
             status=status_argument
         )
         assert csv_link.text == 'Download this report'
+        assert page.find('span', {'id': 'time-left'}).text == 'Available for 7 days'
         mock_get_notifications.assert_called_with(
             service_one['id'],
             fake_uuid,


### PR DESCRIPTION
#### Reviewers: all the substantive changes in this pull request are in cfadead and 9a5fbca. Other changes are detailed in the commits; they’re either refactoring or making the tests more thorough.

***

When we say ‘delivery information is available for 7 days’ you have to infer _when_ the seven days starts. When you come back to the page it still says ‘available for 7 days’ even if you only have a day left to download it. This is confusing.

This pull request changes the text to be relative to now, eg ‘available for 7 days’, ‘available for 1 day’.

***

![image](https://cloud.githubusercontent.com/assets/355079/16949169/1f707802-4db1-11e6-8f8c-1ac290b7105b.png)

