### PR TITLE
Another content change from Gwen

### DIFF
--- a/app/templates/views/registration-continue.html
+++ b/app/templates/views/registration-continue.html
@@ -7,7 +7,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Check your email​</h1>
-  <p>We’ve sent an email to {{ session['user_details']['email'] }}.</p>
+  <p>An email has been sent to {{ session['user_details']['email'] }}.</p>
   <p>Click the link in the email to continue your registration.</p>
 
 {% endblock %}


### PR DESCRIPTION
_Missed this one because it was in a different email_

We don't use 'we'.

It's better to say 'An email has been sent to...'