### PR TITLE
Base ‘% complete’ on notifications requested

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -326,7 +326,7 @@ def get_job_partials(job):
             'partials/jobs/notifications.html',
             notifications=notifications['notifications'],
             more_than_one_page=bool(notifications.get('links', {}).get('next')),
-            percentage_complete=(job['notifications_sent'] / job['notification_count'] * 100),
+            percentage_complete=(job['notifications_requested'] / job['notification_count'] * 100),
             download_link=url_for(
                 '.view_job_csv',
                 service_id=current_service['id'],

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -18,15 +18,14 @@ class JobApiClient(BaseAPIClient):
     @staticmethod
     def __convert_statistics(job):
         results = defaultdict(int)
-        if 'statistics' in job:
-            for outcome in job['statistics']:
-                if outcome['status'] in ['failed', 'technical-failure', 'temporary-failure', 'permanent-failure']:
-                    results['failed'] += outcome['count']
-                if outcome['status'] in ['sending', 'pending', 'created']:
-                    results['sending'] += outcome['count']
-                if outcome['status'] in ['delivered']:
-                    results['delivered'] += outcome['count']
-                results['requested'] += outcome['count']
+        for outcome in job['statistics']:
+            if outcome['status'] in ['failed', 'technical-failure', 'temporary-failure', 'permanent-failure']:
+                results['failed'] += outcome['count']
+            if outcome['status'] in ['sending', 'pending', 'created']:
+                results['sending'] += outcome['count']
+            if outcome['status'] in ['delivered']:
+                results['delivered'] += outcome['count']
+            results['requested'] += outcome['count']
         return results
 
     def get_job(self, service_id, job_id=None, limit_days=None, status=None):

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -19,7 +19,8 @@ class JobApiClient(BaseAPIClient):
         results = {
             'sending': 0,
             'delivered': 0,
-            'failed': 0
+            'failed': 0,
+            'requested': 0
         }
         if 'statistics' in job:
             for outcome in job['statistics']:
@@ -29,6 +30,7 @@ class JobApiClient(BaseAPIClient):
                     results['sending'] += outcome['count']
                 if outcome['status'] in ['delivered']:
                     results['delivered'] += outcome['count']
+                results['requested'] += outcome['count']
         return results
 
     def get_job(self, service_id, job_id=None, limit_days=None, status=None):
@@ -42,6 +44,7 @@ class JobApiClient(BaseAPIClient):
                 job['data']['notifications_sent'] = stats['delivered'] + stats['failed']
                 job['data']['notifications_delivered'] = stats['delivered']
                 job['data']['notifications_failed'] = stats['failed']
+                job['data']['notifications_requested'] = stats['requested']
             return job
 
         params = {}
@@ -55,6 +58,7 @@ class JobApiClient(BaseAPIClient):
                 job['notifications_sent'] = stats['delivered'] + stats['failed']
                 job['notifications_delivered'] = stats['delivered']
                 job['notifications_failed'] = stats['failed']
+                job['notifications_requested'] = stats['requested']
 
         return jobs
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 
 from notifications_python_client.base import BaseAPIClient
 from app.notify_client import _attach_current_user
@@ -16,12 +17,7 @@ class JobApiClient(BaseAPIClient):
 
     @staticmethod
     def __convert_statistics(job):
-        results = {
-            'sending': 0,
-            'delivered': 0,
-            'failed': 0,
-            'requested': 0
-        }
+        results = defaultdict(int)
         if 'statistics' in job:
             for outcome in job['statistics']:
                 if outcome['status'] in ['failed', 'technical-failure', 'temporary-failure', 'permanent-failure']:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -156,6 +156,7 @@ def job_json(service_id,
              original_file_name="thisisatest.csv",
              notification_count=1,
              notifications_sent=1,
+             notifications_requested=1,
              status=None):
     if job_id is None:
         job_id = str(generate_uuid())
@@ -174,6 +175,7 @@ def job_json(service_id,
         'created_at': created_at,
         'notification_count': notification_count,
         'notifications_sent': notifications_sent,
+        'notifications_requested': notifications_requested,
         'status': status,
         'created_by': created_by_json(
             created_by.id,

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -154,6 +154,7 @@ def test_client_parses_job_stats(mocker):
     result = client.get_job(service_id, job_id)
 
     mock_get.assert_called_once_with(url=expected_url, params={})
+    assert result['data']['notifications_requested'] == 80
     assert result['data']['notifications_sent'] == 50
     assert result['data']['notification_count'] == 80
     assert result['data']['notifications_failed'] == 40
@@ -191,6 +192,7 @@ def test_client_parses_empty_job_stats(mocker):
     result = client.get_job(service_id, job_id)
 
     mock_get.assert_called_once_with(url=expected_url, params={})
+    assert result['data']['notifications_requested'] == 0
     assert result['data']['notifications_sent'] == 0
     assert result['data']['notification_count'] == 80
     assert result['data']['notifications_failed'] == 0
@@ -265,10 +267,12 @@ def test_client_parses_job_stats_for_service(mocker):
 
     mock_get.assert_called_once_with(url=expected_url, params={})
     assert result['data'][0]['id'] == job_1_id
+    assert result['data'][0]['notifications_requested'] == 80
     assert result['data'][0]['notifications_sent'] == 50
     assert result['data'][0]['notification_count'] == 80
     assert result['data'][0]['notifications_failed'] == 40
     assert result['data'][1]['id'] == job_2_id
+    assert result['data'][1]['notifications_requested'] == 40
     assert result['data'][1]['notifications_sent'] == 25
     assert result['data'][1]['notification_count'] == 40
     assert result['data'][1]['notifications_failed'] == 20
@@ -325,10 +329,12 @@ def test_client_parses_empty_job_stats_for_service(mocker):
 
     mock_get.assert_called_once_with(url=expected_url, params={})
     assert result['data'][0]['id'] == job_1_id
+    assert result['data'][0]['notifications_requested'] == 0
     assert result['data'][0]['notifications_sent'] == 0
     assert result['data'][0]['notification_count'] == 80
     assert result['data'][0]['notifications_failed'] == 0
     assert result['data'][1]['id'] == job_2_id
+    assert result['data'][1]['notifications_requested'] == 0
     assert result['data'][1]['notifications_sent'] == 0
     assert result['data'][1]['notification_count'] == 40
     assert result['data'][1]['notifications_failed'] == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -864,7 +864,7 @@ def mock_get_job_in_progress(mocker, api_user_active):
         return {"data": job_json(
             service_id, api_user_active, job_id=job_id,
             notification_count=10,
-            notifications_sent=5
+            notifications_requested=5
         )}
 
     return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)


### PR DESCRIPTION
A job is complete when all notifications are delivered or failed.

The ‘report’ is complete once we have all the notifications in the database.

This commit changes the meaning of the percentage from the former to the latter. This is how it was before we removed the aggregate stats for jobs.

This is important, because once the job processing is complete then you can accurately reconcile the report with the CSV file that you’ve uploaded.