### PR TITLE
Bump utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ whitenoise==1.0.6  #manages static assets
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.1.0#egg=notifications-utils==13.1.0
+git+https://github.com/alphagov/notifications-utils.git@13.1.1#egg=notifications-utils==13.1.1


### PR DESCRIPTION
Requires:
- [x] https://github.com/alphagov/notifications-utils/pull/107
- [x] [Nimbus Sans L font](https://fontlibrary.org/en/font/nimbus-sans-l) in regular and bold to be installed on AWS (see https://www.pivotaltracker.com/n/projects/1443052/stories/137788221)