### PR TITLE
Add a back button to the scheduler

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -56,7 +56,7 @@
   let focusSelected = function() {
     setTimeout(
       () => $('[type=radio]:checked').next('label').blur().trigger('focus').addClass('selected'),
-      10
+      50
     );
   };
 
@@ -67,7 +67,6 @@
       let $component = $(component);
       let render = (state, data) => {
         $component.html(states[state].render(data));
-        new GOVUK.SelectionButtons('.block-label input');
       };
       let choices = $('label', $component).toArray().map(function(element) {
         let $element = $(element);
@@ -92,7 +91,7 @@
             ),
             'name': name
           });
-          $('.js-option').eq(0).parent('label').trigger('focus');
+          focusSelected();
 
         })
         .on('click', '.js-option', function(event) {

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -30,6 +30,7 @@
             <label for="{{id}}">{{label}}</label>
           </div>
         {{/choices}}
+        <input type='button' class='js-reset-button js-reset-button-block' value='Back' />
       </div>
     `),
     'chosen': Hogan.compile(`

--- a/app/assets/stylesheets/components/radio-select.scss
+++ b/app/assets/stylesheets/components/radio-select.scss
@@ -33,6 +33,13 @@
 
   }
 
+  .js-reset-button-block {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 20px 20px $gutter 57px;
+  }
+
   .js-enabled & {
 
     overflow: visible;


### PR DESCRIPTION
We’ve seen in research a user getting stuck playing with the scheduler. They picked a day, but then didn’t want to choose one of the options for that day. There’s no way to do this except pick a day and then un-pick it.

What they ended up doing was clicking the grey back button, which took them back to the previous page, making them upload their file again.

This commit adds a ‘back’ link for the scheduler. ‘Back’ seems like sensible naming because that’s the thing that the user tried to click, and the UI of a link matches the thing they clicked to get into this situation.

***

![add-back-link-scheduler](https://cloud.githubusercontent.com/assets/355079/25430847/2a6ad278-2a76-11e7-9395-e079cf81b822.gif)
