### PR TITLE
Rename ‘generate preview’

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -178,7 +178,7 @@
       {% if template.template_type != 'letter' or not request.args.from_test %}
       <input type="submit" class="button" value="Send {{ count_of_recipients }} {{ message_count_label(count_of_recipients, template.template_type, suffix='') }}" />
       {% else %}
-        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="heading-medium">Download as PDF</a>
+        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="heading-medium">Download as a printable PDF</a>
       {% endif %}
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
     </form>

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -178,7 +178,7 @@
       {% if template.template_type != 'letter' or not request.args.from_test %}
       <input type="submit" class="button" value="Send {{ count_of_recipients }} {{ message_count_label(count_of_recipients, template.template_type, suffix='') }}" />
       {% else %}
-        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="heading-medium">Download as a printable PDF</a>
+        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="button">Download as a printable PDF</a>
       {% endif %}
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
     </form>

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -18,7 +18,7 @@
     Example text message
   {% else %}
     {% if template.template_type == 'letter' %}
-      Generate preview
+      Print a test letter
     {% else %}
       Send yourself a test
     {% endif %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -14,7 +14,7 @@
         </div>
         <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
           <a href="{{ url_for(".send_test", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-            {{ 'Generate preview' if template.template_type == 'letter' else 'Send yourself a test' }}
+            {{ 'Print a test letter' if template.template_type == 'letter' else 'Send yourself a test' }}
           </a>
         </div>
         {% endif %}


### PR DESCRIPTION
‘Print a test letter’ seems to be closer to what people’s expectations of what this feature does are.

The word ‘generate’ sounded too much like something the system was doing, rather than something you, the user, were doing.

Also makes the ‘download PDF‘ link into a normal button because it’s the primary action on this page. We use big, bold links for lists of links, eg services, templates.