### PR TITLE
Mark up ‘pill’ component as being tabs

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -9,7 +9,7 @@
   }
 
   a,
-  span {
+  &-selected-item {
     display: block;
     float: left;
     box-sizing: border-box;
@@ -45,7 +45,7 @@
     }
   }
 
-  span {
+  &-selected-item {
     border: 2px solid $black;
     outline: 1px solid rgba($white, 0.1);
     position: relative;

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -2,24 +2,19 @@
 
   display: flex;
 
+  li {
+    width: 25%;
+    flex-grow: 1;
+    text-align: left;
+  }
+
   a,
   span {
     display: block;
-    width: 25%;
-    box-sizing: border-box;
     float: left;
+    box-sizing: border-box;
+    width: 100%;
     padding: 10px;
-    flex-grow: 1;
-    text-align: left;
-
-    &:first-child {
-      margin-left: 0;
-    }
-
-    &:last-child {
-      margin-right: 0;
-    }
-
   }
 
   a {
@@ -56,6 +51,12 @@
     position: relative;
     z-index: 1000;
     color: $text-colour;
+
+    &:focus {
+      z-index: 10;
+      outline: 3px solid $yellow;
+    }
+
   }
 }
 

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -9,15 +9,15 @@
     {% for label, option, link, count in items %}
       {% if current_value == option %}
         <li aria-selected='true' role='tab'>
-          <span tabindex='0'>
+          <div class='pill-selected-item' tabindex='0'>
       {% else %}
         <li aria-selected='false' role='tab'>
           <a href="{{ link }}">
       {% endif %}
-          {{ big_number(count, **big_number_args) }}
-          <div class="pill-label">{{ label }}</div>
+            {{ big_number(count, **big_number_args) }}
+            <div class="pill-label">{{ label }}</div>
       {% if current_value == option %}
-          </span>
+          </div>
       {% else %}
           </a>
       {% endif %}

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -1,26 +1,27 @@
 {% from 'components/big-number.html' import big_number %}
 
 {% macro pill(
-  title,
   items=[],
   current_value=None,
   big_number_args={'smaller': True}
 ) %}
-  <nav role='navigation' class='pill' aria-labelledby="pill_{{title}}">
-    <h2 id="pill_{{title}}" class="visuallyhidden">{{title}}</h2>
+  <ul role='tablist' class='pill'>
     {% for label, option, link, count in items %}
       {% if current_value == option %}
-        <span aria-hidden="true">
+        <li aria-selected='true' role='tab'>
+          <span tabindex='0'>
       {% else %}
-        <a href="{{ link }}">
+        <li aria-selected='false' role='tab'>
+          <a href="{{ link }}">
       {% endif %}
-        {{ big_number(count, **big_number_args) }}
-        <div class="pill-label">{{ label }}</div>
+          {{ big_number(count, **big_number_args) }}
+          <div class="pill-label">{{ label }}</div>
       {% if current_value == option %}
-        </span>
+          </span>
       {% else %}
-        </a>
+          </a>
       {% endif %}
+        </li>
     {% endfor %}
-  </nav>
+  </ul>
 {% endmacro %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -61,19 +61,19 @@
     {% set border = '' if border else 'table-field-noborder' %}
 
     <td class="{{ [field_alignment, border]|join(' ') }}">
-      <span class="{{ 'table-field-status-' + status if status }}">{{ caller() }}</span>
+      <div class="{{ 'table-field-status-' + status if status }}">{{ caller() }}</div>
     </td>
 {%- endmacro %}
 
 {% macro row_heading() -%}
   <th class="table-field">
-    <span>{{ caller() }}</span>
+    {{ caller() }}
   </th>
 {%- endmacro %}
 
 {% macro index_field(text) -%}
   <td class="table-field-index">
-    <span><span class="visually-hidden">Row </span>{{ text }}</span>
+    <span class="visually-hidden">Row </span>{{ text }}
   </td>
 {%- endmacro %}
 

--- a/app/templates/partials/jobs/count.html
+++ b/app/templates/partials/jobs/count.html
@@ -1,5 +1,5 @@
 {% from "components/pill.html" import pill %}
 
 <div class="bottom-gutter ajax-block-container">
-  {{ pill('Status', counts, request.args.get('status', '')) }}
+  {{ pill(counts, request.args.get('status', '')) }}
 </div>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,7 +1,7 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, notification_status_field %}
 {% from "components/page-footer.html" import page_footer %}
 
-<div class="ajax-block-container">
+<div class="ajax-block-container" aria-labelledby='pill-selected-item'>
   {% if job.job_status == 'scheduled' %}
 
     <p>

--- a/app/templates/views/activity/counts.html
+++ b/app/templates/views/activity/counts.html
@@ -2,7 +2,6 @@
 
 <div class='bottom-gutter ajax-block-container'>
   {{ pill(
-    'Status',
     status_filters,
     status
   ) }}

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -2,7 +2,7 @@
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 {% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, notification_status_field %}
 
-<div class="ajax-block-container">
+<div class="ajax-block-container" id='pill-selected-item'>
 
   {% if notifications %}
     <div class='dashboard-table'>

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -18,14 +18,13 @@
   </h1>
   <div class="bottom-gutter">
     {{ pill(
-      'financial year',
       items=years,
       current_value=selected_year,
       big_number_args={'smallest': True},
     ) }}
   </div>
   {% if months %}
-    <div class="body-copy-table">
+    <div class="body-copy-table" id='pill-selected-item'>
       {% call(month, row_index) list_table(
         months,
         caption="Total spend",

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -13,90 +13,91 @@
     <h2 class='heading-large'>Usage</h2>
 
     <div class="bottom-gutter">
-      {{ pill('Year', years, selected_year, big_number_args={'smallest': True}) }}
+      {{ pill(years, selected_year, big_number_args={'smallest': True}) }}
     </div>
-
-    <div class='grid-row'>
-      <div class='column-half'>
-        <h2 class='heading-small'>Emails</h2>
-        <div class="keyline-block">
-          {{ big_number(emails_sent, 'sent', smaller=True) }}
-          {{ big_number("Unlimited", 'free allowance', smaller=True) }}
+    <div id='pill-selected-item'>
+      <div class='grid-row'>
+        <div class='column-half'>
+          <h2 class='heading-small'>Emails</h2>
+          <div class="keyline-block">
+            {{ big_number(emails_sent, 'sent', smaller=True) }}
+            {{ big_number("Unlimited", 'free allowance', smaller=True) }}
+          </div>
+        </div>
+        <div class='column-half'>
+          <h2 class='heading-small'>Text messages</h2>
+          <div class="keyline-block">
+            {{ big_number(sms_sent, 'sent', smaller=True) }}
+            {{ big_number(sms_free_allowance, 'free allowance', smaller=True) }}
+            {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
+            {% if sms_chargeable %}
+              {{ big_number(
+                sms_chargeable,
+                'at {:.2f} pence per message'.format(sms_rate * 100),
+                smaller=True
+              ) }}
+            {% endif %}
+          </div>
         </div>
       </div>
-      <div class='column-half'>
-        <h2 class='heading-small'>Text messages</h2>
-        <div class="keyline-block">
-          {{ big_number(sms_sent, 'sent', smaller=True) }}
-          {{ big_number(sms_free_allowance, 'free allowance', smaller=True) }}
-          {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
-          {% if sms_chargeable %}
+
+      <div class='grid-row'>
+        <div class='column-half'>
+          <div class="keyline-block">
+            &nbsp;
+          </div>
+        </div>
+        <div class='column-half'>
+          <div class="keyline-block">
             {{ big_number(
-              sms_chargeable,
-              'at {:.2f} pence per message'.format(sms_rate * 100),
+              (sms_chargeable * sms_rate),
+              'spent',
+              currency="£",
               smaller=True
             ) }}
-          {% endif %}
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class='grid-row'>
-      <div class='column-half'>
-        <div class="keyline-block">
-          &nbsp;
+      {% if months %}
+        <div class="dashboard-table body-copy-table">
+          {% call(month, row_index) list_table(
+            months,
+            caption="Total spend",
+            caption_visible=False,
+            empty_message='',
+            field_headings=[
+              'By month',
+              hidden_field_heading('Cost'),
+            ],
+            field_headings_visible=True
+          ) %}
+            {% call row_heading() %}
+              {{ month.name }}
+            {% endcall %}
+            {% call field(align='left') %}
+              {{ big_number(
+                sms_rate * month.paid,
+                currency="£",
+                smallest=True
+              ) }}
+              <ul>
+              {% if month.free %}
+                <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
+              {% endif %}
+              {% if month.paid %}
+                <li class="tabular-numbers">{{ "{:,}".format(month.paid) }} text messages at
+                {{- ' {:.2f}p'.format(sms_rate * 100) }}</li>
+              {% endif %}
+              {% if not (month.free or month.paid) %}
+                <li aria-hidden="true">–</li>
+              {% endif %}
+              </ul>
+            {% endcall %}
+          {% endcall %}
         </div>
-      </div>
-      <div class='column-half'>
-        <div class="keyline-block">
-          {{ big_number(
-            (sms_chargeable * sms_rate),
-            'spent',
-            currency="£",
-            smaller=True
-          ) }}
-        </div>
-      </div>
+      {% endif %}
     </div>
-
-    {% if months %}
-      <div class="dashboard-table body-copy-table">
-        {% call(month, row_index) list_table(
-          months,
-          caption="Total spend",
-          caption_visible=False,
-          empty_message='',
-          field_headings=[
-            'By month',
-            hidden_field_heading('Cost'),
-          ],
-          field_headings_visible=True
-        ) %}
-          {% call row_heading() %}
-            {{ month.name }}
-          {% endcall %}
-          {% call field(align='left') %}
-            {{ big_number(
-              sms_rate * month.paid,
-              currency="£",
-              smallest=True
-            ) }}
-            <ul>
-            {% if month.free %}
-              <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
-            {% endif %}
-            {% if month.paid %}
-              <li class="tabular-numbers">{{ "{:,}".format(month.paid) }} text messages at
-              {{- ' {:.2f}p'.format(sms_rate * 100) }}</li>
-            {% endif %}
-            {% if not (month.free or month.paid) %}
-              <li aria-hidden="true">–</li>
-            {% endif %}
-            </ul>
-          {% endcall %}
-        {% endcall %}
-      </div>
-    {% endif %}
 
     <div class="grid-row">
       <div class="column-half">

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -250,11 +250,11 @@ def test_usage_page(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     cols = page.find_all('div', {'class': 'column-half'})
-    nav = page.find('nav', {'class': 'pill'})
+    nav = page.find('ul', {'class': 'pill', 'role': 'tablist'})
     nav_links = nav.find_all('a')
 
     assert normalize_spaces(nav_links[0].text) == '2010 to 2011 financial year'
-    assert normalize_spaces(nav.find('span').text) == '2011 to 2012 financial year'
+    assert normalize_spaces(nav.find('li', {'aria-selected': 'true'}).text) == '2011 to 2012 financial year'
     assert normalize_spaces(nav_links[1].text) == '2012 to 2013 financial year'
 
     assert '123' in cols[0].text


### PR DESCRIPTION
Currently it’s not possible for a screen reader user to know which financial year they’re looking at. From the accessibility report:

> The financial year links are contained in a navigation region - tabbing or arrowing through only reads out the links, not the main information of "2016 to 2017 financial year" - that information is vital for understanding the page content.

This problem also applies to other pages which use the `pill` component, which is effectively tabbed navigation (that reloads the page rather than showing or hiding content on the page).

There are specific ARIA attributes that can be used to mark up a navigation as being tabbed. This commit:

- adds those attributes
- makes the selected ‘tab’ visible to screenreaders and keyboard focusable
- adds a visual focus indicator to the selected tab
- adds `id`s to the parts of the page that are controlled by the tabs so
  that they are labelled as such

This also means changing the pill component from being a `<nav>` to a `<ul>` because `tablist` is not a valid `role` for a `nav`.

Mostly follows the example here: http://accessibility.athena-ict.com/aria/examples/tabpanel2.shtml

## With Voiceover

![aria-tabs](https://cloud.githubusercontent.com/assets/355079/22934024/59e4ed74-f2c5-11e6-9340-cf9bb16f17ae.gif)
