### PR TITLE
Don’t halt Gulp watch task on JS/SASS errors

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -66,6 +66,7 @@ gulp.task('javascripts', () => gulp
     paths.src + 'javascripts/listEntry.js',
     paths.src + 'javascripts/main.js'
   ])
+  .pipe(plugins.prettyerror())
   .pipe(plugins.babel({
     presets: ['es2015']
   }))
@@ -83,6 +84,7 @@ gulp.task('javascripts', () => gulp
 
 gulp.task('sass', () => gulp
   .src(paths.src + '/stylesheets/main*.scss')
+  .pipe(plugins.prettyerror())
   .pipe(plugins.sass({
     outputStyle: 'compressed',
     includePaths: [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "gulp-css-url-adjuster": "0.2.3",
     "gulp-jshint": "2.0.0",
+    "gulp-prettyerror": "1.2.1",
     "gulp-sass-lint": "1.1.1",
     "jshint": "2.9.1",
     "jshint-stylish": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-concat": "2.6.0",
     "gulp-include": "2.1.0",
     "gulp-load-plugins": "1.1.0",
-    "gulp-sass": "2.2.0",
+    "gulp-sass": "3.1.0",
     "gulp-uglify": "1.5.1",
     "hogan": "1.0.2",
     "jquery": "1.11.2",


### PR DESCRIPTION
Problem
---
You make a minor typo, save the file and your Gulp process dies without you realising. You then spend 5 minutes trying to work out why your changes aren’t appearing, no matter what edits you make.

Solution
---

Catch errors raised in processing the JS/SASS files and log them, without killing the process.

How
---

Use a handy plugin called [Gulp PrettyError](https://www.npmjs.com/package/gulp-prettyerror).

What it looks like
---

Before | After
---|---
![image](https://cloud.githubusercontent.com/assets/355079/23856036/f214d07a-07ef-11e7-9df4-5076ca6e341f.png) | <img width="636" alt="screen shot 2017-03-13 at 13 19 48" src="https://cloud.githubusercontent.com/assets/355079/23856049/fb5e6e0c-07ef-11e7-9f50-b9bcd533704a.png">
