### PR TITLE
Bump utils to fix type size of contact block

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@13.9.1#egg=notifications-utils==13.9.1
+git+https://github.com/alphagov/notifications-utils.git@13.9.2#egg=notifications-utils==13.9.2


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/125

Changes:
- https://github.com/alphagov/notifications-utils/compare/13.9.1...contact-block-type-size