### PR TITLE
Increase width of edit letter textbox

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -18,6 +18,10 @@
   @include grid-column(1/8);
 }
 
+.column-five-eighths {
+  @include grid-column(5/8);
+}
+
 .column-seven-eighths {
   @include grid-column(7/8);
 }

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -2,7 +2,7 @@
 .sms-message-wrapper {
 
   width: 100%;
-  max-width: 450px;
+  max-width: 464px;
   box-sizing: border-box;
   padding: $gutter-half $gutter-half $gutter-half $gutter-half;
   background: $panel-colour;

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -30,12 +30,12 @@
 
 .edit-template-link-letter-address {
   @extend %edit-template-link;
-  top: 16.5%; // align bottom edge to bottom of address
+  top: 14.65%; // align bottom edge to bottom of address
   left: -5px;
 }
 
 .edit-template-link-letter-body {
   @extend %edit-template-link;
-  top: 33.3%; // aligns to top of subject
+  top: 38.5%; // aligns to top of subject
   left: -5px;
 }

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -15,11 +15,9 @@
 
     <form method="post">
       <div class="grid-row">
-        <div class="column-three-quarters">
+        <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
-        </div>
-        <div class="column-three-quarters">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
           {% if current_user.has_permissions([], admin_override=True) %}
              {{ radios(form.process_type) }}

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -14,11 +14,9 @@
 
     <form method="post">
       <div class="grid-row">
-        <div class="column-three-quarters">
+        <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
-        </div>
-        <div class="column-three-quarters">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
           {{ page_footer(
             'Save',


### PR DESCRIPTION
# The problem

![image](https://cloud.githubusercontent.com/assets/355079/24852210/9bf23fa8-1dce-11e7-82e5-916fc926d205.png)

The textbox we use for editing letters is the same size as that for email and text messages.

This is problematic because:
- it feels quite cramped – letters will often be longer than emails or text messages
- it has a narrower line length than the printed letters (which is a constant, unlike for emails and text messages)

# Working out the solution

The printed letters have a line length of 137.5mm and a font size of 12.5pt.

137.5mm = 5.41 inches = 389.7pt line length

389.7pt/12.5pt = 31.8em

So we could make the box 31.8em wide, but then it wouldn’t align to our grid.

<img width="1037" alt="screen shot 2017-04-10 at 09 03 18" src="https://cloud.githubusercontent.com/assets/355079/24852320/f098784c-1dce-11e7-9b73-2f85991dbc16.png">

Our grid splits the page into quarters initially because this is how wide the navigation is. So this means that we can use grid units of 1/multiples of four, eg 1/4, 1/8, 1/12, 1/16, etc. But the smaller the denominator, the less effective the grid will be – it gets closer to no grid at all.

After having a play around, 5/8 of the page looks closest to 31.8em. Since the main column of the page is 3/4, we set a column of 5/6 width inside that, which equals 5/8 of the total page.

It’ll never break the lines at the exact same place as the preview, because the textbox uses a  different typeface (with different metrics) from the preview. But it’s close.

# After

![image](https://cloud.githubusercontent.com/assets/355079/24852245/b550c834-1dce-11e7-86c3-5e2c05b69ec8.png)

![image](https://cloud.githubusercontent.com/assets/355079/24852285/d5126baa-1dce-11e7-9365-e885695bb2a6.png)
