### PR TITLE
Make numbers on a job less confusing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -243,7 +243,8 @@ def format_notification_status(status, template_type):
             'temporary-failure': 'Inbox not accepting messages right now',
             'permanent-failure': 'Email address doesn’t exist',
             'delivered': 'Delivered',
-            'sending': 'Sending'
+            'sending': 'Sending',
+            'created': 'Sending'
         },
         'sms': {
             'failed': 'Failed',
@@ -251,7 +252,8 @@ def format_notification_status(status, template_type):
             'temporary-failure': 'Phone not accepting messages right now',
             'permanent-failure': 'Phone number doesn’t exist',
             'delivered': 'Delivered',
-            'sending': 'Sending'
+            'sending': 'Sending',
+            'created': 'Sending'
         }
     }.get(template_type).get(status, status)
 
@@ -263,7 +265,8 @@ def format_notification_status_as_field_status(status):
         'temporary-failure': 'error',
         'permanent-failure': 'error',
         'delivered': None,
-        'sending': 'default'
+        'sending': 'default',
+        'created': 'default'
     }.get(status, 'error')
 
 

--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -31,6 +31,10 @@
   margin-bottom: $gutter-two-thirds;
 }
 
+.bottom-gutter-1-2 {
+  margin-bottom: $gutter-half;
+}
+
 .align-with-heading {
   display: block;
   text-align: center;

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -2,6 +2,7 @@
 import ago
 import time
 import dateutil
+from orderedset import OrderedSet
 from datetime import datetime, timedelta, timezone
 from itertools import chain
 
@@ -51,12 +52,11 @@ def _set_status_filters(filter_args):
     status_filters = filter_args.get('status', [])
     all_failure_statuses = ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
     all_sending_statuses = ['created', 'sending']
-    all_statuses = all_sending_statuses + ['delivered'] + all_failure_statuses
-    return list(chain(
-        (status_filters or all_statuses),
-        all_sending_statuses[:1] if 'sending' in status_filters else [],
-        all_failure_statuses[1:] if 'failed' in status_filters else []
-    ))
+    return list(OrderedSet(chain(
+        (status_filters or all_sending_statuses + ['delivered'] + all_failure_statuses),
+        all_sending_statuses if 'sending' in status_filters else [],
+        all_failure_statuses if 'failed' in status_filters else []
+    )))
 
 
 @main.route("/services/<service_id>/jobs")

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -293,7 +293,7 @@ def _get_job_counts(job, help_argument):
             [
               'Sending', 'sending',
               (
-                  job.get('notifications_sent', 0) -
+                  job.get('notification_count', 0) -
                   job.get('notifications_delivered', 0) -
                   job.get('notifications_failed', 0)
               )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -48,10 +48,11 @@ def _parse_filter_args(filter_dict):
 
 def _set_status_filters(filter_args):
     all_failure_statuses = ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
-    all_statuses = ['sending', 'delivered'] + all_failure_statuses
+    all_sending_statuses = ['created', 'sending']
+    all_statuses = all_sending_statuses + ['delivered'] + all_failure_statuses
     if filter_args.get('status'):
-        if 'processed' in filter_args.get('status'):
-            filter_args['status'] = all_statuses
+        if 'sending' in filter_args.get('status'):
+            filter_args['status'].extend(all_sending_statuses[:1])
         elif 'failed' in filter_args.get('status'):
             filter_args['status'].extend(all_failure_statuses[1:])
     else:
@@ -291,12 +292,10 @@ def _get_job_counts(job, help_argument):
               job.get('notification_count', 0)
             ],
             [
-              'Sending', 'sending',
-              (
-                  job.get('notification_count', 0) -
-                  job.get('notifications_delivered', 0) -
-                  job.get('notifications_failed', 0)
-              )
+              'sending', 'sending',
+              job.get('notification_count', 0) -
+              job.get('notifications_delivered', 0) -
+              job.get('notifications_failed', 0)
             ],
             [
               'delivered', 'delivered',

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -172,7 +172,7 @@ def view_notifications(service_id, message_type):
         limit_days=current_app.config['ACTIVITY_STATS_LIMIT_DAYS'])
     view_dict = dict(
         message_type=message_type,
-        status=filter_args['status']
+        status=request.args.get('status')
     )
     prev_page = None
     if notifications['links'].get('prev', None):

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -250,7 +250,7 @@ def get_status_filters(service, message_type, statistics):
 
     filters = [
         # key, label, option
-        ('requested', 'processed', 'sending,delivered,failed'),
+        ('requested', 'total', 'sending,delivered,failed'),
         ('sending', 'sending', 'sending'),
         ('delivered', 'delivered', 'delivered'),
         ('failed', 'failed', 'failed'),
@@ -287,8 +287,8 @@ def _get_job_counts(job, help_argument):
             count
         ) for label, query_param, count in [
             [
-              'Processed', '',
-              job.get('notifications_sent', 0)
+              'total', '',
+              job.get('notification_count', 0)
             ],
             [
               'Sending', 'sending',
@@ -299,12 +299,12 @@ def _get_job_counts(job, help_argument):
               )
             ],
             [
-              'Delivered', 'delivered',
+              'delivered', 'delivered',
               job.get('notifications_delivered', 0)
             ],
             [
-              'Failed', 'failed',
-              job.get('notifications_failed')
+              'failed', 'failed',
+              job.get('notifications_failed', 0)
             ]
         ]
     ]

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -312,6 +312,9 @@ def _get_job_counts(job, help_argument):
 def get_job_partials(job):
     filter_args = _parse_filter_args(request.args)
     _set_status_filters(filter_args)
+    notifications = notification_api_client.get_notifications_for_service(
+        job['service'], job['id'], status=filter_args.get('status')
+    )
     return {
         'counts': render_template(
             'partials/jobs/count.html',
@@ -321,9 +324,9 @@ def get_job_partials(job):
         ),
         'notifications': render_template(
             'partials/jobs/notifications.html',
-            notifications=notification_api_client.get_notifications_for_service(
-                job['service'], job['id'], status=filter_args.get('status')
-            )['notifications'],
+            notifications=notifications['notifications'],
+            more_than_one_page=bool(notifications.get('links', {}).get('next')),
+            percentage_complete=(job['notifications_sent'] / job['notification_count'] * 100),
             download_link=url_for(
                 '.view_job_csv',
                 service_id=current_service['id'],

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -50,7 +50,7 @@ def _set_status_filters(filter_args):
     all_failure_statuses = ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
     all_statuses = ['sending', 'delivered'] + all_failure_statuses
     if filter_args.get('status'):
-        if 'processed' in filter_args.get('status') or not filter_args.get('status'):
+        if 'processed' in filter_args.get('status'):
             filter_args['status'] = all_statuses
         elif 'failed' in filter_args.get('status'):
             filter_args['status'].extend(all_failure_statuses[1:])

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -50,6 +50,12 @@
     {% endcall %}
   {% endcall %}
 
+  {% if more_than_one_page %}
+    <p class="table-show-more-link">
+      Only showing the first 50 rows
+    </p>
+  {% endif %}
+
 {% if notifications %}
   </div>
 {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -4,12 +4,18 @@
   <div class="dashboard-table">
 {% endif %}
 
-  {% if notifications and not help %}
-    <p class="bottom-gutter">
-      <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
-      &emsp;
-      <span id="time-left">{{ time_left }}</span>
-    </p>
+  {% if not help %}
+    {% if percentage_complete < 100 %}
+      <p class="bottom-gutter hint">
+        Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
+      </p>
+    {% elif notifications %}
+      <p class="bottom-gutter">
+        <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+        &emsp;
+        <span id="time-left">{{ time_left }}</span>
+      </p>
+    {% endif %}
   {% endif %}
 
   {% call(item, row_number) list_table(

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -6,11 +6,11 @@
 
   {% if not help %}
     {% if percentage_complete < 100 %}
-      <p class="bottom-gutter hint">
+      <p class="bottom-gutter-1-2 hint">
         Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
       </p>
     {% elif notifications %}
-      <p class="bottom-gutter">
+      <p class="bottom-gutter-1-2">
         <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
         &emsp;
         <span id="time-left">{{ time_left }}</span>

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -23,7 +23,7 @@
     {% endcall %}
     {% call field() %}
       {{ big_number(
-        item.get('notifications_sent', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0),
+        item.get('notification_count', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0),
         smallest=True
       ) }}
     {% endcall %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -35,9 +35,9 @@
 
   {% if notifications %}
     <p class="bottom-gutter-1-2">
-      <a href="{{ download_link }}" download="download" class="heading-small">Download as a CSV file</a>
+      <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
-      Delivery information is available for 7 days
+      Data available for 7 days
     </p>
   {% endif %}
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -14,9 +14,9 @@
   <h1 class="heading-large">
 
     <span class="visually-hidden">
-      {%- if request_args.get('status') != 'delivered,failed' -%}
+      {%- if status != 'delivered,failed' -%}
         {%- for label, option, _, _ in status_filters -%}
-          {%- if request_args.get('status', 'delivered,failed') == option -%}{{label}} {% endif -%}
+          {%- if status == option -%}{{label}} {% endif -%}
         {%- endfor -%}
       {%- endif -%}
     </span>
@@ -29,7 +29,7 @@
     {{ pill(
       'Status',
       status_filters,
-      request_args.get('status', '')
+      status
     ) }}
   </div>
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -34,7 +34,7 @@
   </div>
 
   {% if notifications %}
-    <p class="bottom-gutter">
+    <p class="bottom-gutter-1-2">
       <a href="{{ download_link }}" download="download" class="heading-small">Download as a CSV file</a>
       &emsp;
       Delivery information is available for 7 days

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -179,7 +179,7 @@ def test_should_show_updates_for_one_job_as_json(
 @pytest.mark.parametrize(
     "status_argument, expected_api_call", [
         (
-            'processed',
+            '',
             ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
         ),
         (
@@ -335,7 +335,7 @@ def test_get_status_filters_calculates_stats(app_):
         ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     assert {label: count for label, _option, _link, count in ret} == {
-        'processed': 6,
+        'total': 6,
         'sending': 3,
         'failed': 2,
         'delivered': 1
@@ -347,7 +347,7 @@ def test_get_status_filters_in_right_order(app_):
         ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     assert [label for label, _option, _link, _count in ret] == [
-        'processed', 'sending', 'delivered', 'failed'
+        'total', 'sending', 'delivered', 'failed'
     ]
 
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -295,10 +295,21 @@ def test_should_show_notifications_for_a_service_with_next_previous(
             ))
         assert response.status_code == 200
         content = response.get_data(as_text=True)
-        assert url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=3) in content
-        assert url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=1) in content
-        assert 'Previous page' in content
-        assert 'Next page' in content
+        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+        next_page_link = page.find('a', {'rel': 'next'})
+        prev_page_link = page.find('a', {'rel': 'previous'})
+        assert (
+            url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=3) in
+            next_page_link['href']
+        )
+        assert 'Next page' in next_page_link.text.strip()
+        assert 'page 3' in next_page_link.text.strip()
+        assert (
+            url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=1) in
+            prev_page_link['href']
+        )
+        assert 'Previous page' in prev_page_link.text.strip()
+        assert 'page 1' in prev_page_link.text.strip()
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -32,15 +32,11 @@ def test_should_return_list_of_all_jobs(app_,
     "status_argument, expected_api_call", [
         (
             '',
-            ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
-        ),
-        (
-            'processed',
-            ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
+            ['created', 'sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
         ),
         (
             'sending',
-            ['sending']
+            ['sending', 'created']
         ),
         (
             'delivered',
@@ -180,11 +176,11 @@ def test_should_show_updates_for_one_job_as_json(
     "status_argument, expected_api_call", [
         (
             '',
-            ['sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
+            ['created', 'sending', 'delivered', 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
         ),
         (
             'sending',
-            ['sending']
+            ['sending', 'created']
         ),
         (
             'delivered',

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -95,6 +95,7 @@ def test_should_show_page_for_one_job(
         )
         assert csv_link.text == 'Download this report'
         assert page.find('span', {'id': 'time-left'}).text == 'Data available for 7 days'
+        assert page.find('p', {'class': 'table-show-more-link'}).text.strip() == 'Only showing the first 50 rows'
         mock_get_notifications.assert_called_with(
             service_one['id'],
             fake_uuid,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -102,6 +102,29 @@ def test_should_show_page_for_one_job(
         )
 
 
+def test_should_show_job_in_progress(
+    app_,
+    service_one,
+    active_user_with_permissions,
+    mock_get_service_template,
+    mock_get_job_in_progress,
+    mocker,
+    mock_get_notifications,
+    fake_uuid
+):
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(active_user_with_permissions, mocker, service_one)
+        response = client.get(url_for(
+            'main.view_job',
+            service_id=service_one['id'],
+            job_id=fake_uuid
+        ))
+
+        assert response.status_code == 200
+        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+        assert page.find('p', {'class': 'hint'}).text.strip() == 'Report is 50% complete…'
+
+
 def test_should_show_not_show_csv_download_in_tour(
     app_,
     service_one,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -910,14 +910,16 @@ def mock_get_notifications(mocker, api_user_active):
                 template={'template_type': set_template_type, 'name': 'name', 'id': 'id', 'version': 1},
                 rows=rows,
                 status=set_status,
-                job=job
+                job=job,
+                with_links=True
             )
         else:
             return notification_json(
                 service_id,
                 rows=rows,
                 status=set_status,
-                job=job
+                job=job,
+                with_links=True
             )
 
     return mocker.patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -859,6 +859,18 @@ def mock_get_job(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_get_job_in_progress(mocker, api_user_active):
+    def _get_job(service_id, job_id):
+        return {"data": job_json(
+            service_id, api_user_active, job_id=job_id,
+            notification_count=10,
+            notifications_sent=5
+        )}
+
+    return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)
+
+
+@pytest.fixture(scope='function')
 def mock_get_jobs(mocker, api_user_active):
     def _get_jobs(service_id, limit_days=None):
         return {"data": [


### PR DESCRIPTION
## Summary

The counts on the job page:
- were stuff we care about more than stuff that a user should care about
- changed in quite a confusing way, eg sending moved up and down and was basically a count of Notify’s throughput, which is not a user-friendly concept

This PR changes the counts to:
- be less abstract
- only ever move in one direction

It also changes the download link to only show when processing has finished.

## Before

![img_5717](https://cloud.githubusercontent.com/assets/355079/17360610/4b6b4392-5964-11e6-8640-5b16f3cfff9b.JPG)

## After

![img_5718](https://cloud.githubusercontent.com/assets/355079/17360619/51dad292-5964-11e6-9e4c-84178ec98d44.JPG)

## In action

![final countdown 9](https://cloud.githubusercontent.com/assets/355079/17360626/5b29625a-5964-11e6-88a2-5e84b72d1556.gif)
