### PR TITLE
Fix setting and display of letter branding

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -45,7 +45,7 @@ def service_settings(service_id):
         'views/service-settings.html',
         organisation=organisation,
         letter_branding=letter_branding_organisations.get(
-            current_service.get('dvla_org_id', '001')
+            current_service.get('dvla_organisation', '001')
         )
     )
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -92,7 +92,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             'branding',
             'organisation',
             'letter_contact_block',
-            'dvla_org_id',
+            'dvla_organisation',
         }
         if disallowed_attributes:
             raise TypeError('Not allowed to update service attributes: {}'.format(


### PR DESCRIPTION
API and Admin were not using the same name for the organisation ID that we have set with DVLA.