### PR TITLE
Request id logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,7 +25,7 @@ from flask_wtf import CsrfProtect
 from functools import partial
 
 from notifications_python_client.errors import HTTPError
-from notifications_utils import logging
+from notifications_utils import logging, request_id
 from notifications_utils.recipients import validate_phone_number, InvalidPhoneError
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
@@ -78,6 +78,7 @@ def create_app():
     init_app(application)
     logging.init_app(application)
     init_csrf(application)
+    request_id.init_app(application)
 
     service_api_client.init_app(application)
     user_api_client.init_app(application)

--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -1,4 +1,7 @@
 from flask_login import current_user
+from flask import has_request_context, request
+from notifications_python_client.base import BaseAPIClient
+from notifications_python_client.version import __version__
 
 
 def _attach_current_user(data):
@@ -6,3 +9,20 @@ def _attach_current_user(data):
         created_by=current_user.id,
         **data
     )
+
+
+class NotifyAdminAPIClient(BaseAPIClient):
+    def generate_headers(self, api_token):
+        headers = {
+            "Content-type": "application/json",
+            "Authorization": "Bearer {}".format(api_token),
+            "User-agent": "NOTIFY-API-PYTHON-CLIENT/{}".format(__version__)
+        }
+        return self._add_request_id_header(headers)
+
+    @staticmethod
+    def _add_request_id_header(headers):
+        if not has_request_context():
+            return headers
+        headers['NotifyRequestID'] = request.request_id
+        return headers

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -1,6 +1,4 @@
-from notifications_python_client.base import BaseAPIClient
-from app.notify_client import _attach_current_user
-
+from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 
 # must match key types in notifications-api/app/models.py
 KEY_TYPE_NORMAL = 'normal'
@@ -8,7 +6,7 @@ KEY_TYPE_TEAM = 'team'
 KEY_TYPE_TEST = 'test'
 
 
-class ApiKeyApiClient(BaseAPIClient):
+class ApiKeyApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/events_api_client.py
+++ b/app/notify_client/events_api_client.py
@@ -1,7 +1,7 @@
-from notifications_python_client.base import BaseAPIClient
+from app.notify_client import NotifyAdminAPIClient
 
 
-class EventsApiClient(BaseAPIClient):
+class EventsApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -1,11 +1,9 @@
 
-from notifications_python_client.base import BaseAPIClient
-
-from app.notify_client import _attach_current_user
+from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 from app.notify_client.models import InvitedUser
 
 
-class InviteApiClient(BaseAPIClient):
+class InviteApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
 
-from notifications_python_client.base import BaseAPIClient
-from app.notify_client import _attach_current_user
+from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 
 
-class JobApiClient(BaseAPIClient):
+class JobApiClient(NotifyAdminAPIClient):
 
     JOB_STATUSES = {
         'scheduled',

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -1,7 +1,7 @@
-from notifications_python_client.base import BaseAPIClient
+from app.notify_client import NotifyAdminAPIClient
 
 
-class NotificationApiClient(BaseAPIClient):
+class NotificationApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/organisations_client.py
+++ b/app/notify_client/organisations_client.py
@@ -1,7 +1,7 @@
-from notifications_python_client.base import BaseAPIClient
+from app.notify_client import NotifyAdminAPIClient
 
 
-class OrganisationsClient(BaseAPIClient):
+class OrganisationsClient(NotifyAdminAPIClient):
 
     def __init__(self):
         super().__init__("a", "b", "c")

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -1,8 +1,8 @@
-from notifications_python_client.base import BaseAPIClient
-from app.notify_client import _attach_current_user
+
+from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 
 
-class ProviderClient(BaseAPIClient):
+class ProviderClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 from flask import url_for
-from notifications_python_client.base import BaseAPIClient
 from app.utils import BrowsableItem
-from app.notify_client import _attach_current_user
+from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 
 
-class ServiceAPIClient(BaseAPIClient):
+class ServiceAPIClient(NotifyAdminAPIClient):
     # Fudge assert in the super __init__ so
     # we can set those variables later.
     def __init__(self):

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -1,7 +1,8 @@
-from notifications_python_client.base import BaseAPIClient
+
+from app.notify_client import NotifyAdminAPIClient
 
 
-class StatusApiClient(BaseAPIClient):
+class StatusApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -1,7 +1,7 @@
-from notifications_python_client.base import BaseAPIClient
+from app.notify_client import NotifyAdminAPIClient
 
 
-class TemplateStatisticsApiClient(BaseAPIClient):
+class TemplateStatisticsApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -1,6 +1,6 @@
-from notifications_python_client.notifications import BaseAPIClient
 from notifications_python_client.errors import HTTPError
 
+from app.notify_client import NotifyAdminAPIClient
 from app.notify_client.models import User
 
 ALLOWED_ATTRIBUTES = {
@@ -10,7 +10,7 @@ ALLOWED_ATTRIBUTES = {
 }
 
 
-class UserApiClient(BaseAPIClient):
+class UserApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a", "b", "c")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pyexcel-xlsx==0.1.0
 pyexcel-ods3==0.1.1
 pytz==2016.4
 
-git+https://github.com/alphagov/notifications-python-client.git@3.0.0#egg=notifications-python-client==3.0.0
+git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
 git+https://github.com/alphagov/notifications-utils.git@10.0.0#egg=notifications-utils==10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
-git+https://github.com/alphagov/notifications-utils.git@10.0.0#egg=notifications-utils==10.0.0
+git+https://github.com/alphagov/notifications-utils.git@10.3.0#egg=notifications-utils==10.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ pytz==2016.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
-git+https://github.com/alphagov/notifications-utils.git@10.3.0#egg=notifications-utils==10.3.0
+git+https://github.com/alphagov/notifications-utils.git@10.3.1#egg=notifications-utils==10.3.1


### PR DESCRIPTION
[Blocked until Utils merged]

Sets up request ID logging in the Admin app. This ties together all log events to the same request, including the API.

- Every request sets a request ID as a UUID
- This is set on the headers of the request
- passed to the logger and logged against each log event
- passed to the API to ensure API logs against the same ID

Depends on
- [ ] https://github.com/alphagov/notifications-utils/pull/89