### PR TITLE
Fix future ‘last edited’ date

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -279,12 +279,15 @@ def format_date_short(date):
 
 
 def format_delta(date):
+    delta = (
+        datetime.now(timezone.utc)
+    ) - (
+        gmt_timezones(date)
+    )
+    if delta < timedelta(seconds=30):
+        return "just now"
     return ago.human(
-        (
-            datetime.now(timezone.utc)
-        ) - (
-            dateutil.parser.parse(date)
-        ),
+        delta,
         future_tense='{} from now',  # No-one should ever see this
         past_tense='{} ago',
         precision=1

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -24,7 +24,7 @@
 
   {% if template._template.updated_at %}
     <div class="bottom-gutter-2">
-      <h2 class="heading-small">Last edited {{ template._template.updated_at|format_datetime_relative }}</h2>
+      <h2 class="heading-small">Last edited {{ template._template.updated_at|format_delta }}</h2>
       <p>
         <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
       </p>


### PR DESCRIPTION
The `format_datetime_relative` filter is only used by the scheduling stuff, which only deals with dates in the future.

When used on dates in the past (more than 1 day ago) it gets confused and defaults to ‘tomorrow’.

The `format_delta` method does a similar thing, but works for past and future dates.

Users can still click through to the next page to see the exact date and time of the edits.