### PR TITLE
Add beta banner to homepage

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -1,7 +1,7 @@
 // Extra CSS overlaying elements
 
 #global-header-bar {
-  background-color: $red;
+  background-color: $govuk-blue;
 }
 
 #global-header {
@@ -173,4 +173,9 @@ details summary {
     border-top: 0;
   }
 
+}
+
+.phase-banner-beta {
+  border: 0;
+  margin-bottom: -$gutter + 2px;
 }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -30,6 +30,7 @@ $path: '/static/images/';
 @import 'elements/layout';
 @import 'elements/lists';
 @import 'elements/panels';
+@import 'elements/phase-banner';
 @import 'elements/tables';
 
 

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -5,9 +5,11 @@
   <!--[if gt IE 8]><!-->
   <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main.css') }}" />
   <!--<![endif]-->
+  {% if current_user.is_authenticated %}
   <style>
-    #global-header-bar { background-color: {{header_colour}} }
+      #global-header-bar { background-color: {{header_colour}} }
   </style>
+  {% endif %}
   <!--[if IE 6]>
   <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main-ie6.css') }}" />
   <![endif]-->

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -9,6 +9,13 @@
 
 {% block maincolumn_content %}
 
+  <div class="phase-banner-beta">
+    <p>
+      <strong class="phase-tag">BETA</strong>
+      <span>This is a new service – your <a href="{{ url_for('main.feedback') }}">feedback</a> will help us to improve it.</span>
+    </p>
+  </div>
+
   {% call banner_wrapper(type='intro') %}
     <h1 class="heading-medium">
       GOV.UK Notify makes it easy to send text messages and emails to


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/17205487/3bf4e000-54a3-11e6-9ff7-810a2e2c2653.png)


Because the homepage of the app is discoverable to the public, it makes “gives the wrong impression” for it not to have a beta banner.

Also makes the strip at the top red only when you’re logged in. Mainly because the red/beta orange/blue combo looks gross. And also because you’re not in admin mode until you’re logged in.