### PR TITLE
Reword resend email page

### DIFF
--- a/app/templates/views/password-reset-sent.html
+++ b/app/templates/views/password-reset-sent.html
@@ -8,9 +8,9 @@ GOV.UK Notify
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">Now check your email</h1>
+    <h1 class="heading-large">Check your email</h1>
 
-    <p>We’ve sent you an email with a link to reset your password.</p>
+    <p>Click the link in the email to reset your password.</p>
 
   </div>
 </div>

--- a/app/templates/views/resend-email-verification.html
+++ b/app/templates/views/resend-email-verification.html
@@ -11,7 +11,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Check your email</h1>
-    <p>In order to verify your email address we've sent a new confirmation link to {{email}}</p>
+    <p>A new confirmation email has been sent to {{email}}</p>
   </div>
 </div>
 

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -21,7 +21,7 @@ def test_should_render_email_verification_resend_show_email_address_and_resend_v
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
             assert page.h1.string == 'Check your email'
-            expected = "In order to verify your email address we've sent a new confirmation link to {}".format(api_user_active.email_address)  # noqa
+            expected = "A new confirmation email has been sent to {}".format(api_user_active.email_address)
 
             message = page.find_all('p')[1].text
             assert message == expected

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -22,7 +22,7 @@ def test_should_redirect_to_password_reset_sent_for_valid_email(
             url_for('.forgot_password'),
             data={'email_address': api_user_active.email_address})
         assert response.status_code == 200
-        assert 'We’ve sent you an email with a link to reset your password.' \
+        assert 'Click the link in the email to reset your password.' \
                in response.get_data(as_text=True)
         app.user_api_client.send_reset_password_url.assert_called_once_with(api_user_active.email_address)
 
@@ -39,6 +39,6 @@ def test_should_redirect_to_password_reset_sent_for_missing_email(
             url_for('.forgot_password'),
             data={'email_address': api_user_active.email_address})
         assert response.status_code == 200
-        assert 'We’ve sent you an email with a link to reset your password.' \
+        assert 'Click the link in the email to reset your password.' \
                in response.get_data(as_text=True)
         app.user_api_client.send_reset_password_url.assert_called_once_with(api_user_active.email_address)


### PR DESCRIPTION
Changes the wording to match: https://github.com/alphagov/notifications-admin/blob/166870c5362fecd856006f264e3fe182440b87c4/app/templates/views/registration-continue.html#L10

We don’t use ‘we‘.

The ‘in order to‘ bit is unnecessarily verbose.