### PR TITLE
Fix issue where row_number starts from 3 on a job report download

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -164,8 +164,15 @@ def generate_notifications_csv(**kwargs):
 
 def format_notification_for_csv(notification):
     from app import format_datetime_24h, format_notification_status
+    #  row_number can be 0 so we need to check for it
+    row_num = notification.get('job_row_number')
+    if row_num is not None and row_num >= 0:
+        row_num += 1
+    else:
+        row_num = ''
+
     return {
-        'Row number': int(notification['job_row_number']) + 2 if notification.get('job_row_number') else '',
+        'Row number': row_num,
         'Recipient': notification['to'],
         'Template': notification['template']['name'],
         'Type': notification['template']['template_type'],

--- a/app/utils.py
+++ b/app/utils.py
@@ -166,10 +166,7 @@ def format_notification_for_csv(notification):
     from app import format_datetime_24h, format_notification_status
     #  row_number can be 0 so we need to check for it
     row_num = notification.get('job_row_number')
-    if row_num is not None and row_num >= 0:
-        row_num += 1
-    else:
-        row_num = ''
+    row_num = '' if row_num is None else row_num + 1
 
     return {
         'Row number': row_num,


### PR DESCRIPTION
This fixes an issue where a job report download starts with a `row_number` of 3.

# **Issue**

We were originally checking to see if a row_number existed with `if dict.get('row_number')...`. This however evaluated to `False` if a row_number was `0`. We were also incrementing the row number by `2` in the format, so the minimum number we could ever format to was `3`.

# **Fix**

Changed the format to explicitly check for `0` and ensure we only increment by `1`. The ensures if a row number is:

```
None -> ''
0 -> 1
1 -> 2
...
```