### PR TITLE
Refactor s3upload.

### DIFF
--- a/app/main/uploader.py
+++ b/app/main/uploader.py
@@ -2,37 +2,18 @@ import uuid
 import botocore
 from boto3 import resource
 from flask import current_app
+from notifications_utils.s3 import s3upload as utils_s3upload
 
 FILE_LOCATION_STRUCTURE = 'service-{}-notify/{}.csv'
 
 
 def s3upload(service_id, filedata, region):
-    s3 = resource('s3')
-    bucket_name = current_app.config['CSV_UPLOAD_BUCKET_NAME']
-    contents = filedata['data']
-
-    exists = True
-    try:
-        s3.meta.client.head_bucket(
-            Bucket=bucket_name)
-    except botocore.exceptions.ClientError as e:
-        error_code = int(e.response['Error']['Code'])
-        if error_code == 404:
-            exists = False
-        else:
-            current_app.logger.error(
-                "Unable to create s3 bucket {}".format(bucket_name))
-            raise e
-
-    if not exists:
-        s3.create_bucket(Bucket=bucket_name,
-                         CreateBucketConfiguration={'LocationConstraint': region})
-
     upload_id = str(uuid.uuid4())
     upload_file_name = FILE_LOCATION_STRUCTURE.format(service_id, upload_id)
-    key = s3.Object(bucket_name, upload_file_name)
-    key.put(Body=contents, ServerSideEncryption='AES256')
-
+    utils_s3upload(filedata=filedata['data'],
+                   region=region,
+                   bucket_name=current_app.config['CSV_UPLOAD_BUCKET_NAME'],
+                   file_location=upload_file_name)
     return upload_id
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@14.0.0#egg=notifications-utils==15.0.1
+git+https://github.com/alphagov/notifications-utils.git@15.0.1#egg=notifications-utils==15.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@14.0.0#egg=notifications-utils==14.0.0
+git+https://github.com/alphagov/notifications-utils.git@14.0.0#egg=notifications-utils==15.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.3#egg=notifications-utils==15.0.3
+git+https://github.com/alphagov/notifications-utils.git@15.0.4#egg=notifications-utils==15.0.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.1#egg=notifications-utils==15.0.1
+git+https://github.com/alphagov/notifications-utils.git@15.0.3#egg=notifications-utils==15.0.3


### PR DESCRIPTION
s3upload now calls into the common notifications-utils method to upload a s3 file.

- [x] https://github.com/alphagov/notifications-utils/pull/138