### PR TITLE
Testing doc

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -100,3 +100,8 @@ def email_template():
 @main.route('/documentation')
 def documentation():
     abort(410)
+
+
+@main.route('/integration_testing')
+def integration_testing():
+    return render_template('views/integration_testing.html')

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -110,6 +110,7 @@
             ] %}
             <li><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ language }} client</a></li>
             {% endfor %}
+            <li><a href="{{ url_for("main.integration_testing") }}">Integration testing</a></li>
           </ul>
         </div>
       </div>

--- a/app/templates/views/api/documentation.html
+++ b/app/templates/views/api/documentation.html
@@ -26,6 +26,7 @@
       <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ name }}</a>
     </li>
     {% endfor %}
+    <li><a href="{{ url_for("main.integration_testing") }}">Integration testing</a></li>
   </ul>
 
   {{ page_footer(

--- a/app/templates/views/integration_testing.html
+++ b/app/templates/views/integration_testing.html
@@ -29,21 +29,21 @@
 
   <h2 class="heading-medium">Live key</h2>
     <p>
-        Once your service is live you are able to create Live keys. You can then use these key to send messages to anyone.
+        Once your service is live you are able to create Live keys. You can then use these keys to send messages to anyone.
     </p>
     <p>
         Messages sent with a live key show up on your dashboard and count against your text message and email allowances.
     </p>
       <p>
-          You should plan to rotate these keys on a regular basis. You may have more than one active key at a time. To revoke the key click the revoke button on the API Key page.
+          You should plan to rotate these keys on a regular basis. You can have more than one active key at a time. To revoke a key click the revoke button on the API Key page.
       </p>
 
     <h2 class="heading-medium">Team key</h2>
     <p>
-     Use a team key for end-to-end functional testing.
+         Use a team key for end-to-end functional testing.
     </p>
     <p>
-        A team key lets you send real messages to members of your team and addresses/numbers that you have added to your whitelist. You will get an error if you use these keys to send messages to anyone else.
+        A team key lets you send real messages to members of your team and address/numbers that you have added to your whitelist. You will get an error if you use these keys to send messages to anyone else.
     </p>
     <p>
         Messages sent with a team key show up on your dashboard and count against your text message and email allowances.
@@ -57,7 +57,7 @@
           Test keys don’t send real messages but do generates realistic responses. There’s no restriction on who you can send to or how many messages you can send per day.
       </p>
       <p>
-        Messages sent using a test key don’t show up on your dashboard or count against your text message and email allowances.
+          Messages sent using a test key don’t show up on your dashboard or count against your text message and email allowances.
       </p>
       <p>
           By default, all messages sent with a test key will result in a delivered status.
@@ -74,22 +74,20 @@
       <h2 class="heading-medium">Smoke testing your integration</h2>
       <p>
          If you need to smoke test your integration with Notify on a regular basis, you should use the smoke test numbers and addresses below.
-      </p>
-      <p>
-         The smoke test numbers and addresses will immediately return a successful response, but won’t send a real message and won’t produce a delivery receipt.
-      </p>
-      <p>
-          You can use the smoke test numbers and addresses with any type of key.
-      </p>
-      <p>
-         If your smoke tests need to fetch a delivery receipt, then use a test key - and don’t use these numbers and addresses.
-
           <li>“07700900000”</li>
           <li>“07700900111”</li>
           <li>“07700900222”</li>
           <li>“simulate-delivered@notifications.service.gov.uk”</li>
           <li>“simulate-delivered-2@notifications.service.gov.uk”</li>
           <li>“simulate-delivered-3@notifications.service.gov.uk”</li>
+      </p>
+      <p>
+         The smoke test numbers and addresses will immediately return a successful response, but won’t send a real message and won’t produce a delivery receipt.
+          The notification ID is not a real ID, you will not be able to fetch the notification by ID.
+      </p>
+      <p>
+          You can use the smoke test numbers and addresses with any type of key.
+          If your smoke tests need to fetch a delivery receipt, then use a test key - and don’t use these numbers and addresses.
       </p>
 
   </div>

--- a/app/templates/views/integration_testing.html
+++ b/app/templates/views/integration_testing.html
@@ -1,0 +1,76 @@
+{% extends "withoutnav_template.html" %}
+
+{% block page_title %}
+  Integration testing - GOV.UK Notify
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Integration testing</h1>
+
+    <p>
+      Service teams should do all their testing within the GOV.UK Notify production environment (https://api.notifications.service.gov.uk).
+    </p>
+    <p>
+        You don’t need different Notify accounts or access to other Notify environments. Instead, there are different types of API key that let you do functional or performance integration testing.
+    </p>
+
+    <h2 class="heading-medium">API Keys</h2>
+    <p>
+        The 3 types of API key that you can create within GOV.UK Notify are:
+    </p>
+    <ul class="list list-bullet">
+      <li>live key - “Send messages to anyone”</li>
+      <li>team key - “Send messages to anyone on my whitelist”</li>
+       <li>test key - “Pretend to send messages to anyone"</li>
+    </ul>
+
+  <h2 class="heading-medium">Live key</h2>
+    <p>
+        Once your service is live you are able to create Live keys. You can then use these key to send messages to anyone.
+    </p>
+    <p>
+        Messages sent with a live key show up on your dashboard and count against your text message and email allowances.
+    </p>
+      <p>
+          You should plan to rotate these keys on a regular basis. You may have more than one active key at a time. To revoke the key simply click the revoke button on the API Key page.
+      </p>
+
+    <h2 class="heading-medium">Team key</h2>
+    <p>
+     Use a team key for end-to-end functional testing.
+    </p>
+    <p>
+        A team key lets you send real messages to members of your team (and addresses/numbers that you have added to your whitelist). You will get an error if you use these keys to send messages to anyone else.
+    </p>
+    <p>
+        Messages sent with a team key show up on your dashboard and count against your text message and email allowances.
+    </p>
+
+    <h2 class="heading-medium">Test key</h2>
+      <p>
+        Use a test key to test the performance of your service and its integration with GOV.UK Notify under load.
+      </p>
+      <p>
+          A test key doesn’t send real messages but generates realistic responses. There’s no restriction on who you can send to or how many messages you can send per day.
+      </p>
+      <p>
+        Messages sent using a test key don’t show up on your dashboard or count against your text message and email allowances.
+      </p>
+      <p>
+          By default, all messages sent with a test key will result in a delivered status.
+      </p>
+      <p>
+          If you want to test failure statuses with a test key, use the following phone numbers and email addresses:
+
+          <li>"07700900003" => temporary failure</li>
+          <li>"07700900002" => permanent failure</li>
+          <li>"temp-fail@simulator.notify" => temporary failure</li>
+          <li>"perm-fail@simulator.notify" => permanent failure</li>
+      </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/views/integration_testing.html
+++ b/app/templates/views/integration_testing.html
@@ -11,15 +11,15 @@
     <h1 class="heading-large">Integration testing</h1>
 
     <p>
-      Service teams should do all their testing within the GOV.UK Notify production environment (https://api.notifications.service.gov.uk).
+      Service teams should do all their testing within the GOV.UK Notify production environment, https://api.notifications.service.gov.uk.
     </p>
     <p>
-        You don’t need different Notify accounts or access to other Notify environments. Instead, there are different types of API key that let you do functional or performance integration testing.
+        You don’t need different Notify accounts or access to other Notify environments. Instead, there are different types of API keys that let you do functional or performance integration testing.
     </p>
 
-    <h2 class="heading-medium">API Keys</h2>
+    <h2 class="heading-medium">Types of API Keys</h2>
     <p>
-        The 3 types of API key that you can create within GOV.UK Notify are:
+        There are 3 types of API key available within GOV.UK Notify:
     </p>
     <ul class="list list-bullet">
       <li>live key - “Send messages to anyone”</li>
@@ -35,7 +35,7 @@
         Messages sent with a live key show up on your dashboard and count against your text message and email allowances.
     </p>
       <p>
-          You should plan to rotate these keys on a regular basis. You may have more than one active key at a time. To revoke the key simply click the revoke button on the API Key page.
+          You should plan to rotate these keys on a regular basis. You may have more than one active key at a time. To revoke the key click the revoke button on the API Key page.
       </p>
 
     <h2 class="heading-medium">Team key</h2>
@@ -43,7 +43,7 @@
      Use a team key for end-to-end functional testing.
     </p>
     <p>
-        A team key lets you send real messages to members of your team (and addresses/numbers that you have added to your whitelist). You will get an error if you use these keys to send messages to anyone else.
+        A team key lets you send real messages to members of your team and addresses/numbers that you have added to your whitelist. You will get an error if you use these keys to send messages to anyone else.
     </p>
     <p>
         Messages sent with a team key show up on your dashboard and count against your text message and email allowances.
@@ -54,7 +54,7 @@
         Use a test key to test the performance of your service and its integration with GOV.UK Notify under load.
       </p>
       <p>
-          A test key doesn’t send real messages but generates realistic responses. There’s no restriction on who you can send to or how many messages you can send per day.
+          Test keys don’t send real messages but do generates realistic responses. There’s no restriction on who you can send to or how many messages you can send per day.
       </p>
       <p>
         Messages sent using a test key don’t show up on your dashboard or count against your text message and email allowances.
@@ -70,6 +70,28 @@
           <li>"temp-fail@simulator.notify" => temporary failure</li>
           <li>"perm-fail@simulator.notify" => permanent failure</li>
       </p>
+
+      <h2 class="heading-medium">Smoke testing your integration</h2>
+      <p>
+         If you need to smoke test your integration with Notify on a regular basis, you should use the smoke test numbers and addresses below.
+      </p>
+      <p>
+         The smoke test numbers and addresses will immediately return a successful response, but won’t send a real message and won’t produce a delivery receipt.
+      </p>
+      <p>
+          You can use the smoke test numbers and addresses with any type of key.
+      </p>
+      <p>
+         If your smoke tests need to fetch a delivery receipt, then use a test key - and don’t use these numbers and addresses.
+
+          <li>“07700900000”</li>
+          <li>“07700900111”</li>
+          <li>“07700900222”</li>
+          <li>“simulate-delivered@notifications.service.gov.uk”</li>
+          <li>“simulate-delivered-2@notifications.service.gov.uk”</li>
+          <li>“simulate-delivered-3@notifications.service.gov.uk”</li>
+      </p>
+
   </div>
 </div>
 

--- a/app/templates/views/integration_testing.html
+++ b/app/templates/views/integration_testing.html
@@ -22,9 +22,9 @@
         There are 3 types of API key available within GOV.UK Notify:
     </p>
     <ul class="list list-bullet">
-      <li>live key - “Send messages to anyone”</li>
-      <li>team key - “Send messages to anyone on my whitelist”</li>
-       <li>test key - “Pretend to send messages to anyone"</li>
+      <li>Live – sends to anyone</li>
+      <li>Team and whitelist – limits who you can send to</li>
+       <li>Test – pretends to send messages</li>
     </ul>
 
   <h2 class="heading-medium">Live key</h2>

--- a/app/templates/views/integration_testing.html
+++ b/app/templates/views/integration_testing.html
@@ -1,3 +1,4 @@
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
 {% extends "withoutnav_template.html" %}
 
 {% block page_title %}
@@ -11,22 +12,34 @@
     <h1 class="heading-large">Integration testing</h1>
 
     <p>
-      Service teams should do all their testing within the GOV.UK Notify production environment, https://api.notifications.service.gov.uk.
-    </p>
-    <p>
-        You don’t need different Notify accounts or access to other Notify environments. Instead, there are different types of API keys that let you do functional or performance integration testing.
+        There are different types of API keys that let you do functional or performance integration testing.
+        You don’t need different GOV.UK Notify accounts or access to other GOV.UK Notify environments.
     </p>
 
     <h2 class="heading-medium">Types of API Keys</h2>
-    <p>
-        There are 3 types of API key available within GOV.UK Notify:
-    </p>
-    <ul class="list list-bullet">
-      <li>Live – sends to anyone</li>
-      <li>Team and whitelist – limits who you can send to</li>
-       <li>Test – pretends to send messages</li>
-    </ul>
+        <div class="bottom-gutter-3-2">
+            {% call mapping_table(
+                caption='Test numbers/address that generate error responses',
+                field_headings=['Label', 'Value'],
+                field_headings_visible=False,
+                caption_visible=False
+              ) %}
+             {% call row() %}
+                  {{ text_field('Live') }}
+                  {{ text_field('sends to anyone') }}
+            {% endcall %}
 
+             {% call row() %}
+                  {{ text_field('Team and whitelist') }}
+                  {{ text_field('limits who you can send to') }}
+            {% endcall %}
+
+             {% call row() %}
+                  {{ text_field('Test') }}
+                  {{ text_field('pretends to send messages') }}
+            {% endcall %}
+            {%endcall%}
+        </div>
   <h2 class="heading-medium">Live key</h2>
     <p>
         Once your service is live you are able to create Live keys. You can then use these keys to send messages to anyone.
@@ -35,26 +48,27 @@
         Messages sent with a live key show up on your dashboard and count against your text message and email allowances.
     </p>
       <p>
-          You should plan to rotate these keys on a regular basis. You can have more than one active key at a time. To revoke a key click the revoke button on the API Key page.
+          You should revoke and re-create these keys on a regular basis. You can have more than one active key at a time. To revoke a key click the revoke button on the API Key page.
       </p>
 
-    <h2 class="heading-medium">Team key</h2>
+    <h2 class="heading-medium">Team and whitelist key</h2>
     <p>
-         Use a team key for end-to-end functional testing.
+         Use a team and whitelist key for end-to-end functional testing.
     </p>
     <p>
-        A team key lets you send real messages to members of your team and address/numbers that you have added to your whitelist. You will get an error if you use these keys to send messages to anyone else.
+        A team and whitelist key lets you send real messages to members of your team and addresses/numbers that you have added to your whitelist. You will get an error if you use these keys to send messages to anyone else.
     </p>
     <p>
-        Messages sent with a team key show up on your dashboard and count against your text message and email allowances.
+        Messages sent with a team and whitelist key show up on your dashboard and count against your text message and email allowances.
     </p>
 
     <h2 class="heading-medium">Test key</h2>
       <p>
-        Use a test key to test the performance of your service and its integration with GOV.UK Notify under load.
+        Use a test key to test the performance of your service and its integration with GOV.UK Notify.
       </p>
       <p>
-          Test keys don’t send real messages but do generates realistic responses. There’s no restriction on who you can send to or how many messages you can send per day.
+          Test keys don’t send real messages but do generates realistic responses.
+          There’s no restriction on who you can send to.
       </p>
       <p>
           Messages sent using a test key don’t show up on your dashboard or count against your text message and email allowances.
@@ -63,23 +77,72 @@
           By default, all messages sent with a test key will result in a delivered status.
       </p>
       <p>
-          If you want to test failure statuses with a test key, use the following phone numbers and email addresses:
+          If you want to test failure responses with a test key, use the following numbers and addresses:
+      <div class="bottom-gutter-3-2">
 
-          <li>"07700900003" => temporary failure</li>
-          <li>"07700900002" => permanent failure</li>
-          <li>"temp-fail@simulator.notify" => temporary failure</li>
-          <li>"perm-fail@simulator.notify" => permanent failure</li>
+          {% call mapping_table(
+            caption='Test numbers/address that generate error responses',
+            field_headings=['Label', 'Value', 'Action'],
+            field_headings_visible=False,
+            caption_visible=False
+          ) %}
+            {% call row() %}
+              {{ text_field('07700900003') }}
+              {{ text_field('temporary failure') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('07700900002') }}
+              {{ text_field('permanent failure') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('temp-fail@simulator.notify') }}
+              {{ text_field('temporary failure') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('perm-fail@simulator.notify') }}
+              {{ text_field('permanent failure') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('any other valid number or address') }}
+              {{ text_field('delivered') }}
+            {% endcall %}
+          {% endcall %}
+
+      </div>
       </p>
 
       <h2 class="heading-medium">Smoke testing your integration</h2>
       <p>
-         If you need to smoke test your integration with Notify on a regular basis, you should use the smoke test numbers and addresses below.
-          <li>“07700900000”</li>
-          <li>“07700900111”</li>
-          <li>“07700900222”</li>
-          <li>“simulate-delivered@notifications.service.gov.uk”</li>
-          <li>“simulate-delivered-2@notifications.service.gov.uk”</li>
-          <li>“simulate-delivered-3@notifications.service.gov.uk”</li>
+         If you need to smoke test your integration with GOV.UK Notify on a regular basis, you should use the smoke test numbers and addresses below.
+<div class="bottom-gutter-3-2">
+        {% call mapping_table(
+            caption='Test numbers/address that generate error responses',
+            field_headings=['Label'],
+            field_headings_visible=False,
+            caption_visible=False
+          ) %}
+            {% call row() %}
+              {{ text_field('07700900111') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('07700900222') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('07700900333') }}
+            {% endcall %}
+            {% call row() %}
+              {{ text_field('simulate-delivered@notifications.service.gov.uk') }}
+            {% endcall %}
+           {% call row() %}
+              {{ text_field('simulate-delivered-2@notifications.service.gov.uk') }}
+            {% endcall %}
+
+           {% call row() %}
+              {{ text_field('simulate-delivered-3@notifications.service.gov.uk') }}
+            {% endcall %}
+          {% endcall %}
+      </div>
+
       </p>
       <p>
          The smoke test numbers and addresses will immediately return a successful response, but won’t send a real message and won’t produce a delivery receipt.
@@ -87,7 +150,7 @@
       </p>
       <p>
           You can use the smoke test numbers and addresses with any type of key.
-          If your smoke tests need to fetch a delivery receipt, then use a test key - and don’t use these numbers and addresses.
+          If your smoke tests need to get the status of a message, then use a test key and don’t use these numbers and addresses.
       </p>
 
   </div>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -18,7 +18,7 @@ def test_logged_in_user_redirects_to_choose_service(app_,
 
 
 @pytest.mark.parametrize('view', [
-    'cookies', 'trial_mode', 'pricing', 'terms', 'delivery_and_failure'
+    'cookies', 'trial_mode', 'pricing', 'terms', 'delivery_and_failure', 'integration_testing'
 ])
 def test_static_pages(app_, view):
     with app_.test_request_context(), app_.test_client() as client:


### PR DESCRIPTION
Testing document let's the developers know all the testing options for Notify. 
The document is linked to in the footer and the document page.

