### PR TITLE
Combine related tests into one

### DIFF
--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -23,6 +23,7 @@ from tests.conftest import (
     mock_get_international_service,
     mock_get_service_template,
     mock_get_service_email_template,
+    SERVICE_ONE_ID,
 )
 
 template_types = ['email', 'sms']
@@ -204,32 +205,6 @@ def test_upload_csv_invalid_extension(
     assert "invalid.txt isn’t a spreadsheet that Notify can read" in resp.get_data(as_text=True)
 
 
-def test_upload_valid_csv_shows_page_title(
-    logged_in_client,
-    mocker,
-    mock_get_service_template_with_placeholders,
-    mock_s3_upload,
-    mock_get_users_by_service,
-    mock_get_detailed_service_for_today,
-    service_one,
-    fake_uuid,
-):
-
-    mocker.patch('app.main.views.send.s3download', return_value="""
-        phone number,name\n07700900986,Jo
-    """)
-
-    response = logged_in_client.post(
-        url_for('main.send_messages', service_id=service_one['id'], template_id=fake_uuid),
-        data={'file': (BytesIO(''.encode('utf-8')), 'valid.csv')},
-        follow_redirects=True,
-    )
-
-    assert response.status_code == 200
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.h1.text.strip() == 'Preview of Two week reminder'
-
-
 def test_upload_valid_csv_shows_file_contents(
     logged_in_client,
     mocker,
@@ -237,7 +212,6 @@ def test_upload_valid_csv_shows_file_contents(
     mock_s3_upload,
     mock_get_users_by_service,
     mock_get_detailed_service_for_today,
-    service_one,
     fake_uuid,
 ):
 
@@ -247,13 +221,14 @@ def test_upload_valid_csv_shows_file_contents(
     """)
 
     response = logged_in_client.post(
-        url_for('main.send_messages', service_id=service_one['id'], template_id=fake_uuid),
+        url_for('main.send_messages', service_id=SERVICE_ONE_ID, template_id=fake_uuid),
         data={'file': (BytesIO(''.encode('utf-8')), 'valid.csv')},
         follow_redirects=True,
     )
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.text.strip() == 'Preview of Two week reminder'
     for index, cell in enumerate([
         '<td class="table-field-index"> <span class=""> 2 </span> </td>',
         '<td class="table-field-center-aligned "> <div class=""> 07700900986 </div> </td>',


### PR DESCRIPTION
These tests were both requesting the same page with the same input, saves a lot of boilerplate if they’re not separated.