### PR TITLE
Make letter previews unclickable

### DIFF
--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -8,7 +8,7 @@ $iso-paper-ratio: 141.42135624%;
 
 .letter {
 
-  padding: 0;
+  padding: $iso-paper-ratio 0 0 0;
   margin: 0 0 $gutter 0;
   position: relative;
   background: $panel-colour;
@@ -26,16 +26,6 @@ $iso-paper-ratio: 141.42135624%;
     animation: ellipsis steps(4,end) 1.3s infinite;
     content: "\2026"; // ellipsis
     width: 0px;
-  }
-
-  a {
-    display: block;
-    overflow: hidden;
-    width: 100%;
-    height: 0;
-    padding: $iso-paper-ratio 0 0 0;
-    position: relative;
-    z-index: 20;
   }
 
   img {

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -118,6 +118,13 @@ def view_job(service_id, job_id):
                 version=job['template_version']
             )['data'],
             current_service,
+            letter_preview_url=url_for(
+                '.view_template_version_preview',
+                service_id=service_id,
+                template_id=job['template'],
+                version=job['template_version'],
+                filetype='png',
+            ),
         ),
         status=request.args.get('status', ''),
         updates_url=url_for(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -87,7 +87,12 @@ def send_messages(service_id, template_id):
         service_api_client.get_service_template(service_id, template_id)['data'],
         current_service,
         show_recipient=True,
-        letter_preview_url=url_for('.view_template', service_id=service_id, template_id=template_id),
+        letter_preview_url=url_for(
+            '.view_letter_template_preview',
+            service_id=service_id,
+            template_id=template_id,
+            filetype='png',
+        ),
     )
 
     form = CsvUploadForm()
@@ -149,7 +154,12 @@ def send_test(service_id, template_id):
         service_api_client.get_service_template(service_id, template_id)['data'],
         current_service,
         show_recipient=True,
-        letter_preview_url=url_for('.view_template', service_id=service_id, template_id=template_id),
+        letter_preview_url=url_for(
+            '.view_letter_template_preview',
+            service_id=service_id,
+            template_id=template_id,
+            filetype='png',
+        ),
     )
 
     if len(template.placeholders) == 0 or request.method == 'POST':
@@ -212,10 +222,11 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
         current_service,
         show_recipient=True,
         letter_preview_url=url_for(
-            '.check_messages',
+            '.check_messages_preview',
             service_id=service_id,
             template_type=template_type,
-            upload_id=upload_id
+            upload_id=upload_id,
+            filetype='png',
         ) if not letters_as_pdf else None
     )
     recipients = RecipientCSV(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -84,7 +84,12 @@ def view_template(service_id, template_id):
             template,
             current_service,
             expand_emails=True,
-            letter_preview_url=url_for('.view_template', service_id=service_id, template_id=template_id),
+            letter_preview_url=url_for(
+                '.view_letter_template_preview',
+                service_id=service_id,
+                template_id=template_id,
+                filetype='png',
+            ),
             show_recipient=True,
             page_count=page_count,
         ),
@@ -108,10 +113,11 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
         current_service,
         expand_emails=True,
         letter_preview_url=url_for(
-            '.view_template_version',
+            '.view_template_version_preview',
             service_id=service_id,
             template_id=template_id,
             version=version,
+            filetype='png',
         ) if not letters_as_pdf else None
     ))
 
@@ -344,7 +350,12 @@ def delete_service_template(service_id, template_id):
             template,
             current_service,
             expand_emails=True,
-            letter_preview_url=url_for('.view_template', service_id=service_id, template_id=template['id']),
+            letter_preview_url=url_for(
+                '.view_letter_template_preview',
+                service_id=service_id,
+                template_id=template['id'],
+                filetype='png',
+            ),
             show_recipient=True,
         )
     )
@@ -370,10 +381,11 @@ def view_template_versions(service_id, template_id):
                 current_service,
                 expand_emails=True,
                 letter_preview_url=url_for(
-                    '.view_template_version',
+                    '.view_template_version_preview',
                     service_id=service_id,
                     template_id=template_id,
                     version=template['version'],
+                    filetype='png',
                 )
             )
             for template in service_api_client.get_service_template_versions(service_id, template_id)['data']

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,7 +19,7 @@ from flask_login import current_user
 from notifications_utils.template import (
     SMSPreviewTemplate,
     EmailPreviewTemplate,
-    LetterPDFLinkTemplate,
+    LetterImageTemplate,
     LetterPreviewTemplate,
 )
 
@@ -274,9 +274,9 @@ def get_template(
         )
     if 'letter' == template['template_type']:
         if letter_preview_url:
-            return LetterPDFLinkTemplate(
+            return LetterImageTemplate(
                 template,
-                preview_url=letter_preview_url,
+                image_url=letter_preview_url,
                 page_count=int(page_count),
             )
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@16.2.0#egg=notifications-utils==16.2.0
+git+https://github.com/alphagov/notifications-utils.git@17.0.1#egg=notifications-utils==17.0.1


### PR DESCRIPTION
Brings in:
- [x] alphagov/notifications-utils#159
- [x] https://github.com/alphagov/notifications-utils/pull/160

Means:
- renaming a bunch of things
- removing any CSS that targeted the link, and make it target the containing element instead