### PR TITLE
Make position of letter edit links absolute

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -25,7 +25,7 @@
 .edit-template-link-letter-contact {
   @extend %edit-template-link;
   right: -25px;
-  top: 13.3%; // align to top of contact block
+  top: 138px; // align to top of contact block
 }
 
 .edit-template-link-letter-address {
@@ -36,6 +36,6 @@
 
 .edit-template-link-letter-body {
   @extend %edit-template-link;
-  top: 38.5%; // aligns to top of subject
+  top: 400px; // aligns to top of subject
   left: -5px;
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -24,7 +24,7 @@ function display_result {
   fi
 }
 
-if [ -d venv ]; then
+if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
 pycodestyle .


### PR DESCRIPTION
Previously they were relative (ie percentages). This made sure that they worked on mobile, when the letter might be narrower.

However it broke when the preview was more than one page, because 13% of the height of 2 pages is different to 13% of the height of one pages.

This commit changes the positions to be pixel values, which match the calculated percentage values when the preview is one page.