### PR TITLE
Sanitize HTML in templates using utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ whitenoise==1.0.6  #manages static assets
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.1.1#egg=notifications-utils==13.1.1
+git+https://github.com/alphagov/notifications-utils.git@13.2.0#egg=notifications-utils==13.2.0

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -112,7 +112,7 @@ def test_should_show_page_for_one_job(
         page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
         assert page.h1.text.strip() == 'thisisatest.csv'
         assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == (
-            '{}: Your vehicle tax is about to expire'.format(service_one['name'])
+            '{}: Template <em>content</em> with & entity'.format(service_one['name'])
         )
         assert ' '.join(page.find('tbody').find('tr').text.split()) == (
             '07123456789 Delivered 1 January at 11:10am'

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -479,7 +479,7 @@ def test_should_show_preview_letter_message(
     mock_get_service_letter_template.assert_called_with(service_id, template_id)
     assert mock_letter_preview.call_args[0][0]['message'] == (
         '<h2>Subject</h2>\n'
-        '<p>Your vehicle tax is about to expire</p>'
+        '<p>Template &lt;em&gt;content&lt;/em&gt; with &amp; entity</p>'
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -128,7 +128,7 @@ def test_should_redirect_when_saving_a_template(app_,
             mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
             template_id = fake_uuid
             name = "new name"
-            content = "template content"
+            content = "template <em>content</em> with & entity"
             data = {
                 'id': template_id,
                 'name': name,
@@ -165,7 +165,7 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
             data = {
                 'id': template_id,
                 'name': "new name",
-                'template_content': "change the content",
+                'template_content': "new template <em>content</em> with & entity",
                 'template_type': 'sms',
                 'service': service['id'],
                 'process_type': 'priority'
@@ -178,7 +178,14 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
             assert response.location == url_for(
                 '.view_template', service_id=service['id'], template_id=template_id, _external=True)
             mock_update_service_template.assert_called_with(
-                template_id, "new name", 'sms', "change the content", service['id'], None, 'priority')
+                template_id,
+                "new name",
+                'sms',
+                "new template <em>content</em> with & entity",
+                service['id'],
+                None,
+                'priority'
+            )
 
 
 def test_should_403_when_edit_template_with_process_type_of_priority_for_non_platform_admin(
@@ -197,7 +204,7 @@ def test_should_403_when_edit_template_with_process_type_of_priority_for_non_pla
             data = {
                 'id': template_id,
                 'name': "new name",
-                'template_content': "template content",
+                'template_content': "template <em>content</em> with & entity",
                 'template_type': 'sms',
                 'service': service['id'],
                 'process_type': 'priority'
@@ -226,7 +233,7 @@ def test_should_403_when_create_template_with_process_type_of_priority_for_non_p
             data = {
                 'id': template_id,
                 'name': "new name",
-                'template_content': "template content",
+                'template_content': "template <em>content</em> with & entity",
                 'template_type': 'sms',
                 'service': service['id'],
                 'process_type': 'priority'
@@ -362,7 +369,7 @@ def test_should_redirect_when_saving_a_template_email(app_,
             service_id = fake_uuid
             template_id = fake_uuid
             name = "new name"
-            content = "template content ((thing)) ((date))"
+            content = "template <em>content</em> with & entity ((thing)) ((date))"
             subject = "subject"
             data = {
                 'id': template_id,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -35,7 +35,7 @@ def test_should_show_page_for_one_template(
 
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)
-    assert "Your vehicle tax is about to expire" in response.get_data(as_text=True)
+    assert "Template &lt;em&gt;content&lt;/em&gt; with &amp; entity" in response.get_data(as_text=True)
     assert "Use priority queue?" not in response.get_data(as_text=True)
     mock_get_service_template.assert_called_with(
         service_id, template_id)
@@ -63,7 +63,7 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
 
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)
-    assert "Your vehicle tax is about to expire" in response.get_data(as_text=True)
+    assert "Template &lt;em&gt;content&lt;/em&gt; with &amp; entity" in response.get_data(as_text=True)
     assert "Use priority queue?" in response.get_data(as_text=True)
     mock_get_service_template.assert_called_with(
         service_id, template_id)
@@ -419,7 +419,7 @@ def test_should_show_delete_template_page_with_time_block(app_,
     assert 'Test template was last used 10 minutes ago. Are you sure you want to delete it?' in content
     assert 'Are you sure' in content
     assert 'Two week reminder' in content
-    assert 'Your vehicle tax is about to expire' in content
+    assert 'Template &lt;em&gt;content&lt;/em&gt; with &amp; entity' in content
     mock_get_service_template.assert_called_with(service_id, template_id)
 
 
@@ -453,7 +453,7 @@ def test_should_show_delete_template_page_with_never_used_block(app_,
             assert 'Two week reminder has never been used. Are you sure you want to delete it?' in content
             assert 'Are you sure' in content
             assert 'Two week reminder' in content
-            assert 'Your vehicle tax is about to expire' in content
+            assert 'Template &lt;em&gt;content&lt;/em&gt; with &amp; entity' in content
             mock_get_service_template.assert_called_with(service_id, template_id)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,7 @@ def mock_get_services_with_one_service(mocker, fake_uuid, user=None):
 def mock_get_service_template(mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(
-            service_id, template_id, "Two week reminder", "sms", "Your vehicle tax is about to expire")
+            service_id, template_id, "Two week reminder", "sms", "Template <em>content</em> with & entity")
         if version:
             template.update({'version': version})
         return {'data': template}
@@ -248,7 +248,7 @@ def mock_get_service_template_with_priority(mocker):
     def _get(service_id, template_id, version=None):
 
         template = template_json(
-            service_id, template_id, "Two week reminder", "sms", "Your vehicle tax is about to expire",
+            service_id, template_id, "Two week reminder", "sms", "Template <em>content</em> with & entity",
             process_type='priority')
         if version:
             template.update({'version': version})
@@ -268,7 +268,7 @@ def mock_get_deleted_template(mocker):
             template_id,
             "Two week reminder",
             "sms",
-            "Your vehicle tax is about to expire",
+            "Template <em>content</em> with & entity",
             archived=True
         )
         if version:
@@ -325,7 +325,7 @@ def mock_get_template_versions(mocker, fake_uuid, user=None):
 def mock_get_service_template_with_placeholders(mocker):
     def _get(service_id, template_id):
         template = template_json(
-            service_id, template_id, "Two week reminder", "sms", "((name)), your vehicle tax is about to expire"
+            service_id, template_id, "Two week reminder", "sms", "((name)), Template <em>content</em> with & entity"
         )
         return {'data': template}
 
@@ -377,7 +377,7 @@ def mock_get_service_letter_template(mocker):
             template_id,
             "Two week reminder",
             "letter",
-            "Your vehicle tax is about to expire", "Subject")
+            "Template <em>content</em> with & entity", "Subject")
         return {'data': template}
 
     return mocker.patch(


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/109

***

We can no longer trust that the content of templates stored in the database is safe.

Utils now has code to sanitise the content of templates.

This commit:
- updates utils to bring this code in
- modifies some integration tests to make sure everything is working (there are more extensive unit tests in utils)