### PR TITLE
Add comma-separation to counts of failed messages

### DIFF
--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -52,7 +52,7 @@
               ) }}
               {% if counts.requested %}
                 <span class="{{ 'failure-highlight' if counts.show_warning else '' }}">
-                  {{ counts.failed }} failed
+                  {{ "{:,}".format(counts.failed) }} failed
                 </span>
               {% else %}
                 –


### PR DESCRIPTION
Fixes this:

![image](https://cloud.githubusercontent.com/assets/355079/22779102/4895c7ea-eeb1-11e6-9c65-141f8d89ca22.png)
