### PR TITLE
Add last updated column (formatted) in view providers table

### DIFF
--- a/app/main/views/providers.py
+++ b/app/main/views/providers.py
@@ -18,7 +18,11 @@ def view_providers():
     providers = provider_client.get_all_providers()['provider_details']
     email_providers = [email for email in providers if email['notification_type'] == 'email']
     sms_providers = [sms for sms in providers if sms['notification_type'] == 'sms']
-    return render_template('views/providers.html', email_providers=email_providers, sms_providers=sms_providers)
+    return render_template(
+        'views/providers.html',
+        email_providers=email_providers,
+        sms_providers=sms_providers
+    )
 
 
 @main.route("/provider/<provider_id>", methods=['GET', 'POST'])

--- a/app/templates/views/providers.html
+++ b/app/templates/views/providers.html
@@ -11,10 +11,6 @@ Providers – GOV.UK Notify
     <div class="column-two-thirds">
         <h1 class="heading-large">Providers</h1>
 
-        <p>
-            Providers on Notify
-        </p>
-
         <h2 class="heading-medium">SMS</h2>
 
         {% call(item, row_number) list_table(
@@ -22,7 +18,7 @@ Providers – GOV.UK Notify
     caption="SMS providers",
     caption_visible=False,
     empty_message='No email providers',
-    field_headings=['Provider', 'Priority', 'Active', ''],
+    field_headings=['Provider', 'Priority', 'Active', 'Last Updated', ''],
     field_headings_visible=True
   ) %}
 
@@ -32,7 +28,14 @@ Providers – GOV.UK Notify
 
     {{ text_field(item.active) }}
 
+    {% if item.updated_at %}
+        {{ text_field(item.updated_at|format_datetime_short) }}
+    {% else %}
+        {{ text_field('None') }}
+    {% endif %}
+
     {{ link_field('change', url_for('main.view_provider', provider_id=item.id)) }}
+
 
   {% endcall %}
 

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -33,7 +33,8 @@ stub_providers = {
             'priority': 1,
             'display_name': 'first_email_provider',
             'identifier': 'first_email',
-            'notification_type': 'email'
+            'notification_type': 'email',
+            'updated_at': None
         },
         {
             'active': True,
@@ -42,6 +43,7 @@ stub_providers = {
             'identifier': 'second_email',
             'id': '0bd529cd-a0fd-43e5-80ee-b95ef6b0d51b',
             'notification_type': 'email',
+            'updated_at': None
         }
     ]
 }
@@ -54,7 +56,8 @@ stub_provider = {
             'priority': 1,
             'display_name': 'first_sms_provider',
             'identifier': 'first_sms',
-            'notification_type': 'sms'
+            'notification_type': 'sms',
+            'updated_at': None
         }
 }
 

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -1,7 +1,10 @@
-from bs4 import BeautifulSoup
-from flask import url_for
 import copy
 import re
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+from flask import url_for
+
 import app
 
 stub_providers = {
@@ -12,7 +15,8 @@ stub_providers = {
             'priority': 1,
             'display_name': 'first_sms_provider',
             'identifier': 'first_sms',
-            'notification_type': 'sms'
+            'notification_type': 'sms',
+            'updated_at': datetime(2017, 1, 16, 15, 20, 40).isoformat()
         },
         {
             'active': True,
@@ -20,7 +24,8 @@ stub_providers = {
             'display_name': 'second_sms_provider',
             'identifier': 'second_sms',
             'id': '0bd529cd-a0fd-43e5-80ee-b95ef6b0d51f',
-            'notification_type': 'sms'
+            'notification_type': 'sms',
+            'updated_at': None
         },
         {
             'id': '6005e192-4738-4962-beec-ebd982d0b03a',
@@ -36,7 +41,7 @@ stub_providers = {
             'display_name': 'second_email_provider',
             'identifier': 'second_email',
             'id': '0bd529cd-a0fd-43e5-80ee-b95ef6b0d51b',
-            'notification_type': 'email'
+            'notification_type': 'email',
         }
     ]
 }
@@ -92,7 +97,8 @@ def test_should_show_all_providers(
             assert table_data[0].text.strip() == "first_sms_provider"
             assert table_data[1].text.strip() == "1"
             assert table_data[2].text.strip() == "True"
-            assert table_data[3].find_all("a")[0]['href'] == '/provider/6005e192-4738-4962-beec-ebd982d0b03f'
+            assert table_data[3].text.strip() == "16 January at 3:20pm"
+            assert table_data[4].find_all("a")[0]['href'] == '/provider/6005e192-4738-4962-beec-ebd982d0b03f'
 
             sms_second_row = sms_table.tbody.find_all('tr')[1]
             table_data = sms_second_row.find_all('td')
@@ -100,7 +106,8 @@ def test_should_show_all_providers(
             assert table_data[0].text.strip() == "second_sms_provider"
             assert table_data[1].text.strip() == "2"
             assert table_data[2].text.strip() == "True"
-            assert table_data[3].find_all("a")[0]['href'] == '/provider/0bd529cd-a0fd-43e5-80ee-b95ef6b0d51f'
+            assert table_data[3].text.strip() == "None"
+            assert table_data[4].find_all("a")[0]['href'] == '/provider/0bd529cd-a0fd-43e5-80ee-b95ef6b0d51f'
 
             email_first_row = email_table.tbody.find_all('tr')[0]
             email_table_data = email_first_row.find_all('td')


### PR DESCRIPTION
This adds a 'Last Updated' column in the provider list table found on Admin -> View Providers.

This will help to identify when a provider was last updated (e.g. priority was changed etc.) and will be especially useful when auto provider-switching is in place. 