### PR TITLE
Make page title on template usage page match link

### DIFF
--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -6,11 +6,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row bottom-gutter">
-    <div class="column-half">
-      <h2 class="heading-large">Templates sent</h2>
-    </div>
-  </div>
+  <h2 class="heading-large">All templates used this year</h2>
 
   {% include 'views/dashboard/template-statistics.html' %}
 


### PR DESCRIPTION
For consistency. Going to revisit this page shortly.

So when you click this link:
![image](https://cloud.githubusercontent.com/assets/355079/22294915/0338d322-e30d-11e6-857e-e64759a78236.png)

You get this page:
![image](https://cloud.githubusercontent.com/assets/355079/22294948/18e0ffb0-e30d-11e6-871a-68df6258d8f9.png)

