### PR TITLE
Api key labels updated to clarify Live, Team and Test

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -69,9 +69,9 @@ def create_api_key(service_id):
     ]
     form = CreateKeyForm(key_names)
     form.key_type.choices = [
-        (KEY_TYPE_NORMAL, 'Send messages to anyone'),
-        (KEY_TYPE_TEAM, 'Send messages to anyone on my whitelist'),
-        (KEY_TYPE_TEST, 'Pretend to send messages to anyone'),
+        (KEY_TYPE_NORMAL, 'Live – sends to anyone'),
+        (KEY_TYPE_TEAM, 'Team and whitelist – limits who you can send to'),
+        (KEY_TYPE_TEST, 'Test – pretends to send messages'),
     ]
     if current_service['restricted']:
         disabled_options = [KEY_TYPE_NORMAL]

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -35,7 +35,7 @@
         {{ item.name }}
         <span class="file-list-hint">
           {% if item.key_type == 'normal' %}
-            <span class="visually-hidden">Live – sends to anyone</span>
+            Live – sends to anyone
           {% elif item.key_type == 'team' %}
             Team and whitelist – limits who you can send to
           {% elif item.key_type == 'test' %}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -35,11 +35,11 @@
         {{ item.name }}
         <span class="file-list-hint">
           {% if item.key_type == 'normal' %}
-            <span class="visually-hidden">Normal</span>
+            <span class="visually-hidden">Live – sends to anyone</span>
           {% elif item.key_type == 'team' %}
-            Sends to anyone on your whitelist
+            Team and whitelist – limits who you can send to
           {% elif item.key_type == 'test' %}
-            Pretends to send messages
+            Test – pretends to send messages
           {% endif %}
         </span>
       </div>


### PR DESCRIPTION
Was confusing as we explained what the keys did, but we didn't have labels for them. So referring to key types again anywhere in the docs became very messy.

Was:
* Send messages to anyone
* Send messages to anyone on my whitelist
* Pretend to send messages to anyone

Now is:
* Live – sends to anyone
* Team and whitelist – limits who you can send to
* Test – pretends to send messages

Also applied these labels to the list of API keys so that once you've set them up you can see what you have got and how they will work, consistently.
