### PR TITLE
Fix HTML showing up on breaking change page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -6,6 +6,7 @@ from flask_login import login_required, current_user
 from flask_weasyprint import HTML, render_pdf
 from dateutil.parser import parse
 
+from notifications_utils.field import escape_html
 from notifications_utils.template import LetterPreviewTemplate
 from notifications_utils.recipients import first_column_headings
 from notifications_python_client.errors import HTTPError
@@ -248,7 +249,7 @@ def edit_service_template(service_id, template_id):
         if form.process_type.data != template['process_type']:
             abort_403_if_not_admin_user()
 
-        subject = form.subject.data if hasattr(form, 'subject') else None
+        subject = escape_html(form.subject.data) if hasattr(form, 'subject') else None
         new_template = get_template({
             'name': form.name.data,
             'content': form.template_content.data,

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -27,7 +27,7 @@
 
   <form method="post">
     <input type="hidden" name="name" value="{{ new_template.name }}" />
-    <input type="hidden" name="subject" value="{{ new_template.subject or '' }}" />
+    <input type="hidden" name="subject" value="{{ new_template._subject or '' }}" />
     <input type="hidden" name="template_content" value="{{ new_template.content }}" />
     <input type="hidden" name="template_id" value="{{ new_template.id }}" />
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -263,9 +263,9 @@ def test_should_show_interstitial_when_making_breaking_change(
         data={
             'id': template_id,
             'name': "new name",
-            'template_content': "hello ((name)) lets talk about ((thing))",
+            'template_content': "hello lets talk about ((thing))",
             'template_type': 'email',
-            'subject': 'reminder',
+            'subject': 'reminder & ((name))',
             'service': service_id,
             'process_type': 'normal'
         }
@@ -286,8 +286,8 @@ def test_should_show_interstitial_when_making_breaking_change(
 
     for key, value in {
         'name': 'new name',
-        'subject': 'reminder',
-        'template_content': 'hello ((name)) lets talk about ((thing))',
+        'subject': 'reminder &amp; ((name))',
+        'template_content': 'hello lets talk about ((thing))',
         'confirm': 'true'
     }.items():
         assert page.find('input', {'name': key})['value'] == value


### PR DESCRIPTION
The breaking change page temporarily holds the changes in hidden inputs on the page. The messages content it gets from the `.content` property on the subject. This is raw and not transformed in any way, so fine.

For the subject it gets the value from the `.subject` attribute on the template. For email templates, this will be transformed to highlight placeholders with `<span class='placeholder'>…`. This means that when the change is confirmed, it’s this encoded version that gets sent to the API. Which is bad, because we then save `<span class='placeholder'>` in the database.

This commit changes the page to look at the `._subject` attribute instead, which is the internal, untransformed version of the subject.