### PR TITLE
Add custom static error pages for 413 and some 5xx errors

### DIFF
--- a/app/assets/error_pages/413.html
+++ b/app/assets/error_pages/413.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en"><!--<![endif]--><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+    <title>GOV.UK Notify - Upload file size limit reached</title>
+
+    <!--[if gt IE 8]><!--><link href="/static/stylesheets/govuk-template.css" media="screen" rel="stylesheet"><!--<![endif]-->
+    <!--[if IE 6]><link href="/static/stylesheets/stylesheets/govuk-template-ie6.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 7]><link href="/static/stylesheets/stylesheets/govuk-template-ie7.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 8]><link href="/static/stylesheets/stylesheets/govuk-template-ie8.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
+    <link href="/static/stylesheets/govuk-template-print.css" media="print" rel="stylesheet">
+
+    <!--[if IE 8]><link href="/static/stylesheets/stylesheets/fonts-ie8.css?0.18.0" media="all" rel="stylesheet" /><![endif]-->
+    <!--[if gte IE 9]><!--><link href="/static/stylesheets/fonts.css" media="all" rel="stylesheet"><!--<![endif]-->
+    <!--[if lt IE 9]><script src="/static/javascripts/javascripts/ie.js?0.18.0"></script><![endif]-->
+
+    <link rel="shortcut icon" href="/static/images/favicon.ico?0.18.0" type="image/x-icon">
+    <link rel="mask-icon" href="/static/images/gov.uk_logotype_crown.svg?0.18.0" color="#0b0c0c">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/static/images/apple-touch-icon-152x152.png?0.18.0">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/static/images/apple-touch-icon-120x120.png?0.18.0">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/static/images/apple-touch-icon-76x76.png?0.18.0">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/apple-touch-icon-60x60.png?0.18.0">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!--[if gt IE 8]><!-->
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/main.css">
+    <!--<![endif]-->
+
+    <!--[if IE 6]>
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/stylesheets/main-ie6.css?15c05585e53d8492f7f0b5afc95d54b4" />
+    <![endif]-->
+    <!--[if IE 7]>
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/stylesheets/main-ie7.css?109878a484bb54a79876f3df007881d4" />
+    <![endif]-->
+    <!--[if IE 8]>
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/stylesheets/main-ie8.css?fb4ddf0b7d274e9a08bd53ab9913b406" />
+    <![endif]-->
+
+  <style type="text/css">:root #content > #right > .dose > .dosesingle,
+:root #content > #center > .dose > .dosesingle
+{display:none !important;}</style></head>
+
+  <body class="js-enabled">
+    <script async="" src="http://www.google-analytics.com/analytics.js"></script>
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink">Skip to main content</a>
+      </div>
+    </div>
+
+    <header role="banner" id="global-header" class="with-proposition">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="/" title="Go to the GOV.UK homepage" id="logo" class="content">
+              <img src="/static/images/gov.uk_logotype_crown_invert_trans.png" width="35" height="31" alt=""> GOV.UK Notify
+            </a>
+          </div>
+
+
+        </div>
+
+      </div>
+    </header>
+
+
+
+
+    <div id="global-header-bar"></div>
+
+
+  <div id="content">
+
+  <main role="main">
+
+
+
+
+
+    <h1 class="heading-large">
+      Upload file size limit reached
+    </h1>
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <p>
+          The files you were trying to upload were too big, please try again with smaller files.
+        </p>
+      </div>
+    </div>
+
+  </main>
+
+  </div>
+
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+
+      <div class="footer-wrapper">
+
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+
+  <nav class="footer-nav">
+    Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+  </nav>
+
+
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+
+                <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+
+    <script src="/static/javascripts/govuk-template.js"></script>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-75215134-1', 'auto');
+    ga('send', 'pageview');
+  </script>
+
+
+</body></html>

--- a/app/assets/error_pages/413.html
+++ b/app/assets/error_pages/413.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en"><!--<![endif]--><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
-    <title>GOV.UK Notify - Upload file size limit reached</title>
+    <title>GOV.UK Notify - The file you uploaded was too big</title>
 
     <!--[if gt IE 8]><!--><link href="/static/stylesheets/govuk-template.css" media="screen" rel="stylesheet"><!--<![endif]-->
     <!--[if IE 6]><link href="/static/stylesheets/stylesheets/govuk-template-ie6.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
@@ -79,12 +79,15 @@
 
 
     <h1 class="heading-large">
-      Upload file size limit reached
+      The file you uploaded was too big
     </h1>
     <div class="grid-row">
       <div class="column-two-thirds">
         <p>
-          The files you were trying to upload were too big, please try again with smaller files.
+          Files must be smaller than 5 MB.
+        </p>
+        <p>
+          <a href="javascript: history.go(-1)">Go back and try again.</a>
         </p>
       </div>
     </div>

--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en"><!--<![endif]--><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+    <title>GOV.UK Notify - Internal Server Error</title>
+
+    <!--[if gt IE 8]><!--><link href="/static/stylesheets/govuk-template.css" media="screen" rel="stylesheet"><!--<![endif]-->
+    <!--[if IE 6]><link href="/static/stylesheets/stylesheets/govuk-template-ie6.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 7]><link href="/static/stylesheets/stylesheets/govuk-template-ie7.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 8]><link href="/static/stylesheets/stylesheets/govuk-template-ie8.css?0.18.0" media="screen" rel="stylesheet" /><![endif]-->
+    <link href="/static/stylesheets/govuk-template-print.css" media="print" rel="stylesheet">
+
+    <!--[if IE 8]><link href="/static/stylesheets/stylesheets/fonts-ie8.css?0.18.0" media="all" rel="stylesheet" /><![endif]-->
+    <!--[if gte IE 9]><!--><link href="/static/stylesheets/fonts.css" media="all" rel="stylesheet"><!--<![endif]-->
+    <!--[if lt IE 9]><script src="/static/javascripts/javascripts/ie.js?0.18.0"></script><![endif]-->
+
+    <link rel="shortcut icon" href="/static/images/favicon.ico?0.18.0" type="image/x-icon">
+    <link rel="mask-icon" href="/static/images/gov.uk_logotype_crown.svg?0.18.0" color="#0b0c0c">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/static/images/apple-touch-icon-152x152.png?0.18.0">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/static/images/apple-touch-icon-120x120.png?0.18.0">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/static/images/apple-touch-icon-76x76.png?0.18.0">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/apple-touch-icon-60x60.png?0.18.0">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!--[if gt IE 8]><!-->
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/main.css">
+    <!--<![endif]-->
+
+    <!--[if IE 6]>
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/stylesheets/main-ie6.css?15c05585e53d8492f7f0b5afc95d54b4" />
+    <![endif]-->
+    <!--[if IE 7]>
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/stylesheets/main-ie7.css?109878a484bb54a79876f3df007881d4" />
+    <![endif]-->
+    <!--[if IE 8]>
+    <link rel="stylesheet" media="screen" href="/static/stylesheets/stylesheets/main-ie8.css?fb4ddf0b7d274e9a08bd53ab9913b406" />
+    <![endif]-->
+
+  <style type="text/css">:root #content > #right > .dose > .dosesingle,
+:root #content > #center > .dose > .dosesingle
+{display:none !important;}</style></head>
+
+  <body class="js-enabled">
+    <script async="" src="http://www.google-analytics.com/analytics.js"></script>
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink">Skip to main content</a>
+      </div>
+    </div>
+
+    <header role="banner" id="global-header" class="with-proposition">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="/" title="Go to the GOV.UK homepage" id="logo" class="content">
+              <img src="/static/images/gov.uk_logotype_crown_invert_trans.png" width="35" height="31" alt=""> GOV.UK Notify
+            </a>
+          </div>
+
+
+        </div>
+
+      </div>
+    </header>
+
+
+
+
+    <div id="global-header-bar"></div>
+
+
+  <div id="content">
+
+  <main role="main">
+
+
+
+
+
+    <h1 class="heading-large">
+      Something unexpected happened, sorry about it.
+    </h1>
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <p>
+          We were notified about the issue, but if the problem persists feel free to contact us.
+        </p>
+      </div>
+    </div>
+
+  </main>
+
+  </div>
+
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+
+      <div class="footer-wrapper">
+
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+
+  <nav class="footer-nav">
+    Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+  </nav>
+
+
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+
+                <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+
+    <script src="/static/javascripts/govuk-template.js"></script>
+
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-75215134-1', 'auto');
+    ga('send', 'pageview');
+  </script>
+
+
+</body></html>

--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -79,12 +79,12 @@
 
 
     <h1 class="heading-large">
-      Something unexpected happened, sorry about it.
+      Sorry, we’re experiencing technical difficulties
     </h1>
     <div class="grid-row">
       <div class="column-two-thirds">
         <p>
-          We were notified about the issue, but if the problem persists feel free to contact us.
+          Try again later.
         </p>
       </div>
     </div>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -103,6 +103,10 @@ gulp.task('images', () => gulp
   .pipe(gulp.dest(paths.dist + 'images/'))
 );
 
+gulp.task('copy:govuk_template:error_page', () => gulp.src(paths.src + 'error_pages/**/*')
+  .pipe(gulp.dest(paths.dist + 'error_pages/'))
+);
+
 
 // Watch for changes and re-run tasks
 gulp.task('watchForChanges', function() {
@@ -141,6 +145,7 @@ gulp.task('default',
     'copy:govuk_template:images',
     'copy:govuk_template:css',
     'copy:govuk_template:js',
+    'copy:govuk_template:error_page',
     'javascripts',
     'sass',
     'images'


### PR DESCRIPTION
I used the template provided by @quis previously for the fail whale page.
The wording is temporary, I'll need the final texts for these pages.

413 page:

<img width="984" alt="413" src="https://cloud.githubusercontent.com/assets/868104/18441139/c6f38768-7903-11e6-82e3-edb11e544cff.png">

500, 502, 503, 504 error page:

<img width="994" alt="5xx" src="https://cloud.githubusercontent.com/assets/868104/18441140/c9247f4c-7903-11e6-8c4f-076092505405.png">

Note: any 404 will be simply showing the <site>/404 url which will show the built-in 404 page.

Infrastructure PR: https://github.com/alphagov/notifications-aws/pull/47