### PR TITLE
Send an email to the user when they change email address

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -22,7 +22,6 @@ from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import (DataRequired, Email, Length, Regexp, Optional)
 
 from app.main.validators import (Blacklist, CsvFileValidator, ValidEmailDomainRegex, NoCommasInPlaceHolders)
-from app.notify_client.api_key_api_client import KEY_TYPE_NORMAL, KEY_TYPE_TEST, KEY_TYPE_TEAM
 
 
 def get_time_value_and_label(future_time):
@@ -283,19 +282,6 @@ class ChangeEmailForm(Form):
         is_valid = self.validate_email_func(field.data)
         if not is_valid:
             raise ValidationError("The email address is already in use")
-
-
-class ConfirmEmailForm(Form):
-    def __init__(self, validate_code_func, *args, **kwargs):
-        self.validate_code_func = validate_code_func
-        super(ConfirmEmailForm, self).__init__(*args, **kwargs)
-
-    email_code = email_code()
-
-    def validate_email_code(self, field):
-        is_valid, msg = self.validate_code_func(field.data)
-        if not is_valid:
-            raise ValidationError(msg)
 
 
 class ChangeMobileNumberForm(Form):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,12 +1,8 @@
-import markdown
-import os
-from flask import (render_template, url_for, redirect, Markup, request, abort)
+from flask import (render_template, url_for, redirect, request, abort)
 from app.main import main
 from app import convert_to_boolean
-from flask_login import login_required
+from flask_login import (login_required, current_user)
 
-from flask.ext.login import current_user
-from mdx_gfm import GithubFlavoredMarkdownExtension
 
 from notifications_utils.renderers import HTMLEmail
 

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -8,11 +8,10 @@ from flask import (
     redirect,
     session,
     abort,
-    url_for,
-    flash
+    url_for
 )
 
-from flask.ext.login import current_user
+from flask_login import current_user
 
 from app.main import main
 

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -9,7 +9,7 @@ from flask import (
     Markup
 )
 
-from flask.ext.login import (
+from flask_login import (
     current_user,
     login_fresh,
     confirm_login

--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -4,7 +4,7 @@ from flask import (
     session
 )
 
-from flask.ext.login import logout_user
+from flask_login import logout_user
 
 from app.main import main
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -25,7 +25,6 @@ from app import user_api_client
 
 NEW_EMAIL = 'new-email'
 NEW_MOBILE = 'new-mob'
-NEW_EMAIL_PASSWORD_CONFIRMED = 'new-email-password-confirmed'
 NEW_MOBILE_PASSWORD_CONFIRMED = 'new-mob-password-confirmed'
 
 
@@ -110,8 +109,7 @@ def user_profile_email_confirm(token):
     user = user_api_client.get_user(user_id)
     user.email_address = new_email
     user_api_client.update_user(user)
-    if session.get(NEW_EMAIL, None):
-        del session[NEW_EMAIL]
+    session.pop(NEW_EMAIL, None)
 
     return redirect(url_for('.user_profile'))
 

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -1,4 +1,4 @@
-from flask.ext.login import current_user
+from flask_login import current_user
 
 
 def _attach_current_user(data):

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -1,4 +1,4 @@
-from flask.ext.login import (UserMixin, login_fresh)
+from flask_login import (UserMixin, login_fresh)
 
 
 class User(UserMixin):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -127,3 +127,8 @@ class UserApiClient(BaseAPIClient):
             return self.update_user(user)
         else:
             return user
+
+    def send_change_email_verification(self, user_id, new_email):
+        endpoint = '/user/{}/change-email-verification'.format(user_id)
+        data = {'email': new_email}
+        self.post(endpoint, data)

--- a/app/templates/views/change-email-continue.html
+++ b/app/templates/views/change-email-continue.html
@@ -1,0 +1,13 @@
+{% extends "withoutnav_template.html" %}
+
+{% block page_title %}
+  Check your email – GOV.UK Notify
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">Check your email​</h1>
+  <p>An email has been sent to {{ new_email }}.</p>
+  <p>Click the link in the email to confirm the change to your email address.</p>
+
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -581,6 +581,11 @@ def api_user_changed_password(fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def mock_send_change_email_verification(mocker):
+    return mocker.patch('app.user_api_client.send_change_email_verification')
+
+
+@pytest.fixture(scope='function')
 def mock_register_user(mocker, api_user_pending):
     def _register(name, email_address, mobile_number, password):
         api_user_pending.name = name


### PR DESCRIPTION
This PR changes the flow to change an email address.
Once the user enter their password, they are told "Check your email".
An email has been sent to them containing a link to notify which contains an encrypted token.
The encrypted token contains the user id and new email address. Once the link is clicked the user's email address is updated to the new email address.
They are redirected to the /user-profile page.

Also in this commit is an update from flask.ext.login to flask_login.