### PR TITLE
Remove HTML entity from permission choice

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -153,7 +153,7 @@ class RegisterUserFromInviteForm(Form):
 
 class PermissionsForm(Form):
     send_messages = BooleanField("Send messages from existing templates")
-    manage_service = BooleanField("Modify this service, its team, and its&nbsp;templates")
+    manage_service = BooleanField("Modify this service, its team, and its templates")
     manage_api_keys = BooleanField("Create and revoke API keys")
 
 


### PR DESCRIPTION
Fixes this:
![image](https://cloud.githubusercontent.com/assets/355079/23256058/d023867a-f9b5-11e6-8e6c-ec6815ccd8ba.png)

Not sure why we had a non-breaking space in here because it didn’t wrap onto two lines anyway. And it wasn’t working because it was showing up encoded, rather than as a raw entity.