### PR TITLE
Letter jobs page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -52,6 +52,7 @@ from app.notify_client.events_api_client import EventsApiClient
 from app.notify_client.provider_client import ProviderClient
 from app.notify_client.organisations_client import OrganisationsClient
 from app.notify_client.models import AnonymousUser
+from app.notify_client.letter_jobs_client import LetterJobsClient
 
 login_manager = LoginManager()
 csrf = CsrfProtect()
@@ -69,6 +70,7 @@ provider_client = ProviderClient()
 organisations_client = OrganisationsClient()
 asset_fingerprinter = AssetFingerprinter()
 statsd_client = StatsdClient()
+letter_jobs_client = LetterJobsClient()
 
 # The current service attached to the request stack.
 current_service = LocalProxy(partial(_lookup_req_object, 'service'))
@@ -100,6 +102,7 @@ def create_app():
     events_api_client.init_app(application)
     provider_client.init_app(application)
     organisations_client.init_app(application)
+    letter_jobs_client.init_app(application)
 
     login_manager.init_app(application)
     login_manager.login_view = 'main.sign_in'

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -26,5 +26,6 @@ from app.main.views import (
     invites,
     feedback,
     providers,
-    platform_admin
+    platform_admin,
+    letter_jobs
 )

--- a/app/main/views/letter_jobs.py
+++ b/app/main/views/letter_jobs.py
@@ -1,0 +1,45 @@
+from flask import (render_template, url_for, redirect, request, abort)
+from app.main import main
+from app import convert_to_boolean
+from flask_login import (login_required, current_user)
+
+
+@main.route("/letter-jobs", methods=['GET', 'POST'])
+@login_required
+def letter_jobs():
+    letter_jobs_list = get_letter_jobs()
+
+    msg = ''
+    if request.method == 'POST':
+        send_letters = request.form.getlist('send_letter')
+        for job_id in send_letters:
+            job = [j for j in letter_jobs_list if job_id == j['job_id']][0]
+            job['send'] = True
+
+        msg = 'sending:{}'.format(send_letters)
+
+    return render_template('views/letter-jobs.html', letter_jobs_list=letter_jobs_list, message=msg)
+
+
+def get_letter_jobs():
+    return [
+        {
+            'service_name': 'test_name',
+            'job_id': 'test_id',
+            'status': 'test_status',
+            'created_at': '2017-04-01'
+        },
+        {
+            'service_name': 'test_name 2',
+            'job_id': 'test_id 2',
+            'status': 'test_status 2',
+            'created_at': '2017-04-02'
+
+        },
+        {
+            'service_name': 'test_name 3',
+            'job_id': 'test_id 3',
+            'status': 'test_status 3',
+            'created_at': '2017-04-03'
+        }
+    ]

--- a/app/notify_client/letter_jobs_client.py
+++ b/app/notify_client/letter_jobs_client.py
@@ -1,0 +1,21 @@
+from app.notify_client import NotifyAdminAPIClient
+
+
+class LetterJobsClient(NotifyAdminAPIClient):
+
+    def __init__(self):
+        super().__init__("a", "b", "c")
+
+    def init_app(self, app):
+        self.base_url = app.config['API_HOST_NAME']
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
+
+    def get_letter_jobs(self):
+        return self.get(url='/letter-jobs')['data']
+
+    def send_letter_jobs(self, job_ids):
+        return self.post(
+            url='/send-letter-jobs',
+            data={"job_ids": job_ids}
+        )['data']

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -52,6 +52,9 @@
                 <li>
                   <a href="{{ url_for('main.view_providers') }}">Providers</a>
                 </li>
+                <li>
+                  <a href="{{ url_for('main.letter_jobs') }}">Letter jobs</a>
+                </li>
             {% endif %}
             <li>
               <a href="{{ url_for('main.sign_out')}}">Sign out</a>

--- a/app/templates/views/letter-jobs.html
+++ b/app/templates/views/letter-jobs.html
@@ -1,0 +1,43 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Show letter jobs
+{% endblock %}
+
+{% block maincolumn_content %}
+
+    <h1 class="heading-large">Letter jobs</h1>
+
+    <form autocomplete="off" method="post">
+      <p>
+        <table>
+          <thead>
+            <tr>
+              <th>Service name</th>
+              <th>Job ID</th>
+              <th>Status</th>
+              <th colspan="2">Created at</th>
+            </tr>
+          </thead>
+        {% for job in letter_jobs_list %}
+            <tr>
+              <td>{{ job.service_name }}</td>
+              <td>{{ job.job_id }}</td>
+              <td>{{ job.status }}</td>
+              <td>{{ job.created_at }}</td>
+              <td><input name="send_letter" value='{{ job.job_id }}' type="checkbox"{% if job.send %} checked{% endif %}></td>
+            </tr>
+        {% endfor %}
+        </table>
+      </p>
+      {{ page_footer('Send') }}
+
+      {% if message %}
+      <p>
+        {{ message }}
+      </p>
+      {% endif %}
+    </form>
+
+{% endblock %}

--- a/app/templates/views/letter-jobs.html
+++ b/app/templates/views/letter-jobs.html
@@ -17,25 +17,31 @@
               <th>Service name</th>
               <th>Job ID</th>
               <th>Status</th>
-              <th colspan="2">Created at</th>
+              <th colspan="3">Created at</th>
             </tr>
           </thead>
+          <tbody>
         {% for job in letter_jobs_list %}
             <tr>
-              <td>{{ job.service_name }}</td>
-              <td>{{ job.job_id }}</td>
-              <td>{{ job.status }}</td>
-              <td>{{ job.created_at }}</td>
-              <td><input name="send_letter" value='{{ job.job_id }}' type="checkbox"{% if job.send %} checked{% endif %}></td>
+              <td>{{ job.service_name.name }}</td>
+              <td>{{ job.id }}</td>
+              <td>{{ job.job_status }}</td>
+              <td>{{ job.created_at|format_datetime_short }}</td>
+              <td><input name="job_id" value='{{ job.id }}' type="checkbox"{% if job.send %} checked{% endif %}></td>
+              <td>{{ job.sending }}</td>
             </tr>
         {% endfor %}
+        </tbody>
         </table>
       </p>
       {{ page_footer('Send') }}
 
       {% if message %}
-      <p>
+      <p id='message'>
         {{ message }}
+        {% if message != 'No jobs selected' %}
+          <div>Refresh page to see status updates</div>
+        {% endif %}
       </p>
       {% endif %}
     </form>

--- a/app/templates/views/letter-jobs.html
+++ b/app/templates/views/letter-jobs.html
@@ -16,6 +16,7 @@
             <tr>
               <th>Service name</th>
               <th>Job ID</th>
+              <th>Count</th>
               <th>Status</th>
               <th colspan="3">Created at</th>
             </tr>
@@ -25,9 +26,10 @@
             <tr>
               <td>{{ job.service_name.name }}</td>
               <td>{{ job.id }}</td>
+              <td>{{ job.notification_count }}</td>
               <td>{{ job.job_status }}</td>
               <td>{{ job.created_at|format_datetime_short }}</td>
-              <td><input name="job_id" value='{{ job.id }}' type="checkbox"{% if job.send %} checked{% endif %}></td>
+              <td><input name="job_id" value='{{ job.id }}' type="checkbox"{% if not (job.job_status == 'ready to send' or job.job_status == 'sent to dvla') %} disabled{% endif %}></td>
               <td>{{ job.sending }}</td>
             </tr>
         {% endfor %}

--- a/tests/app/main/views/test_letter_jobs.py
+++ b/tests/app/main/views/test_letter_jobs.py
@@ -52,9 +52,7 @@ def test_get_letter_jobs_returns_list_of_all_letter_jobs(logged_in_platform_admi
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string == 'Letter jobs'
 
-    table = page.find('table')
-    table_body = table.find('tbody')
-    rows = table_body.find_all('tr')
+    rows = page.select('table tbody tr')
 
     assert len(rows) == len(valid_letter_jobs)
 
@@ -85,9 +83,7 @@ def test_post_letter_jobs_select_1_letter_job_submits_1_job(logged_in_platform_a
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-    table = page.find('table')
-    table_body = table.find('tbody')
-    rows = table_body.find_all('tr')
+    rows = page.select('table tbody tr')
 
     assert len(rows) == len(valid_letter_jobs)
 

--- a/tests/app/main/views/test_letter_jobs.py
+++ b/tests/app/main/views/test_letter_jobs.py
@@ -1,0 +1,103 @@
+from flask import url_for
+from bs4 import BeautifulSoup
+
+from app import format_datetime_short
+
+valid_letter_jobs = [
+    {
+        'service_name': {'name': 'test_name'},
+        'template_version': 1,
+        'id': 'test_id',
+        'job_status': 'test_status',
+        'created_at': '2017-04-01T12:00:00'
+    },
+    {
+        'service_name': {'name': 'test_name 2'},
+        'template_version': 2,
+        'id': 'test_id 2',
+        'job_status': 'test_status 2',
+        'created_at': '2017-04-02T13:00:00'
+    },
+    {
+        'service_name': {'name': 'test_name 3'},
+        'template_version': 3,
+        'id': 'test_id 3',
+        'job_status': 'test_status 3',
+        'created_at': '2017-04-03T14:00:00'
+    }
+]
+
+send_letter_jobs_response = {"response": "Task created to send files to DVLA"}
+
+
+def test_get_letter_jobs_returns_list_of_all_letter_jobs(logged_in_platform_admin_client, mocker):
+    mock_get_letters = mocker.patch('app.letter_jobs_client.get_letter_jobs', return_value=valid_letter_jobs)
+
+    response = logged_in_platform_admin_client.get(url_for('main.letter_jobs'))
+
+    assert mock_get_letters.called
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string == 'Letter jobs'
+
+    table = page.find('table')
+    table_body = table.find('tbody')
+    rows = table_body.find_all('tr')
+
+    assert len(rows) == len(valid_letter_jobs)
+
+    for row_pos in range(len(rows)):
+        cols = rows[row_pos].find_all('td')
+        assert valid_letter_jobs[row_pos]['service_name']['name'] == cols[0].text
+        assert valid_letter_jobs[row_pos]['id'] == cols[1].text
+        assert valid_letter_jobs[row_pos]['job_status'] == cols[2].text
+        assert format_datetime_short(valid_letter_jobs[row_pos]['created_at']) == cols[3].text
+
+
+def test_post_letter_jobs_select_1_letter_job_submits_1_job(logged_in_platform_admin_client, mocker):
+    letter_jobs_first_selected = {'job_id': ['test_id']}
+
+    mock_get_letters = mocker.patch('app.letter_jobs_client.get_letter_jobs', return_value=valid_letter_jobs)
+    mock_send_letters = mocker.patch('app.letter_jobs_client.send_letter_jobs', return_value=send_letter_jobs_response)
+
+    response = logged_in_platform_admin_client.post(url_for('main.letter_jobs'), data=letter_jobs_first_selected)
+
+    assert mock_get_letters.called
+    assert mock_send_letters.called
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    table = page.find('table')
+    table_body = table.find('tbody')
+    rows = table_body.find_all('tr')
+
+    assert len(rows) == len(valid_letter_jobs)
+
+    colr0 = rows[0].find_all('td')
+    colr1 = rows[1].find_all('td')
+    colr2 = rows[2].find_all('td')
+
+    assert colr0[5].text == "sending"
+    assert colr1[5].text == ""
+    assert colr2[5].text == ""
+
+    message = page.find('p', attrs={'id': 'message'}).text
+    assert "Task created to send files to DVLA" in message
+
+
+def test_post_letter_jobs_none_selected_shows_message(logged_in_platform_admin_client, mocker):
+    mock_get_letters = mocker.patch('app.letter_jobs_client.get_letter_jobs', return_value=valid_letter_jobs)
+    mock_send_letters = mocker.patch('app.letter_jobs_client.send_letter_jobs', return_value=send_letter_jobs_response)
+
+    response = logged_in_platform_admin_client.post(url_for('main.letter_jobs'), data={})
+
+    assert mock_get_letters.called
+    assert not mock_send_letters.called
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    message = page.find('p', attrs={'id': 'message'}).text
+
+    assert "No jobs selected" in message


### PR DESCRIPTION
## What 

Added letter jobs page to platform admin with supporting tests in order to allow platform admin users to manually send DVLA letter jobs to the ftp client via the API.

Initially sending a letter job will put the job status as `in progress`, the user will have to wait until it is `ready to send` before they can select the job for sending.

Attempting to click send without selecting a job will display the `No jobs to send` message.

There will be an indication of which jobs were sent, but this information will be lost when clicking on the `Letter jobs` link at the top.

## How to review

execute `pytest tests/app/main/views/test_letter_jobs.py`
