### PR TITLE
Add more markdown to the example email

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -63,8 +63,8 @@ def email_template():
         '\n\n'
         'It has '
         'survived not only'
-        '\n'
-        '*five centuries'
+        '\n\n'
+        '* five centuries'
         '\n'
         '* but also the leap into electronic typesetting'
         '\n\n'
@@ -81,7 +81,15 @@ def email_template():
         'normal distribution of letters, as opposed to using ‘Content '
         'here, content here’, making it look like readable English.'
         '\n\n\n'
+        '1. One'
+        '\n'
+        '2. Two'
+        '\n'
+        '10. Three'
+        '\n\n'
         'This is an example of an email sent using GOV.UK Notify.'
+        '\n\n'
+        'https://www.notifications.service.gov.uk'
     )
 
 


### PR DESCRIPTION
We have a route at /_email for testing the email template.

This commit adds:
- ordered lists
- a URL

And it fixes:
- the unordered list (markdown requires two line break before starting
  a list)

This is so that we can test how these features look locally without having to send an email.