### PR TITLE
Tell users international text messaging is coming

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -277,6 +277,15 @@ def service_set_sms_sender(service_id):
         form=form)
 
 
+@main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_international_sms(service_id):
+    return render_template(
+        'views/service-settings/set-international-sms.html',
+    )
+
+
 @main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -39,6 +39,11 @@
           {{ text_field(current_service.sms_sender or '40604') }}
           {{ edit_field('Change', url_for('.service_set_sms_sender', service_id=current_service.id)) }}
         {% endcall %}
+        {% call row() %}
+          {{ text_field('International text messages') }}
+          {{ text_field('On' if current_service.can_send_international_sms else 'Off') }}
+          {{ edit_field('Change', url_for('.service_set_international_sms', service_id=current_service.id)) }}
+        {% endcall %}
 
         {% if current_service.can_send_letters %}
           {% call row() %}

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -1,0 +1,39 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Text message sender
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">International text messages</h1>
+      {% if current_service.can_send_international_sms %}
+        <p>
+          Your service can send text messages to international phone numbers.
+        </p>
+        <p>
+          If you want to turn it off,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% else %}
+        <p>
+          Sending text messages to international phone numbers is an
+          invitation&#8209;only feature.
+        </p>
+        <p>
+          If you want to try it out,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% endif %}
+      {{ page_footer(
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </div>
+  </div>
+
+{% endblock %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -18,13 +18,15 @@ from tests.conftest import active_user_with_permissions, platform_admin_user
         'Label Value Action',
         'Service name service one Change',
         'Email reply to address None Change',
-        'Text message sender 40604 Change'
+        'Text message sender 40604 Change',
+        'International text messages Off Change',
     ]),
     (platform_admin_user, [
         'Label Value Action',
         'Service name service one Change',
         'Email reply to address None Change',
         'Text message sender 40604 Change',
+        'International text messages Off Change',
         'Label Value Action',
         'Email branding GOV.UK Change',
         'Letter branding HM Government Change',
@@ -69,7 +71,8 @@ def test_should_show_overview_for_service_with_more_things_set(
     for index, row in enumerate([
         'Service name service one Change',
         'Email reply to address test@example.com Change',
-        'Text message sender elevenchars Change'
+        'Text message sender elevenchars Change',
+        'International text messages Off Change',
     ]):
         assert row == " ".join(page.find_all('tr')[index + 1].text.split())
 
@@ -97,7 +100,7 @@ def test_letter_contact_block_shows_None_if_not_set(
     ))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    div = page.find_all('tr')[4].find_all('td')[1].div
+    div = page.find_all('tr')[5].find_all('td')[1].div
     assert div.text.strip() == 'None'
     assert 'default' in div.attrs['class'][0]
 
@@ -115,7 +118,7 @@ def test_escapes_letter_contact_block(
     ))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    div = str(page.find_all('tr')[4].find_all('td')[1].div)
+    div = str(page.find_all('tr')[5].find_all('td')[1].div)
     assert 'foo<br>bar' in div
     assert '<script>' not in div
 


### PR DESCRIPTION
Users might be interested in international SMS. And when it’s fully available, they’ll probably be able to control whether it’s on/off for their service.

Until they point, the only way of getting it is to ask us. So let’s make an in-the-meantime page that directs them to ask us, from the place where they’d be able to do it themselves.

***

![image](https://cloud.githubusercontent.com/assets/355079/25485726/c6d2ab50-2b56-11e7-8683-a885da02034f.png)

***

![image](https://cloud.githubusercontent.com/assets/355079/25485740/d63df072-2b56-11e7-876d-a6b65336f592.png)
