### PR TITLE
Add usage link to navigation

### DIFF
--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -53,6 +53,7 @@
   {% endif %}
   {% if current_user.has_permissions(['manage_users', 'manage_settings'], admin_override=True) %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
+    <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
   {% elif current_user.has_permissions(['view_activity']) %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>


### PR DESCRIPTION
We’ve seen services that have a lot of activity on their dashboard miss the usage feature because the link gets pushed a long way down the page.

We don’t want to move it up the page, because for most users the templates/jobs stuff is more useful. And we don’t want to remove it because it’s a useful part of the onboarding to understand the Notify proposition.

So this commit adds it as a link to the nav, to make users more aware of it, and as a quick way of getting into it for the small subset of users who will care about it (a lot).

Order of the links is determined by what’s likely to be most useful for first time users surfing the nav. Usage is more interesting than settings, but less interesting than team members.

---

![image](https://cloud.githubusercontent.com/assets/355079/22735702/d3f07b60-edf2-11e6-92b8-b6c346910f4a.png)
