### PR TITLE
Add Scottish Enterprise to list of gov domains

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -76,6 +76,7 @@ class Config(object):
         r"ucds\.email",
         r"naturalengland\.org\.uk",
         r"hmcts\.net",
+        r"scotent\.co\.uk",
     ]
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -88,6 +88,7 @@ def _gen_mock_field(x):
     'test@ucds.email',
     'test@naturalengland.org.uk',
     'test@hmcts.net',
+    'test@scotent.co.uk',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
> Scottish Enterprise is Scotland's main economic development agency and a non-departmental public body of the Scottish Government.

– https://www.scottish-enterprise.com/about-us

For some reason their email domain is `scotent.co.uk` (but it redirects to www.scottish-enterprise.com on the web for the some reason ¯\_(ツ)_/¯)

_See Deskpro ticket 3923_