### PR TITLE
Add option to exclude test key usage in stats on platform admin page

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -1,6 +1,9 @@
 import itertools
 
-from flask import render_template
+from flask import (
+    render_template,
+    request
+)
 from flask_login import login_required
 
 from app import service_api_client
@@ -13,10 +16,15 @@ from app.statistics_utils import get_formatted_percentage
 @login_required
 @user_has_permissions(admin_override=True)
 def platform_admin():
+    include_from_test_key = request.args.get('include_from_test_key') != 'False'
     # specifically DO get inactive services
-    services = service_api_client.get_services({'detailed': True})['data']
+    api_args = {'detailed': True}
+    if not include_from_test_key:
+        api_args['include_from_test_key'] = False
+    services = service_api_client.get_services(api_args)['data']
     return render_template(
         'views/platform-admin.html',
+        include_from_test_key=include_from_test_key,
         **get_statistics(sorted(
             services,
             key=lambda service: (service['active'], service['created_at']),

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -47,6 +47,9 @@
                 <li>
                   <a href="{{ url_for('main.platform_admin') }}">Platform admin</a>
                 </li>
+                <li>
+                  <a href="{{ url_for('main.view_providers') }}">Providers</a>
+                </li>
             {% endif %}
             <li>
               <a href="{{ url_for('main.sign_out')}}">Sign out</a>

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -87,45 +87,38 @@
     Platform admin
   </h1>
 
-  <div class="grid-row">
-    <div class="column-one-third">
-      <nav class="navigation">
-        <ul>
-          <li>Showing stats for today</li>
-          {% if include_from_test_key %}
-            <li>Including test key (<a href="{{ url_for('.platform_admin', include_from_test_key=False) }}">change</a>)</li>
-          {% else %}
-            <li>Excluding test key (<a href="{{ url_for('.platform_admin') }}">change</a>)</li>
-          {% endif %}
-        </ul>
-      </nav>
+  <p class="bottom-gutter-2">
+    Showing stats for today&emsp;
+    {% if include_from_test_key %}
+      Including test keys (<a href="{{ url_for('.platform_admin', include_from_test_key=False) }}">change</a>)
+    {% else %}
+      Excluding test keys (<a href="{{ url_for('.platform_admin') }}">change</a>)
+    {% endif %}
+  </p>
+
+  <div class="grid-row bottom-gutter">
+    <div class="column-half">
+      {{ big_number_with_status(
+        global_stats.email.delivered,
+        message_count_label(global_stats.email.delivered, 'email'),
+        global_stats.email.failed,
+        global_stats.email.failure_rate,
+        global_stats.email.failure_rate|float > 3,
+      ) }}
     </div>
-    <main role="main" class="column-two-thirds column-main">
-      <div class="grid-row bottom-gutter">
-        <div class="column-half">
-          {{ big_number_with_status(
-            global_stats.email.delivered,
-            message_count_label(global_stats.email.delivered, 'email'),
-            global_stats.email.failed,
-            global_stats.email.failure_rate,
-            global_stats.email.failure_rate|float > 3,
-          ) }}
-        </div>
-        <div class="column-half">
-          {{ big_number_with_status(
-            global_stats.sms.delivered,
-            message_count_label(global_stats.sms.delivered, 'sms'),
-            global_stats.sms.failed,
-            global_stats.sms.failure_rate,
-            global_stats.sms.failure_rate|float > 3,
-          ) }}
-        </div>
-      </div>
-
-      {{ services_table(live_services, 'Live services') }}
-
-      {{ services_table(trial_mode_services, 'Trial mode services') }}
-    </main>
+    <div class="column-half">
+      {{ big_number_with_status(
+        global_stats.sms.delivered,
+        message_count_label(global_stats.sms.delivered, 'sms'),
+        global_stats.sms.failed,
+        global_stats.sms.failure_rate,
+        global_stats.sms.failure_rate|float > 3,
+      ) }}
+    </div>
   </div>
+
+  {{ services_table(live_services, 'Live services') }}
+
+  {{ services_table(trial_mode_services, 'Trial mode services') }}
 
 {% endblock %}

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
-{% from "components/browse-list.html" import browse_list %}
 {% from "components/table.html" import mapping_table, field, stats_fields, row_group, row, right_aligned_field_heading, hidden_field_heading, text_field %}
 
 {% macro stats_fields(channel, data) -%}
@@ -87,13 +86,6 @@
   <h1 class="heading-large">
     Platform admin
   </h1>
-
-  {{ browse_list([
-    {
-      'title': 'View providers',
-      'link': url_for('.view_providers')
-    },
-  ]) }}
 
   <div class="grid-row">
     <div class="column-one-third">

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -99,6 +99,7 @@
     <div class="column-one-third">
       <nav class="navigation">
         <ul>
+          <li>Showing stats for today</li>
           {% if include_from_test_key %}
             <li>Including test key (<a href="{{ url_for('.platform_admin', include_from_test_key=False) }}">change</a>)</li>
           {% else %}
@@ -108,7 +109,6 @@
       </nav>
     </div>
     <main role="main" class="column-two-thirds column-main">
-      <h2 class='heading-medium'>Today</h2>
       <div class="grid-row bottom-gutter">
         <div class="column-half">
           {{ big_number_with_status(

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -95,31 +95,45 @@
     },
   ]) }}
 
+  <div class="grid-row">
+    <div class="column-one-third">
+      <nav class="navigation">
+        <ul>
+          {% if include_from_test_key %}
+            <li>Including test key (<a href="{{ url_for('.platform_admin', include_from_test_key=False) }}">change</a>)</li>
+          {% else %}
+            <li>Excluding test key (<a href="{{ url_for('.platform_admin') }}">change</a>)</li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+    <main role="main" class="column-two-thirds column-main">
+      <h2 class='heading-medium'>Today</h2>
+      <div class="grid-row bottom-gutter">
+        <div class="column-half">
+          {{ big_number_with_status(
+            global_stats.email.delivered,
+            message_count_label(global_stats.email.delivered, 'email'),
+            global_stats.email.failed,
+            global_stats.email.failure_rate,
+            global_stats.email.failure_rate|float > 3,
+          ) }}
+        </div>
+        <div class="column-half">
+          {{ big_number_with_status(
+            global_stats.sms.delivered,
+            message_count_label(global_stats.sms.delivered, 'sms'),
+            global_stats.sms.failed,
+            global_stats.sms.failure_rate,
+            global_stats.sms.failure_rate|float > 3,
+          ) }}
+        </div>
+      </div>
 
-  <h2 class='heading-medium'>Today</h2>
-  <div class="grid-row bottom-gutter">
-    <div class="column-half">
-      {{ big_number_with_status(
-        global_stats.email.delivered,
-        message_count_label(global_stats.email.delivered, 'email'),
-        global_stats.email.failed,
-        global_stats.email.failure_rate,
-        global_stats.email.failure_rate|float > 3,
-      ) }}
-    </div>
-    <div class="column-half">
-      {{ big_number_with_status(
-        global_stats.sms.delivered,
-        message_count_label(global_stats.sms.delivered, 'sms'),
-        global_stats.sms.failed,
-        global_stats.sms.failure_rate,
-        global_stats.sms.failure_rate|float > 3,
-      ) }}
-    </div>
+      {{ services_table(live_services, 'Live services') }}
+
+      {{ services_table(trial_mode_services, 'Trial mode services') }}
+    </main>
   </div>
-
-  {{ services_table(live_services, 'Live services') }}
-
-  {{ services_table(trial_mode_services, 'Trial mode services') }}
 
 {% endblock %}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -81,7 +81,7 @@ def test_should_render_platform_admin_page(
     assert response.status_code == 200
     resp_data = response.get_data(as_text=True)
     assert 'Platform admin' in resp_data
-    assert 'Today' in resp_data
+    assert 'Showing stats for today' in resp_data
     assert 'Live services' in resp_data
     assert 'Trial mode services' in resp_data
     mock_get_detailed_services.assert_called_once_with({'detailed': True})

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -88,8 +88,8 @@ def test_should_render_platform_admin_page(
 
 
 @pytest.mark.parametrize('include_from_test_key, expected_text, unexpected_text, api_args', [
-    (True, 'Including test key', 'Excluding test key', {'detailed': True}),
-    (False, 'Excluding test key', 'Including test key', {'detailed': True, 'include_from_test_key': False})
+    (True, 'Including test keys', 'Excluding test keys', {'detailed': True}),
+    (False, 'Excluding test keys', 'Including test keys', {'detailed': True, 'include_from_test_key': False})
 ])
 def test_platform_admin_toggle_including_from_test_key(
     include_from_test_key,

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -87,6 +87,43 @@ def test_should_render_platform_admin_page(
     mock_get_detailed_services.assert_called_once_with({'detailed': True})
 
 
+@pytest.mark.parametrize('include_from_test_key, expected_text, unexpected_text, api_args', [
+    (True, 'Including test key', 'Excluding test key', {'detailed': True}),
+    (False, 'Excluding test key', 'Including test key', {'detailed': True, 'include_from_test_key': False})
+])
+def test_platform_admin_toggle_including_from_test_key(
+    include_from_test_key,
+    expected_text,
+    unexpected_text,
+    api_args,
+    app_,
+    platform_admin_user,
+    mocker,
+    mock_get_detailed_services
+):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            mock_get_user(mocker, user=platform_admin_user)
+            client.login(platform_admin_user)
+            response = client.get(url_for('main.platform_admin', include_from_test_key=str(include_from_test_key)))
+
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert expected_text in resp_data
+    assert unexpected_text not in resp_data
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    change_link = page.find('a', text='change')
+    assert change_link['href']
+    query_param = 'include_from_test_key=False'
+    if include_from_test_key:
+        assert query_param in change_link['href']
+    else:
+        assert query_param not in change_link['href']
+
+    mock_get_detailed_services.assert_called_once_with(api_args)
+
+
 def test_create_global_stats_sets_failure_rates(fake_uuid):
     services = [
         service_json(fake_uuid, 'a', []),


### PR DESCRIPTION
Depends on https://github.com/alphagov/notifications-api/pull/758

This page currently includes all notifications for all services, including those sent using a test key. Stats on all other pages exclude test key usage, though, which can lead to confusion for admins comparing numbers between pages. Adding the option to toggle between including and excluding test key usage on the platform admin page gives context for this difference, and allows admins to see live usage of the platform as well as load associated with test key usage.

Also move "Today" heading and providers link to the left column and header respectively.

Thanks @quis for design help ✨ 

Before:
![screen shot 2016-12-05 at 17 15 39](https://cloud.githubusercontent.com/assets/1822424/20895665/3b242d40-bb12-11e6-822f-ed978325cded.png)

After:
![screen shot 2016-12-05 at 17 16 06](https://cloud.githubusercontent.com/assets/1822424/20895673/44bda192-bb12-11e6-9d0d-36ab908d6ffb.png)
