### PR TITLE
Fix all jobs being shown on the dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -128,7 +128,7 @@ def get_dashboard_partials(service_id):
     )
     immediate_jobs = [
         add_rate_to_job(job)
-        for job in job_api_client.get_jobs(service_id, statuses=statuses_to_display)['data']
+        for job in job_api_client.get_jobs(service_id, limit_days=7, statuses=statuses_to_display)['data']
         if job['original_file_name'] != current_app.config['TEST_MESSAGE_FILENAME']
     ]
     service = service_api_client.get_detailed_service(service_id)

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -223,6 +223,7 @@ def test_should_show_recent_jobs_on_dashboard(
 
     second_call = mock_get_jobs.call_args_list[1]
     assert second_call[0] == (SERVICE_ONE_ID,)
+    assert second_call[1]['limit_days'] == 7
     assert 'scheduled' not in second_call[1]['statuses']
 
     assert response.status_code == 200


### PR DESCRIPTION
The dashboard was showing the 50 most recent jobs, not the 50 most recent in the last 7 days.