### PR TITLE
Handle partial letter addresses more gracefully

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ whitenoise==1.0.6  #manages static assets
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.3.0#egg=notifications-utils==13.3.0
+git+https://github.com/alphagov/notifications-utils.git@13.3.1#egg=notifications-utils==13.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ whitenoise==1.0.6  #manages static assets
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.2.1#egg=notifications-utils==13.2.1
+git+https://github.com/alphagov/notifications-utils.git@13.3.0#egg=notifications-utils==13.3.0

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -444,8 +444,10 @@ def test_should_show_preview_letter_message(
     assert response.status_code == 200
     assert response.content_type == expected_content_type
     mock_get_service_letter_template.assert_called_with(service_id, template_id)
+    assert mock_letter_preview.call_args[0][0]['subject'] == (
+        'Subject'
+    )
     assert mock_letter_preview.call_args[0][0]['message'] == (
-        '<h2>Subject</h2>\n'
         '<p>Template &lt;em&gt;content&lt;/em&gt; with &amp; entity</p>'
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -100,10 +100,10 @@ def test_should_show_preview_letter_templates(
     assert response.status_code == 200
     assert response.content_type == expected_content_type
     mock_get_service_email_template.assert_called_with(service_id, template_id, **extra_view_args)
-    print(mock_letter_preview)
-    print(mock_letter_preview.call_args)
+    assert mock_letter_preview.call_args[0][0]['subject'] == (
+        "Your <span class='placeholder'>((thing))</span> is due soon"
+    )
     assert mock_letter_preview.call_args[0][0]['message'] == (
-        "<h2>Your <span class='placeholder'>((thing))</span> is due soon</h2>\n"
         "<p>Your vehicle tax expires on <span class='placeholder'>((date))</span></p>"
     )
 


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/108

Specifically, see these tests for detail of what happens when someone only fills in some of the required/not required lines of an address:
https://github.com/alphagov/notifications-utils/pull/108/commits/9e6cb14a5c3b328efa03c1f88d457e2d1c972a52#diff-e5050dea996611c8bdf32cfe6e8214cdR264