### PR TITLE
Bump utils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
 
-git+https://github.com/alphagov/notifications-utils.git@9.0.0#egg=notifications-utils==9.0.0
+git+https://github.com/alphagov/notifications-utils.git@9.0.2#egg=notifications-utils==9.0.2


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/67 (doesn’t affect this app)
- [x] https://github.com/alphagov/notifications-utils/pull/68