### PR TITLE
Revert "Only show ‘Request to go live’ link to admin users"

### DIFF
--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -35,7 +35,7 @@
 
     <p>
       When you’re ready we can
-      {% if current_service and current_user.has_permissions(['manage_settings'], admin_override=True) %}
+      {% if current_service %}
         <a href="{{ url_for('main.service_request_to_go_live', service_id=current_service.id) }}">remove these restrictions</a>.
       {% else %}
         remove these restrictions.


### PR DESCRIPTION
This reverts commit 385221cf5b8e625cd768a6f1c8ac9cfa16b63f12.

The `current_user.has_permissions()` doesn’t seem to work on non-service pages. Will investigate later.