### PR TITLE
Improve flow of editing letter contact details

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -502,9 +502,7 @@ class ServiceSmsSender(Form):
 
 
 class ServiceLetterContactBlock(Form):
-    letter_contact_block = TextAreaField(
-        'How should users contact you?'
-    )
+    letter_contact_block = TextAreaField()
 
     def validate_letter_contact_block(form, field):
         line_count = field.data.strip().count('\n')

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -275,6 +275,10 @@ def service_set_letter_contact_block(service_id):
             current_service['id'],
             letter_contact_block=form.letter_contact_block.data.replace('\r', '') or None
         )
+        if request.args.get('from_template'):
+            return redirect(
+                url_for('.view_template', service_id=service_id, template_id=request.args.get('from_template'))
+            )
         return redirect(url_for('.service_settings', service_id=service_id))
     return render_template(
         'views/service-settings/set-letter-contact-block.html',

--- a/app/templates/partials/templates/guidance-contact-block.html
+++ b/app/templates/partials/templates/guidance-contact-block.html
@@ -1,8 +1,0 @@
-<h2 class="heading-medium">Contact details</h2>
-<p>
-  Add contact details for your service in
-  <a href="{{ url_for('.service_set_letter_contact_block', service_id=current_service.id) }}">settings</a>.
-</p>
-<p>
-  The text will appear in the top right of all letters your service sends.
-</p>

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -29,7 +29,6 @@
         <aside class="column-three-quarters">
           {% include "partials/templates/guidance-formatting-letters.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
-          {% include "partials/templates/guidance-contact-block.html" %}
         </aside>
       </div>
     </form>

--- a/app/templates/views/service-settings/set-letter-contact-block.html
+++ b/app/templates/views/service-settings/set-letter-contact-block.html
@@ -15,6 +15,7 @@
     <form method="post" class="column-half">
       {{ textbox(
         form.letter_contact_block,
+        label='How should users contact your service?<br>This applies to all the letters you send.'|safe,
         hint='10 lines maximum',
         width='1-1',
         rows=10

--- a/app/templates/views/service-settings/set-letter-contact-block.html
+++ b/app/templates/views/service-settings/set-letter-contact-block.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Letter contact block
+  Letter contact details
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -35,7 +35,7 @@
 <div class="column-whole template-container">
   {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) and template.template_type == 'letter' %}
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
-    <a href="{{ url_for(".service_set_letter_contact_block", service_id=current_service.id) }}" class="edit-template-link-letter-contact">Edit</a>
+    <a href="{{ url_for(".service_set_letter_contact_block", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
     <a href="#" class="edit-template-link-letter-address">Edit</a>
   {% endif %}
   {{ template|string }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1,6 +1,7 @@
 from unittest.mock import call, ANY, Mock
 
 import pytest
+import uuid
 from flask import url_for
 from bs4 import BeautifulSoup
 from werkzeug.exceptions import InternalServerError
@@ -617,6 +618,30 @@ def test_set_letter_contact_block_saves(
     assert response.status_code == 302
     assert response.location == url_for('main.service_settings', service_id=service_one['id'], _external=True)
     mock_update_service.assert_called_once_with(service_one['id'], letter_contact_block='foo bar baz waz')
+
+
+def test_set_letter_contact_block_redirects_to_template(
+    logged_in_client,
+    service_one,
+    mock_update_service,
+):
+    service_one['can_send_letters'] = True
+    fake_template_id = uuid.uuid4()
+    response = logged_in_client.post(
+        url_for(
+            'main.service_set_letter_contact_block',
+            service_id=service_one['id'],
+            from_template=fake_template_id,
+        ),
+        data={'letter_contact_block': ''},
+    )
+    assert response.status_code == 302
+    assert response.location == url_for(
+        'main.view_template',
+        service_id=service_one['id'],
+        template_id=fake_template_id,
+        _external=True,
+    )
 
 
 def test_set_letter_contact_block_has_max_10_lines(


### PR DESCRIPTION
## Go back to template after editing contact details

Users who go to edit the contact details for a letter from the template page get very confused when they click save and are dumped on the settings page. It doesn’t match the way editing other parts of
letter works, and you can’t see an accurate preview of the changes from the settings page.

So this commit changes the flow to go from the _edit contact details_ page back to the _view template_ page when the user has got there by clicking the blue _Edit_ button on the _view template_ page.

## Explain contact details changes apply all letters

This is different to how editing other parts of a letter works, so we should make it explicit.

![image](https://cloud.githubusercontent.com/assets/355079/24604298/291ece96-185c-11e7-8bbe-1fe76a045117.png)
