### PR TITLE
Fix broken journey when going back from check page

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -236,13 +236,13 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
 
     if request.args.get('from_test'):
         extra_args = {'help': 1} if request.args.get('help', '0') != '0' else {}
-        if len(template.placeholders):
+        if len(template.placeholders) or template.template_type == 'letter':
             back_link = url_for(
                 '.send_test', service_id=service_id, template_id=template.id, **extra_args
             )
         else:
             back_link = url_for(
-                '.choose_template', service_id=service_id, **extra_args
+                '.view_template', service_id=service_id, template_id=template.id, **extra_args
             )
         choose_time_form = None
     else:


### PR DESCRIPTION
We’ve seen in letters usability testing that people get stuck in a “no-man’s land” when trying to go back from the _Send yourself a test_ page.

This was broken for two reasons:
- we hadn’t considered that a letter template without placeholders still requires you to fill in the address columns
- we’ve subsequently made the _view template_ page the place where you do your actions, rather than the (old) page with all the templates shown

So this commit fixes it so that the back link always take you back to the page you were previously on, and adds some more test cases so we have all the scenarios accounted for.