### PR TITLE
Fix alignment of year label on usage

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -53,7 +53,7 @@
 
 .align-with-heading-copy {
   display: block;
-  margin-top: 45px;
+  margin-top: 25px;
 }
 
 .align-with-heading-copy-right {


### PR DESCRIPTION
It got pushed down too far when we added the switch service bar in
https://github.com/alphagov/notifications-admin/pull/1029

This commit fixes it so that the text aligns with the baseline of the
`<h1>`.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/20885956/76ab309c-baeb-11e6-9070-3a01f6f44168.png)

## After

![image](https://cloud.githubusercontent.com/assets/355079/20885932/5c93752a-baeb-11e6-9ae9-f2c8d9c090b3.png)
