### PR TITLE
Fix page title on all template statistics

### DIFF
--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  {{ current_service.name }}
+  All templates used this year
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
Broke it here: https://github.com/alphagov/notifications-admin/pull/1150/files#diff-79c89468157588a8d045983245158e9bR4

Third time lucky…