### PR TITLE
Fix problem with AJAX not updating scheduled jobs

### DIFF
--- a/app/templates/partials/jobs/count.html
+++ b/app/templates/partials/jobs/count.html
@@ -1,5 +1,5 @@
 {% from "components/pill.html" import pill %}
 
-<div class="bottom-gutter">
+<div class="bottom-gutter ajax-block-container">
   {{ pill('Status', counts, request.args.get('status', '')) }}
 </div>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,71 +1,73 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, date_field, row_heading %}
 
-{% if job.job_status == 'scheduled' %}
+<div class="ajax-block-container">
+  {% if job.job_status == 'scheduled' %}
 
-  <p>
-    Sending will start at {{ job.scheduled_for|format_time }}
-  </p>
+    <p>
+      Sending will start at {{ job.scheduled_for|format_time }}
+    </p>
 
-{% else %}
+  {% else %}
 
-  {% if notifications %}
-    <div class="dashboard-table">
-  {% endif %}
+    {% if notifications %}
+      <div class="dashboard-table">
+    {% endif %}
 
-    {% if not help %}
-      {% if percentage_complete < 100 %}
-        <p class="bottom-gutter-1-2 hint">
-          Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
-        </p>
-      {% elif notifications %}
-        <p class="bottom-gutter">
-          <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
-          &emsp;
-          <span id="time-left">{{ time_left }}</span>
+      {% if not help %}
+        {% if percentage_complete < 100 %}
+          <p class="bottom-gutter-1-2 hint">
+            Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
+          </p>
+        {% elif notifications %}
+          <p class="bottom-gutter">
+            <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+            &emsp;
+            <span id="time-left">{{ time_left }}</span>
+          </p>
+        {% endif %}
+      {% endif %}
+
+      {% call(item, row_number) list_table(
+        notifications,
+        caption=uploaded_file_name,
+        caption_visible=False,
+        empty_message="No messages to show",
+        field_headings=[
+          'Recipient',
+          'Time',
+          'Status'
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call row_heading() %}
+          {{ item.to }}
+        {% endcall %}
+        {{ date_field(
+          (item.updated_at or item.created_at)|format_datetime_short
+        ) }}
+        {% call field(
+          align='right',
+          status=item.status|format_notification_status_as_field_status
+        ) %}
+          {% if item.status|format_notification_status_as_url %}
+            <a href="{{ item.status|format_notification_status_as_url }}">
+          {% endif %}
+          {{ item.status|format_notification_status(item.template.template_type) }}
+          {% if item.status|format_notification_status_as_url %}
+            </a>
+          {% endif %}
+        {% endcall %}
+      {% endcall %}
+
+      {% if more_than_one_page %}
+        <p class="table-show-more-link">
+          Only showing the first 50 rows
         </p>
       {% endif %}
+
+    {% if notifications %}
+      </div>
     {% endif %}
 
-    {% call(item, row_number) list_table(
-      notifications,
-      caption=uploaded_file_name,
-      caption_visible=False,
-      empty_message="No messages to show",
-      field_headings=[
-        'Recipient',
-        'Time',
-        'Status'
-      ],
-      field_headings_visible=False
-    ) %}
-      {% call row_heading() %}
-        {{ item.to }}
-      {% endcall %}
-      {{ date_field(
-        (item.updated_at or item.created_at)|format_datetime_short
-      ) }}
-      {% call field(
-        align='right',
-        status=item.status|format_notification_status_as_field_status
-      ) %}
-        {% if item.status|format_notification_status_as_url %}
-          <a href="{{ item.status|format_notification_status_as_url }}">
-        {% endif %}
-        {{ item.status|format_notification_status(item.template.template_type) }}
-        {% if item.status|format_notification_status_as_url %}
-          </a>
-        {% endif %}
-      {% endcall %}
-    {% endcall %}
-
-    {% if more_than_one_page %}
-      <p class="table-show-more-link">
-        Only showing the first 50 rows
-      </p>
-    {% endif %}
-
-  {% if notifications %}
-    </div>
   {% endif %}
-
-{% endif %}
+</div>

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,4 +1,4 @@
-<div>
+<div class="ajax-block-container">
   <p class='heading-small bottom-gutter'>
     Uploaded by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
   </p>

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -1,7 +1,7 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
 {% from "components/big-number.html" import big_number -%}
 
-<div class='dashboard-table'>
+<div class='dashboard-table ajax-block-container'>
   {% call(item, row_number) list_table(
     jobs,
     caption="Recent files uploaded",

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -1,7 +1,7 @@
 {% from "components/big-number.html" import big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
 
-<div class="grid-row">
+<div class="grid-row ajax-block-container">
   <div class="column-half">
     {{ big_number_with_status(
       statistics['email']['requested'],

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -2,37 +2,39 @@
 {% from "components/big-number.html" import big_number %}
 {% from "components/show-more.html" import show_more %}
 
-{% if scheduled_jobs %}
-  <div class='dashboard-table'>
-    <h2 class="heading-medium">
-      In the next 24 hours
-    </h2>
-    {% call(item, row_number) list_table(
-      scheduled_jobs,
-      caption="In the next 24 hours",
-      caption_visible=False,
-      empty_message='Nothing to see here',
-      field_headings=[
-        'File',
-        'Messages to be sent'
-      ],
-      field_headings_visible=True
-    ) %}
-      {% call row_heading() %}
-        <div class="file-list">
-          <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
-          <span class="file-list-hint">
-            Sending at {{ item.scheduled_for|format_time }}
-          </span>
-        </div>
+<div class="ajax-block-container">
+  {% if scheduled_jobs %}
+    <div class='dashboard-table'>
+      <h2 class="heading-medium">
+        In the next 24 hours
+      </h2>
+      {% call(item, row_number) list_table(
+        scheduled_jobs,
+        caption="In the next 24 hours",
+        caption_visible=False,
+        empty_message='Nothing to see here',
+        field_headings=[
+          'File',
+          'Messages to be sent'
+        ],
+        field_headings_visible=True
+      ) %}
+        {% call row_heading() %}
+          <div class="file-list">
+            <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+            <span class="file-list-hint">
+              Sending at {{ item.scheduled_for|format_time }}
+            </span>
+          </div>
+        {% endcall %}
+        {% call field() %}
+          {{ big_number(
+            item.notification_count,
+            smallest=True
+          ) }}
+        {% endcall %}
       {% endcall %}
-      {% call field() %}
-        {{ big_number(
-          item.notification_count,
-          smallest=True
-        ) }}
-      {% endcall %}
-    {% endcall %}
-    {{ show_more() }}
-  </div>
-{% endif %}
+      {{ show_more() }}
+    </div>
+  {% endif %}
+</div>

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,6 +1,6 @@
 {% from "components/big-number.html" import big_number %}
 
-<div class='grid-row'>
+<div class='grid-row ajax-block-container'>
   <div class='column-half'>
     <div class="keyline-block">
       {{ big_number("Unlimited", 'free email allowance', smaller=True) }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "babel-core": "6.3.26",
     "babel-preset-es2015": "6.3.13",
-    "diff-dom": "2.0.3",
+    "diff-dom": "2.1.0",
     "govuk-elements-sass": "1.1.1",
     "govuk_frontend_toolkit": "4.6.0",
     "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.18.0/jinja_govuk_template-0.18.0.tgz",


### PR DESCRIPTION
## Make sure partials always have a wrapping `<div>`

The diffDOM Javascript sometimes throws an error if it can’t calculate a diff between the original content of the page and the updated HTML delivered via AJAX. The problem seems to be when there’s not one, consistent top-level element for it to base its calculations on.

This commit:
- makes sure that all AJAX-delivered partials have a wrapping `<div>`
- that this `<div>` has a consistent class name to make it clear why it’s there

## Upgrade diffDOM dependency

Features:
- Expose Diff object

Fixes:
- Reverse actions for modifyComment/Text
- Simplify diff on some text only diffs
- Simplify diff on single element removal