### PR TITLE
Add date range filter to platform admin

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -516,3 +516,8 @@ class Whitelist(Form):
         max_entries=5,
         label="Mobile numbers"
     )
+
+class DateFilterForm(Form):
+    start_date = DateField("Start Date", [validators.optional()])
+    end_date = StringField("End Date", [validators.optional()])
+    include_from_test_key = BooleanField("Include test keys", default='checked')

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -517,7 +517,8 @@ class Whitelist(Form):
         label="Mobile numbers"
     )
 
+
 class DateFilterForm(Form):
     start_date = DateField("Start Date", [validators.optional()])
-    end_date = StringField("End Date", [validators.optional()])
-    include_from_test_key = BooleanField("Include test keys", default='checked')
+    end_date = DateField("End Date", [validators.optional()])
+    include_from_test_key = BooleanField("Include test keys", default="checked", false_values={"N"})

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -516,16 +516,3 @@ class Whitelist(Form):
         max_entries=5,
         label="Mobile numbers"
     )
-
-
-class DateFilterForm(Form):
-    start_date = DateField("Start Date", [validators.optional()])
-    end_date = StringField("End Date", [validators.optional()])
-
-    def validate(self):
-        print("****In validate")
-        if self.start_date.data and not self.end_date.data:
-            print("***** false {}".format(type(self.end_date.errors)))
-            raise ValidationError('Both required')
-        else:
-            return True

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -16,8 +16,8 @@ from wtforms import (
     HiddenField,
     IntegerField,
     RadioField,
-    FieldList
-)
+    FieldList,
+    DateField)
 from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import (DataRequired, Email, Length, Regexp, Optional)
 
@@ -516,3 +516,16 @@ class Whitelist(Form):
         max_entries=5,
         label="Mobile numbers"
     )
+
+
+class DateFilterForm(Form):
+    start_date = DateField("Start Date", [validators.optional()])
+    end_date = StringField("End Date", [validators.optional()])
+
+    def validate(self):
+        print("****In validate")
+        if self.start_date.data and not self.end_date.data:
+            print("***** false {}".format(type(self.end_date.errors)))
+            raise ValidationError('Both required')
+        else:
+            return True

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -19,26 +19,19 @@ from app.statistics_utils import get_formatted_percentage
 @user_has_permissions(admin_override=True)
 def platform_admin():
     form = DateFilterForm(request.args)
-    include_from_test_key = form.include_from_test_key.data
-    start_date = form.start_date.data
-    end_date = form.end_date.data
-    # specifically DO get inactive services
-    api_args = {'detailed': True}
-    if not include_from_test_key:
-        api_args['include_from_test_key'] = False
+    api_args = {'detailed': True,  # specifically DO get inactive services
+                'include_from_test_key': form.include_from_test_key.data
+                }
 
-    if start_date:
-        # For now the start and end date are only set as query params. The previous commit added a form
-        # but I could get the validation right, not did the page look good.
-        # This is just an intermediate pass at returning the data.
-        api_args['start_date'] = start_date
-        api_args['end_date'] = end_date or datetime.utcnow().date()
+    if form.start_date.data:
+        api_args['start_date'] = form.start_date.data
+        api_args['end_date'] = form.end_date.data or datetime.utcnow().date()
 
     services = service_api_client.get_services(api_args)['data']
 
     return render_template(
         'views/platform-admin.html',
-        include_from_test_key=include_from_test_key,
+        include_from_test_key=form.include_from_test_key.data,
         form=form,
         **get_statistics(sorted(
             services,

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -5,33 +5,62 @@ from flask import (
     request
 )
 from flask_login import login_required
+from wtforms import ValidationError
 
 from app import service_api_client
 from app.main import main
+from app.main.forms import DateFilterForm
 from app.utils import user_has_permissions
 from app.statistics_utils import get_formatted_percentage
 
 
-@main.route("/platform-admin")
+@main.route("/platform-admin", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions(admin_override=True)
 def platform_admin():
+    form = DateFilterForm()
     include_from_test_key = request.args.get('include_from_test_key') != 'False'
     # specifically DO get inactive services
     api_args = {'detailed': True}
     if not include_from_test_key:
         api_args['include_from_test_key'] = False
-    services = service_api_client.get_services(api_args)['data']
-    return render_template(
-        'views/platform-admin.html',
-        include_from_test_key=include_from_test_key,
-        **get_statistics(sorted(
-            services,
-            key=lambda service: (service['active'], service['created_at']),
-            reverse=True
-        ))
-    )
+    if form.validate_on_submit():
+        start_date = form.start_date.data
+        end_date = form.end_date.data
 
+        if start_date:
+            print(start_date)
+            print(end_date)
+            api_args['start_date'] = start_date
+            if not end_date:
+                raise ValidationError(message='requires end date', field =form.end_date)
+            api_args['end_date'] = end_date
+
+        services = service_api_client.get_services(api_args)['data']
+
+        return render_template(
+            'views/platform-admin.html',
+            include_from_test_key=include_from_test_key,
+            form=form,
+            **get_statistics(sorted(
+                services,
+                key=lambda service: (service['active'], service['created_at']),
+                reverse=True
+            ))
+        )
+    else:
+        services = service_api_client.get_services(api_args)['data']
+
+        return render_template(
+            'views/platform-admin.html',
+            include_from_test_key=include_from_test_key,
+            form=form,
+            **get_statistics(sorted(
+                services,
+                key=lambda service: (service['active'], service['created_at']),
+                reverse=True
+            ))
+        )
 
 def get_statistics(services):
     return {
@@ -64,7 +93,6 @@ def create_global_stats(services):
 
     for stat in stats.values():
         stat['failure_rate'] = get_formatted_percentage(stat['failed'], stat['requested'])
-
     return stats
 
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -60,7 +60,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Retrieve a list of services.
         """
-        print(params_dict)
         return self.get('/service', params=params_dict)
 
     def get_active_services(self, params_dict=None):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -60,6 +60,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Retrieve a list of services.
         """
+        print(params_dict)
         return self.get('/service', params=params_dict)
 
     def get_active_services(self, params_dict=None):

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -96,11 +96,6 @@
     {% else %}
       Excluding test keys (<a href="{{ url_for('.platform_admin') }}">change</a>)
     {% endif %}
-    <form autocomplete="off" method="post">
-      {{ textbox(form.start_date, hint="Enter start date in format YYYY-MM-DD") }}
-      {{ textbox(form.end_date, hint="Enter end date in format YYYY-MM-DD") }}
-      {{ page_footer('Apply filter') }}
-    </form>
   </p>
 
   <div class="grid-row bottom-gutter">

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -1,4 +1,6 @@
 {% extends "withoutnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
 {% from "components/table.html" import mapping_table, field, stats_fields, row_group, row, right_aligned_field_heading, hidden_field_heading, text_field %}
@@ -94,6 +96,11 @@
     {% else %}
       Excluding test keys (<a href="{{ url_for('.platform_admin') }}">change</a>)
     {% endif %}
+    <form autocomplete="off" method="post">
+      {{ textbox(form.start_date, hint="Enter start date in format YYYY-MM-DD") }}
+      {{ textbox(form.end_date, hint="Enter end date in format YYYY-MM-DD") }}
+      {{ page_footer('Apply filter') }}
+    </form>
   </p>
 
   <div class="grid-row bottom-gutter">

--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
@@ -89,14 +90,16 @@
     Platform admin
   </h1>
 
-  <p class="bottom-gutter-2">
-    Showing stats for today&emsp;
-    {% if include_from_test_key %}
-      Including test keys (<a href="{{ url_for('.platform_admin', include_from_test_key=False) }}">change</a>)
-    {% else %}
-      Excluding test keys (<a href="{{ url_for('.platform_admin') }}">change</a>)
-    {% endif %}
-  </p>
+    <details>
+      <summary>Apply filters</summary>
+      <form autocomplete="off" method="get">
+        {{ textbox(form.start_date, hint="Enter start date in format YYYY-MM-DD") }}
+        {{ textbox(form.end_date, hint="Enter end date in format YYYY-MM-DD") }}
+        {{ checkbox(form.include_from_test_key) }}
+        </br>
+        <input type="submit" class="button">
+      </form>
+    </details>
 
   <div class="grid-row bottom-gutter">
     <div class="column-half">

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -99,7 +99,6 @@ def test_platform_admin_toggle_including_from_test_key(
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
-            print(include_from_test_key)
             mock_get_user(mocker, user=platform_admin_user)
             client.login(platform_admin_user)
             response = client.get(url_for('main.platform_admin', include_from_test_key=include_from_test_key))

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1,14 +1,11 @@
-from datetime import date
-
 from flask import url_for
-from freezegun import freeze_time
 import pytest
 from bs4 import BeautifulSoup
 
 from tests.conftest import mock_get_user
 from tests import service_json
 
-from app.main.views.platform_admin import get_statistics, format_stats_by_service, create_global_stats
+from app.main.views.platform_admin import format_stats_by_service, create_global_stats
 
 
 def test_should_redirect_if_not_logged_in(app_):

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -121,6 +121,28 @@ def test_platform_admin_toggle_including_from_test_key(
     mock_get_detailed_services.assert_called_once_with(api_args)
 
 
+def test_platform_admin_with_date_filter(
+    app_,
+    platform_admin_user,
+    mocker,
+    mock_get_detailed_services
+):
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            mock_get_user(mocker, user=platform_admin_user)
+            client.login(platform_admin_user)
+            response = client.get(url_for('main.platform_admin', start_date='2016-12-20', end_date='2012-12-28'))
+
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert 'Platform admin' in resp_data
+    assert 'Showing stats for today' in resp_data
+    assert 'Live services' in resp_data
+    assert 'Trial mode services' in resp_data
+    mock_get_detailed_services.assert_called_once_with({'detailed': True,
+                                                        'start_date': '2016-12-20', 'end_date': '2012-12-28'})
+
+
 def test_create_global_stats_sets_failure_rates(fake_uuid):
     services = [
         service_json(fake_uuid, 'a', []),


### PR DESCRIPTION
A date range has been added to the platform admin page. 

Be aware that when using this query it looks at the notification_history table, this may results in a slow running query. I will be testing the performance once I get it deployed to production with a large data set. 

<img width="1203" alt="screen shot 2017-01-03 at 11 39 07" src="https://cloud.githubusercontent.com/assets/4282990/21606749/6a684980-d1a9-11e6-985e-27778048643d.png">
