### PR TITLE
Add introducer video to the product page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -379,6 +379,7 @@ def useful_headers_after_request(response):
         "object-src 'self';"
         "font-src 'self' data:;"
         "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
+        "frame-src www.youtube.com;"
     ))
     if 'Cache-Control' in response.headers:
         del response.headers['Cache-Control']

--- a/app/assets/stylesheets/components/vendor/responsive-embed.scss
+++ b/app/assets/stylesheets/components/vendor/responsive-embed.scss
@@ -1,0 +1,60 @@
+/**
+ * Responsive Embed Component
+ *
+ * Notes:
+ *
+ * - Ensure you use either responsive-embed--16by9 or responsive-embed--4by3
+ *   depending on the aspect ratio of your embed.
+ * - Credit: Nicolas Gallagher and SUIT CSS.
+ *
+ * Example Usage:
+ *
+ * <div class="responsive-embed responsive-embed--4by3 responsive-embed--bordered">
+ *   <div class="responsive-embed__wrapper">
+ *     <iframe width="560" height="315" src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" frameborder="0" allowfullscreen=""></iframe>
+ *   </div>
+ * </div>
+ */
+
+.responsive-embed {
+  .responsive-embed__wrapper {
+    position: relative;
+    display: block;
+    height: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .responsive-embed__item,
+  iframe,
+  embed,
+  object,
+  video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+    border: 0;
+  }
+}
+
+.responsive-embed--bordered {
+  padding: 5px;
+  outline: 1px solid $border-colour;
+}
+
+// Modifier class for 16:9 aspect ratio
+.responsive-embed--16by9 {
+  .responsive-embed__wrapper {
+    padding-bottom: 56.25%;
+  }
+}
+
+// Modifier class for 4:3 aspect ratio
+.responsive-embed--4by3 {
+  .responsive-embed__wrapper {
+    padding-bottom: 75%;
+  }
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -60,6 +60,7 @@ $path: '/static/images/';
 @import 'components/list-entry';
 @import 'components/letter';
 @import 'components/vendor/breadcrumbs';
+@import 'components/vendor/responsive-embed';
 
 @import 'views/job';
 @import 'views/edit-template';

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -106,6 +106,16 @@
     </div>
   </div>
   <div class="product-page-section">
+    <h2 class="with-keyline">
+      Introducing GOV.UK Notify
+    </h2>
+    <div class="responsive-embed responsive-embed--16by9 responsive-embed--bordered bottom-gutter-2">
+      <div class="responsive-embed__wrapper">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/i2a2jiwYTd4" frameborder="0" allowfullscreen></iframe>
+      </div>
+    </div>
+  </div>
+  <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2">
       <h2>Who’s using GOV.UK Notify</h2>
       <div class="grid-row bottom-gutter">

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -12,4 +12,5 @@ def test_owasp_useful_headers_set(app_):
         "object-src 'self';"
         "font-src 'self' data:;"
         "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk data:;"
+        "frame-src www.youtube.com;"
     )


### PR DESCRIPTION
It’s always been the plan to put this video on the product page. Just getting round to it now.

Watch the video here: https://www.youtube.com/watch?v=i2a2jiwYTd4

Uses the CSS developed by the service manual team, taken from here: https://github.com/alphagov/product-page-example/blob/a5c613f07bca47a15f67c529615bc83995aea3b5/source/stylesheets/modules/_responsive-embed.scss

---

![image](https://cloud.githubusercontent.com/assets/355079/22212543/0da67c5e-e189-11e6-82e3-a6e63ea2f239.png)
