### PR TITLE
Show pricing and number of services on product page

### DIFF
--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -81,7 +81,7 @@
     margin-bottom: $gutter-half;
 
     h2 {
-      @include bold-36;
+      @include bold-27;
       margin: 0 0 $gutter;
     }
 
@@ -95,6 +95,11 @@
       margin: 0 0 $gutter * 1.5 0;
     }
 
+  }
+
+  &-big-number {
+    @include bold-48($tabular-numbers: true);
+    margin: 0 0 0 0;
   }
 
 }

--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -26,7 +26,7 @@
         <li>Up to 306 characters = 2 text messages</li>
         <li>Up to 459 characters = 3 text messages</li>
       </ul></li>
-      <li>Standard text message rate: 1.65p + VAT</li>
+      <li>Standard text message rate: 1.65 pence + VAT</li>
     </ul>
 
     <p>

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -95,7 +95,32 @@
       </div>
     </div>
   </div>
-  <div class="product-page-section bottom-gutter-2">
+  <div class="product-page-section">
+    <div class="with-keyline bottom-gutter-2">
+      <h2>Pricing</h2>
+      <div class="grid-row bottom-gutter">
+        <div class="column-half">
+          <h3 class="visually-hidden">Emails</h3>
+          <div class="product-page-big-number">Unlimited</div>
+          free emails
+        </div>
+        <div class="column-half">
+          <h3 class="visually-hidden">Text messages</h3>
+          <div class="product-page-big-number">250,000</div>
+          free text messages a year, then
+          1.65 pence per message
+        </div>
+      </div>
+      <div class="grid-row bottom-gutter">
+        <div class="column-three-quarters">
+          <p>
+            There’s no monthly charge, no setup fee and no procurement process.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="product-page-section">
     <div class="grid-row">
       <div class="column-half">
         <h2 class="with-keyline">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -97,6 +97,23 @@
   </div>
   <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2">
+      <h2>Who’s using GOV.UK Notify</h2>
+      <div class="grid-row bottom-gutter">
+        <div class="column-half">
+          <h3 class="visually-hidden">Services</h3>
+          <div class="product-page-big-number">23</div>
+          services
+        </div>
+        <div class="column-half">
+          <h3 class="visually-hidden">Departments</h3>
+          <div class="product-page-big-number">14</div>
+          departments
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="product-page-section">
+    <div class="with-keyline bottom-gutter-2">
       <h2>Pricing</h2>
       <div class="grid-row bottom-gutter">
         <div class="column-half">

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -37,7 +37,7 @@
           {% if sms_chargeable %}
             {{ big_number(
               sms_chargeable,
-              'at {:.2f}p per message'.format(sms_rate * 100),
+              'at {:.2f} pence per message'.format(sms_rate * 100),
               smaller=True
             ) }}
           {% endif %}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/21313240/93593b1e-c5e8-11e6-98c0-54b1d77450b7.png)

## Add pricing to the product page

‘How much does it cost’ is one of the user needs that we identified for the product page.

Cost is not the primary reason someone would use Notify (they’re more likely to cite ease, or that it’s ‘official’). However if you _don’t_ mention cost then it looks like we’re hiding something or that there’s a catch. So putting it on the page allays fears that people might have, rather than pushing them towards using it.

Visually I’ve dropped the size of the `<h2>`s on this page so that there’s enough difference between them and the big numbers. The idea of the big numbers being big is to catch people’s attention as they scroll down the page, by breaking up the rhythm.

## Use ‘pence’ in full on pricing and usage pages

This matches what we now do on the product page.

From the GOV.UK style guide:
> Write out pence in full: calls will cost 4 pence per minute from a landline.

– https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#money

## Add number of services to product page

One of the user needs that we identified is not wanting to be the first to use it. It feels like a much less risky choice if there are already other people in government using it.

The easiest way to communicate this is with counts of how many services. The count of departments is good because it shows breadth, where the count of services shows depth.

Hard coded for now because we have no automatic way of splitting our test services from real live services.