### PR TITLE
Fix deskpro user email

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ in a separate terminal from the app
 
 ```
 echo "
-export NOTIFY_ADMIN_ENVIRONMENT='config.Development'
+export NOTIFY_ENVIRONMENT='development'
 export ADMIN_CLIENT_SECRET='dev-notify-secret-key'
 export ADMIN_CLIENT_USER_NAME='dev-notify-admin'
 export API_HOST_NAME='http://localhost:6011'
@@ -69,7 +69,6 @@ export DANGEROUS_SALT='dev-notify-salt'
 export SECRET_KEY='dev-notify-secret-key'
 export DESKPRO_API_HOST=""
 export DESKPRO_API_KEY=""
-export DESKPRO_PERSON_EMAIL=""
 export DESKPRO_DEPT_ID=""
 export DESKPRO_ASSIGNED_AGENT_TEAM_ID=""
 "> environment.sh

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -9,7 +9,8 @@ def feedback():
     form = Feedback()
     if form.validate_on_submit():
         data = {
-            'person_email': current_app.config.get('DESKPRO_PERSON_EMAIL'),
+            'person_email': form.email_address.data,
+            'person_name': form.name.data,
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Notify feedback',

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -8,18 +8,19 @@ from app.main.forms import Feedback
 def feedback():
     form = Feedback()
     if form.validate_on_submit():
+        user_supplied_email = form.email_address.data != ''
+        feedback_msg = 'Environment: {}\n{}\n{}'.format(
+            url_for('main.index', _external=True),
+            '' if user_supplied_email else '{} (no email address supplied)'.format(form.name.data),
+            form.feedback.data
+        )
         data = {
-            'person_email': form.email_address.data,
-            'person_name': form.name.data,
+            'person_email': form.email_address.data or current_app.config.get('DESKPRO_PERSON_EMAIL'),
+            'person_name': form.name.data or None,
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Notify feedback',
-            'message': 'Environment: {}\n\n{}\n{}\n{}'.format(
-                url_for('main.index', _external=True),
-                form.name.data,
-                form.email_address.data,
-                form.feedback.data
-            )
+            'message': feedback_msg
         }
         headers = {
             "X-DeskPRO-API-Key": current_app.config.get('DESKPRO_API_KEY'),

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -108,9 +108,7 @@ def service_request_to_go_live(service_id):
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live',
-            'message': "From {} <{}> on behalf of {} ({})\n\nUsage estimate\n---\n\n{}".format(
-                current_user.name,
-                current_user.email_address,
+            'message': "On behalf of {} ({})\n\nUsage estimate\n---\n\n{}".format(
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 form.usage.data

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -103,7 +103,8 @@ def service_request_to_go_live(service_id):
     if form.validate_on_submit():
 
         data = {
-            'person_email': current_app.config.get('DESKPRO_PERSON_EMAIL'),
+            'person_email': current_user.email_address,
+            'person_name': current_user.name,
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live',

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ class Config(object):
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'
     DESKPRO_API_HOST = os.environ['DESKPRO_API_HOST']
     DESKPRO_API_KEY = os.environ['DESKPRO_API_KEY']
-    DESKPRO_PERSON_EMAIL = os.environ['DESKPRO_PERSON_EMAIL']
+    DESKPRO_PERSON_EMAIL = 'donotreply@notifications.service.gov.uk'
     DESKPRO_DEPT_ID = os.environ['DESKPRO_DEPT_ID']
     DESKPRO_ASSIGNED_AGENT_TEAM_ID = os.environ['DESKPRO_ASSIGNED_AGENT_TEAM_ID']
     ACTIVITY_STATS_LIMIT_DAYS = 7

--- a/environment_test.sh
+++ b/environment_test.sh
@@ -6,6 +6,5 @@ export DANGEROUS_SALT='dev-notify-salt'
 export SECRET_KEY='dev-notify-secret-key'
 export DESKPRO_API_HOST=""
 export DESKPRO_API_KEY=""
-export DESKPRO_PERSON_EMAIL=""
 export DESKPRO_DEPT_ID=""
 export DESKPRO_ASSIGNED_AGENT_TEAM_ID=""

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,8 +30,6 @@ display_result $? 1 "Code style check"
 npm test
 display_result $? 2 "Front end code style check"
 
-export NOTIFY_ADMIN_ENVIRONMENT='config.Test'
-
 ## Code coverage
 py.test -n2 --cov=app --cov-report=term-missing tests/
 display_result $? 3 "Code coverage"

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -241,10 +241,9 @@ def test_should_redirect_after_request_to_go_live(
                     'subject': 'Request to go live',
                     'department_id': ANY,
                     'agent_team_id': ANY,
-                    'message': 'From Test User <test@user.gov.uk> on behalf of Test Service (http://localhost/services/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/dashboard)\n\nUsage estimate\n---\n\nOne million messages',  # noqa
-                # noqa
-                    # noqa
-                    'person_email': ANY
+                    'message': 'On behalf of Test Service (http://localhost/services/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/dashboard)\n\nUsage estimate\n---\n\nOne million messages',  # noqa
+                    'person_name': api_user_active.name,
+                    'person_email': api_user_active.email_address
                 },
                 headers=ANY
             )


### PR DESCRIPTION
that five minute fix turned out to be about an hour cos of some edge cases.

also i cleaned up behind martyn's changes to the environment files 😉 

### in deskpro: 

![image](https://cloud.githubusercontent.com/assets/5020841/17410950/de27c4d0-5a6d-11e6-996e-799ddc781908.png)

### the user sees responses like:
![image](https://cloud.githubusercontent.com/assets/5020841/17411101/9bd0f286-5a6e-11e6-853b-940ed7591807.png)


