### PR TITLE
Add remaining endpoints for PDFs and PNGs

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -96,7 +96,7 @@ class UKMobileNumber(TelField):
         try:
             validate_phone_number(self.data)
         except InvalidPhoneError as e:
-            raise ValidationError(e.message)
+            raise ValidationError(str(e))
 
 
 def mobile_number():

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -213,10 +213,7 @@ def send_from_api(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['GET'])
-@login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
-def check_messages(service_id, template_type, upload_id):
+def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
 
     if not session.get('upload_data'):
         return redirect(url_for('main.choose_template', service_id=service_id, template_type=template_type))
@@ -275,8 +272,7 @@ def check_messages(service_id, template_type, upload_id):
 
     session['upload_data']['notification_count'] = len(list(recipients.rows))
     session['upload_data']['valid'] = not recipients.has_errors
-    return render_template(
-        'views/check.html',
+    return dict(
         recipients=recipients,
         first_recipient=first_recipient,
         template=template,
@@ -295,6 +291,16 @@ def check_messages(service_id, template_type, upload_id):
         choose_time_form=choose_time_form,
         back_link=back_link,
         help=get_help_argument()
+    )
+
+
+@main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['GET'])
+@login_required
+@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+def check_messages(service_id, template_type, upload_id):
+    return render_template(
+        'views/check.html',
+        **_check_messages(service_id, template_type, upload_id)
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -77,6 +77,14 @@ def view_letter_template_as_image(service_id, template_id):
     return send_file(output, mimetype='image/png')
 
 
+def _view_template_version(service_id, template_id, version, letters_as_pdf=False):
+    return dict(template=get_template(
+        service_api_client.get_service_template(service_id, template_id, version)['data'],
+        current_service,
+        expand_emails=True,
+    ))
+
+
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")
 @login_required
 @user_has_permissions(
@@ -91,11 +99,7 @@ def view_letter_template_as_image(service_id, template_id):
 def view_template_version(service_id, template_id, version):
     return render_template(
         'views/templates/template_history.html',
-        template=get_template(
-            service_api_client.get_service_template(service_id, template_id, version)['data'],
-            current_service,
-            expand_emails=True
-        )
+        **_view_template_version(service_id=service_id, template_id=template_id, version=version)
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -47,7 +47,8 @@ def view_template(service_id, template_id):
         template=get_template(
             service_api_client.get_service_template(service_id, template_id)['data'],
             current_service,
-            expand_emails=True
+            expand_emails=True,
+            letter_preview_url=url_for('.view_template', service_id=service_id, template_id=template_id)
         )
     )
 
@@ -66,7 +67,7 @@ def view_letter_template_as_pdf(service_id, template_id):
 @main.route("/services/<service_id>/templates/<template_id>.png")
 @login_required
 @user_has_permissions('view_activity', admin_override=True)
-def view_letter_template_as_image(service_id, template_id):
+def view_letter_template_as_png(service_id, template_id):
     output = BytesIO()
     with Image(
         blob=view_letter_template_as_pdf(service_id, template_id).get_data()
@@ -79,9 +80,15 @@ def view_letter_template_as_image(service_id, template_id):
 
 def _view_template_version(service_id, template_id, version, letters_as_pdf=False):
     return dict(template=get_template(
-        service_api_client.get_service_template(service_id, template_id, version)['data'],
+        service_api_client.get_service_template(service_id, template_id, version=version)['data'],
         current_service,
         expand_emails=True,
+        letter_preview_url=url_for(
+            '.view_template_version',
+            service_id=service_id,
+            template_id=template_id,
+            version=version,
+        ) if not letters_as_pdf else None
     ))
 
 
@@ -101,6 +108,47 @@ def view_template_version(service_id, template_id, version):
         'views/templates/template_history.html',
         **_view_template_version(service_id=service_id, template_id=template_id, version=version)
     )
+
+
+@main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.pdf")
+@login_required
+@user_has_permissions(
+    'view_activity',
+    'send_texts',
+    'send_emails',
+    'manage_templates',
+    'manage_api_keys',
+    admin_override=True,
+    any_=True
+)
+def view_template_version_as_pdf(service_id, template_id, version):
+    return render_pdf(HTML(string=str(
+        LetterPreviewTemplate(
+            service_api_client.get_service_template(service_id, template_id, version=version)['data'],
+        )
+    )))
+
+
+@main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.png")
+@login_required
+@user_has_permissions(
+    'view_activity',
+    'send_texts',
+    'send_emails',
+    'manage_templates',
+    'manage_api_keys',
+    admin_override=True,
+    any_=True
+)
+def view_template_version_as_png(service_id, template_id, version):
+    output = BytesIO()
+    with Image(
+        blob=view_template_version_as_pdf(service_id, template_id, version).get_data()
+    ) as image:
+        with image.convert('png') as converted:
+            converted.save(file=output)
+    output.seek(0)
+    return send_file(output, mimetype='image/png')
 
 
 @main.route("/services/<service_id>/templates/add-<template_type>", methods=['GET', 'POST'])
@@ -266,7 +314,17 @@ def view_template_versions(service_id, template_id):
     return render_template(
         'views/templates/choose_history.html',
         versions=[
-            get_template(template, current_service, expand_emails=True)
+            get_template(
+                template,
+                current_service,
+                expand_emails=True,
+                letter_preview_url=url_for(
+                    '.view_template_version',
+                    service_id=service_id,
+                    template_id=template_id,
+                    version=template['version'],
+                )
+            )
             for template in service_api_client.get_service_template_versions(service_id, template_id)['data']
         ]
     )

--- a/app/utils.py
+++ b/app/utils.py
@@ -264,7 +264,8 @@ def get_template(
 def png_from_pdf(pdf_endpoint):
     output = BytesIO()
     with Image(
-        blob=pdf_endpoint.get_data()
+        blob=pdf_endpoint.get_data(),
+        resolution=96,
     ) as image:
         with image.convert('png') as converted:
             converted.save(file=output)

--- a/app/utils.py
+++ b/app/utils.py
@@ -12,6 +12,7 @@ from notifications_utils.template import (
     SMSPreviewTemplate,
     EmailPreviewTemplate,
     LetterPDFLinkTemplate,
+    LetterPreviewTemplate,
 )
 
 import pyexcel
@@ -224,7 +225,13 @@ def is_gov_user(email_address):
     return bool(re.search(email_regex, email_address.lower()))
 
 
-def get_template(template, service, show_recipient=False, expand_emails=False):
+def get_template(
+    template,
+    service,
+    show_recipient=False,
+    expand_emails=False,
+    letter_preview_url=None,
+):
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
             template,
@@ -241,7 +248,12 @@ def get_template(template, service, show_recipient=False, expand_emails=False):
             show_recipient=show_recipient
         )
     if 'letter' == template['template_type']:
-        return LetterPDFLinkTemplate(
-            template,
-            service_id=service['id'],
-        )
+        if letter_preview_url:
+            return LetterPDFLinkTemplate(
+                template,
+                preview_url=letter_preview_url,
+            )
+        else:
+            return LetterPreviewTemplate(
+                template
+            )

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,12 +1,14 @@
 import re
 import csv
-from io import StringIO
+from io import StringIO, BytesIO
 from os import path
 from functools import wraps
 import unicodedata
 
 from flask import (abort, current_app, session, request, redirect, url_for)
 from flask_login import current_user
+
+from wand.image import Image
 
 from notifications_utils.template import (
     SMSPreviewTemplate,
@@ -257,3 +259,17 @@ def get_template(
             return LetterPreviewTemplate(
                 template
             )
+
+
+def png_from_pdf(pdf_endpoint):
+    output = BytesIO()
+    with Image(
+        blob=pdf_endpoint.get_data()
+    ) as image:
+        with image.convert('png') as converted:
+            converted.save(file=output)
+    output.seek(0)
+    return dict(
+        filename_or_fp=output,
+        mimetype='image/png',
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ wand==0.4.4
 
 git+https://github.com/alphagov/notifications-python-client.git@3.0.1#egg=notifications-python-client==3.0.1
 
-git+https://github.com/alphagov/notifications-utils.git@12.1.1#egg=notifications-utils==12.1.1
+git+https://github.com/alphagov/notifications-utils.git@13.0.1#egg=notifications-utils==13.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,7 +316,7 @@ def mock_get_service_template_with_placeholders(mocker):
 
 @pytest.fixture(scope='function')
 def mock_get_service_email_template(mocker):
-    def _create(service_id, template_id):
+    def _get(service_id, template_id, version=None):
         template = template_json(
             service_id,
             template_id,
@@ -328,7 +328,7 @@ def mock_get_service_email_template(mocker):
         return {'data': template}
 
     return mocker.patch(
-        'app.service_api_client.get_service_template', side_effect=_create)
+        'app.service_api_client.get_service_template', side_effect=_get)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Depends on:

- [x] https://github.com/alphagov/notifications-utils/pull/103
- [x] https://github.com/alphagov/notifications-utils/pull/105

Template | With CSV
---|---
![image](https://cloud.githubusercontent.com/assets/355079/21360288/3180523e-c6d7-11e6-8ace-5b46ba8ea22a.png) | ![image](https://cloud.githubusercontent.com/assets/355079/21360274/23a6cbc0-c6d7-11e6-811c-21d418a834c5.png)


***

Right now we can show what a letter template looks like as a PDF or PNG.

This PR completes the work so this is also possible when:

- showing a template with the placeholders replaced
- showing any version of a template