### PR TITLE
Fix newlines in HTML emails

### DIFF
--- a/app/templates/components/email-message.html
+++ b/app/templates/components/email-message.html
@@ -50,7 +50,7 @@
       {% if not expanded %}
       <div class="email-message-body-wrapper">
       {% endif %}
-        {{ body|nl2br }}
+        {{ body }}
       {% if not expanded %}
       </div>
       <div class='toggle' tabindex='0'>...<span class='visually-hidden'>show full email</span></div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.0.0#egg=notifications-python-client==1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@8.7.1#egg=notifications-utils==8.7.1
+git+https://github.com/alphagov/notifications-utils.git@8.7.2#egg=notifications-utils==8.7.2


### PR DESCRIPTION
This problem was masked because the email message component was also replacing newlines with `<br>`s.

Implements:
- [x] https://github.com/alphagov/notifications-utils/pull/60