### PR TITLE
Create or update templates with priority as platform admin

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -270,8 +270,8 @@ class SMSTemplateForm(Form):
             NoCommasInPlaceHolders()
         ]
     )
-    process_type = SelectField(u'Select priority or normal', choices=[('normal', 'normal'),
-                                                                      ('priority', 'priority')],
+    process_type = SelectField(u'Use priority queue?', choices=[('normal', 'no'),
+                                                                ('priority', 'yes')],
                                default='normal')
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,4 +1,5 @@
 import pytz
+from flask_login import current_user
 from flask_wtf import Form
 from datetime import datetime, timedelta
 from notifications_utils.recipients import (
@@ -17,7 +18,8 @@ from wtforms import (
     IntegerField,
     RadioField,
     FieldList,
-    DateField)
+    DateField,
+    SelectField)
 from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import (DataRequired, Email, Length, Regexp, Optional)
 
@@ -268,6 +270,9 @@ class SMSTemplateForm(Form):
             NoCommasInPlaceHolders()
         ]
     )
+    process_type = SelectField(u'Select priority or normal', choices=[('normal', 'normal'),
+                                                                      ('priority', 'priority')],
+                               default='normal')
 
 
 class EmailTemplateForm(SMSTemplateForm):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -116,7 +116,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         data = _attach_current_user({})
         return self.delete(endpoint, data)
 
-    def create_service_template(self, name, type_, content, service_id, subject=None):
+    def create_service_template(self, name, type_, content, service_id, subject=None, process_type='normal'):
         """
         Create a service template.
         """
@@ -124,7 +124,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "name": name,
             "template_type": type_,
             "content": content,
-            "service": service_id
+            "service": service_id,
+            "process_type": process_type
         }
         if subject:
             data.update({
@@ -132,9 +133,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             })
         data = _attach_current_user(data)
         endpoint = "/service/{0}/template".format(service_id)
+        print('got here in create_service_template')
         return self.post(endpoint, data)
 
-    def update_service_template(self, id_, name, type_, content, service_id, subject=None):
+    def update_service_template(self, id_, name, type_, content, service_id, subject=None, process_type=None):
         """
         Update a service template.
         """
@@ -148,6 +150,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         if subject:
             data.update({
                 'subject': subject
+            })
+        if process_type:
+            data.update({
+                'process_type': process_type
             })
         data = _attach_current_user(data)
         endpoint = "/service/{0}/template/{1}".format(service_id, id_)

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -20,6 +20,9 @@
         </div>
         <div class="column-three-quarters">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
+          {% if current_user.has_permissions([], admin_override=True) %}
+            {{ textbox(form.process_type, width='1-1') }}
+          {% endif %}
           {{ page_footer(
             'Save',
             delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template_id) if template_id or None,

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -19,6 +19,9 @@
         </div>
         <div class="column-two-thirds">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=5) }}
+          {% if current_user.has_permissions([], admin_override=True) %}
+            {{ textbox(form.process_type, width='1-1') }}
+          {% endif %}
           {{ page_footer(
             'Save',
             delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template_id) if template_id or None,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -84,7 +84,8 @@ def template_json(service_id,
                   content="template content",
                   subject=None,
                   version=1,
-                  archived=False):
+                  archived=False,
+                  process_type='normal'):
     template = {
         'id': id_,
         'name': name,
@@ -93,7 +94,8 @@ def template_json(service_id,
         'service': service_id,
         'version': version,
         'updated_at': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f'),
-        'archived': archived
+        'archived': archived,
+        'process_type': process_type
     }
     if subject is not None:
         template['subject'] = subject

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -36,7 +36,7 @@ def test_should_show_page_for_one_template(
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)
     assert "Your vehicle tax is about to expire" in response.get_data(as_text=True)
-    assert "Select priority or normal" not in response.get_data(as_text=True)
+    assert "Use priority queue?" not in response.get_data(as_text=True)
     mock_get_service_template.assert_called_with(
         service_id, template_id)
 
@@ -64,7 +64,7 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)
     assert "Your vehicle tax is about to expire" in response.get_data(as_text=True)
-    assert "Select priority or normal" in response.get_data(as_text=True)
+    assert "Use priority queue?" in response.get_data(as_text=True)
     mock_get_service_template.assert_called_with(
         service_id, template_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,23 @@ def mock_get_service_template(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_service_template_with_priority(mocker):
+    def _get(service_id, template_id, version=None):
+
+        template = template_json(
+            service_id, template_id, "Two week reminder", "sms", "Your vehicle tax is about to expire",
+            process_type='priority')
+        if version:
+            template.update({'version': version})
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template',
+        side_effect=_get
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_deleted_template(mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
@@ -381,7 +398,7 @@ def mock_create_service_template(mocker, fake_uuid):
 
 @pytest.fixture(scope='function')
 def mock_update_service_template(mocker):
-    def _update(id_, name, type_, content, service, subject=None):
+    def _update(id_, name, type_, content, service, subject=None, process_type=None):
         template = template_json(
             service, id_, name, type_, content, subject)
         return {'data': template}
@@ -393,7 +410,7 @@ def mock_update_service_template(mocker):
 
 @pytest.fixture(scope='function')
 def mock_create_service_template_content_too_big(mocker):
-    def _create(name, type_, content, service, subject=None):
+    def _create(name, type_, content, service, subject=None, process_type=None):
         json_mock = Mock(return_value={
             'message': {'content': ["Content has a character count greater than the limit of 459"]},
             'result': 'error'
@@ -411,7 +428,7 @@ def mock_create_service_template_content_too_big(mocker):
 
 @pytest.fixture(scope='function')
 def mock_update_service_template_400_content_too_big(mocker):
-    def _update(id_, name, type_, content, service, subject=None):
+    def _update(id_, name, type_, content, service, subject=None, process_type=None):
         json_mock = Mock(return_value={
             'message': {'content': ["Content has a character count greater than the limit of 459"]},
             'result': 'error'


### PR DESCRIPTION
Add a selectField to edit and create templates that is only visible for platform admins that makes the template a `priority` template.

There is a check that the template can not be created as priority if the user is not a platform admin.
There is a check that the template can not change the `priority` unless they are a platform admin.

<img width="628" alt="screen shot 2017-01-18 at 16 06 06" src="https://cloud.githubusercontent.com/assets/4282990/22071753/12f10ea8-dd98-11e6-9106-6e4bf36f28eb.png">


https://www.pivotaltracker.com/story/show/135429147