### PR TITLE
Put template IDs back on the dashboard

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -135,10 +135,11 @@
 
 {% macro spark_bar_field(
   count,
-  max_count
+  max_count,
+  id=None
 ) %}
   {% call field(align='right') %}
-    <span class="spark-bar">
+    <span {% if id %}id="{{ id }}"{% endif %} class="spark-bar">
       <span style="width: {{ count / max_count * 100 }}%">
         {{ big_number(
           count,

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -25,7 +25,7 @@
       </span>
     {% endcall %}
     {% if template_statistics|length > 1 %}
-      {{ spark_bar_field(item.count, most_used_template_count) }}
+      {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
     {% else %}
       {% call field() %}
         <span id='{{item.template_id}}' class="heading-small">


### PR DESCRIPTION
Removed as part of refactoring the code to generate the graphs of template usage on the dashboard: https://github.com/alphagov/notifications-admin/commit/4a226a7a29d83a4187ae2df089098bbdcebf2202#diff-cf78cb5c29a2d3c4d45b61d8617824b7L29

Didn’t realise that they were used by the functional tests.

This commit puts them back while keeping the code reuse.