### PR TITLE
Give platform admin users visibilty of API pages

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -9,7 +9,7 @@ from app.notify_client.api_key_api_client import KEY_TYPE_NORMAL, KEY_TYPE_TEST,
 
 @main.route("/services/<service_id>/api")
 @login_required
-@user_has_permissions('manage_api_keys')
+@user_has_permissions('manage_api_keys', admin_override=True)
 def api_integration(service_id):
     return render_template(
         'views/api/index.html',
@@ -23,7 +23,7 @@ def api_integration(service_id):
 
 @main.route("/services/<service_id>/api/documentation")
 @login_required
-@user_has_permissions('manage_api_keys')
+@user_has_permissions('manage_api_keys', admin_override=True)
 def api_documentation(service_id):
     return render_template(
         'views/api/documentation.html'
@@ -32,7 +32,7 @@ def api_documentation(service_id):
 
 @main.route("/services/<service_id>/api/whitelist", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_api_keys')
+@user_has_permissions('manage_api_keys', admin_override=True)
 def whitelist(service_id):
     form = Whitelist()
     if form.validate_on_submit():
@@ -51,7 +51,7 @@ def whitelist(service_id):
 
 @main.route("/services/<service_id>/api/keys")
 @login_required
-@user_has_permissions('manage_api_keys')
+@user_has_permissions('manage_api_keys', admin_override=True)
 def api_keys(service_id):
     return render_template(
         'views/api/keys.html',
@@ -90,7 +90,7 @@ def create_api_key(service_id):
 
 @main.route("/services/<service_id>/api/keys/revoke/<key_id>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_api_keys')
+@user_has_permissions('manage_api_keys', admin_override=True)
 def revoke_api_key(service_id, key_id):
     key_name = api_key_api_client.get_api_keys(service_id=service_id, key_id=key_id)['apiKeys'][0]['name']
     if request.method == 'GET':

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -57,7 +57,7 @@
   {% elif current_user.has_permissions(['view_activity']) %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
-  {% if current_user.has_permissions(['manage_api_keys']) %}
+  {% if current_user.has_permissions(['manage_api_keys'], admin_override=True) %}
     <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
   {% endif %}
   </ul>


### PR DESCRIPTION
Platform admins should be able to see what’s going on with a service’s API integration, including:
- messages sent
- contents of whitelist
- names of keys

They should also be able to revoke keys in an emergency.

The only thing they _shouldn’t_ be able to do is create new keys (because then they’d be able to send messages as the service).