### PR TITLE
Make CSRF tokens last as long as the session

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,7 @@ class Config(object):
     SHOW_STYLEGUIDE = True
     TOKEN_MAX_AGE_SECONDS = 3600
     WTF_CSRF_ENABLED = True
+    WTF_CSRF_TIME_LIMIT = None
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'
     DESKPRO_PERSON_EMAIL = 'donotreply@notifications.service.gov.uk'
     ACTIVITY_STATS_LIMIT_DAYS = 7
@@ -80,7 +81,6 @@ class Config(object):
 class Development(Config):
     DEBUG = True
     SESSION_COOKIE_SECURE = False
-    WTF_CSRF_ENABLED = False
     SESSION_PROTECTION = None
     STATSD_ENABLED = False
     CSV_UPLOAD_BUCKET_NAME = 'development-notifications-csv-upload'
@@ -89,6 +89,7 @@ class Development(Config):
 class Test(Development):
     DEBUG = True
     STATSD_ENABLED = True
+    WTF_CSRF_ENABLED = False
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
     NOTIFY_ENVIRONMENT = 'test'
 


### PR DESCRIPTION
If you’re filling out a form then it should be possible to submit it for as long as you’re logged in. We keep you logged in for quite a long time now. This is partly for people using assistive tech, who might be slower to fill in forms, and partly for people who get distracted in the middle of a task and come back to it later.

The expiry on our CSRF tokens was more aggressive (3600 seconds – 1 hour) than our sessions. This commit sets the CSRF tokens to not expire, so in effect they last as long as the session.

Also tweaks the config to have CSRF on locally (to replicate production more closely) and only disable it for tests (because it’s a pain to grab the tokens in tests).