### PR TITLE
Use python wheels to speed up AS deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ build: dependencies generate-version-file ## Build project
 
 .PHONY: build-codedeploy-artifact
 build-codedeploy-artifact: ## Build the deploy artifact for CodeDeploy
+	pip3 wheel --wheel-dir=wheelhouse -r requirements.txt
 	mkdir -p target
 	zip -r -x@deploy-exclude.lst target/notifications-admin.zip *
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ build: dependencies generate-version-file ## Build project
 
 .PHONY: build-codedeploy-artifact
 build-codedeploy-artifact: ## Build the deploy artifact for CodeDeploy
+	pip3 install wheel
 	pip3 wheel --wheel-dir=wheelhouse -r requirements.txt
 	mkdir -p target
 	zip -r -x@deploy-exclude.lst target/notifications-admin.zip *

--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 echo "Install dependencies"
+
 cd /home/notify-app/notifications-admin;
-pip3 install -r /home/notify-app/notifications-admin/requirements.txt
+
+pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-admin/requirements.txt


### PR DESCRIPTION
Currently AS deployment takes reasonably long due to installing dependencies from requirements.txt each time. This has been optimised so that the artifact used for deployment includes a wheelhouse (wheels for all dependencies) from which the packages can be installed instead of having to resolve PyPi for each dependency.
