### PR TITLE
Fix pagination on activity page

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -173,7 +173,8 @@ def view_notifications(service_id, message_type):
         'views/notifications.html',
         partials=get_notifications(service_id, message_type),
         message_type=message_type,
-        status=request.args.get('status')
+        status=request.args.get('status'),
+        page=request.args.get('page', 1)
     )
 
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -20,7 +20,7 @@
 
   {{ ajax_block(
     partials,
-    url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
+    url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),
     'notifications'
   ) }}
 


### PR DESCRIPTION
The activity page was AJAXified in https://github.com/alphagov/notifications-admin/pull/952 but this didn’t take pagination into account.

So if you visited page 2, the contents of the page would be replaced by Javascript with the contents of page 1. So you’d never be able to see anything beyond page 1, expect for a brief fraction of a second when the page loaded.

This commit makes sure the AJAX request uses whatever page parameter is in the URL of the original page.