### PR TITLE
Show template usage broken down by month

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -189,3 +189,13 @@
 a.table-show-more-link {
   color: $link-colour;
 }
+
+.table-no-data {
+  @include core-16;
+  color: $secondary-text-colour;
+  margin-top: 10px;
+  margin-bottom: $gutter * 1.3333;
+  border-top: 1px solid $border-colour;
+  border-bottom: 1px solid $border-colour;
+  padding: 0.75em 0 0.5625em 0;
+}

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -81,3 +81,16 @@
   @include bold-19;
   color: $error-colour;
 }
+
+.template-usage-table {
+
+  border-top: 1px solid $border-colour;
+  border-bottom: 1px solid $border-colour;
+  margin-top: 10px;
+  margin-bottom: $gutter * 1.3333;
+
+  .table {
+    margin-bottom: 5px;
+  }
+
+}

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -20,6 +20,12 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
             params=params
         )['data']
 
+    def get_monthly_template_statistics_for_service(self, service_id, year):
+
+        return self.get(
+            url='/service/{}/notifications/templates/monthly?year={}'.format(service_id, year)
+        )['data']
+
     def get_template_statistics_for_template(self, service_id, template_id):
 
         return self.get(

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -1,3 +1,5 @@
+{% from "components/big-number.html" import big_number %}
+
 {% macro mapping_table(caption='', field_headings=[], field_headings_visible=True, caption_visible=True) -%}
   <table class="table">
     <caption class="heading-medium table-heading{{ ' visuallyhidden' if not caption_visible}}">
@@ -126,6 +128,23 @@
         notification.created_at|format_datetime_short,
         (notification.updated_at or notification.created_at)|format_datetime_short
       ) }}
+    </span>
+  {% endcall %}
+{% endmacro %}
+
+
+{% macro spark_bar_field(
+  count,
+  max_count
+) %}
+  {% call field(align='right') %}
+    <span class="spark-bar">
+      <span style="width: {{ count / max_count * 100 }}%">
+        {{ big_number(
+          count,
+          smallest=True
+        ) }}
+      </span>
     </span>
   {% endcall %}
 {% endmacro %}

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -1,13 +1,58 @@
+{% from "components/message-count-label.html" import message_count_label %}
+{% from "components/pill.html" import pill %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
+
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  All templates used this year
+  Templates used
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">All templates used this year</h1>
+  <h1 class="heading-large">Templates used</h1>
 
-  {% include 'views/dashboard/template-statistics.html' %}
+  <div class="bottom-gutter-3-2">
+    {{ pill(
+      items=years,
+      current_value=selected_year,
+      big_number_args={'smallest': True},
+    ) }}
+  </div>
+
+  <div class="dashboard">
+    {% for month in months %}
+      <h2>{{ month.name }}</h2>
+      {% if not month.templates_used %}
+        <p class="table-no-data">
+          No messages sent
+        </p>
+      {% else %}
+        <div class='dashboard-table template-usage-table'>
+          {% call(item, row_number) list_table(
+            month.templates_used,
+            caption=month.name,
+            caption_visible=False,
+            empty_message='',
+            field_headings=[
+              'Template',
+              'Messages sent'
+            ],
+            field_headings_visible=False
+          ) %}
+            {% call row_heading() %}
+              <span class="spark-bar-label">
+                <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
+                <span class="file-list-hint">
+                  {{ message_count_label(1, item.type, suffix='template')|capitalize }}
+                </span>
+              </span>
+            {% endcall %}
+            {{ spark_bar_field(item.requested_count, most_used_template_count) }}
+          {% endcall %}
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
 
 {% endblock %}

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -32,14 +32,14 @@
     {{ ajax_block(partials, updates_url, 'totals') }}
     {{ show_more(
       url_for('.monthly', service_id=current_service.id),
-      'See activity breakdown'
+      'See messages sent per month'
     ) }}
 
     {% if partials['has_template_statistics'] %}
       {{ ajax_block(partials, updates_url, 'template-statistics') }}
       {{ show_more(
         url_for('.template_history', service_id=current_service.id),
-        'See all templates used this year'
+        'See templates used by month'
       ) }}
     {% endif %}
 

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -6,14 +6,14 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  Activity breakdown
+  Messages sent,
   {{ selected_year }} to {{ selected_year + 1 }} financial year
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    Activity breakdown
+    Messages sent
   </h1>
   <div class="bottom-gutter">
     {{ pill(

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -1,7 +1,7 @@
 {% from "components/big-number.html" import big_number %}
 {% from "components/message-count-label.html" import message_count_label %}
 {% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
 
 <div class='dashboard-table'>
   {% call(item, row_number) list_table(
@@ -25,16 +25,7 @@
       </span>
     {% endcall %}
     {% if template_statistics|length > 1 %}
-      {% call field(align='right') %}
-        <span id='{{item.template_id}}' class="spark-bar">
-          <span style="width: {{ item.count / most_used_template_count * 100 }}%">
-            {{ big_number(
-              item.count,
-              smallest=True
-            ) }}
-          </span>
-        </span>
-      {% endcall %}
+      {{ spark_bar_field(item.count, most_used_template_count) }}
     {% else %}
       {% call field() %}
         <span id='{{item.template_id}}' class="heading-small">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1278,6 +1278,28 @@ def mock_get_template_statistics(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def mock_get_monthly_template_statistics(mocker, service_one, fake_uuid):
+    def _stats(service_id, year):
+        return {
+            datetime.utcnow().strftime('%Y-%m'): {
+                fake_uuid: {
+                    "counts": {
+                        "sending": 1,
+                        "delivered": 1,
+                    },
+                    "name": 'My first template',
+                    "type": 'sms',
+                    "id": fake_uuid,
+                }
+            }
+        }
+    return mocker.patch(
+        'app.template_statistics_client.get_monthly_template_statistics_for_service',
+        side_effect=_stats
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_template_statistics_for_template(mocker, service_one):
     def _get_stats(service_id, template_id):
         template = template_json(service_id, template_id, "Test template", "sms", "Something very interesting")


### PR DESCRIPTION
This follows on from:
- https://github.com/alphagov/notifications-admin/pull/1094
- https://github.com/alphagov/notifications-admin/pull/1109

It depends on:
- [x] https://github.com/alphagov/notifications-api/pull/829

A year is too long. Month-by-month is a better timeframe for making decisions or seeing patterns in your usage.

![image](https://cloud.githubusercontent.com/assets/355079/23129405/7af46f44-f77a-11e6-958c-e483643f9436.png)

***
![image](https://cloud.githubusercontent.com/assets/355079/23129450/a41c4f40-f77a-11e6-8700-0f94195b628d.png)
