### PR TITLE
Using new endpoint for template statistics

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -199,6 +199,8 @@ def delete_service_template(service_id, template_id):
     except HTTPError as e:
         if e.status_code == 404:
             message = '{} has never been used'.format(template['name'])
+        else:
+            raise e
 
     flash('{}. Are you sure you want to delete it?'.format(message), 'delete')
     return render_template(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 
 from notifications_utils.template import Template
 from notifications_utils.recipients import first_column_heading
-from notify_client import HTTPError
+from notifications_python_client.errors import HTTPError
 
 from app.main import main
 from app.utils import user_has_permissions

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 
 from notifications_utils.template import Template
 from notifications_utils.recipients import first_column_heading
-from notifications_python_client.errors import HTTPError
+from notify_client import HTTPError
 
 from app.main import main
 from app.utils import user_has_permissions

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -213,6 +213,10 @@ def notification_json(
             'next': '/service/{}/notifications'.format(service_id),
             'last': '/service/{}/notifications'.format(service_id)
         }
+    job_payload = None
+    if job:
+        job_payload = {'id': job['id'], 'original_file_name': job['original_file_name']}
+
     data = {
         'notifications': [{
             'to': to,
@@ -220,7 +224,7 @@ def notification_json(
                 'id': template['id'],
                 'name': template['name'],
                 'template_type': template['template_type']},
-            'job': {'id': job['id'], 'original_file_name': job['original_file_name']} if job else None,
+            'job': job_payload,
             'sent_at': sent_at,
             'status': status,
             'created_at': created_at,
@@ -228,9 +232,54 @@ def notification_json(
             'job_row_number': job_row_number,
             'template_version': template['version']
         } for i in range(rows)],
-        'total': 5,
+        'total': rows,
         'page_size': 50,
         'links': links
+    }
+    return data
+
+
+def single_notification_json(
+    service_id,
+    job=None,
+    template=None,
+    to='07123456789',
+    status=None,
+    sent_at=None,
+    job_row_number=None,
+    created_at=None,
+    updated_at=None
+):
+    if template is None:
+        template = template_json(service_id, str(generate_uuid()))
+    if sent_at is None:
+        sent_at = str(datetime.utcnow().time())
+    if created_at is None:
+        created_at = str(datetime.utcnow().time())
+    if updated_at is None:
+        updated_at = str((datetime.utcnow() + timedelta(minutes=1)).time())
+    if status is None:
+        status = 'delivered'
+    job_payload = None
+    if job:
+        job_payload = {'id': job['id'], 'original_file_name': job['original_file_name']}
+
+    data = {
+        'sent_at': sent_at,
+        'billable_units': 1,
+        'status': status,
+        'created_at': created_at,
+        'reference': None,
+        'updated_at': updated_at,
+        'template_version': 5,
+        'service': service_id,
+        'id': '29441662-17ce-4ffe-9502-fcaed73b2826',
+        'template': template,
+        'job_row_number': 0,
+        'notification_type': 'sms',
+        'api_key': None,
+        'job': job_payload,
+        'sent_by': 'mmg'
     }
     return data
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -243,21 +243,19 @@ def single_notification_json(
     service_id,
     job=None,
     template=None,
-    to='07123456789',
     status=None,
     sent_at=None,
-    job_row_number=None,
     created_at=None,
     updated_at=None
 ):
     if template is None:
         template = template_json(service_id, str(generate_uuid()))
     if sent_at is None:
-        sent_at = str(datetime.utcnow().time())
+        sent_at = str(datetime.utcnow())
     if created_at is None:
-        created_at = str(datetime.utcnow().time())
+        created_at = str(datetime.utcnow())
     if updated_at is None:
-        updated_at = str((datetime.utcnow() + timedelta(minutes=1)).time())
+        updated_at = str(datetime.utcnow() + timedelta(minutes=1))
     if status is None:
         status = 'delivered'
     job_payload = None

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -5,7 +5,7 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 from freezegun import freeze_time
-from notify_client import HTTPError
+from notifications_python_client.errors import HTTPError
 
 from tests import validate_route_permission, template_json, single_notification_json
 from app.main.views.templates import get_last_use_message, get_human_readable_delta

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from app.notify_client.models import (
     InvitedUser
 )
 
-from notify_client.errors import HTTPError
+from notifications_python_client.errors import HTTPError
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from app.notify_client.models import (
     InvitedUser
 )
 
-from notifications_python_client.errors import HTTPError
+from notify_client.errors import HTTPError
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from . import (
     notification_json,
     invite_json,
     sample_uuid,
-    generate_uuid)
+    generate_uuid, single_notification_json)
 from app.notify_client.models import (
     User,
     InvitedUser
@@ -1091,20 +1091,8 @@ def mock_get_template_statistics(mocker, service_one, fake_uuid):
 def mock_get_template_statistics_for_template(mocker, service_one):
     def _get_stats(service_id, template_id):
         template = template_json(service_id, template_id, "Test template", "sms", "Something very interesting")
-        return [
-            {
-                "usage_count": 1,
-                "template": {
-                    "name": template['name'],
-                    "template_type": template['template_type'],
-                    "id": template['id']
-                },
-                "service": template['service'],
-                "id": str(generate_uuid()),
-                "day": "2016-04-04",
-                "updated_at": "2016-04-04T12:00:00.000000+00:00"
-            }
-        ]
+        notification = single_notification_json(service_id, template=template)
+        return notification
 
     return mocker.patch(
         'app.template_statistics_client.get_template_statistics_for_template', side_effect=_get_stats)


### PR DESCRIPTION
Review BUT DON'T MERGE

Requires 
- https://github.com/alphagov/notifications-admin/pull/876
- https://github.com/alphagov/notifications-admin/pull/878
- https://github.com/alphagov/notifications-admin/pull/886

- gets notifications by template id, returning the most recent to illustrate the last use of that template.