### PR TITLE
Allow international phone numbers in spreadsheet

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -60,9 +60,7 @@ def get_example_csv_fields(column_headers, use_example_as_example, submitted_fie
 def get_example_csv_rows(template, use_example_as_example=True, submitted_fields=False):
     return {
         'email': ['test@example.com'] if use_example_as_example else [current_user.email_address],
-        'sms': ['07700 900321'] if use_example_as_example else [validate_and_format_phone_number(
-            current_user.mobile_number, human_readable=True
-        )],
+        'sms': ['07700 900321'] if use_example_as_example else [current_user.mobile_number],
         'letter': [
             (submitted_fields or {}).get(
                 key, get_example_letter_address(key) if use_example_as_example else key

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -218,7 +218,6 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
             upload_id=upload_id
         ) if not letters_as_pdf else None
     )
-
     recipients = RecipientCSV(
         contents,
         template_type=template.template_type,
@@ -228,7 +227,8 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
         whitelist=itertools.chain.from_iterable(
             [user.name, user.mobile_number, user.email_address] for user in users
         ) if current_service['restricted'] else None,
-        remaining_messages=remaining_messages
+        remaining_messages=remaining_messages,
+        international_sms=current_service['can_send_international_sms'],
     )
 
     if request.args.get('from_test'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@16.0.0#egg=notifications-utils==16.0.0
+git+https://github.com/alphagov/notifications-utils.git@16.2.0#egg=notifications-utils==16.2.0

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -293,7 +293,7 @@ def test_send_test_sms_message(
     fake_uuid
 ):
 
-    expected_data = {'data': 'phone number\r\n07700 900 762\r\n', 'file_name': 'Test message'}
+    expected_data = {'data': 'phone number\r\n07700 900762\r\n', 'file_name': 'Test message'}
     mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')
 
     response = logged_in_client.get(
@@ -344,7 +344,7 @@ def test_send_test_sms_message_with_placeholders(
 ):
 
     expected_data = {
-        'data': 'phone number,name\r\n07700 900 762,Jo\r\n',
+        'data': 'phone number,name\r\n07700 900762,Jo\r\n',
         'file_name': 'Test message'
     }
     mocker.patch('app.main.views.send.s3download', return_value='phone number\r\n+4412341234')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,15 @@ def mock_get_service(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_get_international_service(mocker, api_user_active):
+    def _get(service_id):
+        service = service_json(service_id, users=[api_user_active.id], can_send_international_sms=True)
+        return {'data': service}
+
+    return mocker.patch('app.service_api_client.get_service', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
 def mock_get_detailed_service(mocker, api_user_active):
     def _get(service_id):
         return {


### PR DESCRIPTION
If a service can send internationally, our CSV validation should not catch valid international phone numbers. This means calling through to code added to utils in:
- [x] alphagov/notifications-utils#156