### PR TITLE
Filter and navigate usage by financial year

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -213,8 +213,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_service_history(self, service_id):
         return self.get('/service/{0}/history'.format(service_id))
 
-    def get_service_usage(self, service_id):
-        return self.get('/service/{0}/fragment/aggregate_statistics'.format(service_id))
+    def get_service_usage(self, service_id, year=None):
+        return self.get(
+            '/service/{0}/fragment/aggregate_statistics'.format(service_id),
+            params=dict(year=year)
+        )
 
     def get_weekly_notification_stats(self, service_id):
         return self.get(url='/service/{}/notifications/weekly'.format(service_id))

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -3,7 +3,8 @@
 {% macro pill(
   title,
   items=[],
-  current_value=None
+  current_value=None,
+  big_number_args={'smaller': True}
 ) %}
   <nav role='navigation' class='pill' aria-labelledby="pill_{{title}}">
     <h2 id="pill_{{title}}" class="visuallyhidden">{{title}}</h2>
@@ -13,8 +14,8 @@
       {% else %}
         <a href="{{ link }}">
       {% endif %}
-          {{ big_number(count, smaller=True) }}
-          <div class="pill-label">{{ label }}</div>
+        {{ big_number(count, **big_number_args) }}
+        <div class="pill-label">{{ label }}</div>
       {% if current_value == option %}
         </span>
       {% else %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -1,5 +1,6 @@
 {% from "components/big-number.html" import big_number %}
 {% from "components/table.html" import list_table, field, hidden_field_heading, row_heading, text_field %}
+{% from "components/pill.html" import pill %}
 
 {% extends "withnav_template.html" %}
 
@@ -9,15 +10,10 @@
 
 {% block maincolumn_content %}
 
-    <div class='grid-row'>
-      <div class='column-half'>
-        <h2 class='heading-large'>Usage</h2>
-      </div>
-      <div class='column-half'>
-        <div class='align-with-heading-copy'>
-          Financial year {{ year }} to {{ year + 1 }}
-        </div>
-      </div>
+    <h2 class='heading-large'>Usage</h2>
+
+    <div class="bottom-gutter">
+      {{ pill('Year', years, selected_year, big_number_args={'smallest': True}) }}
     </div>
 
     <div class='grid-row'>
@@ -63,45 +59,51 @@
       </div>
     </div>
 
-    <div class="dashboard-table body-copy-table">
-      {% call(month, row_index) list_table(
-        months,
-        caption="Total spend",
-        caption_visible=False,
-        empty_message='',
-        field_headings=[
-          'By month',
-          hidden_field_heading('Cost'),
-        ],
-        field_headings_visible=True
-      ) %}
-        {% call row_heading() %}
-          {{ month.name }}
+    {% if months %}
+      <div class="dashboard-table body-copy-table">
+        {% call(month, row_index) list_table(
+          months,
+          caption="Total spend",
+          caption_visible=False,
+          empty_message='',
+          field_headings=[
+            'By month',
+            hidden_field_heading('Cost'),
+          ],
+          field_headings_visible=True
+        ) %}
+          {% call row_heading() %}
+            {{ month.name }}
+          {% endcall %}
+          {% call field(align='left') %}
+            {{ big_number(
+              sms_rate * month.paid,
+              currency="£",
+              smallest=True
+            ) }}
+            <ul>
+            {% if month.free %}
+              <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
+            {% endif %}
+            {% if month.paid %}
+              <li class="tabular-numbers">{{ "{:,}".format(month.paid) }} text messages at
+              {{- ' {:.2f}p'.format(sms_rate * 100) }}</li>
+            {% endif %}
+            {% if not (month.free or month.paid) %}
+              <li aria-hidden="true">–</li>
+            {% endif %}
+            </ul>
+          {% endcall %}
         {% endcall %}
-        {% call field(align='left') %}
-          {{ big_number(
-            sms_rate * month.paid,
-            currency="£",
-            smallest=True
-          ) }}
-          <ul>
-          {% if month.free %}
-            <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
-          {% endif %}
-          {% if month.paid %}
-            <li class="tabular-numbers">{{ "{:,}".format(month.paid) }} text messages at
-            {{- ' {:.2f}p'.format(sms_rate * 100) }}</li>
-          {% endif %}
-          {% if not (month.free or month.paid) %}
-            <li aria-hidden="true">–</li>
-          {% endif %}
-          </ul>
-        {% endcall %}
-      {% endcall %}
-    </div>
+      </div>
+    {% endif %}
 
     <div class="grid-row">
-      <div class="column-half">&nbsp;</div>
+      <div class="column-half">
+        <p class="align-with-heading-copy">
+          Financial year ends 31 March.
+        </p>
+      </div>
       <div class="column-half">
         <p class="align-with-heading-copy">
           What counts as 1 text message?<br />

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,7 @@ from io import StringIO, BytesIO
 from os import path
 from functools import wraps
 import unicodedata
+from datetime import datetime
 
 from flask import (
     abort,
@@ -322,3 +323,10 @@ def png_from_pdf(pdf_endpoint):
         filename_or_fp=output,
         mimetype='image/png',
     )
+
+
+def get_current_financial_year():
+    now = datetime.utcnow()
+    current_month = int(now.strftime('%-m'))
+    current_year = int(now.strftime('%Y'))
+    return current_year if current_month > 3 else current_year - 1

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -148,3 +148,7 @@ def test_generate_notifications_csv_formats_row_number_correctly(mocker, row_num
 
     assert len(csv_rows) == 1
     assert csv_rows[0].get('Row number') == expected_result
+
+
+def normalize_spaces(string):
+    return ' '.join(string.split())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1256,7 +1256,7 @@ def mock_get_template_statistics_for_template(mocker, service_one):
 
 @pytest.fixture(scope='function')
 def mock_get_usage(mocker, service_one, fake_uuid):
-    def _get_usage(service_id):
+    def _get_usage(service_id, year=None):
         return {'data': {
             "sms_count": 456123,
             "email_count": 123


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/803

***

Right now we tell people that the usage page is for the current financial year. This is a lie – it’s for all time.

So this commit calls through to the API to get the stats for (by default) the current financial year.

We already do this for the monthly breakdown, this just does the same thing for the yearly totals.

It also adds navigation to show the data for other financial years:
- previous so you can go back and see your usage and verify that the bill you’re about to pay is correct
- next so that you can check what your SMS allowance is going to be before you actually get into it

***

![usage-by-year](https://cloud.githubusercontent.com/assets/355079/22368967/29a1dc64-e481-11e6-948a-e1b69199ea4d.gif)
