### PR TITLE
Fix missing skiplink target on product page

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -249,3 +249,7 @@ details .arrow {
 .block-label input[disabled] {
   opacity: 0.5;
 }
+
+#content.override-elements-content {
+  padding-bottom: 0;
+}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -10,8 +10,8 @@
 
 {% block maincolumn_content %}
 
-  <div class="product-page-intro" id="main">
-    <div class="product-page-intro-wrapper">
+  <div class="product-page-intro">
+    <div class="product-page-intro-wrapper override-elements-content" id="content">
       <nav class="breadcrumbs breadcrumbs--inverse" aria-label="Breadcrumbs">
        <ol itemscope itemtype="http://schema.org/BreadcrumbList">
          <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">


### PR DESCRIPTION
We didn’t have an element with an `id` of `content` on the product page because we didn’t want the styles that come with it (from GOV.UK Elements here: https://github.com/alphagov/govuk_elements/blob/d6226bd2c8c7e256f995c0f519daaa4035c6bd54/public/sass/elements/_layout.scss#L9-L20)

This meant that the skiplink didn’t work on the product page because it’s target was not on the page. The skiplink’s target is hardcoded to point at `#content`.

The proper way to fix this would be to not hardcode the skiplink to point at `#content`, ie what this pull request does: https://github.com/alphagov/govuk_template/pull/275

Until that is merged, we can hack around the problem by overriding the styles that Elements applies to `#content`, which is what this pull request does.