### PR TITLE
Fix left-hand column width on the tour

### DIFF
--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -13,10 +13,18 @@
       <a href="{{ url_for('main.choose_service') }}" class="navigation-service-switch">Switch service</a>
     </div>
     <div class="grid-row">
-      <div class="column-one-quarter">
+      {% if help %}
+        <div class="column-one-third">
+      {% else %}
+        <div class="column-one-quarter">
+      {% endif %}
         {% include "main_nav.html" %}
       </div>
-      <main role="main" class="column-three-quarters column-main">
+      {% if help %}
+        <main role="main" class="column-two-thirds column-main">
+      {% else %}
+        <main role="main" class="column-three-quarters column-main">
+      {% endif %}
         {% include 'flash_messages.html' %}
         {% block maincolumn_content %}{% endblock %}
       </main>


### PR DESCRIPTION
When we moved from ⅓<sup>rd</sup>/⅔<sup>rd</sup> columns to ¼<sup>th</sup>/¾<sup>th</sup> columns we should have excluded the tour page. The tour page needs the width of the ⅓<sup>rd</sup> column to look right.

## Before

![image](https://cloud.githubusercontent.com/assets/355079/25488565/462b0034-2b5f-11e7-8e0b-77ec8becb889.png)

## After 

![image](https://cloud.githubusercontent.com/assets/355079/25488543/3712f3c2-2b5f-11e7-8d87-03978cf99f3a.png)

***

Thanks to @alexmuller and @edwardhorsford for spotting this.