### PR TITLE
ᵂᴵᴾ Show upcoming jobs on the dashboard

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -16,6 +16,12 @@
 
 }
 
+.big-number-inline {
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 5px;
+}
+
 .big-number-smaller {
 
   @extend %big-number;
@@ -40,7 +46,7 @@
 
   @extend %big-number;
   position: relative;
-  margin-bottom: $gutter-half;
+  margin-bottom: $gutter-two-thirds;
 
   .big-number {
     padding: $gutter-half;

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -1,3 +1,4 @@
+%show-more,
 .show-more {
 
   @include core-16;
@@ -8,7 +9,7 @@
   border-top: 1px solid $border-colour;
 
   &:focus {
-    
+
     outline: none;
     color: $text-colour;
     box-shadow: 0 -10px 0 0 $yellow;
@@ -31,4 +32,9 @@
     border-bottom: 1px solid $light-blue;
   }
 
+}
+
+.show-more-empty {
+  @extend %show-more;
+  margin-top: -10px;
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -10,11 +10,20 @@
 
 .dashboard-table {
 
+  .heading-medium {
+    margin-bottom: 5px;
+  }
+
   .table {
     table-layout: fixed;
   }
 
-  .table-field-headings,
+  .table-field-headings {
+    th {
+      font-size: 0;
+    }
+  }
+
   .table-field-headings-visible {
     th {
       padding-bottom: 5px;

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -140,6 +140,23 @@ def get_dashboard_partials(service_id):
     service = service_api_client.get_detailed_service(service_id)
 
     return {
+        'upcoming': render_template(
+            'views/dashboard/_upcoming.html',
+            upcoming_jobs=[
+                {
+                    'original_file_name': '_GAAP_show_tell 2.csv',
+                    'created_at': '2016-08-09T08:57:29.031581+00:00',
+                    'notification_count': 3984,
+                    'sending_at': '5pm'
+                },
+                {
+                    'original_file_name': 'example self.csv',
+                    'created_at': '2016-08-09T10:01:29.031581+00:00',
+                    'notification_count': 1,
+                    'sending_at': '11pm'
+                }
+            ]
+        ),
         'totals': render_template(
             'views/dashboard/_totals.html',
             service_id=service_id,

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -1,8 +1,8 @@
-{% macro big_number(number, label, link=None, currency='', smaller=False, smallest=False) %}
+{% macro big_number(number, label, link=None, currency='', smaller=False, smallest=False, inline=False) %}
   {% if link %}
     <a class="big-number-link" href="{{ link }}">
   {% endif %}
-  <div class="big-number{% if smaller %}-smaller{% endif %}{% if smallest %}-smallest{% endif %}">
+  <div class="big-number{% if smaller %}-smaller{% endif %}{% if smallest %}-smallest{% endif %} {% if inline %}big-number-inline{% endif %}">
     <div class="big-number-number">
       {% if number is number %}
         {% if currency %}

--- a/app/templates/components/show-more.html
+++ b/app/templates/components/show-more.html
@@ -1,3 +1,7 @@
-{% macro show_more(url, label) %}
-  <a href="{{ url }}" class="show-more"><span>{{ label }}</span></a>
+{% macro show_more(url=None, label=None) %}
+  {% if url and label %}
+    <a href="{{ url }}" class="show-more"><span>{{ label }}</span></a>
+  {% else %}
+    <span class="show-more-empty"></span>
+  {% endif %}
 {% endmacro %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -10,7 +10,7 @@
         Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
       </p>
     {% elif notifications %}
-      <p class="bottom-gutter-1-2">
+      <p class="bottom-gutter">
         <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
         &emsp;
         <span id="time-left">{{ time_left }}</span>

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -1,0 +1,38 @@
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/big-number.html" import big_number %}
+{% from "components/show-more.html" import show_more %}
+
+{% if upcoming_jobs %}
+  <div class='dashboard-table'>
+    <h2 class="heading-medium">
+      In the next 24 hours
+    </h2>
+    {% call(item, row_number) list_table(
+      upcoming_jobs,
+      caption="In the next 24 hours",
+      caption_visible=False,
+      empty_message='Nothing to see here',
+      field_headings=[
+        'File',
+        'Status'
+      ],
+      field_headings_visible=False
+    ) %}
+      {% call row_heading() %}
+        <div class="file-list">
+          <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+          <span class="file-list-hint">Uploaded {{ item.created_at|format_datetime_short }}</span>
+        </div>
+      {% endcall %}
+      {% call field() %}
+        {{ big_number(
+          item.notification_count,
+          smallest=True,
+          inline=True
+        ) }}
+        sending at {{ item.sending_at }}
+      {% endcall %}
+    {% endcall %}
+    {{ show_more() }}
+  </div>
+{% endif %}

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -23,6 +23,8 @@
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 
+    {{ ajax_block(partials, updates_url, 'upcoming') }}
+
     <h2 class="heading-medium">
       In the last 7 days
     </h2>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -34,7 +34,7 @@
   </div>
 
   {% if notifications %}
-    <p class="bottom-gutter-1-2">
+    <p class="bottom-gutter">
       <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
       Data available for 7 days


### PR DESCRIPTION
This commit is only a prototype of the UI, it doesn’t make any functional changes.

![image](https://cloud.githubusercontent.com/assets/355079/17516198/e3b4e03e-5e34-11e6-89db-0ea798806247.png)

- adds a new ‘in the next 24 hours’ section to the dashboard which lists upcoming jobs
- tweaks some spacing on the dashboard so that it doesn’t look like too much of a mess