### PR TITLE
Fix address column handling

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -77,7 +77,6 @@ def get_example_letter_address(key):
     return {
         'address line 1': 'A. Name',
         'address line 2': '123 Example Street',
-        'address line 3': 'Example town',
         'postcode': 'XM4 5HQ'
     }.get(key, '')
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -287,13 +287,17 @@ def edit_service_template(service_id, template_id):
         }, current_service)
         template_change = get_template(template, current_service).compare_to(new_template)
         if template_change.has_different_placeholders and not request.form.get('confirm'):
+            example_column_headings = (
+                first_column_headings[new_template.template_type] +
+                list(new_template.placeholders)
+            )
             return render_template(
                 'views/templates/breaking-change.html',
                 template_change=template_change,
                 new_template=new_template,
-                column_headings=list(ascii_uppercase[:len(new_template.placeholders) + 1]),
+                column_headings=list(ascii_uppercase[:len(example_column_headings)]),
                 example_rows=[
-                    first_column_headings[new_template.template_type] + list(new_template.placeholders),
+                    example_column_headings,
                     get_example_csv_rows(new_template),
                     get_example_csv_rows(new_template)
                 ],

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -41,8 +41,8 @@
 
   <p>
     When you send messages using this template you’ll need
-    {{ new_template.placeholders|length + 1 }}
-    column{{ 's' if new_template.placeholders|length > 0 else '' }} of data:
+    {{ column_headings|length }}
+    column{{ 's' if column_headings|length > 1 else '' }} of data:
   </p>
 
   <div class="spreadsheet">

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@14.0.0#egg=notifications-utils==14.0.0
+git+https://github.com/alphagov/notifications-utils.git@15.0.1#egg=notifications-utils==15.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,15 +336,15 @@ def mock_get_service_template_with_placeholders(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_get_service_email_template(mocker):
+def mock_get_service_email_template(mocker, content=None, subject=None):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id,
             template_id,
             "Two week reminder",
             "email",
-            "Your vehicle tax expires on ((date))",
-            "Your ((thing)) is due soon"
+            content or "Your vehicle tax expires on ((date))",
+            subject or "Your ((thing)) is due soon",
         )
         return {'data': template}
 
@@ -354,30 +354,24 @@ def mock_get_service_email_template(mocker):
 
 @pytest.fixture(scope='function')
 def mock_get_service_email_template_without_placeholders(mocker):
-    def _create(service_id, template_id):
-        template = template_json(
-            service_id,
-            template_id,
-            "Two week reminder",
-            "email",
-            "Your vehicle tax expires soon",
-            "Your thing is due soon"
-        )
-        return {'data': template}
-
-    return mocker.patch(
-        'app.service_api_client.get_service_template', side_effect=_create)
+    return mock_get_service_email_template(
+        mocker,
+        content="Your vehicle tax expires soon",
+        subject="Your thing is due soon",
+    )
 
 
 @pytest.fixture(scope='function')
-def mock_get_service_letter_template(mocker):
+def mock_get_service_letter_template(mocker, content=None, subject=None):
     def _create(service_id, template_id):
         template = template_json(
             service_id,
             template_id,
             "Two week reminder",
             "letter",
-            "Template <em>content</em> with & entity", "Subject")
+            content or "Template <em>content</em> with & entity",
+            subject or "Subject",
+        )
         return {'data': template}
 
     return mocker.patch(


### PR DESCRIPTION
# Bring in utils fixes:

See:
- [x] https://github.com/alphagov/notifications-utils/pull/137

# Fix no. of column headers on breaking change page

### Before

![image](https://cloud.githubusercontent.com/assets/355079/24747423/3242f880-1ab4-11e7-8d3d-52679d2b7c2e.png)

### After

<img width="892" alt="screen shot 2017-04-06 at 10 17 17" src="https://cloud.githubusercontent.com/assets/355079/24747430/3951b080-1ab4-11e7-823d-6c25ecbd3448.png">


# 	Don’t fill out address line 3 in the example

![image](https://cloud.githubusercontent.com/assets/355079/24747465/54b37818-1ab4-11e7-89e0-a254bd662676.png)

Address line 3 is optional. Currently the only way we have of indicating to users what is/isn’t optional is by using the example. Which probably isn’t ideal, but should at least be correct.


