### PR TITLE
Add npm (v3 or greater) as a README dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Brew is a package manager for OSX. The following command installs brew:
 
 Languages needed
 - Python 3.4
-- [Node](http://nodejs.org/) 5.0.0 or greater
+- [Node](https://nodejs.org/) 5.0.0 or greater
+- [npm](https://www.npmjs.com/) 3.0.0 or greater
 ```shell
     brew install node
 ```


### PR DESCRIPTION
Experienced an error to do with the way npm handles its dependency
paths. [Basic idea is here](https://docs.npmjs.com/how-npm-works/npm3#npm-v3-dependency-resolution).

My npm v2.x.x was failing because it couldn't find my Hogan library.
Upgrading npm, nuking `node_modules` and reinstalling/rebuilding finally fixed everything.