### PR TITLE
Fix exception raised when a pending user attempts to complete 'forgotten password' flow

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -28,7 +28,6 @@ from app.main.forms import LoginForm
 
 @main.route('/sign-in', methods=(['GET', 'POST']))
 def sign_in():
-
     if current_user and current_user.is_authenticated:
         return redirect(url_for('main.choose_service'))
 

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -24,6 +24,7 @@ def two_factor():
     form = TwoFactorForm(_check_code)
 
     if form.validate_on_submit():
+        import pdb; pdb.set_trace()
         try:
             user = user_api_client.get_user(user_id)
             services = service_api_client.get_services({'user_id': str(user_id)}).get('data', [])
@@ -32,7 +33,9 @@ def two_factor():
                 user.set_password(session['user_details']['password'])
                 user.reset_failed_login_count()
                 user_api_client.update_user(user)
-            login_user(user, remember=True)
+
+            activated_user = user_api_client.activate_user(user)
+            login_user(activated_user, remember=True)
         finally:
             del session['user_details']
 

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -26,6 +26,7 @@ def two_factor():
     if form.validate_on_submit():
         try:
             user = user_api_client.get_user(user_id)
+
             services = service_api_client.get_services({'user_id': str(user_id)}).get('data', [])
             # Check if coming from new password page
             if 'password' in session['user_details']:

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -26,14 +26,12 @@ def two_factor():
     if form.validate_on_submit():
         try:
             user = user_api_client.get_user(user_id)
-
             services = service_api_client.get_services({'user_id': str(user_id)}).get('data', [])
             # Check if coming from new password page
             if 'password' in session['user_details']:
                 user.set_password(session['user_details']['password'])
                 user.reset_failed_login_count()
                 user_api_client.update_user(user)
-
             activated_user = user_api_client.activate_user(user)
             login_user(activated_user, remember=True)
         finally:

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -24,7 +24,6 @@ def two_factor():
     form = TwoFactorForm(_check_code)
 
     if form.validate_on_submit():
-        import pdb; pdb.set_trace()
         try:
             user = user_api_client.get_user(user_id)
             services = service_api_client.get_services({'user_id': str(user_id)}).get('data', [])

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -124,5 +124,8 @@ class UserApiClient(BaseAPIClient):
         return True
 
     def activate_user(self, user):
-        user.state = 'active'
-        return self.update_user(user)
+        if user.state == 'pending':
+            user.state = 'active'
+            return self.update_user(user)
+        else:
+            return user

--- a/app/utils.py
+++ b/app/utils.py
@@ -54,6 +54,7 @@ def user_has_permissions(*permissions, admin_override=False, any_=False):
 def redirect_to_sign_in(f):
     @wraps(f)
     def wrapped(*args, **kwargs):
+        import pdb; pdb.set_trace()
         if 'user_details' not in session:
             return redirect(url_for('main.sign_in'))
         else:

--- a/app/utils.py
+++ b/app/utils.py
@@ -54,7 +54,6 @@ def user_has_permissions(*permissions, admin_override=False, any_=False):
 def redirect_to_sign_in(f):
     @wraps(f)
     def wrapped(*args, **kwargs):
-        import pdb; pdb.set_trace()
         if 'user_details' not in session:
             return redirect(url_for('main.sign_in'))
         else:

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -39,15 +39,16 @@ def test_should_redirect_to_add_service_when_sms_code_is_correct(app_,
 
 
 def test_should_activate_user_after_verify(app_,
-                                           api_user_active,
-                                           mock_get_user,
+                                           mocker,
+                                           api_user_pending,
                                            mock_send_verify_code,
                                            mock_check_verify_code,
                                            mock_update_user):
+    mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
+                session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
             client.post(url_for('main.verify'),
                         data={'sms_code': '12345'})
             assert mock_update_user.called


### PR DESCRIPTION
1. If a pending user executes the 'forgotten password' flow (click link in email + two factor auth) an exception is raised as their account has not been activated. If a user was able to complete the 'forgotten password' flow successfully, their account should be activated as at this point we are sure they have access to the email account and phone. The corresponding test was also added.

2. Fixes a test ensuring that a user is activated after they verify. Previous to this an activated user was passed in which does not test the functionality correctly.

3. Ensure the DB write that activates the user is only carried out if necessary.