### PR TITLE
Really hide the ‘download CSV’ link in the tour

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -97,7 +97,8 @@ def view_job(service_id, job_id):
             ".view_job_updates",
             service_id=service_id,
             job_id=job['id'],
-            status=request.args.get('status', '')
+            status=request.args.get('status', ''),
+            help=get_help_argument()
         ),
         partials=get_job_partials(job),
         help=get_help_argument()

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -121,6 +121,13 @@ def test_should_show_not_show_csv_download_in_tour(
 
         assert response.status_code == 200
         assert url_for(
+            'main.view_job_updates',
+            service_id=service_one['id'],
+            job_id=fake_uuid,
+            status='',
+            help=3
+        ).replace('&', '&amp;') in response.get_data(as_text=True)
+        assert url_for(
             'main.view_job_csv',
             service_id=service_one['id'],
             job_id=fake_uuid


### PR DESCRIPTION
Tried to do this in https://github.com/alphagov/notifications-admin/pull/743

Didn’t account for it reappearing when the AJAX fired, because the AJAX request didn’t account for whether or not the user was in the tour.