### PR TITLE
Update patched Weasyprint fork to alphagov hosted

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,10 @@ Flask-Script==2.0.5
 Flask-WTF==0.11
 Flask-Login==0.3.2
 Flask-WeasyPrint==0.5
+
+# Can be removed when https://github.com/mozilla/bleach/issues/229 is fixed
 git+https://github.com/alphagov/WeasyPrint.git@older-html5lib#egg=WeasyPrint==0.33
+
 html5lib==1.0b8
 credstash==1.8.0
 boto3==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 Flask-WTF==0.11
 Flask-Login==0.3.2
 Flask-WeasyPrint==0.5
-git+https://github.com/quis/WeasyPrint.git@older-html5lib#egg=WeasyPrint==0.33
+git+https://github.com/alphagov/WeasyPrint.git@older-html5lib#egg=WeasyPrint==0.33
 html5lib==1.0b8
 credstash==1.8.0
 boto3==1.3.0


### PR DESCRIPTION
Better than it being on my personal Github account.

Reasons why we’re doing this in the first place in this commit: https://github.com/alphagov/WeasyPrint/commit/99718c2caf768324a1f0c2fd29a438e0a850837d