### PR TITLE
Fix empty jobs table showing on dashbord

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -146,7 +146,7 @@ def get_dashboard_partials(service_id):
             'views/dashboard/_jobs.html',
             jobs=immediate_jobs
         ),
-        'has_jobs': bool(jobs),
+        'has_jobs': bool(immediate_jobs),
         'usage': render_template(
             'views/dashboard/_usage.html',
             **calculate_usage(service_api_client.get_service_usage(service_id)['data'])


### PR DESCRIPTION
If you have scheduled and then cancelled jobs this would be enough to show the jobs block on the dashboard (in other words it wasn’t filtering out cancelled jobs). However the contents of the table _were_ filtering out cancelled jobs, so the table would be empty and look broken.

This commit changes the conditional to operate on the `list` of jobs with cancelled ones filtered out.