### PR TITLE
Make Gwen’s content changes

### DIFF
--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -14,7 +14,7 @@ Create an account – GOV.UK Notify
     <p>Your account will be created with this email: {{email_address}}</p>
     <form method="post" autocomplete="nope">
       {{ textbox(form.name, width='3-4') }}
-      {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a verification code by text message') }}
+      {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       {{ textbox(form.password, hint="Your password must have at least 10 characters", width='3-4') }}
       {{ page_footer("Continue") }}
       {{form.service}}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -14,7 +14,7 @@ Create an account – GOV.UK Notify
     <form method="post" autocomplete="nope">
       {{ textbox(form.name, width='3-4') }}
       {{ textbox(form.email_address, hint="Must be from a central government organisation", width='3-4', safe_error_message=True) }}
-      {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a verification code by text message') }}
+      {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       {{ textbox(form.password, hint="At least 10 characters", width='3-4') }}
       {{ page_footer("Continue") }}
     </form>

--- a/app/templates/views/registration-continue.html
+++ b/app/templates/views/registration-continue.html
@@ -6,7 +6,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">​Now check your email​</h1>
+  <h1 class="heading-large">Check your email​</h1>
   <p>We’ve sent an email to {{ session['user_details']['email'] }}.</p>
   <p>Click the link in the email to continue your registration.</p>
 

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -30,7 +30,7 @@
 
         {{ textbox(
           form.usage,
-          label='Estimate how many emails and/or text messages you’ll send each month',
+          label='Estimate how many emails and text messages you’ll send each month',
           hint='If your estimate is likely to change, tell us how ',
           width='1-1',
           rows=5
@@ -57,7 +57,7 @@
           </li>
         </ul>
 
-        {{ page_footer('Request to go live') }}  
+        {{ page_footer('Request to go live') }}
       </form>
 
     </div>

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -13,7 +13,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large">Check your phone</h1>
 
-    <p>We’ve sent you a text message with a verification code.</p>
+    <p>We’ve sent you a text message with a security code.</p>
 
     <form autocomplete="off" method="post">
       {{ textbox(

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -8,7 +8,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">Resend verification code</h1>
+    <h1 class="heading-large">Resend security code</h1>
 
     <p>Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can resend it.</p>
 
@@ -16,7 +16,7 @@
 
 
       <p>
-      <a class="button" href="{{url_for('main.check_and_resend_verification_code')}}" role="button">Resend verification code</a>
+      <a class="button" href="{{url_for('main.check_and_resend_verification_code')}}" role="button">Resend security code</a>
       </p>
   </div>
 </div>

--- a/app/templates/views/verify-mobile.html
+++ b/app/templates/views/verify-mobile.html
@@ -10,10 +10,10 @@ Confirm your  mobile number – GOV.UK Notify
   <div class="column-two-thirds">
     <h1 class="heading-large">Confirm your mobile number</h1>
 
-    <p>We've sent you a confirmation code by text message.</p>
+    <p>We’ve sent you a security code by text message.</p>
 
       <p>
-      <label class="form-label" for="email">Enter confirmation code<br>
+      <label class="form-label" for="email">Enter security code<br>
       <input class="form-control-1-4" id="email" type="text"><br>
       <span class="font-xsmall"><a href="{{ url_for('.text-not-received-2') }}">I haven't received a text</a></span>
       </p>

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -42,7 +42,7 @@ def test_should_render_correct_resend_template_for_active_user(app_,
             assert response.status_code == 200
 
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string == 'Resend verification code'
+            assert page.h1.string == 'Resend security code'
             # there shouldn't be a form for updating mobile number
             assert page.find('form') is None
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -17,7 +17,7 @@ def test_should_render_two_factor_page(app_,
                     'email': api_user_active.email_address}
         response = client.get(url_for('main.two_factor'))
         assert response.status_code == 200
-        assert '''We’ve sent you a text message with a verification code.''' in response.get_data(as_text=True)
+        assert '''We’ve sent you a text message with a security code.''' in response.get_data(as_text=True)
 
 
 def test_should_login_user_and_redirect_to_service_dashboard(app_,

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -18,7 +18,7 @@ def test_should_return_verify_template(app_,
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
             assert page.h1.text == 'Check your phone'
             message = page.find_all('p')[1].text
-            assert message == "We’ve sent you a text message with a verification code."
+            assert message == "We’ve sent you a text message with a security code."
 
 
 def test_should_redirect_to_add_service_when_sms_code_is_correct(app_,


### PR DESCRIPTION
Gwen has made some suggestions after looking through the app:

- Change 'verification code' to 'security code': extensive testing on Verify has shown that this is understood better
- Lose the 'now' from the 'Now check your email' title
- Remove and/or from request to go live page: we don't use 'and/or' - should just stick to 'and'