### PR TITLE
For the brief moment when we have incompatible API versions out,

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -186,9 +186,7 @@ def delete_service_template(service_id, template_id):
     template['template_content'] = template['content']
     form = form_objects[template['template_type']](**template)
 
-    template_statistics = template_statistics_client.get_template_statistics_for_template(service_id, template['id'])
-    last_use_message = get_last_use_message(form.name.data, template_statistics)
-    flash('{}. Are you sure you want to delete it?'.format(last_use_message), 'delete')
+    flash('Are you sure you want to delete it?', 'delete')
     return render_template(
         'views/edit-{}-template.html'.format(template['template_type']),
         h1='Edit template',

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -249,7 +249,6 @@ def test_should_show_delete_template_page(app_,
     assert 'Two week reminder' in content
     assert 'Your vehicle tax is about to expire' in content
     mock_get_service_template.assert_called_with(service_id, template_id)
-    mock_get_template_statistics_for_template.assert_called_with(service_id, template_id)
 
 
 def test_should_redirect_when_deleting_a_template(app_,


### PR DESCRIPTION
We won't call template stats by template id as the format has changed. So just ask the question "do you want to delete" without the context.

