### PR TITLE
Don’t let people create a normal key in trial mode

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -68,13 +68,12 @@ def create_api_key(service_id):
         key['name'] for key in api_key_api_client.get_api_keys(service_id=service_id)['apiKeys']
     ]
     form = CreateKeyForm(key_names)
-    form.key_type.choices = [
-        (KEY_TYPE_NORMAL, 'Send messages to anyone{}'.format(
-            ', once this service is not in trial mode' if current_service['restricted'] else ''
-        )),
+    form.key_type.choices = filter(None, [
+        (KEY_TYPE_NORMAL, 'Send messages to anyone{}')
+        if not current_service['restricted'] else None,
         (KEY_TYPE_TEST, 'Simulate sending messages to anyone'),
         (KEY_TYPE_TEAM, 'Only send messages to your team or whitelist')
-    ]
+    ])
     if form.validate_on_submit():
         secret = api_key_api_client.create_api_key(
             service_id=service_id,


### PR DESCRIPTION
![img_5944_compressed](https://cloud.githubusercontent.com/assets/355079/19233055/0f4c7582-8edb-11e6-9d05-0e27e776ce16.jpg)

You can’t properly use a normal key when your service is in trial mode.

It’s theoretically useful to create a live key in preparation for going live. This utility outweighs the confusion it causes for people creating their first keys in trial mode.

We should just remove the confusing option.

![image](https://cloud.githubusercontent.com/assets/355079/19192489/4aed71d4-8c9e-11e6-8b03-d4ae5bc1a516.png)

## Depends on

- [x] https://github.com/alphagov/notifications-admin/pull/970