### PR TITLE
Remove old API key and service ID combo

### DIFF
--- a/app/templates/views/api/keys/show.html
+++ b/app/templates/views/api/keys/show.html
@@ -32,17 +32,4 @@
 
     </div>
 
-    <h2 class='heading-medium'>For older API clients</h2>
-
-    <p>
-      If the client you’re using needs a service ID and an API key,
-      use these values:
-    </p>
-
-    <div class="bottom-gutter">
-      {{ api_key(service_id, 'Service ID', thing='service ID') }}
-    </div>
-
-    {{ api_key(secret, 'API key') }}
-
 {% endblock %}

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -156,14 +156,12 @@ def test_should_create_api_key_with_type_normal(
     )
 
     assert response.status_code == 200
+
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    keys = page.find_all('span', {'class': 'api-key-key'})
-    for index, key in enumerate([
-        'some_default_key_name_12-{}-{}'.format(service_id, fake_uuid),
-        service_id,
-        fake_uuid
-    ]):
-        assert keys[index].text.strip() == key
+
+    assert page.find('span', {'class': 'api-key-key'}).text.strip() == (
+        'some_default_key_name_12-{}-{}'.format(service_id, fake_uuid)
+    )
 
     post.assert_called_once_with(url='/service/{}/api-key'.format(service_id), data={
         'name': 'Some default key name 1/2',


### PR DESCRIPTION
Once all our users have upgraded to the latest clients they won’t need this. The latest clients only use the combined key and service ID.

Discuss: when can we safely remove it?