### PR TITLE
Tidy up tests

### DIFF
--- a/tests/app/main/test_add_service_form.py
+++ b/tests/app/main/test_add_service_form.py
@@ -2,11 +2,10 @@ from app.main.forms import AddServiceForm
 from werkzeug.datastructures import MultiDict
 
 
-def test_form_should_have_errors_when_duplicate_service_is_added(app_):
+def test_form_should_have_errors_when_duplicate_service_is_added(client):
     def _get_form_names():
         return ['some.service', 'more.names']
-    with app_.test_request_context():
-        form = AddServiceForm(_get_form_names,
-                              formdata=MultiDict([('name', 'some service')]))
-        form.validate()
-        assert {'name': ['This service name is already in use']} == form.errors
+    form = AddServiceForm(_get_form_names,
+                          formdata=MultiDict([('name', 'some service')]))
+    form.validate()
+    assert {'name': ['This service name is already in use']} == form.errors

--- a/tests/app/main/test_choose_time_form.py
+++ b/tests/app/main/test_choose_time_form.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_contains_next_24h(app_):
+def test_form_contains_next_24h():
 
     choices = ChooseTimeForm().scheduled_for.choices
 
@@ -34,12 +34,12 @@ def test_form_contains_next_24h(app_):
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_defaults_to_now(app_):
+def test_form_defaults_to_now():
     assert ChooseTimeForm().scheduled_for.data == ''
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_contains_next_three_days(app_):
+def test_form_contains_next_three_days():
     assert ChooseTimeForm().scheduled_for.categories == [
         'Later today', 'Tomorrow', 'Sunday', 'Monday'
     ]

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -5,16 +5,15 @@ from werkzeug.datastructures import MultiDict
 from app.main.forms import CreateKeyForm
 
 
-def test_return_validation_error_when_key_name_exists(app_):
+def test_return_validation_error_when_key_name_exists(client):
     def _get_names():
         return ['some key', 'another key']
 
-    with app_.test_request_context():
-        form = CreateKeyForm(_get_names(),
-                             formdata=MultiDict([('key_name', 'Some key')]))
-        form.key_type.choices = [('a', 'a'), ('b', 'b')]
-        form.validate()
-        assert form.errors['key_name'] == ['A key with this name already exists']
+    form = CreateKeyForm(_get_names(),
+                         formdata=MultiDict([('key_name', 'Some key')]))
+    form.key_type.choices = [('a', 'a'), ('b', 'b')]
+    form.validate()
+    assert form.errors['key_name'] == ['A key with this name already exists']
 
 
 @pytest.mark.parametrize(
@@ -23,12 +22,11 @@ def test_return_validation_error_when_key_name_exists(app_):
         ('invalid', 'Not a valid choice')
     ]
 )
-def test_return_validation_error_when_key_type_not_chosen(app_, key_type, expected_error):
+def test_return_validation_error_when_key_type_not_chosen(client, key_type, expected_error):
 
-    with app_.test_request_context():
-        form = CreateKeyForm(
-            [],
-            formdata=MultiDict([('key_name', 'Some key'), ('key_type', key_type)]))
-        form.key_type.choices = [('a', 'a'), ('b', 'b')]
-        form.validate()
-        assert form.errors['key_type'] == [expected_error]
+    form = CreateKeyForm(
+        [],
+        formdata=MultiDict([('key_name', 'Some key'), ('key_type', key_type)]))
+    form.key_type.choices = [('a', 'a'), ('b', 'b')]
+    form.validate()
+    assert form.errors['key_type'] == [expected_error]

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -2,9 +2,8 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 
-def test_bad_url_returns_page_not_found(app_):
-    with app_.test_client() as client:
-        response = client.get('/bad_url')
-        assert response.status_code == 404
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.string.strip() == 'Page could not be found'
+def test_bad_url_returns_page_not_found(client):
+    response = client.get('/bad_url')
+    assert response.status_code == 404
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Page could not be found'

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -5,7 +5,15 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from flask import request
 
 
-def _test_permissions(app_, usr, permissions, service_id, will_succeed, any_=False, admin_override=False):
+def _test_permissions(
+    app_,
+    usr,
+    permissions,
+    service_id,
+    will_succeed,
+    any_=False,
+    admin_override=False,
+):
     with app_.test_request_context() as ctx:
         request.view_args.update({'service_id': service_id})
         with app_.test_client() as client:
@@ -23,7 +31,10 @@ def _test_permissions(app_, usr, permissions, service_id, will_succeed, any_=Fal
                     pass
 
 
-def test_user_has_permissions_on_endpoint_fail(app_, mocker):
+def test_user_has_permissions_on_endpoint_fail(
+    app_,
+    mocker,
+):
     user = _user_with_permissions()
     mocker.patch('app.user_api_client.get_user', return_value=user)
     _test_permissions(
@@ -34,8 +45,10 @@ def test_user_has_permissions_on_endpoint_fail(app_, mocker):
         False)
 
 
-def test_user_has_permissions_success(app_,
-                                      mocker):
+def test_user_has_permissions_success(
+    app_,
+    mocker,
+):
     user = _user_with_permissions()
     mocker.patch('app.user_api_client.get_user', return_value=user)
     _test_permissions(
@@ -46,7 +59,10 @@ def test_user_has_permissions_success(app_,
         True)
 
 
-def test_user_has_permissions_or(app_, mocker):
+def test_user_has_permissions_or(
+    app_,
+    mocker,
+):
     user = _user_with_permissions()
     mocker.patch('app.user_api_client.get_user', return_value=user)
     _test_permissions(
@@ -58,8 +74,10 @@ def test_user_has_permissions_or(app_, mocker):
         any_=True)
 
 
-def test_user_has_permissions_multiple(app_,
-                                       mocker):
+def test_user_has_permissions_multiple(
+    app_,
+    mocker,
+):
     user = _user_with_permissions()
     mocker.patch('app.user_api_client.get_user', return_value=user)
     _test_permissions(
@@ -70,8 +88,10 @@ def test_user_has_permissions_multiple(app_,
         will_succeed=True)
 
 
-def test_exact_permissions(app_,
-                           mocker):
+def test_exact_permissions(
+    app_,
+    mocker,
+):
     user = _user_with_permissions()
     mocker.patch('app.user_api_client.get_user', return_value=user)
     _test_permissions(
@@ -82,9 +102,11 @@ def test_exact_permissions(app_,
         True)
 
 
-def test_platform_admin_user_can_access_page(app_,
-                                             platform_admin_user,
-                                             mocker):
+def test_platform_admin_user_can_access_page(
+    app_,
+    platform_admin_user,
+    mocker,
+):
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     _test_permissions(
         app_,
@@ -95,9 +117,11 @@ def test_platform_admin_user_can_access_page(app_,
         admin_override=True)
 
 
-def test_platform_admin_user_can_not_access_page(app_,
-                                                 platform_admin_user,
-                                                 mocker):
+def test_platform_admin_user_can_not_access_page(
+    app_,
+    platform_admin_user,
+    mocker,
+):
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     _test_permissions(
         app_,
@@ -108,7 +132,9 @@ def test_platform_admin_user_can_not_access_page(app_,
         admin_override=False)
 
 
-def test_no_user_returns_401_unauth(app_):
+def test_no_user_returns_401_unauth(
+    app_
+):
     from flask_login import current_user
     assert not current_user
     _test_permissions(

--- a/tests/app/main/test_two_factor_form.py
+++ b/tests/app/main/test_two_factor_form.py
@@ -4,7 +4,10 @@ from app.main.forms import TwoFactorForm
 from app import user_api_client
 
 
-def test_form_is_valid_returns_no_errors(app_, mock_check_verify_code):
+def test_form_is_valid_returns_no_errors(
+    app_,
+    mock_check_verify_code,
+):
     with app_.test_request_context(method='POST',
                                    data={'sms_code': '12345'}) as req:
         def _check_code(code):
@@ -14,7 +17,10 @@ def test_form_is_valid_returns_no_errors(app_, mock_check_verify_code):
         assert len(form.errors) == 0
 
 
-def test_returns_errors_when_code_is_too_short(app_, mock_check_verify_code):
+def test_returns_errors_when_code_is_too_short(
+    app_,
+    mock_check_verify_code,
+):
     with app_.test_request_context(method='POST',
                                    data={'sms_code': '145'}) as req:
         def _check_code(code):
@@ -25,7 +31,10 @@ def test_returns_errors_when_code_is_too_short(app_, mock_check_verify_code):
         assert set(form.errors) == set({'sms_code': ['Code must be 5 digits', 'Code does not match']})
 
 
-def test_returns_errors_when_code_is_missing(app_, mock_check_verify_code):
+def test_returns_errors_when_code_is_missing(
+    app_,
+    mock_check_verify_code,
+):
     with app_.test_request_context(method='POST',
                                    data={}) as req:
         def _check_code(code):
@@ -36,7 +45,10 @@ def test_returns_errors_when_code_is_missing(app_, mock_check_verify_code):
         assert set(form.errors) == set({'sms_code': ['Code must not be empty']})
 
 
-def test_returns_errors_when_code_contains_letters(app_, mock_check_verify_code):
+def test_returns_errors_when_code_contains_letters(
+    app_,
+    mock_check_verify_code,
+):
     with app_.test_request_context(method='POST',
                                    data={'sms_code': 'asdfg'}) as req:
         def _check_code(code):
@@ -47,8 +59,10 @@ def test_returns_errors_when_code_contains_letters(app_, mock_check_verify_code)
         assert set(form.errors) == set({'sms_code': ['Code must be 5 digits', 'Code does not match']})
 
 
-def test_should_return_errors_when_code_is_expired(app_,
-                                                   mock_check_verify_code_code_expired):
+def test_should_return_errors_when_code_is_expired(
+    app_,
+    mock_check_verify_code_code_expired,
+):
     with app_.test_request_context(method='POST',
                                    data={'sms_code': '23456'}) as req:
         def _check_code(code):

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -9,60 +9,56 @@ from unittest.mock import Mock
     'govuknotify', '11111111', 'kittykat', 'evangeli'
 ])
 def test_should_raise_validation_error_for_password(
-    app_,
+    client,
     mock_get_user_by_email,
     password,
 ):
-    with app_.test_request_context():
-        form = RegisterUserForm()
-        form.name.data = 'test'
-        form.email_address.data = 'teset@example.gov.uk'
-        form.mobile_number.data = '441231231231'
-        form.password.data = password
+    form = RegisterUserForm()
+    form.name.data = 'test'
+    form.email_address.data = 'teset@example.gov.uk'
+    form.mobile_number.data = '441231231231'
+    form.password.data = password
 
-        form.validate()
-        assert 'Choose a password that’s harder to guess' in form.errors['password']
+    form.validate()
+    assert 'Choose a password that’s harder to guess' in form.errors['password']
 
 
 def test_valid_email_not_in_valid_domains(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        form = RegisterUserForm(email_address="test@test.com", mobile_number='441231231231')
-        assert not form.validate()
-        assert "Enter a central government email address" in form.errors['email_address'][0]
+    form = RegisterUserForm(email_address="test@test.com", mobile_number='441231231231')
+    assert not form.validate()
+    assert "Enter a central government email address" in form.errors['email_address'][0]
 
 
 def test_valid_email_in_valid_domains(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        form = RegisterUserForm(
-            name="test",
-            email_address="test@my.gov.uk",
-            mobile_number='4407888999111',
-            password='an uncommon password')
-        form.validate()
-        assert form.errors == {}
+    form = RegisterUserForm(
+        name="test",
+        email_address="test@my.gov.uk",
+        mobile_number='4407888999111',
+        password='an uncommon password')
+    form.validate()
+    assert form.errors == {}
 
 
 def test_invalid_email_address_error_message(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        form = RegisterUserForm(
-            name="test",
-            email_address="test.com",
-            mobile_number='4407888999111',
-            password='1234567890')
-        assert not form.validate()
+    form = RegisterUserForm(
+        name="test",
+        email_address="test.com",
+        mobile_number='4407888999111',
+        password='1234567890')
+    assert not form.validate()
 
-        form = RegisterUserForm(
-            name="test",
-            email_address="test.com",
-            mobile_number='4407888999111',
-            password='1234567890')
-        assert not form.validate()
+    form = RegisterUserForm(
+        name="test",
+        email_address="test.com",
+        mobile_number='4407888999111',
+        password='1234567890')
+    assert not form.validate()
 
 
 def _gen_mock_field(x):
@@ -94,12 +90,11 @@ def _gen_mock_field(x):
     'test@hmcts.net',
 ])
 def test_valid_list_of_white_list_email_domains(
-    app_,
+    client,
     email,
 ):
-    with app_.test_request_context():
-        email_domain_validators = ValidGovEmail()
-        email_domain_validators(None, _gen_mock_field(email))
+    email_domain_validators = ValidGovEmail()
+    email_domain_validators(None, _gen_mock_field(email))
 
 
 @pytest.mark.parametrize("email", [
@@ -129,44 +124,41 @@ def test_valid_list_of_white_list_email_domains(
     'test@ucds.com'
 ])
 def test_invalid_list_of_white_list_email_domains(
-    app_,
+    client,
     email,
 ):
-    with app_.test_request_context():
-        email_domain_validators = ValidGovEmail()
-        with pytest.raises(ValidationError):
-            email_domain_validators(None, _gen_mock_field(email))
+    email_domain_validators = ValidGovEmail()
+    with pytest.raises(ValidationError):
+        email_domain_validators(None, _gen_mock_field(email))
 
 
 def test_for_commas_in_placeholders(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        with pytest.raises(ValidationError) as error:
-            NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name,date))'))
-        assert str(error.value) == 'You can’t have commas in your fields'
-        NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name))'))
+    with pytest.raises(ValidationError) as error:
+        NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name,date))'))
+    assert str(error.value) == 'You can’t have commas in your fields'
+    NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name))'))
 
 
 def test_sms_sender_form_validation(
-    app_,
+    client,
     mock_get_user_by_email,
 ):
-    with app_.test_request_context():
-        form = ServiceSmsSender()
+    form = ServiceSmsSender()
 
-        form.sms_sender.data = 'elevenchars'
-        form.validate()
-        assert not form.errors
+    form.sms_sender.data = 'elevenchars'
+    form.validate()
+    assert not form.errors
 
-        form.sms_sender.data = ''
-        form.validate()
-        assert not form.errors
+    form.sms_sender.data = ''
+    form.validate()
+    assert not form.errors
 
-        form.sms_sender.data = 'morethanelevenchars'
-        form.validate()
-        assert "Enter fewer than 11 characters" == form.errors['sms_sender'][0]
+    form.sms_sender.data = 'morethanelevenchars'
+    form.validate()
+    assert "Enter fewer than 11 characters" == form.errors['sms_sender'][0]
 
-        form.sms_sender.data = '###########'
-        form.validate()
-        assert 'Use letters and numbers only' == form.errors['sms_sender'][0]
+    form.sms_sender.data = '###########'
+    form.validate()
+    assert 'Use letters and numbers only' == form.errors['sms_sender'][0]

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -8,7 +8,11 @@ from unittest.mock import Mock
 @pytest.mark.parametrize('password', [
     'govuknotify', '11111111', 'kittykat', 'evangeli'
 ])
-def test_should_raise_validation_error_for_password(app_, mock_get_user_by_email, password):
+def test_should_raise_validation_error_for_password(
+    app_,
+    mock_get_user_by_email,
+    password,
+):
     with app_.test_request_context():
         form = RegisterUserForm()
         form.name.data = 'test'
@@ -20,14 +24,18 @@ def test_should_raise_validation_error_for_password(app_, mock_get_user_by_email
         assert 'Choose a password that’s harder to guess' in form.errors['password']
 
 
-def test_valid_email_not_in_valid_domains(app_):
+def test_valid_email_not_in_valid_domains(
+    app_
+):
     with app_.test_request_context():
         form = RegisterUserForm(email_address="test@test.com", mobile_number='441231231231')
         assert not form.validate()
         assert "Enter a central government email address" in form.errors['email_address'][0]
 
 
-def test_valid_email_in_valid_domains(app_):
+def test_valid_email_in_valid_domains(
+    app_
+):
     with app_.test_request_context():
         form = RegisterUserForm(
             name="test",
@@ -38,7 +46,9 @@ def test_valid_email_in_valid_domains(app_):
         assert form.errors == {}
 
 
-def test_invalid_email_address_error_message(app_):
+def test_invalid_email_address_error_message(
+    app_
+):
     with app_.test_request_context():
         form = RegisterUserForm(
             name="test",
@@ -83,7 +93,10 @@ def _gen_mock_field(x):
     'test@naturalengland.org.uk',
     'test@hmcts.net',
 ])
-def test_valid_list_of_white_list_email_domains(app_, email):
+def test_valid_list_of_white_list_email_domains(
+    app_,
+    email,
+):
     with app_.test_request_context():
         email_domain_validators = ValidGovEmail()
         email_domain_validators(None, _gen_mock_field(email))
@@ -115,14 +128,19 @@ def test_valid_list_of_white_list_email_domains(app_, email):
     'test@police.test.uk',
     'test@ucds.com'
 ])
-def test_invalid_list_of_white_list_email_domains(app_, email):
+def test_invalid_list_of_white_list_email_domains(
+    app_,
+    email,
+):
     with app_.test_request_context():
         email_domain_validators = ValidGovEmail()
         with pytest.raises(ValidationError):
             email_domain_validators(None, _gen_mock_field(email))
 
 
-def test_for_commas_in_placeholders(app_):
+def test_for_commas_in_placeholders(
+    app_
+):
     with app_.test_request_context():
         with pytest.raises(ValidationError) as error:
             NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name,date))'))
@@ -130,7 +148,10 @@ def test_for_commas_in_placeholders(app_):
         NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name))'))
 
 
-def test_sms_sender_form_validation(app_, mock_get_user_by_email):
+def test_sms_sender_form_validation(
+    app_,
+    mock_get_user_by_email,
+):
     with app_.test_request_context():
         form = ServiceSmsSender()
 

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -9,16 +9,18 @@ from tests.conftest import sample_invite as create_sample_invite
 from tests.conftest import mock_check_invite_token as mock_check_token_invite
 
 
-def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(app_,
-                                                                          service_one,
-                                                                          api_user_active,
-                                                                          sample_invite,
-                                                                          mock_get_service,
-                                                                          mock_check_invite_token,
-                                                                          mock_get_user_by_email,
-                                                                          mock_get_users_by_service,
-                                                                          mock_accept_invite,
-                                                                          mock_add_user_to_service):
+def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
+    app_,
+    service_one,
+    api_user_active,
+    sample_invite,
+    mock_get_service,
+    mock_check_invite_token,
+    mock_get_user_by_email,
+    mock_get_users_by_service,
+    mock_accept_invite,
+    mock_add_user_to_service,
+):
 
     expected_service = service_one['id']
     expected_redirect_location = 'http://localhost/services/{}/dashboard'.format(expected_service)
@@ -38,16 +40,18 @@ def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(app_,
             assert response.location == expected_redirect_location
 
 
-def test_existing_user_with_no_permissions_accept_invite(app_,
-                                                         mocker,
-                                                         service_one,
-                                                         api_user_active,
-                                                         sample_invite,
-                                                         mock_check_invite_token,
-                                                         mock_get_user_by_email,
-                                                         mock_get_users_by_service,
-                                                         mock_add_user_to_service,
-                                                         mock_get_service):
+def test_existing_user_with_no_permissions_accept_invite(
+    app_,
+    mocker,
+    service_one,
+    api_user_active,
+    sample_invite,
+    mock_check_invite_token,
+    mock_get_user_by_email,
+    mock_get_users_by_service,
+    mock_add_user_to_service,
+    mock_get_service,
+):
 
     expected_service = service_one['id']
     sample_invite['permissions'] = ''
@@ -63,10 +67,12 @@ def test_existing_user_with_no_permissions_accept_invite(app_,
             assert response.status_code == 302
 
 
-def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(app_,
-                                                                 mocker,
-                                                                 sample_invite,
-                                                                 mock_get_service):
+def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
+    app_,
+    mocker,
+    sample_invite,
+    mock_get_service,
+):
 
     sample_invite['status'] = 'accepted'
     invite = InvitedUser(**sample_invite)
@@ -83,13 +89,15 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(app_,
             assert flash_banners[0].text.strip() == 'Please log in to access this page.'
 
 
-def test_existing_user_of_service_get_redirected_to_signin(app_,
-                                                           mocker,
-                                                           api_user_active,
-                                                           sample_invite,
-                                                           mock_get_service,
-                                                           mock_get_user_by_email,
-                                                           mock_accept_invite):
+def test_existing_user_of_service_get_redirected_to_signin(
+    app_,
+    mocker,
+    api_user_active,
+    sample_invite,
+    mock_get_service,
+    mock_get_user_by_email,
+    mock_accept_invite,
+):
     sample_invite['email_address'] = api_user_active.email_address
     invite = InvitedUser(**sample_invite)
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
@@ -107,16 +115,18 @@ def test_existing_user_of_service_get_redirected_to_signin(app_,
             assert mock_accept_invite.call_count == 1
 
 
-def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(app_,
-                                                                     service_one,
-                                                                     api_user_active,
-                                                                     sample_invite,
-                                                                     mock_check_invite_token,
-                                                                     mock_get_user_by_email,
-                                                                     mock_get_users_by_service,
-                                                                     mock_add_user_to_service,
-                                                                     mock_accept_invite,
-                                                                     mock_get_service):
+def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
+    app_,
+    service_one,
+    api_user_active,
+    sample_invite,
+    mock_check_invite_token,
+    mock_get_user_by_email,
+    mock_get_users_by_service,
+    mock_add_user_to_service,
+    mock_accept_invite,
+    mock_get_service,
+):
 
     expected_service = service_one['id']
     expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
@@ -138,13 +148,15 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(app_,
             assert flash_banners[0].text.strip() == 'Please log in to access this page.'
 
 
-def test_new_user_accept_invite_calls_api_and_redirects_to_registration(app_,
-                                                                        service_one,
-                                                                        mock_check_invite_token,
-                                                                        mock_dont_get_user_by_email,
-                                                                        mock_add_user_to_service,
-                                                                        mock_get_users_by_service,
-                                                                        mock_get_service):
+def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
+    app_,
+    service_one,
+    mock_check_invite_token,
+    mock_dont_get_user_by_email,
+    mock_add_user_to_service,
+    mock_get_users_by_service,
+    mock_get_service,
+):
 
     expected_redirect_location = 'http://localhost/register-from-invite'
 
@@ -160,13 +172,15 @@ def test_new_user_accept_invite_calls_api_and_redirects_to_registration(app_,
             assert response.location == expected_redirect_location
 
 
-def test_new_user_accept_invite_calls_api_and_views_registration_page(app_,
-                                                                      service_one,
-                                                                      mock_check_invite_token,
-                                                                      mock_dont_get_user_by_email,
-                                                                      mock_add_user_to_service,
-                                                                      mock_get_users_by_service,
-                                                                      mock_get_service):
+def test_new_user_accept_invite_calls_api_and_views_registration_page(
+    app_,
+    service_one,
+    mock_check_invite_token,
+    mock_dont_get_user_by_email,
+    mock_add_user_to_service,
+    mock_get_users_by_service,
+    mock_get_service,
+):
 
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -197,11 +211,13 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(app_,
             assert service.attrs['value'] == service_one['id']
 
 
-def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation(app_,
-                                                                                 service_one,
-                                                                                 mocker,
-                                                                                 mock_get_user,
-                                                                                 mock_get_service):
+def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation(
+    app_,
+    service_one,
+    mocker,
+    mock_get_user,
+    mock_get_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             cancelled_invitation = create_sample_invite(mocker, service_one, status='cancelled')
@@ -214,19 +230,21 @@ def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation
             assert page.h1.string.strip() == 'The invitation you were sent has been cancelled'
 
 
-def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(app_,
-                                                                               service_one,
-                                                                               sample_invite,
-                                                                               api_user_active,
-                                                                               mock_check_invite_token,
-                                                                               mock_dont_get_user_by_email,
-                                                                               mock_is_email_unique,
-                                                                               mock_register_user,
-                                                                               mock_send_verify_code,
-                                                                               mock_accept_invite,
-                                                                               mock_get_users_by_service,
-                                                                               mock_add_user_to_service,
-                                                                               mock_get_service):
+def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
+    app_,
+    service_one,
+    sample_invite,
+    api_user_active,
+    mock_check_invite_token,
+    mock_dont_get_user_by_email,
+    mock_is_email_unique,
+    mock_register_user,
+    mock_send_verify_code,
+    mock_accept_invite,
+    mock_get_users_by_service,
+    mock_add_user_to_service,
+    mock_get_service,
+):
 
     expected_service = service_one['id']
     expected_email = sample_invite['email_address']
@@ -268,13 +286,15 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(a
             assert mock_accept_invite.call_count == 1
 
 
-def test_signed_in_existing_user_cannot_use_anothers_invite(app_,
-                                                            mocker,
-                                                            api_user_active,
-                                                            sample_invite,
-                                                            mock_get_user,
-                                                            mock_accept_invite,
-                                                            mock_get_service):
+def test_signed_in_existing_user_cannot_use_anothers_invite(
+    app_,
+    mocker,
+    api_user_active,
+    sample_invite,
+    mock_get_user,
+    mock_accept_invite,
+    mock_get_service,
+):
     invite = InvitedUser(**sample_invite)
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
     mocker.patch('app.user_api_client.get_users_for_service', return_value=[api_user_active])
@@ -295,28 +315,30 @@ def test_signed_in_existing_user_cannot_use_anothers_invite(app_,
             assert mock_accept_invite.call_count == 0
 
 
-def test_new_invited_user_verifies_and_added_to_service(app_,
-                                                        service_one,
-                                                        sample_invite,
-                                                        api_user_active,
-                                                        mock_check_invite_token,
-                                                        mock_dont_get_user_by_email,
-                                                        mock_is_email_unique,
-                                                        mock_register_user,
-                                                        mock_send_verify_code,
-                                                        mock_check_verify_code,
-                                                        mock_get_user,
-                                                        mock_update_user,
-                                                        mock_add_user_to_service,
-                                                        mock_accept_invite,
-                                                        mock_get_service,
-                                                        mock_get_service_templates,
-                                                        mock_get_template_statistics,
-                                                        mock_get_jobs,
-                                                        mock_has_permissions,
-                                                        mock_get_users_by_service,
-                                                        mock_get_detailed_service,
-                                                        mock_get_usage):
+def test_new_invited_user_verifies_and_added_to_service(
+    app_,
+    service_one,
+    sample_invite,
+    api_user_active,
+    mock_check_invite_token,
+    mock_dont_get_user_by_email,
+    mock_is_email_unique,
+    mock_register_user,
+    mock_send_verify_code,
+    mock_check_verify_code,
+    mock_get_user,
+    mock_update_user,
+    mock_add_user_to_service,
+    mock_accept_invite,
+    mock_get_service,
+    mock_get_service_templates,
+    mock_get_template_statistics,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_users_by_service,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
 
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -10,7 +10,7 @@ from tests.conftest import mock_check_invite_token as mock_check_token_invite
 
 
 def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
-    app_,
+    client,
     service_one,
     api_user_active,
     sample_invite,
@@ -26,22 +26,19 @@ def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     expected_redirect_location = 'http://localhost/services/{}/dashboard'.format(expected_service)
     expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
 
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
+    mock_check_invite_token.assert_called_with('thisisnotarealtoken')
+    mock_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
+    assert mock_accept_invite.call_count == 1
+    mock_add_user_to_service.assert_called_with(expected_service, api_user_active.id, expected_permissions)
 
-            mock_check_invite_token.assert_called_with('thisisnotarealtoken')
-            mock_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
-            assert mock_accept_invite.call_count == 1
-            mock_add_user_to_service.assert_called_with(expected_service, api_user_active.id, expected_permissions)
-
-            assert response.status_code == 302
-            assert response.location == expected_redirect_location
+    assert response.status_code == 302
+    assert response.location == expected_redirect_location
 
 
 def test_existing_user_with_no_permissions_accept_invite(
-    app_,
+    client,
     mocker,
     service_one,
     api_user_active,
@@ -58,17 +55,14 @@ def test_existing_user_with_no_permissions_accept_invite(
     expected_permissions = []
     mocker.patch('app.invite_api_client.accept_invite', return_value=sample_invite)
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
+    mock_add_user_to_service.assert_called_with(expected_service, api_user_active.id, expected_permissions)
 
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
-            mock_add_user_to_service.assert_called_with(expected_service, api_user_active.id, expected_permissions)
-
-            assert response.status_code == 302
+    assert response.status_code == 302
 
 
 def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
-    app_,
+    client,
     mocker,
     sample_invite,
     mock_get_service,
@@ -78,19 +72,17 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
     invite = InvitedUser(**sample_invite)
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
-            assert response.status_code == 200
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'Sign in'
-            flash_banners = page.find_all('div', class_='banner-default')
-            assert len(flash_banners) == 1
-            assert flash_banners[0].text.strip() == 'Please log in to access this page.'
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Sign in'
+    flash_banners = page.find_all('div', class_='banner-default')
+    assert len(flash_banners) == 1
+    assert flash_banners[0].text.strip() == 'Please log in to access this page.'
 
 
 def test_existing_user_of_service_get_redirected_to_signin(
-    app_,
+    client,
     mocker,
     api_user_active,
     sample_invite,
@@ -103,20 +95,18 @@ def test_existing_user_of_service_get_redirected_to_signin(
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
     mocker.patch('app.user_api_client.get_users_for_service', return_value=[api_user_active])
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
-            assert response.status_code == 200
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'Sign in'
-            flash_banners = page.find_all('div', class_='banner-default')
-            assert len(flash_banners) == 1
-            assert flash_banners[0].text.strip() == 'Please log in to access this page.'
-            assert mock_accept_invite.call_count == 1
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Sign in'
+    flash_banners = page.find_all('div', class_='banner-default')
+    assert len(flash_banners) == 1
+    assert flash_banners[0].text.strip() == 'Please log in to access this page.'
+    assert mock_accept_invite.call_count == 1
 
 
 def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
-    app_,
+    client,
     service_one,
     api_user_active,
     sample_invite,
@@ -130,26 +120,24 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
 
     expected_service = service_one['id']
     expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
-    with app_.test_request_context():
-        with app_.test_client() as client:
 
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
 
-            mock_check_invite_token.assert_called_with('thisisnotarealtoken')
-            mock_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
-            mock_add_user_to_service.assert_called_with(expected_service, api_user_active.id, expected_permissions)
-            assert mock_accept_invite.call_count == 1
+    mock_check_invite_token.assert_called_with('thisisnotarealtoken')
+    mock_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
+    mock_add_user_to_service.assert_called_with(expected_service, api_user_active.id, expected_permissions)
+    assert mock_accept_invite.call_count == 1
 
-            assert response.status_code == 200
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'Sign in'
-            flash_banners = page.find_all('div', class_='banner-default')
-            assert len(flash_banners) == 1
-            assert flash_banners[0].text.strip() == 'Please log in to access this page.'
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Sign in'
+    flash_banners = page.find_all('div', class_='banner-default')
+    assert len(flash_banners) == 1
+    assert flash_banners[0].text.strip() == 'Please log in to access this page.'
 
 
 def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
-    app_,
+    client,
     service_one,
     mock_check_invite_token,
     mock_dont_get_user_by_email,
@@ -160,20 +148,17 @@ def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
 
     expected_redirect_location = 'http://localhost/register-from-invite'
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
 
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
+    mock_check_invite_token.assert_called_with('thisisnotarealtoken')
+    mock_dont_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
 
-            mock_check_invite_token.assert_called_with('thisisnotarealtoken')
-            mock_dont_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
-
-            assert response.status_code == 302
-            assert response.location == expected_redirect_location
+    assert response.status_code == 302
+    assert response.location == expected_redirect_location
 
 
 def test_new_user_accept_invite_calls_api_and_views_registration_page(
-    app_,
+    client,
     service_one,
     mock_check_invite_token,
     mock_dont_get_user_by_email,
@@ -182,56 +167,51 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(
     mock_get_service,
 ):
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
 
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
+    mock_check_invite_token.assert_called_with('thisisnotarealtoken')
+    mock_dont_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
 
-            mock_check_invite_token.assert_called_with('thisisnotarealtoken')
-            mock_dont_get_user_by_email.assert_called_with('invited_user@test.gov.uk')
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Create an account'
 
-            assert response.status_code == 200
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'Create an account'
+    email_in_page = page.find('main').find('p')
+    assert email_in_page.text.strip() == 'Your account will be created with this email: invited_user@test.gov.uk'  # noqa
 
-            email_in_page = page.find('main').find('p')
-            assert email_in_page.text.strip() == 'Your account will be created with this email: invited_user@test.gov.uk'  # noqa
+    form = page.find('form')
+    name = form.find('input', id='name')
+    password = form.find('input', id='password')
+    service = form.find('input', type='hidden', id='service')
+    email = form.find('input', type='hidden', id='email_address')
 
-            form = page.find('form')
-            name = form.find('input', id='name')
-            password = form.find('input', id='password')
-            service = form.find('input', type='hidden', id='service')
-            email = form.find('input', type='hidden', id='email_address')
-
-            assert email
-            assert email.attrs['value'] == 'invited_user@test.gov.uk'
-            assert name
-            assert password
-            assert service
-            assert service.attrs['value'] == service_one['id']
+    assert email
+    assert email.attrs['value'] == 'invited_user@test.gov.uk'
+    assert name
+    assert password
+    assert service
+    assert service.attrs['value'] == service_one['id']
 
 
 def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation(
-    app_,
+    client,
     service_one,
     mocker,
     mock_get_user,
     mock_get_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            cancelled_invitation = create_sample_invite(mocker, service_one, status='cancelled')
-            mock_check_token_invite(mocker, cancelled_invitation)
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
+    cancelled_invitation = create_sample_invite(mocker, service_one, status='cancelled')
+    mock_check_token_invite(mocker, cancelled_invitation)
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
 
-            app.invite_api_client.check_token.assert_called_with('thisisnotarealtoken')
-            assert response.status_code == 200
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == 'The invitation you were sent has been cancelled'
+    app.invite_api_client.check_token.assert_called_with('thisisnotarealtoken')
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'The invitation you were sent has been cancelled'
 
 
 def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
-    app_,
+    client,
     service_one,
     sample_invite,
     api_user_active,
@@ -251,43 +231,41 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     expected_from_user = service_one['users'][0]
     expected_redirect_location = 'http://localhost/register-from-invite'
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
-            with client.session_transaction() as session:
-                assert response.status_code == 302
-                assert response.location == expected_redirect_location
-                invited_user = session.get('invited_user')
-                assert invited_user
-                assert expected_service == invited_user['service']
-                assert expected_email == invited_user['email_address']
-                assert expected_from_user == invited_user['from_user']
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
+    with client.session_transaction() as session:
+        assert response.status_code == 302
+        assert response.location == expected_redirect_location
+        invited_user = session.get('invited_user')
+        assert invited_user
+        assert expected_service == invited_user['service']
+        assert expected_email == invited_user['email_address']
+        assert expected_from_user == invited_user['from_user']
 
-            data = {'service': invited_user['service'],
-                    'email_address': invited_user['email_address'],
-                    'from_user': invited_user['from_user'],
-                    'password': 'longpassword',
-                    'mobile_number': '+447890123456',
-                    'name': 'Invited User'
-                    }
+    data = {'service': invited_user['service'],
+            'email_address': invited_user['email_address'],
+            'from_user': invited_user['from_user'],
+            'password': 'longpassword',
+            'mobile_number': '+447890123456',
+            'name': 'Invited User'
+            }
 
-            expected_redirect_location = 'http://localhost/verify'
-            response = client.post(url_for('main.register_from_invite'), data=data)
-            assert response.status_code == 302
-            assert response.location == expected_redirect_location
+    expected_redirect_location = 'http://localhost/verify'
+    response = client.post(url_for('main.register_from_invite'), data=data)
+    assert response.status_code == 302
+    assert response.location == expected_redirect_location
 
-            mock_send_verify_code.assert_called_once_with(ANY, 'sms', data['mobile_number'])
+    mock_send_verify_code.assert_called_once_with(ANY, 'sms', data['mobile_number'])
 
-            mock_register_user.assert_called_with(data['name'],
-                                                  data['email_address'],
-                                                  data['mobile_number'],
-                                                  data['password'])
+    mock_register_user.assert_called_with(data['name'],
+                                          data['email_address'],
+                                          data['mobile_number'],
+                                          data['password'])
 
-            assert mock_accept_invite.call_count == 1
+    assert mock_accept_invite.call_count == 1
 
 
 def test_signed_in_existing_user_cannot_use_anothers_invite(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     sample_invite,
@@ -299,24 +277,21 @@ def test_signed_in_existing_user_cannot_use_anothers_invite(
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
     mocker.patch('app.user_api_client.get_users_for_service', return_value=[api_user_active])
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
-            assert response.status_code == 403
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == '403'
-            flash_banners = page.find_all('div', class_='banner-dangerous')
-            assert len(flash_banners) == 1
-            banner_contents = flash_banners[0].text.strip()
-            assert "You’re signed in as test@user.gov.uk." in banner_contents
-            assert "This invite is for another email address." in banner_contents
-            assert "Sign out and click the link again to accept this invite." in banner_contents
-            assert mock_accept_invite.call_count == 0
+    response = logged_in_client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
+    assert response.status_code == 403
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == '403'
+    flash_banners = page.find_all('div', class_='banner-dangerous')
+    assert len(flash_banners) == 1
+    banner_contents = flash_banners[0].text.strip()
+    assert "You’re signed in as test@user.gov.uk." in banner_contents
+    assert "This invite is for another email address." in banner_contents
+    assert "Sign out and click the link again to accept this invite." in banner_contents
+    assert mock_accept_invite.call_count == 0
 
 
 def test_new_invited_user_verifies_and_added_to_service(
-    app_,
+    client,
     service_one,
     sample_invite,
     api_user_active,
@@ -340,35 +315,33 @@ def test_new_invited_user_verifies_and_added_to_service(
     mock_get_usage,
 ):
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            # visit accept token page
-            response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
-            data = {'service': sample_invite['service'],
-                    'email_address': sample_invite['email_address'],
-                    'from_user': sample_invite['from_user'],
-                    'password': 'longpassword',
-                    'mobile_number': '+447890123456',
-                    'name': 'Invited User'
-                    }
+    # visit accept token page
+    response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
+    data = {'service': sample_invite['service'],
+            'email_address': sample_invite['email_address'],
+            'from_user': sample_invite['from_user'],
+            'password': 'longpassword',
+            'mobile_number': '+447890123456',
+            'name': 'Invited User'
+            }
 
-            # get redirected to register from invite
-            response = client.post(url_for('main.register_from_invite'), data=data)
+    # get redirected to register from invite
+    response = client.post(url_for('main.register_from_invite'), data=data)
 
-            # that sends user on to verify
-            response = client.post(url_for('main.verify'), data={'sms_code': '12345'}, follow_redirects=True)
+    # that sends user on to verify
+    response = client.post(url_for('main.verify'), data={'sms_code': '12345'}, follow_redirects=True)
 
-            # when they post codes back to admin user should be added to
-            # service and sent on to dash board
-            expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
+    # when they post codes back to admin user should be added to
+    # service and sent on to dash board
+    expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
 
-            with client.session_transaction() as session:
-                new_user_id = session['user_id']
-                mock_add_user_to_service.assert_called_with(data['service'], new_user_id, expected_permissions)
-                mock_accept_invite.assert_called_with(data['service'], sample_invite['id'])
-                mock_check_verify_code.assert_called_once_with(new_user_id, '12345', 'sms')
-                assert service_one['id'] == session['service_id']
+    with client.session_transaction() as session:
+        new_user_id = session['user_id']
+        mock_add_user_to_service.assert_called_with(data['service'], new_user_id, expected_permissions)
+        mock_accept_invite.assert_called_with(data['service'], sample_invite['id'])
+        mock_check_verify_code.assert_called_once_with(new_user_id, '12345', 'sms')
+        assert service_one['id'] == session['service_id']
 
-            raw_html = response.data.decode('utf-8')
-            page = BeautifulSoup(raw_html, 'html.parser')
-            element = page.find('h2').text == 'Trial mode'
+    raw_html = response.data.decode('utf-8')
+    page = BeautifulSoup(raw_html, 'html.parser')
+    element = page.find('h2').text == 'Trial mode'

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -17,132 +17,117 @@ def test_non_gov_user_cannot_see_add_service_button(
 
 
 def test_get_should_render_add_service_template(
-    app_,
+    logged_in_client,
     api_user_active,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active, mocker)
-            response = client.get(url_for('main.add_service'))
-            assert response.status_code == 200
-            assert 'Which service do you want to set up notifications for?' in response.get_data(as_text=True)
+    response = logged_in_client.get(url_for('main.add_service'))
+    assert response.status_code == 200
+    assert 'Which service do you want to set up notifications for?' in response.get_data(as_text=True)
 
 
 def test_should_add_service_and_redirect_to_tour_when_no_services(
     app_,
+    logged_in_client,
     mocker,
     mock_create_service,
     mock_create_service_template,
     mock_get_services_with_no_services,
     api_user_active,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active, mocker)
-            response = client.post(
-                url_for('main.add_service'),
-                data={'name': 'testing the post'})
-            assert mock_get_services_with_no_services.called
-            mock_create_service.assert_called_once_with(
-                service_name='testing the post',
-                message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
-                restricted=True,
-                user_id=api_user_active.id,
-                email_from='testing.the.post'
-            )
-            assert len(mock_create_service_template.call_args_list) == 1
-            assert session['service_id'] == 101
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.send_test',
-                service_id=101,
-                template_id="Example text message template",
-                help=1,
-                _external=True
-            )
+    response = logged_in_client.post(
+        url_for('main.add_service'),
+        data={'name': 'testing the post'})
+    assert mock_get_services_with_no_services.called
+    mock_create_service.assert_called_once_with(
+        service_name='testing the post',
+        message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
+        restricted=True,
+        user_id=api_user_active.id,
+        email_from='testing.the.post'
+    )
+    assert len(mock_create_service_template.call_args_list) == 1
+    assert session['service_id'] == 101
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.send_test',
+        service_id=101,
+        template_id="Example text message template",
+        help=1,
+        _external=True
+    )
 
 
 def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     app_,
+    logged_in_client,
     mocker,
     mock_create_service,
     mock_create_service_template,
     mock_get_services,
     api_user_active,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active, mocker)
-            response = client.post(
-                url_for('main.add_service'),
-                data={'name': 'testing the post'})
-            assert mock_get_services.called
-            mock_create_service.assert_called_once_with(
-                service_name='testing the post',
-                message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
-                restricted=True,
-                user_id=api_user_active.id,
-                email_from='testing.the.post'
-            )
-            assert len(mock_create_service_template.call_args_list) == 0
-            assert session['service_id'] == 101
-            assert response.status_code == 302
-            assert response.location == url_for('main.service_dashboard', service_id=101, _external=True)
+    response = logged_in_client.post(
+        url_for('main.add_service'),
+        data={'name': 'testing the post'})
+    assert mock_get_services.called
+    mock_create_service.assert_called_once_with(
+        service_name='testing the post',
+        message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
+        restricted=True,
+        user_id=api_user_active.id,
+        email_from='testing.the.post'
+    )
+    assert len(mock_create_service_template.call_args_list) == 0
+    assert session['service_id'] == 101
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_dashboard', service_id=101, _external=True)
 
 
 def test_should_return_form_errors_when_service_name_is_empty(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active, mocker)
-            response = client.post(url_for('main.add_service'), data={})
-            assert response.status_code == 200
-            assert 'Can’t be empty' in response.get_data(as_text=True)
+    response = logged_in_client.post(url_for('main.add_service'), data={})
+    assert response.status_code == 200
+    assert 'Can’t be empty' in response.get_data(as_text=True)
 
 
 def test_should_return_form_errors_with_duplicate_service_name_regardless_of_case(
-    app_,
+    logged_in_client,
     mocker,
     service_one,
     api_user_active,
     mock_create_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active, mocker, service_one)
-            mocker.patch('app.service_api_client.find_all_service_email_from',
-                         return_value=['service_one', 'service.two'])
-            response = client.post(url_for('main.add_service'), data={'name': 'SERVICE TWO'})
+    mocker.patch('app.service_api_client.find_all_service_email_from',
+                 return_value=['service_one', 'service.two'])
+    response = logged_in_client.post(url_for('main.add_service'), data={'name': 'SERVICE TWO'})
 
-            assert response.status_code == 200
-            assert 'This service name is already in use' in response.get_data(as_text=True)
-            app.service_api_client.find_all_service_email_from.assert_called_once_with()
-            assert not mock_create_service.called
+    assert response.status_code == 200
+    assert 'This service name is already in use' in response.get_data(as_text=True)
+    app.service_api_client.find_all_service_email_from.assert_called_once_with()
+    assert not mock_create_service.called
 
 
 def test_non_whitelist_user_cannot_access_create_service_page(
-    client,
+    logged_in_client,
     mock_login,
     mock_get_non_govuser,
     api_nongov_user_active,
 ):
-    client.login(api_nongov_user_active)
     assert not is_gov_user(api_nongov_user_active.email_address)
-    response = client.get(url_for('main.add_service'))
+    response = logged_in_client.get(url_for('main.add_service'))
     assert response.status_code == 403
 
 
 def test_non_whitelist_user_cannot_create_service(
-    client,
+    logged_in_client,
     mock_login,
     mock_get_non_govuser,
     api_nongov_user_active,
 ):
-    client.login(api_nongov_user_active)
     assert not is_gov_user(api_nongov_user_active.email_address)
-    response = client.post(url_for('main.add_service'), data={'name': 'SERVICE TWO'})
+    response = logged_in_client.post(url_for('main.add_service'), data={'name': 'SERVICE TWO'})
     assert response.status_code == 403

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -4,19 +4,23 @@ import app
 from app.utils import is_gov_user
 
 
-def test_non_gov_user_cannot_see_add_service_button(client,
-                                                    mock_login,
-                                                    mock_get_non_govuser,
-                                                    api_nongov_user_active):
+def test_non_gov_user_cannot_see_add_service_button(
+    client,
+    mock_login,
+    mock_get_non_govuser,
+    api_nongov_user_active,
+):
     client.login(api_nongov_user_active)
     response = client.get(url_for('main.choose_service'))
     assert 'Add a new service' not in response.get_data(as_text=True)
     assert response.status_code == 200
 
 
-def test_get_should_render_add_service_template(app_,
-                                                api_user_active,
-                                                mocker):
+def test_get_should_render_add_service_template(
+    app_,
+    api_user_active,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active, mocker)
@@ -25,12 +29,14 @@ def test_get_should_render_add_service_template(app_,
             assert 'Which service do you want to set up notifications for?' in response.get_data(as_text=True)
 
 
-def test_should_add_service_and_redirect_to_tour_when_no_services(app_,
-                                                                  mocker,
-                                                                  mock_create_service,
-                                                                  mock_create_service_template,
-                                                                  mock_get_services_with_no_services,
-                                                                  api_user_active):
+def test_should_add_service_and_redirect_to_tour_when_no_services(
+    app_,
+    mocker,
+    mock_create_service,
+    mock_create_service_template,
+    mock_get_services_with_no_services,
+    api_user_active,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active, mocker)
@@ -57,12 +63,14 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(app_,
             )
 
 
-def test_should_add_service_and_redirect_to_dashboard_when_existing_service(app_,
-                                                                            mocker,
-                                                                            mock_create_service,
-                                                                            mock_create_service_template,
-                                                                            mock_get_services,
-                                                                            api_user_active):
+def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
+    app_,
+    mocker,
+    mock_create_service,
+    mock_create_service_template,
+    mock_get_services,
+    api_user_active,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active, mocker)
@@ -83,9 +91,11 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(app_
             assert response.location == url_for('main.service_dashboard', service_id=101, _external=True)
 
 
-def test_should_return_form_errors_when_service_name_is_empty(app_,
-                                                              mocker,
-                                                              api_user_active):
+def test_should_return_form_errors_when_service_name_is_empty(
+    app_,
+    mocker,
+    api_user_active,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active, mocker)
@@ -94,11 +104,13 @@ def test_should_return_form_errors_when_service_name_is_empty(app_,
             assert 'Can’t be empty' in response.get_data(as_text=True)
 
 
-def test_should_return_form_errors_with_duplicate_service_name_regardless_of_case(app_,
-                                                                                  mocker,
-                                                                                  service_one,
-                                                                                  api_user_active,
-                                                                                  mock_create_service):
+def test_should_return_form_errors_with_duplicate_service_name_regardless_of_case(
+    app_,
+    mocker,
+    service_one,
+    api_user_active,
+    mock_create_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active, mocker, service_one)
@@ -112,20 +124,24 @@ def test_should_return_form_errors_with_duplicate_service_name_regardless_of_cas
             assert not mock_create_service.called
 
 
-def test_non_whitelist_user_cannot_access_create_service_page(client,
-                                                              mock_login,
-                                                              mock_get_non_govuser,
-                                                              api_nongov_user_active):
+def test_non_whitelist_user_cannot_access_create_service_page(
+    client,
+    mock_login,
+    mock_get_non_govuser,
+    api_nongov_user_active,
+):
     client.login(api_nongov_user_active)
     assert not is_gov_user(api_nongov_user_active.email_address)
     response = client.get(url_for('main.add_service'))
     assert response.status_code == 403
 
 
-def test_non_whitelist_user_cannot_create_service(client,
-                                                  mock_login,
-                                                  mock_get_non_govuser,
-                                                  api_nongov_user_active):
+def test_non_whitelist_user_cannot_create_service(
+    client,
+    mock_login,
+    mock_get_non_govuser,
+    api_nongov_user_active,
+):
     client.login(api_nongov_user_active)
     assert not is_gov_user(api_nongov_user_active.email_address)
     response = client.post(url_for('main.add_service'), data={'name': 'SERVICE TWO'})

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -89,12 +89,14 @@ def test_should_show_api_documentation_page(
         assert page.h1.string.strip() == 'Documentation'
 
 
-def test_should_show_empty_api_keys_page(app_,
-                                         api_user_pending,
-                                         mock_login,
-                                         mock_get_no_api_keys,
-                                         mock_get_service,
-                                         mock_has_permissions):
+def test_should_show_empty_api_keys_page(
+    app_,
+    api_user_pending,
+    mock_login,
+    mock_get_no_api_keys,
+    mock_get_service,
+    mock_has_permissions,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_pending)
@@ -107,13 +109,15 @@ def test_should_show_empty_api_keys_page(app_,
         mock_get_no_api_keys.assert_called_once_with(service_id=service_id)
 
 
-def test_should_show_api_keys_page(app_,
-                                   api_user_active,
-                                   mock_login,
-                                   mock_get_api_keys,
-                                   mock_get_service,
-                                   mock_has_permissions,
-                                   fake_uuid):
+def test_should_show_api_keys_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_api_keys,
+    mock_get_service,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -127,13 +131,15 @@ def test_should_show_api_keys_page(app_,
         mock_get_api_keys.assert_called_once_with(service_id=fake_uuid)
 
 
-def test_should_show_create_api_key_page(app_,
-                                         api_user_active,
-                                         mock_login,
-                                         mock_get_api_keys,
-                                         mock_get_service,
-                                         mock_has_permissions,
-                                         fake_uuid):
+def test_should_show_create_api_key_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_api_keys,
+    mock_get_service,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -143,14 +149,16 @@ def test_should_show_create_api_key_page(app_,
         assert response.status_code == 200
 
 
-def test_should_create_api_key_with_type_normal(app_,
-                                                api_user_active,
-                                                mock_login,
-                                                mock_get_api_keys,
-                                                mock_get_live_service,
-                                                mock_has_permissions,
-                                                fake_uuid,
-                                                mocker):
+def test_should_create_api_key_with_type_normal(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_api_keys,
+    mock_get_live_service,
+    mock_has_permissions,
+    fake_uuid,
+    mocker,
+):
     post = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.post', return_value={'data': fake_uuid})
     service_id = str(uuid.uuid4())
 
@@ -189,7 +197,7 @@ def test_cant_create_normal_api_key_in_trial_mode(
     mock_get_service,
     mock_has_permissions,
     fake_uuid,
-    mocker
+    mocker,
 ):
     mock_post = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.post')
 
@@ -205,13 +213,15 @@ def test_cant_create_normal_api_key_in_trial_mode(
     mock_post.assert_not_called()
 
 
-def test_should_show_confirm_revoke_api_key(app_,
-                                            api_user_active,
-                                            mock_login,
-                                            mock_get_api_keys,
-                                            mock_get_service,
-                                            mock_has_permissions,
-                                            fake_uuid):
+def test_should_show_confirm_revoke_api_key(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_api_keys,
+    mock_get_service,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -222,14 +232,16 @@ def test_should_show_confirm_revoke_api_key(app_,
         mock_get_api_keys.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
 
 
-def test_should_redirect_after_revoking_api_key(app_,
-                                                api_user_active,
-                                                mock_login,
-                                                mock_revoke_api_key,
-                                                mock_get_api_keys,
-                                                mock_get_service,
-                                                mock_has_permissions,
-                                                fake_uuid):
+def test_should_redirect_after_revoking_api_key(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_revoke_api_key,
+    mock_get_api_keys,
+    mock_get_service,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -246,12 +258,14 @@ def test_should_redirect_after_revoking_api_key(app_,
     'main.create_api_key',
     'main.revoke_api_key'
 ])
-def test_route_permissions(mocker,
-                           app_,
-                           api_user_active,
-                           service_one,
-                           mock_get_api_keys,
-                           route):
+def test_route_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_api_keys,
+    route,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -269,12 +283,14 @@ def test_route_permissions(mocker,
     'main.create_api_key',
     'main.revoke_api_key'
 ])
-def test_route_invalid_permissions(mocker,
-                                   app_,
-                                   api_user_active,
-                                   service_one,
-                                   mock_get_api_keys,
-                                   route):
+def test_route_invalid_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_api_keys,
+    route,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -293,7 +309,7 @@ def test_should_show_whitelist_page(
     api_user_active,
     mock_get_service,
     mock_has_permissions,
-    mock_get_whitelist
+    mock_get_whitelist,
 ):
     client.login(api_user_active)
     response = client.get(url_for('main.whitelist', service_id=str(uuid.uuid4())))

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -9,35 +9,32 @@ from tests import validate_route_permission
 
 
 def test_should_show_api_page(
-    app_,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_service,
     mock_has_permissions,
     mock_get_notifications
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.string.strip() == 'API integration'
-        rows = page.find_all('details')
-        assert len(rows) == 5
-        for index, row in enumerate(rows):
-            assert row.find('h3').string.strip() == '07123456789'
+    response = logged_in_client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'API integration'
+    rows = page.find_all('details')
+    assert len(rows) == 5
+    for index, row in enumerate(rows):
+        assert row.find('h3').string.strip() == '07123456789'
 
 
 def test_should_show_api_page_with_lots_of_notifications(
-    client,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_service,
     mock_has_permissions,
     mock_get_notifications_with_previous_next
 ):
-    client.login(api_user_active)
-    response = client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
+    response = logged_in_client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     rows = page.find_all('div', {'class': 'api-notifications-item'})
     assert ' '.join(rows[len(rows) - 1].text.split()) == (
@@ -46,71 +43,64 @@ def test_should_show_api_page_with_lots_of_notifications(
 
 
 def test_should_show_api_page_with_no_notifications(
-    client,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_service,
     mock_has_permissions,
     mock_get_notifications_with_no_notifications
 ):
-    client.login(api_user_active)
-    response = client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
+    response = logged_in_client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     rows = page.find_all('div', {'class': 'api-notifications-item'})
     assert 'When you send messages via the API they’ll appear here.' in rows[len(rows) - 1].text.strip()
 
 
 def test_should_show_api_page_for_live_service(
-    app_,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_live_service,
     mock_has_permissions
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert 'Your service is in trial mode' not in page.find('main').text
+    response = logged_in_client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert 'Your service is in trial mode' not in page.find('main').text
 
 
 def test_should_show_api_documentation_page(
-    app_,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_service,
     mock_has_permissions
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.api_documentation', service_id=str(uuid.uuid4())))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.string.strip() == 'Documentation'
+    response = logged_in_client.get(url_for('main.api_documentation', service_id=str(uuid.uuid4())))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Documentation'
 
 
 def test_should_show_empty_api_keys_page(
-    app_,
+    client,
     api_user_pending,
     mock_login,
     mock_get_no_api_keys,
     mock_get_service,
     mock_has_permissions,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_pending)
-            service_id = str(uuid.uuid4())
-            response = client.get(url_for('main.api_keys', service_id=service_id))
+    client.login(api_user_pending)
+    service_id = str(uuid.uuid4())
+    response = client.get(url_for('main.api_keys', service_id=service_id))
 
-        assert response.status_code == 200
-        assert 'You haven’t created any API keys yet' in response.get_data(as_text=True)
-        assert 'Create an API key' in response.get_data(as_text=True)
-        mock_get_no_api_keys.assert_called_once_with(service_id=service_id)
+    assert response.status_code == 200
+    assert 'You haven’t created any API keys yet' in response.get_data(as_text=True)
+    assert 'Create an API key' in response.get_data(as_text=True)
+    mock_get_no_api_keys.assert_called_once_with(service_id=service_id)
 
 
 def test_should_show_api_keys_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_api_keys,
@@ -118,21 +108,18 @@ def test_should_show_api_keys_page(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.api_keys', service_id=fake_uuid))
+    response = logged_in_client.get(url_for('main.api_keys', service_id=fake_uuid))
 
-        assert response.status_code == 200
-        resp_data = response.get_data(as_text=True)
-        assert 'some key name' in resp_data
-        assert 'another key name' in resp_data
-        assert 'Revoked 1 January at 1:00am' in resp_data
-        mock_get_api_keys.assert_called_once_with(service_id=fake_uuid)
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert 'some key name' in resp_data
+    assert 'another key name' in resp_data
+    assert 'Revoked 1 January at 1:00am' in resp_data
+    mock_get_api_keys.assert_called_once_with(service_id=fake_uuid)
 
 
 def test_should_show_create_api_key_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_api_keys,
@@ -140,17 +127,15 @@ def test_should_show_create_api_key_page(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            response = client.get(url_for('main.create_api_key', service_id=fake_uuid))
+    logged_in_client.login(api_user_active)
+    service_id = fake_uuid
+    response = logged_in_client.get(url_for('main.create_api_key', service_id=fake_uuid))
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
 
 def test_should_create_api_key_with_type_normal(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_api_keys,
@@ -162,15 +147,13 @@ def test_should_create_api_key_with_type_normal(
     post = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.post', return_value={'data': fake_uuid})
     service_id = str(uuid.uuid4())
 
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.post(
-            url_for('main.create_api_key', service_id=service_id),
-            data={
-                'key_name': 'Some default key name 1/2',
-                'key_type': 'normal'
-            }
-        )
+    response = logged_in_client.post(
+        url_for('main.create_api_key', service_id=service_id),
+        data={
+            'key_name': 'Some default key name 1/2',
+            'key_type': 'normal'
+        }
+    )
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -190,7 +173,7 @@ def test_should_create_api_key_with_type_normal(
 
 
 def test_cant_create_normal_api_key_in_trial_mode(
-    client,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_api_keys,
@@ -201,8 +184,7 @@ def test_cant_create_normal_api_key_in_trial_mode(
 ):
     mock_post = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.post')
 
-    client.login(api_user_active)
-    response = client.post(
+    response = logged_in_client.post(
         url_for('main.create_api_key', service_id=uuid.uuid4()),
         data={
             'key_name': 'some default key name',
@@ -214,7 +196,7 @@ def test_cant_create_normal_api_key_in_trial_mode(
 
 
 def test_should_show_confirm_revoke_api_key(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_api_keys,
@@ -222,18 +204,14 @@ def test_should_show_confirm_revoke_api_key(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.revoke_api_key', service_id=fake_uuid, key_id=fake_uuid))
-
-        assert response.status_code == 200
-        assert 'some key name' in response.get_data(as_text=True)
-        mock_get_api_keys.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
+    response = logged_in_client.get(url_for('main.revoke_api_key', service_id=fake_uuid, key_id=fake_uuid))
+    assert response.status_code == 200
+    assert 'some key name' in response.get_data(as_text=True)
+    mock_get_api_keys.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
 
 
 def test_should_redirect_after_revoking_api_key(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_revoke_api_key,
@@ -242,15 +220,12 @@ def test_should_redirect_after_revoking_api_key(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.post(url_for('main.revoke_api_key', service_id=fake_uuid, key_id=fake_uuid))
+    response = logged_in_client.post(url_for('main.revoke_api_key', service_id=fake_uuid, key_id=fake_uuid))
 
-        assert response.status_code == 302
-        assert response.location == url_for('.api_keys', service_id=fake_uuid, _external=True)
-        mock_revoke_api_key.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
-        mock_get_api_keys.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
+    assert response.status_code == 302
+    assert response.location == url_for('.api_keys', service_id=fake_uuid, _external=True)
+    mock_revoke_api_key.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
+    mock_get_api_keys.assert_called_once_with(service_id=fake_uuid, key_id=fake_uuid)
 
 
 @pytest.mark.parametrize('route', [
@@ -304,15 +279,14 @@ def test_route_invalid_permissions(
 
 
 def test_should_show_whitelist_page(
-    client,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_service,
     mock_has_permissions,
     mock_get_whitelist,
 ):
-    client.login(api_user_active)
-    response = client.get(url_for('main.whitelist', service_id=str(uuid.uuid4())))
+    response = logged_in_client.get(url_for('main.whitelist', service_id=str(uuid.uuid4())))
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     textboxes = page.find_all('input', {'type': 'text'})
     for index, value in enumerate(
@@ -322,14 +296,13 @@ def test_should_show_whitelist_page(
 
 
 def test_should_update_whitelist(
-    client,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_service,
     mock_has_permissions,
     mock_update_whitelist
 ):
-    client.login(api_user_active)
     service_id = str(uuid.uuid4())
     data = OrderedDict([
         ('email_addresses-1', 'test@example.com'),
@@ -337,7 +310,7 @@ def test_should_update_whitelist(
         ('phone_numbers-0', '07900900000')
     ])
 
-    response = client.post(
+    response = logged_in_client.post(
         url_for('main.whitelist', service_id=service_id),
         data=data
     )

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -1,11 +1,13 @@
 from flask import url_for
 
 
-def test_should_show_choose_services_page(app_,
-                                          mock_login,
-                                          mock_get_user,
-                                          api_user_active,
-                                          mock_get_services):
+def test_should_show_choose_services_page(
+    app_,
+    mock_login,
+    mock_get_user,
+    api_user_active,
+    mock_get_services,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -39,7 +41,7 @@ def test_redirect_if_only_one_service(
     app_,
     mock_login,
     api_user_active,
-    mock_get_services_with_one_service
+    mock_get_services_with_one_service,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -70,7 +72,7 @@ def test_redirect_if_service_in_session(
     mock_login,
     api_user_active,
     mock_get_services,
-    mock_get_service
+    mock_get_service,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -87,7 +89,9 @@ def test_redirect_if_service_in_session(
         )
 
 
-def test_should_redirect_if_not_logged_in(app_):
+def test_should_redirect_if_not_logged_in(
+    app_
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             response = client.get(url_for('main.show_all_services_or_dashboard'))

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -2,35 +2,31 @@ from flask import url_for
 
 
 def test_should_show_choose_services_page(
-    app_,
+    logged_in_client,
     mock_login,
     mock_get_user,
     api_user_active,
     mock_get_services,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.choose_service'))
+    response = logged_in_client.get(url_for('main.choose_service'))
 
-        assert response.status_code == 200
-        resp_data = response.get_data(as_text=True)
-        assert 'Choose service' in resp_data
-        services = mock_get_services.side_effect()
-        assert mock_get_services.called
-        assert services['data'][0]['name'] in resp_data
-        assert services['data'][1]['name'] in resp_data
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert 'Choose service' in resp_data
+    services = mock_get_services.side_effect()
+    assert mock_get_services.called
+    assert services['data'][0]['name'] in resp_data
+    assert services['data'][1]['name'] in resp_data
 
 
 def test_should_show_choose_services_page_if_no_services(
-    client,
+    logged_in_client,
     mock_login,
     api_user_active,
 ):
     # if users last service has been archived there'll be no services
     # mock_login already patches get_services to return no data
-    client.login(api_user_active)
-    response = client.get(url_for('main.choose_service'))
+    response = logged_in_client.get(url_for('main.choose_service'))
     assert response.status_code == 200
     resp_data = response.get_data(as_text=True)
     assert 'Choose service' in resp_data
@@ -38,62 +34,52 @@ def test_should_show_choose_services_page_if_no_services(
 
 
 def test_redirect_if_only_one_service(
-    app_,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_services_with_one_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.show_all_services_or_dashboard'))
+    response = logged_in_client.get(url_for('main.show_all_services_or_dashboard'))
 
-        service = mock_get_services_with_one_service.side_effect()['data'][0]
-        assert response.status_code == 302
-        assert response.location == url_for('main.service_dashboard', service_id=service['id'], _external=True)
+    service = mock_get_services_with_one_service.side_effect()['data'][0]
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_dashboard', service_id=service['id'], _external=True)
 
 
 def test_redirect_if_multiple_services(
-    app_,
+    logged_in_client,
     mock_login,
     api_user_active,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.show_all_services_or_dashboard'))
+    response = logged_in_client.get(url_for('main.show_all_services_or_dashboard'))
 
-        assert response.status_code == 302
-        assert response.location == url_for('main.choose_service', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for('main.choose_service', _external=True)
 
 
 def test_redirect_if_service_in_session(
-    app_,
+    logged_in_client,
     mock_login,
     api_user_active,
     mock_get_services,
     mock_get_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            with client.session_transaction() as session:
-                session['service_id'] = '147ad62a-2951-4fa1-9ca0-093cd1a52c52'
-            response = client.get(url_for('main.show_all_services_or_dashboard'))
+    with logged_in_client.session_transaction() as session:
+        session['service_id'] = '147ad62a-2951-4fa1-9ca0-093cd1a52c52'
+    response = logged_in_client.get(url_for('main.show_all_services_or_dashboard'))
 
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.service_dashboard',
-            service_id='147ad62a-2951-4fa1-9ca0-093cd1a52c52',
-            _external=True
-        )
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_dashboard',
+        service_id='147ad62a-2951-4fa1-9ca0-093cd1a52c52',
+        _external=True
+    )
 
 
 def test_should_redirect_if_not_logged_in(
+    logged_in_client,
     app_
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            response = client.get(url_for('main.show_all_services_or_dashboard'))
-            assert response.status_code == 302
-            assert url_for('main.index', _external=True) in response.location
+    response = logged_in_client.get(url_for('main.show_all_services_or_dashboard'))
+    assert response.status_code == 302
+    assert url_for('main.index', _external=True) in response.location

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -4,55 +4,50 @@ from bs4 import BeautifulSoup
 
 
 def test_should_render_email_verification_resend_show_email_address_and_resend_verify_email(
-    app_,
+    client,
     mocker,
     api_user_active,
     mock_get_user_by_email,
     mock_send_verify_email,
 ):
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.get(url_for('main.resend_email_verification'))
+    assert response.status_code == 200
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.get(url_for('main.resend_email_verification'))
-            assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string == 'Check your email'
+    expected = "A new confirmation email has been sent to {}".format(api_user_active.email_address)
 
-            assert page.h1.string == 'Check your email'
-            expected = "A new confirmation email has been sent to {}".format(api_user_active.email_address)
-
-            message = page.find_all('p')[1].text
-            assert message == expected
-            mock_send_verify_email.assert_called_with(api_user_active.id, api_user_active.email_address)
+    message = page.find_all('p')[1].text
+    assert message == expected
+    mock_send_verify_email.assert_called_with(api_user_active.id, api_user_active.email_address)
 
 
 def test_should_render_correct_resend_template_for_active_user(
-    app_,
+    client,
     api_user_active,
     mock_get_user_by_email,
     mock_send_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.get(url_for('main.check_and_resend_text_code'))
-            assert response.status_code == 200
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.get(url_for('main.check_and_resend_text_code'))
+    assert response.status_code == 200
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string == 'Resend security code'
-            # there shouldn't be a form for updating mobile number
-            assert page.find('form') is None
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string == 'Resend security code'
+    # there shouldn't be a form for updating mobile number
+    assert page.find('form') is None
 
 
 def test_should_render_correct_resend_template_for_pending_user(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_send_verify_code,
@@ -60,26 +55,24 @@ def test_should_render_correct_resend_template_for_pending_user(
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_pending.id,
-                    'email': api_user_pending.email_address}
-            response = client.get(url_for('main.check_and_resend_text_code'))
-            assert response.status_code == 200
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_pending.id,
+            'email': api_user_pending.email_address}
+    response = client.get(url_for('main.check_and_resend_text_code'))
+    assert response.status_code == 200
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string == 'Check your mobile number'
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string == 'Check your mobile number'
 
-            expected = 'Check your mobile phone number is correct and then resend the security code.'
-            message = page.find_all('p')[1].text
-            assert message == expected
-            assert page.find('form').input['value'] == api_user_pending.mobile_number
+    expected = 'Check your mobile phone number is correct and then resend the security code.'
+    message = page.find_all('p')[1].text
+    assert message == expected
+    assert page.find('form').input['value'] == api_user_pending.mobile_number
 
 
 def test_should_resend_verify_code_and_update_mobile_for_pending_user(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_update_user,
@@ -88,40 +81,36 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_pending.id,
-                    'email': api_user_pending.email_address}
-            response = client.post(url_for('main.check_and_resend_text_code'),
-                                   data={'mobile_number': '+447700900460'})
-            assert response.status_code == 302
-            assert response.location == url_for('main.verify', _external=True)
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_pending.id,
+            'email': api_user_pending.email_address}
+    response = client.post(url_for('main.check_and_resend_text_code'),
+                           data={'mobile_number': '+447700900460'})
+    assert response.status_code == 302
+    assert response.location == url_for('main.verify', _external=True)
 
-            mock_update_user.assert_called_once_with(api_user_pending)
-            mock_send_verify_code.assert_called_once_with(api_user_pending.id, 'sms', to='+447700900460')
+    mock_update_user.assert_called_once_with(api_user_pending)
+    mock_send_verify_code.assert_called_once_with(api_user_pending.id, 'sms', to='+447700900460')
 
 
 def test_check_and_redirect_to_two_factor_if_user_active(
-    app_,
+    client,
     api_user_active,
     mock_get_user_by_email,
     mock_send_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.get(url_for('main.check_and_resend_verification_code'))
-            assert response.status_code == 302
-            assert response.location == url_for('main.two_factor', _external=True)
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.get(url_for('main.check_and_resend_verification_code'))
+    assert response.status_code == 302
+    assert response.location == url_for('main.two_factor', _external=True)
 
 
 def test_check_and_redirect_to_verify_if_user_pending(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_get_user_pending,
@@ -130,15 +119,13 @@ def test_check_and_redirect_to_verify_if_user_pending(
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_pending.id,
-                    'email': api_user_pending.email_address}
-            response = client.get(url_for('main.check_and_resend_verification_code'))
-            assert response.status_code == 302
-            assert response.location == url_for('main.verify', _external=True)
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_pending.id,
+            'email': api_user_pending.email_address}
+    response = client.get(url_for('main.check_and_resend_verification_code'))
+    assert response.status_code == 302
+    assert response.location == url_for('main.verify', _external=True)
 
 
 @pytest.mark.parametrize('endpoint', [
@@ -147,11 +134,10 @@ def test_check_and_redirect_to_verify_if_user_pending(
     'main.check_and_resend_verification_code',
 ])
 def test_redirect_to_sign_in_if_not_logged_in(
-    app_,
+    client,
     endpoint,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        response = client.get(url_for(endpoint))
+    response = client.get(url_for(endpoint))
 
-        assert response.location == url_for('main.sign_in', _external=True)
-        assert response.status_code == 302
+    assert response.location == url_for('main.sign_in', _external=True)
+    assert response.status_code == 302

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -3,11 +3,13 @@ from flask import url_for
 from bs4 import BeautifulSoup
 
 
-def test_should_render_email_verification_resend_show_email_address_and_resend_verify_email(app_,
-                                                                                            mocker,
-                                                                                            api_user_active,
-                                                                                            mock_get_user_by_email,
-                                                                                            mock_send_verify_email):
+def test_should_render_email_verification_resend_show_email_address_and_resend_verify_email(
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_send_verify_email,
+):
 
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -28,10 +30,12 @@ def test_should_render_email_verification_resend_show_email_address_and_resend_v
             mock_send_verify_email.assert_called_with(api_user_active.id, api_user_active.email_address)
 
 
-def test_should_render_correct_resend_template_for_active_user(app_,
-                                                               api_user_active,
-                                                               mock_get_user_by_email,
-                                                               mock_send_verify_code):
+def test_should_render_correct_resend_template_for_active_user(
+    app_,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_send_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -47,10 +51,12 @@ def test_should_render_correct_resend_template_for_active_user(app_,
             assert page.find('form') is None
 
 
-def test_should_render_correct_resend_template_for_pending_user(app_,
-                                                                mocker,
-                                                                api_user_pending,
-                                                                mock_send_verify_code):
+def test_should_render_correct_resend_template_for_pending_user(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_send_verify_code,
+):
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
@@ -72,11 +78,13 @@ def test_should_render_correct_resend_template_for_pending_user(app_,
             assert page.find('form').input['value'] == api_user_pending.mobile_number
 
 
-def test_should_resend_verify_code_and_update_mobile_for_pending_user(app_,
-                                                                      mocker,
-                                                                      api_user_pending,
-                                                                      mock_update_user,
-                                                                      mock_send_verify_code):
+def test_should_resend_verify_code_and_update_mobile_for_pending_user(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_update_user,
+    mock_send_verify_code,
+):
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
@@ -95,10 +103,12 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(app_,
             mock_send_verify_code.assert_called_once_with(api_user_pending.id, 'sms', to='+447700900460')
 
 
-def test_check_and_redirect_to_two_factor_if_user_active(app_,
-                                                         api_user_active,
-                                                         mock_get_user_by_email,
-                                                         mock_send_verify_code):
+def test_check_and_redirect_to_two_factor_if_user_active(
+    app_,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_send_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -110,11 +120,13 @@ def test_check_and_redirect_to_two_factor_if_user_active(app_,
             assert response.location == url_for('main.two_factor', _external=True)
 
 
-def test_check_and_redirect_to_verify_if_user_pending(app_,
-                                                      mocker,
-                                                      api_user_pending,
-                                                      mock_get_user_pending,
-                                                      mock_send_verify_code):
+def test_check_and_redirect_to_verify_if_user_pending(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_get_user_pending,
+    mock_send_verify_code,
+):
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
@@ -134,7 +146,10 @@ def test_check_and_redirect_to_verify_if_user_pending(app_,
     'main.check_and_resend_text_code',
     'main.check_and_resend_verification_code',
 ])
-def test_redirect_to_sign_in_if_not_logged_in(app_, endpoint):
+def test_redirect_to_sign_in_if_not_logged_in(
+    app_,
+    endpoint,
+):
     with app_.test_request_context(), app_.test_client() as client:
         response = client.get(url_for(endpoint))
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -32,18 +32,18 @@ stub_template_stats = [
 
 
 def test_get_started(
-        app_,
-        mocker,
-        api_user_active,
-        mock_get_service,
-        mock_get_service_templates_when_no_templates_exist,
-        mock_get_user,
-        mock_get_user_by_email,
-        mock_login,
-        mock_get_jobs,
-        mock_has_permissions,
-        mock_get_detailed_service,
-        mock_get_usage
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_service,
+    mock_get_service_templates_when_no_templates_exist,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_detailed_service,
+    mock_get_usage,
 ):
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
@@ -58,18 +58,18 @@ def test_get_started(
 
 
 def test_get_started_is_hidden_once_templates_exist(
-        app_,
-        mocker,
-        api_user_active,
-        mock_get_service,
-        mock_get_service_templates,
-        mock_get_user,
-        mock_get_user_by_email,
-        mock_login,
-        mock_get_jobs,
-        mock_has_permissions,
-        mock_get_detailed_service,
-        mock_get_usage
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_service,
+    mock_get_service_templates,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_detailed_service,
+    mock_get_usage,
 ):
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
@@ -82,18 +82,20 @@ def test_get_started_is_hidden_once_templates_exist(
     assert 'Get started' not in response.get_data(as_text=True)
 
 
-def test_should_show_recent_templates_on_dashboard(app_,
-                                                   mocker,
-                                                   api_user_active,
-                                                   mock_get_service,
-                                                   mock_get_service_templates,
-                                                   mock_get_user,
-                                                   mock_get_user_by_email,
-                                                   mock_login,
-                                                   mock_get_jobs,
-                                                   mock_has_permissions,
-                                                   mock_get_detailed_service,
-                                                   mock_get_usage):
+def test_should_show_recent_templates_on_dashboard(
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_service,
+    mock_get_service_templates,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
 
@@ -125,16 +127,16 @@ def test_should_show_recent_templates_on_dashboard(app_,
 
 
 def test_should_show_all_templates_on_template_statistics_page(
-        app_,
-        mocker,
-        api_user_active,
-        mock_get_service,
-        mock_get_service_templates,
-        mock_get_user,
-        mock_get_user_by_email,
-        mock_login,
-        mock_get_jobs,
-        mock_has_permissions
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_service,
+    mock_get_service_templates,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_jobs,
+    mock_has_permissions,
 ):
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
@@ -176,7 +178,7 @@ def test_should_show_upcoming_jobs_on_dashboard(
     mock_get_detailed_service,
     mock_get_jobs,
     mock_has_permissions,
-    mock_get_usage
+    mock_get_usage,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(api_user_active)
@@ -215,7 +217,7 @@ def test_should_show_recent_jobs_on_dashboard(
     mock_get_detailed_service,
     mock_get_jobs,
     mock_has_permissions,
-    mock_get_usage
+    mock_get_usage,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(api_user_active)
@@ -253,7 +255,7 @@ def test_usage_page(
     mock_get_user,
     mock_has_permissions,
     mock_get_usage,
-    mock_get_billable_units
+    mock_get_billable_units,
 ):
     client.login(api_user_active)
     response = client.get(url_for('main.usage', service_id=SERVICE_ONE_ID, year=2000))
@@ -290,7 +292,7 @@ def test_usage_page_for_invalid_year(
     api_user_active,
     mock_get_service,
     mock_get_user,
-    mock_has_permissions
+    mock_has_permissions,
 ):
     client.login(api_user_active)
     assert client.get(url_for('main.usage', service_id=SERVICE_ONE_ID, year='abcd')).status_code == 404
@@ -309,15 +311,17 @@ def _test_dashboard_menu(mocker, app_, usr, service, permissions):
             return client.get(url_for('main.service_dashboard', service_id=service['id']))
 
 
-def test_menu_send_messages(mocker,
-                            app_,
-                            api_user_active,
-                            service_one,
-                            mock_get_service_templates,
-                            mock_get_jobs,
-                            mock_get_template_statistics,
-                            mock_get_detailed_service,
-                            mock_get_usage):
+def test_menu_send_messages(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
@@ -341,15 +345,17 @@ def test_menu_send_messages(mocker,
         assert url_for('main.view_providers') not in page
 
 
-def test_menu_manage_service(mocker,
-                             app_,
-                             api_user_active,
-                             service_one,
-                             mock_get_service_templates,
-                             mock_get_jobs,
-                             mock_get_template_statistics,
-                             mock_get_detailed_service,
-                             mock_get_usage):
+def test_menu_manage_service(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
@@ -372,15 +378,17 @@ def test_menu_manage_service(mocker,
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
 
 
-def test_menu_manage_api_keys(mocker,
-                              app_,
-                              api_user_active,
-                              service_one,
-                              mock_get_service_templates,
-                              mock_get_jobs,
-                              mock_get_template_statistics,
-                              mock_get_detailed_service,
-                              mock_get_usage):
+def test_menu_manage_api_keys(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
@@ -403,15 +411,17 @@ def test_menu_manage_api_keys(mocker,
         assert url_for('main.api_integration', service_id=service_one['id']) in page
 
 
-def test_menu_all_services_for_platform_admin_user(mocker,
-                                                   app_,
-                                                   platform_admin_user,
-                                                   service_one,
-                                                   mock_get_service_templates,
-                                                   mock_get_jobs,
-                                                   mock_get_template_statistics,
-                                                   mock_get_detailed_service,
-                                                   mock_get_usage):
+def test_menu_all_services_for_platform_admin_user(
+    mocker,
+    app_,
+    platform_admin_user,
+    service_one,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     with app_.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
@@ -429,17 +439,19 @@ def test_menu_all_services_for_platform_admin_user(mocker,
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
 
 
-def test_route_for_service_permissions(mocker,
-                                       app_,
-                                       api_user_active,
-                                       service_one,
-                                       mock_get_service,
-                                       mock_get_user,
-                                       mock_get_service_templates,
-                                       mock_get_jobs,
-                                       mock_get_template_statistics,
-                                       mock_get_detailed_service,
-                                       mock_get_usage):
+def test_route_for_service_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service,
+    mock_get_user,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -467,16 +479,18 @@ def test_aggregate_template_stats():
     assert expected[1]['template_type'] == 'sms'
 
 
-def test_service_dashboard_updates_gets_dashboard_totals(mocker,
-                                                         app_,
-                                                         active_user_with_permissions,
-                                                         service_one,
-                                                         mock_get_user,
-                                                         mock_get_service_templates,
-                                                         mock_get_template_statistics,
-                                                         mock_get_detailed_service,
-                                                         mock_get_jobs,
-                                                         mock_get_usage):
+def test_service_dashboard_updates_gets_dashboard_totals(
+    mocker,
+    app_,
+    active_user_with_permissions,
+    service_one,
+    mock_get_user,
+    mock_get_service_templates,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_jobs,
+    mock_get_usage,
+):
     dashboard_totals = mocker.patch('app.main.views.dashboard.get_dashboard_totals', return_value={
         'email': {'requested': 123, 'delivered': 0, 'failed': 0},
         'sms': {'requested': 456, 'delivered': 0, 'failed': 0}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -32,7 +32,7 @@ stub_template_stats = [
 
 
 def test_get_started(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_get_service,
@@ -48,9 +48,7 @@ def test_get_started(
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
 
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
     # mock_get_service_templates_when_no_templates_exist.assert_called_once_with(SERVICE_ONE_ID)
     assert response.status_code == 200
@@ -58,7 +56,7 @@ def test_get_started(
 
 
 def test_get_started_is_hidden_once_templates_exist(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_get_service,
@@ -73,9 +71,7 @@ def test_get_started_is_hidden_once_templates_exist(
 ):
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
     # mock_get_service_templates.assert_called_once_with(SERVICE_ONE_ID)
     assert response.status_code == 200
@@ -83,7 +79,7 @@ def test_get_started_is_hidden_once_templates_exist(
 
 
 def test_should_show_recent_templates_on_dashboard(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_get_service,
@@ -99,35 +95,32 @@ def test_should_show_recent_templates_on_dashboard(
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
-        assert response.status_code == 200
-        response.get_data(as_text=True)
-        mock_template_stats.assert_called_once_with(SERVICE_ONE_ID, limit_days=7)
+    assert response.status_code == 200
+    response.get_data(as_text=True)
+    mock_template_stats.assert_called_once_with(SERVICE_ONE_ID, limit_days=7)
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        headers = [header.text.strip() for header in page.find_all('h2') + page.find_all('h1')]
-        assert 'Test Service' in headers
-        assert 'In the last 7 days' in headers
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    headers = [header.text.strip() for header in page.find_all('h2') + page.find_all('h1')]
+    assert 'Test Service' in headers
+    assert 'In the last 7 days' in headers
 
-        table_rows = page.find_all('tbody')[1].find_all('tr')
+    table_rows = page.find_all('tbody')[1].find_all('tr')
 
-        assert len(table_rows) == 2
+    assert len(table_rows) == 2
 
-        assert 'two' in table_rows[0].find_all('th')[0].text
-        assert 'Email template' in table_rows[0].find_all('th')[0].text
-        assert '200' in table_rows[0].find_all('td')[0].text
+    assert 'two' in table_rows[0].find_all('th')[0].text
+    assert 'Email template' in table_rows[0].find_all('th')[0].text
+    assert '200' in table_rows[0].find_all('td')[0].text
 
-        assert 'one' in table_rows[1].find_all('th')[0].text
-        assert 'Text message template' in table_rows[1].find_all('th')[0].text
-        assert '100' in table_rows[1].find_all('td')[0].text
+    assert 'one' in table_rows[1].find_all('th')[0].text
+    assert 'Text message template' in table_rows[1].find_all('th')[0].text
+    assert '100' in table_rows[1].find_all('td')[0].text
 
 
 def test_should_show_all_templates_on_template_statistics_page(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_get_service,
@@ -141,32 +134,29 @@ def test_should_show_all_templates_on_template_statistics_page(
     mock_template_stats = mocker.patch('app.template_statistics_client.get_template_statistics_for_service',
                                        return_value=copy.deepcopy(stub_template_stats))
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.template_history', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.template_history', service_id=SERVICE_ONE_ID))
 
-        assert response.status_code == 200
-        response.get_data(as_text=True)
-        mock_template_stats.assert_called_once_with(SERVICE_ONE_ID)
+    assert response.status_code == 200
+    response.get_data(as_text=True)
+    mock_template_stats.assert_called_once_with(SERVICE_ONE_ID)
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        table_rows = page.find_all('tbody')[0].find_all('tr')
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    table_rows = page.find_all('tbody')[0].find_all('tr')
 
-        assert len(table_rows) == 2
+    assert len(table_rows) == 2
 
-        assert 'two' in table_rows[0].find_all('th')[0].text
-        assert 'Email template' in table_rows[0].find_all('th')[0].text
-        assert '200' in table_rows[0].find_all('td')[0].text
+    assert 'two' in table_rows[0].find_all('th')[0].text
+    assert 'Email template' in table_rows[0].find_all('th')[0].text
+    assert '200' in table_rows[0].find_all('td')[0].text
 
-        assert 'one' in table_rows[1].find_all('th')[0].text
-        assert 'Text message template' in table_rows[1].find_all('th')[0].text
-        assert '100' in table_rows[1].find_all('td')[0].text
+    assert 'one' in table_rows[1].find_all('th')[0].text
+    assert 'Text message template' in table_rows[1].find_all('th')[0].text
+    assert '100' in table_rows[1].find_all('td')[0].text
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_show_upcoming_jobs_on_dashboard(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_get_service,
@@ -180,9 +170,7 @@ def test_should_show_upcoming_jobs_on_dashboard(
     mock_has_permissions,
     mock_get_usage,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
     first_call = mock_get_jobs.call_args_list[0]
     assert first_call[0] == (SERVICE_ONE_ID,)
@@ -205,7 +193,7 @@ def test_should_show_upcoming_jobs_on_dashboard(
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_show_recent_jobs_on_dashboard(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_get_service,
@@ -219,9 +207,7 @@ def test_should_show_recent_jobs_on_dashboard(
     mock_has_permissions,
     mock_get_usage,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
     second_call = mock_get_jobs.call_args_list[1]
     assert second_call[0] == (SERVICE_ONE_ID,)
@@ -249,7 +235,7 @@ def test_should_show_recent_jobs_on_dashboard(
 
 @freeze_time("2016-12-31 11:09:00.061258")
 def test_usage_page(
-    client,
+    logged_in_client,
     api_user_active,
     mock_get_service,
     mock_get_user,
@@ -257,8 +243,7 @@ def test_usage_page(
     mock_get_usage,
     mock_get_billable_units,
 ):
-    client.login(api_user_active)
-    response = client.get(url_for('main.usage', service_id=SERVICE_ONE_ID, year=2000))
+    response = logged_in_client.get(url_for('main.usage', service_id=SERVICE_ONE_ID, year=2000))
 
     assert response.status_code == 200
 
@@ -288,14 +273,13 @@ def test_usage_page(
 
 @freeze_time("2016-12-31 11:09:00.061258")
 def test_usage_page_for_invalid_year(
-    client,
+    logged_in_client,
     api_user_active,
     mock_get_service,
     mock_get_user,
     mock_has_permissions,
 ):
-    client.login(api_user_active)
-    assert client.get(url_for('main.usage', service_id=SERVICE_ONE_ID, year='abcd')).status_code == 404
+    assert logged_in_client.get(url_for('main.usage', service_id=SERVICE_ONE_ID, year='abcd')).status_code == 404
 
 
 def _test_dashboard_menu(mocker, app_, usr, service, permissions):
@@ -481,7 +465,7 @@ def test_aggregate_template_stats():
 
 def test_service_dashboard_updates_gets_dashboard_totals(
     mocker,
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     service_one,
     mock_get_user,
@@ -496,9 +480,7 @@ def test_service_dashboard_updates_gets_dashboard_totals(
         'sms': {'requested': 456, 'delivered': 0, 'failed': 0}
     })
 
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
+    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 
     assert response.status_code == 200
 

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -8,14 +8,13 @@ from flask import url_for
         ({'govuk_banner': 'false'}, 'false')
     ]
 )
-def test_renders(app_, mocker, query_args, result):
-    with app_.test_request_context(), app_.test_client() as client:
+def test_renders(client, mocker, query_args, result):
 
-        mock_convert_to_boolean = mocker.patch('app.main.views.index.convert_to_boolean')
-        mocker.patch('app.main.views.index.HTMLEmailTemplate.__str__', return_value='rendered')
+    mock_convert_to_boolean = mocker.patch('app.main.views.index.convert_to_boolean')
+    mocker.patch('app.main.views.index.HTMLEmailTemplate.__str__', return_value='rendered')
 
-        response = client.get(url_for('main.email_template', **query_args))
+    response = client.get(url_for('main.email_template', **query_args))
 
-        assert response.status_code == 200
-        assert response.get_data(as_text=True) == 'rendered'
-        mock_convert_to_boolean.assert_called_once_with(result)
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == 'rendered'
+    mock_convert_to_boolean.assert_called_once_with(result)

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -7,12 +7,11 @@ from tests.conftest import api_user_active as create_active_user
 import app
 
 
-def test_should_render_forgot_password(app_):
-    with app_.test_request_context():
-        response = app_.test_client().get(url_for('.forgot_password'))
-        assert response.status_code == 200
-        assert 'We’ll send you an email to create a new password.' \
-               in response.get_data(as_text=True)
+def test_should_render_forgot_password(client):
+    response = client.get(url_for('.forgot_password'))
+    assert response.status_code == 200
+    assert 'We’ll send you an email to create a new password.' \
+           in response.get_data(as_text=True)
 
 
 @pytest.mark.parametrize('email_address', [
@@ -20,36 +19,34 @@ def test_should_render_forgot_password(app_):
     'someuser@notonwhitelist.com'
 ])
 def test_should_redirect_to_password_reset_sent_for_valid_email(
-    app_,
+    client,
     fake_uuid,
     email_address,
     mocker,
 ):
-    with app_.test_request_context():
-        sample_user = create_active_user(fake_uuid, email_address=email_address)
-        mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
-        response = app_.test_client().post(
-            url_for('.forgot_password'),
-            data={'email_address': sample_user.email_address})
-        assert response.status_code == 200
-        assert 'Click the link in the email to reset your password.' \
-               in response.get_data(as_text=True)
-        app.user_api_client.send_reset_password_url.assert_called_once_with(sample_user.email_address)
+    sample_user = create_active_user(fake_uuid, email_address=email_address)
+    mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
+    response = client.post(
+        url_for('.forgot_password'),
+        data={'email_address': sample_user.email_address})
+    assert response.status_code == 200
+    assert 'Click the link in the email to reset your password.' \
+           in response.get_data(as_text=True)
+    app.user_api_client.send_reset_password_url.assert_called_once_with(sample_user.email_address)
 
 
 def test_should_redirect_to_password_reset_sent_for_missing_email(
-    app_,
+    client,
     api_user_active,
     mocker,
 ):
-    with app_.test_request_context():
 
-        mocker.patch('app.user_api_client.send_reset_password_url', side_effect=HTTPError(Response(status=404),
-                                                                                          'Not found'))
-        response = app_.test_client().post(
-            url_for('.forgot_password'),
-            data={'email_address': api_user_active.email_address})
-        assert response.status_code == 200
-        assert 'Click the link in the email to reset your password.' \
-               in response.get_data(as_text=True)
-        app.user_api_client.send_reset_password_url.assert_called_once_with(api_user_active.email_address)
+    mocker.patch('app.user_api_client.send_reset_password_url', side_effect=HTTPError(Response(status=404),
+                                                                                      'Not found'))
+    response = client.post(
+        url_for('.forgot_password'),
+        data={'email_address': api_user_active.email_address})
+    assert response.status_code == 200
+    assert 'Click the link in the email to reset your password.' \
+           in response.get_data(as_text=True)
+    app.user_api_client.send_reset_password_url.assert_called_once_with(api_user_active.email_address)

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -20,10 +20,11 @@ def test_should_render_forgot_password(app_):
     'someuser@notonwhitelist.com'
 ])
 def test_should_redirect_to_password_reset_sent_for_valid_email(
-        app_,
-        fake_uuid,
-        email_address,
-        mocker):
+    app_,
+    fake_uuid,
+    email_address,
+    mocker,
+):
     with app_.test_request_context():
         sample_user = create_active_user(fake_uuid, email_address=email_address)
         mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
@@ -37,9 +38,10 @@ def test_should_redirect_to_password_reset_sent_for_valid_email(
 
 
 def test_should_redirect_to_password_reset_sent_for_missing_email(
-        app_,
-        api_user_active,
-        mocker):
+    app_,
+    api_user_active,
+    mocker,
+):
     with app_.test_request_context():
 
         mocker.patch('app.user_api_client.send_reset_password_url', side_effect=HTTPError(Response(status=404),

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -1,7 +1,6 @@
 
-def test_owasp_useful_headers_set(app_):
-    with app_.test_request_context():
-        response = app_.test_client().get('/')
+def test_owasp_useful_headers_set(client):
+    response = client.get('/')
     assert response.status_code == 200
     assert response.headers['X-Frame-Options'] == 'deny'
     assert response.headers['X-Content-Type-Options'] == 'nosniff'

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -2,11 +2,13 @@ import pytest
 from flask import url_for
 
 
-def test_logged_in_user_redirects_to_choose_service(app_,
-                                                    api_user_active,
-                                                    mock_get_user,
-                                                    mock_get_user_by_email,
-                                                    mock_login):
+def test_logged_in_user_redirects_to_choose_service(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -3,26 +3,25 @@ from flask import url_for
 
 
 def test_logged_in_user_redirects_to_choose_service(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_login,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.index'))
-            assert response.status_code == 302
+    response = logged_in_client.get(url_for('main.index'))
+    assert response.status_code == 302
 
-            response = client.get(url_for('main.sign_in', follow_redirects=True))
-            assert response.location == url_for('main.choose_service', _external=True)
+    response = logged_in_client.get(url_for('main.sign_in', follow_redirects=True))
+    assert response.location == url_for('main.choose_service', _external=True)
 
 
 @pytest.mark.parametrize('view', [
     'cookies', 'trial_mode', 'pricing', 'terms', 'delivery_and_failure', 'integration_testing'
 ])
-def test_static_pages(app_, view):
-    with app_.test_request_context(), app_.test_client() as client:
-        response = client.get(url_for('main.{}'.format(view)))
-        assert response.status_code == 200
+def test_static_pages(
+    client,
+    view,
+):
+    response = client.get(url_for('main.{}'.format(view)))
+    assert response.status_code == 200

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -38,7 +38,7 @@ def test_get_jobs_should_return_list_of_all_real_jobs(
     service_one,
     active_user_with_permissions,
     mock_get_jobs,
-    mocker
+    mocker,
 ):
     client.login(active_user_with_permissions, mocker, service_one)
     response = client.get(url_for('main.view_jobs', service_id=service_one['id']))
@@ -55,7 +55,7 @@ def test_get_jobs_shows_page_links(
     service_one,
     active_user_with_permissions,
     mock_get_jobs,
-    mocker
+    mocker,
 ):
     client.login(active_user_with_permissions, mocker, service_one)
     response = client.get(url_for('main.view_jobs', service_id=service_one['id']))
@@ -97,7 +97,7 @@ def test_should_show_page_for_one_job(
     mock_get_notifications,
     fake_uuid,
     status_argument,
-    expected_api_call
+    expected_api_call,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -145,7 +145,7 @@ def test_get_jobs_should_tell_user_if_more_than_one_page(
     service_one,
     mock_get_job,
     mock_get_service_template,
-    mock_get_notifications_with_previous_next
+    mock_get_notifications_with_previous_next,
 ):
     response = logged_in_client.get(url_for(
         'main.view_job',
@@ -167,7 +167,7 @@ def test_should_show_job_in_progress(
     mock_get_job_in_progress,
     mocker,
     mock_get_notifications,
-    fake_uuid
+    fake_uuid,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -191,7 +191,7 @@ def test_should_show_scheduled_job(
     mock_get_scheduled_job,
     mocker,
     mock_get_notifications,
-    fake_uuid
+    fake_uuid,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -212,7 +212,7 @@ def test_should_cancel_job(
     service_one,
     active_user_with_permissions,
     fake_uuid,
-    mocker
+    mocker,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -234,7 +234,7 @@ def test_should_not_show_cancelled_job(
     active_user_with_permissions,
     mock_get_cancelled_job,
     mocker,
-    fake_uuid
+    fake_uuid,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -255,7 +255,7 @@ def test_should_show_not_show_csv_download_in_tour(
     mock_get_job,
     mocker,
     mock_get_notifications,
-    fake_uuid
+    fake_uuid,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -289,7 +289,7 @@ def test_should_show_updates_for_one_job_as_json(
     mock_get_notifications,
     mock_get_job,
     mocker,
-    fake_uuid
+    fake_uuid,
 ):
     job_json = mock_get_job(service_one['id'], fake_uuid)['data']
     with app_.test_request_context():
@@ -353,7 +353,7 @@ def test_can_show_notifications(
     status_argument,
     expected_api_call,
     page_argument,
-    expected_page_argument
+    expected_page_argument,
 ):
     response = logged_in_client.get(url_for(
         'main.view_notifications',
@@ -405,7 +405,7 @@ def test_should_show_notifications_for_a_service_with_next_previous(
     active_user_with_permissions,
     mock_get_notifications_with_previous_next,
     mock_get_detailed_service,
-    mocker
+    mocker,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -487,12 +487,12 @@ def test_get_status_filters_constructs_links(app_):
 
 
 def test_html_contains_notification_id(
-        client,
-        service_one,
-        active_user_with_permissions,
-        mock_get_notifications,
-        mock_get_detailed_service,
-        mocker
+    client,
+    service_one,
+    active_user_with_permissions,
+    mock_get_notifications,
+    mock_get_detailed_service,
+    mocker,
 ):
     client.login(active_user_with_permissions, mocker, service_one)
     response = client.get(url_for(

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -34,14 +34,13 @@ def _csv_notifications(notifications_json):
 
 
 def test_get_jobs_should_return_list_of_all_real_jobs(
-    client,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_jobs,
     mocker,
 ):
-    client.login(active_user_with_permissions, mocker, service_one)
-    response = client.get(url_for('main.view_jobs', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.view_jobs', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -51,14 +50,13 @@ def test_get_jobs_should_return_list_of_all_real_jobs(
 
 
 def test_get_jobs_shows_page_links(
-    client,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_jobs,
     mocker,
 ):
-    client.login(active_user_with_permissions, mocker, service_one)
-    response = client.get(url_for('main.view_jobs', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.view_jobs', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -88,7 +86,7 @@ def test_get_jobs_shows_page_links(
 )
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_show_page_for_one_job(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_service_template,
@@ -99,43 +97,41 @@ def test_should_show_page_for_one_job(
     status_argument,
     expected_api_call,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for(
-            'main.view_job',
-            service_id=service_one['id'],
-            job_id=fake_uuid,
-            status=status_argument
-        ))
+    response = logged_in_client.get(url_for(
+        'main.view_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid,
+        status=status_argument
+    ))
 
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.text.strip() == 'thisisatest.csv'
-        assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == (
-            '{}: Template <em>content</em> with & entity'.format(service_one['name'])
-        )
-        assert ' '.join(page.find('tbody').find('tr').text.split()) == (
-            '07123456789 Delivered 1 January at 11:10am'
-        )
-        assert page.find('div', {'data-key': 'notifications'})['data-resource'] == url_for(
-            'main.view_job_updates',
-            service_id=service_one['id'],
-            job_id=fake_uuid,
-            status=status_argument,
-        )
-        csv_link = page.find('a', {'download': 'download'})
-        assert csv_link['href'] == url_for(
-            'main.view_job_csv',
-            service_id=service_one['id'],
-            job_id=fake_uuid,
-            status=status_argument
-        )
-        assert csv_link.text == 'Download this report'
-        assert page.find('span', {'id': 'time-left'}).text == 'Data available for 7 days'
-        mock_get_notifications.assert_called_with(
-            service_one['id'],
-            fake_uuid,
-            status=expected_api_call
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.text.strip() == 'thisisatest.csv'
+    assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == (
+        '{}: Template <em>content</em> with & entity'.format(service_one['name'])
+    )
+    assert ' '.join(page.find('tbody').find('tr').text.split()) == (
+        '07123456789 Delivered 1 January at 11:10am'
+    )
+    assert page.find('div', {'data-key': 'notifications'})['data-resource'] == url_for(
+        'main.view_job_updates',
+        service_id=service_one['id'],
+        job_id=fake_uuid,
+        status=status_argument,
+    )
+    csv_link = page.find('a', {'download': 'download'})
+    assert csv_link['href'] == url_for(
+        'main.view_job_csv',
+        service_id=service_one['id'],
+        job_id=fake_uuid,
+        status=status_argument
+    )
+    assert csv_link.text == 'Download this report'
+    assert page.find('span', {'id': 'time-left'}).text == 'Data available for 7 days'
+    mock_get_notifications.assert_called_with(
+        service_one['id'],
+        fake_uuid,
+        status=expected_api_call
         )
 
 
@@ -160,7 +156,7 @@ def test_get_jobs_should_tell_user_if_more_than_one_page(
 
 
 def test_should_show_job_in_progress(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_service_template,
@@ -169,22 +165,21 @@ def test_should_show_job_in_progress(
     mock_get_notifications,
     fake_uuid,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for(
-            'main.view_job',
-            service_id=service_one['id'],
-            job_id=fake_uuid
-        ))
 
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find('p', {'class': 'hint'}).text.strip() == 'Report is 50% complete…'
+    response = logged_in_client.get(url_for(
+        'main.view_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid
+    ))
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find('p', {'class': 'hint'}).text.strip() == 'Report is 50% complete…'
 
 
 @freeze_time("2016-01-01T00:00:00.061258")
 def test_should_show_scheduled_job(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_service_template,
@@ -193,62 +188,56 @@ def test_should_show_scheduled_job(
     mock_get_notifications,
     fake_uuid,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for(
-            'main.view_job',
-            service_id=service_one['id'],
-            job_id=fake_uuid
-        ))
+    response = logged_in_client.get(url_for(
+        'main.view_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid
+    ))
 
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find('main').find_all('p')[1].text.strip() == 'Sending will start today at midnight'
-        assert page.find('input', {'type': 'submit', 'value': 'Cancel sending'})
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find('main').find_all('p')[1].text.strip() == 'Sending will start today at midnight'
+    assert page.find('input', {'type': 'submit', 'value': 'Cancel sending'})
 
 
 def test_should_cancel_job(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     fake_uuid,
     mocker,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_job')
-        response = client.post(url_for(
-            'main.cancel_job',
-            service_id=service_one['id'],
-            job_id=fake_uuid
-        ))
+    mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_job')
+    response = logged_in_client.post(url_for(
+        'main.cancel_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid
+    ))
 
-        mock_cancel.assert_called_once_with(service_one['id'], fake_uuid)
-        assert response.status_code == 302
-        assert response.location == url_for('main.service_dashboard', service_id=service_one['id'], _external=True)
+    mock_cancel.assert_called_once_with(service_one['id'], fake_uuid)
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_dashboard', service_id=service_one['id'], _external=True)
 
 
 def test_should_not_show_cancelled_job(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_cancelled_job,
     mocker,
     fake_uuid,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for(
-            'main.view_job',
-            service_id=service_one['id'],
-            job_id=fake_uuid
-        ))
+    response = logged_in_client.get(url_for(
+        'main.view_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid
+    ))
 
-        assert response.status_code == 404
+    assert response.status_code == 404
 
 
 def test_should_show_not_show_csv_download_in_tour(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_service_template,
@@ -257,33 +246,31 @@ def test_should_show_not_show_csv_download_in_tour(
     mock_get_notifications,
     fake_uuid,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for(
-            'main.view_job',
-            service_id=service_one['id'],
-            job_id=fake_uuid,
-            help=3
-        ))
+    response = logged_in_client.get(url_for(
+        'main.view_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid,
+        help=3
+    ))
 
-        assert response.status_code == 200
-        assert url_for(
-            'main.view_job_updates',
-            service_id=service_one['id'],
-            job_id=fake_uuid,
-            status='',
-            help=3
-        ).replace('&', '&amp;') in response.get_data(as_text=True)
-        assert url_for(
-            'main.view_job_csv',
-            service_id=service_one['id'],
-            job_id=fake_uuid
-        ) not in response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert url_for(
+        'main.view_job_updates',
+        service_id=service_one['id'],
+        job_id=fake_uuid,
+        status='',
+        help=3
+    ).replace('&', '&amp;') in response.get_data(as_text=True)
+    assert url_for(
+        'main.view_job_csv',
+        service_id=service_one['id'],
+        job_id=fake_uuid
+    ) not in response.get_data(as_text=True)
 
 
 @freeze_time("2016-01-01 00:00:00.000001")
 def test_should_show_updates_for_one_job_as_json(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_notifications,
@@ -292,22 +279,19 @@ def test_should_show_updates_for_one_job_as_json(
     fake_uuid,
 ):
     job_json = mock_get_job(service_one['id'], fake_uuid)['data']
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for('main.view_job_updates', service_id=service_one['id'], job_id=fake_uuid))
+    response = logged_in_client.get(url_for('main.view_job_updates', service_id=service_one['id'], job_id=fake_uuid))
 
-        assert response.status_code == 200
-        content = json.loads(response.get_data(as_text=True))
-        assert 'sending' in content['counts']
-        assert 'delivered' in content['counts']
-        assert 'failed' in content['counts']
-        assert 'Recipient' in content['notifications']
-        assert '07123456789' in content['notifications']
-        assert 'Status' in content['notifications']
-        assert 'Delivered' in content['notifications']
-        assert '12:01am' in content['notifications']
-        assert 'Sent by Test User on 1 January at midnight' in content['status']
+    assert response.status_code == 200
+    content = json.loads(response.get_data(as_text=True))
+    assert 'sending' in content['counts']
+    assert 'delivered' in content['counts']
+    assert 'failed' in content['counts']
+    assert 'Recipient' in content['notifications']
+    assert '07123456789' in content['notifications']
+    assert 'Status' in content['notifications']
+    assert 'Delivered' in content['notifications']
+    assert '12:01am' in content['notifications']
+    assert 'Sent by Test User on 1 January at midnight' in content['status']
 
 
 @pytest.mark.parametrize(
@@ -400,39 +384,36 @@ def test_can_show_notifications(
 
 
 def test_should_show_notifications_for_a_service_with_next_previous(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_notifications_with_previous_next,
     mock_get_detailed_service,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.view_notifications',
-                service_id=service_one['id'],
-                message_type='sms',
-                page=2
-            ))
-        assert response.status_code == 200
-        content = response.get_data(as_text=True)
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        next_page_link = page.find('a', {'rel': 'next'})
-        prev_page_link = page.find('a', {'rel': 'previous'})
-        assert (
-            url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=3) in
-            next_page_link['href']
-        )
-        assert 'Next page' in next_page_link.text.strip()
-        assert 'page 3' in next_page_link.text.strip()
-        assert (
-            url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=1) in
-            prev_page_link['href']
-        )
-        assert 'Previous page' in prev_page_link.text.strip()
-        assert 'page 1' in prev_page_link.text.strip()
+    response = logged_in_client.get(url_for(
+        'main.view_notifications',
+        service_id=service_one['id'],
+        message_type='sms',
+        page=2
+    ))
+    assert response.status_code == 200
+    content = response.get_data(as_text=True)
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    next_page_link = page.find('a', {'rel': 'next'})
+    prev_page_link = page.find('a', {'rel': 'previous'})
+    assert (
+        url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=3) in
+        next_page_link['href']
+    )
+    assert 'Next page' in next_page_link.text.strip()
+    assert 'page 3' in next_page_link.text.strip()
+    assert (
+        url_for('main.view_notifications', service_id=service_one['id'], message_type='sms', page=1) in
+        prev_page_link['href']
+    )
+    assert 'Previous page' in prev_page_link.text.strip()
+    assert 'page 1' in prev_page_link.text.strip()
 
 
 @pytest.mark.parametrize(
@@ -457,9 +438,8 @@ STATISTICS = {
 }
 
 
-def test_get_status_filters_calculates_stats(app_):
-    with app_.test_request_context():
-        ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
+def test_get_status_filters_calculates_stats(client):
+    ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     assert {label: count for label, _option, _link, count in ret} == {
         'total': 6,
@@ -469,33 +449,30 @@ def test_get_status_filters_calculates_stats(app_):
     }
 
 
-def test_get_status_filters_in_right_order(app_):
-    with app_.test_request_context():
-        ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
+def test_get_status_filters_in_right_order(client):
+    ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     assert [label for label, _option, _link, _count in ret] == [
         'total', 'sending', 'delivered', 'failed'
     ]
 
 
-def test_get_status_filters_constructs_links(app_):
-    with app_.test_request_context():
-        ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
+def test_get_status_filters_constructs_links(client):
+    ret = get_status_filters({'id': 'foo'}, 'sms', STATISTICS)
 
     link = ret[0][2]
     assert link == '/services/foo/notifications/sms?status={}'.format(quote('sending,delivered,failed'))
 
 
 def test_html_contains_notification_id(
-    client,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_get_notifications,
     mock_get_detailed_service,
     mocker,
 ):
-    client.login(active_user_with_permissions, mocker, service_one)
-    response = client.get(url_for(
+    response = logged_in_client.get(url_for(
         'main.view_notifications',
         service_id=service_one['id'],
         message_type='sms',

--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -21,7 +21,7 @@ def test_letters_access_restricted(
     can_send_letters,
     response_code,
     mock_get_service_templates,
-    url
+    url,
 ):
     service = service_json(can_send_letters=can_send_letters)
     mocker.patch('app.service_api_client.get_service', return_value={"data": service})
@@ -39,7 +39,7 @@ def test_letters_lets_in_without_permission(
     mock_has_permissions,
     api_user_active,
     mock_get_service_templates,
-    url
+    url,
 ):
     service = service_json(can_send_letters=True)
     mocker.patch('app.service_api_client.get_service', return_value={"data": service})

--- a/tests/app/main/views/test_main_nav.py
+++ b/tests/app/main/views/test_main_nav.py
@@ -31,7 +31,7 @@ def test_can_see_letters_without_permissions(
     mocker,
     mock_login,
     mock_has_permissions,
-    api_user_active
+    api_user_active,
 ):
     service = service_json(can_send_letters=True)
     mocker.patch('app.service_api_client.get_service', return_value={"data": service})

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -8,10 +8,10 @@ from tests.conftest import service_one as create_sample_service
 
 
 def test_should_show_overview_page(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        mock_get_invites_for_service
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_invites_for_service,
 ):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
@@ -26,9 +26,9 @@ def test_should_show_overview_page(
 
 
 def test_should_show_page_for_one_user(
-        app_,
-        active_user_with_permissions,
-        mocker
+    app_,
+    active_user_with_permissions,
+    mocker,
 ):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
@@ -40,11 +40,11 @@ def test_should_show_page_for_one_user(
 
 
 def test_edit_user_permissions(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        mock_get_invites_for_service,
-        mock_set_user_permissions
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_invites_for_service,
+    mock_set_user_permissions,
 ):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
@@ -78,12 +78,12 @@ def test_edit_user_permissions(
 
 
 def test_edit_some_user_permissions(
-        app_,
-        mocker,
-        active_user_with_permissions,
-        sample_invite,
-        mock_get_invites_for_service,
-        mock_set_user_permissions
+    app_,
+    mocker,
+    active_user_with_permissions,
+    sample_invite,
+    mock_get_invites_for_service,
+    mock_set_user_permissions,
 ):
     service = create_sample_service(active_user_with_permissions)
     data = [InvitedUser(**sample_invite)]
@@ -117,9 +117,9 @@ def test_edit_some_user_permissions(
 
 
 def test_should_show_page_for_inviting_user(
-        app_,
-        active_user_with_permissions,
-        mocker
+    app_,
+    active_user_with_permissions,
+    mocker,
 ):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
@@ -136,12 +136,12 @@ def test_should_show_page_for_inviting_user(
     ('test@nonwhitelist.com', False)
 ])
 def test_invite_user(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        sample_invite,
-        email_address,
-        gov_user
+    app_,
+    active_user_with_permissions,
+    mocker,
+    sample_invite,
+    email_address,
+    gov_user,
 ):
     service = create_sample_service(active_user_with_permissions)
     sample_invite['email_address'] = 'test@example.gov.uk'
@@ -177,10 +177,11 @@ def test_invite_user(
                                                                     expected_permissions)
 
 
-def test_cancel_invited_user_cancels_user_invitations(app_,
-                                                      active_user_with_permissions,
-                                                      mocker
-                                                      ):
+def test_cancel_invited_user_cancels_user_invitations(
+    app_,
+    active_user_with_permissions,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             mocker.patch('app.invite_api_client.cancel_invited_user')
@@ -195,10 +196,12 @@ def test_cancel_invited_user_cancels_user_invitations(app_,
             assert response.location == url_for('main.manage_users', service_id=service['id'], _external=True)
 
 
-def test_manage_users_shows_invited_user(app_,
-                                         mocker,
-                                         active_user_with_permissions,
-                                         sample_invite):
+def test_manage_users_shows_invited_user(
+    app_,
+    mocker,
+    active_user_with_permissions,
+    sample_invite,
+):
     service = create_sample_service(active_user_with_permissions)
     data = [InvitedUser(**sample_invite)]
     with app_.test_request_context():
@@ -218,10 +221,12 @@ def test_manage_users_shows_invited_user(app_,
             assert invited_users_list.find_all('a')[0].text.strip() == 'Cancel invitation'
 
 
-def test_manage_users_does_not_show_accepted_invite(app_,
-                                                    mocker,
-                                                    active_user_with_permissions,
-                                                    sample_invite):
+def test_manage_users_does_not_show_accepted_invite(
+    app_,
+    mocker,
+    active_user_with_permissions,
+    sample_invite,
+):
     import uuid
     invited_user_id = uuid.uuid4()
     sample_invite['id'] = invited_user_id
@@ -245,10 +250,10 @@ def test_manage_users_does_not_show_accepted_invite(app_,
 
 
 def test_user_cant_invite_themselves(
-        app_,
-        mocker,
-        active_user_with_permissions,
-        mock_create_invite
+    app_,
+    mocker,
+    active_user_with_permissions,
+    mock_create_invite,
 ):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
@@ -271,10 +276,12 @@ def test_user_cant_invite_themselves(
         assert not mock_create_invite.called
 
 
-def test_no_permission_manage_users_page(app_,
-                                         service_one,
-                                         api_user_active,
-                                         mocker):
+def test_no_permission_manage_users_page(
+    app_,
+    service_one,
+    api_user_active,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active, mocker, service_one)
@@ -285,10 +292,12 @@ def test_no_permission_manage_users_page(app_,
             assert "Team members" not in resp_text
 
 
-def test_get_remove_user_from_service(app_,
-                                      active_user_with_permissions,
-                                      service_one,
-                                      mocker):
+def test_get_remove_user_from_service(
+    app_,
+    active_user_with_permissions,
+    service_one,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions, mocker, service_one)
@@ -302,13 +311,15 @@ def test_get_remove_user_from_service(app_,
             assert "Remove user from service" in response.get_data(as_text=True)
 
 
-def test_remove_user_from_service(app_,
-                                  active_user_with_permissions,
-                                  service_one,
-                                  mocker,
-                                  mock_get_users_by_service,
-                                  mock_get_user,
-                                  mock_remove_user_from_service):
+def test_remove_user_from_service(
+    app_,
+    active_user_with_permissions,
+    service_one,
+    mocker,
+    mock_get_users_by_service,
+    mock_get_user,
+    mock_remove_user_from_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions, mocker, service_one)
@@ -325,12 +336,13 @@ def test_remove_user_from_service(app_,
 
 
 def test_can_remove_user_from_service_as_platform_admin(
-        app_,
-        service_one,
-        platform_admin_user,
-        active_user_with_permissions,
-        mock_remove_user_from_service,
-        mocker):
+    app_,
+    service_one,
+    platform_admin_user,
+    active_user_with_permissions,
+    mock_remove_user_from_service,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(platform_admin_user, mocker, service_one)
@@ -347,12 +359,13 @@ def test_can_remove_user_from_service_as_platform_admin(
 
 
 def test_can_invite_user_as_platform_admin(
-        app_,
-        service_one,
-        platform_admin_user,
-        active_user_with_permissions,
-        mock_get_invites_for_service,
-        mocker):
+    app_,
+    service_one,
+    platform_admin_user,
+    active_user_with_permissions,
+    mock_get_invites_for_service,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -7,78 +7,73 @@ from notifications_utils.url_safe_token import generate_token
 
 def test_should_render_new_password_template(
     app_,
+    client,
     api_user_active,
     mock_login,
     mock_send_verify_code,
     mock_get_user_by_email_request_password_reset,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            data = json.dumps({'email': api_user_active.email_address, 'created_at': str(datetime.utcnow())})
-            token = generate_token(data, app_.config['SECRET_KEY'],
-                                   app_.config['DANGEROUS_SALT'])
-        response = client.get(url_for('.new_password', token=token))
-        assert response.status_code == 200
-        assert 'You can now create a new password for your account.' in response.get_data(as_text=True)
+    data = json.dumps({'email': api_user_active.email_address, 'created_at': str(datetime.utcnow())})
+    token = generate_token(data, app_.config['SECRET_KEY'],
+                           app_.config['DANGEROUS_SALT'])
+    response = client.get(url_for('.new_password', token=token))
+    assert response.status_code == 200
+    assert 'You can now create a new password for your account.' in response.get_data(as_text=True)
 
 
 def test_should_return_404_when_email_address_does_not_exist(
     app_,
+    client,
     mock_get_user_by_email_not_found,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            data = json.dumps({'email': 'no_user@d.gov.uk', 'created_at': str(datetime.utcnow())})
-            token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
-        response = client.get(url_for('.new_password', token=token))
-        assert response.status_code == 404
+    data = json.dumps({'email': 'no_user@d.gov.uk', 'created_at': str(datetime.utcnow())})
+    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    response = client.get(url_for('.new_password', token=token))
+    assert response.status_code == 404
 
 
 def test_should_redirect_to_two_factor_when_password_reset_is_successful(
     app_,
+    client,
     mock_get_user_by_email_request_password_reset,
     mock_login,
     mock_send_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            user = mock_get_user_by_email_request_password_reset.return_value
-            data = json.dumps({'email': user.email_address, 'created_at': str(datetime.utcnow())})
-            token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
-        response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
-        assert response.status_code == 302
-        assert response.location == url_for('.two_factor', _external=True)
-        mock_get_user_by_email_request_password_reset.assert_called_once_with(user.email_address)
+    user = mock_get_user_by_email_request_password_reset.return_value
+    data = json.dumps({'email': user.email_address, 'created_at': str(datetime.utcnow())})
+    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
+    assert response.status_code == 302
+    assert response.location == url_for('.two_factor', _external=True)
+    mock_get_user_by_email_request_password_reset.assert_called_once_with(user.email_address)
 
 
 def test_should_redirect_index_if_user_has_already_changed_password(
     app_,
+    client,
     mock_get_user_by_email_user_changed_password,
     mock_login,
     mock_send_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            user = mock_get_user_by_email_user_changed_password.return_value
-            data = json.dumps({'email': user.email_address, 'created_at': str(datetime.utcnow())})
-            token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
-        response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
-        assert response.status_code == 302
-        assert response.location == url_for('.index', _external=True)
-        mock_get_user_by_email_user_changed_password.assert_called_once_with(user.email_address)
+    user = mock_get_user_by_email_user_changed_password.return_value
+    data = json.dumps({'email': user.email_address, 'created_at': str(datetime.utcnow())})
+    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
+    assert response.status_code == 302
+    assert response.location == url_for('.index', _external=True)
+    mock_get_user_by_email_user_changed_password.assert_called_once_with(user.email_address)
 
 
 def test_should_redirect_to_forgot_password_with_flash_message_when_token_is_expired(
     app_,
+    client,
     mock_get_user_by_email_request_password_reset,
     mock_login,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            app_.config['TOKEN_MAX_AGE_SECONDS'] = -1000
-            user = mock_get_user_by_email_request_password_reset.return_value
-            token = generate_token(user.email_address, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
-        response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
-        assert response.status_code == 302
-        assert response.location == url_for('.forgot_password', _external=True)
-        app_.config['TOKEN_MAX_AGE_SECONDS'] = 3600
+    app_.config['TOKEN_MAX_AGE_SECONDS'] = -1000
+    user = mock_get_user_by_email_request_password_reset.return_value
+    token = generate_token(user.email_address, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
+    assert response.status_code == 302
+    assert response.location == url_for('.forgot_password', _external=True)
+    app_.config['TOKEN_MAX_AGE_SECONDS'] = 3600

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -5,11 +5,13 @@ from flask import url_for
 from notifications_utils.url_safe_token import generate_token
 
 
-def test_should_render_new_password_template(app_,
-                                             api_user_active,
-                                             mock_login,
-                                             mock_send_verify_code,
-                                             mock_get_user_by_email_request_password_reset):
+def test_should_render_new_password_template(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_send_verify_code,
+    mock_get_user_by_email_request_password_reset,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             data = json.dumps({'email': api_user_active.email_address, 'created_at': str(datetime.utcnow())})
@@ -20,7 +22,10 @@ def test_should_render_new_password_template(app_,
         assert 'You can now create a new password for your account.' in response.get_data(as_text=True)
 
 
-def test_should_return_404_when_email_address_does_not_exist(app_, mock_get_user_by_email_not_found):
+def test_should_return_404_when_email_address_does_not_exist(
+    app_,
+    mock_get_user_by_email_not_found,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             data = json.dumps({'email': 'no_user@d.gov.uk', 'created_at': str(datetime.utcnow())})
@@ -29,10 +34,12 @@ def test_should_return_404_when_email_address_does_not_exist(app_, mock_get_user
         assert response.status_code == 404
 
 
-def test_should_redirect_to_two_factor_when_password_reset_is_successful(app_,
-                                                                         mock_get_user_by_email_request_password_reset,
-                                                                         mock_login,
-                                                                         mock_send_verify_code):
+def test_should_redirect_to_two_factor_when_password_reset_is_successful(
+    app_,
+    mock_get_user_by_email_request_password_reset,
+    mock_login,
+    mock_send_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             user = mock_get_user_by_email_request_password_reset.return_value
@@ -44,10 +51,12 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(app_,
         mock_get_user_by_email_request_password_reset.assert_called_once_with(user.email_address)
 
 
-def test_should_redirect_index_if_user_has_already_changed_password(app_,
-                                                                    mock_get_user_by_email_user_changed_password,
-                                                                    mock_login,
-                                                                    mock_send_verify_code):
+def test_should_redirect_index_if_user_has_already_changed_password(
+    app_,
+    mock_get_user_by_email_user_changed_password,
+    mock_login,
+    mock_send_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             user = mock_get_user_by_email_user_changed_password.return_value
@@ -60,7 +69,9 @@ def test_should_redirect_index_if_user_has_already_changed_password(app_,
 
 
 def test_should_redirect_to_forgot_password_with_flash_message_when_token_is_expired(
-        app_, mock_get_user_by_email_request_password_reset, mock_login
+    app_,
+    mock_get_user_by_email_request_password_reset,
+    mock_login,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -11,28 +11,23 @@ from app.main.views.platform_admin import format_stats_by_service, create_global
 
 
 def test_should_redirect_if_not_logged_in(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            response = client.get(url_for('main.platform_admin'))
-            assert response.status_code == 302
-            assert url_for('main.index', _external=True) in response.location
+    response = client.get(url_for('main.platform_admin'))
+    assert response.status_code == 302
+    assert url_for('main.index', _external=True) in response.location
 
 
 def test_should_403_if_not_platform_admin(
-    app_,
+    client,
     active_user_with_permissions,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=active_user_with_permissions)
-            client.login(active_user_with_permissions)
+    mock_get_user(mocker, user=active_user_with_permissions)
+    client.login(active_user_with_permissions)
+    response = client.get(url_for('main.platform_admin'))
 
-            response = client.get(url_for('main.platform_admin'))
-
-            assert response.status_code == 403
+    assert response.status_code == 403
 
 
 @pytest.mark.parametrize('restricted, table_index, research_mode, displayed', [
@@ -46,7 +41,7 @@ def test_should_show_research_and_restricted_mode(
     table_index,
     research_mode,
     displayed,
-    app_,
+    client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
@@ -56,11 +51,9 @@ def test_should_show_research_and_restricted_mode(
     services[0]['statistics'] = create_stats()
 
     mock_get_detailed_services.return_value = {'data': services}
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=platform_admin_user)
-            client.login(platform_admin_user)
-            response = client.get(url_for('main.platform_admin'))
+    mock_get_user(mocker, user=platform_admin_user)
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.platform_admin'))
 
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True, 'include_from_test_key': True})
@@ -72,16 +65,14 @@ def test_should_show_research_and_restricted_mode(
 
 
 def test_should_render_platform_admin_page(
-    app_,
+    client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=platform_admin_user)
-            client.login(platform_admin_user)
-            response = client.get(url_for('main.platform_admin'))
+    mock_get_user(mocker, user=platform_admin_user)
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.platform_admin'))
 
     assert response.status_code == 200
     resp_data = response.get_data(as_text=True)
@@ -98,32 +89,28 @@ def test_should_render_platform_admin_page(
 def test_platform_admin_toggle_including_from_test_key(
     include_from_test_key,
     api_args,
-    app_,
+    client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=platform_admin_user)
-            client.login(platform_admin_user)
-            response = client.get(url_for('main.platform_admin', include_from_test_key=include_from_test_key))
+    mock_get_user(mocker, user=platform_admin_user)
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.platform_admin', include_from_test_key=include_from_test_key))
 
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with(api_args)
 
 
 def test_platform_admin_with_date_filter(
-    app_,
+    client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=platform_admin_user)
-            client.login(platform_admin_user)
-            response = client.get(url_for('main.platform_admin', start_date='2016-12-20', end_date='2016-12-28'))
+    mock_get_user(mocker, user=platform_admin_user)
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.platform_admin', start_date='2016-12-20', end_date='2016-12-28'))
 
     assert response.status_code == 200
     resp_data = response.get_data(as_text=True)
@@ -224,7 +211,7 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     restricted,
     table_index,
     research_mode,
-    app_,
+    client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
@@ -241,11 +228,9 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     )
 
     mock_get_detailed_services.return_value = {'data': services}
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mock_get_user(mocker, user=platform_admin_user)
-            client.login(platform_admin_user)
-            response = client.get(url_for('main.platform_admin'))
+    mock_get_user(mocker, user=platform_admin_user)
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.platform_admin'))
 
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True, 'include_from_test_key': True})

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -10,7 +10,9 @@ from tests import service_json
 from app.main.views.platform_admin import format_stats_by_service, create_global_stats
 
 
-def test_should_redirect_if_not_logged_in(app_):
+def test_should_redirect_if_not_logged_in(
+    app_
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             response = client.get(url_for('main.platform_admin'))
@@ -18,7 +20,11 @@ def test_should_redirect_if_not_logged_in(app_):
             assert url_for('main.index', _external=True) in response.location
 
 
-def test_should_403_if_not_platform_admin(app_, active_user_with_permissions, mocker):
+def test_should_403_if_not_platform_admin(
+    app_,
+    active_user_with_permissions,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             mock_get_user(mocker, user=active_user_with_permissions)
@@ -44,7 +50,7 @@ def test_should_show_research_and_restricted_mode(
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
-    fake_uuid
+    fake_uuid,
 ):
     services = [service_json(fake_uuid, 'My Service', [], restricted=restricted, research_mode=research_mode)]
     services[0]['statistics'] = create_stats()
@@ -95,7 +101,7 @@ def test_platform_admin_toggle_including_from_test_key(
     app_,
     platform_admin_user,
     mocker,
-    mock_get_detailed_services
+    mock_get_detailed_services,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -111,7 +117,7 @@ def test_platform_admin_with_date_filter(
     app_,
     platform_admin_user,
     mocker,
-    mock_get_detailed_services
+    mock_get_detailed_services,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -124,10 +130,12 @@ def test_platform_admin_with_date_filter(
     assert 'Platform admin' in resp_data
     assert 'Live services' in resp_data
     assert 'Trial mode services' in resp_data
-    mock_get_detailed_services.assert_called_once_with({'include_from_test_key': False,
-                                                        'start_date': datetime.date(2016, 12, 20),
-                                                        'end_date': datetime.date(2016, 12, 28),
-                                                        'detailed': True})
+    mock_get_detailed_services.assert_called_once_with({
+        'include_from_test_key': False,
+        'start_date': datetime.date(2016, 12, 20),
+        'end_date': datetime.date(2016, 12, 28),
+        'detailed': True,
+    })
 
 
 def test_create_global_stats_sets_failure_rates(fake_uuid):
@@ -220,7 +228,7 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
-    fake_uuid
+    fake_uuid,
 ):
     services = [service_json(fake_uuid, 'My Service', [], restricted=restricted, research_mode=research_mode)]
     services[0]['statistics'] = create_stats(
@@ -268,7 +276,7 @@ def test_should_show_archived_services_last(
     mocker,
     mock_get_detailed_services,
     restricted,
-    table_index
+    table_index,
 ):
     services = [
         service_json(name='C', restricted=restricted, active=False, created_at='2002-02-02 12:00:00'),
@@ -302,7 +310,7 @@ def test_shows_archived_label_instead_of_live_or_research_mode_label(
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
-    research_mode
+    research_mode,
 ):
     services = [
         service_json(restricted=False, research_mode=research_mode, active=False)
@@ -328,7 +336,7 @@ def test_should_show_correct_sent_totals_for_platform_admin(
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
-    fake_uuid
+    fake_uuid,
 ):
     services = [service_json(fake_uuid, 'My Service', [])]
     services[0]['statistics'] = create_stats(

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -63,9 +63,9 @@ stub_provider = {
 
 
 def test_should_show_all_providers(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
     mock_providers = mocker.patch(
         'app.provider_client.get_all_providers',
@@ -130,9 +130,9 @@ def test_should_show_all_providers(
 
 
 def test_should_show_provider_detail(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
     mock_providers = mocker.patch(
         'app.provider_client.get_provider_by_id',
@@ -158,9 +158,9 @@ def test_should_show_provider_detail(
 
 
 def test_should_show_error_on_bad_provider_priority(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
     mock_providers = mocker.patch(
         'app.provider_client.get_provider_by_id',
@@ -180,9 +180,9 @@ def test_should_show_error_on_bad_provider_priority(
 
 
 def test_should_show_error_on_negative_provider_priority(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
     mock_providers = mocker.patch(
         'app.provider_client.get_provider_by_id',
@@ -202,9 +202,9 @@ def test_should_show_error_on_negative_provider_priority(
 
 
 def test_should_show_error_on_too_big_provider_priority(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
     mock_providers = mocker.patch(
         'app.provider_client.get_provider_by_id',
@@ -224,9 +224,9 @@ def test_should_show_error_on_too_big_provider_priority(
 
 
 def test_should_show_error_on_too_little_provider_priority(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
     mock_providers = mocker.patch(
         'app.provider_client.get_provider_by_id',
@@ -246,9 +246,9 @@ def test_should_show_error_on_too_little_provider_priority(
 
 
 def test_should_update_provider_priority(
-        app_,
-        platform_admin_user,
-        mocker
+    app_,
+    platform_admin_user,
+    mocker,
 ):
 
     mock_providers = mocker.patch(

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -63,7 +63,7 @@ stub_provider = {
 
 
 def test_should_show_all_providers(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -72,65 +72,63 @@ def test_should_show_all_providers(
         return_value=copy.deepcopy(stub_providers)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.get(url_for('main.view_providers'))
+    client.login(platform_admin_user, mocker)
+    response = client.get(url_for('main.view_providers'))
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-            h1 = [header.text.strip() for header in page.find_all('h1')]
+    h1 = [header.text.strip() for header in page.find_all('h1')]
 
-            assert 'Providers' in h1
+    assert 'Providers' in h1
 
-            h2 = [header.text.strip() for header in page.find_all('h2')]
+    h2 = [header.text.strip() for header in page.find_all('h2')]
 
-            assert 'Email' in h2
-            assert 'SMS' in h2
+    assert 'Email' in h2
+    assert 'SMS' in h2
 
-            tables = page.find_all('table')
-            assert len(tables) == 2
+    tables = page.find_all('table')
+    assert len(tables) == 2
 
-            sms_table = tables[0]
-            email_table = tables[1]
+    sms_table = tables[0]
+    email_table = tables[1]
 
-            sms_first_row = sms_table.tbody.find_all('tr')[0]
-            table_data = sms_first_row.find_all('td')
+    sms_first_row = sms_table.tbody.find_all('tr')[0]
+    table_data = sms_first_row.find_all('td')
 
-            assert table_data[0].text.strip() == "first_sms_provider"
-            assert table_data[1].text.strip() == "1"
-            assert table_data[2].text.strip() == "True"
-            assert table_data[3].text.strip() == "16 January at 3:20pm"
-            assert table_data[4].find_all("a")[0]['href'] == '/provider/6005e192-4738-4962-beec-ebd982d0b03f'
+    assert table_data[0].text.strip() == "first_sms_provider"
+    assert table_data[1].text.strip() == "1"
+    assert table_data[2].text.strip() == "True"
+    assert table_data[3].text.strip() == "16 January at 3:20pm"
+    assert table_data[4].find_all("a")[0]['href'] == '/provider/6005e192-4738-4962-beec-ebd982d0b03f'
 
-            sms_second_row = sms_table.tbody.find_all('tr')[1]
-            table_data = sms_second_row.find_all('td')
+    sms_second_row = sms_table.tbody.find_all('tr')[1]
+    table_data = sms_second_row.find_all('td')
 
-            assert table_data[0].text.strip() == "second_sms_provider"
-            assert table_data[1].text.strip() == "2"
-            assert table_data[2].text.strip() == "True"
-            assert table_data[3].text.strip() == "None"
-            assert table_data[4].find_all("a")[0]['href'] == '/provider/0bd529cd-a0fd-43e5-80ee-b95ef6b0d51f'
+    assert table_data[0].text.strip() == "second_sms_provider"
+    assert table_data[1].text.strip() == "2"
+    assert table_data[2].text.strip() == "True"
+    assert table_data[3].text.strip() == "None"
+    assert table_data[4].find_all("a")[0]['href'] == '/provider/0bd529cd-a0fd-43e5-80ee-b95ef6b0d51f'
 
-            email_first_row = email_table.tbody.find_all('tr')[0]
-            email_table_data = email_first_row.find_all('td')
+    email_first_row = email_table.tbody.find_all('tr')[0]
+    email_table_data = email_first_row.find_all('td')
 
-            assert email_table_data[0].text.strip() == "first_email_provider"
-            assert email_table_data[1].text.strip() == "1"
-            assert email_table_data[2].text.strip() == "True"
-            assert email_table_data[3].find_all("a")[0]['href'] == '/provider/6005e192-4738-4962-beec-ebd982d0b03a'
+    assert email_table_data[0].text.strip() == "first_email_provider"
+    assert email_table_data[1].text.strip() == "1"
+    assert email_table_data[2].text.strip() == "True"
+    assert email_table_data[3].find_all("a")[0]['href'] == '/provider/6005e192-4738-4962-beec-ebd982d0b03a'
 
-            email_second_row = email_table.tbody.find_all('tr')[1]
-            email_table_data = email_second_row.find_all('td')
+    email_second_row = email_table.tbody.find_all('tr')[1]
+    email_table_data = email_second_row.find_all('td')
 
-            assert email_table_data[0].text.strip() == "second_email_provider"
-            assert email_table_data[1].text.strip() == "2"
-            assert email_table_data[2].text.strip() == "True"
-            assert email_table_data[3].find_all("a")[0]['href'] == '/provider/0bd529cd-a0fd-43e5-80ee-b95ef6b0d51b'
+    assert email_table_data[0].text.strip() == "second_email_provider"
+    assert email_table_data[1].text.strip() == "2"
+    assert email_table_data[2].text.strip() == "True"
+    assert email_table_data[3].find_all("a")[0]['href'] == '/provider/0bd529cd-a0fd-43e5-80ee-b95ef6b0d51b'
 
 
 def test_should_show_provider_detail(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -139,26 +137,24 @@ def test_should_show_provider_detail(
         return_value=copy.deepcopy(stub_provider)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.get(url_for('main.view_provider', provider_id='12345'))
+    client.login(platform_admin_user, mocker)
+    response = client.get(url_for('main.view_provider', provider_id='12345'))
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-            h1 = [header.text.strip() for header in page.find_all('h1')]
+    h1 = [header.text.strip() for header in page.find_all('h1')]
 
-            assert 'first_sms_provider' in h1
+    assert 'first_sms_provider' in h1
 
-            form = [form for form in page.find_all('form')]
+    form = [form for form in page.find_all('form')]
 
-            form_elements = [element for element in form[0].find_all('input')]
-            assert form_elements[0]['value'] == '1'
-            assert form_elements[0]['name'] == 'priority'
+    form_elements = [element for element in form[0].find_all('input')]
+    assert form_elements[0]['value'] == '1'
+    assert form_elements[0]['name'] == 'priority'
 
 
 def test_should_show_error_on_bad_provider_priority(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -167,20 +163,18 @@ def test_should_show_error_on_bad_provider_priority(
         return_value=copy.deepcopy(stub_provider)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.post(
-                url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
-                data={'priority': "not valid"})
+    client.login(platform_admin_user, mocker)
+    response = client.post(
+        url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
+        data={'priority': "not valid"})
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert response.status_code == 200
-        assert "Not a valid integer value" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert response.status_code == 200
+    assert "Not a valid integer value" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
 
 
 def test_should_show_error_on_negative_provider_priority(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -189,20 +183,18 @@ def test_should_show_error_on_negative_provider_priority(
         return_value=copy.deepcopy(stub_provider)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.post(
-                url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
-                data={'priority': -1})
+    client.login(platform_admin_user, mocker)
+    response = client.post(
+        url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
+        data={'priority': -1})
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert response.status_code == 200
-        assert "Must be between 1 and 100" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert response.status_code == 200
+    assert "Must be between 1 and 100" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
 
 
 def test_should_show_error_on_too_big_provider_priority(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -211,20 +203,18 @@ def test_should_show_error_on_too_big_provider_priority(
         return_value=copy.deepcopy(stub_provider)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.post(
-                url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
-                data={'priority': 101})
+    client.login(platform_admin_user, mocker)
+    response = client.post(
+        url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
+        data={'priority': 101})
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert response.status_code == 200
-        assert "Must be between 1 and 100" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert response.status_code == 200
+    assert "Must be between 1 and 100" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
 
 
 def test_should_show_error_on_too_little_provider_priority(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -233,20 +223,18 @@ def test_should_show_error_on_too_little_provider_priority(
         return_value=copy.deepcopy(stub_provider)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.post(
-                url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
-                data={'priority': 0})
+    client.login(platform_admin_user, mocker)
+    response = client.post(
+        url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
+        data={'priority': 0})
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert response.status_code == 200
-        assert "Must be between 1 and 100" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert response.status_code == 200
+    assert "Must be between 1 and 100" in str(page.find_all("span", {"class": re.compile(r"error-message")})[0])
 
 
 def test_should_update_provider_priority(
-    app_,
+    client,
     platform_admin_user,
     mocker,
 ):
@@ -261,13 +249,11 @@ def test_should_update_provider_priority(
         return_value=copy.deepcopy(stub_provider)
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker)
-            response = client.post(
-                url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
-                data={'priority': 2})
+    client.login(platform_admin_user, mocker)
+    response = client.post(
+        url_for('main.view_provider', provider_id=stub_provider['provider_details']['id']),
+        data={'priority': 2})
 
-        app.provider_client.update_provider.assert_called_with(stub_provider['provider_details']['id'], 2)
-        assert response.status_code == 302
-        assert response.location == 'http://localhost/providers'
+    app.provider_client.update_provider.assert_called_with(stub_provider['provider_details']['id'], 2)
+    assert response.status_code == 302
+    assert response.location == 'http://localhost/providers'

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -15,17 +15,16 @@ def test_render_register_returns_template_with_form(client):
 
 
 def test_logged_in_user_redirects_to_choose_service(
-    client,
+    logged_in_client,
     api_user_active,
     mock_get_user_by_email,
     mock_send_verify_code,
     mock_login,
 ):
-    client.login(api_user_active)
-    response = client.get(url_for('main.register'))
+    response = logged_in_client.get(url_for('main.register'))
     assert response.status_code == 302
 
-    response = client.get(url_for('main.sign_in', follow_redirects=True))
+    response = logged_in_client.get(url_for('main.sign_in', follow_redirects=True))
     assert response.location == url_for('main.choose_service', _external=True)
 
 

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -14,11 +14,13 @@ def test_render_register_returns_template_with_form(client):
     assert 'Create an account' in response.get_data(as_text=True)
 
 
-def test_logged_in_user_redirects_to_choose_service(client,
-                                                    api_user_active,
-                                                    mock_get_user_by_email,
-                                                    mock_send_verify_code,
-                                                    mock_login):
+def test_logged_in_user_redirects_to_choose_service(
+    client,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_send_verify_code,
+    mock_login,
+):
     client.login(api_user_active)
     response = client.get(url_for('main.register'))
     assert response.status_code == 302
@@ -27,13 +29,15 @@ def test_logged_in_user_redirects_to_choose_service(client,
     assert response.location == url_for('main.choose_service', _external=True)
 
 
-def test_register_creates_new_user_and_redirects_to_continue_page(client,
-                                                                  mock_send_verify_code,
-                                                                  mock_register_user,
-                                                                  mock_get_user_by_email_not_found,
-                                                                  mock_is_email_unique,
-                                                                  mock_send_verify_email,
-                                                                  mock_login):
+def test_register_creates_new_user_and_redirects_to_continue_page(
+    client,
+    mock_send_verify_code,
+    mock_register_user,
+    mock_get_user_by_email_not_found,
+    mock_is_email_unique,
+    mock_send_verify_email,
+    mock_login,
+):
     user_data = {'name': 'Some One Valid',
                  'email_address': 'notfound@example.gov.uk',
                  'mobile_number': '+4407700900460',
@@ -52,10 +56,12 @@ def test_register_creates_new_user_and_redirects_to_continue_page(client,
                                           user_data['password'])
 
 
-def test_process_register_returns_200_when_mobile_number_is_invalid(client,
-                                                                    mock_send_verify_code,
-                                                                    mock_get_user_by_email_not_found,
-                                                                    mock_login):
+def test_process_register_returns_200_when_mobile_number_is_invalid(
+    client,
+    mock_send_verify_code,
+    mock_get_user_by_email_not_found,
+    mock_login,
+):
     response = client.post(url_for('main.register'),
                            data={'name': 'Bad Mobile',
                                  'email_address': 'bad_mobile@example.gov.uk',
@@ -66,10 +72,12 @@ def test_process_register_returns_200_when_mobile_number_is_invalid(client,
     assert 'Must not contain letters or symbols' in response.get_data(as_text=True)
 
 
-def test_should_return_200_when_email_is_not_gov_uk(client,
-                                                    mock_send_verify_code,
-                                                    mock_get_user_by_email,
-                                                    mock_login):
+def test_should_return_200_when_email_is_not_gov_uk(
+    client,
+    mock_send_verify_code,
+    mock_get_user_by_email,
+    mock_login,
+):
     response = client.post(url_for('main.register'),
                            data={'name': 'Bad Mobile',
                                  'email_address': 'bad_mobile@example.not.right',
@@ -80,14 +88,16 @@ def test_should_return_200_when_email_is_not_gov_uk(client,
     assert 'Enter a central government email address' in response.get_data(as_text=True)
 
 
-def test_should_add_user_details_to_session(client,
-                                            mock_send_verify_code,
-                                            mock_register_user,
-                                            mock_get_user,
-                                            mock_get_user_by_email_not_found,
-                                            mock_is_email_unique,
-                                            mock_send_verify_email,
-                                            mock_login):
+def test_should_add_user_details_to_session(
+    client,
+    mock_send_verify_code,
+    mock_register_user,
+    mock_get_user,
+    mock_get_user_by_email_not_found,
+    mock_is_email_unique,
+    mock_send_verify_email,
+    mock_login,
+):
     user_data = {
         'name': 'Test Codes',
         'email_address': 'notfound@example.gov.uk',
@@ -101,9 +111,11 @@ def test_should_add_user_details_to_session(client,
     assert session['user_details']['email'] == user_data['email_address']
 
 
-def test_should_return_200_if_password_is_blacklisted(client,
-                                                      mock_get_user_by_email,
-                                                      mock_login):
+def test_should_return_200_if_password_is_blacklisted(
+    client,
+    mock_get_user_by_email,
+    mock_login,
+):
     response = client.post(url_for('main.register'),
                            data={'name': 'Bad Mobile',
                                  'email_address': 'bad_mobile@example.not.right',
@@ -114,10 +126,12 @@ def test_should_return_200_if_password_is_blacklisted(client,
     assert 'Choose a password that’s harder to guess' in response.get_data(as_text=True)
 
 
-def test_register_with_existing_email_sends_emails(client,
-                                                   api_user_active,
-                                                   mock_get_user_by_email,
-                                                   mock_send_already_registered_email):
+def test_register_with_existing_email_sends_emails(
+    client,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_send_already_registered_email,
+):
     user_data = {
         'name': 'Already Hasaccount',
         'email_address': api_user_active.email_address,
@@ -131,12 +145,14 @@ def test_register_with_existing_email_sends_emails(client,
     assert response.location == url_for('main.registration_continue', _external=True)
 
 
-def test_register_from_invite_(client,
-                               fake_uuid,
-                               mock_is_email_unique,
-                               mock_register_user,
-                               mock_send_verify_code,
-                               mock_accept_invite):
+def test_register_from_invite_(
+    client,
+    fake_uuid,
+    mock_is_email_unique,
+    mock_register_user,
+    mock_send_verify_code,
+    mock_accept_invite,
+):
     invited_user = InvitedUser(fake_uuid, fake_uuid, "",
                                "invited@user.com",
                                ["manage_users"],
@@ -154,11 +170,13 @@ def test_register_from_invite_(client,
     assert response.location == url_for('main.verify', _external=True)
 
 
-def test_register_from_invite_when_user_registers_in_another_browser(client,
-                                                                     api_user_active,
-                                                                     mock_is_email_not_unique,
-                                                                     mock_get_user_by_email,
-                                                                     mock_accept_invite):
+def test_register_from_invite_when_user_registers_in_another_browser(
+    client,
+    api_user_active,
+    mock_is_email_not_unique,
+    mock_get_user_by_email,
+    mock_accept_invite,
+):
     invited_user = InvitedUser(api_user_active.id, api_user_active.id, "",
                                api_user_active.email_address,
                                ["manage_users"],

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -39,7 +39,7 @@ def test_that_test_files_exist():
 def test_upload_files_in_different_formats(
     filename,
     acceptable_file,
-    app_,
+    logged_in_client,
     api_user_active,
     mocker,
     mock_login,
@@ -50,9 +50,8 @@ def test_upload_files_in_different_formats(
     fake_uuid,
 ):
 
-    with app_.test_request_context(), app_.test_client() as client, open(filename, 'rb') as uploaded:
-        client.login(api_user_active)
-        response = client.post(
+    with open(filename, 'rb') as uploaded:
+        response = logged_in_client.post(
             url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
             data={'file': (BytesIO(uploaded.read()), filename)},
             content_type='multipart/form-data'
@@ -73,7 +72,7 @@ def test_upload_files_in_different_formats(
 
 
 def test_upload_csvfile_with_errors_shows_check_page_with_errors(
-    app_,
+    logged_in_client,
     api_user_active,
     mocker,
     mock_login,
@@ -95,32 +94,29 @@ def test_upload_csvfile_with_errors_shows_check_page_with_errors(
         """
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            initial_upload = client.post(
-                url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
-                data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
-                content_type='multipart/form-data',
-                follow_redirects=True
-            )
-            reupload = client.post(
-                url_for('main.check_messages', service_id=fake_uuid, template_type='sms', upload_id='abc123'),
-                data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
-                content_type='multipart/form-data',
-                follow_redirects=True
-            )
-        for response in [initial_upload, reupload]:
-            assert response.status_code == 200
-            content = response.get_data(as_text=True)
-            assert 'There is a problem with your data' in content
-            assert '+447700900986' in content
-            assert 'Missing' in content
-            assert 'Re-upload your file' in content
+    initial_upload = logged_in_client.post(
+        url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
+        data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
+        content_type='multipart/form-data',
+        follow_redirects=True
+    )
+    reupload = logged_in_client.post(
+        url_for('main.check_messages', service_id=fake_uuid, template_type='sms', upload_id='abc123'),
+        data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
+        content_type='multipart/form-data',
+        follow_redirects=True
+    )
+    for response in [initial_upload, reupload]:
+        assert response.status_code == 200
+        content = response.get_data(as_text=True)
+        assert 'There is a problem with your data' in content
+        assert '+447700900986' in content
+        assert 'Missing' in content
+        assert 'Re-upload your file' in content
 
 
 def test_upload_csv_invalid_extension(
-    app_,
+    logged_in_client,
     api_user_active,
     mocker,
     mock_login,
@@ -133,22 +129,19 @@ def test_upload_csv_invalid_extension(
     fake_uuid,
 ):
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            resp = client.post(
-                url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
-                data={'file': (BytesIO('contents'.encode('utf-8')), 'invalid.txt')},
-                content_type='multipart/form-data',
-                follow_redirects=True
-            )
+    resp = logged_in_client.post(
+        url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
+        data={'file': (BytesIO('contents'.encode('utf-8')), 'invalid.txt')},
+        content_type='multipart/form-data',
+        follow_redirects=True
+    )
 
-        assert resp.status_code == 200
-        assert "invalid.txt isn’t a spreadsheet that Notify can read" in resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert "invalid.txt isn’t a spreadsheet that Notify can read" in resp.get_data(as_text=True)
 
 
 def test_send_test_sms_message(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -164,19 +157,16 @@ def test_send_test_sms_message(
     expected_data = {'data': 'phone number\r\n07700 900 762\r\n', 'file_name': 'Test message'}
     mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(
-                url_for('main.send_test', service_id=fake_uuid, template_id=fake_uuid),
-                follow_redirects=True
-            )
-        assert response.status_code == 200
-        mock_s3_upload.assert_called_with(fake_uuid, expected_data, 'eu-west-1')
+    response = logged_in_client.get(
+        url_for('main.send_test', service_id=fake_uuid, template_id=fake_uuid),
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    mock_s3_upload.assert_called_with(fake_uuid, expected_data, 'eu-west-1')
 
 
 def test_send_test_email_message(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -192,19 +182,16 @@ def test_send_test_email_message(
     expected_data = {'data': 'email address\r\ntest@user.gov.uk\r\n', 'file_name': 'Test message'}
     mocker.patch('app.main.views.send.s3download', return_value='email address\r\ntest@user.gov.uk')
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(
-                url_for('main.send_test', service_id=fake_uuid, template_id=fake_uuid),
-                follow_redirects=True
-            )
-        assert response.status_code == 200
-        mock_s3_upload.assert_called_with(fake_uuid, expected_data, 'eu-west-1')
+    response = logged_in_client.get(
+        url_for('main.send_test', service_id=fake_uuid, template_id=fake_uuid),
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    mock_s3_upload.assert_called_with(fake_uuid, expected_data, 'eu-west-1')
 
 
 def test_send_test_sms_message_with_placeholders(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -223,24 +210,21 @@ def test_send_test_sms_message_with_placeholders(
     }
     mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.post(
-                url_for(
-                    'main.send_test',
-                    service_id=fake_uuid,
-                    template_id=fake_uuid
-                ),
-                data={'name': 'Jo'},
-                follow_redirects=True
-            )
-        assert response.status_code == 200
-        mock_s3_upload.assert_called_with(fake_uuid, expected_data, 'eu-west-1')
+    response = logged_in_client.post(
+        url_for(
+            'main.send_test',
+            service_id=fake_uuid,
+            template_id=fake_uuid
+        ),
+        data={'name': 'Jo'},
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    mock_s3_upload.assert_called_with(fake_uuid, expected_data, 'eu-west-1')
 
 
 def test_api_info_page(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -250,19 +234,16 @@ def test_api_info_page(
     mock_has_permissions,
     fake_uuid
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(
-                url_for('main.send_from_api', service_id=fake_uuid, template_id=fake_uuid),
-                follow_redirects=True
-            )
-        assert response.status_code == 200
-        assert 'API info' in response.get_data(as_text=True)
+    response = logged_in_client.get(
+        url_for('main.send_from_api', service_id=fake_uuid, template_id=fake_uuid),
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert 'API info' in response.get_data(as_text=True)
 
 
 def test_download_example_csv(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -272,20 +253,17 @@ def test_download_example_csv(
     fake_uuid
 ):
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(
-                url_for('main.get_example_csv', service_id=fake_uuid, template_id=fake_uuid),
-                follow_redirects=True
-            )
-        assert response.status_code == 200
-        assert response.get_data(as_text=True) == 'phone number\r\n07700 900321\r\n'
-        assert 'text/csv' in response.headers['Content-Type']
+    response = logged_in_client.get(
+        url_for('main.get_example_csv', service_id=fake_uuid, template_id=fake_uuid),
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == 'phone number\r\n07700 900321\r\n'
+    assert 'text/csv' in response.headers['Content-Type']
 
 
 def test_upload_csvfile_with_valid_phone_shows_all_numbers(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -305,32 +283,29 @@ def test_upload_csvfile_with_valid_phone_shows_all_numbers(
         ])
     )
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.post(
-                url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
-                data={'file': (BytesIO(''.encode('utf-8')), 'valid.csv')},
-                content_type='multipart/form-data',
-                follow_redirects=True
-            )
-            with client.session_transaction() as sess:
-                assert sess['upload_data']['template_id'] == fake_uuid
-                assert sess['upload_data']['original_file_name'] == 'valid.csv'
-                assert sess['upload_data']['notification_count'] == 53
+    response = logged_in_client.post(
+        url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
+        data={'file': (BytesIO(''.encode('utf-8')), 'valid.csv')},
+        content_type='multipart/form-data',
+        follow_redirects=True
+    )
+    with logged_in_client.session_transaction() as sess:
+        assert sess['upload_data']['template_id'] == fake_uuid
+        assert sess['upload_data']['original_file_name'] == 'valid.csv'
+        assert sess['upload_data']['notification_count'] == 53
 
-            content = response.get_data(as_text=True)
-            assert response.status_code == 200
-            assert '07700 900701' in content
-            assert '07700 900749' in content
-            assert '07700 900750' not in content
-            assert 'Only showing the first 50 rows' in content
+    content = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert '07700 900701' in content
+    assert '07700 900749' in content
+    assert '07700 900750' not in content
+    assert 'Only showing the first 50 rows' in content
 
-            mock_get_detailed_service_for_today.assert_called_once_with(fake_uuid)
+    mock_get_detailed_service_for_today.assert_called_once_with(fake_uuid)
 
 
 def test_test_message_can_only_be_sent_now(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -343,25 +318,23 @@ def test_test_message_can_only_be_sent_now(
     fake_uuid
 ):
 
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['upload_data'] = {
-                'original_file_name': 'Test message',
-                'template_id': fake_uuid,
-                'notification_count': 1,
-                'valid': True
-            }
-        response = client.get(url_for(
-            'main.check_messages',
-            service_id=fake_uuid,
-            upload_id=fake_uuid,
-            template_type='sms',
-            from_test=True
-        ))
+    with logged_in_client.session_transaction() as session:
+        session['upload_data'] = {
+            'original_file_name': 'Test message',
+            'template_id': fake_uuid,
+            'notification_count': 1,
+            'valid': True
+        }
+    response = logged_in_client.get(url_for(
+        'main.check_messages',
+        service_id=fake_uuid,
+        upload_id=fake_uuid,
+        template_type='sms',
+        from_test=True
+    ))
 
-        content = response.get_data(as_text=True)
-        assert 'name="scheduled_for"' not in content
+    content = response.get_data(as_text=True)
+    assert 'name="scheduled_for"' not in content
 
 
 @pytest.mark.parametrize(
@@ -370,7 +343,7 @@ def test_test_message_can_only_be_sent_now(
     ]
 )
 def test_create_job_should_call_api(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_create_job,
@@ -387,17 +360,15 @@ def test_create_job_should_call_api(
     original_file_name = data['original_file_name']
     template_id = data['template']
     notification_count = data['notification_count']
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        with client.session_transaction() as session:
-            session['upload_data'] = {
-                'original_file_name': original_file_name,
-                'template_id': template_id,
-                'notification_count': notification_count,
-                'valid': True
-            }
-        url = url_for('main.start_job', service_id=service_one['id'], upload_id=job_id)
-        response = client.post(url, data={'scheduled_for': when}, follow_redirects=True)
+    with logged_in_client.session_transaction() as session:
+        session['upload_data'] = {
+            'original_file_name': original_file_name,
+            'template_id': template_id,
+            'notification_count': notification_count,
+            'valid': True
+        }
+    url = url_for('main.start_job', service_id=service_one['id'], upload_id=job_id)
+    response = logged_in_client.post(url, data={'scheduled_for': when}, follow_redirects=True)
 
     assert response.status_code == 200
     assert original_file_name in response.get_data(as_text=True)
@@ -480,7 +451,7 @@ def test_should_show_preview_letter_message(
 
 
 def test_check_messages_should_revalidate_file_when_uploading_file(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_create_job,
@@ -505,22 +476,19 @@ def test_check_messages_should_revalidate_file_when_uploading_file(
         """
     )
     data = mock_get_job(service_one['id'], fake_uuid)['data']
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            with client.session_transaction() as session:
-                session['upload_data'] = {'original_file_name': 'invalid.csv',
-                                          'template_id': data['template'],
-                                          'notification_count': data['notification_count'],
-                                          'valid': True}
-            response = client.post(
-                url_for('main.start_job', service_id=service_id, upload_id=data['id']),
-                data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
-                content_type='multipart/form-data',
-                follow_redirects=True
-            )
-            assert response.status_code == 200
-            assert 'There is a problem with your data' in response.get_data(as_text=True)
+    with logged_in_client.session_transaction() as session:
+        session['upload_data'] = {'original_file_name': 'invalid.csv',
+                                  'template_id': data['template'],
+                                  'notification_count': data['notification_count'],
+                                  'valid': True}
+    response = logged_in_client.post(
+        url_for('main.start_job', service_id=service_id, upload_id=data['id']),
+        data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
+        content_type='multipart/form-data',
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert 'There is a problem with your data' in response.get_data(as_text=True)
 
 
 @pytest.mark.parametrize('route, response_code', [
@@ -532,6 +500,7 @@ def test_check_messages_should_revalidate_file_when_uploading_file(
 def test_route_permissions(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_get_service_template,
@@ -544,20 +513,19 @@ def test_route_permissions(
     route,
     response_code,
 ):
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            response_code,
-            url_for(
-                route,
-                service_id=service_one['id'],
-                template_type='sms',
-                template_id=fake_uuid),
-            ['send_texts', 'send_emails', 'send_letters'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        response_code,
+        url_for(
+            route,
+            service_id=service_one['id'],
+            template_type='sms',
+            template_id=fake_uuid),
+        ['send_texts', 'send_emails', 'send_letters'],
+        api_user_active,
+        service_one)
 
 
 @pytest.mark.parametrize('route', [
@@ -569,6 +537,7 @@ def test_route_permissions(
 def test_route_invalid_permissions(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_get_service_template,
@@ -579,25 +548,25 @@ def test_route_invalid_permissions(
     fake_uuid,
     route,
 ):
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            403,
-            url_for(
-                route,
-                service_id=service_one['id'],
-                template_type='sms',
-                template_id=fake_uuid),
-            ['blah'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        403,
+        url_for(
+            route,
+            service_id=service_one['id'],
+            template_type='sms',
+            template_id=fake_uuid),
+        ['blah'],
+        api_user_active,
+        service_one)
 
 
 def test_route_choose_template_manage_service_permissions(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_login,
@@ -607,38 +576,38 @@ def test_route_choose_template_manage_service_permissions(
     mock_get_service_templates,
     mock_get_jobs,
 ):
-    with app_.test_request_context():
-        template_id = mock_get_service_templates(service_one['id'])['data'][0]['id']
-        resp = validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            200,
-            url_for(
-                'main.choose_template',
-                service_id=service_one['id'],
-                template_type='sms'),
-            ['manage_users', 'manage_templates', 'manage_settings'],
-            api_user_active,
-            service_one)
-        page = resp.get_data(as_text=True)
-        assert url_for(
-            "main.send_messages",
+    template_id = mock_get_service_templates(service_one['id'])['data'][0]['id']
+    resp = validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        200,
+        url_for(
+            'main.choose_template',
             service_id=service_one['id'],
-            template_id=template_id) not in page
-        assert url_for(
-            "main.send_test",
-            service_id=service_one['id'],
-            template_id=template_id) not in page
-        assert url_for(
-            "main.edit_service_template",
-            service_id=service_one['id'],
-            template_id=template_id) in page
+            template_type='sms'),
+        ['manage_users', 'manage_templates', 'manage_settings'],
+        api_user_active,
+        service_one)
+    page = resp.get_data(as_text=True)
+    assert url_for(
+        "main.send_messages",
+        service_id=service_one['id'],
+        template_id=template_id) not in page
+    assert url_for(
+        "main.send_test",
+        service_id=service_one['id'],
+        template_id=template_id) not in page
+    assert url_for(
+        "main.edit_service_template",
+        service_id=service_one['id'],
+        template_id=template_id) in page
 
 
 def test_route_choose_template_send_messages_permissions(
     mocker,
     app_,
+    client,
     active_user_with_permissions,
     service_one,
     mock_get_service,
@@ -646,38 +615,38 @@ def test_route_choose_template_send_messages_permissions(
     mock_get_service_templates,
     mock_get_jobs,
 ):
-    with app_.test_request_context():
-        template_id = None
-        for temp in mock_get_service_templates(service_one['id'])['data']:
-            if temp['template_type'] == 'sms':
-                template_id = temp['id']
-        assert template_id
-        resp = validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            200,
-            url_for(
-                'main.choose_template',
-                service_id=service_one['id'],
-                template_type='sms'),
-            ['send_texts', 'send_emails', 'send_letters'],
-            active_user_with_permissions,
-            service_one)
-        page = resp.get_data(as_text=True)
-        assert url_for(
-            "main.send_messages",
+    template_id = None
+    for temp in mock_get_service_templates(service_one['id'])['data']:
+        if temp['template_type'] == 'sms':
+            template_id = temp['id']
+    assert template_id
+    resp = validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        200,
+        url_for(
+            'main.choose_template',
             service_id=service_one['id'],
-            template_id=template_id) in page
-        assert url_for(
-            "main.edit_service_template",
-            service_id=service_one['id'],
-            template_id=template_id) not in page
+            template_type='sms'),
+        ['send_texts', 'send_emails', 'send_letters'],
+        active_user_with_permissions,
+        service_one)
+    page = resp.get_data(as_text=True)
+    assert url_for(
+        "main.send_messages",
+        service_id=service_one['id'],
+        template_id=template_id) in page
+    assert url_for(
+        "main.edit_service_template",
+        service_id=service_one['id'],
+        template_id=template_id) not in page
 
 
 def test_route_choose_template_manage_api_keys_permissions(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_get_user,
@@ -686,39 +655,38 @@ def test_route_choose_template_manage_api_keys_permissions(
     mock_get_service_templates,
     mock_get_jobs,
 ):
-    with app_.test_request_context():
-        template_id = None
-        for temp in mock_get_service_templates(service_one['id'])['data']:
-            if temp['template_type'] == 'sms':
-                template_id = temp['id']
-        assert template_id
-        resp = validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            200,
-            url_for(
-                'main.choose_template',
-                service_id=service_one['id'],
-                template_type='sms'),
-            ['manage_api_keys'],
-            api_user_active,
-            service_one)
-        page = resp.get_data(as_text=True)
-        assert url_for(
-            "main.send_test",
+    template_id = None
+    for temp in mock_get_service_templates(service_one['id'])['data']:
+        if temp['template_type'] == 'sms':
+            template_id = temp['id']
+    assert template_id
+    resp = validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        200,
+        url_for(
+            'main.choose_template',
             service_id=service_one['id'],
-            template_id=template_id) not in page
-        assert url_for(
-            "main.edit_service_template",
-            service_id=service_one['id'],
-            template_id=template_id) not in page
-        page = BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
-        links = page.findAll('a', href=re.compile('^' + url_for(
-            "main.send_from_api",
-            service_id=service_one['id'],
-            template_id=template_id)))
-        assert len(links) == 1
+            template_type='sms'),
+        ['manage_api_keys'],
+        api_user_active,
+        service_one)
+    page = resp.get_data(as_text=True)
+    assert url_for(
+        "main.send_test",
+        service_id=service_one['id'],
+        template_id=template_id) not in page
+    assert url_for(
+        "main.edit_service_template",
+        service_id=service_one['id'],
+        template_id=template_id) not in page
+    page = BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
+    links = page.findAll('a', href=re.compile('^' + url_for(
+        "main.send_from_api",
+        service_id=service_one['id'],
+        template_id=template_id)))
+    assert len(links) == 1
 
 
 @pytest.mark.parametrize(
@@ -739,7 +707,7 @@ def test_route_choose_template_manage_api_keys_permissions(
     ]
 )
 def test_check_messages_back_link(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user_by_email,
@@ -753,30 +721,28 @@ def test_check_messages_back_link(
     extra_args,
     expected_url
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['upload_data'] = {'original_file_name': 'valid.csv',
-                                      'template_id': fake_uuid,
-                                      'notification_count': 1,
-                                      'valid': True}
-        response = client.get(url_for(
-            'main.check_messages',
-            service_id=fake_uuid,
-            upload_id=fake_uuid,
-            template_type='sms',
-            from_test=True,
-            **extra_args
-        ))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert (
-            page.findAll('a', {'class': 'page-footer-back-link'})[0]['href']
-        ) == expected_url(service_id=fake_uuid, template_id=fake_uuid)
+    with logged_in_client.session_transaction() as session:
+        session['upload_data'] = {'original_file_name': 'valid.csv',
+                                  'template_id': fake_uuid,
+                                  'notification_count': 1,
+                                  'valid': True}
+    response = logged_in_client.get(url_for(
+        'main.check_messages',
+        service_id=fake_uuid,
+        upload_id=fake_uuid,
+        template_type='sms',
+        from_test=True,
+        **extra_args
+    ))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert (
+        page.findAll('a', {'class': 'page-footer-back-link'})[0]['href']
+    ) == expected_url(service_id=fake_uuid, template_id=fake_uuid)
 
 
 def test_go_to_dashboard_after_tour(
-    app_,
+    logged_in_client,
     mocker,
     api_user_active,
     mock_login,
@@ -786,16 +752,13 @@ def test_go_to_dashboard_after_tour(
     fake_uuid
 ):
 
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
+    resp = logged_in_client.get(
+        url_for('main.go_to_dashboard_after_tour', service_id=fake_uuid, example_template_id=fake_uuid)
+    )
 
-        resp = client.get(
-            url_for('main.go_to_dashboard_after_tour', service_id=fake_uuid, example_template_id=fake_uuid)
-        )
-
-        assert resp.status_code == 302
-        assert resp.location == url_for("main.service_dashboard", service_id=fake_uuid, _external=True)
-        mock_delete_service_template.assert_called_once_with(fake_uuid, fake_uuid)
+    assert resp.status_code == 302
+    assert resp.location == url_for("main.service_dashboard", service_id=fake_uuid, _external=True)
+    mock_delete_service_template.assert_called_once_with(fake_uuid, fake_uuid)
 
 
 @pytest.mark.parametrize('num_requested,expected_msg', [
@@ -804,7 +767,7 @@ def test_go_to_dashboard_after_tour(
 ], ids=['none_sent', 'some_sent'])
 def test_check_messages_shows_too_many_messages_errors(
     mocker,
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_users_by_service,
@@ -828,19 +791,17 @@ def test_check_messages_shows_too_many_messages_errors(
         }
     })
 
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['upload_data'] = {'original_file_name': 'valid.csv',
-                                      'template_id': fake_uuid,
-                                      'notification_count': 1,
-                                      'valid': True}
-        response = client.get(url_for(
-            'main.check_messages',
-            service_id=fake_uuid,
-            template_type='sms',
-            upload_id=fake_uuid
-        ))
+    with logged_in_client.session_transaction() as session:
+        session['upload_data'] = {'original_file_name': 'valid.csv',
+                                  'template_id': fake_uuid,
+                                  'notification_count': 1,
+                                  'valid': True}
+    response = logged_in_client.get(url_for(
+        'main.check_messages',
+        service_id=fake_uuid,
+        template_type='sms',
+        upload_id=fake_uuid
+    ))
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.find('h1').text.strip() == 'Too many recipients'
@@ -883,8 +844,7 @@ def test_check_messages_shows_trial_mode_error(
 
 
 def test_check_messages_shows_over_max_row_error(
-    client,
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_users_by_service,
@@ -901,10 +861,9 @@ def test_check_messages_shows_over_max_row_error(
     mock_recipients.__len__.return_value = 99999
     mock_recipients.too_many_rows.return_value = True
 
-    client.login(api_user_active)
-    with client.session_transaction() as session:
+    with logged_in_client.session_transaction() as session:
         session['upload_data'] = {'template_id': fake_uuid}
-    response = client.get(url_for(
+    response = logged_in_client.get(url_for(
         'main.check_messages',
         service_id=fake_uuid,
         template_type='sms',

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -47,7 +47,7 @@ def test_upload_files_in_different_formats(
     mock_get_service_template,
     mock_s3_upload,
     mock_has_permissions,
-    fake_uuid
+    fake_uuid,
 ):
 
     with app_.test_request_context(), app_.test_client() as client, open(filename, 'rb') as uploaded:
@@ -83,7 +83,7 @@ def test_upload_csvfile_with_errors_shows_check_page_with_errors(
     mock_has_permissions,
     mock_get_users_by_service,
     mock_get_detailed_service_for_today,
-    fake_uuid
+    fake_uuid,
 ):
 
     mocker.patch(
@@ -119,17 +119,19 @@ def test_upload_csvfile_with_errors_shows_check_page_with_errors(
             assert 'Re-upload your file' in content
 
 
-def test_upload_csv_invalid_extension(app_,
-                                      api_user_active,
-                                      mocker,
-                                      mock_login,
-                                      mock_get_service,
-                                      mock_get_service_template,
-                                      mock_s3_upload,
-                                      mock_has_permissions,
-                                      mock_get_users_by_service,
-                                      mock_get_detailed_service_for_today,
-                                      fake_uuid):
+def test_upload_csv_invalid_extension(
+    app_,
+    api_user_active,
+    mocker,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template,
+    mock_s3_upload,
+    mock_has_permissions,
+    mock_get_users_by_service,
+    mock_get_detailed_service_for_today,
+    fake_uuid,
+):
 
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -527,19 +529,21 @@ def test_check_messages_should_revalidate_file_when_uploading_file(
     ('main.get_example_csv', 200),
     ('main.send_test', 302)
 ])
-def test_route_permissions(mocker,
-                           app_,
-                           api_user_active,
-                           service_one,
-                           mock_get_service_template,
-                           mock_get_service_templates,
-                           mock_get_jobs,
-                           mock_get_notifications,
-                           mock_create_job,
-                           mock_s3_upload,
-                           fake_uuid,
-                           route,
-                           response_code):
+def test_route_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_template,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_notifications,
+    mock_create_job,
+    mock_s3_upload,
+    fake_uuid,
+    route,
+    response_code,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -562,17 +566,19 @@ def test_route_permissions(mocker,
     'main.get_example_csv',
     'main.send_test'
 ])
-def test_route_invalid_permissions(mocker,
-                                   app_,
-                                   api_user_active,
-                                   service_one,
-                                   mock_get_service_template,
-                                   mock_get_service_templates,
-                                   mock_get_jobs,
-                                   mock_get_notifications,
-                                   mock_create_job,
-                                   fake_uuid,
-                                   route):
+def test_route_invalid_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_template,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_notifications,
+    mock_create_job,
+    fake_uuid,
+    route,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -589,16 +595,18 @@ def test_route_invalid_permissions(mocker,
             service_one)
 
 
-def test_route_choose_template_manage_service_permissions(mocker,
-                                                          app_,
-                                                          api_user_active,
-                                                          service_one,
-                                                          mock_login,
-                                                          mock_get_user,
-                                                          mock_get_service,
-                                                          mock_check_verify_code,
-                                                          mock_get_service_templates,
-                                                          mock_get_jobs):
+def test_route_choose_template_manage_service_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_login,
+    mock_get_user,
+    mock_get_service,
+    mock_check_verify_code,
+    mock_get_service_templates,
+    mock_get_jobs,
+):
     with app_.test_request_context():
         template_id = mock_get_service_templates(service_one['id'])['data'][0]['id']
         resp = validate_route_permission(
@@ -628,14 +636,16 @@ def test_route_choose_template_manage_service_permissions(mocker,
             template_id=template_id) in page
 
 
-def test_route_choose_template_send_messages_permissions(mocker,
-                                                         app_,
-                                                         active_user_with_permissions,
-                                                         service_one,
-                                                         mock_get_service,
-                                                         mock_check_verify_code,
-                                                         mock_get_service_templates,
-                                                         mock_get_jobs):
+def test_route_choose_template_send_messages_permissions(
+    mocker,
+    app_,
+    active_user_with_permissions,
+    service_one,
+    mock_get_service,
+    mock_check_verify_code,
+    mock_get_service_templates,
+    mock_get_jobs,
+):
     with app_.test_request_context():
         template_id = None
         for temp in mock_get_service_templates(service_one['id'])['data']:
@@ -665,15 +675,17 @@ def test_route_choose_template_send_messages_permissions(mocker,
             template_id=template_id) not in page
 
 
-def test_route_choose_template_manage_api_keys_permissions(mocker,
-                                                           app_,
-                                                           api_user_active,
-                                                           service_one,
-                                                           mock_get_user,
-                                                           mock_get_service,
-                                                           mock_check_verify_code,
-                                                           mock_get_service_templates,
-                                                           mock_get_jobs):
+def test_route_choose_template_manage_api_keys_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_user,
+    mock_get_service,
+    mock_check_verify_code,
+    mock_get_service_templates,
+    mock_get_jobs,
+):
     with app_.test_request_context():
         template_id = None
         for temp in mock_get_service_templates(service_one['id'])['data']:

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -15,7 +15,7 @@ def test_should_show_overview(
     active_user_with_permissions,
     mocker,
     service_one,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_one)
@@ -39,7 +39,7 @@ def test_should_show_overview_for_service_with_more_things_set(
     active_user_with_permissions,
     mocker,
     service_with_reply_to_addresses,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(active_user_with_permissions, mocker, service_with_reply_to_addresses)
@@ -55,10 +55,12 @@ def test_should_show_overview_for_service_with_more_things_set(
         assert row == " ".join(page.find_all('tr')[index + 1].text.split())
 
 
-def test_should_show_service_name(app_,
-                                  active_user_with_permissions,
-                                  mocker,
-                                  service_one):
+def test_should_show_service_name(
+    app_,
+    active_user_with_permissions,
+    mocker,
+    service_one,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions, mocker, service_one)
@@ -71,15 +73,17 @@ def test_should_show_service_name(app_,
         app.service_api_client.get_service.assert_called_with(service_one['id'])
 
 
-def test_should_redirect_after_change_service_name(app_,
-                                                   service_one,
-                                                   active_user_with_permissions,
-                                                   mock_login,
-                                                   mock_get_user,
-                                                   mock_get_service,
-                                                   mock_update_service,
-                                                   mock_get_services,
-                                                   mock_has_permissions):
+def test_should_redirect_after_change_service_name(
+    app_,
+    service_one,
+    active_user_with_permissions,
+    mock_login,
+    mock_get_user,
+    mock_get_service,
+    mock_update_service,
+    mock_get_services,
+    mock_has_permissions,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions)
@@ -121,7 +125,7 @@ def test_switch_service_to_live(
     mock_get_service,
     mock_update_service,
     mock_has_permissions,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -166,7 +170,7 @@ def test_switch_service_to_restricted(
     mock_get_live_service,
     mock_update_service,
     mock_has_permissions,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -184,10 +188,12 @@ def test_switch_service_to_restricted(
         )
 
 
-def test_should_not_allow_duplicate_names(app_,
-                                          active_user_with_permissions,
-                                          mocker,
-                                          service_one):
+def test_should_not_allow_duplicate_names(
+    app_,
+    active_user_with_permissions,
+    mocker,
+    service_one,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions, mocker, service_one)
@@ -204,10 +210,12 @@ def test_should_not_allow_duplicate_names(app_,
         app.service_api_client.find_all_service_email_from.assert_called_once_with()
 
 
-def test_should_show_service_name_confirmation(app_,
-                                               active_user_with_permissions,
-                                               mocker,
-                                               service_one):
+def test_should_show_service_name_confirmation(
+    app_,
+    active_user_with_permissions,
+    mocker,
+    service_one,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions, mocker, service_one)
@@ -228,7 +236,7 @@ def test_should_redirect_after_service_name_confirmation(
     mocker,
     mock_update_service,
     mock_verify_password,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -251,14 +259,16 @@ def test_should_redirect_after_service_name_confirmation(
         assert mock_verify_password.called
 
 
-def test_should_raise_duplicate_name_handled(app_,
-                                             active_user_with_permissions,
-                                             service_one,
-                                             mocker,
-                                             mock_get_services,
-                                             mock_update_service_raise_httperror_duplicate_name,
-                                             mock_verify_password,
-                                             fake_uuid):
+def test_should_raise_duplicate_name_handled(
+    app_,
+    active_user_with_permissions,
+    service_one,
+    mocker,
+    mock_get_services,
+    mock_update_service_raise_httperror_duplicate_name,
+    mock_verify_password,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(active_user_with_permissions, mocker, service_one)
@@ -276,14 +286,16 @@ def test_should_raise_duplicate_name_handled(app_,
         assert mock_verify_password.called
 
 
-def test_should_show_request_to_go_live(app_,
-                                        api_user_active,
-                                        mock_get_service,
-                                        mock_get_user,
-                                        mock_get_user_by_email,
-                                        mock_login,
-                                        mock_has_permissions,
-                                        fake_uuid):
+def test_should_show_request_to_go_live(
+    app_,
+    api_user_active,
+    mock_get_service,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -304,7 +316,7 @@ def test_should_redirect_after_request_to_go_live(
     mock_get_service,
     mock_has_permissions,
     mock_get_organisation,
-    mocker
+    mocker,
 ):
     mock_post = mocker.patch(
         'app.main.views.feedback.requests.post',
@@ -358,7 +370,7 @@ def test_log_error_on_request_to_go_live(
     mock_get_user,
     mock_get_service,
     mock_has_permissions,
-    mocker
+    mocker,
 ):
     mock_post = mocker.patch(
         'app.main.views.service_settings.requests.post',
@@ -398,7 +410,13 @@ def test_log_error_on_request_to_go_live(
     'main.service_request_to_go_live',
     'main.archive_service'
 ])
-def test_route_permissions(mocker, app_, api_user_active, service_one, route):
+def test_route_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    route,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -421,7 +439,13 @@ def test_route_permissions(mocker, app_, api_user_active, service_one, route):
     'main.service_switch_can_send_letters',
     'main.archive_service',
 ])
-def test_route_invalid_permissions(mocker, app_, api_user_active, service_one, route):
+def test_route_invalid_permissions(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    route,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -440,7 +464,13 @@ def test_route_invalid_permissions(mocker, app_, api_user_active, service_one, r
     'main.service_name_change_confirm',
     'main.service_request_to_go_live',
 ])
-def test_route_for_platform_admin(mocker, app_, platform_admin_user, service_one, route):
+def test_route_for_platform_admin(
+    mocker,
+    app_,
+    platform_admin_user,
+    service_one,
+    route,
+):
     with app_.test_request_context():
         validate_route_permission(mocker,
                                   app_,
@@ -457,7 +487,13 @@ def test_route_for_platform_admin(mocker, app_, platform_admin_user, service_one
     'main.service_switch_research_mode',
     'main.service_switch_can_send_letters',
 ])
-def test_route_for_platform_admin_update_service(mocker, app_, platform_admin_user, service_one, route):
+def test_route_for_platform_admin_update_service(
+    mocker,
+    app_,
+    platform_admin_user,
+    service_one,
+    route,
+):
     mocker.patch('app.service_api_client.archive_service')
     with app_.test_request_context():
         validate_route_permission(mocker,
@@ -476,7 +512,7 @@ def test_set_reply_to_email_address(
     mocker,
     mock_update_service,
     service_one,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -492,10 +528,12 @@ def test_set_reply_to_email_address(
         )
 
 
-def test_if_reply_to_email_address_set_then_form_populated(app_,
-                                                           active_user_with_permissions,
-                                                           mocker,
-                                                           service_one):
+def test_if_reply_to_email_address_set_then_form_populated(
+    app_,
+    active_user_with_permissions,
+    mocker,
+    service_one,
+):
     service_one['reply_to_email_address'] = 'test@service.gov.uk'
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -515,7 +553,7 @@ def test_switch_service_to_research_mode(
     active_user_with_permissions,
     mock_get_service,
     mock_has_permissions,
-    mocker
+    mocker,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         mocker.patch('app.service_api_client.post', return_value=service_one)
@@ -534,14 +572,15 @@ def test_switch_service_to_research_mode(
 
 
 def test_switch_service_from_research_mode_to_normal(
-        app_,
-        service_one,
-        mock_login,
-        mock_get_user,
-        active_user_with_permissions,
-        mock_get_service,
-        mock_has_permissions,
-        mocker):
+    app_,
+    service_one,
+    mock_login,
+    mock_get_user,
+    active_user_with_permissions,
+    mock_get_service,
+    mock_has_permissions,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             service = service_json(
@@ -570,7 +609,7 @@ def test_shows_research_mode_indicator(
     mock_get_service,
     mock_has_permissions,
     mock_get_organisation,
-    mocker
+    mocker,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -604,7 +643,7 @@ def test_does_not_show_research_mode_indicator(
     mock_get_service,
     mock_has_permissions,
     mock_get_organisation,
-    mocker
+    mocker,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -623,7 +662,7 @@ def test_set_text_message_sender(
     mocker,
     mock_update_service,
     service_one,
-    mock_get_organisation
+    mock_get_organisation,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -640,10 +679,12 @@ def test_set_text_message_sender(
         )
 
 
-def test_if_sms_sender_set_then_form_populated(app_,
-                                               active_user_with_permissions,
-                                               mocker,
-                                               service_one):
+def test_if_sms_sender_set_then_form_populated(
+    app_,
+    active_user_with_permissions,
+    mocker,
+    service_one,
+):
     service_one['sms_sender'] = 'elevenchars'
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -656,7 +697,11 @@ def test_if_sms_sender_set_then_form_populated(app_,
 
 
 def test_should_show_branding(
-    mocker, app_, platform_admin_user, service_one, mock_get_organisations
+    mocker,
+    app_,
+    platform_admin_user,
+    service_one,
+    mock_get_organisations,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(platform_admin_user, mocker, service_one)
@@ -679,7 +724,11 @@ def test_should_show_branding(
 
 
 def test_should_show_organisations(
-    mocker, app_, platform_admin_user, service_one, mock_get_organisations
+    mocker,
+    app_,
+    platform_admin_user,
+    service_one,
+    mock_get_organisations,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(platform_admin_user, mocker, service_one)
@@ -702,7 +751,12 @@ def test_should_show_organisations(
 
 
 def test_should_set_branding_and_organisations(
-    mocker, app_, platform_admin_user, service_one, mock_get_organisations, mock_update_service
+    mocker,
+    app_,
+    platform_admin_user,
+    service_one,
+    mock_get_organisations,
+    mock_update_service,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(platform_admin_user, mocker, service_one)
@@ -726,7 +780,12 @@ def test_should_set_branding_and_organisations(
         )
 
 
-def test_switch_service_enable_letters(client, platform_admin_user, service_one, mocker):
+def test_switch_service_enable_letters(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     mocked_fn = mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
 
     client.login(platform_admin_user, mocker, service_one)
@@ -737,7 +796,11 @@ def test_switch_service_enable_letters(client, platform_admin_user, service_one,
     assert mocked_fn.call_args == call(service_one['id'], {'can_send_letters': True})
 
 
-def test_switch_service_disable_letters(client, platform_admin_user, mocker):
+def test_switch_service_disable_letters(
+    client,
+    platform_admin_user,
+    mocker,
+):
     service = service_json("1234", "Test Service", [], can_send_letters=True)
     mocker.patch('app.service_api_client.get_service', return_value={"data": service})
     mocked_fn = mocker.patch('app.service_api_client.update_service_with_properties', return_value=service)
@@ -750,7 +813,12 @@ def test_switch_service_disable_letters(client, platform_admin_user, mocker):
     assert mocked_fn.call_args == call(service['id'], {"can_send_letters": False})
 
 
-def test_archive_service_after_confirm(client, platform_admin_user, service_one, mocker):
+def test_archive_service_after_confirm(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     mocked_fn = mocker.patch('app.service_api_client.post', return_value=service_one)
 
     client.login(platform_admin_user, mocker, service_one)
@@ -761,7 +829,12 @@ def test_archive_service_after_confirm(client, platform_admin_user, service_one,
     assert mocked_fn.call_args == call('/service/{}/archive'.format(service_one['id']), data=None)
 
 
-def test_archive_service_prompts_user(client, platform_admin_user, service_one, mocker):
+def test_archive_service_prompts_user(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     mocked_fn = mocker.patch('app.service_api_client.post')
 
     client.login(platform_admin_user, mocker, service_one)
@@ -773,7 +846,12 @@ def test_archive_service_prompts_user(client, platform_admin_user, service_one, 
     assert mocked_fn.called is False
 
 
-def test_cant_archive_inactive_service(client, platform_admin_user, service_one, mocker):
+def test_cant_archive_inactive_service(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     service_one['active'] = False
 
     client.login(platform_admin_user, mocker, service_one)
@@ -784,7 +862,12 @@ def test_cant_archive_inactive_service(client, platform_admin_user, service_one,
     assert 'Archive service' not in {a.text for a in page.find_all('a', class_='button')}
 
 
-def test_suspend_service_after_confirm(client, platform_admin_user, service_one, mocker):
+def test_suspend_service_after_confirm(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     mocked_fn = mocker.patch('app.service_api_client.post', return_value=service_one)
 
     client.login(platform_admin_user, mocker, service_one)
@@ -795,7 +878,12 @@ def test_suspend_service_after_confirm(client, platform_admin_user, service_one,
     assert mocked_fn.call_args == call('/service/{}/suspend'.format(service_one['id']), data=None)
 
 
-def test_suspend_service_prompts_user(client, platform_admin_user, service_one, mocker):
+def test_suspend_service_prompts_user(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     mocked_fn = mocker.patch('app.service_api_client.post')
 
     client.login(platform_admin_user, mocker, service_one)
@@ -808,7 +896,12 @@ def test_suspend_service_prompts_user(client, platform_admin_user, service_one, 
     assert mocked_fn.called is False
 
 
-def test_cant_suspend_inactive_service(client, platform_admin_user, service_one, mocker):
+def test_cant_suspend_inactive_service(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     service_one['active'] = False
 
     client.login(platform_admin_user, mocker, service_one)
@@ -819,7 +912,12 @@ def test_cant_suspend_inactive_service(client, platform_admin_user, service_one,
     assert 'Suspend service' not in {a.text for a in page.find_all('a', class_='button')}
 
 
-def test_resume_service_after_confirm(client, platform_admin_user, service_one, mocker):
+def test_resume_service_after_confirm(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     service_one['active'] = False
     mocked_fn = mocker.patch('app.service_api_client.post', return_value=service_one)
 
@@ -831,7 +929,12 @@ def test_resume_service_after_confirm(client, platform_admin_user, service_one, 
     assert mocked_fn.call_args == call('/service/{}/resume'.format(service_one['id']), data=None)
 
 
-def test_resume_service_prompts_user(client, platform_admin_user, service_one, mocker):
+def test_resume_service_prompts_user(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     service_one['active'] = False
     mocked_fn = mocker.patch('app.service_api_client.post')
 
@@ -845,7 +948,12 @@ def test_resume_service_prompts_user(client, platform_admin_user, service_one, m
     assert mocked_fn.called is False
 
 
-def test_cant_resume_active_service(client, platform_admin_user, service_one, mocker):
+def test_cant_resume_active_service(
+    client,
+    platform_admin_user,
+    service_one,
+    mocker,
+):
     client.login(platform_admin_user, mocker, service_one)
     response = client.get(url_for('main.service_settings', service_id=service_one['id']))
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -11,17 +11,15 @@ from tests import validate_route_permission, service_json
 
 
 def test_should_show_overview(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     service_one,
     mock_get_organisation,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_one)
-        response = client.get(url_for(
-            'main.service_settings', service_id=service_one['id']
-        ))
+    response = logged_in_client.get(url_for(
+        'main.service_settings', service_id=service_one['id']
+    ))
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.find('h1').text == 'Settings'
@@ -35,17 +33,16 @@ def test_should_show_overview(
 
 
 def test_should_show_overview_for_service_with_more_things_set(
-    app_,
+    client,
     active_user_with_permissions,
     mocker,
     service_with_reply_to_addresses,
     mock_get_organisation,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions, mocker, service_with_reply_to_addresses)
-        response = client.get(url_for(
-            'main.service_settings', service_id=service_with_reply_to_addresses['id']
-        ))
+    client.login(active_user_with_permissions, mocker, service_with_reply_to_addresses)
+    response = client.get(url_for(
+        'main.service_settings', service_id=service_with_reply_to_addresses['id']
+    ))
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     for index, row in enumerate([
         'Service name service one Change',
@@ -56,25 +53,22 @@ def test_should_show_overview_for_service_with_more_things_set(
 
 
 def test_should_show_service_name(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     service_one,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for(
-                'main.service_name_change', service_id=service_one['id']))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find('h1').text == 'Change your service name'
-        assert page.find('input', attrs={"type": "text"})['value'] == 'service one'
-        app.service_api_client.get_service.assert_called_with(service_one['id'])
+    response = logged_in_client.get(url_for(
+        'main.service_name_change', service_id=service_one['id']))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find('h1').text == 'Change your service name'
+    assert page.find('input', attrs={"type": "text"})['value'] == 'service one'
+    app.service_api_client.get_service.assert_called_with(service_one['id'])
 
 
 def test_should_redirect_after_change_service_name(
-    app_,
+    logged_in_client,
     service_one,
     active_user_with_permissions,
     mock_login,
@@ -84,22 +78,19 @@ def test_should_redirect_after_change_service_name(
     mock_get_services,
     mock_has_permissions,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions)
-            response = client.post(
-                url_for('main.service_name_change', service_id=service_one['id']),
-                data={'name': "new name"})
+    response = logged_in_client.post(
+        url_for('main.service_name_change', service_id=service_one['id']),
+        data={'name': "new name"})
 
-        assert response.status_code == 302
-        settings_url = url_for(
-            'main.service_name_change_confirm', service_id=service_one['id'], _external=True)
-        assert settings_url == response.location
-        assert mock_get_services.called
+    assert response.status_code == 302
+    settings_url = url_for(
+        'main.service_name_change_confirm', service_id=service_one['id'], _external=True)
+    assert settings_url == response.location
+    assert mock_get_services.called
 
 
 def test_show_restricted_service(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -108,16 +99,14 @@ def test_show_restricted_service(
     mock_get_service,
     mock_get_organisation,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions)
-        response = client.get(url_for('main.service_settings', service_id=service_one['id']))
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find('h1').text == 'Settings'
-        assert page.find_all('h2')[1].text == 'Your service is in trial mode'
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find('h1').text == 'Settings'
+    assert page.find_all('h2')[1].text == 'Your service is in trial mode'
 
 
 def test_switch_service_to_live(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -127,24 +116,21 @@ def test_switch_service_to_live(
     mock_has_permissions,
     mock_get_organisation,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions)
-            response = client.get(
-                url_for('main.service_switch_live', service_id=service_one['id']))
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.service_settings',
-            service_id=service_one['id'], _external=True)
-        mock_update_service.assert_called_with(
-            service_one['id'],
-            message_limit=250000,
-            restricted=False
-        )
+    response = logged_in_client.get(
+        url_for('main.service_switch_live', service_id=service_one['id']))
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_settings',
+        service_id=service_one['id'], _external=True)
+    mock_update_service.assert_called_with(
+        service_one['id'],
+        message_limit=250000,
+        restricted=False
+    )
 
 
 def test_show_live_service(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -153,16 +139,14 @@ def test_show_live_service(
     mock_has_permissions,
     mock_get_organisation,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(active_user_with_permissions)
-        response = client.get(url_for('main.service_settings', service_id=service_one['id']))
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find('h1').text.strip() == 'Settings'
-        assert 'Your service is in trial mode' not in page.text
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find('h1').text.strip() == 'Settings'
+    assert 'Your service is in trial mode' not in page.text
 
 
 def test_switch_service_to_restricted(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -172,65 +156,55 @@ def test_switch_service_to_restricted(
     mock_has_permissions,
     mock_get_organisation,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions)
-            response = client.get(
-                url_for('main.service_switch_live', service_id=service_one['id']))
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.service_settings',
-            service_id=service_one['id'], _external=True)
-        mock_update_service.assert_called_with(
-            service_one['id'],
-            message_limit=50,
-            restricted=True
-        )
+    response = logged_in_client.get(
+        url_for('main.service_switch_live', service_id=service_one['id']))
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_settings',
+        service_id=service_one['id'], _external=True)
+    mock_update_service.assert_called_with(
+        service_one['id'],
+        message_limit=50,
+        restricted=True
+    )
 
 
 def test_should_not_allow_duplicate_names(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     service_one,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            mocker.patch('app.service_api_client.find_all_service_email_from',
-                         return_value=['service_one', 'service.two'])
-            service_id = service_one['id']
-            response = client.post(
-                url_for('main.service_name_change', service_id=service_id),
-                data={'name': "SErvICE TWO"})
+    mocker.patch('app.service_api_client.find_all_service_email_from',
+                 return_value=['service_one', 'service.two'])
+    service_id = service_one['id']
+    response = logged_in_client.post(
+        url_for('main.service_name_change', service_id=service_id),
+        data={'name': "SErvICE TWO"})
 
-        assert response.status_code == 200
-        resp_data = response.get_data(as_text=True)
-        assert 'This service name is already in use' in resp_data
-        app.service_api_client.find_all_service_email_from.assert_called_once_with()
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert 'This service name is already in use' in resp_data
+    app.service_api_client.find_all_service_email_from.assert_called_once_with()
 
 
 def test_should_show_service_name_confirmation(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     service_one,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
+    response = logged_in_client.get(url_for(
+        'main.service_name_change_confirm', service_id=service_one['id']))
 
-            response = client.get(url_for(
-                'main.service_name_change_confirm', service_id=service_one['id']))
-
-        assert response.status_code == 200
-        resp_data = response.get_data(as_text=True)
-        assert 'Change your service name' in resp_data
-        app.service_api_client.get_service.assert_called_with(service_one['id'])
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert 'Change your service name' in resp_data
+    app.service_api_client.get_service.assert_called_with(service_one['id'])
 
 
 def test_should_redirect_after_service_name_confirmation(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     service_one,
     mocker,
@@ -238,29 +212,27 @@ def test_should_redirect_after_service_name_confirmation(
     mock_verify_password,
     mock_get_organisation,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            service_id = service_one['id']
-            service_new_name = 'New Name'
-            with client.session_transaction() as session:
-                session['service_name_change'] = service_new_name
-            response = client.post(url_for(
-                'main.service_name_change_confirm', service_id=service_id))
+    logged_in_client.login(active_user_with_permissions, mocker, service_one)
+    service_id = service_one['id']
+    service_new_name = 'New Name'
+    with logged_in_client.session_transaction() as session:
+        session['service_name_change'] = service_new_name
+    response = logged_in_client.post(url_for(
+        'main.service_name_change_confirm', service_id=service_id))
 
-        assert response.status_code == 302
-        settings_url = url_for('main.service_settings', service_id=service_id, _external=True)
-        assert settings_url == response.location
-        mock_update_service.assert_called_once_with(
-            service_id,
-            name=service_new_name,
-            email_from=email_safe(service_new_name)
-        )
-        assert mock_verify_password.called
+    assert response.status_code == 302
+    settings_url = url_for('main.service_settings', service_id=service_id, _external=True)
+    assert settings_url == response.location
+    mock_update_service.assert_called_once_with(
+        service_id,
+        name=service_new_name,
+        email_from=email_safe(service_new_name)
+    )
+    assert mock_verify_password.called
 
 
 def test_should_raise_duplicate_name_handled(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     service_one,
     mocker,
@@ -269,25 +241,22 @@ def test_should_raise_duplicate_name_handled(
     mock_verify_password,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            service_new_name = 'New Name'
-            with client.session_transaction() as session:
-                session['service_name_change'] = service_new_name
-            response = client.post(url_for(
-                'main.service_name_change_confirm', service_id=service_one['id']))
+    service_new_name = 'New Name'
+    with logged_in_client.session_transaction() as session:
+        session['service_name_change'] = service_new_name
+    response = logged_in_client.post(url_for(
+        'main.service_name_change_confirm', service_id=service_one['id']))
 
-        assert response.status_code == 302
-        name_change_url = url_for(
-            'main.service_name_change', service_id=service_one['id'], _external=True)
-        assert name_change_url == response.location
-        assert mock_update_service_raise_httperror_duplicate_name.called
-        assert mock_verify_password.called
+    assert response.status_code == 302
+    name_change_url = url_for(
+        'main.service_name_change', service_id=service_one['id'], _external=True)
+    assert name_change_url == response.location
+    assert mock_update_service_raise_httperror_duplicate_name.called
+    assert mock_verify_password.called
 
 
 def test_should_show_request_to_go_live(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_get_service,
     mock_get_user,
@@ -296,21 +265,18 @@ def test_should_show_request_to_go_live(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            response = client.get(
-                url_for('main.service_request_to_go_live', service_id=service_id))
-        service = mock_get_service.side_effect(service_id)['data']
-        assert response.status_code == 200
-        resp_data = response.get_data(as_text=True)
-        assert 'Request to go live' in resp_data
-        assert mock_get_service.called
+    service_id = fake_uuid
+    response = logged_in_client.get(
+        url_for('main.service_request_to_go_live', service_id=service_id))
+    service = mock_get_service.side_effect(service_id)['data']
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert 'Request to go live' in resp_data
+    assert mock_get_service.called
 
 
 def test_should_redirect_after_request_to_go_live(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_get_user,
     mock_get_service,
@@ -321,51 +287,49 @@ def test_should_redirect_after_request_to_go_live(
     mock_post = mocker.patch(
         'app.main.views.feedback.requests.post',
         return_value=Mock(status_code=201))
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.post(
-                url_for('main.service_request_to_go_live', service_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a6'),
-                data={
-                    'mou': 'yes',
-                    'channel': 'emails',
-                    'start_date': '01/01/2017',
-                    'start_volume': '100,000',
-                    'peak_volume': '2,000,000',
-                    'upload_or_api': 'API'
-                },
-                follow_redirects=True
-            )
-            assert response.status_code == 200
-            mock_post.assert_called_with(
-                ANY,
-                data={
-                    'subject': 'Request to go live',
-                    'department_id': ANY,
-                    'agent_team_id': ANY,
-                    'message': ANY,
-                    'person_name': api_user_active.name,
-                    'person_email': api_user_active.email_address
-                },
-                headers=ANY
-            )
+    response = logged_in_client.post(
+        url_for('main.service_request_to_go_live', service_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a6'),
+        data={
+            'mou': 'yes',
+            'channel': 'emails',
+            'start_date': '01/01/2017',
+            'start_volume': '100,000',
+            'peak_volume': '2,000,000',
+            'upload_or_api': 'API'
+        },
+        follow_redirects=True
+    )
+    assert response.status_code == 200
+    mock_post.assert_called_with(
+        ANY,
+        data={
+            'subject': 'Request to go live',
+            'department_id': ANY,
+            'agent_team_id': ANY,
+            'message': ANY,
+            'person_name': api_user_active.name,
+            'person_email': api_user_active.email_address
+        },
+        headers=ANY
+    )
 
-            returned_message = mock_post.call_args[1]['data']['message']
-            assert 'emails' in returned_message
-            assert '01/01/2017' in returned_message
-            assert '100,000' in returned_message
-            assert '2,000,000' in returned_message
-            assert 'API' in returned_message
+    returned_message = mock_post.call_args[1]['data']['message']
+    assert 'emails' in returned_message
+    assert '01/01/2017' in returned_message
+    assert '100,000' in returned_message
+    assert '2,000,000' in returned_message
+    assert 'API' in returned_message
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        flash_banner = page.find('div', class_='banner-default').string.strip()
-        h1 = page.find('h1').string.strip()
-        assert flash_banner == 'We’ve received your request to go live'
-        assert h1 == 'Settings'
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    flash_banner = page.find('div', class_='banner-default').string.strip()
+    h1 = page.find('h1').string.strip()
+    assert flash_banner == 'We’ve received your request to go live'
+    assert h1 == 'Settings'
 
 
 def test_log_error_on_request_to_go_live(
     app_,
+    logged_in_client,
     api_user_active,
     mock_get_user,
     mock_get_service,
@@ -382,25 +346,22 @@ def test_log_error_on_request_to_go_live(
             }
         )
     )
-    with app_.test_request_context():
-        mock_logger = mocker.patch.object(app_.logger, 'error')
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            with pytest.raises(InternalServerError):
-                resp = client.post(
-                    url_for('main.service_request_to_go_live', service_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a6'),
-                    data={
-                        'mou': 'yes',
-                        'channel': 'emails',
-                        'start_date': 'start_date',
-                        'start_volume': 'start_volume',
-                        'peak_volume': 'peak_volume',
-                        'upload_or_api': 'API'
-                    }
-                )
-            mock_logger.assert_called_with(
-                "Deskpro create ticket request failed with {} '{}'".format(mock_post().status_code, mock_post().json())
-            )
+    mock_logger = mocker.patch.object(app_.logger, 'error')
+    with pytest.raises(InternalServerError):
+        resp = logged_in_client.post(
+            url_for('main.service_request_to_go_live', service_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a6'),
+            data={
+                'mou': 'yes',
+                'channel': 'emails',
+                'start_date': 'start_date',
+                'start_volume': 'start_volume',
+                'peak_volume': 'peak_volume',
+                'upload_or_api': 'API'
+            }
+        )
+    mock_logger.assert_called_with(
+        "Deskpro create ticket request failed with {} '{}'".format(mock_post().status_code, mock_post().json())
+    )
 
 
 @pytest.mark.parametrize('route', [
@@ -413,20 +374,20 @@ def test_log_error_on_request_to_go_live(
 def test_route_permissions(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     route,
 ):
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            200,
-            url_for(route, service_id=service_one['id']),
-            ['manage_settings'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        200,
+        url_for(route, service_id=service_one['id']),
+        ['manage_settings'],
+        api_user_active,
+        service_one)
 
 
 @pytest.mark.parametrize('route', [
@@ -442,20 +403,20 @@ def test_route_permissions(
 def test_route_invalid_permissions(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     route,
 ):
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            403,
-            url_for(route, service_id=service_one['id']),
-            ['blah'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        403,
+        url_for(route, service_id=service_one['id']),
+        ['blah'],
+        api_user_active,
+        service_one)
 
 
 @pytest.mark.parametrize('route', [
@@ -467,19 +428,19 @@ def test_route_invalid_permissions(
 def test_route_for_platform_admin(
     mocker,
     app_,
+    client,
     platform_admin_user,
     service_one,
     route,
 ):
-    with app_.test_request_context():
-        validate_route_permission(mocker,
-                                  app_,
-                                  "GET",
-                                  200,
-                                  url_for(route, service_id=service_one['id']),
-                                  [],
-                                  platform_admin_user,
-                                  service_one)
+    validate_route_permission(mocker,
+                              app_,
+                              "GET",
+                              200,
+                              url_for(route, service_id=service_one['id']),
+                              [],
+                              platform_admin_user,
+                              service_one)
 
 
 @pytest.mark.parametrize('route', [
@@ -490,63 +451,57 @@ def test_route_for_platform_admin(
 def test_route_for_platform_admin_update_service(
     mocker,
     app_,
+    client,
     platform_admin_user,
     service_one,
     route,
 ):
     mocker.patch('app.service_api_client.archive_service')
-    with app_.test_request_context():
-        validate_route_permission(mocker,
-                                  app_,
-                                  "GET",
-                                  302,
-                                  url_for(route, service_id=service_one['id']),
-                                  [],
-                                  platform_admin_user,
-                                  service_one)
+    validate_route_permission(mocker,
+                              app_,
+                              "GET",
+                              302,
+                              url_for(route, service_id=service_one['id']),
+                              [],
+                              platform_admin_user,
+                              service_one)
 
 
 def test_set_reply_to_email_address(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     mock_update_service,
     service_one,
     mock_get_organisation,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            data = {"email_address": "test@someservice.gov.uk"}
-            response = client.post(url_for('main.service_set_reply_to_email', service_id=service_one['id']),
-                                   data=data,
-                                   follow_redirects=True)
-        assert response.status_code == 200
-        mock_update_service.assert_called_with(
-            service_one['id'],
-            reply_to_email_address="test@someservice.gov.uk"
-        )
+    data = {"email_address": "test@someservice.gov.uk"}
+    response = logged_in_client.post(url_for('main.service_set_reply_to_email', service_id=service_one['id']),
+                                     data=data,
+                                     follow_redirects=True)
+    assert response.status_code == 200
+    mock_update_service.assert_called_with(
+        service_one['id'],
+        reply_to_email_address="test@someservice.gov.uk"
+    )
 
 
 def test_if_reply_to_email_address_set_then_form_populated(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     service_one,
 ):
     service_one['reply_to_email_address'] = 'test@service.gov.uk'
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for('main.service_set_reply_to_email', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.service_set_reply_to_email', service_id=service_one['id']))
 
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find(id='email_address')['value'] == 'test@service.gov.uk'
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find(id='email_address')['value'] == 'test@service.gov.uk'
 
 
 def test_switch_service_to_research_mode(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -555,24 +510,21 @@ def test_switch_service_to_research_mode(
     mock_has_permissions,
     mocker,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        mocker.patch('app.service_api_client.post', return_value=service_one)
-
-        client.login(active_user_with_permissions)
-        response = client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
-        assert response.status_code == 302
-        assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
-        app.service_api_client.post.assert_called_with(
-            '/service/{}'.format(service_one['id']),
-            {
-                'research_mode': True,
-                'created_by': active_user_with_permissions.id
-            }
-        )
+    mocker.patch('app.service_api_client.post', return_value=service_one)
+    response = logged_in_client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
+    app.service_api_client.post.assert_called_with(
+        '/service/{}'.format(service_one['id']),
+        {
+            'research_mode': True,
+            'created_by': active_user_with_permissions.id
+        }
+    )
 
 
 def test_switch_service_from_research_mode_to_normal(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -581,27 +533,24 @@ def test_switch_service_from_research_mode_to_normal(
     mock_has_permissions,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            service = service_json(
-                users=[active_user_with_permissions.id],
-                restricted=True,
-                research_mode=True
-            )
-            mocker.patch('app.service_api_client.get_service', return_value={"data": service})
-            mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
+    service = service_json(
+        users=[active_user_with_permissions.id],
+        restricted=True,
+        research_mode=True
+    )
+    mocker.patch('app.service_api_client.get_service', return_value={"data": service})
+    mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
 
-            client.login(active_user_with_permissions)
-            response = client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
-            assert response.status_code == 302
-            assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
-            app.service_api_client.update_service_with_properties.assert_called_with(
-                service_one['id'], {"research_mode": False}
-            )
+    response = logged_in_client.get(url_for('main.service_switch_research_mode', service_id=service_one['id']))
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
+    app.service_api_client.update_service_with_properties.assert_called_with(
+        service_one['id'], {"research_mode": False}
+    )
 
 
 def test_shows_research_mode_indicator(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -611,31 +560,28 @@ def test_shows_research_mode_indicator(
     mock_get_organisation,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            service = service_json(
-                "1234",
-                "Test Service",
-                [active_user_with_permissions.id],
-                message_limit=1000,
-                active=False,
-                restricted=True,
-                research_mode=True
-            )
-            mocker.patch('app.service_api_client.get_service', return_value={"data": service})
-            mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
+    service = service_json(
+        "1234",
+        "Test Service",
+        [active_user_with_permissions.id],
+        message_limit=1000,
+        active=False,
+        restricted=True,
+        research_mode=True
+    )
+    mocker.patch('app.service_api_client.get_service', return_value={"data": service})
+    mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
 
-            client.login(active_user_with_permissions)
-            response = client.get(url_for('main.service_settings', service_id=service_one['id']))
-            assert response.status_code == 200
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
+    assert response.status_code == 200
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            element = page.find('span', {"id": "research-mode"})
-            assert element.text == 'research mode'
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    element = page.find('span', {"id": "research-mode"})
+    assert element.text == 'research mode'
 
 
 def test_does_not_show_research_mode_indicator(
-    app_,
+    logged_in_client,
     service_one,
     mock_login,
     mock_get_user,
@@ -645,151 +591,135 @@ def test_does_not_show_research_mode_indicator(
     mock_get_organisation,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions)
-            response = client.get(url_for('main.service_settings', service_id=service_one['id']))
-            assert response.status_code == 200
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
+    assert response.status_code == 200
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            element = page.find('span', {"id": "research-mode"})
-            assert not element
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    element = page.find('span', {"id": "research-mode"})
+    assert not element
 
 
 def test_set_text_message_sender(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     mock_update_service,
     service_one,
     mock_get_organisation,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            data = {"sms_sender": "elevenchars"}
-            response = client.post(url_for('main.service_set_sms_sender', service_id=service_one['id']),
-                                   data=data,
-                                   follow_redirects=True)
-        assert response.status_code == 200
+    data = {"sms_sender": "elevenchars"}
+    response = logged_in_client.post(url_for('main.service_set_sms_sender', service_id=service_one['id']),
+                                     data=data,
+                                     follow_redirects=True)
+    assert response.status_code == 200
 
-        mock_update_service.assert_called_with(
-            service_one['id'],
-            sms_sender="elevenchars"
-        )
+    mock_update_service.assert_called_with(
+        service_one['id'],
+        sms_sender="elevenchars"
+    )
 
 
 def test_if_sms_sender_set_then_form_populated(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     service_one,
 ):
     service_one['sms_sender'] = 'elevenchars'
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service_one)
-            response = client.get(url_for('main.service_set_sms_sender', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.service_set_sms_sender', service_id=service_one['id']))
 
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.find(id='sms_sender')['value'] == 'elevenchars'
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find(id='sms_sender')['value'] == 'elevenchars'
 
 
 def test_should_show_branding(
     mocker,
-    app_,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mock_get_organisations,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(platform_admin_user, mocker, service_one)
-        response = client.get(url_for(
-            'main.service_set_branding_and_org', service_id=service_one['id']
-        ))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    response = logged_in_client.get(url_for(
+        'main.service_set_branding_and_org', service_id=service_one['id']
+    ))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-        assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
-        assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
-        assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
+    assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
+    assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
+    assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
 
-        assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
-        assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
-        assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
+    assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
+    assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
+    assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
 
-        app.organisations_client.get_organisations.assert_called_once_with()
-        app.service_api_client.get_service.assert_called_once_with(service_one['id'])
+    app.organisations_client.get_organisations.assert_called_once_with()
+    app.service_api_client.get_service.assert_called_once_with(service_one['id'])
 
 
 def test_should_show_organisations(
     mocker,
-    app_,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mock_get_organisations,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(platform_admin_user, mocker, service_one)
-        response = client.get(url_for(
-            'main.service_set_branding_and_org', service_id=service_one['id']
-        ))
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    response = logged_in_client.get(url_for(
+        'main.service_set_branding_and_org', service_id=service_one['id']
+    ))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-        assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
-        assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
-        assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
+    assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
+    assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
+    assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
 
-        assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
-        assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
-        assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
+    assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
+    assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
+    assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
 
-        app.organisations_client.get_organisations.assert_called_once_with()
-        app.service_api_client.get_service.assert_called_once_with(service_one['id'])
+    app.organisations_client.get_organisations.assert_called_once_with()
+    app.service_api_client.get_service.assert_called_once_with(service_one['id'])
 
 
 def test_should_set_branding_and_organisations(
     mocker,
-    app_,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mock_get_organisations,
     mock_update_service,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(platform_admin_user, mocker, service_one)
-        response = client.post(
-            url_for(
-                'main.service_set_branding_and_org', service_id=service_one['id']
-            ),
-            data={
-                'branding_type': 'org',
-                'organisation': 'organisation-id'
-            }
-        )
-        assert response.status_code == 302
-        assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
+    response = logged_in_client.post(
+        url_for(
+            'main.service_set_branding_and_org', service_id=service_one['id']
+        ),
+        data={
+            'branding_type': 'org',
+            'organisation': 'organisation-id'
+        }
+    )
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
 
-        app.organisations_client.get_organisations.assert_called_once_with()
-        app.service_api_client.update_service.assert_called_once_with(
-            service_one['id'],
-            branding='org',
-            organisation='organisation-id'
-        )
+    app.organisations_client.get_organisations.assert_called_once_with()
+    app.service_api_client.update_service.assert_called_once_with(
+        service_one['id'],
+        branding='org',
+        organisation='organisation-id'
+    )
 
 
 def test_switch_service_enable_letters(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     mocked_fn = mocker.patch('app.service_api_client.update_service_with_properties', return_value=service_one)
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.service_switch_can_send_letters', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.service_switch_can_send_letters', service_id=service_one['id']))
 
     assert response.status_code == 302
     assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
@@ -797,7 +727,7 @@ def test_switch_service_enable_letters(
 
 
 def test_switch_service_disable_letters(
-    client,
+    logged_in_client,
     platform_admin_user,
     mocker,
 ):
@@ -805,8 +735,7 @@ def test_switch_service_disable_letters(
     mocker.patch('app.service_api_client.get_service', return_value={"data": service})
     mocked_fn = mocker.patch('app.service_api_client.update_service_with_properties', return_value=service)
 
-    client.login(platform_admin_user, mocker, service)
-    response = client.get(url_for('main.service_switch_can_send_letters', service_id=service['id']))
+    response = logged_in_client.get(url_for('main.service_switch_can_send_letters', service_id=service['id']))
 
     assert response.status_code == 302
     assert response.location == url_for('main.service_settings', service_id=service['id'], _external=True)
@@ -814,15 +743,14 @@ def test_switch_service_disable_letters(
 
 
 def test_archive_service_after_confirm(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     mocked_fn = mocker.patch('app.service_api_client.post', return_value=service_one)
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.post(url_for('main.archive_service', service_id=service_one['id']))
+    response = logged_in_client.post(url_for('main.archive_service', service_id=service_one['id']))
 
     assert response.status_code == 302
     assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
@@ -830,15 +758,14 @@ def test_archive_service_after_confirm(
 
 
 def test_archive_service_prompts_user(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     mocked_fn = mocker.patch('app.service_api_client.post')
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.archive_service', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.archive_service', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -847,15 +774,14 @@ def test_archive_service_prompts_user(
 
 
 def test_cant_archive_inactive_service(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     service_one['active'] = False
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.service_settings', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -863,15 +789,14 @@ def test_cant_archive_inactive_service(
 
 
 def test_suspend_service_after_confirm(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     mocked_fn = mocker.patch('app.service_api_client.post', return_value=service_one)
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.post(url_for('main.suspend_service', service_id=service_one['id']))
+    response = logged_in_client.post(url_for('main.suspend_service', service_id=service_one['id']))
 
     assert response.status_code == 302
     assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
@@ -879,15 +804,14 @@ def test_suspend_service_after_confirm(
 
 
 def test_suspend_service_prompts_user(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     mocked_fn = mocker.patch('app.service_api_client.post')
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.suspend_service', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.suspend_service', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -897,15 +821,14 @@ def test_suspend_service_prompts_user(
 
 
 def test_cant_suspend_inactive_service(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
     service_one['active'] = False
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.service_settings', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -913,7 +836,7 @@ def test_cant_suspend_inactive_service(
 
 
 def test_resume_service_after_confirm(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
@@ -921,8 +844,7 @@ def test_resume_service_after_confirm(
     service_one['active'] = False
     mocked_fn = mocker.patch('app.service_api_client.post', return_value=service_one)
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.post(url_for('main.resume_service', service_id=service_one['id']))
+    response = logged_in_client.post(url_for('main.resume_service', service_id=service_one['id']))
 
     assert response.status_code == 302
     assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
@@ -930,7 +852,7 @@ def test_resume_service_after_confirm(
 
 
 def test_resume_service_prompts_user(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
@@ -938,8 +860,7 @@ def test_resume_service_prompts_user(
     service_one['active'] = False
     mocked_fn = mocker.patch('app.service_api_client.post')
 
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.resume_service', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.resume_service', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
@@ -949,13 +870,12 @@ def test_resume_service_prompts_user(
 
 
 def test_cant_resume_active_service(
-    client,
+    logged_in_client,
     platform_admin_user,
     service_one,
     mocker,
 ):
-    client.login(platform_admin_user, mocker, service_one)
-    response = client.get(url_for('main.service_settings', service_id=service_one['id']))
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -3,10 +3,9 @@ from bs4 import BeautifulSoup
 
 
 def test_render_sign_in_returns_sign_in_template(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        response = app_.test_client().get(url_for('main.sign_in'))
+    response = client.get(url_for('main.sign_in'))
     assert response.status_code == 200
     assert 'Sign in' in response.get_data(as_text=True)
     assert 'Email address' in response.get_data(as_text=True)
@@ -22,94 +21,87 @@ def test_logged_in_user_redirects_to_choose_service(
 
 
 def test_process_sign_in_return_2fa_template(
-    app_,
+    client,
     api_user_active,
     mock_send_verify_code,
     mock_get_user,
     mock_get_user_by_email,
     mock_verify_password,
 ):
-
-    with app_.test_request_context():
-        response = app_.test_client().post(
-            url_for('main.sign_in'), data={
-                'email_address': 'valid@example.gov.uk',
-                'password': 'val1dPassw0rd!'})
-        assert response.status_code == 302
-        assert response.location == url_for('.two_factor', _external=True)
+    response = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': 'valid@example.gov.uk',
+            'password': 'val1dPassw0rd!'})
+    assert response.status_code == 302
+    assert response.location == url_for('.two_factor', _external=True)
     mock_verify_password.assert_called_with(api_user_active.id, 'val1dPassw0rd!')
 
 
 def test_should_return_locked_out_true_when_user_is_locked(
-    app_,
+    client,
     mock_get_user_by_email_locked,
 ):
-    with app_.test_request_context():
-        resp = app_.test_client().post(
-            url_for('main.sign_in'), data={
-                'email_address': 'valid@example.gov.uk',
-                'password': 'whatIsMyPassword!'})
-        assert resp.status_code == 200
-        assert 'The email address or password you entered is incorrect' in resp.get_data(as_text=True)
+    resp = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': 'valid@example.gov.uk',
+            'password': 'whatIsMyPassword!'})
+    assert resp.status_code == 200
+    assert 'The email address or password you entered is incorrect' in resp.get_data(as_text=True)
 
 
 def test_should_return_200_when_user_does_not_exist(
-    app_,
+    client,
     mock_get_user_by_email_not_found,
 ):
-    with app_.test_request_context():
-        response = app_.test_client().post(
-            url_for('main.sign_in'), data={
-                'email_address': 'notfound@gov.uk',
-                'password': 'doesNotExist!'})
+    response = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': 'notfound@gov.uk',
+            'password': 'doesNotExist!'})
     assert response.status_code == 200
     assert 'The email address or password you entered is incorrect' in response.get_data(as_text=True)
 
 
 def test_should_return_redirect_when_user_is_pending(
-    app_,
+    client,
     mock_get_user_by_email_pending,
     mock_verify_password,
 ):
-    with app_.test_request_context():
-        response = app_.test_client().post(
-            url_for('main.sign_in'), data={
-                'email_address': 'pending_user@example.gov.uk',
-                'password': 'val1dPassw0rd!'}, follow_redirects=True)
+    response = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': 'pending_user@example.gov.uk',
+            'password': 'val1dPassw0rd!'}, follow_redirects=True)
 
-        page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-        assert page.h1.string == 'Sign in'
-        assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string == 'Sign in'
+    assert response.status_code == 200
 
 
 def test_should_attempt_redirect_when_user_is_pending(
-    app_,
+    client,
     mock_get_user_by_email_pending,
     mock_verify_password,
 ):
-    with app_.test_request_context():
-        response = app_.test_client().post(
-            url_for('main.sign_in'), data={
-                'email_address': 'pending_user@example.gov.uk',
-                'password': 'val1dPassw0rd!'})
-        assert response.location == url_for('main.resend_email_verification', _external=True)
-        assert response.status_code == 302
+    response = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': 'pending_user@example.gov.uk',
+            'password': 'val1dPassw0rd!'})
+    assert response.location == url_for('main.resend_email_verification', _external=True)
+    assert response.status_code == 302
 
 
 def test_not_fresh_session_login_redirects_to_dashboard(
-    client,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user_by_email,
     mock_verify_password,
     mock_get_services_with_one_service,
 ):
-    client.login(api_user_active)
-    with client.session_transaction() as session:
+    with logged_in_client.session_transaction() as session:
         assert session['_fresh']
         session['_fresh'] = False
     # This should skip the two factor
-    response = client.post(
+    response = logged_in_client.post(
         url_for('main.sign_in'), data={
             'email_address': api_user_active.email_address,
             'password': 'val1dPassw0rd!'})
@@ -120,19 +112,18 @@ def test_not_fresh_session_login_redirects_to_dashboard(
 
 
 def test_not_fresh_session_login_redirects_to_choose_service(
-    client,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user_by_email,
     mock_verify_password,
     mock_get_services,
 ):
-    client.login(api_user_active)
-    with client.session_transaction() as session:
+    with logged_in_client.session_transaction() as session:
         assert session['_fresh']
         session['_fresh'] = False
     # This should skip the two factor
-    response = client.post(
+    response = logged_in_client.post(
         url_for('main.sign_in'), data={
             'email_address': api_user_active.email_address,
             'password': 'val1dPassw0rd!'})

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -2,7 +2,9 @@ from flask import url_for
 from bs4 import BeautifulSoup
 
 
-def test_render_sign_in_returns_sign_in_template(app_):
+def test_render_sign_in_returns_sign_in_template(
+    app_
+):
     with app_.test_request_context():
         response = app_.test_client().get(url_for('main.sign_in'))
     assert response.status_code == 200
@@ -12,17 +14,21 @@ def test_render_sign_in_returns_sign_in_template(app_):
     assert 'Forgot your password?' in response.get_data(as_text=True)
 
 
-def test_logged_in_user_redirects_to_choose_service(logged_in_client):
+def test_logged_in_user_redirects_to_choose_service(
+    logged_in_client
+):
     response = logged_in_client.get(url_for('main.sign_in'))
     assert response.location == url_for('main.choose_service', _external=True)
 
 
-def test_process_sign_in_return_2fa_template(app_,
-                                             api_user_active,
-                                             mock_send_verify_code,
-                                             mock_get_user,
-                                             mock_get_user_by_email,
-                                             mock_verify_password):
+def test_process_sign_in_return_2fa_template(
+    app_,
+    api_user_active,
+    mock_send_verify_code,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_verify_password,
+):
 
     with app_.test_request_context():
         response = app_.test_client().post(
@@ -34,8 +40,10 @@ def test_process_sign_in_return_2fa_template(app_,
     mock_verify_password.assert_called_with(api_user_active.id, 'val1dPassw0rd!')
 
 
-def test_should_return_locked_out_true_when_user_is_locked(app_,
-                                                           mock_get_user_by_email_locked):
+def test_should_return_locked_out_true_when_user_is_locked(
+    app_,
+    mock_get_user_by_email_locked,
+):
     with app_.test_request_context():
         resp = app_.test_client().post(
             url_for('main.sign_in'), data={
@@ -45,8 +53,10 @@ def test_should_return_locked_out_true_when_user_is_locked(app_,
         assert 'The email address or password you entered is incorrect' in resp.get_data(as_text=True)
 
 
-def test_should_return_200_when_user_does_not_exist(app_,
-                                                    mock_get_user_by_email_not_found):
+def test_should_return_200_when_user_does_not_exist(
+    app_,
+    mock_get_user_by_email_not_found,
+):
     with app_.test_request_context():
         response = app_.test_client().post(
             url_for('main.sign_in'), data={
@@ -56,9 +66,11 @@ def test_should_return_200_when_user_does_not_exist(app_,
     assert 'The email address or password you entered is incorrect' in response.get_data(as_text=True)
 
 
-def test_should_return_redirect_when_user_is_pending(app_,
-                                                     mock_get_user_by_email_pending,
-                                                     mock_verify_password):
+def test_should_return_redirect_when_user_is_pending(
+    app_,
+    mock_get_user_by_email_pending,
+    mock_verify_password,
+):
     with app_.test_request_context():
         response = app_.test_client().post(
             url_for('main.sign_in'), data={
@@ -70,9 +82,11 @@ def test_should_return_redirect_when_user_is_pending(app_,
         assert response.status_code == 200
 
 
-def test_should_attempt_redirect_when_user_is_pending(app_,
-                                                      mock_get_user_by_email_pending,
-                                                      mock_verify_password):
+def test_should_attempt_redirect_when_user_is_pending(
+    app_,
+    mock_get_user_by_email_pending,
+    mock_verify_password,
+):
     with app_.test_request_context():
         response = app_.test_client().post(
             url_for('main.sign_in'), data={
@@ -88,7 +102,7 @@ def test_not_fresh_session_login_redirects_to_dashboard(
     mock_login,
     mock_get_user_by_email,
     mock_verify_password,
-    mock_get_services_with_one_service
+    mock_get_services_with_one_service,
 ):
     client.login(api_user_active)
     with client.session_transaction() as session:
@@ -104,22 +118,23 @@ def test_not_fresh_session_login_redirects_to_dashboard(
     assert response.location == url_for(
         'main.service_dashboard', service_id=service_dct['id'], _external=True)
 
-    def test_not_fresh_session_login_redirects_to_choose_service(
-        client,
-        api_user_active,
-        mock_login,
-        mock_get_user_by_email,
-        mock_verify_password,
-        mock_get_services
-    ):
-        client.login(api_user_active)
-        with client.session_transaction() as session:
-            assert session['_fresh']
-            session['_fresh'] = False
-        # This should skip the two factor
-        response = client.post(
-            url_for('main.sign_in'), data={
-                'email_address': api_user_active.email_address,
-                'password': 'val1dPassw0rd!'})
-        assert response.status_code == 302
-        assert response.location == url_for('main.choose_service', _external=True)
+
+def test_not_fresh_session_login_redirects_to_choose_service(
+    client,
+    api_user_active,
+    mock_login,
+    mock_get_user_by_email,
+    mock_verify_password,
+    mock_get_services,
+):
+    client.login(api_user_active)
+    with client.session_transaction() as session:
+        assert session['_fresh']
+        session['_fresh'] = False
+    # This should skip the two factor
+    response = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': api_user_active.email_address,
+            'password': 'val1dPassw0rd!'})
+    assert response.status_code == 302
+    assert response.location == url_for('main.choose_service', _external=True)

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -1,7 +1,9 @@
 from flask import url_for
 
 
-def test_render_sign_out_redirects_to_sign_in(app_):
+def test_render_sign_out_redirects_to_sign_in(
+    app_
+):
     with app_.test_request_context():
         response = app_.test_client().get(
             url_for('main.sign_out'))
@@ -10,18 +12,20 @@ def test_render_sign_out_redirects_to_sign_in(app_):
             'main.index', _external=True)
 
 
-def test_sign_out_user(app_,
-                       mock_get_service,
-                       api_user_active,
-                       mock_get_user,
-                       mock_get_user_by_email,
-                       mock_login,
-                       mock_get_service_templates,
-                       mock_get_jobs,
-                       mock_has_permissions,
-                       mock_get_template_statistics,
-                       mock_get_detailed_service,
-                       mock_get_usage):
+def test_sign_out_user(
+    app_,
+    mock_get_service,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_login,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_has_permissions,
+    mock_get_template_statistics,
+    mock_get_detailed_service,
+    mock_get_usage,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -2,18 +2,17 @@ from flask import url_for
 
 
 def test_render_sign_out_redirects_to_sign_in(
-    app_
+    client
 ):
-    with app_.test_request_context():
-        response = app_.test_client().get(
-            url_for('main.sign_out'))
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.index', _external=True)
+    response = client.get(
+        url_for('main.sign_out'))
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.index', _external=True)
 
 
 def test_sign_out_user(
-    app_,
+    logged_in_client,
     mock_get_service,
     api_user_active,
     mock_get_user,
@@ -26,18 +25,15 @@ def test_sign_out_user(
     mock_get_detailed_service,
     mock_get_usage,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            with client.session_transaction() as session:
-                assert session.get('user_id') is not None
-            # Check we are logged in
-            response = client.get(
-                url_for('main.service_dashboard', service_id="123"))
-            assert response.status_code == 200
-            response = client.get(url_for('main.sign_out'))
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.index', _external=True)
-            with client.session_transaction() as session:
-                assert session.get('user_id') is None
+    with logged_in_client.session_transaction() as session:
+        assert session.get('user_id') is not None
+    # Check we are logged in
+    response = logged_in_client.get(
+        url_for('main.service_dashboard', service_id="123"))
+    assert response.status_code == 200
+    response = logged_in_client.get(url_for('main.sign_out'))
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.index', _external=True)
+    with logged_in_client.session_transaction() as session:
+        assert session.get('user_id') is None

--- a/tests/app/main/views/test_template_history.py
+++ b/tests/app/main/views/test_template_history.py
@@ -3,7 +3,7 @@ from flask import url_for
 
 
 def test_view_template_version(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -13,22 +13,19 @@ def test_view_template_version(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            version = 1
-            all_versions_link = url_for(
-                'main.view_template_versions',
-                service_id=service_id,
-                template_id=template_id
-            )
-            resp = client.get(url_for(
-                '.view_template_version',
-                service_id=service_id,
-                template_id=template_id,
-                version=version))
+    service_id = fake_uuid
+    template_id = fake_uuid
+    version = 1
+    all_versions_link = url_for(
+        'main.view_template_versions',
+        service_id=service_id,
+        template_id=template_id
+    )
+    resp = logged_in_client.get(url_for(
+        '.view_template_version',
+        service_id=service_id,
+        template_id=template_id,
+        version=version))
 
     assert resp.status_code == 200
     resp_data = resp.get_data(as_text=True)
@@ -44,7 +41,7 @@ def test_view_template_version(
 
 
 def test_view_template_versions(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -55,17 +52,14 @@ def test_view_template_versions(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            version = 1
-            resp = client.get(url_for(
-                '.view_template_versions',
-                service_id=service_id,
-                template_id=template_id
-            ))
+    service_id = fake_uuid
+    template_id = fake_uuid
+    version = 1
+    resp = logged_in_client.get(url_for(
+        '.view_template_versions',
+        service_id=service_id,
+        template_id=template_id
+    ))
 
     assert resp.status_code == 200
     resp_data = resp.get_data(as_text=True)

--- a/tests/app/main/views/test_template_history.py
+++ b/tests/app/main/views/test_template_history.py
@@ -2,15 +2,17 @@ import json
 from flask import url_for
 
 
-def test_view_template_version(app_,
-                               api_user_active,
-                               mock_login,
-                               mock_get_service,
-                               mock_get_template_version,
-                               mock_get_user,
-                               mock_get_user_by_email,
-                               mock_has_permissions,
-                               fake_uuid):
+def test_view_template_version(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_template_version,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -41,16 +43,18 @@ def test_view_template_version(app_,
     )
 
 
-def test_view_template_versions(app_,
-                                api_user_active,
-                                mock_login,
-                                mock_get_service,
-                                mock_get_template_versions,
-                                mock_get_service_template,
-                                mock_get_user,
-                                mock_get_user_by_email,
-                                mock_has_permissions,
-                                fake_uuid):
+def test_view_template_versions(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_template_versions,
+    mock_get_service_template,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -14,11 +14,11 @@ from app.main.views.templates import get_last_use_message, get_human_readable_de
 
 
 def test_should_show_page_for_one_template(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        mock_get_service_template,
-        fake_uuid
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_service_template,
+    fake_uuid,
 ):
 
     service = create_sample_service(active_user_with_permissions)
@@ -42,11 +42,11 @@ def test_should_show_page_for_one_template(
 
 
 def test_should_show_page_template_with_priority_select_if_platform_admin(
-        app_,
-        platform_admin_user,
-        mocker,
-        mock_get_service_template,
-        fake_uuid
+    app_,
+    platform_admin_user,
+    mocker,
+    mock_get_service_template,
+    fake_uuid,
 ):
 
     service = create_sample_service(platform_admin_user)
@@ -93,7 +93,7 @@ def test_should_show_preview_letter_templates(
     mock_get_user_by_email,
     mock_has_permissions,
     fake_uuid,
-    mocker
+    mocker,
 ):
     client.login(api_user_active)
     service_id, template_id = repeat(fake_uuid, 2)
@@ -115,12 +115,14 @@ def test_should_show_preview_letter_templates(
     )
 
 
-def test_should_redirect_when_saving_a_template(app_,
-                                                active_user_with_permissions,
-                                                mocker,
-                                                mock_get_service_template,
-                                                mock_update_service_template,
-                                                fake_uuid):
+def test_should_redirect_when_saving_a_template(
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_service_template,
+    mock_update_service_template,
+    fake_uuid,
+):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -150,12 +152,13 @@ def test_should_redirect_when_saving_a_template(app_,
 
 
 def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        mock_get_service_template_with_priority,
-        mock_update_service_template,
-        fake_uuid):
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_service_template_with_priority,
+    mock_update_service_template,
+    fake_uuid,
+):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -189,12 +192,13 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
 
 
 def test_should_403_when_edit_template_with_process_type_of_priority_for_non_platform_admin(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        mock_get_service_template,
-        mock_update_service_template,
-        fake_uuid):
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_service_template,
+    mock_update_service_template,
+    fake_uuid,
+):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -218,12 +222,13 @@ def test_should_403_when_edit_template_with_process_type_of_priority_for_non_pla
 
 
 def test_should_403_when_create_template_with_process_type_of_priority_for_non_platform_admin(
-        app_,
-        active_user_with_permissions,
-        mocker,
-        mock_get_service_template,
-        mock_update_service_template,
-        fake_uuid):
+    app_,
+    active_user_with_permissions,
+    mocker,
+    mock_get_service_template,
+    mock_update_service_template,
+    fake_uuid,
+):
     service = create_sample_service(active_user_with_permissions)
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -247,16 +252,16 @@ def test_should_403_when_create_template_with_process_type_of_priority_for_non_p
 
 
 def test_should_show_interstitial_when_making_breaking_change(
-        app_,
-        api_user_active,
-        mock_login,
-        mock_get_service_email_template,
-        mock_update_service_template,
-        mock_get_user,
-        mock_get_service,
-        mock_get_user_by_email,
-        mock_has_permissions,
-        fake_uuid
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service_email_template,
+    mock_update_service_template,
+    mock_get_user,
+    mock_get_service,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
 ):
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -291,16 +296,18 @@ def test_should_show_interstitial_when_making_breaking_change(
                 assert page.find('input', {'name': key})['value'] == value
 
 
-def test_should_not_create_too_big_template(app_,
-                                            api_user_active,
-                                            mock_login,
-                                            mock_get_service_template,
-                                            mock_get_user,
-                                            mock_get_service,
-                                            mock_get_user_by_email,
-                                            mock_create_service_template_content_too_big,
-                                            mock_has_permissions,
-                                            fake_uuid):
+def test_should_not_create_too_big_template(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service_template,
+    mock_get_user,
+    mock_get_service,
+    mock_get_user_by_email,
+    mock_create_service_template_content_too_big,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -323,16 +330,18 @@ def test_should_not_create_too_big_template(app_,
             assert "Content has a character count greater than the limit of 459" in resp.get_data(as_text=True)
 
 
-def test_should_not_update_too_big_template(app_,
-                                            api_user_active,
-                                            mock_login,
-                                            mock_get_service_template,
-                                            mock_get_user,
-                                            mock_get_service,
-                                            mock_get_user_by_email,
-                                            mock_update_service_template_400_content_too_big,
-                                            mock_has_permissions,
-                                            fake_uuid):
+def test_should_not_update_too_big_template(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service_template,
+    mock_get_user,
+    mock_get_service,
+    mock_get_user_by_email,
+    mock_update_service_template_400_content_too_big,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -355,16 +364,18 @@ def test_should_not_update_too_big_template(app_,
             assert "Content has a character count greater than the limit of 459" in resp.get_data(as_text=True)
 
 
-def test_should_redirect_when_saving_a_template_email(app_,
-                                                      api_user_active,
-                                                      mock_login,
-                                                      mock_get_service_email_template,
-                                                      mock_update_service_template,
-                                                      mock_get_user,
-                                                      mock_get_service,
-                                                      mock_get_user_by_email,
-                                                      mock_has_permissions,
-                                                      fake_uuid):
+def test_should_redirect_when_saving_a_template_email(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service_email_template,
+    mock_update_service_template,
+    mock_get_user,
+    mock_get_service,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -396,16 +407,18 @@ def test_should_redirect_when_saving_a_template_email(app_,
                 template_id, name, 'email', content, service_id, subject, 'normal')
 
 
-def test_should_show_delete_template_page_with_time_block(app_,
-                                                          api_user_active,
-                                                          mock_login,
-                                                          mock_get_service,
-                                                          mock_get_service_template,
-                                                          mock_get_user,
-                                                          mock_get_user_by_email,
-                                                          mock_has_permissions,
-                                                          fake_uuid,
-                                                          mocker):
+def test_should_show_delete_template_page_with_time_block(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with freeze_time('2012-01-01 12:00:00'):
@@ -432,16 +445,18 @@ def test_should_show_delete_template_page_with_time_block(app_,
     mock_get_service_template.assert_called_with(service_id, template_id)
 
 
-def test_should_show_delete_template_page_with_never_used_block(app_,
-                                                                api_user_active,
-                                                                mock_login,
-                                                                mock_get_service,
-                                                                mock_get_service_template,
-                                                                mock_get_user,
-                                                                mock_get_user_by_email,
-                                                                mock_has_permissions,
-                                                                fake_uuid,
-                                                                mocker):
+def test_should_show_delete_template_page_with_never_used_block(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+    mocker,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             mocker.patch(
@@ -466,16 +481,18 @@ def test_should_show_delete_template_page_with_never_used_block(app_,
             mock_get_service_template.assert_called_with(service_id, template_id)
 
 
-def test_should_redirect_when_deleting_a_template(app_,
-                                                  api_user_active,
-                                                  mock_login,
-                                                  mock_get_service,
-                                                  mock_get_service_template,
-                                                  mock_delete_service_template,
-                                                  mock_get_user,
-                                                  mock_get_user_by_email,
-                                                  mock_has_permissions,
-                                                  fake_uuid):
+def test_should_redirect_when_deleting_a_template(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_service_template,
+    mock_delete_service_template,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -509,15 +526,15 @@ def test_should_redirect_when_deleting_a_template(app_,
 
 @freeze_time('2016-01-01T15:00')
 def test_should_show_page_for_a_deleted_template(
-        app_,
-        api_user_active,
-        mock_login,
-        mock_get_service,
-        mock_get_deleted_template,
-        mock_get_user,
-        mock_get_user_by_email,
-        mock_has_permissions,
-        fake_uuid
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_service,
+    mock_get_deleted_template,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_has_permissions,
+    fake_uuid,
 ):
     with app_.test_request_context(), app_.test_client() as client:
         client.login(api_user_active)
@@ -545,14 +562,16 @@ def test_should_show_page_for_a_deleted_template(
     'main.edit_service_template',
     'main.delete_service_template'
 ])
-def test_route_permissions(route,
-                           mocker,
-                           app_,
-                           api_user_active,
-                           service_one,
-                           mock_get_service_template,
-                           mock_get_template_statistics_for_template,
-                           fake_uuid):
+def test_route_permissions(
+    route,
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_template,
+    mock_get_template_statistics_for_template,
+    fake_uuid,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,
@@ -569,11 +588,13 @@ def test_route_permissions(route,
             service_one)
 
 
-def test_route_permissions_for_choose_template(mocker,
-                                               app_,
-                                               api_user_active,
-                                               service_one,
-                                               mock_get_service_templates):
+def test_route_permissions_for_choose_template(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_templates,
+):
     mocker.patch('app.job_api_client.get_job')
     with app_.test_request_context():
         validate_route_permission(
@@ -595,14 +616,16 @@ def test_route_permissions_for_choose_template(mocker,
     'main.edit_service_template',
     'main.delete_service_template'
 ])
-def test_route_invalid_permissions(route,
-                                   mocker,
-                                   app_,
-                                   api_user_active,
-                                   service_one,
-                                   mock_get_service_template,
-                                   mock_get_template_statistics_for_template,
-                                   fake_uuid):
+def test_route_invalid_permissions(
+    route,
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_template,
+    mock_get_template_statistics_for_template,
+    fake_uuid,
+):
     with app_.test_request_context():
         validate_route_permission(
             mocker,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -14,7 +14,7 @@ from app.main.views.templates import get_last_use_message, get_human_readable_de
 
 
 def test_should_show_page_for_one_template(
-    app_,
+    client,
     active_user_with_permissions,
     mocker,
     mock_get_service_template,
@@ -22,16 +22,13 @@ def test_should_show_page_for_one_template(
 ):
 
     service = create_sample_service(active_user_with_permissions)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service)
-            mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
-            service_id = service['id']
-            template_id = fake_uuid
-            response = client.get(url_for(
-                '.edit_service_template',
-                service_id=service_id,
-                template_id=template_id))
+    client.login(active_user_with_permissions, mocker, service)
+    service_id = service['id']
+    template_id = fake_uuid
+    response = client.get(url_for(
+        '.edit_service_template',
+        service_id=service_id,
+        template_id=template_id))
 
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)
@@ -42,7 +39,7 @@ def test_should_show_page_for_one_template(
 
 
 def test_should_show_page_template_with_priority_select_if_platform_admin(
-    app_,
+    logged_in_client,
     platform_admin_user,
     mocker,
     mock_get_service_template,
@@ -50,16 +47,13 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
 ):
 
     service = create_sample_service(platform_admin_user)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(platform_admin_user, mocker, service)
-            mocker.patch('app.user_api_client.get_users_for_service', return_value=[platform_admin_user])
-            service_id = service['id']
-            template_id = fake_uuid
-            response = client.get(url_for(
-                '.edit_service_template',
-                service_id=service_id,
-                template_id=template_id))
+    mocker.patch('app.user_api_client.get_users_for_service', return_value=[platform_admin_user])
+    service_id = service['id']
+    template_id = fake_uuid
+    response = logged_in_client.get(url_for(
+        '.edit_service_template',
+        service_id=service_id,
+        template_id=template_id))
 
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)
@@ -84,7 +78,7 @@ def test_should_show_preview_letter_templates(
     extra_view_args,
     view_suffix,
     expected_content_type,
-    client,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -95,9 +89,8 @@ def test_should_show_preview_letter_templates(
     fake_uuid,
     mocker,
 ):
-    client.login(api_user_active)
     service_id, template_id = repeat(fake_uuid, 2)
-    response = client.get(url_for(
+    response = logged_in_client.get(url_for(
         '{}_{}'.format(view, view_suffix),
         service_id=service_id,
         template_id=template_id,
@@ -116,7 +109,7 @@ def test_should_show_preview_letter_templates(
 
 
 def test_should_redirect_when_saving_a_template(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     mock_get_service_template,
@@ -124,35 +117,32 @@ def test_should_redirect_when_saving_a_template(
     fake_uuid,
 ):
     service = create_sample_service(active_user_with_permissions)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service)
-            mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
-            template_id = fake_uuid
-            name = "new name"
-            content = "template <em>content</em> with & entity"
-            data = {
-                'id': template_id,
-                'name': name,
-                'template_content': content,
-                'template_type': 'sms',
-                'service': service['id'],
-                'process_type': 'normal'
-            }
-            response = client.post(url_for(
-                '.edit_service_template',
-                service_id=service['id'],
-                template_id=template_id), data=data)
+    mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
+    template_id = fake_uuid
+    name = "new name"
+    content = "template <em>content</em> with & entity"
+    data = {
+        'id': template_id,
+        'name': name,
+        'template_content': content,
+        'template_type': 'sms',
+        'service': service['id'],
+        'process_type': 'normal'
+    }
+    response = logged_in_client.post(url_for(
+        '.edit_service_template',
+        service_id=service['id'],
+        template_id=template_id), data=data)
 
-            assert response.status_code == 302
-            assert response.location == url_for(
-                '.view_template', service_id=service['id'], template_id=template_id, _external=True)
-            mock_update_service_template.assert_called_with(
-                template_id, name, 'sms', content, service['id'], None, 'normal')
+    assert response.status_code == 302
+    assert response.location == url_for(
+        '.view_template', service_id=service['id'], template_id=template_id, _external=True)
+    mock_update_service_template.assert_called_with(
+        template_id, name, 'sms', content, service['id'], None, 'normal')
 
 
 def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
-    app_,
+    logged_in_client,
     active_user_with_permissions,
     mocker,
     mock_get_service_template_with_priority,
@@ -160,39 +150,36 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
     fake_uuid,
 ):
     service = create_sample_service(active_user_with_permissions)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service)
-            mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
-            template_id = fake_uuid
-            data = {
-                'id': template_id,
-                'name': "new name",
-                'template_content': "new template <em>content</em> with & entity",
-                'template_type': 'sms',
-                'service': service['id'],
-                'process_type': 'priority'
-            }
-            response = client.post(url_for(
-                '.edit_service_template',
-                service_id=service['id'],
-                template_id=template_id), data=data)
-            assert response.status_code == 302
-            assert response.location == url_for(
-                '.view_template', service_id=service['id'], template_id=template_id, _external=True)
-            mock_update_service_template.assert_called_with(
-                template_id,
-                "new name",
-                'sms',
-                "new template <em>content</em> with & entity",
-                service['id'],
-                None,
-                'priority'
-            )
+    mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
+    template_id = fake_uuid
+    data = {
+        'id': template_id,
+        'name': "new name",
+        'template_content': "new template <em>content</em> with & entity",
+        'template_type': 'sms',
+        'service': service['id'],
+        'process_type': 'priority'
+    }
+    response = logged_in_client.post(url_for(
+        '.edit_service_template',
+        service_id=service['id'],
+        template_id=template_id), data=data)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        '.view_template', service_id=service['id'], template_id=template_id, _external=True)
+    mock_update_service_template.assert_called_with(
+        template_id,
+        "new name",
+        'sms',
+        "new template <em>content</em> with & entity",
+        service['id'],
+        None,
+        'priority'
+    )
 
 
 def test_should_403_when_edit_template_with_process_type_of_priority_for_non_platform_admin(
-    app_,
+    client,
     active_user_with_permissions,
     mocker,
     mock_get_service_template,
@@ -200,29 +187,27 @@ def test_should_403_when_edit_template_with_process_type_of_priority_for_non_pla
     fake_uuid,
 ):
     service = create_sample_service(active_user_with_permissions)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service)
-            mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
-            template_id = fake_uuid
-            data = {
-                'id': template_id,
-                'name': "new name",
-                'template_content': "template <em>content</em> with & entity",
-                'template_type': 'sms',
-                'service': service['id'],
-                'process_type': 'priority'
-            }
-            response = client.post(url_for(
-                '.edit_service_template',
-                service_id=service['id'],
-                template_id=template_id), data=data)
-            assert response.status_code == 403
-            mock_update_service_template.called == 0
+    client.login(active_user_with_permissions, mocker, service)
+    mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
+    template_id = fake_uuid
+    data = {
+        'id': template_id,
+        'name': "new name",
+        'template_content': "template <em>content</em> with & entity",
+        'template_type': 'sms',
+        'service': service['id'],
+        'process_type': 'priority'
+    }
+    response = client.post(url_for(
+        '.edit_service_template',
+        service_id=service['id'],
+        template_id=template_id), data=data)
+    assert response.status_code == 403
+    mock_update_service_template.called == 0
 
 
 def test_should_403_when_create_template_with_process_type_of_priority_for_non_platform_admin(
-    app_,
+    client,
     active_user_with_permissions,
     mocker,
     mock_get_service_template,
@@ -230,29 +215,27 @@ def test_should_403_when_create_template_with_process_type_of_priority_for_non_p
     fake_uuid,
 ):
     service = create_sample_service(active_user_with_permissions)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(active_user_with_permissions, mocker, service)
-            mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
-            template_id = fake_uuid
-            data = {
-                'id': template_id,
-                'name': "new name",
-                'template_content': "template <em>content</em> with & entity",
-                'template_type': 'sms',
-                'service': service['id'],
-                'process_type': 'priority'
-            }
-            response = client.post(url_for(
-                '.add_service_template',
-                service_id=service['id'],
-                template_type='sms'), data=data)
-            assert response.status_code == 403
-            mock_update_service_template.called == 0
+    client.login(active_user_with_permissions, mocker, service)
+    mocker.patch('app.user_api_client.get_users_for_service', return_value=[active_user_with_permissions])
+    template_id = fake_uuid
+    data = {
+        'id': template_id,
+        'name': "new name",
+        'template_content': "template <em>content</em> with & entity",
+        'template_type': 'sms',
+        'service': service['id'],
+        'process_type': 'priority'
+    }
+    response = client.post(url_for(
+        '.add_service_template',
+        service_id=service['id'],
+        template_type='sms'), data=data)
+    assert response.status_code == 403
+    mock_update_service_template.called == 0
 
 
 def test_should_show_interstitial_when_making_breaking_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service_email_template,
@@ -263,41 +246,38 @@ def test_should_show_interstitial_when_making_breaking_change(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            response = client.post(
-                url_for('.edit_service_template', service_id=service_id, template_id=template_id),
-                data={
-                    'id': template_id,
-                    'name': "new name",
-                    'template_content': "hello",
-                    'template_type': 'email',
-                    'subject': 'reminder',
-                    'service': service_id,
-                    'process_type': 'normal'
-                }
-            )
+    service_id = fake_uuid
+    template_id = fake_uuid
+    response = logged_in_client.post(
+        url_for('.edit_service_template', service_id=service_id, template_id=template_id),
+        data={
+            'id': template_id,
+            'name': "new name",
+            'template_content': "hello",
+            'template_type': 'email',
+            'subject': 'reminder',
+            'service': service_id,
+            'process_type': 'normal'
+        }
+    )
 
-            assert response.status_code == 200
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.string.strip() == "Confirm changes"
-            assert page.find('a', {'class': 'page-footer-back-link'})['href'] == url_for(".edit_service_template",
-                                                                                         service_id=service_id,
-                                                                                         template_id=template_id)
-            for key, value in {
-                'name': 'new name',
-                'subject': 'reminder',
-                'template_content': 'hello',
-                'confirm': 'true'
-            }.items():
-                assert page.find('input', {'name': key})['value'] == value
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == "Confirm changes"
+    assert page.find('a', {'class': 'page-footer-back-link'})['href'] == url_for(".edit_service_template",
+                                                                                 service_id=service_id,
+                                                                                 template_id=template_id)
+    for key, value in {
+        'name': 'new name',
+        'subject': 'reminder',
+        'template_content': 'hello',
+        'confirm': 'true'
+    }.items():
+        assert page.find('input', {'name': key})['value'] == value
 
 
 def test_should_not_create_too_big_template(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service_template,
@@ -308,30 +288,27 @@ def test_should_not_create_too_big_template(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_type = 'sms'
-            data = {
-                'name': "new name",
-                'template_content': "template content",
-                'template_type': template_type,
-                'service': service_id,
-                'process_type': 'normal'
-            }
-            resp = client.post(url_for(
-                '.add_service_template',
-                service_id=service_id,
-                template_type=template_type
-            ), data=data)
+    service_id = fake_uuid
+    template_type = 'sms'
+    data = {
+        'name': "new name",
+        'template_content': "template content",
+        'template_type': template_type,
+        'service': service_id,
+        'process_type': 'normal'
+    }
+    resp = logged_in_client.post(url_for(
+        '.add_service_template',
+        service_id=service_id,
+        template_type=template_type
+    ), data=data)
 
-            assert resp.status_code == 200
-            assert "Content has a character count greater than the limit of 459" in resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert "Content has a character count greater than the limit of 459" in resp.get_data(as_text=True)
 
 
 def test_should_not_update_too_big_template(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service_template,
@@ -342,30 +319,27 @@ def test_should_not_update_too_big_template(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            data = {
-                'id': fake_uuid,
-                'name': "new name",
-                'template_content': "template content",
-                'service': service_id,
-                'template_type': 'sms',
-                'process_type': 'normal'
-            }
-            resp = client.post(url_for(
-                '.edit_service_template',
-                service_id=service_id,
-                template_id=template_id), data=data)
+    service_id = fake_uuid
+    template_id = fake_uuid
+    data = {
+        'id': fake_uuid,
+        'name': "new name",
+        'template_content': "template content",
+        'service': service_id,
+        'template_type': 'sms',
+        'process_type': 'normal'
+    }
+    resp = logged_in_client.post(url_for(
+        '.edit_service_template',
+        service_id=service_id,
+        template_id=template_id), data=data)
 
-            assert resp.status_code == 200
-            assert "Content has a character count greater than the limit of 459" in resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert "Content has a character count greater than the limit of 459" in resp.get_data(as_text=True)
 
 
 def test_should_redirect_when_saving_a_template_email(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service_email_template,
@@ -376,39 +350,36 @@ def test_should_redirect_when_saving_a_template_email(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            name = "new name"
-            content = "template <em>content</em> with & entity ((thing)) ((date))"
-            subject = "subject"
-            data = {
-                'id': template_id,
-                'name': name,
-                'template_content': content,
-                'template_type': 'email',
-                'service': service_id,
-                'subject': subject,
-                'process_type': 'normal'
-            }
-            response = client.post(url_for(
-                '.edit_service_template',
-                service_id=service_id,
-                template_id=template_id), data=data)
-            assert response.status_code == 302
-            assert response.location == url_for(
-                '.view_template',
-                service_id=service_id,
-                template_id=template_id,
-                _external=True)
-            mock_update_service_template.assert_called_with(
-                template_id, name, 'email', content, service_id, subject, 'normal')
+    service_id = fake_uuid
+    template_id = fake_uuid
+    name = "new name"
+    content = "template <em>content</em> with & entity ((thing)) ((date))"
+    subject = "subject"
+    data = {
+        'id': template_id,
+        'name': name,
+        'template_content': content,
+        'template_type': 'email',
+        'service': service_id,
+        'subject': subject,
+        'process_type': 'normal'
+    }
+    response = logged_in_client.post(url_for(
+        '.edit_service_template',
+        service_id=service_id,
+        template_id=template_id), data=data)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        '.view_template',
+        service_id=service_id,
+        template_id=template_id,
+        _external=True)
+    mock_update_service_template.assert_called_with(
+        template_id, name, 'email', content, service_id, subject, 'normal')
 
 
 def test_should_show_delete_template_page_with_time_block(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -419,23 +390,20 @@ def test_should_show_delete_template_page_with_time_block(
     fake_uuid,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with freeze_time('2012-01-01 12:00:00'):
-                template = template_json('1234', '1234', "Test template", "sms", "Something very interesting")
-                notification = single_notification_json('1234', template=template)
+    with freeze_time('2012-01-01 12:00:00'):
+        template = template_json('1234', '1234', "Test template", "sms", "Something very interesting")
+        notification = single_notification_json('1234', template=template)
 
-                mocker.patch('app.template_statistics_client.get_template_statistics_for_template',
-                             return_value=notification)
+        mocker.patch('app.template_statistics_client.get_template_statistics_for_template',
+                     return_value=notification)
 
-            with freeze_time('2012-01-01 12:10:00'):
-                client.login(api_user_active)
-                service_id = fake_uuid
-                template_id = fake_uuid
-                response = client.get(url_for(
-                    '.delete_service_template',
-                    service_id=service_id,
-                    template_id=template_id))
+    with freeze_time('2012-01-01 12:10:00'):
+        service_id = fake_uuid
+        template_id = fake_uuid
+        response = logged_in_client.get(url_for(
+            '.delete_service_template',
+            service_id=service_id,
+            template_id=template_id))
     content = response.get_data(as_text=True)
     assert response.status_code == 200
     assert 'Test template was last used 10 minutes ago. Are you sure you want to delete it?' in content
@@ -446,7 +414,7 @@ def test_should_show_delete_template_page_with_time_block(
 
 
 def test_should_show_delete_template_page_with_never_used_block(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -457,32 +425,28 @@ def test_should_show_delete_template_page_with_never_used_block(
     fake_uuid,
     mocker,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            mocker.patch(
-                'app.template_statistics_client.get_template_statistics_for_template',
-                side_effect=HTTPError(response=Mock(status_code=404), message="Default message")
-            )
+    mocker.patch(
+        'app.template_statistics_client.get_template_statistics_for_template',
+        side_effect=HTTPError(response=Mock(status_code=404), message="Default message")
+    )
+    service_id = fake_uuid
+    template_id = fake_uuid
+    response = logged_in_client.get(url_for(
+        '.delete_service_template',
+        service_id=service_id,
+        template_id=template_id))
 
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            response = client.get(url_for(
-                '.delete_service_template',
-                service_id=service_id,
-                template_id=template_id))
-
-            content = response.get_data(as_text=True)
-            assert response.status_code == 200
-            assert 'Two week reminder has never been used. Are you sure you want to delete it?' in content
-            assert 'Are you sure' in content
-            assert 'Two week reminder' in content
-            assert 'Template &lt;em&gt;content&lt;/em&gt; with &amp; entity' in content
-            mock_get_service_template.assert_called_with(service_id, template_id)
+    content = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'Two week reminder has never been used. Are you sure you want to delete it?' in content
+    assert 'Are you sure' in content
+    assert 'Two week reminder' in content
+    assert 'Template &lt;em&gt;content&lt;/em&gt; with &amp; entity' in content
+    mock_get_service_template.assert_called_with(service_id, template_id)
 
 
 def test_should_redirect_when_deleting_a_template(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -493,40 +457,37 @@ def test_should_redirect_when_deleting_a_template(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            service_id = fake_uuid
-            template_id = fake_uuid
-            name = "new name"
-            type_ = "sms"
-            content = "template content"
-            data = {
-                'id': str(template_id),
-                'name': name,
-                'template_type': type_,
-                'content': content,
-                'service': service_id
-            }
-            response = client.post(url_for(
-                '.delete_service_template',
-                service_id=service_id,
-                template_id=template_id
-            ), data=data)
+    service_id = fake_uuid
+    template_id = fake_uuid
+    name = "new name"
+    type_ = "sms"
+    content = "template content"
+    data = {
+        'id': str(template_id),
+        'name': name,
+        'template_type': type_,
+        'content': content,
+        'service': service_id
+    }
+    response = logged_in_client.post(url_for(
+        '.delete_service_template',
+        service_id=service_id,
+        template_id=template_id
+    ), data=data)
 
-            assert response.status_code == 302
-            assert response.location == url_for(
-                '.choose_template',
-                service_id=service_id, template_type=type_, _external=True)
-            mock_get_service_template.assert_called_with(
-                service_id, template_id)
-            mock_delete_service_template.assert_called_with(
-                service_id, template_id)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        '.choose_template',
+        service_id=service_id, template_type=type_, _external=True)
+    mock_get_service_template.assert_called_with(
+        service_id, template_id)
+    mock_delete_service_template.assert_called_with(
+        service_id, template_id)
 
 
 @freeze_time('2016-01-01T15:00')
 def test_should_show_page_for_a_deleted_template(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_service,
@@ -536,25 +497,23 @@ def test_should_show_page_for_a_deleted_template(
     mock_has_permissions,
     fake_uuid,
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        client.login(api_user_active)
-        service_id = fake_uuid
-        template_id = fake_uuid
-        response = client.get(url_for(
-            '.view_template',
-            service_id=service_id,
-            template_id=template_id
-        ))
+    service_id = fake_uuid
+    template_id = fake_uuid
+    response = logged_in_client.get(url_for(
+        '.view_template',
+        service_id=service_id,
+        template_id=template_id
+    ))
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        content = response.get_data(as_text=True)
-        assert url_for("main.edit_service_template", service_id=fake_uuid, template_id=fake_uuid) not in content
-        assert url_for("main.send_from_api", service_id=fake_uuid, template_id=fake_uuid) not in content
-        assert url_for("main.send_test", service_id=fake_uuid, template_id=fake_uuid) not in content
-        assert "This template was deleted<br/>1 January 2016" in content
+    content = response.get_data(as_text=True)
+    assert url_for("main.edit_service_template", service_id=fake_uuid, template_id=fake_uuid) not in content
+    assert url_for("main.send_from_api", service_id=fake_uuid, template_id=fake_uuid) not in content
+    assert url_for("main.send_test", service_id=fake_uuid, template_id=fake_uuid) not in content
+    assert "This template was deleted<br/>1 January 2016" in content
 
-        mock_get_deleted_template.assert_called_with(service_id, template_id)
+    mock_get_deleted_template.assert_called_with(service_id, template_id)
 
 
 @pytest.mark.parametrize('route', [
@@ -566,49 +525,49 @@ def test_route_permissions(
     route,
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_get_service_template,
     mock_get_template_statistics_for_template,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            200,
-            url_for(
-                route,
-                service_id=service_one['id'],
-                template_type='sms',
-                template_id=fake_uuid),
-            ['manage_templates'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        200,
+        url_for(
+            route,
+            service_id=service_one['id'],
+            template_type='sms',
+            template_id=fake_uuid),
+        ['manage_templates'],
+        api_user_active,
+        service_one)
 
 
 def test_route_permissions_for_choose_template(
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_get_service_templates,
 ):
     mocker.patch('app.job_api_client.get_job')
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            200,
-            url_for(
-                'main.choose_template',
-                service_id=service_one['id'],
-                template_type='sms'),
-            ['view_activity'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        200,
+        url_for(
+            'main.choose_template',
+            service_id=service_one['id'],
+            template_type='sms'),
+        ['view_activity'],
+        api_user_active,
+        service_one)
 
 
 @pytest.mark.parametrize('route', [
@@ -620,26 +579,26 @@ def test_route_invalid_permissions(
     route,
     mocker,
     app_,
+    client,
     api_user_active,
     service_one,
     mock_get_service_template,
     mock_get_template_statistics_for_template,
     fake_uuid,
 ):
-    with app_.test_request_context():
-        validate_route_permission(
-            mocker,
-            app_,
-            "GET",
-            403,
-            url_for(
-                route,
-                service_id=service_one['id'],
-                template_type='sms',
-                template_id=fake_uuid),
-            ['view_activity'],
-            api_user_active,
-            service_one)
+    validate_route_permission(
+        mocker,
+        app_,
+        "GET",
+        403,
+        url_for(
+            route,
+            service_id=service_one['id'],
+            template_type='sms',
+            template_id=fake_uuid),
+        ['view_activity'],
+        api_user_active,
+        service_one)
 
 
 def test_get_last_use_message_returns_no_template_message():

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -4,9 +4,11 @@ from tests.conftest import SERVICE_ONE_ID
 from unittest.mock import ANY
 
 
-def test_should_render_two_factor_page(app_,
-                                       api_user_active,
-                                       mock_get_user_by_email):
+def test_should_render_two_factor_page(
+    app_,
+    api_user_active,
+    mock_get_user_by_email,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             # TODO this lives here until we work out how to
@@ -20,13 +22,15 @@ def test_should_render_two_factor_page(app_,
         assert '''We’ve sent you a text message with a security code.''' in response.get_data(as_text=True)
 
 
-def test_should_login_user_and_redirect_to_service_dashboard(app_,
-                                                             api_user_active,
-                                                             mock_get_user,
-                                                             mock_get_user_by_email,
-                                                             mock_check_verify_code,
-                                                             mock_get_services_with_one_service,
-                                                             mock_events):
+def test_should_login_user_and_redirect_to_service_dashboard(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_check_verify_code,
+    mock_get_services_with_one_service,
+    mock_events,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -45,12 +49,14 @@ def test_should_login_user_and_redirect_to_service_dashboard(app_,
         mock_events.assert_called_with('sucessful_login', ANY)
 
 
-def test_should_login_user_and_should_redirect_to_next_url(app_,
-                                                           api_user_active,
-                                                           mock_get_user,
-                                                           mock_get_user_by_email,
-                                                           mock_check_verify_code,
-                                                           mock_get_services):
+def test_should_login_user_and_should_redirect_to_next_url(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_check_verify_code,
+    mock_get_services,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -67,12 +73,14 @@ def test_should_login_user_and_should_redirect_to_next_url(app_,
             )
 
 
-def test_should_login_user_and_not_redirect_to_external_url(app_,
-                                                            api_user_active,
-                                                            mock_get_user,
-                                                            mock_get_user_by_email,
-                                                            mock_check_verify_code,
-                                                            mock_get_services_with_one_service):
+def test_should_login_user_and_not_redirect_to_external_url(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_check_verify_code,
+    mock_get_services_with_one_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -89,12 +97,14 @@ def test_should_login_user_and_not_redirect_to_external_url(app_,
             )
 
 
-def test_should_login_user_and_redirect_to_choose_services(app_,
-                                                           api_user_active,
-                                                           mock_get_user,
-                                                           mock_get_user_by_email,
-                                                           mock_check_verify_code,
-                                                           mock_get_services):
+def test_should_login_user_and_redirect_to_choose_services(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_check_verify_code,
+    mock_get_services,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -108,10 +118,12 @@ def test_should_login_user_and_redirect_to_choose_services(app_,
             assert response.location == url_for('main.choose_service', _external=True)
 
 
-def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(app_,
-                                                                      api_user_active,
-                                                                      mock_get_user_by_email,
-                                                                      mock_check_verify_code_code_not_found):
+def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(
+    app_,
+    api_user_active,
+    mock_get_user_by_email,
+    mock_check_verify_code_code_not_found,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -124,12 +136,14 @@ def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(app_,
             assert 'Code not found' in response.get_data(as_text=True)
 
 
-def test_should_login_user_when_multiple_valid_codes_exist(app_,
-                                                           api_user_active,
-                                                           mock_get_user,
-                                                           mock_get_user_by_email,
-                                                           mock_check_verify_code,
-                                                           mock_get_services_with_one_service):
+def test_should_login_user_when_multiple_valid_codes_exist(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_check_verify_code,
+    mock_get_services_with_one_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -141,12 +155,14 @@ def test_should_login_user_when_multiple_valid_codes_exist(app_,
             assert response.status_code == 302
 
 
-def test_remember_me_set(app_,
-                         api_user_active,
-                         mock_get_user,
-                         mock_get_user_by_email,
-                         mock_check_verify_code,
-                         mock_get_services_with_one_service):
+def test_remember_me_set(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_get_user_by_email,
+    mock_check_verify_code,
+    mock_get_services_with_one_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -158,12 +174,14 @@ def test_remember_me_set(app_,
             assert response.status_code == 302
 
 
-def test_two_factor_should_set_password_when_new_password_exists_in_session(app_,
-                                                                            api_user_active,
-                                                                            mock_get_user,
-                                                                            mock_check_verify_code,
-                                                                            mock_get_services_with_one_service,
-                                                                            mock_update_user):
+def test_two_factor_should_set_password_when_new_password_exists_in_session(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_check_verify_code,
+    mock_get_services_with_one_service,
+    mock_update_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -184,12 +202,14 @@ def test_two_factor_should_set_password_when_new_password_exists_in_session(app_
             mock_update_user.assert_called_once_with(api_user_active)
 
 
-def test_two_factor_reset_login_count_called(app_,
-                                             api_user_locked,
-                                             mock_get_locked_user,
-                                             mock_update_user,
-                                             mock_check_verify_code,
-                                             mock_get_services_with_one_service):
+def test_two_factor_reset_login_count_called(
+    app_,
+    api_user_locked,
+    mock_get_locked_user,
+    mock_update_user,
+    mock_check_verify_code,
+    mock_get_services_with_one_service,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -212,9 +232,11 @@ def test_two_factor_reset_login_count_called(app_,
             mock_update_user.assert_called_with(api_user_locked)
 
 
-def test_two_factor_should_redirect_to_sign_in_if_user_not_in_session(app_,
-                                                                      api_user_active,
-                                                                      mock_get_user):
+def test_two_factor_should_redirect_to_sign_in_if_user_not_in_session(
+    app_,
+    api_user_active,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
 
@@ -224,12 +246,13 @@ def test_two_factor_should_redirect_to_sign_in_if_user_not_in_session(app_,
             assert response.location == url_for('main.sign_in', _external=True)
 
 
-def test_two_factor_should_activate_pending_user(app_,
-                                                 mocker,
-                                                 api_user_pending,
-                                                 mock_check_verify_code,
-                                                 mock_update_user
-                                                 ):
+def test_two_factor_should_activate_pending_user(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_check_verify_code,
+    mock_update_user,
+):
     mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)
     mocker.patch('app.service_api_client.get_services', return_value={'data': []})
     with app_.test_request_context():

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -5,25 +5,23 @@ from unittest.mock import ANY
 
 
 def test_should_render_two_factor_page(
-    app_,
+    client,
     api_user_active,
     mock_get_user_by_email,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            # TODO this lives here until we work out how to
-            # reassign the session after it is lost mid register process
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-        response = client.get(url_for('main.two_factor'))
-        assert response.status_code == 200
-        assert '''We’ve sent you a text message with a security code.''' in response.get_data(as_text=True)
+    # TODO this lives here until we work out how to
+    # reassign the session after it is lost mid register process
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.get(url_for('main.two_factor'))
+    assert response.status_code == 200
+    assert '''We’ve sent you a text message with a security code.''' in response.get_data(as_text=True)
 
 
 def test_should_login_user_and_redirect_to_service_dashboard(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
@@ -31,223 +29,202 @@ def test_should_login_user_and_redirect_to_service_dashboard(
     mock_get_services_with_one_service,
     mock_events,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.service_dashboard',
-                service_id=SERVICE_ONE_ID,
-                _external=True
-            )
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_dashboard',
+        service_id=SERVICE_ONE_ID,
+        _external=True
+    )
 
-        mock_events.assert_called_with('sucessful_login', ANY)
+    mock_events.assert_called_with('sucessful_login', ANY)
 
 
 def test_should_login_user_and_should_redirect_to_next_url(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor', next='/services/{}/dashboard'.format(SERVICE_ONE_ID)),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.service_dashboard',
-                service_id=SERVICE_ONE_ID,
-                _external=True
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor', next='/services/{}/dashboard'.format(SERVICE_ONE_ID)),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_dashboard',
+        service_id=SERVICE_ONE_ID,
+        _external=True
             )
 
 
 def test_should_login_user_and_not_redirect_to_external_url(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services_with_one_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor', next='http://www.google.com'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.service_dashboard',
-                service_id=SERVICE_ONE_ID,
-                _external=True
-            )
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor', next='http://www.google.com'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_dashboard',
+        service_id=SERVICE_ONE_ID,
+        _external=True
+    )
 
 
 def test_should_login_user_and_redirect_to_choose_services(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '12345'})
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '12345'})
 
-            assert response.status_code == 302
-            assert response.location == url_for('main.choose_service', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for('main.choose_service', _external=True)
 
 
 def test_should_return_200_with_sms_code_error_when_sms_code_is_wrong(
-    app_,
+    client,
     api_user_active,
     mock_get_user_by_email,
     mock_check_verify_code_code_not_found,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '23456'})
-            assert response.status_code == 200
-            assert 'Code not found' in response.get_data(as_text=True)
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '23456'})
+    assert response.status_code == 200
+    assert 'Code not found' in response.get_data(as_text=True)
 
 
 def test_should_login_user_when_multiple_valid_codes_exist(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services_with_one_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '23456'})
-            assert response.status_code == 302
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '23456'})
+    assert response.status_code == 302
 
 
 def test_remember_me_set(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services_with_one_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address}
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '23456', 'remember_me': True})
-            assert response.status_code == 302
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address}
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '23456', 'remember_me': True})
+    assert response.status_code == 302
 
 
 def test_two_factor_should_set_password_when_new_password_exists_in_session(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_check_verify_code,
     mock_get_services_with_one_service,
     mock_update_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_active.id,
-                    'email': api_user_active.email_address,
-                    'password': 'changedpassword'}
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_active.id,
+            'email': api_user_active.email_address,
+            'password': 'changedpassword'}
 
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.service_dashboard',
-                service_id=SERVICE_ONE_ID,
-                _external=True
-            )
-            api_user_active.password = 'changedpassword'
-            mock_update_user.assert_called_once_with(api_user_active)
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_dashboard',
+        service_id=SERVICE_ONE_ID,
+        _external=True
+    )
+    api_user_active.password = 'changedpassword'
+    mock_update_user.assert_called_once_with(api_user_active)
 
 
 def test_two_factor_reset_login_count_called(
-    app_,
+    client,
     api_user_locked,
     mock_get_locked_user,
     mock_update_user,
     mock_check_verify_code,
     mock_get_services_with_one_service,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                new_password = "1234567890"
-                session['user_details'] = {
-                    'id': api_user_locked.id,
-                    'email': api_user_locked.email_address,
-                    'password': new_password
-                }
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for(
-                'main.service_dashboard',
-                service_id=SERVICE_ONE_ID,
-                _external=True
-            )
-            api_user_locked.reset_failed_login_count()
-            api_user_locked.password = new_password
-            mock_update_user.assert_called_with(api_user_locked)
+    with client.session_transaction() as session:
+        new_password = "1234567890"
+        session['user_details'] = {
+            'id': api_user_locked.id,
+            'email': api_user_locked.email_address,
+            'password': new_password
+        }
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.service_dashboard',
+        service_id=SERVICE_ONE_ID,
+        _external=True
+    )
+    api_user_locked.reset_failed_login_count()
+    api_user_locked.password = new_password
+    mock_update_user.assert_called_with(api_user_locked)
 
 
 def test_two_factor_should_redirect_to_sign_in_if_user_not_in_session(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-
-            response = client.post(url_for('main.two_factor'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for('main.sign_in', _external=True)
+    response = client.post(url_for('main.two_factor'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for('main.sign_in', _external=True)
 
 
 def test_two_factor_should_activate_pending_user(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_check_verify_code,
@@ -255,14 +232,12 @@ def test_two_factor_should_activate_pending_user(
 ):
     mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)
     mocker.patch('app.service_api_client.get_services', return_value={'data': []})
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {
-                    'id': api_user_pending.id,
-                    'email_address': api_user_pending.email_address
-                }
-            client.post(url_for('main.two_factor'), data={'sms_code': '12345'})
+    with client.session_transaction() as session:
+        session['user_details'] = {
+            'id': api_user_pending.id,
+            'email_address': api_user_pending.email_address
+        }
+    client.post(url_for('main.two_factor'), data={'sms_code': '12345'})
 
-            assert mock_update_user.called
-            assert api_user_pending.is_active
+    assert mock_update_user.called
+    assert api_user_pending.is_active

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -4,322 +4,273 @@ from notifications_utils.url_safe_token import generate_token
 
 
 def test_should_show_overview_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.user_profile'))
+    response = logged_in_client.get(url_for('main.user_profile'))
 
-        assert 'Your profile' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Your profile' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_show_name_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for('main.user_profile_name'))
+    response = logged_in_client.get(url_for('main.user_profile_name'))
 
-        assert 'Change your name' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Change your name' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_redirect_after_name_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
     mock_update_user_attribute,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            new_name = 'New Name'
-            data = {'new_name': new_name}
-            response = client.post(url_for(
-                'main.user_profile_name'), data=data)
+    new_name = 'New Name'
+    data = {'new_name': new_name}
+    response = logged_in_client.post(url_for(
+        'main.user_profile_name'), data=data)
 
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.user_profile', _external=True)
-        api_user_active.name = new_name
-        assert mock_update_user_attribute.called
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.user_profile', _external=True)
+    api_user_active.name = new_name
+    assert mock_update_user_attribute.called
 
 
 def test_should_show_email_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-            response = client.get(url_for(
-                'main.user_profile_email'))
+    response = logged_in_client.get(url_for(
+        'main.user_profile_email'))
 
-        assert 'Change your email address' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Change your email address' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_redirect_after_email_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_is_email_unique,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        data = {'email_address': 'new_notify@notify.gov.uk'}
-        response = client.post(
-            url_for('main.user_profile_email'),
-            data=data)
+    data = {'email_address': 'new_notify@notify.gov.uk'}
+    response = logged_in_client.post(
+        url_for('main.user_profile_email'),
+        data=data)
 
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.user_profile_email_authenticate', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.user_profile_email_authenticate', _external=True)
 
 
 def test_should_show_authenticate_after_email_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['new-email'] = 'new_notify@notify.gov.uk'
-        response = client.get(url_for('main.user_profile_email_authenticate'))
+    with logged_in_client.session_transaction() as session:
+        session['new-email'] = 'new_notify@notify.gov.uk'
+    response = logged_in_client.get(url_for('main.user_profile_email_authenticate'))
 
-        assert response.status_code == 200
-        assert 'Change your email address' in response.get_data(as_text=True)
-        assert 'Confirm' in response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'Change your email address' in response.get_data(as_text=True)
+    assert 'Confirm' in response.get_data(as_text=True)
 
 
 def test_should_render_change_email_continue_after_authenticate_email(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_verify_password,
     mock_send_change_email_verification,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        data = {'password': '12345'}
-        with client.session_transaction() as session:
-            session['new-email'] = 'new_notify@notify.gov.uk'
-        response = client.post(
-            url_for('main.user_profile_email_authenticate'),
-            data=data)
-        assert response.status_code == 200
-        assert 'Click the link in the email to confirm the change to your email address.' \
-               in response.get_data(as_text=True)
+    data = {'password': '12345'}
+    with logged_in_client.session_transaction() as session:
+        session['new-email'] = 'new_notify@notify.gov.uk'
+    response = logged_in_client.post(
+        url_for('main.user_profile_email_authenticate'),
+        data=data)
+    assert response.status_code == 200
+    assert 'Click the link in the email to confirm the change to your email address.' \
+           in response.get_data(as_text=True)
 
 
 def test_should_redirect_to_user_profile_when_user_confirms_email_link(
     app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_update_user_attribute,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
 
-        token = generate_token(payload=json.dumps({'user_id': api_user_active.id, 'email': 'new_email@gov.uk'}),
-                               secret=app_.config['SECRET_KEY'], salt=app_.config['DANGEROUS_SALT'])
-        response = client.get(url_for('main.user_profile_email_confirm', token=token))
+    token = generate_token(payload=json.dumps({'user_id': api_user_active.id, 'email': 'new_email@gov.uk'}),
+                           secret=app_.config['SECRET_KEY'], salt=app_.config['DANGEROUS_SALT'])
+    response = logged_in_client.get(url_for('main.user_profile_email_confirm', token=token))
 
-        assert response.status_code == 302
-        assert response.location == url_for('main.user_profile', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for('main.user_profile', _external=True)
 
 
 def test_should_show_mobile_number_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        response = client.get(url_for('main.user_profile_mobile_number'))
+    response = logged_in_client.get(url_for('main.user_profile_mobile_number'))
 
-        assert 'Change your mobile number' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Change your mobile number' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_redirect_after_mobile_number_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        data = {'mobile_number': '07121231234'}
-        response = client.post(
-            url_for('main.user_profile_mobile_number'),
-            data=data)
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.user_profile_mobile_number_authenticate', _external=True)
+    data = {'mobile_number': '07121231234'}
+    response = logged_in_client.post(
+        url_for('main.user_profile_mobile_number'),
+        data=data)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.user_profile_mobile_number_authenticate', _external=True)
 
 
 def test_should_show_authenticate_after_mobile_number_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['new-mob'] = '+441234123123'
-        response = client.get(
-            url_for('main.user_profile_mobile_number_authenticate'))
+    with logged_in_client.session_transaction() as session:
+        session['new-mob'] = '+441234123123'
+    response = logged_in_client.get(
+        url_for('main.user_profile_mobile_number_authenticate'))
 
-        assert 'Change your mobile number' in response.get_data(as_text=True)
-        assert 'Confirm' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Change your mobile number' in response.get_data(as_text=True)
+    assert 'Confirm' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_redirect_after_mobile_number_authenticate(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
     mock_verify_password,
     mock_send_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['new-mob'] = '+441234123123'
-        data = {'password': '12345667'}
-        response = client.post(
-            url_for('main.user_profile_mobile_number_authenticate'),
-            data=data)
+    with logged_in_client.session_transaction() as session:
+        session['new-mob'] = '+441234123123'
+    data = {'password': '12345667'}
+    response = logged_in_client.post(
+        url_for('main.user_profile_mobile_number_authenticate'),
+        data=data)
 
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.user_profile_mobile_number_confirm', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.user_profile_mobile_number_confirm', _external=True)
 
 
 def test_should_show_confirm_after_mobile_number_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['new-mob-password-confirmed'] = True
-        response = client.get(
-            url_for('main.user_profile_mobile_number_confirm'))
+    with logged_in_client.session_transaction() as session:
+        session['new-mob-password-confirmed'] = True
+    response = logged_in_client.get(
+        url_for('main.user_profile_mobile_number_confirm'))
 
-        assert 'Change your mobile number' in response.get_data(as_text=True)
-        assert 'Confirm' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Change your mobile number' in response.get_data(as_text=True)
+    assert 'Confirm' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_redirect_after_mobile_number_confirm(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
     mock_update_user_attribute,
     mock_check_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        with client.session_transaction() as session:
-            session['new-mob-password-confirmed'] = True
-            session['new-mob'] = '+441234123123'
-        data = {'sms_code': '12345'}
-        response = client.post(
-            url_for('main.user_profile_mobile_number_confirm'),
-            data=data)
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.user_profile', _external=True)
+    with logged_in_client.session_transaction() as session:
+        session['new-mob-password-confirmed'] = True
+        session['new-mob'] = '+441234123123'
+    data = {'sms_code': '12345'}
+    response = logged_in_client.post(
+        url_for('main.user_profile_mobile_number_confirm'),
+        data=data)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.user_profile', _external=True)
 
 
 def test_should_show_password_page(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        response = client.get(url_for('main.user_profile_password'))
+    response = logged_in_client.get(url_for('main.user_profile_password'))
 
-        assert 'Change your password' in response.get_data(as_text=True)
-        assert response.status_code == 200
+    assert 'Change your password' in response.get_data(as_text=True)
+    assert response.status_code == 200
 
 
 def test_should_redirect_after_password_change(
-    app_,
+    logged_in_client,
     api_user_active,
     mock_login,
     mock_get_user,
     mock_update_user,
     mock_verify_password,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            client.login(api_user_active)
-        data = {
-            'new_password': 'the new password',
-            'old_password': 'the old password'}
-        response = client.post(
-            url_for('main.user_profile_password'),
-            data=data)
+    data = {
+        'new_password': 'the new password',
+        'old_password': 'the old password'}
+    response = logged_in_client.post(
+        url_for('main.user_profile_password'),
+        data=data)
 
-        assert response.status_code == 302
-        assert response.location == url_for(
-            'main.user_profile', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.user_profile', _external=True)
 
 
 def test_non_gov_user_cannot_see_change_email_link(
-    client,
+    logged_in_client,
     api_nongov_user_active,
     mock_login,
     mock_get_non_govuser,
 ):
-    client.login(api_nongov_user_active)
-    response = client.get(url_for('main.user_profile'))
+    response = logged_in_client.get(url_for('main.user_profile'))
     assert '<a href="/user-profile/email">' not in response.get_data(as_text=True)
     assert 'Your profile' in response.get_data(as_text=True)
     assert response.status_code == 200
 
 
 def test_non_gov_user_cannot_access_change_email_page(
-    client,
+    logged_in_client,
     api_nongov_user_active,
     mock_login,
     mock_get_non_govuser,
 ):
-    client.login(api_nongov_user_active)
-    response = client.get(url_for('main.user_profile_email'))
+    response = logged_in_client.get(url_for('main.user_profile_email'))
     assert response.status_code == 403

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -3,10 +3,12 @@ from flask import url_for
 from notifications_utils.url_safe_token import generate_token
 
 
-def test_should_show_overview_page(app_,
-                                   api_user_active,
-                                   mock_login,
-                                   mock_get_user):
+def test_should_show_overview_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -16,10 +18,12 @@ def test_should_show_overview_page(app_,
         assert response.status_code == 200
 
 
-def test_should_show_name_page(app_,
-                               api_user_active,
-                               mock_login,
-                               mock_get_user):
+def test_should_show_name_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -29,11 +33,13 @@ def test_should_show_name_page(app_,
         assert response.status_code == 200
 
 
-def test_should_redirect_after_name_change(app_,
-                                           api_user_active,
-                                           mock_login,
-                                           mock_get_user,
-                                           mock_update_user_attribute):
+def test_should_redirect_after_name_change(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+    mock_update_user_attribute,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -49,10 +55,12 @@ def test_should_redirect_after_name_change(app_,
         assert mock_update_user_attribute.called
 
 
-def test_should_show_email_page(app_,
-                                api_user_active,
-                                mock_login,
-                                mock_get_user):
+def test_should_show_email_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -63,10 +71,12 @@ def test_should_show_email_page(app_,
         assert response.status_code == 200
 
 
-def test_should_redirect_after_email_change(app_,
-                                            api_user_active,
-                                            mock_login,
-                                            mock_is_email_unique):
+def test_should_redirect_after_email_change(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_is_email_unique,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -80,9 +90,11 @@ def test_should_redirect_after_email_change(app_,
             'main.user_profile_email_authenticate', _external=True)
 
 
-def test_should_show_authenticate_after_email_change(app_,
-                                                     api_user_active,
-                                                     mock_login):
+def test_should_show_authenticate_after_email_change(
+    app_,
+    api_user_active,
+    mock_login,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -95,11 +107,13 @@ def test_should_show_authenticate_after_email_change(app_,
         assert 'Confirm' in response.get_data(as_text=True)
 
 
-def test_should_render_change_email_continue_after_authenticate_email(app_,
-                                                                      api_user_active,
-                                                                      mock_login,
-                                                                      mock_verify_password,
-                                                                      mock_send_change_email_verification):
+def test_should_render_change_email_continue_after_authenticate_email(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_verify_password,
+    mock_send_change_email_verification,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -114,11 +128,12 @@ def test_should_render_change_email_continue_after_authenticate_email(app_,
                in response.get_data(as_text=True)
 
 
-def test_should_redirect_to_user_profile_when_user_confirms_email_link(app_,
-                                                                       api_user_active,
-                                                                       mock_login,
-                                                                       mock_update_user_attribute
-                                                                       ):
+def test_should_redirect_to_user_profile_when_user_confirms_email_link(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_update_user_attribute,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -131,10 +146,12 @@ def test_should_redirect_to_user_profile_when_user_confirms_email_link(app_,
         assert response.location == url_for('main.user_profile', _external=True)
 
 
-def test_should_show_mobile_number_page(app_,
-                                        api_user_active,
-                                        mock_login,
-                                        mock_get_user):
+def test_should_show_mobile_number_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -144,10 +161,12 @@ def test_should_show_mobile_number_page(app_,
         assert response.status_code == 200
 
 
-def test_should_redirect_after_mobile_number_change(app_,
-                                                    api_user_active,
-                                                    mock_login,
-                                                    mock_get_user):
+def test_should_redirect_after_mobile_number_change(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -160,10 +179,12 @@ def test_should_redirect_after_mobile_number_change(app_,
             'main.user_profile_mobile_number_authenticate', _external=True)
 
 
-def test_should_show_authenticate_after_mobile_number_change(app_,
-                                                             api_user_active,
-                                                             mock_login,
-                                                             mock_get_user):
+def test_should_show_authenticate_after_mobile_number_change(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -177,12 +198,14 @@ def test_should_show_authenticate_after_mobile_number_change(app_,
         assert response.status_code == 200
 
 
-def test_should_redirect_after_mobile_number_authenticate(app_,
-                                                          api_user_active,
-                                                          mock_login,
-                                                          mock_get_user,
-                                                          mock_verify_password,
-                                                          mock_send_verify_code):
+def test_should_redirect_after_mobile_number_authenticate(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+    mock_verify_password,
+    mock_send_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -198,10 +221,12 @@ def test_should_redirect_after_mobile_number_authenticate(app_,
             'main.user_profile_mobile_number_confirm', _external=True)
 
 
-def test_should_show_confirm_after_mobile_number_change(app_,
-                                                        api_user_active,
-                                                        mock_login,
-                                                        mock_get_user):
+def test_should_show_confirm_after_mobile_number_change(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -215,12 +240,14 @@ def test_should_show_confirm_after_mobile_number_change(app_,
         assert response.status_code == 200
 
 
-def test_should_redirect_after_mobile_number_confirm(app_,
-                                                     api_user_active,
-                                                     mock_login,
-                                                     mock_get_user,
-                                                     mock_update_user_attribute,
-                                                     mock_check_verify_code):
+def test_should_redirect_after_mobile_number_confirm(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+    mock_update_user_attribute,
+    mock_check_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -236,10 +263,12 @@ def test_should_redirect_after_mobile_number_confirm(app_,
             'main.user_profile', _external=True)
 
 
-def test_should_show_password_page(app_,
-                                   api_user_active,
-                                   mock_login,
-                                   mock_get_user):
+def test_should_show_password_page(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -249,12 +278,14 @@ def test_should_show_password_page(app_,
         assert response.status_code == 200
 
 
-def test_should_redirect_after_password_change(app_,
-                                               api_user_active,
-                                               mock_login,
-                                               mock_get_user,
-                                               mock_update_user,
-                                               mock_verify_password):
+def test_should_redirect_after_password_change(
+    app_,
+    api_user_active,
+    mock_login,
+    mock_get_user,
+    mock_update_user,
+    mock_verify_password,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(api_user_active)
@@ -270,10 +301,12 @@ def test_should_redirect_after_password_change(app_,
             'main.user_profile', _external=True)
 
 
-def test_non_gov_user_cannot_see_change_email_link(client,
-                                                   api_nongov_user_active,
-                                                   mock_login,
-                                                   mock_get_non_govuser):
+def test_non_gov_user_cannot_see_change_email_link(
+    client,
+    api_nongov_user_active,
+    mock_login,
+    mock_get_non_govuser,
+):
     client.login(api_nongov_user_active)
     response = client.get(url_for('main.user_profile'))
     assert '<a href="/user-profile/email">' not in response.get_data(as_text=True)
@@ -281,10 +314,12 @@ def test_non_gov_user_cannot_see_change_email_link(client,
     assert response.status_code == 200
 
 
-def test_non_gov_user_cannot_access_change_email_page(client,
-                                                      api_nongov_user_active,
-                                                      mock_login,
-                                                      mock_get_non_govuser):
+def test_non_gov_user_cannot_access_change_email_page(
+    client,
+    api_nongov_user_active,
+    mock_login,
+    mock_get_non_govuser,
+):
     client.login(api_nongov_user_active)
     response = client.get(url_for('main.user_profile_email'))
     assert response.status_code == 403

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -4,46 +4,42 @@ from bs4 import BeautifulSoup
 
 
 def test_should_return_verify_template(
-    app_,
+    client,
     api_user_active,
     mock_send_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            # TODO this lives here until we work out how to
-            # reassign the session after it is lost mid register process
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
-            response = client.get(url_for('main.verify'))
-            assert response.status_code == 200
+    # TODO this lives here until we work out how to
+    # reassign the session after it is lost mid register process
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
+    response = client.get(url_for('main.verify'))
+    assert response.status_code == 200
 
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.text == 'Check your phone'
-            message = page.find_all('p')[1].text
-            assert message == "We’ve sent you a text message with a security code."
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.text == 'Check your phone'
+    message = page.find_all('p')[1].text
+    assert message == "We’ve sent you a text message with a security code."
 
 
 def test_should_redirect_to_add_service_when_sms_code_is_correct(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_update_user,
     mock_check_verify_code,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
-            response = client.post(url_for('main.verify'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 302
-            assert response.location == url_for('main.add_service', first='first', _external=True)
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
+    response = client.post(url_for('main.verify'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 302
+    assert response.location == url_for('main.add_service', first='first', _external=True)
 
-            mock_check_verify_code.assert_called_once_with(api_user_active.id, '12345', 'sms')
+    mock_check_verify_code.assert_called_once_with(api_user_active.id, '12345', 'sms')
 
 
 def test_should_activate_user_after_verify(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_send_verify_code,
@@ -51,34 +47,30 @@ def test_should_activate_user_after_verify(
     mock_update_user,
 ):
     mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
-            client.post(url_for('main.verify'),
-                        data={'sms_code': '12345'})
-            assert mock_update_user.called
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
+    client.post(url_for('main.verify'),
+                data={'sms_code': '12345'})
+    assert mock_update_user.called
 
 
 def test_should_return_200_when_sms_code_is_wrong(
-    app_,
+    client,
     api_user_active,
     mock_get_user,
     mock_check_verify_code_code_not_found,
 ):
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
-            response = client.post(url_for('main.verify'),
-                                   data={'sms_code': '12345'})
-            assert response.status_code == 200
-            resp_data = response.get_data(as_text=True)
-            assert resp_data.count('Code not found') == 1
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
+    response = client.post(url_for('main.verify'),
+                           data={'sms_code': '12345'})
+    assert response.status_code == 200
+    resp_data = response.get_data(as_text=True)
+    assert resp_data.count('Code not found') == 1
 
 
 def test_verify_email_redirects_to_verify_if_token_valid(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_get_user_pending,
@@ -89,19 +81,17 @@ def test_verify_email_redirects_to_verify_if_token_valid(
     token_data = {"user_id": api_user_pending.id, "secret_code": 12345}
     mocker.patch('app.main.views.verify.check_token', return_value=json.dumps(token_data))
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
 
-            response = client.get(url_for('main.verify_email', token='notreal'))
+    response = client.get(url_for('main.verify_email', token='notreal'))
 
-            assert response.status_code == 302
-            assert response.location == url_for('main.verify', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for('main.verify', _external=True)
 
 
 def test_verify_email_redirects_to_email_sent_if_token_expired(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_check_verify_code,
@@ -109,19 +99,17 @@ def test_verify_email_redirects_to_email_sent_if_token_expired(
     from itsdangerous import SignatureExpired
     mocker.patch('app.main.views.verify.check_token', side_effect=SignatureExpired('expired'))
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
 
-            response = client.get(url_for('main.verify_email', token='notreal'))
+    response = client.get(url_for('main.verify_email', token='notreal'))
 
-            assert response.status_code == 302
-            assert response.location == url_for('main.resend_email_verification', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for('main.resend_email_verification', _external=True)
 
 
 def test_verify_email_redirects_to_email_sent_if_token_used(
-    app_,
+    client,
     mocker,
     api_user_pending,
     mock_get_user_pending,
@@ -131,19 +119,17 @@ def test_verify_email_redirects_to_email_sent_if_token_used(
     from itsdangerous import SignatureExpired
     mocker.patch('app.main.views.verify.check_token', side_effect=SignatureExpired('expired'))
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_pending.email_address, 'id': api_user_pending.id}
 
-            response = client.get(url_for('main.verify_email', token='notreal'))
+    response = client.get(url_for('main.verify_email', token='notreal'))
 
-            assert response.status_code == 302
-            assert response.location == url_for('main.resend_email_verification', _external=True)
+    assert response.status_code == 302
+    assert response.location == url_for('main.resend_email_verification', _external=True)
 
 
 def test_verify_email_redirects_to_sign_in_if_user_active(
-    app_,
+    client,
     mocker,
     api_user_active,
     mock_get_user,
@@ -154,23 +140,20 @@ def test_verify_email_redirects_to_sign_in_if_user_active(
     token_data = {"user_id": api_user_active.id, "secret_code": 12345}
     mocker.patch('app.main.views.verify.check_token', return_value=json.dumps(token_data))
 
-    with app_.test_request_context():
-        with app_.test_client() as client:
-            with client.session_transaction() as session:
-                session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
+    with client.session_transaction() as session:
+        session['user_details'] = {'email_address': api_user_active.email_address, 'id': api_user_active.id}
 
-            response = client.get(url_for('main.verify_email', token='notreal'), follow_redirects=True)
-            page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-            assert page.h1.text == 'Sign in'
-            flash_banner = page.find('div', class_='banner-dangerous').string.strip()
-            assert flash_banner == "That verification link has expired."
+    response = client.get(url_for('main.verify_email', token='notreal'), follow_redirects=True)
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.text == 'Sign in'
+    flash_banner = page.find('div', class_='banner-dangerous').string.strip()
+    assert flash_banner == "That verification link has expired."
 
 
 def test_verify_redirects_to_sign_in_if_not_logged_in(
-    app_
+    client
 ):
-    with app_.test_request_context(), app_.test_client() as client:
-        response = client.get(url_for('main.verify'))
+    response = client.get(url_for('main.verify'))
 
-        assert response.location == url_for('main.sign_in', _external=True)
-        assert response.status_code == 302
+    assert response.location == url_for('main.sign_in', _external=True)
+    assert response.status_code == 302

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -3,9 +3,11 @@ from flask import url_for
 from bs4 import BeautifulSoup
 
 
-def test_should_return_verify_template(app_,
-                                       api_user_active,
-                                       mock_send_verify_code):
+def test_should_return_verify_template(
+    app_,
+    api_user_active,
+    mock_send_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             # TODO this lives here until we work out how to
@@ -21,11 +23,13 @@ def test_should_return_verify_template(app_,
             assert message == "We’ve sent you a text message with a security code."
 
 
-def test_should_redirect_to_add_service_when_sms_code_is_correct(app_,
-                                                                 api_user_active,
-                                                                 mock_get_user,
-                                                                 mock_update_user,
-                                                                 mock_check_verify_code):
+def test_should_redirect_to_add_service_when_sms_code_is_correct(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_update_user,
+    mock_check_verify_code,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -38,12 +42,14 @@ def test_should_redirect_to_add_service_when_sms_code_is_correct(app_,
             mock_check_verify_code.assert_called_once_with(api_user_active.id, '12345', 'sms')
 
 
-def test_should_activate_user_after_verify(app_,
-                                           mocker,
-                                           api_user_pending,
-                                           mock_send_verify_code,
-                                           mock_check_verify_code,
-                                           mock_update_user):
+def test_should_activate_user_after_verify(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_send_verify_code,
+    mock_check_verify_code,
+    mock_update_user,
+):
     mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)
     with app_.test_request_context():
         with app_.test_client() as client:
@@ -54,10 +60,12 @@ def test_should_activate_user_after_verify(app_,
             assert mock_update_user.called
 
 
-def test_should_return_200_when_sms_code_is_wrong(app_,
-                                                  api_user_active,
-                                                  mock_get_user,
-                                                  mock_check_verify_code_code_not_found):
+def test_should_return_200_when_sms_code_is_wrong(
+    app_,
+    api_user_active,
+    mock_get_user,
+    mock_check_verify_code_code_not_found,
+):
     with app_.test_request_context():
         with app_.test_client() as client:
             with client.session_transaction() as session:
@@ -69,12 +77,14 @@ def test_should_return_200_when_sms_code_is_wrong(app_,
             assert resp_data.count('Code not found') == 1
 
 
-def test_verify_email_redirects_to_verify_if_token_valid(app_,
-                                                         mocker,
-                                                         api_user_pending,
-                                                         mock_get_user_pending,
-                                                         mock_send_verify_code,
-                                                         mock_check_verify_code):
+def test_verify_email_redirects_to_verify_if_token_valid(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_get_user_pending,
+    mock_send_verify_code,
+    mock_check_verify_code,
+):
     import json
     token_data = {"user_id": api_user_pending.id, "secret_code": 12345}
     mocker.patch('app.main.views.verify.check_token', return_value=json.dumps(token_data))
@@ -90,10 +100,12 @@ def test_verify_email_redirects_to_verify_if_token_valid(app_,
             assert response.location == url_for('main.verify', _external=True)
 
 
-def test_verify_email_redirects_to_email_sent_if_token_expired(app_,
-                                                               mocker,
-                                                               api_user_pending,
-                                                               mock_check_verify_code):
+def test_verify_email_redirects_to_email_sent_if_token_expired(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_check_verify_code,
+):
     from itsdangerous import SignatureExpired
     mocker.patch('app.main.views.verify.check_token', side_effect=SignatureExpired('expired'))
 
@@ -108,12 +120,14 @@ def test_verify_email_redirects_to_email_sent_if_token_expired(app_,
             assert response.location == url_for('main.resend_email_verification', _external=True)
 
 
-def test_verify_email_redirects_to_email_sent_if_token_used(app_,
-                                                            mocker,
-                                                            api_user_pending,
-                                                            mock_get_user_pending,
-                                                            mock_send_verify_code,
-                                                            mock_check_verify_code_code_expired):
+def test_verify_email_redirects_to_email_sent_if_token_used(
+    app_,
+    mocker,
+    api_user_pending,
+    mock_get_user_pending,
+    mock_send_verify_code,
+    mock_check_verify_code_code_expired,
+):
     from itsdangerous import SignatureExpired
     mocker.patch('app.main.views.verify.check_token', side_effect=SignatureExpired('expired'))
 
@@ -128,12 +142,14 @@ def test_verify_email_redirects_to_email_sent_if_token_used(app_,
             assert response.location == url_for('main.resend_email_verification', _external=True)
 
 
-def test_verify_email_redirects_to_sign_in_if_user_active(app_,
-                                                          mocker,
-                                                          api_user_active,
-                                                          mock_get_user,
-                                                          mock_send_verify_code,
-                                                          mock_check_verify_code):
+def test_verify_email_redirects_to_sign_in_if_user_active(
+    app_,
+    mocker,
+    api_user_active,
+    mock_get_user,
+    mock_send_verify_code,
+    mock_check_verify_code,
+):
     import json
     token_data = {"user_id": api_user_active.id, "secret_code": 12345}
     mocker.patch('app.main.views.verify.check_token', return_value=json.dumps(token_data))
@@ -150,7 +166,9 @@ def test_verify_email_redirects_to_sign_in_if_user_active(app_,
             assert flash_banner == "That verification link has expired."
 
 
-def test_verify_redirects_to_sign_in_if_not_logged_in(app_):
+def test_verify_redirects_to_sign_in_if_not_logged_in(
+    app_
+):
     with app_.test_request_context(), app_.test_client() as client:
         response = client.get(url_for('main.verify'))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,6 +570,7 @@ def active_user_with_permissions(fake_uuid):
     user_data = {'id': fake_uuid,
                  'name': 'Test User',
                  'password': 'somepassword',
+                 'password_changed_at': str(datetime.utcnow()),
                  'email_address': 'test@user.gov.uk',
                  'mobile_number': '07700 900762',
                  'state': 'active',


### PR DESCRIPTION
# Normalize whitespace in test arguments

We have a bunch of different styles of handling when function definitions span multiple lines, which they almost always do with tests.

Here’s why an argument per line, single indent is best:
- cleaner diffs when you change the name of a method (one line change instead of multiple lines)
- works better on narrow screens, eg Github’s diff view, or with two terminals side by side on a laptop screen
- works with any editor’s indenting shortcuts, no need for an IDE

Also, trailing comma in the list of arguments is good because adding a new argument to a method becomes a one line, not two line diff.

This makes a cleaner diff for the next commit…

# …use `client` and `logged_in_client` fixtures
Wherever possible, because Don’t Repeat Yourself.