### PR TITLE
Fix button shadow colour on product page

### DIFF
--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -36,6 +36,7 @@
 
     .button {
 
+      @include box-shadow(0 2px 0 darken($govuk-blue, 15%));
       background: $white;
       margin-right: 15px;
 


### PR DESCRIPTION
The button was inheriting a green box shadow from the default GOV.UK button style, which is typically used on a white background. On the blue background, a darker blue shadow looks better I think.

The 15% darkening is the same as used by the default green button: https://github.com/alphagov/govuk_frontend_toolkit/blob/a3fe44e00ef3e364376a138fbffa8495af9906df/stylesheets/design-patterns/_buttons.scss#L36

Before | After
---|---
![image](https://cloud.githubusercontent.com/assets/355079/21259760/ca7aa850-c37a-11e6-8f62-8c20d8043270.png) | ![image](https://cloud.githubusercontent.com/assets/355079/21259744/ba617322-c37a-11e6-8260-61fba018e7cf.png)


@nickcolley I have no idea now you spotted this, but thanks.