### PR TITLE
letters on paas - bump utils to 13.10.0

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -32,6 +32,7 @@ def set_config_env_vars(vcap_services):
 def extract_notify_config(notify_config):
     os.environ['ADMIN_CLIENT_SECRET'] = notify_config['credentials']['admin_client_secret']
     os.environ['API_HOST_NAME'] = notify_config['credentials']['api_host_name']
+    os.environ['ADMIN_BASE_URL'] = notify_config['credentials']['admin_base_url']
     os.environ['SECRET_KEY'] = notify_config['credentials']['secret_key']
     os.environ['DANGEROUS_SALT'] = notify_config['credentials']['dangerous_salt']
 

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,9 @@ class Config(object):
     DESKPRO_API_HOST = os.environ['DESKPRO_API_HOST']
     DESKPRO_API_KEY = os.environ['DESKPRO_API_KEY']
 
+    # if we're not on cloudfoundry, we can get to this app from localhost. but on cloudfoundry its different
+    ADMIN_BASE_URL = os.environ.get('ADMIN_BASE_URL', 'https://localhost:6012')
+
     # Hosted graphite statsd prefix
     STATSD_PREFIX = os.getenv('STATSD_PREFIX')
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1,7 +1,16 @@
 from datetime import datetime, timedelta
 from string import ascii_uppercase
 
-from flask import request, render_template, redirect, url_for, flash, abort, send_file
+from flask import (
+    request,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    abort,
+    send_file,
+    current_app
+)
 from flask_login import login_required, current_user
 from flask_weasyprint import HTML, render_pdf
 from dateutil.parser import parse
@@ -86,6 +95,7 @@ def view_letter_template_as_pdf(service_id, template_id):
         LetterPreviewTemplate(
             service_api_client.get_service_template(service_id, template_id)['data'],
             contact_block=current_service['letter_contact_block'],
+            admin_base_url=current_app.config['ADMIN_BASE_URL']
         )
     )))
 
@@ -147,6 +157,7 @@ def view_template_version_as_pdf(service_id, template_id, version):
         LetterPreviewTemplate(
             service_api_client.get_service_template(service_id, template_id, version=version)['data'],
             contact_block=current_service['letter_contact_block'],
+            admin_base_url=current_app.config['ADMIN_BASE_URL']
         )
     )))
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -323,6 +323,7 @@ def get_template(
             return LetterPreviewTemplate(
                 template,
                 contact_block=service['letter_contact_block'],
+                admin_base_url=current_app.config['ADMIN_BASE_URL']
             )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@13.9.4#egg=notifications-utils==13.9.4
+git+https://github.com/alphagov/notifications-utils.git@13.10.0#egg=notifications-utils==13.10.0

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -12,6 +12,7 @@ def notify_config():
         'name': 'notify-config',
         'credentials': {
             'api_host_name': 'api host name',
+            'admin_base_url': 'admin base url',
             'admin_client_secret': 'admin client secret',
             'secret_key': 'secret key',
             'dangerous_salt': 'dangerous salt',
@@ -100,6 +101,7 @@ def test_notify_config():
     extract_cloudfoundry_config()
 
     assert os.environ['API_HOST_NAME'] == 'api host name'
+    assert os.environ['ADMIN_BASE_URL'] == 'admin base url'
     assert os.environ['ADMIN_CLIENT_SECRET'] == 'admin client secret'
     assert os.environ['SECRET_KEY'] == 'secret key'
     assert os.environ['DANGEROUS_SALT'] == 'dangerous salt'


### PR DESCRIPTION
pass in the base URL - if not set in the environment this is set to localhost, but on paas we can pull this out of vcap_services so that letters render properly on paas

i couldn't think of any nice tests for this since it's very hard to work out whats happening inside a pdf

but when i changed it locally it seemed alright /shrug