### PR TITLE
Use python wheels to speed up deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ generate-version-file: ## Generates the app version file
 
 .PHONY: build
 build: dependencies generate-version-file ## Build project
+	./venv/bin/pip-accel wheel --wheel-dir=wheelhouse -r requirements.txt
 	npm run build
 
 .PHONY: build-codedeploy-artifact

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -31,6 +31,7 @@ RUN \
 	echo "Install global pip packages" \
 	&& pip install \
 		virtualenv \
-		awscli
+		awscli \
+		wheel
 
 WORKDIR /var/project

--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -2,4 +2,4 @@
 
 echo "Install dependencies"
 cd /home/notify-app/notifications-admin;
-pip3 install -r /home/notify-app/notifications-admin/requirements.txt
+pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-admin/requirements.txt


### PR DESCRIPTION
These replicate the changes that were made to the api for speeding up our deployments. Our requirements will be downloaded and cached as wheels prior to deployment. 