### PR TITLE
Remove old target directory and include any dotfiles in the zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,9 @@ cf-build: dependencies generate-version-file ## Build project
 
 .PHONY: build-codedeploy-artifact
 build-codedeploy-artifact: ## Build the deploy artifact for CodeDeploy
+	rm -rf target
 	mkdir -p target
-	zip -r -x@deploy-exclude.lst target/notifications-admin.zip *
+	zip -y -q -r -x@deploy-exclude.lst target/notifications-admin.zip ./
 
 .PHONY: upload-codedeploy-artifact ## Upload the deploy artifact for CodeDeploy
 upload-codedeploy-artifact: check-env-vars


### PR DESCRIPTION
This removes the old target directory (containing api files) before recreating it and also ensures any dotfiles are included in the zip file.