### PR TITLE
Fix spacing on no permissions banner

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -78,46 +78,6 @@
 
 }
 
-.banner-mode {
-
-  @extend %banner;
-  background: $govuk-blue;
-  color: $white;
-  margin: 0 0 $gutter 0;
-  padding: $gutter-half;
-
-  p {
-    margin: 0 0 10px 0;
-  }
-
-  a {
-
-    &:link,
-    &:visited {
-      color: $white;
-    }
-
-    &:hover,
-    &:active {
-      color: $light-blue-25;
-    }
-
-    &:active,
-    &:focus {
-      background-color: $yellow;
-      color: $govuk-blue;
-    }
-
-  }
-
-  &-action {
-    display: block;
-    text-align: right;
-    float: right;
-  }
-
-}
-
 .banner-tour {
 
   @extend %banner;

--- a/app/templates/views/dashboard/no-permissions-banner.html
+++ b/app/templates/views/dashboard/no-permissions-banner.html
@@ -1,5 +1,5 @@
 {% from "components/banner.html" import banner_wrapper %}
 
-{% call banner_wrapper(type="mode") %}
+{% call banner_wrapper(type="default") %}
   You only have permission to view this service
 {% endcall %}


### PR DESCRIPTION
Didn’t align with navigation.

# Before

<img width="997" alt="screen shot 2017-04-12 at 09 53 07" src="https://cloud.githubusercontent.com/assets/355079/24949695/7403b87a-1f66-11e7-8134-4e41880c6645.png">

#After 

<img width="996" alt="screen shot 2017-04-12 at 09 52 49" src="https://cloud.githubusercontent.com/assets/355079/24949691/6c2fa9ba-1f66-11e7-8b9a-2d803349bba7.png">