### PR TITLE
Revert "Revert "Don’t let people create a normal key in trial mode""

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -68,13 +68,12 @@ def create_api_key(service_id):
         key['name'] for key in api_key_api_client.get_api_keys(service_id=service_id)['apiKeys']
     ]
     form = CreateKeyForm(key_names)
-    form.key_type.choices = [
-        (KEY_TYPE_NORMAL, 'Send messages to anyone{}'.format(
-            ', once this service is not in trial mode' if current_service['restricted'] else ''
-        )),
+    form.key_type.choices = filter(None, [
+        (KEY_TYPE_NORMAL, 'Send messages to anyone{}')
+        if not current_service['restricted'] else None,
         (KEY_TYPE_TEST, 'Simulate sending messages to anyone'),
         (KEY_TYPE_TEAM, 'Only send messages to your team or whitelist')
-    ]
+    ])
     if form.validate_on_submit():
         secret = api_key_api_client.create_api_key(
             service_id=service_id,


### PR DESCRIPTION
Reverts alphagov/notifications-admin#976

Shouldn’t be merged until this functional tests pull request is merged:
https://github.com/alphagov/notifications-functional-tests/pull/39