### PR TITLE
Fix errant &nbsp; on request to go live page

### DIFF
--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -7,7 +7,7 @@
   <div class="form-group {% if field.errors %} error{% endif %}">
     <fieldset>
       <legend class="form-label">
-        {{ field.label.text }}
+        {{ field.label.text|safe }}
         {% if field.errors %}
           <span class="error-message">
             {{ field.errors[0] }}


### PR DESCRIPTION
![screen_shot_2017-02-28_at_16 44 28_720](https://cloud.githubusercontent.com/assets/355079/23415869/8b5b8e44-fdd8-11e6-980f-aa3c5ae901b5.png)

***

There’s a good reason for having the `&nbsp;` – it stops GOV.UK Notify being split across two lines (which could happen on a smaller viewport, eg mobile). Gotta protect the brand.

Not good for the brand for the `&nbsp;` to be showing up encoded in the page though 😬

This got broken as part of 3f41090a9428934bef480baceb07b4eae8a84fd4

The label for a form should never have user-submitted content in it, so using `safe` is fine.
