### PR TITLE
Revert "Don’t let people create a normal key in trial mode"

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -68,12 +68,13 @@ def create_api_key(service_id):
         key['name'] for key in api_key_api_client.get_api_keys(service_id=service_id)['apiKeys']
     ]
     form = CreateKeyForm(key_names)
-    form.key_type.choices = filter(None, [
-        (KEY_TYPE_NORMAL, 'Send messages to anyone{}')
-        if not current_service['restricted'] else None,
+    form.key_type.choices = [
+        (KEY_TYPE_NORMAL, 'Send messages to anyone{}'.format(
+            ', once this service is not in trial mode' if current_service['restricted'] else ''
+        )),
         (KEY_TYPE_TEST, 'Simulate sending messages to anyone'),
         (KEY_TYPE_TEAM, 'Only send messages to your team or whitelist')
-    ])
+    ]
     if form.validate_on_submit():
         secret = api_key_api_client.create_api_key(
             service_id=service_id,

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -147,7 +147,7 @@ def test_should_create_api_key_with_type_normal(app_,
                                                 api_user_active,
                                                 mock_login,
                                                 mock_get_api_keys,
-                                                mock_get_live_service,
+                                                mock_get_service,
                                                 mock_has_permissions,
                                                 fake_uuid,
                                                 mocker):
@@ -171,33 +171,6 @@ def test_should_create_api_key_with_type_normal(app_,
         'key_type': 'normal',
         'created_by': api_user_active.id
     })
-
-
-def test_cant_create_normal_api_key_in_trial_mode(
-    client,
-    api_user_active,
-    mock_login,
-    mock_get_api_keys,
-    mock_get_service,
-    mock_has_permissions,
-    fake_uuid,
-    mocker
-):
-    mock_post = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.post')
-
-    client.login(api_user_active)
-    response = client.post(
-        url_for('main.create_api_key', service_id=uuid.uuid4()),
-        data={
-            'key_name': 'some default key name',
-            'key_type': 'normal'
-        }
-    )
-    assert response.status_code == 200
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.find('span', {'class': 'error-message'}).text.strip() == 'Not a valid choice'
-
-    mock_post.assert_not_called()
 
 
 def test_should_show_confirm_revoke_api_key(app_,


### PR DESCRIPTION
Reverts alphagov/notifications-admin#969

This is breaking the functional tests. Will have to think of a way around this tomorrow.