### PR TITLE
Remove the red header meaning signed in to admin

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -5,11 +5,9 @@
   <!--[if gt IE 8]><!-->
   <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main.css') }}" />
   <!--<![endif]-->
-  {% if current_user.is_authenticated %}
   <style>
       #global-header-bar { background-color: {{header_colour}} }
   </style>
-  {% endif %}
   <!--[if IE 6]>
   <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main-ie6.css') }}" />
   <![endif]-->

--- a/config.py
+++ b/config.py
@@ -81,20 +81,20 @@ class Test(Development):
 
 class Preview(Config):
     HTTP_PROTOCOL = 'https'
-    HEADER_COLOUR = '#F47738'  # $orange
+    HEADER_COLOUR = '#F499BE'  # $baby-pink
     CSV_UPLOAD_BUCKET_NAME = 'preview-notifications-csv-upload'
 
 
 class Staging(Config):
     SHOW_STYLEGUIDE = False
     HTTP_PROTOCOL = 'https'
-    HEADER_COLOUR = '#F47738'  # $orange
+    HEADER_COLOUR = '#6F72AF'  # $mauve
     CSV_UPLOAD_BUCKET_NAME = 'staging-notify-csv-upload'
 
 
 class Live(Config):
     SHOW_STYLEGUIDE = False
-    HEADER_COLOUR = '#B10E1E'  # $red
+    HEADER_COLOUR = '#005EA5'  # $govuk-blue
     HTTP_PROTOCOL = 'https'
     CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
 


### PR DESCRIPTION
> Make the header bar red
>
> Red for admin is a good reckon.

– 286fc308d9a64ab8effa3b9a575591b2f2f942da (part of https://github.com/alphagov/notifications-admin/pull/130)

Starting to think it’s not such a good reckon. Users could take a guess at what it meant, but they often guessed wrong or were mystified.

However, changing the colour of the header bar _is_ useful for us internally to see which environment we’re in. So this commit makes three changes:

1. On live, the header bar is always standard GOV.UK blue

2. On other environments, the header bar is some other colour (local is very different, staging and preview are related colours)

3. If an environment has a different header colour, it has it even when you’re not logged in.

***

**Local**

![image](https://cloud.githubusercontent.com/assets/355079/20632085/de9691b2-b332-11e6-976a-dec2bd170192.png)

**Preview**

![image](https://cloud.githubusercontent.com/assets/355079/20632095/ec8cc174-b332-11e6-9262-998b8acb734e.png)

**Staging**

![image](https://cloud.githubusercontent.com/assets/355079/20632102/fbafe53c-b332-11e6-9e9a-6e782240bda1.png)

**Live**

![image](https://cloud.githubusercontent.com/assets/355079/20632109/086fd002-b333-11e6-840d-320d0acdb3ab.png)
