### PR TITLE
ᴡɪᴘ Make a queued state for jobs and make it count down

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -241,7 +241,8 @@ def format_notification_status(status, template_type):
             'temporary-failure': 'Inbox not accepting messages right now',
             'permanent-failure': 'Email address doesn’t exist',
             'delivered': 'Delivered',
-            'sending': 'Sending'
+            'sending': 'Sending',
+            'created': 'Queued'
         },
         'sms': {
             'failed': 'Failed',
@@ -249,7 +250,8 @@ def format_notification_status(status, template_type):
             'temporary-failure': 'Phone not accepting messages right now',
             'permanent-failure': 'Phone number doesn’t exist',
             'delivered': 'Delivered',
-            'sending': 'Sending'
+            'sending': 'Sending',
+            'created': 'Queued'
         }
     }.get(template_type).get(status, status)
 
@@ -261,6 +263,7 @@ def format_notification_status_as_field_status(status):
         'temporary-failure': 'error',
         'permanent-failure': 'error',
         'delivered': None,
+        'created': 'default',
         'sending': 'default'
     }.get(status, 'error')
 

--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -31,6 +31,10 @@
   margin-bottom: $gutter-two-thirds;
 }
 
+.bottom-gutter-1-2 {
+  margin-bottom: $gutter-half;
+}
+
 .align-with-heading {
   display: block;
   text-align: center;

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -311,6 +311,9 @@ def _get_job_counts(job, help_argument):
 def get_job_partials(job):
     filter_args = _parse_filter_args(request.args)
     _set_status_filters(filter_args)
+    notifications = notification_api_client.get_notifications_for_service(
+        job['service'], job['id'], status=filter_args.get('status')
+    )
     return {
         'counts': render_template(
             'partials/jobs/count.html',
@@ -320,9 +323,8 @@ def get_job_partials(job):
         ),
         'notifications': render_template(
             'partials/jobs/notifications.html',
-            notifications=notification_api_client.get_notifications_for_service(
-                job['service'], job['id'], status=filter_args.get('status')
-            )['notifications'],
+            notifications=notifications['notifications'],
+            more_than_one_page=bool(notifications.get('links', {}).get('next')),
             download_link=url_for(
                 '.view_job_csv',
                 service_id=current_service['id'],

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -293,7 +293,7 @@ def _get_job_counts(job, help_argument):
             [
               'Sending', 'sending',
               (
-                  job.get('notifications_sent', 0) -
+                  job.get('notification_count', 0) -
                   job.get('notifications_delivered', 0) -
                   job.get('notifications_failed', 0)
               )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -297,11 +297,11 @@ def _get_job_counts(job, help_argument):
               job.get('notifications_failed', 0)
             ],
             [
-              'Delivered', 'delivered',
+              'delivered', 'delivered',
               job.get('notifications_delivered', 0)
             ],
             [
-              'Failed', 'failed',
+              'failed', 'failed',
               job.get('notifications_failed', 0)
             ]
         ]

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -50,7 +50,7 @@ def _set_status_filters(filter_args):
     all_failure_statuses = ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
     all_statuses = ['sending', 'delivered'] + all_failure_statuses
     if filter_args.get('status'):
-        if 'processed' in filter_args.get('status') or not filter_args.get('status'):
+        if 'processed' in filter_args.get('status'):
             filter_args['status'] = all_statuses
         elif 'failed' in filter_args.get('status'):
             filter_args['status'].extend(all_failure_statuses[1:])

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -250,7 +250,6 @@ def get_status_filters(service, message_type, statistics):
 
     filters = [
         # key, label, option
-        ('requested', 'processed', 'sending,delivered,failed'),
         ('sending', 'sending', 'sending'),
         ('delivered', 'delivered', 'delivered'),
         ('failed', 'failed', 'failed'),
@@ -287,16 +286,15 @@ def _get_job_counts(job, help_argument):
             count
         ) for label, query_param, count in [
             [
-              'Processed', '',
+              'queued', 'created',
+              job.get('notification_count', 0) -
               job.get('notifications_sent', 0)
             ],
             [
-              'Sending', 'sending',
-              (
-                  job.get('notification_count', 0) -
-                  job.get('notifications_delivered', 0) -
-                  job.get('notifications_failed', 0)
-              )
+              'sending', 'sending',
+              job.get('notifications_sent', 0) -
+              job.get('notifications_delivered', 0) -
+              job.get('notifications_failed', 0)
             ],
             [
               'Delivered', 'delivered',
@@ -304,7 +302,7 @@ def _get_job_counts(job, help_argument):
             ],
             [
               'Failed', 'failed',
-              job.get('notifications_failed')
+              job.get('notifications_failed', 0)
             ]
         ]
     ]

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -44,6 +44,12 @@
     {% endcall %}
   {% endcall %}
 
+  {% if more_than_one_page %}
+    <p class="table-show-more-link">
+      Only showing the first 50 rows
+    </p>
+  {% endif %}
+
 {% if notifications %}
   </div>
 {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -5,7 +5,7 @@
 {% endif %}
 
   {% if notifications and not help %}
-    <p class="bottom-gutter">
+    <p class="bottom-gutter-1-2">
       <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
       <span id="time-left">{{ time_left }}</span>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -35,9 +35,9 @@
 
   {% if notifications %}
     <p class="bottom-gutter-1-2">
-      <a href="{{ download_link }}" download="download" class="heading-small">Download as a CSV file</a>
+      <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
-      Delivery information is available for 7 days
+      Data available for 7 days
     </p>
   {% endif %}
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -34,7 +34,7 @@
   </div>
 
   {% if notifications %}
-    <p class="bottom-gutter">
+    <p class="bottom-gutter-1-2">
       <a href="{{ download_link }}" download="download" class="heading-small">Download as a CSV file</a>
       &emsp;
       Delivery information is available for 7 days

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -35,8 +35,8 @@ def test_should_return_list_of_all_jobs(app_,
             ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
         ),
         (
-            'processed',
-            ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
+            'created',
+            ['created']
         ),
         (
             'sending',
@@ -179,7 +179,7 @@ def test_should_show_updates_for_one_job_as_json(
 @pytest.mark.parametrize(
     "status_argument, expected_api_call", [
         (
-            'processed',
+            '',
             ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
         ),
         (
@@ -335,7 +335,6 @@ def test_get_status_filters_calculates_stats(app_):
         ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     assert {label: count for label, _option, _link, count in ret} == {
-        'processed': 6,
         'sending': 3,
         'failed': 2,
         'delivered': 1
@@ -347,7 +346,7 @@ def test_get_status_filters_in_right_order(app_):
         ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     assert [label for label, _option, _link, _count in ret] == [
-        'processed', 'sending', 'delivered', 'failed'
+        'sending', 'delivered', 'failed'
     ]
 
 
@@ -356,4 +355,4 @@ def test_get_status_filters_constructs_links(app_):
         ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     link = ret[0][2]
-    assert link == '/services/foo/notifications/sms?status={}'.format(quote('sending,delivered,failed'))
+    assert link == '/services/foo/notifications/sms?status={}'.format(quote('sending'))

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -99,6 +99,7 @@ def test_should_show_page_for_one_job(
         )
         assert csv_link.text == 'Download this report'
         assert page.find('span', {'id': 'time-left'}).text == 'Data available for 7 days'
+        assert page.find('p', {'class': 'table-show-more-link'}).text.strip() == 'Only showing the first 50 rows'
         mock_get_notifications.assert_called_with(
             service_one['id'],
             fake_uuid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -898,14 +898,16 @@ def mock_get_notifications(mocker, api_user_active):
                 template={'template_type': set_template_type, 'name': 'name', 'id': 'id', 'version': 1},
                 rows=rows,
                 status=set_status,
-                job=job
+                job=job,
+                with_links=True
             )
         else:
             return notification_json(
                 service_id,
                 rows=rows,
                 status=set_status,
-                job=job
+                job=job,
+                with_links=True
             )
 
     return mocker.patch(


### PR DESCRIPTION
It’s weird for the first count on a job to ramp up to ~200 or so and then float around as new rows are being added and older ones are being marked as delivered/failed.

It’s got no relationship to the size of the file that you uploaded. What you really want to know
is how much work Notify has remaining to do.

So let’s make a new state (queued) which is total file size minus sent. The notifications that get shown in this state are the created ones.

When nothing is queued, it switches to processed, so you can still see all the messages.


![final countdown 8](https://cloud.githubusercontent.com/assets/355079/17336082/858237f6-58d4-11e6-8e1f-6ff653cd7b96.gif)
