### PR TITLE
Remove edit address block link

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -36,7 +36,6 @@
   {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) and template.template_type == 'letter' %}
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
     <a href="{{ url_for(".service_set_letter_contact_block", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
-    <a href="#" class="edit-template-link-letter-address">Edit</a>
   {% endif %}
   {{ template|string }}
 </div>


### PR DESCRIPTION
It was confusing because it didn’t do anything. We think the research tomorrow will go more smoothly if we remove it. It should come back in the same place when it actually works.