### PR TITLE
Update two-factor to use new update password endpoint and refactor tests

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -29,9 +29,7 @@ def two_factor():
             services = service_api_client.get_active_services({'user_id': str(user_id)}).get('data', [])
             # Check if coming from new password page
             if 'password' in session['user_details']:
-                user.set_password(session['user_details']['password'])
-                user.reset_failed_login_count()
-                user_api_client.update_user(user)
+                user_api_client.update_password(user.id, password=session['user_details']['password'])
             if user.is_locked():
                 form.sms_code.errors.append('Code not found')
                 return render_template('views/two-factor.html', form=form)

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -110,9 +110,6 @@ class User(UserMixin):
     def failed_login_count(self, num):
         self._failed_login_count += num
 
-    def reset_failed_login_count(self):
-        self._failed_login_count = 0
-
     def is_locked(self):
         return self.failed_login_count >= self.max_failed_login_count
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -164,7 +164,7 @@ def test_two_factor_should_set_password_when_new_password_exists_in_session(
     mock_get_user,
     mock_check_verify_code,
     mock_get_services_with_one_service,
-    mock_update_user,
+    mock_update_user_password,
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -180,36 +180,7 @@ def test_two_factor_should_set_password_when_new_password_exists_in_session(
         service_id=SERVICE_ONE_ID,
         _external=True
     )
-    api_user_active.password = 'changedpassword'
-    mock_update_user.assert_called_once_with(api_user_active)
-
-
-def test_two_factor_reset_login_count_called(
-    client,
-    api_user_locked,
-    mock_get_locked_user,
-    mock_update_user,
-    mock_check_verify_code,
-    mock_get_services_with_one_service,
-):
-    with client.session_transaction() as session:
-        new_password = "1234567890"
-        session['user_details'] = {
-            'id': api_user_locked.id,
-            'email': api_user_locked.email_address,
-            'password': new_password
-        }
-    response = client.post(url_for('main.two_factor'),
-                           data={'sms_code': '12345'})
-    assert response.status_code == 302
-    assert response.location == url_for(
-        'main.service_dashboard',
-        service_id=SERVICE_ONE_ID,
-        _external=True
-    )
-    api_user_locked.reset_failed_login_count()
-    api_user_locked.password = new_password
-    mock_update_user.assert_called_once_with(api_user_locked)
+    mock_update_user_password.assert_called_once_with(api_user_active.id, password='changedpassword')
 
 
 def test_two_factor_returns_error_when_user_is_locked(


### PR DESCRIPTION
This makes the two-factor flow use the new method of updating passwords (new endpoint).

If the user is coming from the new password page, the password is set and the login count is reset. Instead of using the old `update_user` method, this uses the new `update_password` method. On the API, this resets the login count and changes the password.