### PR TITLE
Letters from template-preview service

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,8 @@ class Config(object):
     # if we're not on cloudfoundry, we can get to this app from localhost. but on cloudfoundry its different
     ADMIN_BASE_URL = os.environ.get('ADMIN_BASE_URL', 'http://localhost:6012')
 
+    TEMPLATE_PREVIEW_SERVICE_URL = os.environ.get('TEMPLATE_PREVIEW_SERVICE_URL', 'http://localhost:6013')
+
     # Hosted graphite statsd prefix
     STATSD_PREFIX = os.getenv('STATSD_PREFIX')
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -19,7 +19,6 @@ from flask import (
 )
 
 from flask_login import login_required, current_user
-from flask_weasyprint import HTML, render_pdf
 
 from notifications_utils.columns import Columns
 from notifications_utils.recipients import RecipientCSV, first_column_headings, validate_and_format_phone_number
@@ -36,9 +35,9 @@ from app.utils import (
     get_errors_for_csv,
     Spreadsheet,
     get_help_argument,
-    get_template,
-    png_from_pdf,
+    get_template
 )
+from app.template_previews import TemplatePreview
 
 
 def get_page_headings(template_type):
@@ -291,24 +290,14 @@ def check_messages(service_id, template_type, upload_id):
     )
 
 
-@main.route("/services/<service_id>/<template_type>/check/<upload_id>.pdf", methods=['GET'])
+@main.route("/services/<service_id>/<template_type>/check/<upload_id>.<filetype>", methods=['GET'])
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
-def check_messages_as_pdf(service_id, template_type, upload_id):
+def check_messages_preview(service_id, template_type, upload_id, filetype):
     template = _check_messages(
         service_id, template_type, upload_id, letters_as_pdf=True
     )['template']
-    return render_pdf(HTML(string=str(template)))
-
-
-@main.route("/services/<service_id>/<template_type>/check/<upload_id>.png", methods=['GET'])
-@login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
-def check_messages_as_png(service_id, template_type, upload_id):
-    return send_file(**png_from_pdf(
-        check_messages_as_pdf(service_id, template_type, upload_id)
-    ))
-
+    return TemplatePreview.from_utils_template(template, filetype)
 
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['POST'])
 @login_required

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -1,0 +1,17 @@
+from flask import current_app, current_service
+import requests
+
+
+def get_template_preview(template, filetype):
+    data = {
+        "letter_contact_block": current_service['letter_contact_block'],
+        "admin_base_url": current_app.config['ADMIN_BASE_URL'],
+        "template": template,
+        "values": None
+    }
+    resp = requests.post(
+        '{}/preview.{}'.format(current_app.config['TEMPLATE_PREVIEW_SERVICE_URL'], filetype),
+        json=data,
+        headers={'Authorization': 'Token my-secret-key'}
+    )
+    return (resp.content, resp.status_code, resp.headers.items())

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -1,17 +1,29 @@
-from flask import current_app, current_service
+from flask import current_app
 import requests
 
+from app import current_service
 
-def get_template_preview(template, filetype):
-    data = {
-        "letter_contact_block": current_service['letter_contact_block'],
-        "admin_base_url": current_app.config['ADMIN_BASE_URL'],
-        "template": template,
-        "values": None
-    }
-    resp = requests.post(
-        '{}/preview.{}'.format(current_app.config['TEMPLATE_PREVIEW_SERVICE_URL'], filetype),
-        json=data,
-        headers={'Authorization': 'Token my-secret-key'}
-    )
-    return (resp.content, resp.status_code, resp.headers.items())
+
+class TemplatePreview:
+    @classmethod
+    def from_database_object(cls, template, filetype, values=None):
+        data = {
+            "letter_contact_block": current_service['letter_contact_block'],
+            "admin_base_url": current_app.config['ADMIN_BASE_URL'],
+            "template": template,
+            "values": values
+        }
+        resp = requests.post(
+            '{}/preview.{}'.format(current_app.config['TEMPLATE_PREVIEW_SERVICE_URL'], filetype),
+            json=data,
+            headers={'Authorization': 'Token my-secret-key'}
+        )
+        return (resp.content, resp.status_code, resp.headers.items())
+
+    @classmethod
+    def from_utils_template(cls, template, filetype):
+        return cls.from_database_object(
+            template._template,
+            filetype,
+            template.values
+        )

--- a/app/utils.py
+++ b/app/utils.py
@@ -16,8 +16,6 @@ from flask import (
 )
 from flask_login import current_user
 
-from wand.image import Image
-
 from notifications_utils.template import (
     SMSPreviewTemplate,
     EmailPreviewTemplate,
@@ -325,21 +323,6 @@ def get_template(
                 contact_block=service['letter_contact_block'],
                 admin_base_url=current_app.config['ADMIN_BASE_URL']
             )
-
-
-def png_from_pdf(pdf_endpoint):
-    output = BytesIO()
-    with Image(
-        blob=pdf_endpoint.get_data(),
-        resolution=150,
-    ) as image:
-        with image.convert('png') as converted:
-            converted.save(file=output)
-    output.seek(0)
-    return dict(
-        filename_or_fp=output,
-        mimetype='image/png',
-    )
 
 
 def get_current_financial_year():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,7 @@ Flask==0.10.1
 Flask-Script==2.0.5
 Flask-WTF==0.11
 Flask-Login==0.3.2
-Flask-WeasyPrint==0.5
 
-html5lib==1.0b10
 credstash==1.8.0
 boto3==1.4.4
 Pygments==2.0.2
@@ -20,7 +18,6 @@ pyexcel-xlsx==0.1.0
 pyexcel-ods3==0.1.1
 pytz==2016.4
 six==1.10.0
-wand==0.4.4
 gunicorn==19.6.0
 whitenoise==1.0.6  #manages static assets
 


### PR DESCRIPTION
This is to get letter previews working again. They now run from another service, so pango/imagemagick/ghostscript etc are no longer dependencies

### To run this service locally

Checkout https://github.com/alphagov/notifications-template-preview, and run it locally on port 6013.

### To run this service on PaaS

Ensure service has been pushed to PaaS, then make sure that notify-admin has the `notify-template-preview` cf service added to it - the config should pick up the credentials and URL from that