### PR TITLE
Removed unused method

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -10,15 +10,6 @@ class NotificationApiClient(BaseAPIClient):
         self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
         self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
-    def get_all_notifications(self, page=None):
-        params = {}
-        if page is not None:
-            params['page'] = page
-        return self.get(
-            url='/notifications',
-            params=params
-        )
-
     def get_notifications_for_service(
         self,
         service_id,

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -2,20 +2,6 @@ import pytest
 from app.notify_client.notification_api_client import NotificationApiClient
 
 
-def test_client_gets_notifications(mocker):
-
-    mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
-    NotificationApiClient().get_all_notifications()
-    mock_get.assert_called_once_with(url='/notifications', params={})
-
-
-def test_client_gets_notifications_with_page(mocker):
-
-    mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
-    NotificationApiClient().get_all_notifications(page=99)
-    mock_get.assert_called_once_with(url='/notifications', params={'page': 99})
-
-
 @pytest.mark.parametrize("arguments,expected_call", [
     (
         {},


### PR DESCRIPTION
Removed get_all_notifications method from notification_api_client as it is not longer being used.