### PR TITLE
Re-add Google Analytics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -359,10 +359,10 @@ def useful_headers_after_request(response):
     response.headers.add('X-XSS-Protection', '1; mode=block')
     response.headers.add('Content-Security-Policy', (
         "default-src 'self' 'unsafe-inline';"
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' data:;"
+        "script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;"
         "object-src 'self';"
         "font-src 'self' data:;"
-        "img-src 'self' *.notifications.service.gov.uk data:;"
+        "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
     ))
     if 'Cache-Control' in response.headers:
         del response.headers['Cache-Control']

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -129,4 +129,12 @@
 
 {% block body_end %}
   <script type="text/javascript" src="{{ asset_url('javascripts/all.js') }}" /></script>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-75215134-1', 'auto');
+    ga('send', 'pageview');
+  </script>
 {% endblock %}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -135,6 +135,10 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-75215134-1', 'auto');
-    ga('send', 'pageview');
+    // strip UUIDs
+    page = window.location.href.replace(
+      /[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}/g, '…'
+    )
+    ga('send', 'pageview', page);
   </script>
 {% endblock %}

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -8,8 +8,8 @@ def test_owasp_useful_headers_set(app_):
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
     assert response.headers['Content-Security-Policy'] == (
         "default-src 'self' 'unsafe-inline';"
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' data:;"
+        "script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;"
         "object-src 'self';"
         "font-src 'self' data:;"
-        "img-src 'self' *.notifications.service.gov.uk data:;"
+        "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
     )


### PR DESCRIPTION
## Revert "Remove Google Analytics"

This reverts commit f31170f.

## Remove UUIDs from URLs sent to Google Analytics

If all our URLs are unique (because they contain service/job/template IDs) then it makes it hard to aggregate how users are behaving across a range of services/jobs/templates.

This commit replaces anything that looks like a UUID in a URL with `…`.

_Regex taken from http://stackoverflow.com/a/18516125/147318_

<img width="1252" alt="screen shot 2016-10-05 at 10 58 03" src="https://cloud.githubusercontent.com/assets/355079/19108990/29c36496-8aeb-11e6-88f9-b5e3a044ef02.png">
