### PR TITLE
Add more logging for getting next page logic

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -154,9 +154,9 @@ def generate_notifications_csv(**kwargs):
         kwargs['page'] = 1
 
     while kwargs['page']:
+        current_app.logger.info('Current kwargs: {}'.format(kwargs))
         notifications_resp = notification_api_client.get_notifications_for_service(**kwargs)
         current_app.logger.info('Total notifications for csv job: {}'.format(notifications_resp['total']))
-        current_app.logger.info('Notification response links: {}'.format(notifications_resp['links']))
         notifications_list = notifications_resp['notifications']
         for x in notifications_list:
             csvwriter.writerow(format_notification_for_csv(x))
@@ -166,8 +166,14 @@ def generate_notifications_csv(**kwargs):
             yield line
 
         if notifications_resp['links'].get('next'):
+            current_app.logger.info('Next link exists')
+            current_app.logger.info('Notification response links: {}'.format(notifications_resp['links']))
+            current_app.logger.info('Current page {}'.format(kwargs['page']))
             kwargs['page'] += 1
         else:
+            current_app.logger.info('No next link exists')
+            current_app.logger.info('Notification response links: {}'.format(notifications_resp['links']))
+            current_app.logger.info('Current page {}'.format(kwargs['page']))
             return
 
 


### PR DESCRIPTION
After reviewing logs, it seems that no more than two API calls are made to retrieve paginated notifications. 

This could be resulting from the logic used to get the paginated notifications or a deeper issue around not keeping the streaming connection open.

This adds more logging in hope to gain more clarity around the former. 

Note: These are temporary logs due to not being able to reproduce locally or any other environment other than production (due to the way we store history). **These will be removed.**