### PR TITLE
Remove notification-statistics endpoints from totals boxes 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -325,7 +325,7 @@ def register_errorhandlers(application):
     @application.errorhandler(HTTPError)
     def render_http_error(error):
         application.logger.error("API {} failed with status {} message {}".format(
-            error.response.url,
+            error.response.url if error.response else 'unknown',
             error.status_code,
             error.message
         ))

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -324,7 +324,11 @@ def register_errorhandlers(application):
 
     @application.errorhandler(HTTPError)
     def render_http_error(error):
-        application.logger.error("API called failed with status {} message {}".format(error.status_code, error.message))
+        application.logger.error("API {} failed with status {} message {}".format(
+            error.response.url,
+            error.status_code,
+            error.message
+        ))
         error_code = error.status_code
         if error_code not in [401, 404, 403, 500]:
             error_code = 500

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -154,7 +154,7 @@ def get_dashboard_partials(service_id):
         'totals': render_template(
             'views/dashboard/_totals.html',
             service_id=service_id,
-            statistics=get_dashboard_totals(service)
+            statistics=get_dashboard_totals(service['data']['statistics'])
         ),
         'template-statistics': render_template(
             'views/dashboard/template-statistics.html',
@@ -176,11 +176,11 @@ def get_dashboard_partials(service_id):
     }
 
 
-def get_dashboard_totals(service):
-    for msg_type in service['data']['statistics'].values():
+def get_dashboard_totals(statistics):
+    for msg_type in statistics.values():
         msg_type['failed_percentage'] = get_formatted_percentage(msg_type['failed'], msg_type['requested'])
         msg_type['show_warning'] = float(msg_type['failed_percentage']) > 3
-    return service['data']['statistics']
+    return statistics
 
 
 def calculate_usage(usage):

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -154,9 +154,7 @@ def get_dashboard_partials(service_id):
     return {
         'totals': render_template(
             'views/dashboard/_totals.html',
-            statistics=add_rates_to(sum_of_statistics(
-                statistics_api_client.get_statistics_for_service(service_id, limit_days=7)['data']
-            ))
+            statistics=get_dashboard_totals(service_id)
         ),
         'template-statistics': render_template(
             'views/dashboard/template-statistics.html',
@@ -176,6 +174,12 @@ def get_dashboard_partials(service_id):
             **calculate_usage(service_api_client.get_service_usage(service_id)['data'])
         ),
     }
+
+
+def get_dashboard_totals(service_id):
+    return add_rates_to(sum_of_statistics(
+        statistics_api_client.get_statistics_for_service(service_id, limit_days=7)['data']
+    ))
 
 
 def calculate_usage(usage):

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -148,8 +148,7 @@ def get_dashboard_partials(service_id):
         lambda job: job['original_file_name'] != current_app.config['TEST_MESSAGE_FILENAME'],
         job_api_client.get_job(service_id, limit_days=7)['data']
     ))
-
-    service = service_api_client.get_service(service_id, detailed=True)
+    service = service_api_client.get_detailed_service(service_id)
 
     return {
         'totals': render_template(
@@ -178,10 +177,10 @@ def get_dashboard_partials(service_id):
 
 
 def get_dashboard_totals(service):
-    for msg_type in service['statistics']:
+    for msg_type in service['data']['statistics'].values():
         msg_type['failed_percentage'] = get_formatted_percentage(msg_type['failed'], msg_type['requested'])
-        msg_type['show_warning'] = msg_type['failed_percentage'] > 3
-    return service['statistics']
+        msg_type['show_warning'] = float(msg_type['failed_percentage']) > 3
+    return service['data']['statistics']
 
 
 def calculate_usage(usage):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -41,12 +41,14 @@ class ServiceAPIClient(NotificationsAPIClient):
         data = _attach_current_user({})
         return self.delete(endpoint, data)
 
-    def get_service(self, service_id, *params):
+    def get_service(self, service_id, detailed=False):
         """
         Retrieve a service.
         """
+        params = {'detailed': True} if detailed else {}
         return self.get(
-            '/service/{0}'.format(service_id))
+            '/service/{0}'.format(service_id),
+            params=params)
 
     def get_services(self, *params):
         """

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -41,7 +41,13 @@ class ServiceAPIClient(NotificationsAPIClient):
         data = _attach_current_user({})
         return self.delete(endpoint, data)
 
-    def get_service(self, service_id, detailed=False):
+    def get_service(self, service_id):
+        return self._get_service(service_id, False)
+
+    def get_detailed_service(self, service_id):
+        return self._get_service(service_id, True)
+
+    def _get_service(self, service_id, detailed):
         """
         Retrieve a service.
         """

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -31,23 +31,24 @@ def sum_of_statistics(delivery_statistics):
 def add_rates_to(delivery_statistics):
 
     return dict(
-        emails_failure_rate=(
-            "{0:.1f}".format(
-                float(delivery_statistics['emails_failed']) / delivery_statistics['emails_requested'] * 100
-            )
-            if delivery_statistics['emails_requested'] else 0
-        ),
-        sms_failure_rate=(
-            "{0:.1f}".format(
-                float(delivery_statistics['sms_failed']) / delivery_statistics['sms_requested'] * 100
-            )
-            if delivery_statistics['sms_requested'] else 0
-        ),
+        email_failure_rate=get_formatted_percentage(
+            delivery_statistics['email_failed'],
+            delivery_statistics['email_requested']),
+        sms_failure_rate=get_formatted_percentage(
+            delivery_statistics['sms_failed'],
+            delivery_statistics['sms_requested']),
         week_end_datetime=parser.parse(
             delivery_statistics.get('week_end', str(datetime.utcnow()))
         ),
         **delivery_statistics
     )
+
+
+def get_formatted_percentage(x, tot):
+    """
+    Return a percentage to one decimal place (respecting )
+    """
+    return "{0:.1f}".format((float(x) / tot * 100)) if tot else 0
 
 
 def statistics_by_state(statistics):

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -48,7 +48,7 @@ def get_formatted_percentage(x, tot):
     """
     Return a percentage to one decimal place (respecting )
     """
-    return "{0:.1f}".format((float(x) / tot * 100)) if tot else 0
+    return "{0:.1f}".format((float(x) / tot * 100)) if tot else '0'
 
 
 def statistics_by_state(statistics):

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -31,9 +31,9 @@ def sum_of_statistics(delivery_statistics):
 def add_rates_to(delivery_statistics):
 
     return dict(
-        email_failure_rate=get_formatted_percentage(
-            delivery_statistics['email_failed'],
-            delivery_statistics['email_requested']),
+        emails_failure_rate=get_formatted_percentage(
+            delivery_statistics['emails_failed'],
+            delivery_statistics['emails_requested']),
         sms_failure_rate=get_formatted_percentage(
             delivery_statistics['sms_failed'],
             delivery_statistics['sms_requested']),

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -9,8 +9,8 @@
       statistics['email']['failed'],
       statistics['email']['failed_percentage'],
       statistics['email']['show_warning'],
-      failure_link=url_for(".view_notifications", service_id=id, message_type='email', status='failed'),
-      link=url_for(".view_notifications", service_id=id, message_type='email', status='sending,delivered,failed')
+      failure_link=url_for(".view_notifications", service_id=service_id, message_type='email', status='failed'),
+      link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed')
     ) }}
   </div>
   <div class="column-half">

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -4,24 +4,24 @@
 <div class="grid-row">
   <div class="column-half">
     {{ big_number_with_status(
-      statistics.emails_requested,
-      message_count_label(statistics.emails_requested, 'email', suffix=''),
-      statistics.emails_failed,
-      statistics.get('emails_failure_rate', 0.0),
-      statistics.get('emails_failure_rate', 0)|float > 3,
-      failure_link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='failed'),
-      link=url_for(".view_notifications", service_id=current_service.id, message_type='email', status='sending,delivered,failed')
+      statistics['email']['requested'],
+      message_count_label(statistics['email']['requested'], 'email', suffix=''),
+      statistics['email']['failed'],
+      statistics['email']['failed_percentage'],
+      statistics['email']['show_warning'],
+      failure_link=url_for(".view_notifications", service_id=id, message_type='email', status='failed'),
+      link=url_for(".view_notifications", service_id=id, message_type='email', status='sending,delivered,failed')
     ) }}
   </div>
   <div class="column-half">
     {{ big_number_with_status(
-      statistics.sms_requested,
-      message_count_label(statistics.sms_requested, 'sms', suffix=''),
-      statistics.sms_failed,
-      statistics.get('sms_failure_rate', 0.0),
-      statistics.get('sms_failure_rate', 0)|float > 3,
-      failure_link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='failed'),
-      link=url_for(".view_notifications", service_id=current_service.id, message_type='sms', status='sending,delivered,failed')
+      statistics['sms']['requested'],
+      message_count_label(statistics['sms']['requested'], 'sms', suffix=''),
+      statistics['sms']['failed'],
+      statistics['sms']['failed_percentage'],
+      statistics['sms']['show_warning'],
+      failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
+      link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed')
     ) }}
   </div>
 </div>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,11 +13,11 @@ class TestClient(FlaskClient):
             session['user_id'] = user.id
             session['_fresh'] = True
         if mocker:
-            mocker.patch('app.user_api_client.get_user', return_value=user)
-            mocker.patch('app.events_api_client.create_event')
-        if mocker and service:
-            session['service_id'] = service['id']
-            mocker.patch('app.service_api_client.get_service', return_value={'data': service})
+            get_user_mock = mocker.patch('app.user_api_client.get_user', return_value=user)
+            create_event_mock = mocker.patch('app.events_api_client.create_event')
+            if service:
+                session['service_id'] = service['id']
+                get_service_mock = mocker.patch('app.service_api_client.get_service', return_value={'data': service})
         login_user(user, remember=True)
 
     def login_fresh(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,11 +13,11 @@ class TestClient(FlaskClient):
             session['user_id'] = user.id
             session['_fresh'] = True
         if mocker:
-            get_user_mock = mocker.patch('app.user_api_client.get_user', return_value=user)
-            create_event_mock = mocker.patch('app.events_api_client.create_event')
-            if service:
-                session['service_id'] = service['id']
-                get_service_mock = mocker.patch('app.service_api_client.get_service', return_value={'data': service})
+            mocker.patch('app.user_api_client.get_user', return_value=user)
+            mocker.patch('app.events_api_client.create_event')
+        if mocker and service:
+            session['service_id'] = service['id']
+            mocker.patch('app.service_api_client.get_service', return_value={'data': service})
         login_user(user, remember=True)
 
     def login_fresh(self):

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -314,7 +314,10 @@ def test_new_invited_user_verifies_and_added_to_service(app_,
                                                         mock_get_service_statistics,
                                                         mock_get_template_statistics,
                                                         mock_get_jobs,
-                                                        mock_has_permissions):
+                                                        mock_has_permissions,
+                                                        mock_get_users_by_service,
+                                                        mock_get_detailed_service,
+                                                        mock_get_usage):
 
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -6,14 +6,14 @@ from tests import validate_route_permission
 
 
 def test_should_show_empty_api_keys_page(app_,
-                                         api_user_active,
+                                         api_user_pending,
                                          mock_login,
                                          mock_get_no_api_keys,
                                          mock_get_service,
                                          mock_has_permissions):
     with app_.test_request_context():
         with app_.test_client() as client:
-            client.login(api_user_active)
+            client.login(api_user_pending)
             service_id = str(uuid.uuid4())
             response = client.get(url_for('main.api_keys', service_id=service_id))
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -100,7 +100,6 @@ def test_get_started_is_hidden_once_templates_exist(
     mock_has_permissions,
     mock_get_usage
 ):
-
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
 
@@ -376,14 +375,6 @@ def test_menu_all_services_for_platform_admin_user(mocker,
         assert url_for('main.view_notifications', service_id=service_one['id'], message_type='sms') in page
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
 
-        # Should this be here??
-        # template_json = mock_get_service_templates(service_one['id'])['data'][0]
-
-        # assert url_for(
-        #    'main.edit_service_template',
-        #    service_id=service_one['id'],
-        #    template_id=template_json['id']) in page
-
 
 def test_route_for_service_permissions(mocker,
                                        app_,
@@ -424,3 +415,20 @@ def test_aggregate_template_stats():
             assert item['usage_count'] == 13
         elif item['template'].id == 2:
             assert item['usage_count'] == 206
+
+
+def test_service_dashboard_updates_gets_detailed_service(mocker,
+                                                         app_,
+                                                         active_user_with_permissions,
+                                                         service_one,
+                                                         mock_get_service,
+                                                         mock_get_service_statistics,
+                                                         mock_get_usage,
+                                                         ):
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(active_user_with_permissions, mocker, service_one)
+        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+
+    assert response.status_code == 200
+    # mock_get_service_statistics.assert_not_called()
+    # mock_get_service.assert_called_once_with(service_one.id, detailed=True)

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -69,6 +69,7 @@ def test_get_started(
     mock_login,
     mock_get_jobs,
     mock_has_permissions,
+    mock_get_detailed_service,
     mock_get_usage
 ):
 
@@ -98,11 +99,11 @@ def test_get_started_is_hidden_once_templates_exist(
     mock_login,
     mock_get_jobs,
     mock_has_permissions,
+    mock_get_detailed_service,
     mock_get_usage
 ):
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
-
     with app_.test_request_context(), app_.test_client() as client:
         client.login(api_user_active)
         response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
@@ -117,13 +118,13 @@ def test_should_show_recent_templates_on_dashboard(app_,
                                                    api_user_active,
                                                    mock_get_service,
                                                    mock_get_service_templates,
-                                                   mock_get_service_statistics,
                                                    mock_get_aggregate_service_statistics,
                                                    mock_get_user,
                                                    mock_get_user_by_email,
                                                    mock_login,
                                                    mock_get_jobs,
                                                    mock_has_permissions,
+                                                   mock_get_detailed_service,
                                                    mock_get_usage):
 
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
@@ -136,7 +137,6 @@ def test_should_show_recent_templates_on_dashboard(app_,
 
         assert response.status_code == 200
         response.get_data(as_text=True)
-        mock_get_service_statistics.assert_called_once_with(SERVICE_ONE_ID, limit_days=7)
         mock_template_stats.assert_called_once_with(SERVICE_ONE_ID, limit_days=7)
 
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -210,6 +210,7 @@ def test_should_show_recent_jobs_on_dashboard(
     mock_get_user_by_email,
     mock_login,
     mock_get_template_statistics,
+    mock_get_detailed_service,
     mock_get_jobs,
     mock_has_permissions,
     mock_get_usage
@@ -261,6 +262,7 @@ def test_menu_send_messages(mocker,
                             mock_get_service_templates,
                             mock_get_jobs,
                             mock_get_template_statistics,
+                            mock_get_detailed_service,
                             mock_get_usage):
 
     with app_.test_request_context():
@@ -295,6 +297,7 @@ def test_menu_manage_service(mocker,
                              mock_get_service_templates,
                              mock_get_jobs,
                              mock_get_template_statistics,
+                             mock_get_detailed_service,
                              mock_get_usage):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
@@ -327,6 +330,7 @@ def test_menu_manage_api_keys(mocker,
                               mock_get_service_templates,
                               mock_get_jobs,
                               mock_get_template_statistics,
+                              mock_get_detailed_service,
                               mock_get_usage):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
@@ -358,6 +362,7 @@ def test_menu_all_services_for_platform_admin_user(mocker,
                                                    mock_get_service_templates,
                                                    mock_get_jobs,
                                                    mock_get_template_statistics,
+                                                   mock_get_detailed_service,
                                                    mock_get_usage):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
@@ -386,6 +391,7 @@ def test_route_for_service_permissions(mocker,
                                        mock_get_jobs,
                                        mock_get_service_statistics,
                                        mock_get_template_statistics,
+                                       mock_get_detailed_service,
                                        mock_get_usage):
     routes = [
         'main.service_dashboard']
@@ -424,10 +430,10 @@ def test_service_dashboard_updates_gets_dashboard_totals(mocker,
                                                          mock_get_user,
                                                          mock_get_service_templates,
                                                          mock_get_template_statistics,
+                                                         mock_get_detailed_service,
                                                          mock_get_jobs,
                                                          mock_get_service_statistics,
-                                                         mock_get_usage,
-                                                         mock_get_detailed_service):
+                                                         mock_get_usage):
     dashboard_totals = mocker.patch('app.main.views.dashboard.get_dashboard_totals', return_value={
         'email': {'requested': 0, 'delivered': 0, 'failed': 0},
         'sms': {'requested': 0, 'delivered': 0, 'failed': 0}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -417,18 +417,19 @@ def test_aggregate_template_stats():
             assert item['usage_count'] == 206
 
 
-def test_service_dashboard_updates_gets_detailed_service(mocker,
+def test_service_dashboard_updates_gets_dashboard_totals(mocker,
                                                          app_,
                                                          active_user_with_permissions,
                                                          service_one,
-                                                         mock_get_service,
                                                          mock_get_service_statistics,
-                                                         mock_get_usage,
-                                                         ):
+                                                         mock_get_usage):
+    dashboard_totals = mocker.patch('app.main.views.dashboard.get_dashboard_totals', return_value={
+        'email': {'requested': 0, 'delivered': 0, 'failed': 0},
+        'sms': {'requested': 0, 'delivered': 0, 'failed': 0}
+    })
+
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
         response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
     assert response.status_code == 200
-    # mock_get_service_statistics.assert_not_called()
-    # mock_get_service.assert_called_once_with(service_one.id, detailed=True)

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -421,8 +421,13 @@ def test_service_dashboard_updates_gets_dashboard_totals(mocker,
                                                          app_,
                                                          active_user_with_permissions,
                                                          service_one,
+                                                         mock_get_user,
+                                                         mock_get_service_templates,
+                                                         mock_get_template_statistics,
+                                                         mock_get_jobs,
                                                          mock_get_service_statistics,
-                                                         mock_get_usage):
+                                                         mock_get_usage,
+                                                         mock_get_detailed_service):
     dashboard_totals = mocker.patch('app.main.views.dashboard.get_dashboard_totals', return_value={
         'email': {'requested': 0, 'delivered': 0, 'failed': 0},
         'sms': {'requested': 0, 'delivered': 0, 'failed': 0}

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -21,6 +21,7 @@ def test_sign_out_user(app_,
                        mock_get_jobs,
                        mock_has_permissions,
                        mock_get_template_statistics,
+                       mock_get_detailed_service,
                        mock_get_usage):
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -19,3 +19,19 @@ def test_client_posts_archived_true_when_deleting_template(mocker):
 
     client.delete_service_template(service_id, template_id)
     mock_post.assert_called_once_with(expected_url, data=expected_data)
+
+
+def test_client_gets_service_with_no_params(mocker):
+    client = ServiceAPIClient()
+    mock_post = mocker.patch('app.notify_client.service_api_client.ServiceAPIClient.get')
+
+    client.get_service('foo')
+    mock_post.assert_called_once_with('/service/foo', params={})
+
+
+def test_client_gets_service_with_detailed_params(mocker):
+    client = ServiceAPIClient()
+    mock_post = mocker.patch('app.notify_client.service_api_client.ServiceAPIClient.get')
+
+    client.get_detailed_service('foo')
+    mock_post.assert_called_once_with('/service/foo', params={'detailed': True})

--- a/tests/app/test_statistics_utils.py
+++ b/tests/app/test_statistics_utils.py
@@ -53,7 +53,7 @@ def test_sum_of_statistics_sums_inputs():
 
 
 @pytest.mark.parametrize('emails_failed,emails_requested,expected_failure_rate', [
-    (0, 0, 0),
+    (0, 0, '0'),
     (0, 1, '0.0'),
     (1, 3, '33.3')
 ])
@@ -69,7 +69,7 @@ def test_add_rates_sets_email_failure_rate(emails_failed, emails_requested, expe
 
 
 @pytest.mark.parametrize('sms_failed,sms_requested,expected_failure_rate', [
-    (0, 0, 0),
+    (0, 0, '0'),
     (0, 1, '0.0'),
     (1, 3, '33.3')
 ])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,18 +55,28 @@ def fake_uuid():
 
 @pytest.fixture(scope='function')
 def mock_get_service(mocker, api_user_active):
-    def _get(service_id, detailed=False):
+    def _get(service_id):
         service = service_json(
             service_id, "Test Service", [api_user_active.id], message_limit=1000,
             active=False, restricted=True)
-        if detailed:
-            service['statistics'] = {
-                'email': {'requested': 0, 'delivered': 0, 'failed': 0},
-                'sms': {'requested': 0, 'delivered': 0, 'failed': 0}
-            }
         return {'data': service}
 
     return mocker.patch('app.service_api_client.get_service', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def mock_get_detailed_service(mocker, api_user_active):
+    def _get(service_id):
+        service = service_json(
+            service_id, "Test Service", [api_user_active.id], message_limit=1000,
+            active=False, restricted=True)
+        service['statistics'] = {
+            'email': {'requested': 0, 'delivered': 0, 'failed': 0},
+            'sms': {'requested': 0, 'delivered': 0, 'failed': 0}
+        }
+        return {'data': service}
+
+    return mocker.patch('app.service_api_client.get_detailed_service', side_effect=_get)
 
 
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,10 +55,15 @@ def fake_uuid():
 
 @pytest.fixture(scope='function')
 def mock_get_service(mocker, api_user_active):
-    def _get(service_id):
+    def _get(service_id, detailed=False):
         service = service_json(
             service_id, "Test Service", [api_user_active.id], message_limit=1000,
             active=False, restricted=True)
+        if detailed:
+            service['statistics'] = {
+                'email': {'requested': 0, 'delivered': 0, 'failed': 0},
+                'sms': {'requested': 0, 'delivered': 0, 'failed': 0}
+            }
         return {'data': service}
 
     return mocker.patch('app.service_api_client.get_service', side_effect=_get)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,14 +67,15 @@ def mock_get_service(mocker, api_user_active):
 @pytest.fixture(scope='function')
 def mock_get_detailed_service(mocker, api_user_active):
     def _get(service_id):
-        service = service_json(
-            service_id, "Test Service", [api_user_active.id], message_limit=1000,
-            active=False, restricted=True)
-        service['statistics'] = {
-            'email': {'requested': 0, 'delivered': 0, 'failed': 0},
-            'sms': {'requested': 0, 'delivered': 0, 'failed': 0}
+        return {
+            'data': {
+                'id': service_id,
+                'statistics': {
+                    'email': {'requested': 0, 'delivered': 0, 'failed': 0},
+                    'sms': {'requested': 0, 'delivered': 0, 'failed': 0}
+                }
+            }
         }
-        return {'data': service}
 
     return mocker.patch('app.service_api_client.get_detailed_service', side_effect=_get)
 


### PR DESCRIPTION
( depends on https://github.com/alphagov/notifications-api/pull/540 )

hoo boy. Lots of blood sweat and tears went into this one.

* Some refactoring of existing `statistics_utils` functions to pull out some shared functionality
* adding `mock_get_detailed_service` to any test that hits the dashboard - `test_new_invited_user_verifies_and_added_to_service` needed a bunch of other mocks for reasons I can't decipher
* changing the partial `_totals.html` to use the slightly different, more nested new statistics structure fresh from the detailed service endpoint

(#803 waiting on this)