### PR TITLE
Add helpful column heading for screenreader users

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -73,7 +73,7 @@
 
 {% macro index_field(text) -%}
   <td class="table-field-index">
-    <span class="visually-hidden">Row </span>{{ text }}
+    <span>{{ text }}</span>
   </td>
 {%- endmacro %}
 

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -170,7 +170,9 @@
     recipients.initial_annotated_rows_with_errors if row_errors and not recipients.missing_column_headers else recipients.initial_annotated_rows,
     caption=original_file_name,
     caption_visible=False,
-    field_headings=['1'] + recipients.column_headers
+    field_headings=[
+      '<span class="visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
+    ] + recipients.column_headers
   ) %}
     {{ index_field(item.index + 2) }}
     {% for column in recipients.column_headers %}


### PR DESCRIPTION
When a screenreader user navigates a table, they use the columns headings to orientate themselves. A column heading of ‘1’ is not helpful.

So this commit adds some hidden text for screenreader users, which tells them exactly what the column contains: the number of the row in the original file.

The previous solution to this issue (549695d) was wrong, so this PR also reverts that.