### PR TITLE
Add monthly breakdown of usage

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -179,3 +179,16 @@ details summary {
   border: 0;
   margin-bottom: -$gutter + 2px;
 }
+
+.body-copy-table {
+
+  table th,
+  table td {
+    font-size: 19px;
+  }
+
+}
+
+.tabular-numbers {
+  @include core-19($tabular-numbers: true);
+}

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -31,7 +31,7 @@
   }
 
   .table-field-heading-first {
-    width: 52.5%
+    width: 52.5%;
   }
 
   .table-row {

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -211,6 +211,9 @@ class ServiceAPIClient(NotificationsAPIClient):
     def update_whitelist(self, service_id, data):
         return self.put(url='/service/{}/whitelist'.format(service_id), data=data)
 
+    def get_billable_units(self, service_id, year):
+        return self.get(url='/service/{}/billable-units?year={}'.format(service_id, year))
+
 
 class ServicesBrowsableItem(BrowsableItem):
     @property

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -1,4 +1,5 @@
 {% from "components/big-number.html" import big_number %}
+{% from "components/table.html" import list_table, field, hidden_field_heading, row_heading, text_field %}
 
 {% extends "withnav_template.html" %}
 
@@ -13,7 +14,9 @@
         <h2 class='heading-large'>Usage</h2>
       </div>
       <div class='column-half'>
-        <span class="align-with-heading-copy">1 April 2016 to date</span>
+        <div class='align-with-heading-copy'>
+          Financial year {{ year }} to {{ year + 1 }}
+        </div>
       </div>
     </div>
 
@@ -49,7 +52,7 @@
         </div>
       </div>
       <div class='column-half'>
-        <div class="keyline-block bottom-gutter">
+        <div class="keyline-block">
           {{ big_number(
             (sms_chargeable * sms_rate),
             'spent',
@@ -57,7 +60,50 @@
             smaller=True
           ) }}
         </div>
-        <p>
+      </div>
+    </div>
+
+    <div class="dashboard-table body-copy-table">
+      {% call(month, row_index) list_table(
+        months,
+        caption="Total spend",
+        caption_visible=False,
+        empty_message='',
+        field_headings=[
+          'By month',
+          hidden_field_heading('Cost'),
+        ],
+        field_headings_visible=True
+      ) %}
+        {% call row_heading() %}
+          {{ month.name }}
+        {% endcall %}
+        {% call field(align='left') %}
+          {{ big_number(
+            sms_rate * month.paid,
+            currency="£",
+            smallest=True
+          ) }}
+          <ul>
+          {% if month.free %}
+            <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
+          {% endif %}
+          {% if month.paid %}
+            <li class="tabular-numbers">{{ "{:,}".format(month.paid) }} text messages at
+            {{- ' {:.2f}p'.format(sms_rate * 100) }}</li>
+          {% endif %}
+          {% if not (month.free or month.paid) %}
+            <li aria-hidden="true">–</li>
+          {% endif %}
+          </ul>
+        {% endcall %}
+      {% endcall %}
+    </div>
+
+    <div class="grid-row">
+      <div class="column-half">&nbsp;</div>
+      <div class="column-half">
+        <p class="align-with-heading-copy">
           What counts as 1 text message?<br />
           See <a href="{{ url_for('.pricing') }}">pricing</a>.
         </p>

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -335,6 +335,17 @@ def test_can_show_notifications(
             page=expected_page_argument
         ) == page.find("div", {'data-key': 'notifications'})['data-resource']
 
+        path_to_json = page.find("div", {'data-key': 'notifications'})['data-resource']
+
+        assert (
+            '/services/{}/notifications/{}.json?status={}&page={}'.format(
+                service_one['id'], message_type, status_argument, expected_page_argument
+            ) in path_to_json or
+            '/services/{}/notifications/{}.json?page={}&status={}'.format(
+                service_one['id'], message_type, expected_page_argument, status_argument
+            ) in path_to_json
+        )
+
         mock_get_notifications.assert_called_with(
             limit_days=7,
             page=expected_page_argument,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1172,12 +1172,24 @@ def mock_get_template_statistics_for_template(mocker, service_one):
 def mock_get_usage(mocker, service_one, fake_uuid):
     def _get_usage(service_id):
         return {'data': {
-            "sms_count": 123,
-            "email_count": 456
+            "sms_count": 456123,
+            "email_count": 123
         }}
 
     return mocker.patch(
         'app.service_api_client.get_service_usage', side_effect=_get_usage)
+
+
+@pytest.fixture(scope='function')
+def mock_get_billable_units(mocker):
+    def _get_usage(service_id, year):
+        return {
+            "April": 123,
+            "March": 456123
+        }
+
+    return mocker.patch(
+        'app.service_api_client.get_billable_units', side_effect=_get_usage)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<img width="942" alt="screen shot 2016-09-30 at 15 34 39" src="https://cloud.githubusercontent.com/assets/355079/19042113/b560c102-8982-11e6-8373-2833a83c303d.png">

***

- shows all the months from start of given financial year to now or end of given financial year (whichever is earliest)
- shows a breakdown of free and paid text messages for each of these months

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/699