### PR TITLE
Fix bug where every service was ‘in’ trial mode

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -39,22 +39,24 @@
       {% endcall %}
     </div>
 
-    <div class="bottom-gutter-2">
+    {% if current_service.restricted %}
+      <div class="bottom-gutter-2">
 
-      <h2 class="heading-medium">Your service is in trial mode</h2>
+        <h2 class="heading-medium">Your service is in trial mode</h2>
 
-      <ul class='list list-bullet'>
-        <li>you can only send messages to yourself</li>
-        <li>you can add people to your team, then you can send messages to them too</li>
-        <li>you can only send 50 messages per day</li>
-      </ul>
+        <ul class='list list-bullet'>
+          <li>you can only send messages to yourself</li>
+          <li>you can add people to your team, then you can send messages to them too</li>
+          <li>you can only send 50 messages per day</li>
+        </ul>
 
-      <p>
-        To remove these restrictions
-        <a href="{{ url_for('.service_request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
-      </p>
+        <p>
+          To remove these restrictions
+          <a href="{{ url_for('.service_request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+        </p>
 
-    </div>
+      </div>
+    {% endif %}
 
     {% if current_user.has_permissions([], admin_override=True) %}
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -93,6 +93,24 @@ def test_should_redirect_after_change_service_name(app_,
         assert mock_get_services.called
 
 
+def test_show_restricted_service(
+    app_,
+    service_one,
+    mock_login,
+    mock_get_user,
+    active_user_with_permissions,
+    mock_has_permissions,
+    mock_get_service,
+    mock_get_organisation,
+):
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(active_user_with_permissions)
+        response = client.get(url_for('main.service_settings', service_id=service_one['id']))
+        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+        assert page.find('h1').text == 'Settings'
+        assert page.find_all('h2')[1].text == 'Your service is in trial mode'
+
+
 def test_switch_service_to_live(
     app_,
     service_one,
@@ -118,6 +136,24 @@ def test_switch_service_to_live(
             message_limit=250000,
             restricted=False
         )
+
+
+def test_show_live_service(
+    app_,
+    service_one,
+    mock_login,
+    mock_get_user,
+    active_user_with_permissions,
+    mock_get_live_service,
+    mock_has_permissions,
+    mock_get_organisation,
+):
+    with app_.test_request_context(), app_.test_client() as client:
+        client.login(active_user_with_permissions)
+        response = client.get(url_for('main.service_settings', service_id=service_one['id']))
+        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+        assert page.find('h1').text.strip() == 'Settings'
+        assert 'Your service is in trial mode' not in page.text
 
 
 def test_switch_service_to_restricted(


### PR DESCRIPTION
The message on the service settings page was being shown for every service, whether or not they were in trial mode.