### PR TITLE
notification-utils 9.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
 
-git+https://github.com/alphagov/notifications-utils.git@9.0.2#egg=notifications-utils==9.0.2
+git+https://github.com/alphagov/notifications-utils.git@9.0.5#egg=notifications-utils==9.0.5


### PR DESCRIPTION
Uses more restrictive email regex to prevent people adding emails with leading quotes, semicolons, etc, that SES rejects and end up as a Technical Failure