### PR TITLE
Fix: Platform admin showing incorrect sent totals

### DIFF
--- a/app/templates/views/platform-admin.html
+++ b/app/templates/views/platform-admin.html
@@ -104,7 +104,7 @@
   <div class="grid-row bottom-gutter">
     <div class="column-half">
       {{ big_number_with_status(
-        global_stats.email.delivered,
+        global_stats.email.delivered + global_stats.email.failed,
         message_count_label(global_stats.email.delivered, 'email'),
         global_stats.email.failed,
         global_stats.email.failure_rate,
@@ -113,7 +113,7 @@
     </div>
     <div class="column-half">
       {{ big_number_with_status(
-        global_stats.sms.delivered,
+        global_stats.sms.delivered + global_stats.sms.failed,
         message_count_label(global_stats.sms.delivered, 'sms'),
         global_stats.sms.failed,
         global_stats.sms.failure_rate,

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -147,7 +147,6 @@ def test_create_global_stats_sets_failure_rates(fake_uuid):
     )
 
     stats = create_global_stats(services)
-
     assert stats == {
         'email': {
             'delivered': 2,
@@ -248,7 +247,6 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     service_row_group = table_body.find_all('tbody')[0].find_all('tr')
     email_stats = service_row_group[0].find_all('div', class_='big-number-number')
     sms_stats = service_row_group[1].find_all('div', class_='big-number-number')
-
     email_sending, email_delivered, email_failed = [int(x.text.strip()) for x in email_stats]
     sms_sending, sms_delivered, sms_failed = [int(x.text.strip()) for x in sms_stats]
 
@@ -323,3 +321,38 @@ def test_shows_archived_label_instead_of_live_or_research_mode_label(
     service_mode = table_body.find_all('tbody')[0].find_all('tr')[1].td.text.strip()
     # get second column, which contains flags as text.
     assert service_mode == 'archived'
+
+
+def test_should_show_correct_sent_totals_for_platform_admin(
+    app_,
+    platform_admin_user,
+    mocker,
+    mock_get_detailed_services,
+    fake_uuid
+):
+    services = [service_json(fake_uuid, 'My Service', [])]
+    services[0]['statistics'] = create_stats(
+        emails_requested=100,
+        emails_delivered=20,
+        emails_failed=40,
+        sms_requested=100,
+        sms_delivered=10,
+        sms_failed=30
+    )
+
+    mock_get_detailed_services.return_value = {'data': services}
+    with app_.test_request_context():
+        with app_.test_client() as client:
+            mock_get_user(mocker, user=platform_admin_user)
+            client.login(platform_admin_user)
+            response = client.get(url_for('main.platform_admin'))
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    totals = page.find_all('div', 'big-number-with-status')
+    email_total = int(totals[0].find_all('div', 'big-number-number')[0].text.strip())
+    sms_total = int(totals[1].find_all('div', 'big-number-number')[0].text.strip())
+
+    assert email_total == 60
+    assert sms_total == 40

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -324,7 +324,7 @@ def test_shows_archived_label_instead_of_live_or_research_mode_label(
 
 
 def test_should_show_correct_sent_totals_for_platform_admin(
-    app_,
+    client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
@@ -341,11 +341,9 @@ def test_should_show_correct_sent_totals_for_platform_admin(
     )
 
     mock_get_detailed_services.return_value = {'data': services}
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=platform_admin_user)
-            client.login(platform_admin_user)
-            response = client.get(url_for('main.platform_admin'))
+    mock_get_user(mocker, user=platform_admin_user)
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.platform_admin'))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')


### PR DESCRIPTION
This fixes an issue where the platform admin page shows incorrect sent total values.

# **Issue**

The total email and sms sent figures are set to the sum of delivered notifications. E.g. If we sent 100 sms messages and 80 of those were delivered while 20 failed, then the total would incorrectly show 80 only. 

# **Fix**

Changed the total to include the sum of delivered _and_ failed.