### PR TITLE
Fix API log page in Firefox

### DIFF
--- a/app/assets/javascripts/detailsPolyfill.js
+++ b/app/assets/javascripts/detailsPolyfill.js
@@ -133,22 +133,20 @@
 
       // If this is not a native implementation, create an arrow
       // inside the summary
-      if (!NATIVE_DETAILS) {
 
-        var twisty = document.createElement('i');
+      var twisty = document.createElement('i');
 
-        if (openAttr === true) {
-          twisty.className = 'arrow arrow-open';
-          twisty.appendChild(document.createTextNode('\u25bc'));
-        } else {
-          twisty.className = 'arrow arrow-closed';
-          twisty.appendChild(document.createTextNode('\u25ba'));
-        }
-
-        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
-        details.__summary.__twisty.setAttribute('aria-hidden', 'true');
-
+      if (openAttr === true) {
+        twisty.className = 'arrow arrow-open';
+        twisty.appendChild(document.createTextNode('\u25bc'));
+      } else {
+        twisty.className = 'arrow arrow-closed';
+        twisty.appendChild(document.createTextNode('\u25ba'));
       }
+
+      details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+      details.__summary.__twisty.setAttribute('aria-hidden', 'true');
+
     }
 
     // Define a statechange function that updates aria-expanded and style.display

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -192,3 +192,25 @@ details summary {
 .tabular-numbers {
   @include core-19($tabular-numbers: true);
 }
+
+summary::-moz-details-marker {
+  display: none;
+}
+summary::-ms-details-marker {
+  display: none;
+}
+summary::-o-details-marker {
+  display: none;
+}
+
+summary::details-marker {
+  display: none;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+details .arrow {
+  font-size: 16px;
+}

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -19,6 +19,7 @@
     }
 
     &-meta {
+      display: block;
       color: $secondary-text-colour;
     }
 

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -61,25 +61,27 @@
           <h3 class="api-notifications-item-recipient">
             {{ notification.to }}
           </h3>
-          <div class="grid-row api-notifications-item-meta">
-            <div class="column-half api-notifications-item-key">
+          <span class="grid-row api-notifications-item-meta">
+            <span class="column-half api-notifications-item-key">
               {{notification.key_name}}
-            </div>
-            <div class="column-half api-notifications-item-time">
+            </span>
+            <span class="column-half api-notifications-item-time">
               <time class="timeago" datetime="{{ notification.created_at }}">
                 {{ notification.created_at|format_delta }}
               </time>
-            </div>
-          </div>
+            </span>
+          </span>
         </summary>
-        <dl id="notification-{{ notification.id }}" class="api-notifications-item-data bottom-gutter-1-2">
-          {% for key in [
-            'id', 'notification_type', 'created_at', 'updated_at', 'sent_at', 'status'
-          ] %}
-            <dt>{{ key }}:</dt>
-            <dd class="api-notifications-item-data-item">{{ notification[key] }}</dd>
-          {% endfor %}
-        </dl>
+        <div>
+          <dl id="notification-{{ notification.id }}" class="api-notifications-item-data bottom-gutter-1-2">
+            {% for key in [
+              'id', 'notification_type', 'created_at', 'updated_at', 'sent_at', 'status'
+            ] %}
+              <dt>{{ key }}:</dt>
+              <dd class="api-notifications-item-data-item">{{ notification[key] }}</dd>
+            {% endfor %}
+          </dl>
+        </div>
       </details>
     {% endfor %}
     {% if api_notifications.notifications %}


### PR DESCRIPTION
The details of each notification were not being hidden on page load in Firefox.

Older versions of Firefox do not natively support the `<details>` element, so we polyfill it.

Because of [the way the polyfill is written](https://github.com/alphagov/govuk_elements/blob/48fde82c721917feed3b7cf9b655e41fcddb3f49/public/javascripts/govuk/details.polyfill.js#L90):

1. There can’t be any `<div>` elements inside the `<summary>` (this commit changes them to be `<span>`s instead, and adds CSS to make sure they wrap as before)
2. The contents to be shown/hidden must be wrapped in a `<div>` (which this commit adds)

***

The latest versions of Firefox _do_ now support the feature (after 5 years 😬), but for some reason they don’t draw the arrow. So this pull request forces the arrow to be polyfilled in all browsers, and hides the browser default one, for those browsers that do render it.