### PR TITLE
Make page <title> on API info match page heading

### DIFF
--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -3,7 +3,7 @@
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
-  API keys – GOV.UK Notify
+  API integration – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/send-from-api.html
+++ b/app/templates/views/send-from-api.html
@@ -4,7 +4,7 @@
 {% from "components/api-key.html" import api_key %}
 
 {% block page_title %}
-  API integration – GOV.UK Notify
+  API info – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
Otherwise you might get it mixed up with the API integration page when you have a bunch of tabs open.