### PR TITLE
Fix dashboard totals in older IE versions

### DIFF
--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -1,27 +1,29 @@
 {% from "components/big-number.html" import big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
 
-<div class="grid-row ajax-block-container">
-  <div id="total-email" class="column-half">
-    {{ big_number_with_status(
-      statistics['email']['requested'],
-      message_count_label(statistics['email']['requested'], 'email', suffix=''),
-      statistics['email']['failed'],
-      statistics['email']['failed_percentage'],
-      statistics['email']['show_warning'],
-      failure_link=url_for(".view_notifications", service_id=service_id, message_type='email', status='failed'),
-      link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed')
-    ) }}
-  </div>
-  <div id="total-sms" class="column-half">
-    {{ big_number_with_status(
-      statistics['sms']['requested'],
-      message_count_label(statistics['sms']['requested'], 'sms', suffix=''),
-      statistics['sms']['failed'],
-      statistics['sms']['failed_percentage'],
-      statistics['sms']['show_warning'],
-      failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
-      link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed')
-    ) }}
+<div class="ajax-block-container">
+  <div class="grid-row">
+    <div id="total-email" class="column-half">
+      {{ big_number_with_status(
+        statistics['email']['requested'],
+        message_count_label(statistics['email']['requested'], 'email', suffix=''),
+        statistics['email']['failed'],
+        statistics['email']['failed_percentage'],
+        statistics['email']['show_warning'],
+        failure_link=url_for(".view_notifications", service_id=service_id, message_type='email', status='failed'),
+        link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed')
+      ) }}
+    </div>
+    <div id="total-sms" class="column-half">
+      {{ big_number_with_status(
+        statistics['sms']['requested'],
+        message_count_label(statistics['sms']['requested'], 'sms', suffix=''),
+        statistics['sms']['failed'],
+        statistics['sms']['failed_percentage'],
+        statistics['sms']['show_warning'],
+        failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
+        link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed')
+      ) }}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The layout of the totals on the dashboard was getting horizontally squashed on older versions of IE.

This was something to do with the `grid-row` CSS class no longer being applied when AJAX updated the page. Grid columns don’t work properly unless they’re contained in a grid row.

This commit wraps the `div` with `grid-row` in another `div`. Not totally sure why this works, but it’s something to do with how the DiffDOM algorithm is working. Seems like the simpler the diff it has to compute, the better chance it has of not messing things up.

## Before

![ie-total](https://cloud.githubusercontent.com/assets/355079/22203230/e48c2ef6-e163-11e6-9551-c5a7f806a54f.gif)

## After

<img width="691" alt="screen shot 2017-01-23 at 12 00 54" src="https://cloud.githubusercontent.com/assets/355079/22203235/ede32716-e163-11e6-8023-98e7e0f67db1.png">
