### PR TITLE
Make whitelist available to live services

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -72,7 +72,7 @@ def create_api_key(service_id):
             ', once this service is not in trial mode' if current_service['restricted'] else ''
         )),
         (KEY_TYPE_TEST, 'Simulate sending messages to anyone'),
-        (KEY_TYPE_TEAM, 'Only send messages to members of your team')
+        (KEY_TYPE_TEAM, 'Only send messages to your team or whitelist')
     ]
     if form.validate_on_submit():
         secret = api_key_api_client.create_api_key(

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -23,24 +23,15 @@
   {% endif %}
 
   <nav class="grid-row bottom-gutter-1-2">
-    {% if current_service.restricted %}
-      <div class="column-one-third">
-        <a class="pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
-      </div>
-      <div class="column-one-third">
-        <a class="pill-separate-item" href="{{ url_for('.whitelist', service_id=current_service.id) }}">Whitelist</a>
-      </div>
-      <div class="column-one-third">
-        <a class="pill-separate-item" href="{{ url_for('.api_documentation', service_id=current_service.id) }}">Documentation</a>
-      </div>
-    {% else %}
-      <div class="column-half">
-        <a class="pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
-      </div>
-      <div class="column-half">
-        <a class="pill-separate-item" href="{{ url_for('.api_documentation', service_id=current_service.id) }}">Documentation</a>
-      </div>
-    {% endif %}
+    <div class="column-one-third">
+      <a class="pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
+    </div>
+    <div class="column-one-third">
+      <a class="pill-separate-item" href="{{ url_for('.whitelist', service_id=current_service.id) }}">Whitelist</a>
+    </div>
+    <div class="column-one-third">
+      <a class="pill-separate-item" href="{{ url_for('.api_documentation', service_id=current_service.id) }}">Documentation</a>
+    </div>
   </nav>
 
   <div class="grid-row">

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -38,7 +38,7 @@
           {% if item.key_type == 'normal' %}
             <span class="visually-hidden">Normal</span>
           {% elif item.key_type == 'team' %}
-            Only sends to team members
+            Only sends to team members or whitelist
           {% elif item.key_type == 'test' %}
             Simulates sending messages
           {% endif %}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/19192794/5435e7a2-8c9f-11e6-9be8-0141ce72e340.png)

Why would a live service need the whitelist? Because the team key will also let you send to members of your whitelist (so this commit relabels it to say so).

![image](https://cloud.githubusercontent.com/assets/355079/19192768/40933aa6-8c9f-11e6-97b9-ee99282736c5.png)

## Depends on

- [x] https://github.com/alphagov/notifications-api/pull/705