### PR TITLE
ensure robustness of email_safe function

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -3,8 +3,11 @@ import csv
 from io import StringIO
 from os import path
 from functools import wraps
+import unicodedata
+
 from flask import (abort, current_app, session, request, redirect, url_for)
 from flask_login import current_user
+
 import pyexcel
 import pyexcel.ext.io
 import pyexcel.ext.xls
@@ -141,10 +144,14 @@ def generate_previous_next_dict(view, service_id, page, title, url_args):
 
 
 def email_safe(string, whitespace='.'):
-    return "".join([
-        character.lower() if character.isalnum() or character == whitespace else ""
-        for character in re.sub(r"\s+", whitespace, string.strip())
-    ])
+    # strips accents, diacritics etc
+    string = ''.join(c for c in unicodedata.normalize('NFD', string) if unicodedata.category(c) != 'Mn')
+    string = ''.join(
+        word.lower() if word.isalnum() or word == whitespace else ''
+        for word in re.sub(r'\s+', whitespace, string.strip())
+    )
+    string = re.sub(r'\.{2,}', '.', string)
+    return string.strip('.')
 
 
 class Spreadsheet():

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -8,11 +8,20 @@ from freezegun import freeze_time
 from app.utils import email_safe, generate_notifications_csv, generate_previous_dict, generate_next_dict, Spreadsheet
 
 
-def test_email_safe_return_dot_separated_email_domain():
-    test_name = 'SOME service  with+stuff+ b123'
-    expected = 'some.service.withstuff.b123'
-    actual = email_safe(test_name)
-    assert actual == expected
+@pytest.mark.parametrize('service_name, safe_email', [
+    ('name with spaces', 'name.with.spaces'),
+    ('singleword', 'singleword'),
+    ('UPPER CASE', 'upper.case'),
+    ('Service - with dash', 'service.with.dash'),
+    ('lots      of spaces', 'lots.of.spaces'),
+    ('name.with.dots', 'name.with.dots'),
+    ('name-with-other-delimiters', 'namewithotherdelimiters'),
+    ('.leading', 'leading'),
+    ('trailing.', 'trailing'),
+    ('üńïçödë wördś', 'unicode.words'),
+])
+def test_email_safe_return_dot_separated_email_domain(service_name, safe_email):
+    assert email_safe(service_name) == safe_email
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* remove leading, trailing, or consecutive periods
* strip unicode accents, umlauts, diacritics etc

![image](https://cloud.githubusercontent.com/assets/5020841/19776378/c214311c-9c6b-11e6-9e3b-9295e2d89381.png)

![image](https://cloud.githubusercontent.com/assets/5020841/19776438/038ac246-9c6c-11e6-8234-0ca67e0e1da6.png)

