### PR TITLE
Render letter templates as PNGs and PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Languages needed
 - [Node](https://nodejs.org/) 5.0.0 or greater
 - [npm](https://www.npmjs.com/) 3.0.0 or greater
 ```shell
-    brew install node
+    brew install node imagemagick ghostscript cairo pango
 ```
 
 [NPM](npmjs.org) is Node's package management tool. `n` is a tool for managing

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -1,6 +1,7 @@
 $outline-width: 5px;
 
 .letter {
+
   font-family: Helvetica, Arial, sans-serif;
   box-shadow:
   1px 1px 0 0 $panel-colour,
@@ -8,6 +9,16 @@ $outline-width: 5px;
   -1px 1px 0 0 $panel-colour,
   -2px 2px 0 0 rgba($panel-colour, 0.5);
   outline: $outline-width solid rgba($text-colour, 0.1);
-  padding: 20px;
+  padding: 0;
   margin: $outline-width $outline-width $gutter;
+
+  a {
+    display: block;
+  }
+
+  img {
+    display: block;
+    max-width: 100%;
+  }
+
 }

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -3,8 +3,7 @@ from app.main import main
 from app import convert_to_boolean
 from flask_login import (login_required, current_user)
 
-
-from notifications_utils.renderers import HTMLEmail
+from notifications_utils.template import HTMLEmailTemplate
 
 
 @main.route('/')
@@ -57,9 +56,7 @@ def terms():
 
 @main.route('/_email')
 def email_template():
-    return HTMLEmail(
-        govuk_banner=convert_to_boolean(request.args.get('govuk_banner', True))
-    )(
+    return str(HTMLEmailTemplate({'subject': 'foo', 'content': (
         'Lorem Ipsum is simply dummy text of the printing and typesetting '
         'industry.\n\nLorem Ipsum has been the industry’s standard dummy '
         'text ever since the 1500s, when an unknown printer took a galley '
@@ -96,7 +93,8 @@ def email_template():
         'This is an example of an email sent using GOV.UK Notify.'
         '\n\n'
         'https://www.notifications.service.gov.uk'
-    )
+    )}, govuk_banner=convert_to_boolean(request.args.get('govuk_banner', True))
+    ))
 
 
 @main.route('/documentation')

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -16,7 +16,6 @@ from flask import (
 )
 from flask_login import login_required
 from werkzeug.datastructures import MultiDict
-from notifications_utils.template import Template
 
 from app import (
     job_api_client,
@@ -31,7 +30,8 @@ from app.utils import (
     generate_previous_dict,
     user_has_permissions,
     generate_notifications_csv,
-    get_help_argument
+    get_help_argument,
+    get_template,
 )
 from app.statistics_utils import add_rate_to_job
 
@@ -108,14 +108,13 @@ def view_job(service_id, job_id):
         'views/jobs/job.html',
         finished=(total_notifications == processed_notifications),
         uploaded_file_name=job['original_file_name'],
-        template=Template(
+        template=get_template(
             service_api_client.get_service_template(
                 service_id=service_id,
                 template_id=job['template'],
                 version=job['template_version']
             )['data'],
-            prefix=current_service['name'],
-            sms_sender=current_service['sms_sender']
+            current_service,
         ),
         status=request.args.get('status', ''),
         updates_url=url_for(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -20,6 +20,7 @@ from flask_login import login_required, current_user
 from notifications_utils.columns import Columns
 from notifications_utils.template import Template
 from notifications_utils.recipients import RecipientCSV, first_column_headings, validate_and_format_phone_number
+from notifications_utils.renderers import EmailPreview, SMSPreview, LetterPDFLink
 
 from app.main import main
 from app.main.forms import CsvUploadForm, ChooseTimeForm, get_next_days_until, get_furthest_possible_scheduled_time

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -3,10 +3,12 @@ from string import ascii_uppercase
 
 from flask import request, render_template, redirect, url_for, flash, abort
 from flask_login import login_required
+from flask_weasyprint import HTML, render_pdf
 from dateutil.parser import parse
 
 from notifications_utils.template import Template
 from notifications_utils.recipients import first_column_headings
+from notifications_utils.renderers import LetterPreview
 from notifications_python_client.errors import HTTPError
 
 from app.main import main
@@ -49,6 +51,17 @@ def view_template(service_id, template_id):
         'views/templates/template.html',
         template=template
     )
+
+
+@main.route("/services/<service_id>/templates/<template_id>.pdf")
+@login_required
+@user_has_permissions('view_activity', admin_override=True)
+def view_letter_template_as_pdf(service_id, template_id):
+    template = Template(
+        service_api_client.get_service_template(service_id, template_id)['data'],
+        renderer=LetterPreview()
+    )
+    return render_pdf(HTML(string=template.rendered))
 
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -161,7 +161,11 @@ def edit_service_template(service_id, template_id):
             return render_template(
                 'views/templates/breaking-change.html',
                 template_change=template_change,
-                new_template=new_template,
+                new_template={
+                    'name': form.name.data,
+                    'subject': subject,
+                    'content': form.template_content.data,
+                },
                 column_headings=list(ascii_uppercase[:len(new_template.placeholders) + 1]),
                 example_rows=[
                     first_column_headings[new_template.template_type] + list(new_template.placeholders),

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -127,7 +127,7 @@
 
   {% endif %}
 
-  {{ template.rendered }}
+  {{ template|string }}
 
   {% if errors %}
     {% if request.args.from_test %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -12,7 +12,7 @@
       {{ uploaded_file_name }}
     </h1>
 
-    {{ template.rendered }}
+    {{ template|string }}
 
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}

--- a/app/templates/views/send-from-api.html
+++ b/app/templates/views/send-from-api.html
@@ -11,7 +11,7 @@
       API info
   </h1>
 
-  {{ template.rendered }}
+  {{ template|string }}
 
   <div class="bottom-gutter">
     {{ api_key(template.id, name="Template ID", thing='template ID') }}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -19,7 +19,7 @@
     <h1 class="heading-large">Send yourself a test</h1>
   {% endif %}
 
-  {{ template.rendered }}
+  {{ template|string }}
 
   <form method="post">
     {% call(item, row_number) list_table(

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -11,7 +11,7 @@
 
   <h1 class="heading-large">Upload recipients</h1>
 
-  {{ template.rendered }}
+  {{ template|string }}
 
   <div class="page-footer bottom-gutter">
     {{file_upload(

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -1,5 +1,5 @@
 <div class="column-two-thirds">
-  {{ template.rendered }}
+  {{ template|string }}
 </div>
 <div class="column-one-third">
   {% if template._template.archived %}

--- a/app/templates/views/templates/_template_history.html
+++ b/app/templates/views/templates/_template_history.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="column-two-thirds">
-  {{ template.rendered }}
+  {{ template|string }}
 </div>
 
 <div class="column-one-third">

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,7 +8,7 @@ import unicodedata
 from flask import (abort, current_app, session, request, redirect, url_for)
 from flask_login import current_user
 
-from notifications_utils.renderers import SMSPreview, EmailPreview, LetterPreview
+from notifications_utils.renderers import SMSPreview, EmailPreview, LetterPDFLink
 
 import pyexcel
 import pyexcel.ext.io
@@ -233,5 +233,5 @@ def get_renderer(template_type, service, show_recipient, expand_emails=False):
             sender=service['sms_sender'],
             show_recipient=show_recipient
         ),
-        'letter': LetterPreview(),
+        'letter': LetterPDFLink(service['id']),
     }[template_type]

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -26,6 +26,14 @@ RUN \
 		python-dev \
 		libffi-dev \
 		libssl-dev \
+		libexif-dev \
+		libfreetype6-dev \
+		libjpeg-dev \
+		liblcms2-2 \
+		libtiff5-dev \
+		zlib1g-dev \
+		libpango1.0-dev \
+		libcairo2-dev \
 
 	&& echo "Install nodejs" \
 	&& cd /tmp \

--- a/docker/Dockerfile-build
+++ b/docker/Dockerfile-build
@@ -34,6 +34,8 @@ RUN \
 		zlib1g-dev \
 		libpango1.0-dev \
 		libcairo2-dev \
+		libmagickwand-dev \
+		ghostscript \
 
 	&& echo "Install nodejs" \
 	&& cd /tmp \

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ wand==0.4.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
-git+https://github.com/alphagov/notifications-utils.git@12.1.0#egg=notifications-utils==12.1.0
+git+https://github.com/alphagov/notifications-utils.git@12.1.1#egg=notifications-utils==12.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ wand==0.4.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
-git+https://github.com/alphagov/notifications-utils.git@11.0.2#egg=notifications-utils==11.0.2
+git+https://github.com/alphagov/notifications-utils.git@11.1.0#egg=notifications-utils==11.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-WTF==0.11
 Flask-Login==0.3.2
 Flask-WeasyPrint==0.5
 git+https://github.com/quis/WeasyPrint.git@older-html5lib#egg=WeasyPrint==0.33
-html5lib==0.9999999
+html5lib==1.0b8
 credstash==1.8.0
 boto3==1.3.0
 Pygments==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ Flask==0.10.1
 Flask-Script==2.0.5
 Flask-WTF==0.11
 Flask-Login==0.3.2
+Flask-WeasyPrint==0.5
+git+https://github.com/quis/WeasyPrint.git@older-html5lib#egg=WeasyPrint==0.33
+html5lib==0.9999999
 credstash==1.8.0
 boto3==1.3.0
 Pygments==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ wand==0.4.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
-git+https://github.com/alphagov/notifications-utils.git@11.1.0#egg=notifications-utils==11.1.0
+git+https://github.com/alphagov/notifications-utils.git@12.1.0#egg=notifications-utils==12.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pyexcel-xls==0.1.0
 pyexcel-xlsx==0.1.0
 pyexcel-ods3==0.1.1
 pytz==2016.4
+wand==0.4.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -3,21 +3,19 @@ from flask import url_for
 
 
 @pytest.mark.parametrize(
-    "query_args, params", [
-        ({}, {'govuk_banner': True}),
-        ({'govuk_banner': 'false'}, {'govuk_banner': False})
+    "query_args, result", [
+        ({}, True),
+        ({'govuk_banner': 'false'}, 'false')
     ]
 )
-def test_renders(app_, mocker, query_args, params):
+def test_renders(app_, mocker, query_args, result):
     with app_.test_request_context(), app_.test_client() as client:
 
-        mock_html_email = mocker.patch(
-            'app.main.views.index.HTMLEmail',
-            return_value=lambda x: 'rendered'
-        )
+        mock_convert_to_boolean = mocker.patch('app.main.views.index.convert_to_boolean')
+        mocker.patch('app.main.views.index.HTMLEmailTemplate.__str__', return_value='rendered')
 
         response = client.get(url_for('main.email_template', **query_args))
 
         assert response.status_code == 200
         assert response.get_data(as_text=True) == 'rendered'
-        mock_html_email.assert_called_once_with(**params)
+        mock_convert_to_boolean.assert_called_once_with(result)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -163,7 +163,7 @@ def test_should_show_scheduled_job(
 
         assert response.status_code == 200
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find('main').find_all('p')[2].text.strip() == 'Sending will start today at midnight'
+        assert page.find('main').find_all('p')[1].text.strip() == 'Sending will start today at midnight'
         assert page.find('input', {'type': 'submit', 'value': 'Cancel sending'})
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -175,7 +175,7 @@ def test_send_test_email_message(
     api_user_active,
     mock_login,
     mock_get_service,
-    mock_get_service_email_template,
+    mock_get_service_email_template_without_placeholders,
     mock_s3_upload,
     mock_has_permissions,
     mock_get_users_by_service,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -47,7 +47,7 @@ def test_should_show_page_for_one_template(
         ('.view_letter_template_as_image', 'image/png'),
     ]
 )
-@patch("app.main.views.templates.LetterPreview.__call__")
+@patch("app.main.views.templates.LetterPreviewTemplate")
 def test_should_show_preview_letter_templates(
     mock_letter_preview,
     view,
@@ -56,7 +56,7 @@ def test_should_show_preview_letter_templates(
     api_user_active,
     mock_login,
     mock_get_service,
-    mock_get_service_template,
+    mock_get_service_email_template,
     mock_get_user,
     mock_get_user_by_email,
     mock_has_permissions,
@@ -69,7 +69,7 @@ def test_should_show_preview_letter_templates(
 
     assert response.status_code == 200
     assert response.content_type == expected_content_type
-    mock_get_service_template.assert_called_with(service_id, template_id)
+    mock_get_service_email_template.assert_called_with(service_id, template_id)
     assert mock_letter_preview.call_args[0][0]['content'] == "Your vehicle tax is about to expire"
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -44,6 +44,7 @@ def test_should_show_page_for_one_template(
     'view, expected_content_type',
     [
         ('.view_letter_template_as_pdf', 'application/pdf'),
+        ('.view_letter_template_as_image', 'image/png'),
     ]
 )
 @patch("app.main.views.templates.LetterPreview.__call__")

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -70,7 +70,7 @@ def test_should_show_preview_letter_templates(
     assert response.status_code == 200
     assert response.content_type == expected_content_type
     mock_get_service_email_template.assert_called_with(service_id, template_id)
-    assert mock_letter_preview.call_args[0][0]['content'] == "Your vehicle tax is about to expire"
+    assert mock_letter_preview.call_args[0][0]['content'] == "Your vehicle tax expires on ((date))"
 
 
 def test_should_redirect_when_saving_a_template(app_,
@@ -113,7 +113,7 @@ def test_should_show_interstitial_when_making_breaking_change(
         app_,
         api_user_active,
         mock_login,
-        mock_get_service_template,
+        mock_get_service_email_template,
         mock_update_service_template,
         mock_get_user,
         mock_get_service,
@@ -131,8 +131,9 @@ def test_should_show_interstitial_when_making_breaking_change(
                 data={
                     'id': template_id,
                     'name': "new name",
-                    'template_content': "hello ((name))",
-                    'template_type': 'sms',
+                    'template_content': "hello",
+                    'template_type': 'email',
+                    'subject': 'reminder',
                     'service': service_id
                 }
             )
@@ -143,8 +144,8 @@ def test_should_show_interstitial_when_making_breaking_change(
 
             for key, value in {
                 'name': 'new name',
-                'subject': '',
-                'template_content': 'hello ((name))',
+                'subject': 'reminder',
+                'template_content': 'hello',
                 'confirm': 'true'
             }.items():
                 assert page.find('input', {'name': key})['value'] == value
@@ -229,7 +230,7 @@ def test_should_redirect_when_saving_a_template_email(app_,
             service_id = fake_uuid
             template_id = fake_uuid
             name = "new name"
-            content = "template content"
+            content = "template content ((thing)) ((date))"
             subject = "subject"
             data = {
                 'id': template_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,7 +322,26 @@ def mock_get_service_email_template(mocker):
             template_id,
             "Two week reminder",
             "email",
-            "Your vehicle tax is about to expire", "Subject")
+            "Your vehicle tax expires on ((date))",
+            "Your ((thing)) is due soon"
+        )
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template', side_effect=_create)
+
+
+@pytest.fixture(scope='function')
+def mock_get_service_email_template_without_placeholders(mocker):
+    def _create(service_id, template_id):
+        template = template_json(
+            service_id,
+            template_id,
+            "Two week reminder",
+            "email",
+            "Your vehicle tax expires soon",
+            "Your thing is due soon"
+        )
         return {'data': template}
 
     return mocker.patch(


### PR DESCRIPTION
Depends on and implements:
- [x] alphagov/notifications-utils#84
- [x] alphagov/notifications-utils#86
- [x] https://github.com/alphagov/notifications-utils/pull/94
- [x] https://github.com/alphagov/notifications-aws/pull/106
- [x] https://github.com/alphagov/notifications-utils/pull/100

---

![image](https://cloud.githubusercontent.com/assets/355079/20667672/55ee3018-b562-11e6-9324-696cd96d00ce.png)

![image](https://cloud.githubusercontent.com/assets/355079/20667681/65b58eb0-b562-11e6-88e7-97ff081b6962.png)

## Add an endpoint for generating a PDF of a letter

Previewing a letter is different to previewing an email or text message because:

- a letter has a layout
- the layout is fixed, ie it doesn’t depend on the user’s device
- the ‘send yourself a test’ feature won’t be as useful because it has a lead time, so the feedback loop will be much longer

For these reasons a HTML-only preview of the letter won’t be enough (we don’t reckon). A PDF is more appropriate because:

- it can replicate the layout of the letter exactly
- it has a fixed size
- it is a print format, so the user could even print themselves a copy locally to get a feel for how it will look

This commit makes use of [Flask WeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/) to take a HTML representation of the letter, convert it to a PDF and serve it back to the user.

The actual work to generate the HTML and specify the layout is done in utils,  same as we do for rendering other messages.

## Add endpoint for generating an image of a letter

The PDF preview is all good, but it’s hard, finickity, and feels dirty to embed a PDF in a web page. It’s a more natural thing to embed an image in a web page.

So this commit adds another endpoint to return an image of a letter template. It generates this image from the PDF preview, so the stack looks like:

1. `template.png` (generated in admin)
2. `template.pdf` (generated in admin)
3. HTML preview (generated by a `Renderer` in utils)
4. `Template` instance
5. serialised template from API
6. Template stored in database

The library used to convert the PDF to an image is [Wand](http://docs.wand-py.org/en/0.4.4/), which binds to ImageMagick underneath. So in order to get this working locally on a Mac you will probably need to do: `brew install imagemagick ghostscript cairo pango`.

It should work on Ubuntu/EC2 once this is merged: https://github.com/alphagov/notifications-aws/pull/106

## 	Use PDF link renderer to preview letters

Shows the image preview on the page, and links to the PDF.