### PR TITLE
ᵂᴵᴾ Show scheduled time and cancel button on job page

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,61 +1,79 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, date_field, row_heading %}
+{% from "components/page-footer.html" import page_footer %}
 
-{% if notifications %}
-  <div class="dashboard-table">
-{% endif %}
+{% if true %}
 
-  {% if not help %}
-    {% if percentage_complete < 100 %}
-      <p class="bottom-gutter-1-2 hint">
-        Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
-      </p>
-    {% elif notifications %}
-      <p class="bottom-gutter-1-2">
-        <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
-        &emsp;
-        <span id="time-left">{{ time_left }}</span>
+  <p>
+    Sending will start at 5pm
+  </p>
+
+  {{
+    page_footer(
+      button_text="Cancel sending this file",
+      destructive=True,
+      secondary_link="#",
+      secondary_link_text="Back to dashboard"
+    )
+  }}
+
+{% else %}
+  {% if notifications %}
+    <div class="dashboard-table">
+  {% endif %}
+
+    {% if not help %}
+      {% if percentage_complete < 100 %}
+        <p class="bottom-gutter-1-2 hint">
+          Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
+        </p>
+      {% elif notifications %}
+        <p class="bottom-gutter-1-2">
+          <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+          &emsp;
+          <span id="time-left">{{ time_left }}</span>
+        </p>
+      {% endif %}
+    {% endif %}
+
+    {% call(item, row_number) list_table(
+      notifications,
+      caption=uploaded_file_name,
+      caption_visible=False,
+      empty_message="No messages to show",
+      field_headings=[
+        'Recipient',
+        'Time',
+        'Status'
+      ],
+      field_headings_visible=False
+    ) %}
+      {% call row_heading() %}
+        {{ item.to }}
+      {% endcall %}
+      {{ date_field(
+        (item.updated_at or item.created_at)|format_datetime_short
+      ) }}
+      {% call field(
+        align='right',
+        status=item.status|format_notification_status_as_field_status
+      ) %}
+        {% if item.status|format_notification_status_as_url %}
+          <a href="{{ item.status|format_notification_status_as_url }}">
+        {% endif %}
+        {{ item.status|format_notification_status(item.template.template_type) }}
+        {% if item.status|format_notification_status_as_url %}
+          </a>
+        {% endif %}
+      {% endcall %}
+    {% endcall %}
+
+    {% if more_than_one_page %}
+      <p class="table-show-more-link">
+        Only showing the first 50 rows
       </p>
     {% endif %}
+
+  {% if notifications %}
+    </div>
   {% endif %}
-
-  {% call(item, row_number) list_table(
-    notifications,
-    caption=uploaded_file_name,
-    caption_visible=False,
-    empty_message="No messages to show",
-    field_headings=[
-      'Recipient',
-      'Time',
-      'Status'
-    ],
-    field_headings_visible=False
-  ) %}
-    {% call row_heading() %}
-      {{ item.to }}
-    {% endcall %}
-    {{ date_field(
-      (item.updated_at or item.created_at)|format_datetime_short
-    ) }}
-    {% call field(
-      align='right',
-      status=item.status|format_notification_status_as_field_status
-    ) %}
-      {% if item.status|format_notification_status_as_url %}
-        <a href="{{ item.status|format_notification_status_as_url }}">
-      {% endif %}
-      {{ item.status|format_notification_status(item.template.template_type) }}
-      {% if item.status|format_notification_status_as_url %}
-        </a>
-      {% endif %}
-    {% endcall %}
-  {% endcall %}
-
-  {% if more_than_one_page %}
-    <p class="table-show-more-link">
-      Only showing the first 50 rows
-    </p>
-  {% endif %}
-
-{% if notifications %}
-  </div>
 {% endif %}


### PR DESCRIPTION
This commit is only a prototype of the UI, it doesn’t make any functional changes.

![image](https://cloud.githubusercontent.com/assets/355079/17516388/dabe4b72-5e35-11e6-8fc7-931581559b8e.png)

If you’ve scheduled a job:

- you need to know what time it will start sending
- you need to be able to cancel it

This commit replaces the notification list (which we won’t have for scheduled jobs anyway) with some UI that allows the above.

Once implemented the counts will look like this for a scheduled job:

```
3128    0          0           0
total   sending    delivered   failed
```