### PR TITLE
Fix broken links on template statistics page

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -321,6 +321,7 @@ def format_template_stats_to_list(stats_dict):
                 template['counts'].get(status, 0)
                 for status in REQUESTED_STATUSES
             ),
+            id=template_id,
             **template
         )
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -649,11 +649,13 @@ def test_format_template_stats_to_list():
         'counts': counts,
         'name': 'foo',
         'requested_count': 7,
+        'id': 'template_1_id',
     } in stats_list
     assert {
         'counts': {},
         'name': 'bar',
         'requested_count': 0,
+        'id': 'template_2_id',
     } in stats_list
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1289,7 +1289,6 @@ def mock_get_monthly_template_statistics(mocker, service_one, fake_uuid):
                     },
                     "name": 'My first template',
                     "type": 'sms',
-                    "id": fake_uuid,
                 }
             }
         }


### PR DESCRIPTION
Tests assumed that the API returns the template `id` as part of the object. It doesn’t – it returns it as the key used to look up the object. The `id` was missing from the transformation into the format
used by the front end.

For some reason Flask is fine building the URL with `template_id=None`, but obviously this doesn’t generate a valid link.