### PR TITLE
Add tail to SMS messages

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -1,5 +1,8 @@
+$tail-angle: 20deg;
+
 .sms-message-wrapper {
 
+  position: relative;
   width: 100%;
   max-width: 464px;
   box-sizing: border-box;
@@ -11,6 +14,20 @@
   margin: 0 0 $gutter 0;
   clear: both;
   word-wrap: break-word;
+
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    bottom: -4px;
+    right: -20px;
+    border: 10px solid transparent;
+    border-left-width: 13px;
+    border-right-width: 13px;
+    border-bottom-color: $panel-colour;
+    border-left-color: $panel-colour;
+    transform: rotate($tail-angle);
+  }
 
 }
 

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -1,4 +1,3 @@
-%sms-message-wrapper,
 .sms-message-wrapper {
 
   width: 100%;
@@ -13,44 +12,10 @@
   clear: both;
   word-wrap: break-word;
 
-  p {
-    margin: 0;
-    line-height: 1.6;
-  }
-
-  p + p {
-    margin-top: 20px;
-  }
-
-}
-
-.sms-message-wrapper-with-radio {
-  @extend %sms-message-wrapper;
-  padding-left: 45px;
-  cursor: pointer;
 }
 
 .sms-message-recipient {
   @include copy-19;
   color: $secondary-text-colour;
   margin: 10px 0 0 0;
-}
-
-.sms-message-name {
-  @include bold-24;
-  margin: 20px 0 5px 0;
-}
-
-.sms-message-picker {
-  display: block;
-  margin: 7px 0 0 0;
-  position: absolute;
-  left: 15px;
-  top: 50%;
-  z-index: 50;
-}
-
-.sms-message-from {
-  @include bold-19;
-  display: block;
 }


### PR DESCRIPTION
Because:
- drawing things in CSS is fun
- when we have inbound messages, having a tail pointing the other way will help differentiate which messages are inbound

***

![image](https://cloud.githubusercontent.com/assets/355079/26405411/1aa31cba-408d-11e7-97a1-aa1db95a6683.png)

***

There are some great historic screenshots of the text message template in this PR: https://github.com/alphagov/notifications-admin/pull/27
