### PR TITLE
Fix images on product page in older version of IE

### DIFF
--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -12,10 +12,16 @@
       @extend %site-width-container;
 
       @include media(desktop) {
+
         background-image: file-url('product/proposition-illustration.png');
         background-size: 320px;
         background-repeat: no-repeat;
         background-position: right -14px top -10px;
+
+        @include ie-lte(8) {
+          background-image: none;
+        }
+
       }
 
     }

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -90,7 +90,7 @@
     }
 
     img {
-      max-width: 100%;
+      width: 100%;
       margin: 0 0 $gutter * 1.5 0;
     }
 


### PR DESCRIPTION
## Don’t show hero image on IE8

IE8 doesn’t support background-size, so the image appears too big, the text overlaps it, and everything becomes a mess.

Before | After
---|---
![image](https://cloud.githubusercontent.com/assets/355079/21187431/cefc1830-c20f-11e6-895b-7435b58206cc.png) | ![image](https://cloud.githubusercontent.com/assets/355079/21187451/e479770c-c20f-11e6-9e06-9ef63fe1f815.png)

## Make SVGs 100% wide

Internet Explorer 11 and below don’t scale SVG images properly when they’re used in `<img>` tags. See https://gist.github.com/larrybotha/7881691 for details.

This manifested itself as the SVG images on the product page being smaller when viewed in IE11 than other browsers.

This commit explicitly sets them to be 100% wide, which seems to fix the problem.

Before | After
---|---
![image](https://cloud.githubusercontent.com/assets/355079/21187508/1a4116c4-c210-11e6-929e-424e3936d122.png) | ![image](https://cloud.githubusercontent.com/assets/355079/21187485/0c73ea58-c210-11e6-8480-e5ff4aed6505.png)