### PR TITLE
remove filtering of test messages from jobs

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -69,7 +69,7 @@ def create_api_key(service_id):
     ]
     form = CreateKeyForm(key_names)
     form.key_type.choices = filter(None, [
-        (KEY_TYPE_NORMAL, 'Send messages to anyone{}')
+        (KEY_TYPE_NORMAL, 'Send messages to anyone')
         if not current_service['restricted'] else None,
         (KEY_TYPE_TEST, 'Simulate sending messages to anyone'),
         (KEY_TYPE_TEAM, 'Only send messages to your team or whitelist')

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -129,7 +129,6 @@ def get_dashboard_partials(service_id):
     immediate_jobs = [
         add_rate_to_job(job)
         for job in job_api_client.get_jobs(service_id, limit_days=7, statuses=statuses_to_display)['data']
-        if job['original_file_name'] != current_app.config['TEST_MESSAGE_FILENAME']
     ]
     service = service_api_client.get_detailed_service(service_id)
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -71,7 +71,6 @@ def view_jobs(service_id):
     jobs_response = job_api_client.get_jobs(service_id, statuses=statuses_to_display, page=page)
     jobs = [
         add_rate_to_job(job) for job in jobs_response['data']
-        if job['original_file_name'] != current_app.config['TEST_MESSAGE_FILENAME']
     ]
 
     prev_page = None

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -231,7 +231,6 @@ def test_should_show_recent_jobs_on_dashboard(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     table_rows = page.find_all('tbody')[2].find_all('tr')
 
-    assert "Test message" not in page.text
     assert len(table_rows) == 4
 
     for index, filename in enumerate((

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -27,7 +27,6 @@ def test_get_jobs_should_return_list_of_all_real_jobs(
     assert page.h1.string == 'Uploaded files'
     jobs = [x.text for x in page.tbody.find_all('a', {'class': 'file-list-filename'})]
     assert len(jobs) == 4
-    assert 'Test message' not in jobs
 
 
 def test_get_jobs_shows_page_links(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -914,7 +914,6 @@ def mock_get_jobs(mocker, api_user_active):
                 job_status=job_status
             )
             for filename, scheduled_for, job_status in (
-                ('Test message', '', 'finished'),
                 ('export 1/1/2016.xls', '', 'finished'),
                 ('all email addresses.xlsx', '', 'pending'),
                 ('applicants.ods', '', 'finished'),


### PR DESCRIPTION
actually just code cleanup since this code is now duplicated on the api side

* [x] ~~depends on https://github.com/alphagov/notifications-api/pull/709~~