### PR TITLE
Switched off session protection

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,6 +99,7 @@ def create_app():
     login_manager.init_app(application)
     login_manager.login_view = 'main.sign_in'
     login_manager.login_message_category = 'default'
+    login_manager.session_protection = None
 
     from app.main import main as main_blueprint
     application.register_blueprint(main_blueprint)


### PR DESCRIPTION
Many departments are reporting being logged out during usage of the app
This may be because they present differing IP addresses to Notify on different requests due to outbound proxies and so on
Switching session protection to None means and IP change won't log a user out.

Note this was hard to test on my local build. I could replicate the error on production by switching from my mobile hotspot to wifi and back. However having to use the VPN to sign in (for SQS) from home maybe meant that the issue didn't occur as I couldn't replicate the problem locally (though I did in the office yesterday). So I can't verify this fixes it.

Whoever reviews this would be good to checkit in the office - using different wifi networks.

Thanks
