### PR TITLE
Update password on user profile with new endpoint

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -201,8 +201,7 @@ def user_profile_password():
     form = ChangePasswordForm(_check_password)
 
     if form.validate_on_submit():
-        current_user.set_password(form.new_password.data)
-        user_api_client.update_user(current_user)
+        user_api_client.update_password(current_user.id, password=form.new_password.data)
         return redirect(url_for('.user_profile'))
 
     return render_template(

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -72,6 +72,12 @@ class UserApiClient(NotifyAdminAPIClient):
         user_data = self.post(url, data=data)
         return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
 
+    def update_password(self, user_id, password):
+        data = {"_password": password}
+        url = "/user/{}/update-password".format(user_id)
+        user_data = self.post(url, data=data)
+        return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
+
     def verify_password(self, user_id, password):
         try:
             url = "/user/{}/verify/password".format(user_id)

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -239,7 +239,7 @@ def test_should_redirect_after_password_change(
     api_user_active,
     mock_login,
     mock_get_user,
-    mock_update_user,
+    mock_update_user_password,
     mock_verify_password,
 ):
     data = {

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -22,3 +22,14 @@ def test_client_only_updates_allowed_attributes(mocker):
     with pytest.raises(TypeError) as error:
         UserApiClient().update_user_attribute('user_id', id='1')
     assert str(error.value) == 'Not allowed to update user attributes: id'
+
+
+def test_client_updates_password_separately(mocker, api_user_active):
+    expected_url = '/user/{}/update-password'.format(api_user_active.id)
+    expected_params = {'_password': 'newpassword'}
+    client = UserApiClient()
+    client.max_failed_login_count = 1  # doesn't matter for this test
+    mock_update_password = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
+
+    client.update_password(api_user_active.id, expected_params['_password'])
+    mock_update_password.assert_called_once_with(expected_url, data=expected_params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -802,6 +802,14 @@ def mock_update_user(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_update_user_password(mocker, api_user_active):
+    def _update(user_id, **kwargs):
+        return api_user_active
+
+    return mocker.patch('app.user_api_client.update_password', side_effect=_update)
+
+
+@pytest.fixture(scope='function')
 def mock_update_user_attribute(mocker, api_user_active):
     def _update(user_id, **kwargs):
         return api_user_active


### PR DESCRIPTION
This uses the new endpoint to update a user's password from the profile page. 

This relies on:

- [x] (https://github.com/alphagov/notifications-api/pull/818)