### PR TITLE
Update user profile

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -47,8 +47,8 @@ def user_profile_name():
     form = ChangeNameForm(new_name=current_user.name)
 
     if form.validate_on_submit():
-        current_user.name = form.new_name.data
-        user_api_client.update_user(current_user)
+        user_api_client.update_user(current_user.id,
+                                    name=form.new_name.data)
         return redirect(url_for('.user_profile'))
 
     return render_template(
@@ -107,7 +107,6 @@ def user_profile_email_authenticate():
 @main.route("/user-profile/email/confirm/<token>", methods=['GET'])
 @login_required
 def user_profile_email_confirm(token):
-
     token_data = check_token(token,
                              current_app.config['SECRET_KEY'],
                              current_app.config['DANGEROUS_SALT'],
@@ -115,9 +114,8 @@ def user_profile_email_confirm(token):
     token_data = json.loads(token_data)
     user_id = token_data['user_id']
     new_email = token_data['email']
-    user = user_api_client.get_user(user_id)
-    user.email_address = new_email
-    user_api_client.update_user(user)
+    user_api_client.update_user(user_id,
+                                email_address=new_email)
     session.pop(NEW_EMAIL, None)
 
     return redirect(url_for('.user_profile'))
@@ -179,10 +177,11 @@ def user_profile_mobile_number_confirm():
     form = ConfirmMobileNumberForm(_check_code)
 
     if form.validate_on_submit():
-        current_user.mobile_number = session[NEW_MOBILE]
+        mobile_number = session[NEW_MOBILE]
         del session[NEW_MOBILE]
         del session[NEW_MOBILE_PASSWORD_CONFIRMED]
-        user_api_client.update_user(current_user)
+        user_api_client.update_user(current_user.id,
+                                    mobile_number=mobile_number)
         return redirect(url_for('.user_profile'))
 
     return render_template(
@@ -202,8 +201,8 @@ def user_profile_password():
     form = ChangePasswordForm(_check_password)
 
     if form.validate_on_submit():
-        current_user.set_password(form.new_password.data)
-        user_api_client.update_user(current_user)
+        user_api_client.update_user(current_user.id,
+                                    password=form.new_password.data)
         return redirect(url_for('.user_profile'))
 
     return render_template(

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -48,7 +48,7 @@ def user_profile_name():
 
     if form.validate_on_submit():
         user_api_client.update_user_attribute(current_user.id,
-                                    name=form.new_name.data)
+                                              name=form.new_name.data)
         return redirect(url_for('.user_profile'))
 
     return render_template(
@@ -115,7 +115,7 @@ def user_profile_email_confirm(token):
     user_id = token_data['user_id']
     new_email = token_data['email']
     user_api_client.update_user_attribute(user_id,
-                                email_address=new_email)
+                                          email_address=new_email)
     session.pop(NEW_EMAIL, None)
 
     return redirect(url_for('.user_profile'))
@@ -181,7 +181,7 @@ def user_profile_mobile_number_confirm():
         del session[NEW_MOBILE]
         del session[NEW_MOBILE_PASSWORD_CONFIRMED]
         user_api_client.update_user_attribute(current_user.id,
-                                    mobile_number=mobile_number)
+                                              mobile_number=mobile_number)
         return redirect(url_for('.user_profile'))
 
     return render_template(

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -47,7 +47,7 @@ def user_profile_name():
     form = ChangeNameForm(new_name=current_user.name)
 
     if form.validate_on_submit():
-        user_api_client.update_user(current_user.id,
+        user_api_client.update_user_attribute(current_user.id,
                                     name=form.new_name.data)
         return redirect(url_for('.user_profile'))
 
@@ -114,7 +114,7 @@ def user_profile_email_confirm(token):
     token_data = json.loads(token_data)
     user_id = token_data['user_id']
     new_email = token_data['email']
-    user_api_client.update_user(user_id,
+    user_api_client.update_user_attribute(user_id,
                                 email_address=new_email)
     session.pop(NEW_EMAIL, None)
 
@@ -180,7 +180,7 @@ def user_profile_mobile_number_confirm():
         mobile_number = session[NEW_MOBILE]
         del session[NEW_MOBILE]
         del session[NEW_MOBILE_PASSWORD_CONFIRMED]
-        user_api_client.update_user(current_user.id,
+        user_api_client.update_user_attribute(current_user.id,
                                     mobile_number=mobile_number)
         return redirect(url_for('.user_profile'))
 
@@ -201,8 +201,8 @@ def user_profile_password():
     form = ChangePasswordForm(_check_password)
 
     if form.validate_on_submit():
-        user_api_client.update_user(current_user.id,
-                                    password=form.new_password.data)
+        current_user.set_password(form.new_password.data)
+        user_api_client.update_user(current_user)
         return redirect(url_for('.user_profile'))
 
     return render_template(

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -3,6 +3,12 @@ from notifications_python_client.errors import HTTPError
 
 from app.notify_client.models import User
 
+ALLOWED_ATTRIBUTES = {
+    'name',
+    'email_address',
+    'mobile_number'
+}
+
 
 class UserApiClient(BaseAPIClient):
     def __init__(self):
@@ -47,9 +53,22 @@ class UserApiClient(BaseAPIClient):
             users.append(User(user, max_failed_login_count=self.max_failed_login_count))
         return users
 
-    def update_user(self, user_id, **kwargs):
+    def update_user(self, user):
+        data = user.serialize()
+        url = "/user/{}".format(user.id)
+        user_data = self.put(url, data=data)
+        return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
+
+    def update_user_attribute(self, user_id, **kwargs):
+        data = dict(kwargs)
+        disallowed_attributes = set(data.keys()) - ALLOWED_ATTRIBUTES
+        if disallowed_attributes:
+            raise TypeError('Not allowed to update user attributes: {}'.format(
+                ", ".join(disallowed_attributes)
+            ))
+
         data = dict(**kwargs)
-        url = "/user/{}".format(user_id)
+        url = "/user/{}/update-attribute".format(user_id)
         user_data = self.put(url, data=data)
         return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
 

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -68,8 +68,8 @@ class UserApiClient(BaseAPIClient):
             ))
 
         data = dict(**kwargs)
-        url = "/user/{}/update-attribute".format(user_id)
-        user_data = self.put(url, data=data)
+        url = "/user/{}".format(user_id)
+        user_data = self.post(url, data=data)
         return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
 
     def verify_password(self, user_id, password):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -47,9 +47,9 @@ class UserApiClient(BaseAPIClient):
             users.append(User(user, max_failed_login_count=self.max_failed_login_count))
         return users
 
-    def update_user(self, user):
-        data = user.serialize()
-        url = "/user/{}".format(user.id)
+    def update_user(self, user_id, **kwargs):
+        data = dict(**kwargs)
+        url = "/user/{}".format(user_id)
         user_data = self.put(url, data=data)
         return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -32,8 +32,8 @@ def test_should_show_name_page(app_,
 def test_should_redirect_after_name_change(app_,
                                            api_user_active,
                                            mock_login,
-                                           mock_update_user,
-                                           mock_get_user):
+                                           mock_get_user,
+                                           mock_update_user_attribute):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -46,7 +46,7 @@ def test_should_redirect_after_name_change(app_,
         assert response.location == url_for(
             'main.user_profile', _external=True)
         api_user_active.name = new_name
-        assert mock_update_user.called
+        assert mock_update_user_attribute.called
 
 
 def test_should_show_email_page(app_,
@@ -116,7 +116,8 @@ def test_should_render_change_email_continue_after_authenticate_email(app_,
 
 def test_should_redirect_to_user_profile_when_user_confirms_email_link(app_,
                                                                        api_user_active,
-                                                                       mock_login
+                                                                       mock_login,
+                                                                       mock_update_user_attribute
                                                                        ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -218,6 +219,7 @@ def test_should_redirect_after_mobile_number_confirm(app_,
                                                      api_user_active,
                                                      mock_login,
                                                      mock_get_user,
+                                                     mock_update_user_attribute,
                                                      mock_check_verify_code):
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.notify_client.user_api_client import UserApiClient
 
 
@@ -13,3 +15,10 @@ def test_client_uses_correct_find_by_email(mocker, api_user_active):
     client.get_user_by_email(api_user_active.email_address)
 
     mock_get.assert_called_once_with(expected_url, params=expected_params)
+
+
+def test_client_only_updates_allowed_attributes(mocker):
+    mocker.patch('app.notify_client.current_user', id='1')
+    with pytest.raises(TypeError) as error:
+        UserApiClient().update_user_attribute('user_id', id='1')
+    assert str(error.value) == 'Not allowed to update user attributes: id'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -753,9 +753,9 @@ def mock_verify_password(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_update_user(mocker):
-    def _update(user):
-        return user
+def mock_update_user(mocker, api_user_active):
+    def _update(user_id, **kwargs):
+        return api_user_active
 
     return mocker.patch('app.user_api_client.update_user', side_effect=_update)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -761,6 +761,14 @@ def mock_update_user(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_update_user_attribute(mocker, api_user_active):
+    def _update(user_id, **kwargs):
+        return api_user_active
+
+    return mocker.patch('app.user_api_client.update_user_attribute', side_effect=_update)
+
+
+@pytest.fixture(scope='function')
 def mock_is_email_unique(mocker):
     return mocker.patch('app.user_api_client.is_email_unique', return_value=True)
 


### PR DESCRIPTION
Previous to this we were passing the whole user object when making any update to their profile. This makes it so that we only pass in the changed attribute instead. 

This relies on:

- [x] https://github.com/alphagov/notifications-api/pull/725