### PR TITLE
Hide the recipient table on send yourself a test

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -185,37 +185,41 @@
   {% endif %}
   </div>
 
-  <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
+  {% if not request.args.from_test %}
 
-  {% call(item, row_number) list_table(
-    recipients.initial_annotated_rows_with_errors if row_errors and not recipients.missing_column_headers else recipients.initial_annotated_rows,
-    caption=original_file_name,
-    caption_visible=False,
-    field_headings=[
-      '<span class="visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
-    ] + recipients.column_headers
-  ) %}
-    {{ index_field(item.index + 2) }}
-    {% for column in recipients.column_headers %}
-      {% if item['columns'][column].error and not recipients.missing_column_headers %}
-        {% call field() %}
-          <span class="table-field-error">
-            <span class="table-field-error-label">{{ item['columns'][column].error }}</span>
-            {{ item['columns'][column].data if item['columns'][column].data != None }}
-          </span>
-        {% endcall %}
-      {% elif item['columns'][column].ignore %}
-        {{ text_field(item['columns'][column].data or '', status='default') }}
-      {% else %}
-        {{ text_field(item['columns'][column].data or '') }}
-      {% endif %}
-    {% endfor %}
-    {% if item['columns'].get(None) %}
-      {% for column in item['columns'][None].data %}
-        {{ text_field(column, status='default') }}
+    <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
+
+    {% call(item, row_number) list_table(
+      recipients.initial_annotated_rows_with_errors if row_errors and not recipients.missing_column_headers else recipients.initial_annotated_rows,
+      caption=original_file_name,
+      caption_visible=False,
+      field_headings=[
+        '<span class="visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
+      ] + recipients.column_headers
+    ) %}
+      {{ index_field(item.index + 2) }}
+      {% for column in recipients.column_headers %}
+        {% if item['columns'][column].error and not recipients.missing_column_headers %}
+          {% call field() %}
+            <span class="table-field-error">
+              <span class="table-field-error-label">{{ item['columns'][column].error }}</span>
+              {{ item['columns'][column].data if item['columns'][column].data != None }}
+            </span>
+          {% endcall %}
+        {% elif item['columns'][column].ignore %}
+          {{ text_field(item['columns'][column].data or '', status='default') }}
+        {% else %}
+          {{ text_field(item['columns'][column].data or '') }}
+        {% endif %}
       {% endfor %}
-    {% endif %}
-  {% endcall %}
+      {% if item['columns'].get(None) %}
+        {% for column in item['columns'][None].data %}
+          {{ text_field(column, status='default') }}
+        {% endfor %}
+      {% endif %}
+    {% endcall %}
+
+  {% endif %}
 
 
   {% if recipients.too_many_rows %}


### PR DESCRIPTION
Send yourself a test is:
- a good way of explaining how placeholders work
- a useful tool for checking your work before you send a big batch

It’s not a good way of learning about the relationship between columns in a spreadsheet and placeholders. The ‘example spreadsheet’ thing is good at making that connection. The table on this page isn’t, because it doesn’t _feel_ like you’re making a spreadsheet with the send yourself a test feature (even though that’s what you’re doing in the background). This will be even more the case when we stop putting the input boxes horizontally on one page.

By removing the table from this page it makes the page simpler, which allows people to focus on the important thing – what’s happening to their message.