### PR TITLE
Redirect and resend verification email when pending user attempts to login

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -38,8 +38,8 @@ def sign_in():
         user = user_api_client.get_user_by_email_or_none(form.email_address.data)
         user = _get_and_verify_user(user, form.password.data)
         if user and user.state == 'pending':
-            flash("You haven't verified your email or mobile number yet.")
-            return redirect(url_for('main.sign_in'))
+            flash("You haven't verified your email or mobile number yet. Check your email for a verification link.")
+            return redirect(url_for('main.resend_email_verification'))
 
         if user and session.get('invited_user'):
             invited_user = session.get('invited_user')

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -38,7 +38,6 @@ def sign_in():
         user = user_api_client.get_user_by_email_or_none(form.email_address.data)
         user = _get_and_verify_user(user, form.password.data)
         if user and user.state == 'pending':
-            flash("You haven't verified your email or mobile number yet. Check your email for a verification link.")
             return redirect(url_for('main.resend_email_verification'))
 
         if user and session.get('invited_user'):

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -73,8 +73,6 @@ def test_should_return_redirect_when_user_is_pending(app_,
 
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
         assert page.h1.string == 'Sign in'
-        flash_banner = page.find('div', class_='banner-dangerous').string.strip()
-        assert flash_banner == "You haven't verified your email or mobile number yet. Check your email for a verification link."  # noqa
         assert response.status_code == 200
 
 


### PR DESCRIPTION
When a pending user attempts to create an account/login they will receive another verification email (incase the email was deleted/in spam)

@quis does the message on line 41 sound okay, can amend if required?