### PR TITLE
Open links to documentation in new tabs

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -85,7 +85,7 @@
         <div class="column-one-third">
           <h2>Support</h2>
           <ul>
-            <li><a href="https://status.notifications.service.gov.uk">System status</a></li>            
+            <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="{{ url_for('main.feedback') }}">Support and feedback</a></li>
             <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Chat with the Notify team</a></li>
           </ul>
@@ -109,7 +109,7 @@
               ('Python', 'https://github.com/alphagov/notifications-python-client'),
               ('Ruby', 'https://github.com/alphagov/notifications-ruby-client')
             ] %}
-            <li><a href="{{ url }}">{{ language }} client</a></li>
+            <li><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ language }} client</a></li>
             {% endfor %}
           </ul>
         </div>

--- a/app/templates/views/api/documentation.html
+++ b/app/templates/views/api/documentation.html
@@ -22,7 +22,7 @@
       ('Ruby client', 'https://github.com/alphagov/notifications-ruby-client')
     ] %}
     <li>
-      <a href="{{ url }}">{{ name }}</a>
+      <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ name }}</a>
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Because users have difficulty getting back to the Notify admin interface.

The `rel` attribute mitigates against [a nasty cross-domain vulnerability](https://mathiasbynens.github.io/rel-noopener/).