### PR TITLE
Restrict letter previews to their folded height

### DIFF
--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -11,6 +11,8 @@ $outline-width: 5px;
   outline: $outline-width solid rgba($text-colour, 0.1);
   padding: 0;
   margin: $outline-width $outline-width $gutter;
+  height: 50%;
+  overflow: hidden;
 
   a {
     display: block;

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -1,10 +1,9 @@
 // Easing function from: http://easings.net/#easeOutBack
 $transition-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-$iso-paper-ratio: 70.7%;
+$iso-paper-ratio: 70.710678118%;
 
 .letter {
 
-  font-family: Helvetica, Arial, sans-serif;
   padding: 0;
   margin: 0 0 $gutter 0;
   position: relative;
@@ -15,22 +14,40 @@ $iso-paper-ratio: 70.7%;
     z-index: 10;
     position: absolute;
     top: 2px;
-    left: 0;
+    left: 5px;
     height: 0;
     padding: $iso-paper-ratio 0 0 0;
     width: 100%;
     background: $highlight-colour;
-    transform: skew(-1deg, 0deg) scale(1, 0.99);
     transform-origin: left bottom;
+    transform: scale(1, 0.99);
     box-shadow: inset 0 0 0 2px $panel-colour;
-    transition: transform 0.2s $transition-easing;
+    transition: all 0.2s $transition-easing;
+  }
+
+  &:before {
+    content: "";
+    z-index: 15;
+    position: absolute;
+    bottom: -3px;
+    right: -5px;
+    width: 5px;
+    height: 6px;
+    background: $white;
+    transform: rotate(45deg);
+    box-shadow: inset 2px 0 0 0 $panel-colour;
   }
 
   &:hover {
 
     &:after {
-      transform: skew(-1.5deg, 0deg) scale(1, 0.97);
-      transition: transform 0.1s $transition-easing;
+      transform: skew(-1.3deg, 0deg) scale(1, 0.96);
+      transition: all 0.1s $transition-easing;
+      background: mix($white, $highlight-colour);
+    }
+
+    &:before {
+      transform: rotate(50deg);
     }
 
   }
@@ -44,7 +61,7 @@ $iso-paper-ratio: 70.7%;
     padding: $iso-paper-ratio 0 0 0;
     position: relative;
     z-index: 20;
-    transition: all 0.1s ease-out;
+    box-shadow: 0 2px 0 0 $panel-colour;
 
     &:focus {
 

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -1,3 +1,5 @@
+// Easing function from: http://easings.net/#easeOutBack
+$transition-easing: cubic-bezier(0.175, 0.885, 0.32, 1.275);
 $iso-paper-ratio: 70.7%;
 
 .letter {
@@ -21,6 +23,15 @@ $iso-paper-ratio: 70.7%;
     transform: skew(-1deg, 0deg) scale(1, 0.99);
     transform-origin: left bottom;
     box-shadow: inset 0 0 0 2px $panel-colour;
+    transition: transform 0.2s $transition-easing;
+  }
+
+  &:hover {
+
+    &:after {
+      transform: skew(-1.5deg, 0deg) scale(1, 0.97);
+      transition: transform 0.1s $transition-easing;
+    }
 
   }
 

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -1,26 +1,61 @@
-$outline-width: 5px;
+$iso-paper-ratio: 70.7%;
 
 .letter {
 
   font-family: Helvetica, Arial, sans-serif;
-  box-shadow:
-  1px 1px 0 0 $panel-colour,
-  2px 2px 0 0 rgba($panel-colour, 0.5),
-  -1px 1px 0 0 $panel-colour,
-  -2px 2px 0 0 rgba($panel-colour, 0.5);
-  outline: $outline-width solid rgba($text-colour, 0.1);
   padding: 0;
-  margin: $outline-width $outline-width $gutter;
-  height: 50%;
-  overflow: hidden;
+  margin: 0 0 $gutter 0;
+  position: relative;
+
+  &:after {
+    content: "";
+    display: block;
+    z-index: 10;
+    position: absolute;
+    top: 2px;
+    left: 0;
+    height: 0;
+    padding: $iso-paper-ratio 0 0 0;
+    width: 100%;
+    background: $highlight-colour;
+    transform: skew(-1deg, 0deg) scale(1, 0.99);
+    transform-origin: left bottom;
+    box-shadow: inset 0 0 0 2px $panel-colour;
+
+  }
 
   a {
+
     display: block;
+    overflow: hidden;
+    width: 100%;
+    height: 0;
+    padding: $iso-paper-ratio 0 0 0;
+    position: relative;
+    z-index: 20;
+    transition: all 0.1s ease-out;
+
+    &:focus {
+
+      outline: none;
+      box-shadow: 0 3px 0 0 $yellow;
+
+      img {
+        box-shadow: inset 0 0 0 3px $yellow;
+      }
+
+    }
+
   }
 
   img {
     display: block;
-    max-width: 100%;
+    width: 100%;
+    background: $white;
+    box-shadow: inset 0 0 0 2px $panel-colour;
+    position: absolute;
+    top: 0;
+    left: 0;
   }
 
 }

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -13,15 +13,15 @@ $iso-paper-ratio: 70.710678118%;
     display: block;
     z-index: 10;
     position: absolute;
-    top: 2px;
+    top: 1px;
     left: 5px;
     height: 0;
     padding: $iso-paper-ratio 0 0 0;
     width: 100%;
     background: $highlight-colour;
     transform-origin: left bottom;
-    transform: scale(1, 0.99);
-    box-shadow: inset 0 0 0 2px $panel-colour;
+    transform: scale(1, 0.985);
+    box-shadow: inset 0 0 0 1px $border-colour;
     transition: all 0.2s $transition-easing;
   }
 
@@ -31,11 +31,11 @@ $iso-paper-ratio: 70.710678118%;
     position: absolute;
     bottom: -3px;
     right: -5px;
-    width: 5px;
-    height: 6px;
+    width: 4px;
+    height: 7px;
     background: $white;
     transform: rotate(45deg);
-    box-shadow: inset 2px 0 0 0 $panel-colour;
+    box-shadow: inset 1px 0 0 0 $border-colour;
   }
 
   &:hover {
@@ -43,7 +43,7 @@ $iso-paper-ratio: 70.710678118%;
     &:after {
       transform: skew(-1.3deg, 0deg) scale(1, 0.96);
       transition: all 0.1s $transition-easing;
-      background: mix($white, $highlight-colour);
+      background: mix($highlight-colour, $white);
     }
 
     &:before {
@@ -61,7 +61,7 @@ $iso-paper-ratio: 70.710678118%;
     padding: $iso-paper-ratio 0 0 0;
     position: relative;
     z-index: 20;
-    box-shadow: 0 2px 0 0 $panel-colour;
+    box-shadow: 0 1px 0 0 $border-colour;
 
     &:focus {
 
@@ -80,7 +80,7 @@ $iso-paper-ratio: 70.710678118%;
     display: block;
     width: 100%;
     background: $white;
-    box-shadow: inset 0 0 0 2px $panel-colour;
+    box-shadow: inset 0 0 0 1px $border-colour;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
![folded](https://cloud.githubusercontent.com/assets/355079/21521335/ebc549d4-ccf3-11e6-9e96-2414fb7dcfbf.gif)

---

The letter previews take up too much space on the page (more than a typical email or text message). This means that users have to scroll too much.

When we send the real letters they will be folded in half to fit in the envelope.

So by showing the letter previews on the page cropped to half the letter’s height:
- it reduces the need for scrolling
- it gives an accurate preview of how the letter will be delivered

## Draw the folded half of the letter with CSS

Users might wonder why they can’t see the whole letter. We should make it obvious that it’s because the letter is folded. We can use CSS to draw the bottom half of the page behind the top half. With some transforms this makes it look like the letter is actually folded.

It’s a bit skeuomorphic but:
- I think it achieves the desired effect
- the way we show emails and text messages is also mildly skeuomorphic

## Make the letter unfold slightly on hover

This might be taking the skeuomorphism too far (especially with the animation). But it’s a way of indicating that the letter will ‘unfold’ if you click it. Might revert this, but let’s see how it feels.