### PR TITLE
Tell users that letters are coming

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -286,6 +286,15 @@ def service_set_international_sms(service_id):
     )
 
 
+@main.route("/services/<service_id>/service-settings/set-letters", methods=['GET'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_letters(service_id):
+    return render_template(
+        'views/service-settings/set-letters.html',
+    )
+
+
 @main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -39,10 +39,17 @@
           {{ text_field(current_service.sms_sender or '40604') }}
           {{ edit_field('Change', url_for('.service_set_sms_sender', service_id=current_service.id)) }}
         {% endcall %}
+
         {% call row() %}
           {{ text_field('International text messages') }}
           {{ text_field('On' if current_service.can_send_international_sms else 'Off') }}
           {{ edit_field('Change', url_for('.service_set_international_sms', service_id=current_service.id)) }}
+        {% endcall %}
+
+        {% call row() %}
+          {{ text_field('Letters') }}
+          {{ text_field('On' if current_service.can_send_letters else 'Off') }}
+          {{ edit_field('Change', url_for('.service_set_letters', service_id=current_service.id)) }}
         {% endcall %}
 
         {% if current_service.can_send_letters %}

--- a/app/templates/views/service-settings/set-letters.html
+++ b/app/templates/views/service-settings/set-letters.html
@@ -1,0 +1,38 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Text message sender
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">Letters</h1>
+      {% if current_service.can_send_letters %}
+        <p>
+          Your service can send letters.
+        </p>
+        <p>
+          If you want to stop your sending from sending letters,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% else %}
+        <p>
+          Using GOV.UK Notify to send letters is an invitation&#8209;only feature.
+        </p>
+        <p>
+          If you want to try it out,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% endif %}
+      {{ page_footer(
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
Users might be interested in letters. And when they’re fully available, users will probably be able to control whether letters are on/off for their service.

Until that point, the only way of getting the feature is to ask us. So let’s make an in-the-meantime page that directs them to ask us, from the place where they’d be able to do it themselves.

Wording TBC – don’t merge yet.

***

![image](https://cloud.githubusercontent.com/assets/355079/25613739/39b21b3c-2f27-11e7-9b3b-d37c83a7f988.png)

***

![image](https://cloud.githubusercontent.com/assets/355079/25613758/491548d8-2f27-11e7-8514-4c4c4d18fe57.png)
