### PR TITLE
Generate the version file in the bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,6 @@ export DESKPRO_API_KEY="some-key"
 Your aws credentials should be stored in a folder located at `~/.aws`. Follow [Amazon's instructions](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) for storing them correctly
 
 
-## Generate the application version file
-
-```shell
-    make generate-version-file
-```
-
 ## Running the application
 
 ```shell

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -25,6 +25,9 @@ if [ ! $VIRTUAL_ENV ]; then
   . ./venv/bin/activate
 fi
 
+# we need the version file to exist otherwise the app will blow up
+make generate-version-file
+
 # Install Python development dependencies
 pip3 install -r requirements_for_test.txt
 


### PR DESCRIPTION
This file needs to exist before the app can run, so create it automatically
rather than including it as an extra setup step in the README. The API app
already does this.