### PR TITLE
Fix ghost radio button on API key page

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -252,7 +252,3 @@ details .arrow {
   color: $secondary-text-colour;
   cursor: default;
 }
-
-.multiple-choice input:disabled {
-  opacity: 0.5;
-}


### PR DESCRIPTION
I think the `opacity: 0.5` is a hangover from when the browser default radio buttons were visible on the page – before the new radios and checkboxes.

Fixes this:

![screen_shot_2017-04-26_at_12 53 09](https://cloud.githubusercontent.com/assets/355079/25434044/b30ac58c-2a82-11e7-8d00-22b1c3832a8e.png)

Thanks to @edwardhorsford for spotting.
