### PR TITLE
Make placeholder highlighting align at all size

### DIFF
--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -7,10 +7,10 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   border-radius: 20px;
-  box-shadow: inset 9px 0 0 0 $white, inset -9px 0 0 0 $white, inset 0 -3px 0 0 $white, inset 0 3px 0 0 $white;
+  box-shadow: inset 0.47em 0 0 0 $white, inset -0.47em 0 0 0 $white, inset 0 -0.15em 0 0 $white, inset 0 0.15em 0 0 $white;
 
   .sms-message-wrapper & {
-    box-shadow: inset 9px 0 0 0 $panel-colour, inset -9px 0 0 0 $panel-colour, inset 0 -3.5px 0 0 $panel-colour, inset 0 3.5px 0 0 $panel-colour;
+    box-shadow: inset 0.47em 0 0 0 $panel-colour, inset -0.47em 0 0 0 $panel-colour, inset 0 -0.18em 0 0 $panel-colour, inset 0 0.18em 0 0 $panel-colour;
   }
 
 }
@@ -20,7 +20,7 @@
   padding-left: 3px;
   padding-right: 3px;
   border-radius: 1px;
-  box-shadow: inset 0 -2px 0 0 $white, inset 0 2px 0 0 $white;
+  box-shadow: inset 0 -0.1em 0 0 $white, inset 0 0.1em 0 0 $white;
 }
 
 .placeholder-conditional {
@@ -31,10 +31,10 @@
   border-bottom-left-radius: 20px;
   border-top-right-radius: 8px;
   border-bottom-right-radius: 8px;
-  box-shadow: inset 9px 0 0 0 $white, inset -17px 0 0 0 $white, inset 0 -3px 0 0 $white, inset 0 3px 0 0 $white;
+  box-shadow: inset 0.47em 0 0 0 $white, inset -0.89em 0 0 0 $white, inset 0 -0.16em 0 0 $white, inset 0 0.16em 0 0 $white;
 
   .sms-message-wrapper & {
-    box-shadow: inset 9px 0 0 0 $panel-colour, inset -17px 0 0 0 $panel-colour, inset 0 -3.5px 0 0 $panel-colour, inset 0 3.5px 0 0 $panel-colour;
+    box-shadow: inset 0.47em 0 0 0 $panel-colour, inset -0.89em 0 0 0 $panel-colour, inset 0 -0.18em 0 0 $panel-colour, inset 0 0.18em 0 0 $panel-colour;
   }
 
 }


### PR DESCRIPTION
Because the placeholder highlighting was defined in pixels it got slightly out of line when it was used at larger type sizes, eg inside a heading.

By using `em`s it will scale with the size of the type.

## Before
<img width="521" alt="screen shot 2016-08-30 at 15 33 21" src="https://cloud.githubusercontent.com/assets/355079/18093390/8f23346e-6ec7-11e6-98a8-c3310d74ca0c.png">

## After
<img width="522" alt="screen shot 2016-08-30 at 15 32 59" src="https://cloud.githubusercontent.com/assets/355079/18093375/88d864ee-6ec7-11e6-942e-ed197eae7ca6.png">
