### PR TITLE
Fix overlapping UI with new radio buttons

### DIFF
--- a/app/assets/stylesheets/components/radio-select.scss
+++ b/app/assets/stylesheets/components/radio-select.scss
@@ -29,7 +29,6 @@
 
   .js-enabled & {
 
-    height: 60px;
     overflow: visible;
 
     .multiple-choice {


### PR DESCRIPTION
Not sure what about the new radios is causing this, but they no longer expand the size of the container, causing an overlap.

The fixed height was originally for performance reasons, but removing it doesn’t seem to cause the page to jump around on load, so I think it’s OK.

### Before

<img width="799" alt="screen shot 2017-04-11 at 17 04 40" src="https://cloud.githubusercontent.com/assets/355079/24918738/4cba2c32-1ed9-11e7-8ae9-fd710cf4ca74.png">

### After 

<img width="701" alt="screen shot 2017-04-11 at 17 06 31" src="https://cloud.githubusercontent.com/assets/355079/24918739/4cbe1c34-1ed9-11e7-97f1-5fa458be719e.png">
