### PR TITLE
Update utils for Markdown parsing + subbranding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@8.4.2#egg=notifications-utils==8.4.2
+git+https://github.com/alphagov/notifications-utils.git@8.6.0#egg=notifications-utils==8.6.0


### PR DESCRIPTION
Markdown parsing (will be active but isn’t documented):
- [x] https://github.com/alphagov/notifications-utils/pull/54

Email sub branding (not used yet):
- [x] https://github.com/alphagov/notifications-utils/pull/55