### PR TITLE
Don’t inherit directly from admin template

### DIFF
--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -1,4 +1,4 @@
-{% extends "admin_template.html" %}
+{% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block fullwidth_content %}
+{% block maincolumn_content %}
 
   <h1 class="heading-large">Change your {{ thing }}</h1>
 

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -1,4 +1,4 @@
-{% extends "admin_template.html" %}
+{% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block fullwidth_content %}
+{% block maincolumn_content %}
 
   <h1 class="heading-large">Change your password</h1>
 

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -1,4 +1,4 @@
-{% extends "admin_template.html" %}
+{% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block fullwidth_content %}
+{% block maincolumn_content %}
 
   <h1 class="heading-large">Change your {{ thing }}</h1>
 

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -1,4 +1,4 @@
-{% extends "admin_template.html" %}
+{% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
@@ -6,7 +6,7 @@
 GOV.UK Notify | Service settings
 {% endblock %}
 
-{% block fullwidth_content %}
+{% block maincolumn_content %}
 
   <h1 class="heading-large">Change your {{ thing }}</h1>
 


### PR DESCRIPTION
Pages that don’t have navigation shouldn’t extend the top-level admin template directly.

They should extend `withoutnav_template.html` instead, because then they get a wrapping `<main>` element, which is good semantically and for accessibility, and also defaults the font size to `19px`.