### PR TITLE
Redirect after letter-jobs post

### DIFF
--- a/app/main/views/letter_jobs.py
+++ b/app/main/views/letter_jobs.py
@@ -1,6 +1,6 @@
 import datetime
 
-from flask import render_template, request
+from flask import redirect, render_template, request, session, url_for
 from flask_login import login_required
 
 from app import letter_jobs_client, format_datetime_24h
@@ -12,20 +12,27 @@ from app.utils import user_has_permissions
 @login_required
 @user_has_permissions(admin_override=True)
 def letter_jobs():
-    msg = ''
     letter_jobs_list = letter_jobs_client.get_letter_jobs()
 
     if request.method == 'POST':
         if len(request.form.getlist('job_id')) > 0:
             job_ids = request.form.getlist('job_id')
+            session['job_ids'] = job_ids
 
             response = letter_jobs_client.send_letter_jobs(job_ids)
             msg = response['response']
-
-            for job_id in job_ids:
-                job = [j for j in letter_jobs_list if job_id == j['id']][0]
-                job['sending'] = 'sending'
         else:
             msg = 'No jobs selected'
+
+        session['msg'] = msg
+
+        return redirect(url_for('main.letter_jobs'))
+
+    msg = session.pop('msg', None)
+    job_ids = session.pop('job_ids', None)
+    if job_ids:
+        for job_id in job_ids:
+            job = [j for j in letter_jobs_list if job_id == j['id']][0]
+            job['sending'] = 'sending'
 
     return render_template('views/letter-jobs.html', letter_jobs_list=letter_jobs_list, message=msg)

--- a/tests/app/main/views/test_letter_jobs.py
+++ b/tests/app/main/views/test_letter_jobs.py
@@ -75,7 +75,8 @@ def test_post_letter_jobs_select_1_letter_job_submits_1_job(logged_in_platform_a
     mock_get_letters = mocker.patch('app.letter_jobs_client.get_letter_jobs', return_value=valid_letter_jobs)
     mock_send_letters = mocker.patch('app.letter_jobs_client.send_letter_jobs', return_value=send_letter_jobs_response)
 
-    response = logged_in_platform_admin_client.post(url_for('main.letter_jobs'), data=letter_jobs_first_selected)
+    response = logged_in_platform_admin_client.post(url_for('main.letter_jobs'), data=letter_jobs_first_selected,
+                                                    follow_redirects=True)
 
     assert mock_get_letters.called
     assert mock_send_letters.called
@@ -103,7 +104,7 @@ def test_post_letter_jobs_none_selected_shows_message(logged_in_platform_admin_c
     mock_get_letters = mocker.patch('app.letter_jobs_client.get_letter_jobs', return_value=valid_letter_jobs)
     mock_send_letters = mocker.patch('app.letter_jobs_client.send_letter_jobs', return_value=send_letter_jobs_response)
 
-    response = logged_in_platform_admin_client.post(url_for('main.letter_jobs'), data={})
+    response = logged_in_platform_admin_client.post(url_for('main.letter_jobs'), data={}, follow_redirects=True)
 
     assert mock_get_letters.called
     assert not mock_send_letters.called


### PR DESCRIPTION
## What

In order to prevent a letter job from being resubmitted a redirect was introduced after POST.

## How to review 

execute `pytest tests/app/main/views/test_letter_jobs.py`