### PR TITLE
Fix admin app putting service into research mode

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -89,6 +89,7 @@ class ServiceAPIClient(NotificationsAPIClient):
             'restricted',
             'email_from',
             'reply_to_email_address',
+            'research_mode',
             'sms_sender',
             'created_by',
             'branding',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -592,29 +592,29 @@ def test_if_reply_to_email_address_set_then_form_populated(app_,
 
 
 def test_switch_service_to_research_mode(
-        app_,
-        service_one,
-        mock_login,
-        mock_get_user,
-        active_user_with_permissions,
-        mock_get_service,
-        mock_has_permissions,
-        mocker):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mocker.patch('app.service_api_client.post', return_value=service_one)
+    app_,
+    service_one,
+    mock_login,
+    mock_get_user,
+    active_user_with_permissions,
+    mock_get_service,
+    mock_has_permissions,
+    mocker
+):
+    with app_.test_request_context(), app_.test_client() as client:
+        mocker.patch('app.service_api_client.post', return_value=service_one)
 
-            client.login(active_user_with_permissions)
-            response = client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
-            assert response.status_code == 302
-            assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
-            app.service_api_client.post.assert_called_with(
-                '/service/{}'.format(service_one['id']),
-                {
-                    'research_mode': True,
-                    'created_by': active_user_with_permissions.id
-                }
-            )
+        client.login(active_user_with_permissions)
+        response = client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
+        assert response.status_code == 302
+        assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
+        app.service_api_client.post.assert_called_with(
+            '/service/{}'.format(service_one['id']),
+            {
+                'research_mode': True,
+                'created_by': active_user_with_permissions.id
+            }
+        )
 
 
 def test_switch_service_from_research_mode_to_normal(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -602,14 +602,18 @@ def test_switch_service_to_research_mode(
         mocker):
     with app_.test_request_context():
         with app_.test_client() as client:
-            mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
+            mocker.patch('app.service_api_client.post', return_value=service_one)
 
             client.login(active_user_with_permissions)
             response = client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
             assert response.status_code == 302
             assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
-            app.service_api_client.update_service_with_properties.assert_called_with(
-                service_one['id'], {"research_mode": True}
+            app.service_api_client.post.assert_called_with(
+                '/service/{}'.format(service_one['id']),
+                {
+                    'research_mode': True,
+                    'created_by': active_user_with_permissions.id
+                }
             )
 
 


### PR DESCRIPTION
We changed the `update_service` method to only update individual attributes of a service, and only allow it to update specified attributes in 0cfe106.

We neglected to specify `research_mode` as one of the allowed attributes.

This broke the app’s ability to put a service in or out of research mode.

This commit:
- makes sure the tests cover this eventuality
- fixes the bug by specifying `research_mode` as one of the allowed attributes

_See only the non-whitespace changes in 0f6a090_