### PR TITLE
Make meta email preview meta info wrap nicely

### DIFF
--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -28,6 +28,7 @@ $email-message-gutter: $gutter * 2;
     td {
       width: 99%;
       padding-right: $email-message-gutter;
+      word-break: break-word;
     }
 
   }


### PR DESCRIPTION
Because the email addresses can get pretty long, and have no spaces in them, they sometimes break out of their containing box. This looks messy and causes horizontal scrolling.

## Before

<img width="884" alt="screen shot 2017-05-03 at 15 11 38" src="https://cloud.githubusercontent.com/assets/355079/25664650/2ab8e1f0-3013-11e7-9c2d-7c5d4ae3d8aa.png">

## After

<img width="886" alt="screen shot 2017-05-03 at 15 12 04" src="https://cloud.githubusercontent.com/assets/355079/25664662/31376dc6-3013-11e7-8fa9-28eee6e04bef.png">
