### PR TITLE
Call letter subjects ‘main heading’

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -290,7 +290,7 @@ class EmailTemplateForm(BaseTemplateForm):
 class LetterTemplateForm(EmailTemplateForm):
 
     subject = TextAreaField(
-        u'Title',
+        u'Main heading',
         validators=[DataRequired(message="Can’t be empty")])
 
     template_content = TextAreaField(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -171,9 +171,9 @@ def add_template_by_type(service_id):
             blank_letter = service_api_client.create_service_template(
                 'Untitled',
                 'letter',
-                'Content',
+                'Body',
                 service_id,
-                'Title',
+                'Main heading',
                 'normal',
             )
             return redirect(url_for(

--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -1,10 +1,10 @@
 <h2 class="heading-medium">Formatting</h2>
 <p>
-  To put a title in your template, use a hash:
+  To put a heading in your template, use a hash:
 </p>
 <div class="panel panel-border-wide">
   <p>
-    # This is a title
+    # This is a heading
   </p>
 </div>
 <p>


### PR DESCRIPTION
This is a term that one of our research participants used to describe the big bold text that starts each letter. I think it’s quite a nice plain english term for it.

Also changes the formatting guidance to use the word heading instead of title, for consistency.