### PR TITLE
Fix timeout on download of large CSV reports

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -311,7 +311,7 @@ def format_notification_status(status, template_type):
             'sending': 'Sending',
             'created': 'Sending'
         }
-    }.get(template_type).get(status, status)
+    }[template_type].get(status, status)
 
 
 def format_notification_status_as_time(status, created, updated):

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -422,7 +422,6 @@ def test_can_show_notifications(
             template_type=[message_type]
         )
 
-
         mock_notifications_as_csv.assert_called_with(
             limit_days=7,
             page=expected_page_argument,

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -56,8 +56,7 @@ def test_generate_csv_from_notifications(
                 set_status=status
             )['notifications']
         )
-
-    for row in DictReader(StringIO(csv_content)):
+    for row in DictReader(StringIO(next(csv_content))):
         assert row['Time'] == 'Friday 01 January 2016 at 15:09'
         assert row['Status'] == expected_status
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1008,31 +1008,24 @@ def mock_get_notifications(mocker, api_user_active):
         status=None,
         limit_days=None,
         rows=5,
-        set_template_type=None,
-        set_status=None,
         include_jobs=None,
-        include_from_test_key=None
+        include_from_test_key=None,
     ):
         job = None
         if job_id is not None:
             job = job_json(service_id, api_user_active, job_id=job_id)
-        if set_template_type:
-            return notification_json(
-                service_id,
-                template={'template_type': set_template_type, 'name': 'name', 'id': 'id', 'version': 1},
-                rows=rows,
-                status=set_status,
-                job=job,
-                with_links=True
-            )
+
+        if template_type:
+            template = template_json(service_id, id_=str(generate_uuid()), type_=template_type[0])
         else:
-            return notification_json(
-                service_id,
-                rows=rows,
-                status=set_status,
-                job=job,
-                with_links=True
-            )
+            template = template_json(service_id, id_=str(generate_uuid()))
+
+        return notification_json(
+            service_id,
+            template=template,
+            rows=rows,
+            job=job
+        )
 
     return mocker.patch(
         'app.notification_api_client.get_notifications_for_service',


### PR DESCRIPTION
This fixes the issue on admin where downloading a large CSV report (13,000+) times out.

# **Issue**

We load the contents of a CSV report into memory and attempt to return this to the user. If the CSV has a significant number of rows this can take a long time, or timeout (as discovered by one of our end users).

# **Fix**

Instead of attempting to load the entire contents of the CSV into memory and then return this to the user, we now stream it back in _chunks_ of 5000. This means that if a large CSV is requested for download, Chrome (for example) will take each of these and incrementally build the CSV in a streaming fashion. This prevents the timeout issue.

# **How to test**

Download a report (ideally with a large number of notifications) and keep an eye the bottom bar (on Chrome). The connection will initiate and the download in a streaming fashion.
