### PR TITLE
Error if a CSV file contains more than 50,000 rows

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -15,7 +15,22 @@
 
 {% block maincolumn_content %}
 
-  {% if not recipients.has_recipient_column %}
+  {% if recipients.has_too_many_rows %}
+
+    <div class="bottom-gutter">
+      {% call banner_wrapper(type='dangerous') %}
+        <h1 class='banner-title'>
+          Your file has too many rows
+        </h1>
+        <p>
+          Notify can process up to
+          {{ "{:,}".format(recipients.max_rows) }} rows at once. Your
+          file has {{ "{:,}".format(recipients|length) }} rows.
+        </p>
+      {% endcall %}
+    </div>
+
+  {% elif not recipients.has_recipient_column %}
 
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
@@ -159,7 +174,8 @@
   {% call(item, row_number) list_table(
     recipients.initial_annotated_rows_with_errors if row_errors and not recipients.missing_column_headers else recipients.initial_annotated_rows,
     caption=original_file_name,
-    field_headings=['1'] + recipients.column_headers
+    field_headings=['1'] + recipients.column_headers,
+    empty_message='Can’t show the contents of this file'
   ) %}
     {{ index_field(item.index + 2) }}
     {% for column in recipients.column_headers %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@1.3.0#egg=notifications-python-client==1.3.0
 
-git+https://github.com/alphagov/notifications-utils.git@9.0.6#egg=notifications-utils==9.0.6
+git+https://github.com/alphagov/notifications-utils.git@9.1.0#egg=notifications-utils==9.1.0


### PR DESCRIPTION
We want to limit the number of rows someone can have in a job, because it gets too slow to process the file otherwise.

This should be the first error that a user sees, because we can’t work out if there are other errors until they’ve got the file down to a processable size.

This also means adding a message to say that the file can’t be displayed if it doesn’t contain any processed rows.

**Story**

https://www.pivotaltracker.com/story/show/129830161

**Depends on**

- [x] https://github.com/alphagov/notifications-utils/pull/73