### PR TITLE
Remove external link icon on info security link

### DIFF
--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -144,7 +144,7 @@ Terms of use – GOV.UK Notify
         You agree to send messages consistent with our design patterns, style guide and information security guidelines
       </h3>
 
-      <p>Your messages must follow our <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ" rel="external">design patterns</a>, <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing" rel="external">style guide</a> and <a href="{{ url_for('.information_security') }}" rel="external">information security guidelines</a>.</p>
+      <p>Your messages must follow our <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ" rel="external">design patterns</a>, <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing" rel="external">style guide</a> and <a href="{{ url_for('.information_security') }}">information security guidelines</a>.</p>
 
       <p>Your messages must not contain any personally or commercially sensitive information.</p>
 


### PR DESCRIPTION
It’s an internal link now