### PR TITLE
Ensure all Javascript is served compressed

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -69,7 +69,6 @@ gulp.task('javascripts', () => gulp
   .pipe(plugins.babel({
     presets: ['es2015']
   }))
-  .pipe(plugins.uglify())
   .pipe(plugins.addSrc.prepend([
     paths.npm + 'hogan.js/dist/hogan-3.0.2.js',
     paths.npm + 'jquery/dist/jquery.min.js',
@@ -77,6 +76,7 @@ gulp.task('javascripts', () => gulp
     paths.npm + 'diff-dom/diffDOM.js',
     paths.npm + 'timeago/jquery.timeago.js'
   ]))
+  .pipe(plugins.uglify())
   .pipe(plugins.concat('all.js'))
   .pipe(gulp.dest(paths.dist + 'javascripts/'))
 );


### PR DESCRIPTION
Previously we were running the minification before adding dependencies. This meant that dependencies that don’t come with a minified version were being served in full.

Running Uglify over everything _after_ including the dependencies reduces the weight of the downloaded Javascript by about 50kb.