### PR TITLE
Don’t right align template stats for one template

### DIFF
--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -24,8 +24,8 @@
         </span>
       </span>
     {% endcall %}
-    {% call field(align='right') %}
-      {% if template_statistics|length > 1 %}
+    {% if template_statistics|length > 1 %}
+      {% call field(align='right') %}
         <span id='{{item.template_id}}' class="spark-bar">
           <span style="width: {{ item.count / most_used_template_count * 100 }}%">
             {{ big_number(
@@ -34,14 +34,16 @@
             ) }}
           </span>
         </span>
-      {% else %}
+      {% endcall %}
+    {% else %}
+      {% call field() %}
         <span id='{{item.template_id}}' class="heading-small">
           {{ big_number(
             item.count,
             smallest=True
           ) }}
         </span>
-      {% endif %}
-    {% endcall %}
+      {% endcall %}
+    {% endif %}
   {% endcall %}
 </div>


### PR DESCRIPTION
We don’t show the graph if a user has only used one template.

Stops this happening:
![image](https://cloud.githubusercontent.com/assets/355079/22977649/71a030d2-f387-11e6-8935-450edb880e1e.png)
