### PR TITLE
Show one field at a time on send yourself a test

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,5 +1,7 @@
 $(() => $("time.timeago").timeago());
 
+$(() => GOVUK.stickAtTopWhenScrolling.init());
+
 $(() => GOVUK.modules.start());
 
 $(() => $('.error-message').eq(0).parent('label').next('input').trigger('focus'));

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -1,0 +1,30 @@
+// CSS adapted from
+// https://github.com/alphagov/govuk_frontend_toolkit/blob/d9489a987086471fe30b4b925a81c12cd198c91d/docs/javascript.md#stick-at-top-when-scrolling
+
+.js-stick-at-top-when-scrolling {
+
+  overflow: hidden;
+  margin-left: -$gutter-half;
+  margin-top: -10px;
+  padding: 10px 0 0 $gutter-half;
+
+  .form-group {
+    margin-bottom: 20px;
+  }
+
+}
+
+.content-fixed {
+  position: fixed;
+  top: 0;
+  background: $white;
+  z-index: 100;
+  margin-top: 0;
+  padding-right: $gutter-half;
+  border-bottom: 1px solid $border-colour;
+  box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
+}
+
+.shim {
+  display: block;
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -57,6 +57,7 @@ $path: '/static/images/';
 @import 'components/list-entry';
 @import 'components/letter';
 @import 'components/live-search';
+@import 'components/stick-at-top-when-scrolling';
 @import 'components/vendor/breadcrumbs';
 @import 'components/vendor/responsive-embed';
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,7 +1,6 @@
 import re
 import pytz
 
-from flask_login import current_user
 from flask_wtf import Form
 from datetime import datetime, timedelta
 from notifications_utils.recipients import (

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,6 +1,6 @@
 import re
-
 import pytz
+
 from flask_login import current_user
 from flask_wtf import Form
 from datetime import datetime, timedelta
@@ -619,3 +619,26 @@ class ChooseTemplateType(Form):
 class SearchTemplatesForm(Form):
 
     search = SearchField('Search by name')
+
+
+class PlaceholderForm(Form):
+
+    pass
+
+
+def get_placeholder_form_instance(
+    placeholder_name,
+    dict_to_populate_from,
+    optional_placeholder=False
+):
+
+    PlaceholderForm.placeholder_value = StringField(
+        placeholder_name,
+        validators=[
+            DataRequired(message='Can’t be empty')
+        ] if not optional_placeholder else []
+    )
+
+    return PlaceholderForm(
+        placeholder_value=dict_to_populate_from.get(placeholder_name, '')
+    )

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -240,6 +240,7 @@ def send_test_step(service_id, template_id, step_index):
         )
 
     template.values = get_normalised_send_test_values_from_session()
+    template.values[current_placeholder] = None
 
     return render_template(
         'views/send-test.html',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -162,6 +162,7 @@ def get_example_csv(service_id, template_id):
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def send_test(service_id, template_id):
     session['send_test_values'] = dict()
+    session['send_test_letter_page_count'] = None
     return redirect(url_for(
         '.send_test_step',
         service_id=service_id,
@@ -178,6 +179,9 @@ def send_test_step(service_id, template_id, step_index):
 
     template = service_api_client.get_service_template(service_id, template_id)['data']
 
+    if not session.get('send_test_letter_page_count'):
+        session['send_test_letter_page_count'] = get_page_count_for_letter(template)
+
     template = get_template(
         template,
         current_service,
@@ -189,7 +193,7 @@ def send_test_step(service_id, template_id, step_index):
             template_id=template_id,
             filetype='png',
         ),
-        page_count=get_page_count_for_letter(template),
+        page_count=session['send_test_letter_page_count']
     )
 
     placeholders = fields_to_fill_in(template)
@@ -271,7 +275,6 @@ def send_test_preview(service_id, template_id, filetype):
             template_id=template_id,
             filetype='png',
         ),
-        page_count=get_page_count_for_letter(template),
     )
 
     template.values = get_normalised_send_test_values_from_session()

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -177,6 +177,11 @@ def send_test(service_id, template_id):
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
 def send_test_step(service_id, template_id, step_index):
 
+    if 'send_test_values' not in session:
+        return redirect(url_for(
+            '.send_test', service_id=service_id, template_id=template_id
+        ))
+
     template = service_api_client.get_service_template(service_id, template_id)['data']
 
     if not session.get('send_test_letter_page_count'):
@@ -201,7 +206,12 @@ def send_test_step(service_id, template_id, step_index):
     if len(placeholders) == 0:
         return make_and_upload_csv_file(service_id, template)
 
-    current_placeholder = placeholders[step_index]
+    try:
+        current_placeholder = placeholders[step_index]
+    except IndexError:
+        return redirect(url_for(
+            '.send_test', service_id=service_id, template_id=template_id
+        ))
     optional_placeholder = (current_placeholder in optional_address_columns)
     form = get_placeholder_form_instance(
         current_placeholder,

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -26,7 +26,7 @@
   {% endif %}
   </h1>
 
-  <form method="post" class="js-stick-at-top-when-scrolling">
+  <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus">
     {{ textbox(
       form.placeholder_value,
       hint='Optional' if optional_placeholder else None

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
+{% from "components/textbox.html" import textbox %}
 {% from "components/table.html" import list_table, field, text_field, index_field, index_field_heading %}
 
 {% block service_page_title %}
@@ -28,26 +29,11 @@
   {{ template|string }}
 
   <form method="post">
-    {% call(item, row_number) list_table(
-      example,
-      caption="Fill in the {}".format('field' if (recipient_columns + template.placeholders|list)|length == 2 else 'fields'),
-      field_headings=recipient_columns + template.placeholders|list
-    ) %}
-      {% for column in item %}
-        {% call field() %}
-          {% if loop.index > 1 or template.template_type == 'letter' %}
-            <label class="visuallyhidden" for="placeholder-field-{{ loop.index }}">{{ column }}</label>
-            <input class="form-control form-control-1-1 " data-module="" name="{{ column }}" rows="8" type="text" value="" id="placeholder-field-{{ loop.index }}">
-          {% else %}
-            {{ column }}
-          {% endif %}
-        {% endcall %}
-      {% endfor %}
-    {% endcall %}
-
-    {{ page_footer("Preview", back_link=(
-      url_for('.send_messages', service_id=current_service.id, template_id=template.id)) if not help else None
+    {{ textbox(
+      form.placeholder_value,
+      hint='Optional' if optional_placeholder else None
     ) }}
+    {{ page_footer('Next', back_link=back_link) }}
   </form>
 
 {% endblock %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -26,14 +26,14 @@
   {% endif %}
   </h1>
 
-  {{ template|string }}
-
-  <form method="post">
+  <form method="post" class="js-stick-at-top-when-scrolling">
     {{ textbox(
       form.placeholder_value,
       hint='Optional' if optional_placeholder else None
     ) }}
     {{ page_footer('Next', back_link=back_link) }}
   </form>
+
+  {{ template|string }}
 
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -224,6 +224,15 @@ class Spreadsheet():
             return cls(converted.getvalue(), filename)
 
     @classmethod
+    def from_dict(cls, dictionary, filename=''):
+        return cls.from_rows(
+            zip(
+                *sorted(dictionary.items(), key=lambda pair: pair[0])
+            ),
+            filename
+        )
+
+    @classmethod
     def from_file(cls, file_content, filename=''):
         extension = cls.get_extension(filename)
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -54,6 +54,8 @@ gulp.task('copy:govuk_template:images', () => gulp.src(paths.template + 'assets/
 gulp.task('javascripts', () => gulp
   .src([
     paths.toolkit + 'javascripts/govuk/modules.js',
+    paths.toolkit + 'javascripts/govuk/stop-scrolling-at-footer.js',
+    paths.toolkit + 'javascripts/govuk/stick-at-top-when-scrolling.js',
     paths.src + 'javascripts/detailsPolyfill.js',
     paths.src + 'javascripts/apiKey.js',
     paths.src + 'javascripts/autofocus.js',

--- a/tests/app/main/test_placeholder_form.py
+++ b/tests/app/main/test_placeholder_form.py
@@ -1,0 +1,18 @@
+from app.main.forms import get_placeholder_form_instance
+from wtforms import Label
+
+
+def test_form_class_not_mutated(app_):
+
+    with app_.test_request_context(
+        method='POST',
+        data={'placeholder_value': ''}
+    ) as req:
+        form1 = get_placeholder_form_instance('name', {}, optional_placeholder=False)
+        form2 = get_placeholder_form_instance('city', {}, optional_placeholder=True)
+
+        assert not form1.validate_on_submit()
+        assert form2.validate_on_submit()
+
+        assert str(form1.placeholder_value.label) == '<label for="placeholder_value">name</label>'
+        assert str(form2.placeholder_value.label) == '<label for="placeholder_value">city</label>'

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -4,6 +4,8 @@ from csv import DictReader
 
 import pytest
 
+from collections import OrderedDict
+
 from app.utils import (
     email_safe,
     generate_notifications_csv,
@@ -103,6 +105,20 @@ def test_can_create_spreadsheet_from_large_excel_file():
     with open(str(Path.cwd() / 'tests' / 'spreadsheet_files' / 'excel 2007.xlsx'), 'rb') as xl:
         ret = Spreadsheet.from_file(xl, filename='xl.xlsx')
     assert ret.as_csv_data
+
+
+def test_can_create_spreadsheet_from_dict():
+    assert Spreadsheet.from_dict(OrderedDict(
+        foo='bar',
+        name='Jane',
+    )).as_csv_data == (
+        "foo,name\r\n"
+        "bar,Jane\r\n"
+    )
+
+
+def test_can_create_spreadsheet_from_dict_with_filename():
+    assert Spreadsheet.from_dict({}, filename='empty.csv').as_dict['file_name'] == "empty.csv"
 
 
 def test_generate_notifications_csv_returns_correct_csv_file(_get_notifications_csv_mock):


### PR DESCRIPTION
# Screenshots

## Before

![image](https://cloud.githubusercontent.com/assets/355079/26149728/4fd3fcdc-3af3-11e7-8f84-076bdb89419f.png)

## After

![tour-opp](https://cloud.githubusercontent.com/assets/355079/26196032/87b99de2-3bb5-11e7-838a-8bf9d1aa5608.gif)

***

![tour-opp](https://cloud.githubusercontent.com/assets/355079/26149871/e338dd30-3af3-11e7-961c-3bf25b1c5f61.gif)


# Background on the _Send yourself a test_ feature

We built it because it’s useful for:
- constructing an email/text message/letter without uploading a CSV file
- seeing what the thing your going to send will look like (either by getting it in your inbox or downloading the PDF)
- learning the concept of placeholders, ie understanding they’re thing that gets populated with _stuff_

# The problem with it

The current UI breaks when a template has a lot of placeholders. This is especially apparent with letter templates, which have a minimum of 7 placeholders by virtue of the address.

# Why we have this problem

The idea behind having the form fields side-by-side was to help people understand the relationship between their spreadsheet columns and the placeholders. But this means that the page was doing a lot of work, trying to teach both:
- replacement of placeholders
- link between placeholders and spreadsheet columns

The latter is better explained by the example spreadsheet shown on the upload page. So it can safely be removed from the send yourself a test page – in other words the fields don’t need to be shown side by side.

# Why this solution

Showing them one-at-a-time works well because:
- it’s really obvious, even on first use, what the page is asking you to do
- as your step through each placeholder, you see the message build up with the data you’ve entered – you’re learning how replacement of placeholders works by repetition