### PR TITLE
Fix back button on breaking-change.html

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -218,6 +218,7 @@ def edit_service_template(service_id, template_id):
                     'name': form.name.data,
                     'subject': subject,
                     'content': form.template_content.data,
+                    'id': new_template.id
                 },
                 column_headings=list(ascii_uppercase[:len(new_template.placeholders) + 1]),
                 example_rows=[

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -29,6 +29,8 @@
     <input type="hidden" name="name" value="{{ new_template.name }}" />
     <input type="hidden" name="subject" value="{{ new_template.subject or '' }}" />
     <input type="hidden" name="template_content" value="{{ new_template.content }}" />
+    <input type="hidden" name="template_id" value="{{ new_template.id }}" />
+
     <input type="hidden" name="confirm" value="true" />
     {{ page_footer(
       'Save changes to template',

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -279,7 +279,9 @@ def test_should_show_interstitial_when_making_breaking_change(
             assert response.status_code == 200
             page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
             assert page.h1.string.strip() == "Confirm changes"
-
+            assert page.find('a', {'class': 'page-footer-back-link'})['href'] == url_for(".edit_service_template",
+                                                                                         service_id=service_id,
+                                                                                         template_id=template_id)
             for key, value in {
                 'name': 'new name',
                 'subject': 'reminder',


### PR DESCRIPTION
A bug was reported on where editing a template with a breaking change. The url was not being properly formed, missing the template_id, meaning the back button on the page did not work.

This fixes that, includes a check of the url for the back button.