### PR TITLE
Put template name on preview page

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -150,7 +150,7 @@
   {% else %}
 
     <h1 class="heading-large">
-      Preview
+      Preview of {{ template.name }}
     </h1>
     {{ skip_to_file_contents() }}
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -207,6 +207,32 @@ def test_upload_csv_invalid_extension(
     assert "invalid.txt isn’t a spreadsheet that Notify can read" in resp.get_data(as_text=True)
 
 
+def test_upload_valid_csv_shows_page_title(
+    logged_in_client,
+    mocker,
+    mock_get_service_template_with_placeholders,
+    mock_s3_upload,
+    mock_get_users_by_service,
+    mock_get_detailed_service_for_today,
+    service_one,
+    fake_uuid,
+):
+
+    mocker.patch('app.main.views.send.s3download', return_value="""
+        phone number,name\n07700900986,Jo
+    """)
+
+    response = logged_in_client.post(
+        url_for('main.send_messages', service_id=service_one['id'], template_id=fake_uuid),
+        data={'file': (BytesIO(''.encode('utf-8')), 'valid.csv')},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.text.strip() == 'Preview of Two week reminder'
+
+
 def test_send_test_sms_message(
     logged_in_client,
     mocker,


### PR DESCRIPTION
## Before

![image](https://cloud.githubusercontent.com/assets/355079/23519695/c3453dd0-ff6f-11e6-9358-f4d809776648.png)

## After 

![image](https://cloud.githubusercontent.com/assets/355079/23519671/a7bb69ea-ff6f-11e6-974a-2b4195846725.png)

***

We’ve had a couple of instances where teams have sent the wrong template to a …number of users.

Sometimes templates can be very similar and only have slight variations to tailor them to a specific subset of users. So identifying the right template by sight can be difficult.

We know that teams do give their templates meaningful names, and use these names in other tools (spreadsheets etc) to refer to the templates.

So putting the name of the template on the page where you’re about to send all the messages seems like it’s gives people an easier way of double checking that they’re doing the right thing.

I umm’d and ahh’d over the wording a bit, and think ‘Preview of…’ reads the best. It looks a bit weird because most template names are Title Case. I think it’s better than some ambiguous punctuation (eg ‘Preview: Template name’ or ‘Template name – preview’) though.

***

Some examples of real template names:

# Preview of Example text message template

# Preview of Online LPA payment application reminder

# Preview of Create user account

# Preview of Split journey - Unknown credentials

# Preview of Public user: application without supporting documents

# Preview of Renewal Survey – February

# Preview of CEX New adult

# Preview of Applications are closing tomorrow

# Preview of Your application result - if successful
