### PR TITLE
Fix spacing with heading/banner combination

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -80,7 +80,7 @@ a {
 
 .column-main {
 
-  > .heading-large,
+  .heading-large,
   > .heading-medium {
     margin: 10px 0 15px 0;
   }


### PR DESCRIPTION
Our CSS adjusts the spacing for the first `.heading-large` on the page so that it aligns with the navigation. This doesn’t work when something else comes first on the page, like a notification banner.

But since we only ever user `.heading-large` for the `<h1>`, and there should only be one `<h1>` on the page we can just change the spacing for _all_ `<h1>`s.

# Before 

<img width="686" alt="screen shot 2017-02-23 at 10 29 13" src="https://cloud.githubusercontent.com/assets/355079/23255892/24f59f68-f9b5-11e6-8ec7-469d97719ec8.png">

# After

<img width="686" alt="screen shot 2017-02-23 at 10 28 43" src="https://cloud.githubusercontent.com/assets/355079/23255900/2a65a83a-f9b5-11e6-9634-708ec275c8b3.png">
