### PR TITLE
Use pycodestyle instead of PEP8

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pep8==1.7.0
+pycodestyle==2.3.1
 pytest==3.0.2
 pytest-mock==1.2
 pytest-cov==2.3.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,7 +27,7 @@ function display_result {
 if [ -d venv ]; then
   source ./venv/bin/activate
 fi
-pep8 .
+pycodestyle .
 display_result $? 1 "Code style check"
 
 npm test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 max-line-length = 120
 exclude = ./migrations,./venv,./venv3,./node_modules,./bower_components,./cache
 


### PR DESCRIPTION
PEP8 was renamed to pycodestyle; this issue explains why: PyCQA/pycodestyle#466

This commit changes our tests to use pycodestyle instead of pep8.

No changes to our code were required as a result.