### PR TITLE
Remove fallback for empty SMS sender

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -36,7 +36,7 @@
 
         {% call row() %}
           {{ text_field('Text message sender') }}
-          {{ text_field(current_service.sms_sender or 'GOVUK') }}
+          {{ text_field(current_service.sms_sender) }}
           {{ edit_field('Change', url_for('.service_set_sms_sender', service_id=current_service.id)) }}
         {% endcall %}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,7 +47,7 @@ def service_json(
     restricted=True,
     email_from=None,
     reply_to_email_address=None,
-    sms_sender=None,
+    sms_sender='GOVUK',
     research_mode=False,
     can_send_letters=False,
     can_send_international_sms=False,


### PR DESCRIPTION
The API will **(not yet)** always return a value for this now (defaults to GOV.UK)
