### PR TITLE
Make ‘by month’ heading bold on usage

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -208,9 +208,19 @@ details summary {
 
 .body-copy-table {
 
-  table th,
-  table td {
-    @include core-19;
+  table {
+
+    th,
+    td {
+      @include core-19;
+    }
+
+    thead {
+      th {
+        @include bold-19;
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
So that it has the same visual weight as the other headings of the same level (ie ‘Emails’ and ‘Text messages’).

# Before

![image](https://cloud.githubusercontent.com/assets/355079/23615141/53730972-027d-11e7-9a8b-6935c9e0de5d.png)


# After 

![image](https://cloud.githubusercontent.com/assets/355079/23615127/48df8e5e-027d-11e7-85d3-0423fdda8281.png)
