### PR TITLE
Too many messages

### DIFF
--- a/app/templates/partials/check/too_many_messages.html
+++ b/app/templates/partials/check/too_many_messages.html
@@ -1,0 +1,27 @@
+<div class="bottom-gutter">
+  {% call banner_wrapper(type='dangerous') %}
+    <h1 class='banner-title'>
+      Too many recipients
+    </h1>
+    {% if statistics.emails_requested or statistics.sms_requested %}
+      <p>
+        You can only send {{ current_service.message_limit }}
+        messages per day
+        {%- if current_service.restricted %}
+          in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
+        {%- endif -%}
+        .
+      </p>
+    {% endif %}
+    <p>
+      You can still send
+      {{ current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0) }}
+      messages today, but
+      ‘{{ original_file_name }}’ contains
+      {{ count_of_recipients }} {{ recipients.recipient_column_header }}
+      {%- if count_of_recipients != 1 -%}
+        {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
+      {%- endif %}
+    </p>
+  {% endcall %}
+</div>

--- a/app/templates/partials/check/too_many_messages.html
+++ b/app/templates/partials/check/too_many_messages.html
@@ -3,25 +3,24 @@
     <h1 class='banner-title'>
       Too many recipients
     </h1>
-    {% if statistics.emails_requested or statistics.sms_requested %}
-      <p>
-        You can only send {{ current_service.message_limit }}
-        messages per day
-        {%- if current_service.restricted %}
-          in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
-        {%- endif -%}
-        .
-      </p>
-    {% endif %}
     <p>
-      You can still send
-      {{ current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0) }}
-      messages today, but
+      You can only send {{ current_service.message_limit }} messages per day
+      {%- if current_service.restricted %}
+        in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
+      {%- endif -%}
+      .
+    </p>
+    <p>
+      {% if statistics.emails_requested or statistics.sms_requested %}
+        You can still send
+        {{ current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0) }}
+        messages today, but
+      {% endif %}
       ‘{{ original_file_name }}’ contains
       {{ count_of_recipients }} {{ recipients.recipient_column_header }}
       {%- if count_of_recipients != 1 -%}
         {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
-      {%- endif %}
+      {%- endif %}.
     </p>
   {% endcall %}
 </div>

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -104,35 +104,7 @@
     </div>
 
   {% elif count_of_recipients > (current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0)) %}
-
-    <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous') %}
-        <h1 class='banner-title'>
-          Too many recipients
-        </h1>
-        {% if statistics.emails_requested or statistics.sms_requested %}
-          <p>
-            You can only send {{ current_service.message_limit }}
-            messages per day
-            {%- if current_service.restricted %}
-              in <a href="{{ url_for('.trial_mode')}}">trial mode</a>
-            {%- endif -%}
-            .
-          </p>
-        {% endif %}
-        <p>
-          You can still send
-          {{ current_service.message_limit - statistics.get('emails_requested', 0) - statistics.get('sms_requested', 0) }}
-          messages today, but
-          ‘{{ original_file_name }}’ contains
-          {{ count_of_recipients }} {{ recipients.recipient_column_header }}
-          {%- if count_of_recipients != 1 -%}
-            {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
-          {%- endif %}
-        </p>
-      {% endcall %}
-    </div>
-
+    {% include "partials/check/too_many_messages.html" %}
   {% else %}
 
     <h1 class="heading-large">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def fake_uuid():
 def mock_get_service(mocker, api_user_active):
     def _get(service_id):
         service = service_json(
-            service_id, "Test Service", [api_user_active.id], message_limit=1000,
+            service_id, "Test Service", [api_user_active.id], message_limit=50,
             active=False, restricted=True)
         return {'data': service}
 


### PR DESCRIPTION
A little clean-up ahead of removing statistics from this page - moved the "csv row count goes over your daily limit" warning to its own partial file and cleaned it up a bit - it was previously only showing your total allowed messages and trial mode warning if you had not sent any messages that day - which doesn't really make sense. Now it shows that bit every time, but only shows the "how many messages you have remaining" if you've sent messages.


#### to see the changes to the template, look here: https://github.com/alphagov/notifications-admin/pull/804/commits/afce715a3d59b76392093b33ffeebe08817d42c4?w=1


It now looks like:

![image](https://cloud.githubusercontent.com/assets/5020841/17027299/3e78f7f0-4f5b-11e6-8a42-372c705da5a0.png)

![image](https://cloud.githubusercontent.com/assets/5020841/17027307/4593f846-4f5b-11e6-89f0-cc007f6454e5.png)
