### PR TITLE
Make template usage graph take up 100% of width

### DIFF
--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -32,6 +32,7 @@
   margin-bottom: $gutter-half;
   height: $gutter-half;
   color: $text-colour;
+  text-align: left;
 
   span {
     box-sizing: border-box;

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -24,7 +24,7 @@
         </span>
       </span>
     {% endcall %}
-    {% call field() %}
+    {% call field(align='right') %}
       {% if template_statistics|length > 1 %}
         <span id='{{item.template_id}}' class="spark-bar">
           <span style="width: {{ item.count / most_used_template_count * 100 }}%">


### PR DESCRIPTION
The bars were sitting in a table cell with some right padding, so they never extended all the way to the right. Making it right-aligned removes this padding, then setting the text to left aligned keeps things looking the same.

![alignment](https://cloud.githubusercontent.com/assets/355079/22976406/9e868b28-f382-11e6-8289-2abcedfcaa22.png)
