### PR TITLE
Make label for key type grammatically correct

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -388,7 +388,7 @@ class CreateKeyForm(Form):
         super(CreateKeyForm, self).__init__(*args, **kwargs)
 
     key_type = RadioField(
-        'What should Notify do when you use this key?',
+        'Type of key',
         validators=[
             DataRequired()
         ]


### PR DESCRIPTION
Wasn’t changed when we changed the options. 

Matches the ‘Name for this key’ label on the field above.

![image](https://cloud.githubusercontent.com/assets/355079/25434205/53000908-2a83-11e7-9563-eca2aaa7430d.png)
