### PR TITLE
Remove Google Analytics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -359,10 +359,10 @@ def useful_headers_after_request(response):
     response.headers.add('X-XSS-Protection', '1; mode=block')
     response.headers.add('Content-Security-Policy', (
         "default-src 'self' 'unsafe-inline';"
-        "script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;"
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' data:;"
         "object-src 'self';"
         "font-src 'self' data:;"
-        "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
+        "img-src 'self' *.notifications.service.gov.uk data:;"
     ))
     if 'Cache-Control' in response.headers:
         del response.headers['Cache-Control']

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -129,12 +129,4 @@
 
 {% block body_end %}
   <script type="text/javascript" src="{{ asset_url('javascripts/all.js') }}" /></script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-75215134-1', 'auto');
-    ga('send', 'pageview');
-  </script>
 {% endblock %}

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -8,8 +8,8 @@ def test_owasp_useful_headers_set(app_):
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
     assert response.headers['Content-Security-Policy'] == (
         "default-src 'self' 'unsafe-inline';"
-        "script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;"
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' data:;"
         "object-src 'self';"
         "font-src 'self' data:;"
-        "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
+        "img-src 'self' *.notifications.service.gov.uk data:;"
     )


### PR DESCRIPTION
Reverts https://github.com/alphagov/notifications-admin/pull/306

We’re not looking at the data from Analytics, so shouldn’t be collecting it just in case.

<sup>Brought to you by the fun police.</sup>