### PR TITLE
Tell invited users why we need their phone number

### DIFF
--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -14,7 +14,7 @@ Create an account – GOV.UK Notify
     <p>Your account will be created with this email: {{email_address}}</p>
     <form method="post" autocomplete="nope">
       {{ textbox(form.name, width='3-4') }}
-      {{ textbox(form.mobile_number, width='3-4') }}
+      {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a verification code by text message') }}
       {{ textbox(form.password, hint="Your password must have at least 10 characters", width='3-4') }}
       {{ page_footer("Continue") }}
       {{form.service}}


### PR DESCRIPTION
Copies the hint text from the normal register page.