### PR TITLE
Make ‘too many rows’ error actually work

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -15,7 +15,7 @@
 
 {% block maincolumn_content %}
 
-  {% if recipients.has_too_many_rows %}
+  {% if recipients.too_many_rows %}
 
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
@@ -174,8 +174,7 @@
   {% call(item, row_number) list_table(
     recipients.initial_annotated_rows_with_errors if row_errors and not recipients.missing_column_headers else recipients.initial_annotated_rows,
     caption=original_file_name,
-    field_headings=['1'] + recipients.column_headers,
-    empty_message='Can’t show the contents of this file'
+    field_headings=['1'] + recipients.column_headers
   ) %}
     {{ index_field(item.index + 2) }}
     {% for column in recipients.column_headers %}
@@ -203,7 +202,12 @@
     {% endif %}
   {% endcall %}
 
-  {% if count_of_displayed_recipients < count_of_recipients %}
+
+  {% if recipients.too_many_rows %}
+    <p class="table-show-more-link">
+      Can’t show the contents of this file
+    </p>
+  {% elif count_of_displayed_recipients < count_of_recipients %}
     <p class="table-show-more-link">
       {% if row_errors and not recipients.missing_column_headers %}
         Only showing the first {{ count_of_displayed_recipients }} rows with errors

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -795,7 +795,7 @@ def test_check_messages_shows_over_max_row_error(
     mock_recipients = mocker.patch('app.main.views.send.RecipientCSV').return_value
     mock_recipients.max_rows = 11111
     mock_recipients.__len__.return_value = 99999
-    mock_recipients.has_too_many_rows.return_value = True
+    mock_recipients.too_many_rows.return_value = True
 
     client.login(api_user_active)
     with client.session_transaction() as session:


### PR DESCRIPTION
Was using the wrong attribute name on the instance of `RecipientCSV` (needed to match https://github.com/alphagov/notifications-utils/blob/19df1eb4ef061674708fe9807bfedaa507dd7186/notifications_utils/recipients.py#L156 )

The ‘can’t show file contents’ message wasn’t showing up, now it is.

![image](https://cloud.githubusercontent.com/assets/355079/19432233/a1d349c6-9453-11e6-867c-bfad31c49ae7.png)
