### PR TITLE
Fix overlapping text on tables of notifications

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -282,11 +282,11 @@ def format_notification_status(status, template_type):
     }.get(template_type).get(status, status)
 
 
-def format_notification_status_as_time(status, when):
+def format_notification_status_as_time(status, created, updated):
     return {
-        'sending': ' since {}'.format(when),
-        'created': ' since {}'.format(when)
-    }.get(status, when)
+        'sending': ' since {}'.format(created),
+        'created': ' since {}'.format(created)
+    }.get(status, updated)
 
 
 def format_notification_status_as_field_status(status):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -116,7 +116,7 @@ def create_app():
     application.add_template_filter(format_date_normal)
     application.add_template_filter(format_date_short)
     application.add_template_filter(format_notification_status)
-    application.add_template_filter(format_notification_status_with_time)
+    application.add_template_filter(format_notification_status_as_time)
     application.add_template_filter(format_notification_status_as_field_status)
     application.add_template_filter(format_notification_status_as_url)
 
@@ -282,12 +282,11 @@ def format_notification_status(status, template_type):
     }.get(template_type).get(status, status)
 
 
-def format_notification_status_with_time(status, template_type, when):
+def format_notification_status_as_time(status, when):
     return {
-        'delivered': 'Delivered {}'.format(when),
-        'sending': 'Sending since {}'.format(when),
-        'created': 'Sending since {}'.format(when)
-    }.get(status, format_notification_status(status, template_type))
+        'sending': ' since {}'.format(when),
+        'created': ' since {}'.format(when)
+    }.get(status, when)
 
 
 def format_notification_status_as_field_status(status):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -116,6 +116,7 @@ def create_app():
     application.add_template_filter(format_date_normal)
     application.add_template_filter(format_date_short)
     application.add_template_filter(format_notification_status)
+    application.add_template_filter(format_notification_status_with_time)
     application.add_template_filter(format_notification_status_as_field_status)
     application.add_template_filter(format_notification_status_as_url)
 
@@ -279,6 +280,14 @@ def format_notification_status(status, template_type):
             'created': 'Sending'
         }
     }.get(template_type).get(status, status)
+
+
+def format_notification_status_with_time(status, template_type, when):
+    return {
+        'delivered': 'Delivered {}'.format(when),
+        'sending': 'Sending since {}'.format(when),
+        'created': 'Sending since {}'.format(when)
+    }.get(status, format_notification_status(status, template_type))
 
 
 def format_notification_status_as_field_status(status):

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -40,7 +40,8 @@
       width: 52.5%;
       font-weight: normal;
 
-      .hint {
+      .hint,
+      p {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -122,10 +122,6 @@
     width: 15px;
   }
 
-  &-date {
-    white-space: nowrap;
-  }
-
   p {
     margin: 0 0 5px 0;
   }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -94,6 +94,13 @@
 
       }
 
+      .status-hint {
+        display: block;
+        font-weight: normal;
+        color: $red;
+        margin-top: 5px;
+      }
+
     }
 
     &-yes,

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -104,3 +104,23 @@
 {% macro hidden_field_heading(text) %}
   <span class="visuallyhidden">{{ text }}</span>
 {%- endmacro %}
+
+
+{% macro notification_status_field(notification) %}
+  {% call field(status=notification.status|format_notification_status_as_field_status, align='right') %}
+    {% if notification.status|format_notification_status_as_url %}
+      <a href="{{ notification.status|format_notification_status_as_url }}">
+    {% endif %}
+    {{ notification.status|format_notification_status(
+      notification.template.template_type
+    ) }}
+    {% if notification.status|format_notification_status_as_url %}
+      </a>
+    {% endif %}
+    <span class="status-hint">
+      {{ notification.status|format_notification_status_as_time(
+        (notification.updated_at or notification.created_at)|format_datetime_short
+      ) }}
+    </span>
+  {% endcall %}
+{% endmacro %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -113,6 +113,7 @@
     {% endif %}
     <span class="status-hint">
       {{ notification.status|format_notification_status_as_time(
+        notification.created_at|format_datetime_short,
         (notification.updated_at or notification.created_at)|format_datetime_short
       ) }}
     </span>

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -67,12 +67,6 @@
   </td>
 {%- endmacro %}
 
-{% macro date_field(text) -%}
-  <td class="table-field-date">
-    <span>{{ text }}</span>
-  </td>
-{% endmacro %}
-
 {% macro text_field(text, status='') -%}
   {% call field(status=status) %}
     {{ text }}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -57,13 +57,17 @@
           {% if item.status|format_notification_status_as_url %}
             <a href="{{ item.status|format_notification_status_as_url }}">
           {% endif %}
-          {{ item.status|format_notification_status_with_time(
-            item.template.template_type,
-            (item.updated_at or item.created_at)|format_datetime_short
+          {{ item.status|format_notification_status(
+            item.template.template_type
           ) }}
           {% if item.status|format_notification_status_as_url %}
             </a>
           {% endif %}
+          <span class="status-hint">
+            {{ item.status|format_notification_status_as_time(
+              (item.updated_at or item.created_at)|format_datetime_short
+            ) }}
+          </span>
         {% endcall %}
       {% endcall %}
 

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, date_field, row_heading %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, date_field, row_heading, notification_status_field %}
 {% from "components/page-footer.html" import page_footer %}
 
 <div class="ajax-block-container">
@@ -50,25 +50,7 @@
         {% call row_heading() %}
           <p>{{ item.to }}</p>
         {% endcall %}
-        {% call field(
-          align='right',
-          status=item.status|format_notification_status_as_field_status
-        ) %}
-          {% if item.status|format_notification_status_as_url %}
-            <a href="{{ item.status|format_notification_status_as_url }}">
-          {% endif %}
-          {{ item.status|format_notification_status(
-            item.template.template_type
-          ) }}
-          {% if item.status|format_notification_status_as_url %}
-            </a>
-          {% endif %}
-          <span class="status-hint">
-            {{ item.status|format_notification_status_as_time(
-              (item.updated_at or item.created_at)|format_datetime_short
-            ) }}
-          </span>
-        {% endcall %}
+        {{ notification_status_field(item) }}
       {% endcall %}
 
       {% if more_than_one_page %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, date_field, row_heading, notification_status_field %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, notification_status_field %}
 {% from "components/page-footer.html" import page_footer %}
 
 <div class="ajax-block-container">

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -43,17 +43,13 @@
         empty_message="No messages to show",
         field_headings=[
           'Recipient',
-          'Time',
           'Status'
         ],
         field_headings_visible=False
       ) %}
         {% call row_heading() %}
-          {{ item.to }}
+          <p>{{ item.to }}</p>
         {% endcall %}
-        {{ date_field(
-          (item.updated_at or item.created_at)|format_datetime_short
-        ) }}
         {% call field(
           align='right',
           status=item.status|format_notification_status_as_field_status
@@ -61,7 +57,10 @@
           {% if item.status|format_notification_status_as_url %}
             <a href="{{ item.status|format_notification_status_as_url }}">
           {% endif %}
-          {{ item.status|format_notification_status(item.template.template_type) }}
+          {{ item.status|format_notification_status_with_time(
+            item.template.template_type,
+            (item.updated_at or item.created_at)|format_datetime_short
+          ) }}
           {% if item.status|format_notification_status_as_url %}
             </a>
           {% endif %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, notification_status_field %}
+{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, date_field, notification_status_field %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/pill.html" import pill %}
@@ -68,26 +68,7 @@
         </p>
       {% endcall %}
 
-      {% call field(
-        align='right',
-        status=item.status|format_notification_status_as_field_status
-      ) %}
-        {% if item.status|format_notification_status_as_url %}
-          <a href="{{ item.status|format_notification_status_as_url }}">
-        {% endif %}
-        {{ item.status|format_notification_status(
-          item.template.template_type
-        ) }}
-        {% if item.status|format_notification_status_as_url %}
-          </a>
-          <br>
-        {% endif %}
-        <span class="status-hint">
-          {{ item.status|format_notification_status_as_time(
-            (item.updated_at or item.created_at)|format_datetime_short
-          ) }}
-        </span>
-      {% endcall %}
+      {{ notification_status_field(item) }}
 
     {% endcall %}
   {% if notifications %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -75,13 +75,18 @@
         {% if item.status|format_notification_status_as_url %}
           <a href="{{ item.status|format_notification_status_as_url }}">
         {% endif %}
-        {{ item.status|format_notification_status_with_time(
-          item.template.template_type,
-          (item.updated_at or item.created_at)|format_datetime_short
+        {{ item.status|format_notification_status(
+          item.template.template_type
         ) }}
         {% if item.status|format_notification_status_as_url %}
           </a>
+          <br>
         {% endif %}
+        <span class="status-hint">
+          {{ item.status|format_notification_status_as_time(
+            (item.updated_at or item.created_at)|format_datetime_short
+          ) }}
+        </span>
       {% endcall %}
 
     {% endcall %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, date_field %}
+{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, notification_status_field %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/pill.html" import pill %}
@@ -50,7 +50,7 @@
       caption="Recent activity",
       caption_visible=False,
       empty_message='No messages found',
-      field_headings=['Recipient', 'Started', 'Status'],
+      field_headings=['Recipient', 'Status'],
       field_headings_visible=False
     ) %}
 
@@ -68,15 +68,17 @@
         </p>
       {% endcall %}
 
-      {{ date_field(
-        (item.updated_at or item.created_at)|format_datetime_short
-      ) }}
-
-      {% call field(status=item.status|format_notification_status_as_field_status, align='right') %}
+      {% call field(
+        align='right',
+        status=item.status|format_notification_status_as_field_status
+      ) %}
         {% if item.status|format_notification_status_as_url %}
           <a href="{{ item.status|format_notification_status_as_url }}">
         {% endif %}
-        {{ item.status|format_notification_status(item.template.template_type) }}
+        {{ item.status|format_notification_status_with_time(
+          item.template.template_type,
+          (item.updated_at or item.created_at)|format_datetime_short
+        ) }}
         {% if item.status|format_notification_status_as_url %}
           </a>
         {% endif %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, date_field, notification_status_field %}
+{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, notification_status_field %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/pill.html" import pill %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -78,7 +78,7 @@ def test_should_show_page_for_one_job(
             '{}: Your vehicle tax is about to expire'.format(service_one['name'])
         )
         assert ' '.join(page.find('tbody').find('tr').text.split()) == (
-            '07123456789 1 January at 11:10am Delivered'
+            '07123456789 Delivered 1 January at 11:10am'
         )
         assert page.find('div', {'data-key': 'notifications'})['data-resource'] == url_for(
             'main.view_job_updates',


### PR DESCRIPTION
This commit changes the tables of notifications from 3 columns to two columns. This is so the text has more room, so it doesn’t start overlapping.

It also makes sure that if the recipient gets really long that it will be cut off with an ellipsis, rather than overlapping…

I hypothesize that if a notification fails you probably don’t care when it failed, just that it failed.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/18385843/ca4e1a20-768a-11e6-8b2e-3909f654e98a.png)


## After

![image](https://cloud.githubusercontent.com/assets/355079/18385865/f24f96a2-768a-11e6-96f6-d53403f0226b.png)