### PR TITLE
Revert "Revert "Remove check for statistics not being on job""

### DIFF
--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -18,15 +18,14 @@ class JobApiClient(BaseAPIClient):
     @staticmethod
     def __convert_statistics(job):
         results = defaultdict(int)
-        if 'statistics' in job:
-            for outcome in job['statistics']:
-                if outcome['status'] in ['failed', 'technical-failure', 'temporary-failure', 'permanent-failure']:
-                    results['failed'] += outcome['count']
-                if outcome['status'] in ['sending', 'pending', 'created']:
-                    results['sending'] += outcome['count']
-                if outcome['status'] in ['delivered']:
-                    results['delivered'] += outcome['count']
-                results['requested'] += outcome['count']
+        for outcome in job['statistics']:
+            if outcome['status'] in ['failed', 'technical-failure', 'temporary-failure', 'permanent-failure']:
+                results['failed'] += outcome['count']
+            if outcome['status'] in ['sending', 'pending', 'created']:
+                results['sending'] += outcome['count']
+            if outcome['status'] in ['delivered']:
+                results['delivered'] += outcome['count']
+            results['requested'] += outcome['count']
         return results
 
     def get_job(self, service_id, job_id=None, limit_days=None, status=None):

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -71,9 +71,10 @@ class JobApiClient(BaseAPIClient):
         job = self.post(url='/service/{}/job'.format(service_id), data=data)
 
         if 'notifications_sent' not in job['data']:
-            stats = self.__convert_statistics(job)
+            stats = self.__convert_statistics(job['data'])
             job['data']['notifications_sent'] = stats['delivered'] + stats['failed']
             job['data']['notifications_delivered'] = stats['delivered']
             job['data']['notifications_failed'] = stats['failed']
+            job['data']['notifications_requested'] = stats['requested']
 
         return job

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -20,9 +20,17 @@ def test_client_creates_job_data_correctly(mocker, fake_uuid):
     expected_url = '/service/{}/job'.format(service_id)
 
     client = JobApiClient()
-    mock_post = mocker.patch('app.notify_client.job_api_client.JobApiClient.post')
+    mock_post = mocker.patch(
+        'app.notify_client.job_api_client.JobApiClient.post',
+        return_value={'data': dict(statistics=[], **expected_data)}
+    )
 
-    client.create_job(job_id, service_id, template_id, original_file_name, notification_count)
+    result = client.create_job(job_id, service_id, template_id, original_file_name, notification_count)
+
+    assert result['data']['notifications_requested'] == 0
+    assert result['data']['notifications_sent'] == 0
+    assert result['data']['notification_count'] == 1
+    assert result['data']['notifications_failed'] == 0
 
     mock_post.assert_called_once_with(url=expected_url, data=expected_data)
 


### PR DESCRIPTION
## Make sure create job client can handle statistics

The create job endpoint returns the data about the job with a `data:` wrapper. This commit makes sure that, when the client is trying to process a job which has just been created, it looks inside the `data` wrapper.

## Revert alphagov/notifications-admin#918

Don’t need to catch the case where a job doesn’t have statistics any more.

## Depends on
- [x] https://github.com/alphagov/notifications-api/pull/650