### PR TITLE
Show all pages of a letter in the app

### DIFF
--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -6,23 +6,28 @@ from app import current_service
 
 class TemplatePreview:
     @classmethod
-    def from_database_object(cls, template, filetype, values=None):
+    def from_database_object(cls, template, filetype, values=None, page=None):
         data = {
             'letter_contact_block': current_service['letter_contact_block'],
             'template': template,
             'values': values
         }
         resp = requests.post(
-            '{}/preview.{}'.format(current_app.config['TEMPLATE_PREVIEW_API_HOST'], filetype),
+            '{}/preview.{}{}'.format(
+                current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+                filetype,
+                '?page={}'.format(page) if page else '',
+            ),
             json=data,
             headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
         )
         return (resp.content, resp.status_code, resp.headers.items())
 
     @classmethod
-    def from_utils_template(cls, template, filetype):
+    def from_utils_template(cls, template, filetype, page=None):
         return cls.from_database_object(
             template._template,
             filetype,
-            template.values
+            template.values,
+            page=page,
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -295,6 +295,7 @@ def get_template(
     show_recipient=False,
     expand_emails=False,
     letter_preview_url=None,
+    page_count=1,
 ):
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
@@ -316,6 +317,7 @@ def get_template(
             return LetterPDFLinkTemplate(
                 template,
                 preview_url=letter_preview_url,
+                page_count=int(page_count),
             )
         else:
             return LetterPreviewTemplate(

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.4#egg=notifications-utils==15.0.4
-
+git+https://github.com/alphagov/notifications-utils.git@16.0.0#egg=notifications-utils==16.0.0

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -1,30 +1,61 @@
+import pytest
+
+from functools import partial
 from unittest.mock import Mock
 from notifications_utils.template import LetterPreviewTemplate
 
 from app.template_previews import TemplatePreview
 
 
-def test_from_utils_template_calls_through(mocker, mock_get_service_letter_template):
+@pytest.mark.parametrize('partial_call, expected_page_argument', [
+    (partial(TemplatePreview.from_utils_template), None),
+    (partial(TemplatePreview.from_utils_template, page=99), 99),
+])
+def test_from_utils_template_calls_through(
+    mocker,
+    mock_get_service_letter_template,
+    partial_call,
+    expected_page_argument,
+):
     mock_from_db = mocker.patch('app.template_previews.TemplatePreview.from_database_object')
     template = LetterPreviewTemplate(mock_get_service_letter_template(None, None)['data'])
 
-    ret = TemplatePreview.from_utils_template(template, 'foo')
+    ret = partial_call(template, 'foo')
 
     assert ret == mock_from_db.return_value
-    mock_from_db.assert_called_once_with(template._template, 'foo', template.values)
+    mock_from_db.assert_called_once_with(template._template, 'foo', template.values, page=expected_page_argument)
 
 
-def test_from_database_object_makes_request(mocker, client):
+@pytest.mark.parametrize('partial_call, expected_url', [
+    (
+        partial(TemplatePreview.from_database_object, filetype='bar'),
+        'http://localhost:6013/preview.bar',
+    ),
+    (
+        partial(TemplatePreview.from_database_object, filetype='baz'),
+        'http://localhost:6013/preview.baz',
+    ),
+    (
+        partial(TemplatePreview.from_database_object, filetype='bar', page=99),
+        'http://localhost:6013/preview.bar?page=99',
+    ),
+])
+def test_from_database_object_makes_request(
+    mocker,
+    client,
+    partial_call,
+    expected_url,
+):
     resp = Mock(content='a', status_code='b', headers={'c': 'd'})
     request_mock = mocker.patch('app.template_previews.requests.post', return_value=resp)
     mocker.patch('app.template_previews.current_service', __getitem__=Mock(return_value='123'))
 
-    ret = TemplatePreview.from_database_object(template='foo', filetype='bar')
+    ret = partial_call(template='foo')
 
     assert ret[0] == 'a'
     assert ret[1] == 'b'
     assert list(ret[2]) == [('c', 'd')]
-    url = 'http://localhost:6013/preview.bar'
+
     data = {
         'letter_contact_block': '123',
         'template': 'foo',
@@ -32,4 +63,4 @@ def test_from_database_object_makes_request(mocker, client):
     }
     headers = {'Authorization': 'Token my-secret-key'}
 
-    request_mock.assert_called_once_with(url, json=data, headers=headers)
+    request_mock.assert_called_once_with(expected_url, json=data, headers=headers)


### PR DESCRIPTION
In research we’ve seen two problems with the click-to-see-PDF thing:

- it’s not very intuitive that the letter is clickable, or what you can expect when clicking the letter
- people get lost of stuck in the PDF view because it opens in the same tab, or they open it in a new tab and then get find their way back, or …

So this commit changes the show template page to show the entire contents of the letter, same as we do for emails and text messages.

Right now it only does it on the view template page. I think we’ll have to work out a way of showing some kind of truncated version on the _Send yourself a test_ and _Preview_ pages. But that’s for later.

***

Depends on:

- [x] https://github.com/alphagov/notifications-template-preview/pull/7

***

![screencapture-localhost-6012-services-42a9d4f2-1444-4e22-9133-52d9e406213f-templates-8b7efa5e-8fbd-4f1a-8f0f-2a5d6b1656d2-1492700163132](https://cloud.githubusercontent.com/assets/355079/25237508/c688674e-25e2-11e7-92b2-f7894bf5669a.png)
