### PR TITLE
Fix infinite loop in support flow

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -26,7 +26,7 @@ def triage():
         return redirect(url_for(
             '.feedback',
             ticket_type='problem',
-            severe=(form.severe.data == 'yes')
+            severe=form.severe.data
         ))
     return render_template(
         'views/support/triage.html',

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -340,8 +340,8 @@ def test_in_business_hours(when, is_in_business_hours):
 
 
 @pytest.mark.parametrize('choice, expected_redirect_param', [
-    ('yes', True),
-    ('no', False),
+    ('yes', 'yes'),
+    ('no', 'no'),
 ])
 def test_triage_redirects_to_correct_url(client, choice, expected_redirect_param):
     response = client.post(url_for('main.triage'), data={'severe': choice})


### PR DESCRIPTION
The support flow was using `yes` and `no` to mean emergency/not emergency. But not in all places – in one place it was using `True`/`False` instead.

We were treating anything other than `yes`/`no` as a non-answer, which means ask the question again. Because of the `True`/`False` thing, there was no way of the user providing a valid `yes`/`no` answer. Which means that we just kept asking them the question again and again and they got stuck in a loop.