### PR TITLE
Visual tidy up

### DIFF
--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -1,6 +1,7 @@
 .user-list {
 
   @include core-16;
+  margin-bottom: $gutter * 1.5;
 
   &-item {
 

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -8,7 +8,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="grid-row bottom-gutter-1-2">
     <div class="column-two-thirds">
       <h1 class="heading-large">
         API integration
@@ -54,11 +54,11 @@
     {% endif %}
   {% endcall %}
 
-  <div class="bottom-gutter">
+  <div class="bottom-gutter-2">
     {{ api_key(current_service.id, "Service ID", thing="service ID") }}
   </div>
 
-  <h2 class="heading-small">API clients</h2>
+  <h2 class="heading-medium">API clients</h2>
   <ul class="list list-bullet">
     {% for name, url in [
       ('Java', 'https://github.com/alphagov/notifications-java-client'),

--- a/app/templates/views/api-keys/revoke.html
+++ b/app/templates/views/api-keys/revoke.html
@@ -8,22 +8,16 @@
 
 {% block maincolumn_content %}
 
-    <div class="grid-row">
-      <div class="column-two-thirds">
+    <h1 class="heading-large">
+      Revoke API key
+    </h1>
 
-        <h1 class="heading-large">
-          Revoke API key
-        </h1>
-
-        <p>
-          ‘{{ key_name }}’ will no longer let you connect to GOV.UK Notify.
-        </p>
-        <p>
-          You can’t undo this.
-        </p>
-
-      </div>
-    </div>
+    <p>
+      ‘{{ key_name }}’ will no longer let you connect to GOV.UK Notify.
+    </p>
+    <p>
+      You can’t undo this.
+    </p>
 
     <form method="post">
       {{ page_footer(

--- a/app/templates/views/api-keys/show.html
+++ b/app/templates/views/api-keys/show.html
@@ -8,20 +8,15 @@
 
 {% block maincolumn_content %}
 
-    <div class="grid-row">
-      <div class="column-two-thirds">
 
-        <h1 class="heading-large">
-          New API key
-        </h1>
+    <h1 class="heading-large">
+      New API key
+    </h1>
 
-        <p>
-          Copy your key to somewhere safe. You won’t be able to see it again
-          once you leave this page.
-        </p>
-
-      </div>
-    </div>
+    <p>
+      Copy your key to somewhere safe. You won’t be able to see it again
+      once you leave this page.
+    </p>
 
     {{ api_key(secret, key_name) }}
 

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -17,7 +17,7 @@ Manage users – GOV.UK Notify
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="grid-row bottom-gutter">
     <div class="column-two-thirds">
       <h1 class="heading-large">
         Team members
@@ -30,7 +30,7 @@ Manage users – GOV.UK Notify
     {% endif %}
   </div>
 
-  <h2 class="heading-medium">
+  <h2 class="visually-hidden">
     Active
   </h2>
   <div class="user-list">

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -8,9 +8,6 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
-    <div class="column-three-quarters">
-
       <h1 class="heading-large">Request to go live</h1>
 
       <p>
@@ -60,7 +57,5 @@
         {{ page_footer('Request to go live') }}
       </form>
 
-    </div>
-  </div>
 
 {% endblock %}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -35,7 +35,7 @@
 
     <p>
       When you’re ready we can
-      {% if current_service %}
+      {% if current_service and current_user.has_permissions(['manage_settings'], admin_override=True) %}
         <a href="{{ url_for('main.service_request_to_go_live', service_id=current_service.id) }}">remove these restrictions</a>.
       {% else %}
         remove these restrictions.


### PR DESCRIPTION

## Only show ‘Request to go live’ link to admin users

Only users with the manage service permission can access this page, so we should only show the link to users that have this permission.

## Remove ‘active’ title on team page

This section of the page is covered by the ‘Team members’ `<h1>`.

Only the invited users is a special case that needs its own title.

![image](https://cloud.githubusercontent.com/assets/355079/18315375/b13310b8-750e-11e6-95e5-15cb7c638ace.png)

## Remove 2/3rds and 3/4 columns

These columns make the line length too short, and the text less readable.

![image](https://cloud.githubusercontent.com/assets/355079/18315427/e4e67ab2-750e-11e6-945a-335f7357bed5.png)

## Tweak spacing on API keys page

Splits the clients section out a bit more clearly.

![image](https://cloud.githubusercontent.com/assets/355079/18315481/15d6706e-750f-11e6-9b8f-8a07571ce2e1.png)
