### PR TITLE
Make example text message template priority

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -75,7 +75,8 @@ def add_service():
             'Example text message template',
             'sms',
             'Hey ((name)), I’m trying out Notify. Today is ((day of week)) and my favourite colour is ((colour)).',
-            service_id
+            service_id,
+            process_type='priority',
         )
 
         return redirect(url_for(

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -46,7 +46,16 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
         user_id=api_user_active.id,
         email_from='testing.the.post'
     )
-    assert len(mock_create_service_template.call_args_list) == 1
+    mock_create_service_template.assert_called_once_with(
+        'Example text message template',
+        'sms',
+        (
+            'Hey ((name)), I’m trying out Notify. Today is '
+            '((day of week)) and my favourite colour is ((colour)).'
+        ),
+        101,
+        process_type='priority',
+    )
     assert session['service_id'] == 101
     assert response.status_code == 302
     assert response.location == url_for(


### PR DESCRIPTION
The tour teaches you how Notify works by letting you do a thing and then showing you the effect of the thing you’ve just done – a text message on your phone.

This is not as effective if you don’t get the text message quickly. It breaks the association you make between what you’ve done on the computer and what’s happening on your phone.

Slow text message delivery can happen if you’re doing a big job. We can get around this by making your text message use the priority queue.

This was observed in the pilot research session yesterday.