### PR TITLE
Add Natural England to government email domains list

### DIFF
--- a/config.py
+++ b/config.py
@@ -61,13 +61,7 @@ class Config(object):
         r"nhs\.uk",
         r"nhs\.net",
         r"police\.uk",
-        r"kainos\.com",
-        r"salesforce\.com",
-        r"bitzesty\.com",
         r"dclgdatamart\.co\.uk",
-        r"valtech\.co\.uk",
-        r"cgi\.com",
-        r"capita\.co\.uk",
         r"ucds\.email",
         r"naturalengland\.org\.uk",
     ]

--- a/config.py
+++ b/config.py
@@ -68,7 +68,8 @@ class Config(object):
         r"valtech\.co\.uk",
         r"cgi\.com",
         r"capita\.co\.uk",
-        r"ucds\.email"
+        r"ucds\.email",
+        r"naturalengland\.org\.uk",
     ]
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -81,7 +81,8 @@ def _gen_mock_field(x):
     'test@GOV.PoliCe.uk',
     'test@valtech.co.uk',
     'test@cgi.com',
-    'test@ucds.email'
+    'test@ucds.email',
+    'test@naturalengland.org.uk',
 ])
 def test_valid_list_of_white_list_email_domains(app_, email):
     with app_.test_request_context():

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -79,8 +79,6 @@ def _gen_mock_field(x):
     'test@police.uk',
     'test@gov.police.uk',
     'test@GOV.PoliCe.uk',
-    'test@valtech.co.uk',
-    'test@cgi.com',
     'test@ucds.email',
     'test@naturalengland.org.uk',
 ])


### PR DESCRIPTION
> I cannot register as the Email address field will not accept my email
> address format (.org.uk).  Natural England is a non-departmental
> government body sponsored by Defra (Department for Environment, Food
> and Rural Affairs).  Can you register me on the system or change the
> system so it will accept my email address?

– Deskpro ticket

> Natural England is an executive non-departmental public body,
> sponsored by the Department for Environment, Food & Rural Affairs.

– https://www.gov.uk/government/organisations/natural-england

***

Seems legit.

## Also, Don’t allow suppliers to sign up for own accounts

Suppliers need to be invited by people who work for the government.
People who work for the government can invite anyone to join their team,
no matter what their email address is.

So there’s no need for these domains to be in the list now.