### PR TITLE
Fix heading level on template stats and usage pages

### DIFF
--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -6,7 +6,7 @@
 
 {% block maincolumn_content %}
 
-  <h2 class="heading-large">All templates used this year</h2>
+  <h1 class="heading-large">All templates used this year</h1>
 
   {% include 'views/dashboard/template-statistics.html' %}
 

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-    <h2 class='heading-large'>Usage</h2>
+    <h1 class='heading-large'>Usage</h1>
 
     <div class="bottom-gutter">
       {{ pill(years, selected_year, big_number_args={'smallest': True}) }}


### PR DESCRIPTION
It’s the heading for the whole page, should be a `<h1>`.