### PR TITLE
Fix CSV download timeout issue

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -150,7 +150,8 @@ def view_job_csv(service_id, job_id):
                 job_id=job_id,
                 status=filter_args.get('status'),
                 page=request.args.get('page', 1),
-                page_size=5000
+                page_size=5000,
+                format_for_csv=True
             )
         ),
         mimetype='text/csv',

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -20,7 +20,8 @@ class NotificationApiClient(NotifyAdminAPIClient):
         page_size=None,
         limit_days=None,
         include_jobs=None,
-        include_from_test_key=None
+        include_from_test_key=None,
+        format_for_csv=None
     ):
         params = {}
         if page is not None:
@@ -35,6 +36,8 @@ class NotificationApiClient(NotifyAdminAPIClient):
             params['include_jobs'] = include_jobs
         if include_from_test_key is not None:
             params['include_from_test_key'] = include_from_test_key
+        if format_for_csv is not None:
+            params['format_for_csv'] = format_for_csv
         if job_id:
             return self.get(
                 url='/service/{}/job/{}/notifications'.format(service_id, job_id),

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -14,25 +14,6 @@ from tests import notification_json
 from freezegun import freeze_time
 
 
-def _csv_notifications(notifications_json):
-    csvfile = StringIO()
-    csvwriter = csv.writer(csvfile)
-    from app import format_datetime_24h, format_notification_status
-    csvwriter.writerow(['Row number', 'Recipient', 'Template', 'Type', 'Job', 'Status', 'Time'])
-
-    for x in notifications_json:
-        csvwriter.writerow([
-            int(x['job_row_number']) + 2 if 'job_row_number' in x and x['job_row_number'] else '',
-            x['to'],
-            x['template']['name'],
-            x['template']['template_type'],
-            x['job']['original_file_name'] if x['job'] else '',
-            format_notification_status(x['status'], x['template']['template_type']),
-            format_datetime_24h(x['created_at'])
-        ])
-    return csvfile.getvalue()
-
-
 def test_get_jobs_should_return_list_of_all_real_jobs(
     logged_in_client,
     service_one,


### PR DESCRIPTION
This fixes the issue where downloading a large report (10,000+) would timeout after 30s.

## Summary

There were a number of issues identified in Admin:

1. The **API call to retrieve 5000 notifications was slow**, clocking in about 3-4s. This was due to serialisation on the API taking pretty long. This has been reduced down to 2ish seconds in [1]

2. **Buffering**: We were storing each notification inside a buffer and then using `csv` module to prepare in the CSV format. This buffering added an extra 1-2 seconds. 

3. **Formatting**: We were doing multiple operations on the `created_at` for each notification which slowed us down significantly. In particular we were converting back into a `datetime` with `dateutil.parser.parse` and then called `datetime.strftime` twice to finally get it into a friendly format. This was a big bottleneck and cocked in at 1-3s per 5000. This has been moved to the API and refactored down in [1]

## Results

A 50k csv locally running both apps with gunicon (important) now takes 15ish seconds. We previously timed out at 30s for 10k notifications.

## Dependencies 
- [x] https://github.com/alphagov/notifications-api/pull/908 [1]
