### PR TITLE
Don’t show banner on dashboard to API users

### DIFF
--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -19,7 +19,7 @@
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}
       {% endif %}
-    {% elif not current_user.has_permissions(['send_texts', 'send_emails', 'send_letters'], any_=True) %}
+    {% elif not current_user.has_permissions(['send_texts', 'send_emails', 'send_letters', 'manage_api_keys'], any_=True) %}
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 


### PR DESCRIPTION
The "you only have permission to view this service" banner sort of makes sense if you don’t have _any_ permissions, but it doesn’t if you have permission to create API keys. If you can create API keys you can do a lot more than just view the service.