### PR TITLE
Fix page titles that didn’t get fixed before

### DIFF
--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block page_title %}Bad Request{% endblock %}
+{% block per_page_title %}Bad Request{% endblock %}
 {% block maincolumn_content %}
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block page_title %}Unauthorized{% endblock %}
+{% block per_page_title %}Unauthorized{% endblock %}
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block page_title %}Forbidden{% endblock %}
+{% block per_page_title %}Forbidden{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block page_title %}Page not found{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block page_title %}Page not found{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block page_title %}Server error{% endblock %}
+{% block per_page_title %}Server error{% endblock %}
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 
-{% block page_title %}
-  {{ current_service.name }} – GOV.UK Notify
+{% block service_page_title %}
+  {{ current_service.name }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -5,10 +5,9 @@
 
 {% extends "withnav_template.html" %}
 
-{% block page_title %}
+{% block service_page_title %}
   Activity breakdown
   {{ selected_year }} to {{ selected_year + 1 }} financial year
-  – GOV.UK Notify
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -2,8 +2,8 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
-{% block page_title %}
-GOV.UK Notify | Service settings
+{% block per_page_title %}
+  Change your {{ thing }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -2,13 +2,13 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
-{% block page_title %}
-GOV.UK Notify | Service settings
+{% block per_page_title %}
+  Change your password
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change your password</h1>
+    <h1 class="heading-large">Change your password</h1>
 
   <div class="grid-row">
     <div class="column-three-quarters">

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -2,8 +2,8 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
-{% block page_title %}
-GOV.UK Notify | Service settings
+{% block per_page_title %}
+  Change your {{ thing }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -2,8 +2,8 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
 
-{% block page_title %}
-GOV.UK Notify | Service settings
+{% block per_page_title %}
+  Change your {{ thing }}
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
Did most of this work in https://github.com/alphagov/notifications-admin/pull/1118

Missed some of it.

> In pages specific to a service (e.g. dashboard and sub pages) the
> title needs to distinguish which service it applies to. This is mainly
> to give context to screen reader users who could be managing multiple
> services.
>
> Implementing this uses template inheritance:
>
> `page_title` includes `per_page_title` includes `service_page_title`
>
> ‘GOV.UK Notify’ is inserted into every page title.
>
> Pages that set `service_page_title` get the service name inserted too.