### PR TITLE
Show all pages of a letter everywhere

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -37,7 +37,7 @@ from app.utils import (
     get_help_argument,
     get_template
 )
-from app.template_previews import TemplatePreview
+from app.template_previews import TemplatePreview, get_page_count_for_letter
 
 
 def get_page_headings(template_type):
@@ -83,15 +83,19 @@ def get_example_letter_address(key):
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def send_messages(service_id, template_id):
 
+    template = service_api_client.get_service_template(service_id, template_id)['data']
+
     template = get_template(
-        service_api_client.get_service_template(service_id, template_id)['data'],
+        template,
         current_service,
         show_recipient=True,
+        expand_emails=True,
         letter_preview_url=url_for(
             '.view_letter_template_preview',
             service_id=service_id,
             template_id=template_id,
             filetype='png',
+            page_count=get_page_count_for_letter(template),
         ),
     )
 
@@ -150,15 +154,19 @@ def send_test(service_id, template_id):
 
     file_name = current_app.config['TEST_MESSAGE_FILENAME']
 
+    template = service_api_client.get_service_template(service_id, template_id)['data']
+
     template = get_template(
-        service_api_client.get_service_template(service_id, template_id)['data'],
+        template,
         current_service,
         show_recipient=True,
+        expand_emails=True,
         letter_preview_url=url_for(
             '.view_letter_template_preview',
             service_id=service_id,
             template_id=template_id,
             filetype='png',
+            page_count=get_page_count_for_letter(template),
         ),
     )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -19,7 +19,7 @@ from notifications_python_client.errors import HTTPError
 
 from app.main import main
 from app.utils import user_has_permissions, get_template
-from app.template_previews import TemplatePreview
+from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.main.forms import (
     ChooseTemplateType,
     SMSTemplateForm,
@@ -74,10 +74,6 @@ def choose_template(service_id):
 )
 def view_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, template_id)['data']
-    page_count = None
-    if template['template_type'] == 'letter':
-        page_count, _, _ = TemplatePreview.from_database_object(template, filetype='json')
-        page_count = json.loads(page_count.decode('utf-8'))['count']
     return render_template(
         'views/templates/template.html',
         template=get_template(
@@ -91,7 +87,7 @@ def view_template(service_id, template_id):
                 filetype='png',
             ),
             show_recipient=True,
-            page_count=page_count,
+            page_count=get_page_count_for_letter(template),
         ),
     )
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -1,4 +1,4 @@
-from flask import current_app
+from flask import current_app, json
 import requests
 
 from app import current_service
@@ -32,3 +32,14 @@ class TemplatePreview:
             template.values,
             page=page,
         )
+
+
+def get_page_count_for_letter(template, values=None):
+
+    if template['template_type'] != 'letter':
+        return None
+
+    page_count, _, _ = TemplatePreview.from_database_object(template, values, filetype='json')
+    page_count = json.loads(page_count.decode('utf-8'))['count']
+
+    return page_count


### PR DESCRIPTION
Right now showing all the pages in full is the only way we have of showing a letter that makes sense to our users. Maybe in the future we show some kind of truncated version, but the end of the first page is not a good place to truncate the letter.

This commit just extracts the code for showing multiple pages from the `template` views, refactors it for reuse, and includes it in the `send` views.