### PR TITLE
Link to client documentation, not API documentation

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -193,13 +193,9 @@ def send_from_api(service_id, template_id):
         service_api_client.get_service_template(service_id, template_id)['data'],
         prefix=current_service['name']
     )
-    personalisation = {
-        placeholder: "..." for placeholder in template.placeholders
-    }
     return render_template(
         'views/send-from-api.html',
-        template=template,
-        personalisation=json.dumps(personalisation, indent=4) if personalisation else None
+        template=template
     )
 
 

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -92,6 +92,7 @@
         <div class="column-one-third">
           <h2>Help</h2>
           <ul>
+            <li><a href="{{ url_for("main.terms") }}">Terms of use</a></li>
             <li><a href="{{ url_for("main.trial_mode") }}">Trial mode</a></li>
             <li><a href="{{ url_for("main.pricing") }}">Pricing</a></li>
             <li><a href="{{ url_for("main.delivery_and_failure") }}">Delivery and failure</a></li>
@@ -100,7 +101,6 @@
         <div class="column-one-third">
           <h2>Documentation</h2>
           <ul>
-            <li><a href="{{ url_for("main.terms") }}">Terms of use</a></li>
             {% for language, url in [
               ('Java', 'https://github.com/alphagov/notifications-java-client'),
               ('Node JS', 'https://github.com/alphagov/notifications-node-client'),

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -101,7 +101,15 @@
           <h2>Documentation</h2>
           <ul>
             <li><a href="{{ url_for("main.terms") }}">Terms of use</a></li>
-            <li><a href="{{ url_for('main.documentation') }}">API documentation</a></li>
+            {% for language, url in [
+              ('Java', 'https://github.com/alphagov/notifications-java-client'),
+              ('Node JS', 'https://github.com/alphagov/notifications-node-client'),
+              ('PHP', 'https://github.com/alphagov/notifications-php-client'),
+              ('Python', 'https://github.com/alphagov/notifications-python-client'),
+              ('Ruby', 'https://github.com/alphagov/notifications-ruby-client')
+            ] %}
+            <li><a href="{{ url }}">{{ language }} client</a></li>
+            {% endfor %}
           </ul>
         </div>
       </div>

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -99,7 +99,7 @@
           </ul>
         </div>
         <div class="column-one-third">
-          <h2>Documentation</h2>
+          <h2>API documentation</h2>
           <ul>
             {% for language, url in [
               ('Java', 'https://github.com/alphagov/notifications-java-client'),

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -58,11 +58,19 @@
     {{ api_key(current_service.id, "Service ID", thing="service ID") }}
   </div>
 
-  <h2 class="heading-small">Documentation</h2>
-  <p>
-    See the
-    <a href="{{ url_for('.documentation') }}">
-    API documentation</a> for clients and specfications.
-  </p>
+  <h2 class="heading-small">API clients</h2>
+  <ul class="list list-bullet">
+    {% for name, url in [
+      ('Java', 'https://github.com/alphagov/notifications-java-client'),
+      ('Node JS', 'https://github.com/alphagov/notifications-node-client'),
+      ('PHP', 'https://github.com/alphagov/notifications-php-client'),
+      ('Python', 'https://github.com/alphagov/notifications-python-client'),
+      ('Ruby', 'https://github.com/alphagov/notifications-ruby-client')
+    ] %}
+    <li>
+      <a href="{{ url }}">{{ name }}</a>
+    </li>
+    {% endfor %}
+  </ul>
 
 {% endblock %}

--- a/app/templates/views/send-from-api.html
+++ b/app/templates/views/send-from-api.html
@@ -37,8 +37,4 @@
     {{ personalisation|syntax_highlight_json }}
   {% endif %}
 
-  <p>
-    <br />See the <a href="{{ url_for(".documentation") }}">developer documentation</a> for full details.
-  </p>
-
 {% endblock %}

--- a/app/templates/views/send-from-api.html
+++ b/app/templates/views/send-from-api.html
@@ -32,9 +32,4 @@
     {{ api_key(template.id, name="Template ID", thing='template ID') }}
   </div>
 
-  {% if personalisation %}
-    <h2 class="heading-small">Personalisation (all fields are required)</h2>
-    {{ personalisation|syntax_highlight_json }}
-  {% endif %}
-
 {% endblock %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -277,7 +277,6 @@ def test_menu_send_messages(mocker,
             service_id=service_one['id'],
             template_type='sms')in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
-        assert url_for('main.documentation') in page
 
         assert url_for('main.service_settings', service_id=service_one['id']) not in page
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
@@ -312,7 +311,6 @@ def test_menu_manage_service(mocker,
             template_type='sms') in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
         assert url_for('main.service_settings', service_id=service_one['id']) in page
-        assert url_for('main.documentation') in page
 
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
         assert url_for('main.show_all_services') not in page

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -251,7 +251,7 @@ def test_api_info_page(
                 follow_redirects=True
             )
         assert response.status_code == 200
-        assert 'API integration' in response.get_data(as_text=True)
+        assert 'API info' in response.get_data(as_text=True)
 
 
 def test_download_example_csv(


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/17549118/bd335ee2-5ee6-11e6-9354-032833391ce3.png)

![image](https://cloud.githubusercontent.com/assets/355079/17549183/03edf086-5ee7-11e6-9886-6824c16c3f23.png)

## Replace documentation link with links to clients

In research we found that developers orientate themselves around the API clients rather than the documentation.

We should get them to the client documentation as quickly as possible.

We currently link to the API documentation in three places:
- API integration page
- global footer
- template ‘API info’ page

For the first two this commit:
- removes the link to the documentation
- adds links to each of the 5 clients

For the last one it just removes the link entirely.

## Move terms of use into help

Terms of use is non-technical, it should sit alongside the other non-technical things like pricing.

## Rename documentation to API documentation

Everything in this column of the footer is specifically to do with the API now.

## Remove example personalisation from template page

This was of dubious value, and the syntax probably isn’t accurate for all languages.