### PR TITLE
Fix permissions in tests

### DIFF
--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -16,7 +16,7 @@ letters_urls = [
     (False, 403)
 ])
 def test_letters_access_restricted(
-    logged_in_client,
+    logged_in_platform_admin_client,
     mocker,
     can_send_letters,
     response_code,
@@ -26,7 +26,7 @@ def test_letters_access_restricted(
     service = service_json(can_send_letters=can_send_letters)
     mocker.patch('app.service_api_client.get_service', return_value={"data": service})
 
-    response = logged_in_client.get(url(service_id=service['id']))
+    response = logged_in_platform_admin_client.get(url(service_id=service['id']))
 
     assert response.status_code == response_code
 

--- a/tests/app/main/views/test_main_nav.py
+++ b/tests/app/main/views/test_main_nav.py
@@ -1,43 +1,57 @@
 from flask import url_for
 from bs4 import BeautifulSoup
 
-from tests import service_json
+from tests.conftest import mock_get_user
 
 
-def test_can_see_letters_if_allowed(logged_in_client, mocker):
-    service = service_json(can_send_letters=True)
-    mocker.patch('app.service_api_client.get_service', return_value={"data": service})
+def test_can_see_letters_if_allowed(
+    logged_in_client,
+    service_one,
+    mocker,
+    mock_get_users_by_service,
+    mock_get_invites_for_service
+):
+    service_one['can_send_letters'] = True
+    mocker.patch('app.service_api_client.get_service', return_value={"data": service_one})
 
-    response = logged_in_client.get(url_for('main.service_settings', service_id=service['id']))
+    response = logged_in_client.get(url_for('main.manage_users', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert 'Letter templates' in page.find('nav', class_='navigation').text
 
 
-def test_cant_see_letters_if_not_allowed(logged_in_client, mocker):
-    service = service_json(can_send_letters=False)
-    mocker.patch('app.service_api_client.get_service', return_value={"data": service})
+def test_cant_see_letters_if_not_allowed(
+    logged_in_client,
+    service_one,
+    mocker,
+    mock_get_users_by_service,
+    mock_get_invites_for_service
+):
+    service_one['can_send_letters'] = False
+    mocker.patch('app.service_api_client.get_service', return_value={"data": service_one})
 
-    response = logged_in_client.get(url_for('main.service_settings', service_id=service['id']))
+    response = logged_in_client.get(url_for('main.manage_users', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert 'Letter templates' not in page.find('nav', class_='navigation').text
 
 
-def test_can_see_letters_without_permissions(
+def test_can_see_letters_without_edit_permissions(
     client,
     mocker,
-    mock_login,
-    mock_has_permissions,
-    api_user_active,
+    active_user_view_permissions,
+    mock_get_users_by_service,
+    mock_get_invites_for_service,
+    service_one
 ):
-    service = service_json(can_send_letters=True)
-    mocker.patch('app.service_api_client.get_service', return_value={"data": service})
+    mock_get_user(mocker, user=active_user_view_permissions)
+    service_one['can_send_letters'] = True
+    mocker.patch('app.service_api_client.get_service', return_value={"data": service_one})
 
-    client.login(api_user_active)
-    response = client.get(url_for('main.service_settings', service_id=service['id']))
+    client.login(active_user_view_permissions)
+    response = client.get(url_for('main.manage_users', service_id=service_one['id']))
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -122,6 +122,7 @@ def test_upload_csvfile_with_no_recipient_column_shows_error(
     mock_s3_upload,
     mock_get_users_by_service,
     mock_get_detailed_service_for_today,
+    service_one,
     fake_uuid,
 ):
 
@@ -134,7 +135,7 @@ def test_upload_csvfile_with_no_recipient_column_shows_error(
     )
 
     response = logged_in_client.post(
-        url_for('main.send_messages', service_id=fake_uuid, template_id=fake_uuid),
+        url_for('main.send_messages', service_id=service_one['id'], template_id=fake_uuid),
         data={'file': (BytesIO(''.encode('utf-8')), 'invalid.csv')},
         follow_redirects=True,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -520,7 +520,14 @@ def platform_admin_user(fake_uuid):
                  'mobile_number': '07700 900762',
                  'state': 'active',
                  'failed_login_count': 0,
-                 'permissions': {},
+                 'permissions': {SERVICE_ONE_ID: ['send_texts',
+                                                  'send_emails',
+                                                  'send_letters',
+                                                  'manage_users',
+                                                  'manage_templates',
+                                                  'manage_settings',
+                                                  'manage_api_keys',
+                                                  'view_activity']},
                  'platform_admin': True
                  }
     user = User(user_data)
@@ -583,6 +590,25 @@ def active_user_with_permissions(fake_uuid):
                                                   'manage_settings',
                                                   'manage_api_keys',
                                                   'view_activity']},
+                 'platform_admin': False
+                 }
+    user = User(user_data)
+    return user
+
+
+@pytest.fixture
+def active_user_view_permissions(fake_uuid):
+    from app.notify_client.user_api_client import User
+
+    user_data = {'id': fake_uuid,
+                 'name': 'Test User With Permissions',
+                 'password': 'somepassword',
+                 'password_changed_at': str(datetime.utcnow()),
+                 'email_address': 'test@user.gov.uk',
+                 'mobile_number': '07700 900762',
+                 'state': 'active',
+                 'failed_login_count': 0,
+                 'permissions': {SERVICE_ONE_ID: ['view_activity']},
                  'platform_admin': False
                  }
     user = User(user_data)
@@ -1379,6 +1405,7 @@ def logged_in_platform_admin_client(
     service_one,
     mock_login,
 ):
+    mock_get_user(mocker, user=platform_admin_user)
     client.login(platform_admin_user, mocker, service_one)
     yield client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1366,9 +1366,20 @@ def logged_in_client(
     mocker,
     service_one,
     mock_login,
-    mock_has_permissions
 ):
     client.login(active_user_with_permissions, mocker, service_one)
+    yield client
+
+
+@pytest.fixture(scope='function')
+def logged_in_platform_admin_client(
+    client,
+    platform_admin_user,
+    mocker,
+    service_one,
+    mock_login,
+):
+    client.login(platform_admin_user, mocker, service_one)
     yield client
 
 


### PR DESCRIPTION
Essentially, only use mock_has_permissions if you're really sure you don't care about permissions. Not in fixtures that are used by pretty much the entire test suite to log in.


a lot of the changes are replacing `logged_in_client` with the new fixture `logged_in_platform_admin_client` where applicable, and removing unneeded fixture invocations