### PR TITLE
Fix new checkboxes

### DIFF
--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -5,8 +5,8 @@
 ) %}
   <div class="multiple-choice">
     <input
-      id="{{ field.id }}" name="{{ field.name }}" type="checkbox" value="{{ field.data }}"
-      {% if field.checked %}
+      id="{{ field.id }}" name="{{ field.name }}" type="checkbox" value="y"
+      {% if field.data %}
         checked
       {% endif %}
     >


### PR DESCRIPTION
Problems:
- WTForms expects the value of checkboxes to always be `y` (they don’t work like radio buttons, which is where I copied this code for)
- WTForms `BooleanField`s don’t have a checked attribute, they set their data attibute to `True` or `False`