### PR TITLE
Make long SMS sender name error accurate

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -481,7 +481,7 @@ class ServiceSmsSender(Form):
     sms_sender = StringField(
         'Text message sender',
         validators=[
-            Length(max=11, message="Enter fewer than 11 characters")
+            Length(max=11, message="Enter 11 characters or fewer")
         ]
     )
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -185,7 +185,7 @@ def test_sms_sender_form_validation(
 
     form.sms_sender.data = 'morethanelevenchars'
     form.validate()
-    assert "Enter fewer than 11 characters" == form.errors['sms_sender'][0]
+    assert "Enter 11 characters or fewer" == form.errors['sms_sender'][0]
 
     form.sms_sender.data = '###########'
     form.validate()


### PR DESCRIPTION
`<=11` not `< 11`