### PR TITLE
Fix trial mode error message when uploading CSV

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -105,9 +105,9 @@
         <h1 class='banner-title'>
           You can’t send to
           {{ 'this' if count_of_recipients == 1 else 'these' }}
-          {{ recipients.recipient_column_header }}
+          {{ recipients.recipient_column_headers[0] }}
           {%- if count_of_recipients != 1 -%}
-            {{ 'es' if 'email address' == recipients.recipient_column_header else 's' }}
+            {{ 'es' if 'email address' == recipients.recipient_column_headers[0] else 's' }}
           {%- endif %}
         </h1>
         <p>


### PR DESCRIPTION
Problem: it wasn’t saying ‘phone number’ or ‘email address’

Why: we renamed `Recipients.recipient_column_header` to `Recipients.recipient_column_headers`, and made it return a list, not a string.

The fix: take the first item of the list, and use that to decide whether it’s phone numbers or email addresses that you’re not allowed to send to.

_N.B. This won’t work for letters, but we don’t know how trial mode is going to work for letters anyway._

![image](https://cloud.githubusercontent.com/assets/355079/22214189/b74e01be-e18e-11e6-8392-baf2b7bb208f.png)
