### PR TITLE
Add a back to template link on job page

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -24,7 +24,7 @@
 
       {% if not help %}
         {% if percentage_complete < 100 %}
-          <p class="bottom-gutter-1-2 hint">
+          <p class="bottom-gutter hint">
             Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
           </p>
         {% elif notifications %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -19,7 +19,7 @@
   {% else %}
 
     {% if notifications %}
-      <div class="dashboard-table">
+      <div class="dashboard-table bottom-gutter-3-2">
     {% endif %}
 
       {% if not help %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
   {{ uploaded_file_name }}
@@ -17,5 +18,12 @@
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
+
+    {% if not help %}
+      {{ page_footer(
+        secondary_link=url_for('.view_template', service_id=current_service.id, template_id=template.id),
+        secondary_link_text='Back to {}'.format(template.name)
+      ) }}
+    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
When you’ve sent message(s) using a template, often the next thing you want to do is go and send the same template again, or edit it.

Currently there’s no way of getting to a template from a job except for going back to the list of templates and re-finding it.

This commit adds a link at the bottom of the job page that gives you a shortcut back to the individual template, where you can find actions like edit/send/etc.

***

![image](https://cloud.githubusercontent.com/assets/355079/24194608/9b3a0f76-0eee-11e7-9d94-bcfc48391dc9.png)

![image](https://cloud.githubusercontent.com/assets/355079/24194784/4c186cc0-0eef-11e7-8e8b-3e1e0056d295.png)
