### PR TITLE
Show spreadsheet before template if there’s errors

### DIFF
--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -150,7 +150,9 @@
 
   {% endif %}
 
-  {{ template|string }}
+  {% if not errors %}
+    {{ template|string }}
+  {% endif %}
 
   <div class="bottom-gutter-3-2">
   {% if errors %}
@@ -232,6 +234,11 @@
     <p class="table-show-more-link">
       Only showing rows with errors
     </p>
+  {% endif %}
+
+  {% if errors %}
+    <h2 class="heading-medium">Preview of {{ template.name }}</h2>
+    {{ template|string }}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
It’s easier to work out what the errors are in your file if you can see the big red error message right next to the contents of your file.

When users get errors they tend to go back and forth between the error message and the view of the file, not the message and the template preview.

## Before

<img width="754" alt="screen shot 2017-05-19 at 10 17 10" src="https://cloud.githubusercontent.com/assets/355079/26241410/6dfd1f2e-3c7c-11e7-8097-08f3eb5bd5d9.png">

## After

<img width="747" alt="screen shot 2017-05-19 at 10 14 09" src="https://cloud.githubusercontent.com/assets/355079/26241417/741db350-3c7c-11e7-9742-fb4e300548c5.png">

***

![image](https://cloud.githubusercontent.com/assets/355079/26241423/7da8b94c-3c7c-11e7-83b9-083d72d6866a.png)
