### PR TITLE
add sent as a new status

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -314,7 +314,8 @@ def format_notification_status(status, template_type):
             'permanent-failure': 'Email address doesn’t exist',
             'delivered': 'Delivered',
             'sending': 'Sending',
-            'created': 'Sending'
+            'created': 'Sending',
+            'sent': 'Delivered'
         },
         'sms': {
             'failed': 'Failed',
@@ -323,7 +324,8 @@ def format_notification_status(status, template_type):
             'permanent-failure': 'Phone number doesn’t exist',
             'delivered': 'Delivered',
             'sending': 'Sending',
-            'created': 'Sending'
+            'created': 'Sending',
+            'sent': 'Sent internationally'
         },
         'letter': {
             'failed': 'Failed',
@@ -332,7 +334,8 @@ def format_notification_status(status, template_type):
             'permanent-failure': 'Permanent failure',
             'delivered': 'Delivered',
             'sending': 'Sending',
-            'created': 'Sending'
+            'created': 'Sending',
+            'sent': 'Delivered'
         }
     }[template_type].get(status, status)
 
@@ -351,6 +354,7 @@ def format_notification_status_as_field_status(status):
         'temporary-failure': 'error',
         'permanent-failure': 'error',
         'delivered': None,
+        'sent': None,
         'sending': 'default',
         'created': 'default'
     }.get(status, 'error')

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -37,6 +37,7 @@ from app.utils import (
     REQUESTED_STATUSES,
     FAILURE_STATUSES,
     SENDING_STATUSES,
+    DELIVERED_STATUSES,
 )
 from app.statistics_utils import add_rate_to_job
 
@@ -59,6 +60,7 @@ def _set_status_filters(filter_args):
     status_filters = filter_args.get('status', [])
     return list(OrderedSet(chain(
         (status_filters or REQUESTED_STATUSES),
+        DELIVERED_STATUSES if 'delivered' in status_filters else [],
         SENDING_STATUSES if 'sending' in status_filters else [],
         FAILURE_STATUSES if 'failed' in status_filters else []
     )))

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -32,7 +32,7 @@ class JobApiClient(NotifyAdminAPIClient):
                 results['failed'] += outcome['count']
             if outcome['status'] in ['sending', 'pending', 'created']:
                 results['sending'] += outcome['count']
-            if outcome['status'] in ['delivered']:
+            if outcome['status'] in ['delivered', 'sent']:
                 results['delivered'] += outcome['count']
             results['requested'] += outcome['count']
         return results

--- a/app/utils.py
+++ b/app/utils.py
@@ -31,7 +31,7 @@ import pyexcel.ext.ods3
 
 
 SENDING_STATUSES = ['created', 'pending', 'sending']
-DELIVERED_STATUSES = ['delivered']
+DELIVERED_STATUSES = ['delivered', 'sent']
 FAILURE_STATUSES = ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure']
 REQUESTED_STATUSES = SENDING_STATUSES + DELIVERED_STATUSES + FAILURE_STATUSES
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -51,7 +51,7 @@ def test_get_jobs_shows_page_links(
             '',
             [
                 'created', 'pending', 'sending',
-                'delivered',
+                'delivered', 'sent',
                 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
             ]
         ),
@@ -61,7 +61,7 @@ def test_get_jobs_shows_page_links(
         ),
         (
             'delivered',
-            ['delivered']
+            ['delivered', 'sent']
         ),
         (
             'failed',
@@ -188,7 +188,6 @@ def test_should_show_scheduled_job(
 def test_should_cancel_job(
     logged_in_client,
     service_one,
-    active_user_with_permissions,
     fake_uuid,
     mocker,
 ):
@@ -291,7 +290,7 @@ def test_should_show_updates_for_one_job_as_json(
             '',
             [
                 'created', 'pending', 'sending',
-                'delivered',
+                'delivered', 'sent',
                 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
             ]
         ),
@@ -301,7 +300,7 @@ def test_should_show_updates_for_one_job_as_json(
         ),
         (
             'delivered',
-            ['delivered']
+            ['delivered', 'sent']
         ),
         (
             'failed',


### PR DESCRIPTION
functions as delivered - shows up in delivered column, contributes
to delivered stats etc.

![image](https://cloud.githubusercontent.com/assets/5020841/25489863/171d75f2-2b63-11e7-952c-79e4ce02b25b.png)
