### PR TITLE
Add Suspend and Resume service buttons to service-settings page.

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -198,6 +198,31 @@ def archive_service(service_id):
         return service_settings(service_id)
 
 
+@main.route("/services/<service_id>/service-settings/suspend", methods=["GET", "POST"])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def suspend_service(service_id):
+    if request.method == 'POST':
+        service_api_client.suspend_service(service_id)
+        return redirect(url_for('.service_settings', service_id=service_id))
+    else:
+        flash("This will suspend the service and revoke all api keys. Are you sure you want to suspend this service?",
+              'suspend')
+        return service_settings(service_id)
+
+
+@main.route("/services/<service_id>/service-settings/resume", methods=["GET", "POST"])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def resume_service(service_id):
+    if request.method == 'POST':
+        service_api_client.resume_service(service_id)
+        return redirect(url_for('.service_settings', service_id=service_id))
+    else:
+        flash("This will resume the service. New api key are required for this service to use the API.", 'resume')
+        return service_settings(service_id)
+
+
 @main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -106,6 +106,12 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def archive_service(self, service_id):
         return self.post('/service/{}/archive'.format(service_id), data=None)
 
+    def suspend_service(self, service_id):
+        return self.post('/service/{}/suspend'.format(service_id), data=None)
+
+    def resume_service(self, service_id):
+        return self.post('/service/{}/resume'.format(service_id), data=None)
+
     def remove_user_from_service(self, service_id, user_id):
         """
         Remove a user from a service

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -5,7 +5,7 @@
       {{ banner(
         message,
         'default' if ((category == 'default') or (category == 'default_with_tick')) else 'dangerous',
-        delete_button="Yes, {}".format(category) if category in ['delete', 'remove'] else None,
+        delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove'] else None,
         with_tick=True if category == 'default_with_tick' else False
       )}}
     {% endfor %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -115,6 +115,18 @@
               Archive service
             </a>
           </li>
+          <li class="bottom-gutter">
+            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="button">
+              Suspend service
+            </a>
+          </li>
+        {% endif %}
+        {% if not current_service.active %}
+          <li class="bottom-gutter">
+            <a href="{{ url_for('.resume_service', service_id=current_service.id) }}" class="button">
+              Resume service
+            </a>
+          </li>
         {% endif %}
       </ul>
 


### PR DESCRIPTION
This allows a platform admin to suspend a service, mark the service as inactive and revoke api keys.
A service can be resumes, which marks the service as active, the service will need new API keys.

- [x] https://github.com/alphagov/notifications-api/pull/811