### PR TITLE
Stop AJAX updater consuming ever-increasing memory

### DIFF
--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -3,11 +3,16 @@
 
   var queues = {};
   var dd = new diffDOM();
+  var timer;
 
-  var getRenderer = $component => response => dd.apply(
-    $component.get(0),
-    dd.diff($component.get(0), $(response[$component.data('key')]).get(0))
-  );
+  var getRenderer = $component => response => function() {
+    var component = $component.get(0);
+    var updated = $(response[$component.data('key')]).get(0);
+    var diff = dd.diff(component, updated);
+    dd.apply(
+      component, diff
+    );
+  };
 
   var getQueue = resource => (
     queues[resource] = queues[resource] || []
@@ -29,7 +34,7 @@
       () => clearQueue(queue)
     );
 
-    setTimeout(
+    timer = setTimeout(
       () => poll(...arguments), interval
     );
 


### PR DESCRIPTION
The pages with AJAX on were feeling quite sluggish, and it felt like they were making the whole browser slow down.

Looking at the performance stuff in Chrome, the number of DOM nodes was going up and up, which is weird because the number of things on the page wasn’t changing. This was causing the page to consume more and more memory in order to store all these nodes.

<img width="1279" alt="screen shot 2016-08-03 at 08 12 06" src="https://cloud.githubusercontent.com/assets/355079/17360996/116172aa-5966-11e6-9a03-c97ef1474dac.png">

This is kinda beyond my understanding, but I tried a few things and it looks like the browser was having a hard time garbage collecting the temporary bits of DOM used to update the page.

By assigning these bits of DOM to variables before using them it seems that the browser has an easier time cleaning them up.

<img width="1280" alt="screen shot 2016-08-03 at 08 10 29" src="https://cloud.githubusercontent.com/assets/355079/17361005/1a7ac27e-5966-11e6-98d1-c5c049752291.png">

Note that memory consumption and number of nodes are staying a lot more stable in this second screenshot.