### PR TITLE
Fix 500 error if revisiting registration page

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -89,4 +89,6 @@ def _do_registration(form, service=None, send_sms=True, send_email=True):
 
 @main.route('/registration-continue')
 def registration_continue():
+    if not session.get('user_details'):
+        return redirect(url_for('.show_all_services_or_dashboard'))
     return render_template('views/registration-continue.html')


### PR DESCRIPTION
If you go back to this part of the registration flow then you get a 500 error, because we’re relying on something in the session. We clear the registration info from the session after you’ve registered successfully.

Also there were no tests for the happy path of this page either `¯\_(ツ)_/¯`