### PR TITLE
check users' session id.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,6 +50,7 @@ from app.notify_client.user_api_client import UserApiClient
 from app.notify_client.events_api_client import EventsApiClient
 from app.notify_client.provider_client import ProviderClient
 from app.notify_client.organisations_client import OrganisationsClient
+from app.notify_client.models import AnonymousUser
 
 login_manager = LoginManager()
 csrf = CsrfProtect()
@@ -103,6 +104,7 @@ def create_app():
     login_manager.login_view = 'main.sign_in'
     login_manager.login_message_category = 'default'
     login_manager.session_protection = None
+    login_manager.anonymous_user = AnonymousUser
 
     from app.main import main as main_blueprint
     application.register_blueprint(main_blueprint)

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -76,7 +76,13 @@ def sign_in():
             ).format(password_reset=url_for('.forgot_password'))
         ))
 
-    return render_template('views/signin.html', form=form, again=bool(request.args.get('next')))
+    other_device = current_user.logged_in_elsewhere()
+    return render_template(
+        'views/signin.html',
+        form=form,
+        again=bool(request.args.get('next')),
+        other_device=other_device
+    )
 
 
 @login_manager.unauthorized_handler

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -26,6 +26,9 @@ def two_factor():
     if form.validate_on_submit():
         try:
             user = user_api_client.get_user(user_id)
+            # the user will have a new current_session_id set by the API - store it in the cookie so we can match it in
+            # future requests
+            session['current_session_id'] = user.current_session_id
             services = service_api_client.get_active_services({'user_id': str(user_id)}).get('data', [])
             # Check if coming from new password page
             if 'password' in session['user_details']:

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -20,7 +20,8 @@ class User(UserMixin):
         return self.id
 
     def logged_in_elsewhere(self):
-        return session.get('current_session_id') != self.current_session_id
+        # if the current user (ie: db object) has no session, they've never logged in before
+        return self.current_session_id is not None and session.get('current_session_id') != self.current_session_id
 
     @property
     def is_active(self):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -1,3 +1,6 @@
+import uuid
+
+from flask import session
 from notifications_python_client.errors import HTTPError
 
 from app.notify_client import NotifyAdminAPIClient

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -13,9 +13,15 @@
 
     {% if again %}
       <h1 class="heading-large">You need to sign in again</h1>
-      <p>
-        We sign you out if you haven’t used Notify for a while.
-      </p>
+      {% if other_device %}
+        <p>
+          We signed you out because you logged in to Notify on another device.
+        </p>
+      {% else %}
+        <p>
+          We signed you out because you haven’t used Notify for a while.
+        </p>
+      {% endif %}
     {% else %}
       <h1 class="heading-large">Sign in</h1>
       <p>

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ exclude = ./migrations,./venv,./venv3,./node_modules,./bower_components,./cache
 
 [tool:pytest]
 norecursedirs = node_modules bower_components
+xfail_strict=true

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -80,7 +80,7 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
         page.select('main p')[0].text.strip(),
     ) == (
         'You need to sign in again',
-        'We sign you out if you haven’t used Notify for a while.',
+        'We signed you out because you haven’t used Notify for a while.',
     )
 
 
@@ -106,7 +106,7 @@ def test_existing_user_of_service_get_redirected_to_signin(
         page.select('main p')[0].text.strip(),
     ) == (
         'You need to sign in again',
-        'We sign you out if you haven’t used Notify for a while.',
+        'We signed you out because you haven’t used Notify for a while.',
     )
     assert mock_accept_invite.call_count == 1
 
@@ -141,7 +141,7 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
         page.select('main p')[0].text.strip(),
     ) == (
         'You need to sign in again',
-        'We sign you out if you haven’t used Notify for a while.',
+        'We signed you out because you haven’t used Notify for a while.',
     )
 
 


### PR DESCRIPTION
* [x] https://github.com/alphagov/notifications-api/pull/837

when a user enters their 2FA code, the API will store a random UUID
against them in the database - this code is then stored on the cookie
on the front end.

At the beginning of each authenticated request, we do the following
steps:
  * Retrieve the user's cookie, and get the user_id from it
  * Request that user's details from the database
  * populate current_user with the DB model
  * run the login_required decorator, which calls
    current_user.is_authenticated

is_authenticated now also checks that the database model matches the
cookie for session_id. The potential states and meanings are as follows:
```
 database | cookie | meaning
----------+--------+---------
 None     | None   | New user, or system just been deployed.
          |        | Redirect to start page.
----------+--------+---------
 'abc'    | None   | New browser (or cleared cookies). Redirect to
          |        | start page.
----------+--------+---------
 None     | 'abc'  | Invalid state (cookie is set from user obj, so
          |        | would only happen if DB is cleared)
----------+--------+---------
 'abc'    | 'abc'  | Same browser. Business as usual
----------+--------+---------
 'abc'    | 'def'  | Different browser in cookie - db has been changed
          |        | since then. Redirect to start
```