### PR TITLE
Move guidance underneath

### DIFF
--- a/app/templates/partials/templates/guidance-character-count.html
+++ b/app/templates/partials/templates/guidance-character-count.html
@@ -1,12 +1,8 @@
-<details>
-  <summary class="button tertiary-button">Message length</summary>
-  <div id="guidance-personalisation">
-    <p>
-      If your message is long then it will
-      cost more.
-    </p>
-    <p>
-      See <a href="{{ url_for('.pricing') }}">pricing</a> for details.
-    </p>
-  </div>
-</details>
+<h2 class="heading-medium">Message length</h2>
+<p>
+  If your message is long then it will
+  cost more.
+</p>
+<p>
+  See <a href="{{ url_for('.pricing') }}">pricing</a> for details.
+</p>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,0 +1,27 @@
+<h2 class="heading-medium">Formatting</h2>
+<p>
+  To put a title in your template, use a hash:
+</p>
+<div class="panel panel-border-wide">
+  <p>
+    # This is a title
+  </p>
+</div>
+<p>
+  To make bullet points, use asterisks:
+</p>
+<div class="panel panel-border-wide">
+  <p>
+    * point 1<br/>
+    * point 2<br/>
+    * point 3<br/>
+  </p>
+</div>
+<p>
+  To add a callout, use a caret:
+</p>
+<div class="panel panel-border-wide">
+  <p>
+    ^ You must tell us if your circumstances change
+  </p>
+</div>

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -2,3 +2,8 @@
 <p>
   Always use full URLs, starting with https://
 </p>
+<div class="panel panel-border-wide">
+  <p>
+    Apply now at https://www.gov.uk/example
+  </p>
+</div>

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -1,8 +1,4 @@
-<details>
-  <summary class="button tertiary-button">Links and URLs</summary>
-  <div id="guidance-personalisation">
-    <p>
-      Always use full URLs, starting with https://
-    </p>
-  </div>
-</details>
+<h2 class="heading-medium">Links and URLs</h2>
+<p>
+  Always use full URLs, starting with https://
+</p>

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -1,14 +1,12 @@
-<details>
-  <summary class="button tertiary-button">Personalisation</summary>
-  <div id="guidance-personalisation">
-    <p>
-      Use double brackets to add personalisation.
-    </p>
-    <p>
-      Correct: ((name))
-    </p>
-    <p>
-      Incorrect: ((Helen))
-    </p>
-  </div>
-</details>
+<h2 class="heading-medium">
+  Personalisation
+</h2>
+<p>
+  Use double brackets to add personalisation.
+</p>
+<p>
+  Correct: ((name))
+</p>
+<p>
+  Incorrect: ((Helen))
+</p>

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -2,11 +2,10 @@
   Personalisation
 </h2>
 <p>
-  Use double brackets to add personalisation.
+  Use double brackets to personalise your message:
 </p>
-<p>
-  Correct: ((name))
-</p>
-<p>
-  Incorrect: ((Helen))
-</p>
+<div class="panel panel-border-wide">
+  <p>
+    Hello ((first name)), your reference is ((ref number))
+  </p>
+</div>

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -14,11 +14,11 @@
 
     <form method="post">
       <div class="grid-row">
-        <div class="column-two-thirds">
+        <div class="column-three-quarters">
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
         </div>
-        <div class="column-two-thirds">
+        <div class="column-three-quarters">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
           {{ page_footer(
             'Save',
@@ -27,6 +27,7 @@
           ) }}
         </div>
         <aside class="column-whole">
+          {% include "partials/templates/guidance-formatting.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-links.html" %}
         </aside>

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -26,8 +26,7 @@
             delete_link_text='Delete this template'
           ) }}
         </div>
-        <aside class="column-one-third">
-          <h2 style="margin: 0 0 5px 0;">Help</h2>
+        <aside class="column-whole">
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-links.html" %}
         </aside>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -25,8 +25,7 @@
             delete_link_text='Delete this template'
           ) }}
         </div>
-        <aside class="column-one-third">
-          <h2 style="margin: 0 0 5px 0;">Help</h2>
+        <aside class="column-whole">
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-links.html" %}
           {% include "partials/templates/guidance-character-count.html" %}


### PR DESCRIPTION
## Move template guidance underneath

Two problems with having it on the side:
- some users didn’t see it at all
- there wasn’t space to have additional guidance about Markdown-style formatting

## Add Gwen’s initial guidance about formatting

This is based on some work Gwen did for Civil Service Digital. Let’s get it in for now so that we have a starting point from which to improve.

This specifically doesn’t reference ‘optional’ placeholders because I don’t know how best to explain those yet.

## Text message templates

![image](https://cloud.githubusercontent.com/assets/355079/17322692/96ea5f5c-5896-11e6-8370-f613287f4a6b.png)

## Email templates

![image](https://cloud.githubusercontent.com/assets/355079/17322685/8f7fc784-5896-11e6-8216-737723aff5bc.png)
