### PR TITLE
make sure static subdir 404s correctly

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,7 @@ from flask import (
     g,
     url_for)
 from flask._compat import string_types
-from flask.globals import _lookup_req_object
+from flask.globals import _lookup_req_object, _request_ctx_stack
 from flask_login import LoginManager
 from flask_wtf import CsrfProtect
 from functools import partial
@@ -380,10 +380,10 @@ def load_user(user_id):
 
 def load_service_before_request():
     if '/static/' in request.url:
+        _request_ctx_stack.top.service = None
         return
     service_id = request.view_args.get('service_id', session.get('service_id')) if request.view_args \
         else session.get('service_id')
-    from flask.globals import _request_ctx_stack
     if _request_ctx_stack.top is not None:
         _request_ctx_stack.top.service = service_api_client.get_service(service_id)['data'] if service_id else None
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import uuid
 from urllib.parse import urlparse, quote, parse_qs
@@ -7,8 +6,6 @@ import pytest
 from flask import url_for
 from bs4 import BeautifulSoup
 
-from app import utils
-from io import StringIO
 from app.main.views.jobs import get_time_left, get_status_filters
 from tests import notification_json
 from freezegun import freeze_time
@@ -117,7 +114,7 @@ def test_should_show_page_for_one_job(
         service_one['id'],
         fake_uuid,
         status=expected_api_call
-        )
+    )
 
 
 def test_get_jobs_should_tell_user_if_more_than_one_page(
@@ -262,7 +259,6 @@ def test_should_show_updates_for_one_job_as_json(
     mocker,
     fake_uuid,
 ):
-    job_json = mock_get_job(service_one['id'], fake_uuid)['data']
     response = logged_in_client.get(url_for('main.view_job_updates', service_id=service_one['id'], job_id=fake_uuid))
 
     assert response.status_code == 200
@@ -386,7 +382,6 @@ def test_should_show_notifications_for_a_service_with_next_previous(
         page=2
     ))
     assert response.status_code == 200
-    content = response.get_data(as_text=True)
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     next_page_link = page.find('a', {'rel': 'next'})
     prev_page_link = page.find('a', {'rel': 'previous'})

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -88,7 +88,7 @@ def test_if_cant_send_letters_then_cant_see_letter_contact_block(
     assert 'Letter contact block' not in response.get_data(as_text=True)
 
 
-def test_letter_contact_block_shows_None_if_not_set(
+def test_letter_contact_block_shows_none_if_not_set(
     logged_in_client,
     service_one,
     mocker,

--- a/tests/app/main/views/test_template_history.py
+++ b/tests/app/main/views/test_template_history.py
@@ -1,4 +1,3 @@
-import json
 from flask import url_for
 
 
@@ -54,7 +53,6 @@ def test_view_template_versions(
 ):
     service_id = fake_uuid
     template_id = fake_uuid
-    version = 1
     resp = logged_in_client.get(url_for(
         '.view_template_versions',
         service_id=service_id,

--- a/tests/app/test_assets.py
+++ b/tests/app/test_assets.py
@@ -1,9 +1,10 @@
-import app
-
-
-def test_crown_logo(app_):
-    with app_.test_request_context():
-        #  This image is used by the email templates, so we should be really careful to make
-        #  sure that its always there.
-        response = app_.test_client().get('/static/images/email-template/crown-32px.gif')
+def test_crown_logo(client):
+    #  This image is used by the email templates, so we should be really careful to make
+    #  sure that its always there.
+    response = client.get('/static/images/email-template/crown-32px.gif')
     assert response.status_code == 200
+
+
+def test_static_404s_return(client):
+    response = client.get('/static/images/some-image-that-doesnt-exist.png')
+    assert response.status_code == 404

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -3,7 +3,6 @@ from io import StringIO
 from csv import DictReader
 
 import pytest
-from freezegun import freeze_time
 
 from app.utils import (
     email_safe,
@@ -13,7 +12,7 @@ from app.utils import (
     Spreadsheet
 )
 
-from tests import notification_json, single_notification_json, template_json
+from tests import notification_json, single_notification_json
 
 
 def _get_notifications_csv(


### PR DESCRIPTION
before each request, we put the current service on the flask session,
except for with the static folder, cos it's not needed.... except, if
we 404, then we return the 404 template, which checks if you're logged
in or not to display different nav bar items. This was crashing when
current_service wasn't set, so we now set it.

also cleaned up some imports and stuff in test files