### PR TITLE
Link to GOV.UK tech doc format for Python client

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -105,7 +105,7 @@
               ('Java', 'https://github.com/alphagov/notifications-java-client'),
               ('Node JS', 'https://github.com/alphagov/notifications-node-client'),
               ('PHP', 'https://github.com/alphagov/notifications-php-client'),
-              ('Python', 'https://github.com/alphagov/notifications-python-client'),
+              ('Python', 'https://quis.github.io/govuk_documentation_prototype/'),
               ('Ruby', 'https://github.com/alphagov/notifications-ruby-client')
             ] %}
             <li><a href="{{ url }}">{{ language }} client</a></li>

--- a/app/templates/views/api-keys.html
+++ b/app/templates/views/api-keys.html
@@ -64,7 +64,7 @@
       ('Java', 'https://github.com/alphagov/notifications-java-client'),
       ('Node JS', 'https://github.com/alphagov/notifications-node-client'),
       ('PHP', 'https://github.com/alphagov/notifications-php-client'),
-      ('Python', 'https://github.com/alphagov/notifications-python-client'),
+      ('Python', 'https://quis.github.io/govuk_documentation_prototype/'),
       ('Ruby', 'https://github.com/alphagov/notifications-ruby-client')
     ] %}
     <li>


### PR DESCRIPTION
We want to try this out in research tomorrow, instead of the README style doc we’ve been using up to this point.