### PR TITLE
Bump utils to turn on Markdown links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ whitenoise==1.0.6  #manages static assets
 # pin to minor version 3.1.x
 notifications-python-client>=3.1,<3.2
 
-git+https://github.com/alphagov/notifications-utils.git@13.3.1#egg=notifications-utils==13.3.1
+git+https://github.com/alphagov/notifications-utils.git@13.5.0#egg=notifications-utils==13.5.0


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/115

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/823

Changes:
https://github.com/alphagov/notifications-utils/compare/13.3.1...enable-markdown-links