### PR TITLE
Fix misaligned sidebar on the tour

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -116,7 +116,7 @@
   @extend %banner;
   background: $govuk-blue;
   color: $white;
-  margin-top: $gutter;
+  margin-top: 10px;
   padding: $gutter;
   height: 475px;
   overflow: hidden;


### PR DESCRIPTION
Got broken when we moved the service name out of the nav.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/21191166/310e35c4-c21c-11e6-9cd3-2562f8ce055c.png)

## After 

![image](https://cloud.githubusercontent.com/assets/355079/21191141/1ef8fedc-c21c-11e6-8c5b-7cff235e1293.png)
