### PR TITLE
Add ids for dashboard numbers and stats for functional tests

### DIFF
--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -2,7 +2,7 @@
 {% from "components/message-count-label.html" import message_count_label %}
 
 <div class="grid-row ajax-block-container">
-  <div class="column-half">
+  <div id="total-email" class="column-half">
     {{ big_number_with_status(
       statistics['email']['requested'],
       message_count_label(statistics['email']['requested'], 'email', suffix=''),
@@ -13,7 +13,7 @@
       link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed')
     ) }}
   </div>
-  <div class="column-half">
+  <div id="total-sms" class="column-half">
     {{ big_number_with_status(
       statistics['sms']['requested'],
       message_count_label(statistics['sms']['requested'], 'sms', suffix=''),

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -15,6 +15,7 @@
     ],
     field_headings_visible=True
   ) %}
+
     {% call row_heading() %}
       <span class="spark-bar-label">
         <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
@@ -25,7 +26,7 @@
     {% endcall %}
     {% call field() %}
       {% if template_statistics|length > 1 %}
-        <span class="spark-bar">
+        <span id='{{item.template_id}}' class="spark-bar">
           <span style="width: {{ item.count / most_used_template_count * 100 }}%">
             {{ big_number(
               item.count,
@@ -34,7 +35,7 @@
           </span>
         </span>
       {% else %}
-        <span class="heading-small">
+        <span id='{{item.template_id}}' class="heading-small">
           {{ big_number(
             item.count,
             smallest=True


### PR DESCRIPTION
The functional tests do not currently check the dashboard to verify various counts after sending notifications. To ease the process of selecting the desired elements with Selenium, identifiers have been added to the relevant elements. 