### PR TITLE
Remove unused Elements SASS

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -25,7 +25,6 @@ $path: '/static/images/';
 @import 'elements/forms';
 @import 'elements/forms/form-multiple-choice';
 @import 'elements/forms/form-validation';
-@import 'elements/icons';
 @import 'elements/layout';
 @import 'elements/lists';
 @import 'elements/panels';

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -23,7 +23,6 @@ $path: '/static/images/';
 @import 'elements/details';
 @import 'elements/elements-typography';
 @import 'elements/forms';
-@import 'elements/forms/form-validation';
 @import 'elements/forms/form-multiple-choice';
 @import 'elements/forms/form-validation';
 @import 'elements/icons';


### PR DESCRIPTION
## Before

`130K main.css`

## Remove duplicate include

This file is included again two lines below.

`130K main.css` (presumably SASS is clever enough to squash the duplication)

## Remove icons

We don’t use them anywhere, and removing this include should save a bit of file size in the compiled CSS.

`94K main.css` 💥 