### PR TITLE
Make ‘total’ the default status on a job

### DIFF
--- a/app/templates/partials/jobs/count.html
+++ b/app/templates/partials/jobs/count.html
@@ -1,5 +1,5 @@
 {% from "components/pill.html" import pill %}
 
 <div class="bottom-gutter">
-  {{ pill('Status', counts, status) }}
+  {{ pill('Status', counts, request.args.get('status', '')) }}
 </div>


### PR DESCRIPTION
The blue bar on the job page works out which is the current status from the query parameters, not the parameters that the API gets called with.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/17436985/de3881b2-5b12-11e6-9648-e2cddb40972f.png)

## After

![image](https://cloud.githubusercontent.com/assets/355079/17436979/cfe17718-5b12-11e6-9b38-ccea50ff857e.png)