### PR TITLE
Fix 500s

### DIFF
--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -26,7 +26,7 @@
     ).done(
       response => flushQueue(queue, response)
     ).fail(
-      () => clearQueue(queue)
+      () => poll = function(){}
     );
 
     setTimeout(

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -53,7 +53,6 @@ def service_dashboard(service_id):
 
 
 @main.route("/services/<service_id>/dashboard.json")
-@login_required
 @user_has_permissions('view_activity', admin_override=True)
 def service_dashboard_updates(service_id):
     return jsonify(**get_dashboard_partials(service_id))

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -172,7 +172,6 @@ def cancel_job(service_id, job_id):
 
 
 @main.route("/services/<service_id>/jobs/<job_id>.json")
-@login_required
 @user_has_permissions('view_activity', admin_override=True)
 def view_job_updates(service_id, job_id):
     return jsonify(**get_job_partials(

--- a/app/utils.py
+++ b/app/utils.py
@@ -42,7 +42,6 @@ def user_has_permissions(*permissions, admin_override=False, any_=False):
         @wraps(func)
         def wrap_func(*args, **kwargs):
             from flask_login import current_user
-
             if current_user and current_user.is_authenticated:
                 if current_user.has_permissions(
                     permissions=permissions,

--- a/app/utils.py
+++ b/app/utils.py
@@ -42,11 +42,18 @@ def user_has_permissions(*permissions, admin_override=False, any_=False):
         @wraps(func)
         def wrap_func(*args, **kwargs):
             from flask_login import current_user
-            if current_user and current_user.has_permissions(permissions=permissions,
-                                                             admin_override=admin_override, any_=any_):
-                return func(*args, **kwargs)
+
+            if current_user and current_user.is_authenticated:
+                if current_user.has_permissions(
+                    permissions=permissions,
+                    admin_override=admin_override,
+                    any_=any_
+                ):
+                    return func(*args, **kwargs)
+                else:
+                    abort(403)
             else:
-                abort(403)
+                abort(401)
         return wrap_func
     return wrap
 

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -108,7 +108,7 @@ def test_platform_admin_user_can_not_access_page(app_,
         admin_override=False)
 
 
-def test_user_with_permissions_returns_401_unauthenticated_user(app_):
+def test_no_user_returns_401_unauth(app_):
     from flask_login import current_user
     assert not current_user
     _test_permissions(

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -1,7 +1,7 @@
 import pytest
 from app.utils import user_has_permissions
 from app.main.views.index import index
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import Forbidden, Unauthorized
 from flask import request
 
 
@@ -9,7 +9,8 @@ def _test_permissions(app_, usr, permissions, service_id, will_succeed, any_=Fal
     with app_.test_request_context() as ctx:
         request.view_args.update({'service_id': service_id})
         with app_.test_client() as client:
-            client.login(usr)
+            if usr:
+                client.login(usr)
             decorator = user_has_permissions(*permissions, any_=any_, admin_override=admin_override)
             decorated_index = decorator(index)
             if will_succeed:
@@ -17,8 +18,8 @@ def _test_permissions(app_, usr, permissions, service_id, will_succeed, any_=Fal
             else:
                 try:
                     response = decorated_index()
-                    pytest.fail("Failed to throw a forbidden exception")
-                except Forbidden:
+                    pytest.fail("Failed to throw a forbidden or unauthorised exception")
+                except (Forbidden, Unauthorized):
                     pass
 
 
@@ -105,6 +106,17 @@ def test_platform_admin_user_can_not_access_page(app_,
         '',
         will_succeed=False,
         admin_override=False)
+
+
+def test_user_with_permissions_returns_401_unauthenticated_user(app_):
+    from flask_login import current_user
+    assert not current_user
+    _test_permissions(
+        app_,
+        None,
+        [],
+        '',
+        will_succeed=False)
 
 
 def _user_with_permissions():


### PR DESCRIPTION
If a user was on the notifications dashboard (email or sms) and had signed out of the admin app on another tab, 500 responses would be returned.

This changes so we check the user is authenticated first when grabbing their permission set and return the appropriate codes. Additionally further polling of notifications is stopped upon failure. 