### PR TITLE
Fix 500 on trial mode page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -31,7 +31,7 @@ def cookies():
 
 @main.route('/trial-mode')
 def trial_mode():
-    return render_template('views/trial-mode.html', hours=hours)
+    return render_template('views/trial-mode.html')
 
 
 @main.route('/pricing')

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -15,3 +15,12 @@ def test_logged_in_user_redirects_to_choose_service(app_,
 
             response = client.get(url_for('main.sign_in', follow_redirects=True))
             assert response.location == url_for('main.choose_service', _external=True)
+
+
+@pytest.mark.parametrize('view', [
+    'cookies', 'trial_mode', 'pricing', 'terms', 'delivery_and_failure', 'documentation'
+])
+def test_static_pages(app_, view):
+    with app_.test_request_context(), app_.test_client() as client:
+        response = client.get(url_for('main.{}'.format(view)))
+        assert response.status_code == 200


### PR DESCRIPTION
I was using the trial mode page to prototype the time picker as part of 225a61ddd31721296146d56421770ac0fb4c3b7d.

I didn’t clean up properly, and left an errant undefined variable, which caused the trial mode page to `500`.

This commit:
- removes the errant argument
- adds a test for all the static pages to make sure that they at least return a `200`