### PR TITLE
Roadmap page first pass

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -105,3 +105,8 @@ def documentation():
 @main.route('/integration_testing')
 def integration_testing():
     return render_template('views/integration_testing.html')
+
+
+@main.route('/roadmap')
+def roadmap():
+    return render_template('views/roadmap.html')

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -96,6 +96,7 @@
             <li><a href="{{ url_for("main.pricing") }}">Pricing</a></li>
             <li><a href="{{ url_for("main.delivery_and_failure") }}">Delivery and failure</a></li>
             <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
+            <li><a href="{{ url_for("main.roadmap") }}">Roadmap</a></li>
           </ul>
         </div>
         <div class="column-one-third">

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -1,0 +1,65 @@
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
+{% extends "withoutnav_template.html" %}
+
+{% block per_page_title %}
+  Roadmap for GOV.UK Notify
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Roadmap for GOV.UK Notify</h1>
+
+    <p>
+        Here’s a list of the new functionality we’re planning to offer through GOV.UK Notify over the next 6 to 9 months.
+    </p>
+
+    <div class="panel panel-border-wide">
+      <p>
+          This roadmap is a only a guide and may change from month to month.
+      </p>
+    </div>
+
+    <p>
+        If you want to find out more about these features, or have some needs that Notify isn’t yet meeting,
+        please get in touch with us through our <a href="{{ url_for('main.support') }}">support page</a>, or chat with us in our
+        <a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">cross-government Slack channel</a>.
+    </p>
+
+    <h2 class="heading-medium">April 2017</h2>
+      <ul class="list list-bullet">
+        <li>Searching templates</li>
+        <li>Sending letters (invite only)</li>
+        <li>Sending text messages to international numbers</li>
+      </ul>
+
+    <h2 class="heading-medium">May 2017</h2>
+      <ul class="list list-bullet">
+        <li>Supporting replies to text messages (invite only)</li>
+        <li>Retiring version of the API</li>
+        <li>Sending individual messages via Notify interface</li>
+        <li>Restricting notifications to sociable hours</li>
+        <li>Searching for notifications by phone number or email address</li>
+      </ul>
+
+    <h2 class="heading-medium">June to August 2017</h2>
+      <ul class="list list-bullet">
+        <li>Sending letters (available for everyone)</li>
+        <li>Distributing delivery of notifications over a period of time</li>
+        <li>Allowing multiple sender names and reply-to addresses</li>
+        <li>Sending of pre-compiled text messages and emails</li>
+        <li>Checking mobile numbers are valid before sending</li>
+        <li>Providing non-mobile phone 2-factor authentication</li>
+        <li>Sending letters through the API</li>
+        <li>Customising the expiry time for text messages</li>
+      </ul>
+
+    <h2 class="heading-medium">September 2017 and beyond</h2>
+      <ul class="list list-bullet">
+        <li>Sending of pre-compiled letters</li>
+        <li>Allowing people to request to join a service</li>
+        <li>Publishing design patterns for integration</li>
+      </ul>
+
+{% endblock %}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -17,7 +17,7 @@ def test_logged_in_user_redirects_to_choose_service(
 
 
 @pytest.mark.parametrize('view', [
-    'cookies', 'trial_mode', 'pricing', 'terms', 'delivery_and_failure', 'integration_testing'
+    'cookies', 'trial_mode', 'pricing', 'terms', 'delivery_and_failure', 'integration_testing', 'roadmap'
 ])
 def test_static_pages(
     client,


### PR DESCRIPTION
Need to discuss the consistent way for components to refer to roadmaps and banner nav etc, but let's get something out there for our users and we can worry about what's optimal later.