### PR TITLE
Fix top keyline on tables with hidden col headings

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -20,7 +20,7 @@
 
   .table-field-headings {
     th {
-      font-size: 0;
+      font-size: 1px;
     }
   }
 


### PR DESCRIPTION
The way that we collapse column headings so that they don’t take up any vertical space is by setting their `font-size` to zero. However this seems to take them out of the flow of the document, so their top border also disappears. This commit sets the `font-size` to the smallest non-zero value to avoid this.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/18172990/baa182fa-705f-11e6-8a23-cd98c51b5652.png)

## After 

![image](https://cloud.githubusercontent.com/assets/355079/18173004/cda6112c-705f-11e6-8546-6a21edd1586b.png)

## Cause

The reason for this change was tweaking the spacing of the scheduled jobs table in 4342b721f16716b99706d66813b9c8304573f079
