### PR TITLE
Add title to letter jobs page

### DIFF
--- a/app/templates/views/letter-jobs.html
+++ b/app/templates/views/letter-jobs.html
@@ -1,8 +1,8 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 
-{% block service_page_title %}
-  Show letter jobs
+{% block per_page_title %}
+  Letter jobs
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
## What 

The letter jobs page wasn't showing the title correctly due to a bug.

A title to the letter jobs page was added in the correct block.