### PR TITLE
Bump Boto version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WeasyPrint==0.5
 
 html5lib==1.0b10
 credstash==1.8.0
-boto3==1.3.0
+boto3==1.4.4
 Pygments==2.0.2
 py-gfm==0.1.2
 blinker==1.4


### PR DESCRIPTION
Our deploys have stopped working. It’s complaining with an `ImportError` somewhere in Boto:

```
017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR Traceback (most recent call last):
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR   File “/home/vcap/app/.heroku/python/bin/aws”, line 19, in <module>
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR     import awscli.clidriver
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR   File “/app/.heroku/python/lib/python3.5/site-packages/awscli/clidriver.py”, line 33, in <module>
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR     from awscli.help import ProviderHelpCommand
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR   File “/app/.heroku/python/lib/python3.5/site-packages/awscli/help.py”, line 27, in <module>
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR     from awscli.clidocs import ProviderDocumentEventHandler
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR   File “/app/.heroku/python/lib/python3.5/site-packages/awscli/clidocs.py”, line 18, in <module>
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR     from botocore.utils import is_json_value_header
2017-04-04T10:46:26.17+0100 [APP/PROC/WEB/0]ERR ImportError: cannot import name ‘is_json_value_header’
2017-04-04T10:46:26.20+0100 [APP/PROC/WEB/0]OUT Terminating application process with pid
```

Our version of Boto is a year old. Upgrading it to the latest version seems like a good idea.

Not a breaking version number change. Changelog here: https://github.com/boto/boto3/blob/develop/CHANGELOG.rst

Complete changes: https://github.com/boto/boto3/compare/1.3.0...1.4.4