### PR TITLE
Add config to deploy a prototype version of admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,12 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	cf stop notify-admin-rollback
 	cf delete -f notify-admin-rollback
 
+.PHONY: cf-deploy-prototype
+cf-deploy-prototype: ## Deploys the app to Cloud Foundry
+	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	cf target -s ${CF_SPACE}
+	cf push -f manifest-prototype-${CF_SPACE}.yml
+
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release
 	@cf app --guid notify-admin-rollback || exit 1

--- a/manifest-prototype-base.yml
+++ b/manifest-prototype-base.yml
@@ -1,0 +1,17 @@
+---
+
+buildpack: python_buildpack
+command: scripts/run_app_paas.sh gunicorn -w 5 -b 0.0.0.0:$PORT wsgi
+services:
+  - notify-aws
+  - notify-config
+  - notify-template-preview
+  - hosted-graphite
+  - deskpro
+instances: 1
+memory: 1G
+env:
+  NOTIFY_APP_NAME: admin
+
+applications:
+  - name: notify-admin-prototype

--- a/manifest-prototype-preview.yml
+++ b/manifest-prototype-preview.yml
@@ -1,0 +1,6 @@
+---
+
+inherit: manifest-prototype-base.yml
+
+routes:
+  - route: notify-admin-prototype-preview.cloudapps.digital

--- a/manifest-prototype-production.yml
+++ b/manifest-prototype-production.yml
@@ -1,0 +1,6 @@
+---
+
+inherit: manifest-prototype-base.yml
+
+routes:
+  - route: notify-admin-prototype-production.cloudapps.digital

--- a/manifest-prototype-staging.yml
+++ b/manifest-prototype-staging.yml
@@ -1,0 +1,6 @@
+---
+
+inherit: manifest-prototype-base.yml
+
+routes:
+  - route: notify-admin-prototype-staging.cloudapps.digital


### PR DESCRIPTION
Sometimes we want to make changes to the admin app for doing user research that we don’t want all users to see (because we’re not sure if they’re the right changes to be making).

## How we’ve done this up to now

We’d have the participant use a team member’s computer, with the app running locally. This was bad for three reasons:

- requires the time of someone who has the code running locally
- requires the participant to use an unfamiliar computer
- means the participant doesn’t have access to their own Notify account (or an account that we’ve set up for doing user research with)

## The dream*

Two versions of the frontend app, running side by side in production. This pull request makes the dream real. The two versions of admin are:

- the normal admin app, accessible on https://www.notifications.service.gov.uk
- a prototype version meant to be pushed to from a developer’s local machine†, accessible on https://notify-admin-prototype-production.cloudapps.digital (the domain that PaaS gives us)

Both of these apps share the same backing services, eg config, API instance, queues, etc, etc. Which means that the prototype version can be logged into with the same username and password, and the user will see their service and all their templates when they do so.

## Implementation detail

Ideally this wouldn’t mean creating a separate base manifest. However it’s a feature of Cloud Foundry that you can override the application name. Which means a separate base manifest and a bit of duplication. 😞

***

*the ultimate dream would be to have a version of admin deployed for each branch of the admin app, but would get very resource-intensive

†by running `CF_SPACE=preview make preview cf-deploy-prototype`, where `preview` is the name of the space you want to deploy to