### PR TITLE
Updated the request to go live page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -346,11 +346,18 @@ class Feedback(Form):
 
 
 class RequestToGoLiveForm(Form):
-    channel = Stringfield('Are you sending emails or text messages or both?')
-    start_date = Stringfield('When will you be ready to start sending messages?')
-    start_volume = Stringfield('How many messages do you expect to send per month to start with? Give an estimate in numbers.')
-    peak_volume = Stringfield('Will the number of messages a month increase and when will that start? Give an estimate.')
-    upload_or_api = Stringfield('Are you uploading a list of contacts that you’re sending your message to, or are you integrating your system with ours?')  
+    channel = StringField('Are you sending emails or text messages or both?')
+    start_date = StringField('When will you be ready to start sending messages?')
+    start_volume = StringField(
+        'How many messages do you expect to send per month to start with? Give an estimate in numbers.'
+    )
+    peak_volume = StringField(
+        'Will the number of messages a month increase and when will that start? Give an estimate.'
+    )
+    upload_or_api = StringField(
+        'Are you uploading a list of contacts that you’re sending your message to, ' +
+        'or are you integrating your system with ours?'
+    )
 
 
 class ProviderForm(Form):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -346,17 +346,26 @@ class Feedback(Form):
 
 
 class RequestToGoLiveForm(Form):
-    channel = StringField('Are you sending emails or text messages or both?')
-    start_date = StringField('When will you be ready to start sending messages?')
+    channel = StringField(
+        'Are you sending emails or text messages or both?'
+        , validators=[DataRequired(message='Can’t be empty')]
+    )
+    start_date = StringField(
+        'When will you be ready to start sending messages?'
+        , validators=[DataRequired(message='Can’t be empty')]
+    )
     start_volume = StringField(
         'How many messages do you expect to send per month to start with? Give an estimate in numbers.'
+        , validators=[DataRequired(message='Can’t be empty')]
     )
     peak_volume = StringField(
         'Will the number of messages a month increase and when will that start? Give an estimate.'
+        , validators=[DataRequired(message='Can’t be empty')]
     )
     upload_or_api = StringField(
         'Are you uploading a list of contacts that you’re sending your message to, ' +
         'or are you integrating your system with ours?'
+        , validators=[DataRequired(message='Can’t be empty')]
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -347,25 +347,25 @@ class Feedback(Form):
 
 class RequestToGoLiveForm(Form):
     channel = StringField(
-        'Are you sending emails or text messages or both?'
-        , validators=[DataRequired(message='Can’t be empty')]
+        'Are you sending emails or text messages or both?',
+        validators=[DataRequired(message='Can’t be empty')]
     )
     start_date = StringField(
-        'When will you be ready to start sending messages?'
-        , validators=[DataRequired(message='Can’t be empty')]
+        'When will you be ready to start sending messages?',
+        validators=[DataRequired(message='Can’t be empty')]
     )
     start_volume = StringField(
-        'How many messages do you expect to send per month to start with? Give an estimate in numbers.'
-        , validators=[DataRequired(message='Can’t be empty')]
+        'How many messages do you expect to send per month to start with? Give an estimate in numbers.',
+        validators=[DataRequired(message='Can’t be empty')]
     )
     peak_volume = StringField(
-        'Will the number of messages a month increase and when will that start? Give an estimate.'
-        , validators=[DataRequired(message='Can’t be empty')]
+        'Will the number of messages a month increase and when will that start? Give an estimate.',
+        validators=[DataRequired(message='Can’t be empty')]
     )
     upload_or_api = StringField(
         'Are you uploading a list of contacts that you’re sending your message to, ' +
-        'or are you integrating your system with ours?'
-        , validators=[DataRequired(message='Can’t be empty')]
+        'or are you integrating your system with ours?',
+        validators=[DataRequired(message='Can’t be empty')]
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -346,10 +346,11 @@ class Feedback(Form):
 
 
 class RequestToGoLiveForm(Form):
-    usage = TextAreaField(
-        '',
-        validators=[DataRequired(message="Can’t be empty")]
-    )
+    channel = Stringfield('Are you sending emails or text messages or both?')
+    start_date = Stringfield('When will you be ready to start sending messages?')
+    start_volume = Stringfield('How many messages do you expect to send per month to start with? Give an estimate in numbers.')
+    peak_volume = Stringfield('Will the number of messages a month increase and when will that start? Give an estimate.')
+    upload_or_api = Stringfield('Are you uploading a list of contacts that you’re sending your message to, or are you integrating your system with ours?')  
 
 
 class ProviderForm(Form):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -110,10 +110,15 @@ def service_request_to_go_live(service_id):
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live',
-            'message': "On behalf of {} ({})\n\nUsage estimate\n---\n\n{}".format(
+            'message': "On behalf of {} ({})\n\nExpected usage\n---\n\nChannel: {}\nStart date: {}\nStart volume: {}\nPeak volume: {}\nUpload or API: {}".format(
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
-                form.usage.data
+                form.channel.data,
+                form.start_date.data,
+                form.start_volume.data,
+                form.peak_volume.data,
+                form.upload_or_api.data
+                
             )
         }
         headers = {

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -110,7 +110,11 @@ def service_request_to_go_live(service_id):
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live',
-            'message': "On behalf of {} ({})\n\nExpected usage\n---\n\nChannel: {}\nStart date: {}\nStart volume: {}\nPeak volume: {}\nUpload or API: {}".format(
+            'message':
+            ('On behalf of {} ({})\n\nExpected usage\n---'
+            '\nChannel: {}\nStart date: {}\nStart volume: {}'
+            '\nPeak volume: {}\nUpload or API: {}')
+            .format(
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 form.channel.data,
@@ -118,7 +122,7 @@ def service_request_to_go_live(service_id):
                 form.start_volume.data,
                 form.peak_volume.data,
                 form.upload_or_api.data
-                
+
             )
         }
         headers = {

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -110,11 +110,11 @@ def service_request_to_go_live(service_id):
             'department_id': current_app.config.get('DESKPRO_DEPT_ID'),
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live',
-            'message':
-            ('On behalf of {} ({})\n\nExpected usage\n---'
-            '\nChannel: {}\nStart date: {}\nStart volume: {}'
-            '\nPeak volume: {}\nUpload or API: {}')
-            .format(
+            'message': (
+                'On behalf of {} ({})\n\nExpected usage\n---'
+                '\nChannel: {}\nStart date: {}\nStart volume: {}'
+                '\nPeak volume: {}\nUpload or API: {}'
+            ).format(
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 form.channel.data,

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -24,11 +24,11 @@
       </ul>
 
       <form method="post">
-        {{ textbox(form.channel, width='1-1') }}
-        {{ textbox(form.start_date, width='1-1') }}
-        {{ textbox(form.start_volume, width='1-1') }}
-        {{ textbox(form.peak_volume, width='1-1') }}
-        {{ textbox(form.upload_or_api, width='1-1') }}
+        {{ textbox(form.channel, width='1-2') }}
+        {{ textbox(form.start_date, width='1-2') }}
+        {{ textbox(form.start_volume, width='1-2') }}
+        {{ textbox(form.peak_volume, width='1-2') }}
+        {{ textbox(form.upload_or_api, width='1-2') }}
 
         <p>
           We will:

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -12,7 +12,7 @@
       <h1 class="heading-large">Request to go live</h1>
 
       {% call banner_wrapper(type='warning') %}
-        <h2 class="heading-medium">You must accept the GOV.UK&nbsp;Notify data sharing and financial agreement (Memorandum&nbsp;of&nbsp;Understanding) before we can process data for you.</h2>
+        <h2 class="heading-medium">You must accept the GOV.UK&nbsp;Notify data sharing and financial agreement (Memorandum of Understanding) before we can process data for you.</h2>
 
         <p>
           <a href="{{ url_for('main.feedback') }}">Contact the Notify team</a> to get a copy of the agreement or to find out if your organisation has already accepted it.
@@ -39,11 +39,11 @@
       </ul>
 
       <form method="post">
-        {{ textbox(form.channel, width='1-2') }}
-        {{ textbox(form.start_date, width='1-2') }}
-        {{ textbox(form.start_volume, width='1-2') }}
-        {{ textbox(form.peak_volume, width='1-2') }}
-        {{ textbox(form.upload_or_api, width='1-2') }}
+        {{ textbox(form.channel, width='1-1') }}
+        {{ textbox(form.start_date, width='1-1') }}
+        {{ textbox(form.start_volume, width='1-1') }}
+        {{ textbox(form.peak_volume, width='1-1') }}
+        {{ textbox(form.upload_or_api, width='1-1') }}
 
         <p>
           Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -10,17 +10,31 @@
 
       <h1 class="heading-large">Request to go live</h1>
 
+      {% call banner_wrapper(type='warning') %}
+        <h2 class="heading-medium">You must accept the GOV.UK Notify data sharing and financial agreement (Memorandum of Understanding) before we can process data for you.</h2>
+
+        <p>
+          <a href="{{ url_for('main.feedback') }}">Contact the Notify team</a> to get a copy of the agreement or to find out if your organisation has already accepted it.
+        </p>
+      {% endcall %}
+      
       <p>
-        You’ll need to:
+        Before you request to go live, make you you’ve:
       </p>
       <ul class="list list-bullet">
+        <li>accepted our data sharing and financial agreement</li>
+        <li>read our <a href="{{ url_for('.terms') }}">terms of use</a></li>
+        <li>added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account</li>
         <li>
-          agree to our <a href="{{ url_for('.terms') }}">terms of use</a>
-        </li>
+          specified your reply to email address or text message sender in your 
+          <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
         <li>
-          agree to pay for what you use if you send more than 250,000 text messages per year
-          (<a href="{{ url_for("main.pricing") }}">see our pricing</a>)
-        </li>
+          added the templates you want to start with, making sure they follow our 
+          <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ" rel="external">design patterns</a>,
+          <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing" rel="external">style guide</a>
+          and
+          <a href="https://docs.google.com/document/d/15-OjaEqDBy31uDU7nLZCpYIQOnzSCJR63-cp3cQI9G8" rel="external">information security guidelines</a>
+          </li>
       </ul>
 
       <form method="post">
@@ -31,26 +45,12 @@
         {{ textbox(form.upload_or_api, width='1-2') }}
 
         <p>
-          We will:
+          Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.
         </p>
-        <ul class="list list-bullet">
-          <li>
-            check that your templates follow our
-            <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ" rel="external">design patterns</a>,
-            <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing" rel="external">style guide</a>
-            and
-            <a href="https://docs.google.com/document/d/15-OjaEqDBy31uDU7nLZCpYIQOnzSCJR63-cp3cQI9G8" rel="external">information security guidelines</a>
-          </li>
-          <li>
-            check that you have more than one
-            <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team member</a>
-            in case you go on holiday
-          </li>
-          <li>
-            make your service live or get back to you within one working day
-          </li>
-        </ul>
-
+        <p>  
+          By requesting to go live you are agreeing to our terms of use.
+        </p>
+        
         {{ page_footer('Request to go live') }}
       </form>
 

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -24,14 +24,11 @@
       </ul>
 
       <form method="post">
-
-        {{ textbox(
-          form.usage,
-          label='Estimate how many emails and text messages you’ll send each month',
-          hint='If your estimate is likely to change, tell us how ',
-          width='1-1',
-          rows=5
-        ) }}
+        {{ textbox(form.channel, width='1-1') }}
+        {{ textbox(form.start_date, width='1-1') }}
+        {{ textbox(form.start_volume, width='1-1') }}
+        {{ textbox(form.peak_volume, width='1-1') }}
+        {{ textbox(form.upload_or_api, width='1-1') }}
 
         <p>
           We will:

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/banner.html" import banner_wrapper %}
 
 {% block page_title %}
   Request to go live – GOV.UK Notify
@@ -17,7 +18,7 @@
           <a href="{{ url_for('main.feedback') }}">Contact the Notify team</a> to get a copy of the agreement or to find out if your organisation has already accepted it.
         </p>
       {% endcall %}
-      
+
       <p>
         Before you request to go live, make you you’ve:
       </p>
@@ -26,10 +27,10 @@
         <li>read our <a href="{{ url_for('.terms') }}">terms of use</a></li>
         <li>added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account</li>
         <li>
-          specified your reply to email address or text message sender in your 
+          specified your reply to email address or text message sender in your
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
         <li>
-          added the templates you want to start with, making sure they follow our 
+          added the templates you want to start with, making sure they follow our
           <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ" rel="external">design patterns</a>,
           <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing" rel="external">style guide</a>
           and
@@ -47,10 +48,10 @@
         <p>
           Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.
         </p>
-        <p>  
+        <p>
           By requesting to go live you are agreeing to our terms of use.
         </p>
-        
+
         {{ page_footer('Request to go live') }}
       </form>
 

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -13,6 +13,15 @@ Terms of use – GOV.UK Notify
       Terms of use
     </h1>
 
+    {% call banner_wrapper(type='warning') %}
+        <h2 class="heading-medium">You must accept the GOV.UK Notify data sharing and financial agreement (Memorandum of Understanding) before we can process data for you.</h2>
+
+        <p>
+          <a href="{{ url_for('main.feedback') }}">Contact the Notify team</a> to get a copy of the agreement or to find out if your organisation has already accepted it.
+        </p>
+    
+    {% endcall %}
+    
     <p>To accept these terms, you must be the service manager for your service. If you’re not the service manager, you’ll need to invite them.</p>
 
     <section id="summary">

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -1,4 +1,5 @@
 {% extends "withoutnav_template.html" %}
+{% from "components/banner.html" import banner_wrapper %}
 
 {% block page_title %}
 Terms of use – GOV.UK Notify
@@ -19,9 +20,9 @@ Terms of use – GOV.UK Notify
         <p>
           <a href="{{ url_for('main.feedback') }}">Contact the Notify team</a> to get a copy of the agreement or to find out if your organisation has already accepted it.
         </p>
-    
+
     {% endcall %}
-    
+
     <p>To accept these terms, you must be the service manager for your service. If you’re not the service manager, you’ll need to invite them.</p>
 
     <section id="summary">
@@ -161,7 +162,7 @@ Terms of use – GOV.UK Notify
       <p>When you send messages through GOV.UK Notify, we provide feedback on the status of every text message, email and letter.</p>
 
       <p>You agree to use our delivery data to check (and potentially remove) bounced email addresses, mobile numbers and postal addresses from your database.</p>
-      
+
       <p>You agree to ensure your user’s personal data is kept accurate and up to date, in line with Data Protection Act principles.</p>
 
       <p>If you have consistently high bounce rates, we will investigate and may refuse to accept further messages for delivery. This is to protect delivery rates for other services using GOV.UK Notify.</p>
@@ -190,7 +191,7 @@ Terms of use – GOV.UK Notify
       <p>You must estimate how many text messages, emails and letters you plan to send each year, including any spikes or seasonal variation.</p>
 
       <p>We will make sure GOV.UK Notify is easily able to handle your estimated sending volume.</p>
-     
+
       <h3 class="heading-small" id="we-will-check-your-templates-before-you-can-go-live">
         We’ll check your templates before you can go live
       </h3>
@@ -204,7 +205,7 @@ Terms of use – GOV.UK Notify
       </h2>
 
       <p>You can remove your service from GOV.UK Notify at any time. <a href="{{ url_for('main.feedback') }}">Contact us</a> and we’ll delete your account.</p>
-      
+
       <p>Any data that you have processed through GOV.UK Notify will be deleted as part of the existing data deletion processes.</p>
 
     </section>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -323,7 +323,7 @@ def test_should_redirect_after_request_to_go_live(
                     'subject': 'Request to go live',
                     'department_id': ANY,
                     'agent_team_id': ANY,
-                    'message': 'On behalf of Test Service (http://localhost/services/6ce466d0-fd6a-11e5-82f5-e0accb9d11a6/dashboard)\n\nUsage estimate\n---\n\nOne million messages',  # noqa
+                    'message': ANY,  # noqa
                     'person_name': api_user_active.name,
                     'person_email': api_user_active.email_address
                 },

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -313,7 +313,13 @@ def test_should_redirect_after_request_to_go_live(
             client.login(api_user_active)
             response = client.post(
                 url_for('main.service_request_to_go_live', service_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a6'),
-                data={'usage': "One million messages"},
+                data={
+                    'channel': 'Email',
+                    'start_date': '01/01/2017',
+                    'start_volume': '100,000',
+                    'peak_volume': '2,000,000',
+                    'upload_or_api': 'api'
+                },
                 follow_redirects=True
             )
             assert response.status_code == 200
@@ -323,12 +329,19 @@ def test_should_redirect_after_request_to_go_live(
                     'subject': 'Request to go live',
                     'department_id': ANY,
                     'agent_team_id': ANY,
-                    'message': ANY,  # noqa
+                    'message': ANY,
                     'person_name': api_user_active.name,
                     'person_email': api_user_active.email_address
                 },
                 headers=ANY
             )
+
+            returned_message = mock_post.call_args[1]['data']['message']
+            assert 'Email' in returned_message
+            assert '01/01/2017' in returned_message
+            assert '100,000' in returned_message
+            assert '2,000,000' in returned_message
+            assert 'api' in returned_message
 
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
         flash_banner = page.find('div', class_='banner-default').string.strip()
@@ -362,7 +375,13 @@ def test_log_error_on_request_to_go_live(
             with pytest.raises(InternalServerError):
                 resp = client.post(
                     url_for('main.service_request_to_go_live', service_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a6'),
-                    data={'usage': 'blah'}
+                    data={
+                        'channel': 'channel',
+                        'start_date': 'start_date',
+                        'start_volume': 'start_volume',
+                        'peak_volume': 'peak_volume',
+                        'upload_or_api': 'upload_or_api'
+                    }
                 )
             mock_logger.assert_called_with(
                 "Deskpro create ticket request failed with {} '{}'".format(mock_post().status_code, mock_post().json())


### PR DESCRIPTION
As part of a refactor of the terms of use and MoU, we need to make a few changes to the request to go live page.  This will help us collect more useful data from service teams, whilst helping them to know what actually check - so they can get it all ready in advance.

A strong reminder about the MoU has been added to here and also the terms of use page.  We can't share the MoU as it has info and contacts and escalation etc, so the call is to contact us to get a copy.