### PR TITLE
Add back to service link

### DIFF
--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -2,6 +2,11 @@
 
 {% block fullwidth_content %}
   <div id="content">
+    {% if current_user.is_authenticated %}
+    <div class="navigation-service">
+      <a href="{{ url_for('main.show_all_services_or_dashboard') }}">Back to service</a>
+    </div>
+    {% endif %}
     <main role="main">
       {% include 'flash_messages.html' %}
       {% block maincolumn_content %}{% endblock %}


### PR DESCRIPTION
When we moved the ‘Switch service’ link out of the nav on non-service pages it removed any obvious way of getting back to your service on a page that doesn’t have the service navigation (the non-obvious way is to click ‘GOV.UK Notify’ in the black bar).

So this commit adds a ‘Back to service’ link which does the same thing as clicking ‘GOV.UK Notify’ (tries to send you to your last-used service, sends you to the list of services if it can’t).

![back-to-service](https://cloud.githubusercontent.com/assets/355079/23903811/b52bad04-08bd-11e7-937e-8d9e028a3b4b.gif)

