### PR TITLE
Fix button padding on the product page

### DIFF
--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -45,6 +45,7 @@
       @include box-shadow(0 2px 0 darken($govuk-blue, 15%));
       background: $white;
       margin-right: 15px;
+      padding-right: 1.25em;
 
       &:link,
       &:visited,


### PR DESCRIPTION
It’s uneven ever since we upgraded the toolkit. Guess it’s probably allowing space for an arrow image. But I don’t like the arrow image because it looks like it’s pointing at the ‘or sign in’ link.

So this commit overrides the button’s default spacing.

## Before 

![image](https://cloud.githubusercontent.com/assets/355079/25234652/aa5b66fa-25da-11e7-80e8-b192ea56b749.png)

## After

![image](https://cloud.githubusercontent.com/assets/355079/25234644/a2165b12-25da-11e7-863a-f62d00320ae0.png)
