### PR TITLE
Move delete link from the edit template page to the view template page

### DIFF
--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -39,6 +39,10 @@
 
   }
 
+  &-delete-link-without-button {
+    padding-left: 0;
+  }
+
   &-secondary-link {
     display: block;
     margin-top: $gutter;

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -350,9 +350,6 @@ def delete_service_template(service_id, template_id):
             template_type=template['template_type']
         ))
 
-    template['template_content'] = template['content']
-    form = form_objects[template['template_type']](**template)
-
     try:
         last_used_notification = template_statistics_client.get_template_statistics_for_template(
             service_id, template['id']
@@ -370,11 +367,17 @@ def delete_service_template(service_id, template_id):
             raise e
 
     flash('{}. Are you sure you want to delete it?'.format(message), 'delete')
+
     return render_template(
-        'views/edit-{}-template.html'.format(template['template_type']),
-        h1='Edit template',
-        form=form,
-        template_id=template_id)
+        'views/templates/template.html',
+        template=get_template(
+            template,
+            current_service,
+            expand_emails=True,
+            letter_preview_url=url_for('.view_template', service_id=service_id, template_id=template['id']),
+            show_recipient=True,
+        )
+    )
 
 
 @main.route('/services/<service_id>/templates/<template_id>/versions')

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -347,7 +347,6 @@ def delete_service_template(service_id, template_id):
         return redirect(url_for(
             '.choose_template',
             service_id=service_id,
-            template_type=template['template_type']
         ))
 
     try:

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -17,7 +17,7 @@
       <a class="page-footer-back-link" href="{{ back_link }}">{{ back_link_text }}</a>
     {% endif %}
     {% if delete_link %}
-      <span class="page-footer-delete-link">
+      <span class="page-footer-delete-link {% if not button_text %}page-footer-delete-link-without-button{% endif %}">
         <a href="{{ delete_link }}">{{ delete_link_text }}</a>
       </span>
     {% endif %}

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -2,12 +2,14 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
     {% for category, message in messages %}
-      {{ banner(
-        message,
-        'default' if ((category == 'default') or (category == 'default_with_tick')) else 'dangerous',
-        delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove'] else None,
-        with_tick=True if category == 'default_with_tick' else False
-      )}}
+      <div class="bottom-gutter">
+        {{ banner(
+          message,
+          'default' if ((category == 'default') or (category == 'default_with_tick')) else 'dangerous',
+          delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove'] else None,
+          with_tick=True if category == 'default_with_tick' else False
+        )}}
+      </div>
     {% endfor %}
   {% endif %}
 {% endwith %}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -23,9 +23,7 @@
              {{ radios(form.process_type) }}
           {% endif %}
           {{ page_footer(
-            'Save',
-            delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template_id) if template_id or None,
-            delete_link_text='Delete this template'
+            'Save'
           ) }}
         </div>
         <aside class="column-whole">

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -19,9 +19,7 @@
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
           {{ page_footer(
-            'Save',
-            delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template_id) if template_id or None,
-            delete_link_text='Delete this template'
+            'Save'
           ) }}
         </div>
         <aside class="column-three-quarters">

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -24,9 +24,7 @@
             {{ radios(form.process_type) }}
           {% endif %}
           {{ page_footer(
-            'Save',
-            delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template_id) if template_id or None,
-            delete_link_text='Delete this template'
+            'Save'
           ) }}
         </div>
         <aside class="column-whole">

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -23,7 +23,7 @@
   </div>
 
   {% if template._template.updated_at %}
-    <div class="bottom-gutter">
+    <div class="bottom-gutter-1-2">
       <h2 class="heading-small">Last edited {{ template._template.updated_at|format_delta }}</h2>
       <p>
         <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -23,11 +23,20 @@
   </div>
 
   {% if template._template.updated_at %}
-    <div class="bottom-gutter-2">
+    <div class="bottom-gutter">
       <h2 class="heading-small">Last edited {{ template._template.updated_at|format_delta }}</h2>
       <p>
         <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
       </p>
+    </div>
+  {% endif %}
+
+  {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
+    <div class="bottom-gutter">
+      {{ page_footer(
+        delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template.id),
+        delete_link_text='Delete this template'
+      ) }}
     </div>
   {% endif %}
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -580,7 +580,7 @@ def test_should_redirect_when_deleting_a_template(
     assert response.status_code == 302
     assert response.location == url_for(
         '.choose_template',
-        service_id=service_id, template_type=type_, _external=True)
+        service_id=service_id, _external=True)
     mock_get_service_template.assert_called_with(
         service_id, template_id)
     mock_delete_service_template.assert_called_with(


### PR DESCRIPTION
Users were having trouble finding the delete template link. It sort of made sense having it on the edit page before we had the view template page. But it doesn’t make sense now – having to choose to ‘edit’ the template before you can delete is counterintuitive.

The single template page is where you go to choose an action to perform on your template. Deleting is a good example of an action you can perform on a template.

So this PR moves the delete link from the edit template page to the view template page.

***

<img width="796" alt="screen shot 2017-04-18 at 13 43 44" src="https://cloud.githubusercontent.com/assets/355079/25131577/219cfd58-243e-11e7-9123-88440ebb58ef.png">

***

<img width="770" alt="screen shot 2017-04-18 at 13 43 22" src="https://cloud.githubusercontent.com/assets/355079/25131576/2196e4ea-243e-11e7-8c18-be1b12d7f2d4.png">
