### PR TITLE
Make ‘send a one-off message’ a thing

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -26,6 +26,19 @@
   @include grid-column(7/8);
 }
 
+%top-gutter,
+.top-gutter {
+  @extend %contain-floats;
+  display: block;
+  margin-top: $gutter;
+  clear: both;
+}
+
+.top-gutter-4-3 {
+  @extend %top-gutter;
+  margin-top: $gutter * 4 / 3;
+}
+
 %bottom-gutter,
 .bottom-gutter {
   @extend %contain-floats;

--- a/app/config.py
+++ b/app/config.py
@@ -57,7 +57,7 @@ class Config(object):
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'
     DESKPRO_PERSON_EMAIL = 'donotreply@notifications.service.gov.uk'
     ACTIVITY_STATS_LIMIT_DAYS = 7
-    TEST_MESSAGE_FILENAME = 'One-off message'
+    TEST_MESSAGE_FILENAME = 'Report'
 
     STATSD_ENABLED = False
     STATSD_HOST = "statsd.hostedgraphite.com"

--- a/app/config.py
+++ b/app/config.py
@@ -57,7 +57,7 @@ class Config(object):
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'
     DESKPRO_PERSON_EMAIL = 'donotreply@notifications.service.gov.uk'
     ACTIVITY_STATS_LIMIT_DAYS = 7
-    TEST_MESSAGE_FILENAME = 'Test message'
+    TEST_MESSAGE_FILENAME = 'One-off message'
 
     STATSD_ENABLED = False
     STATSD_HOST = "statsd.hostedgraphite.com"

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -7,6 +7,7 @@ from notifications_utils.recipients import (
     validate_phone_number,
     InvalidPhoneError
 )
+from notifications_utils.columns import Columns
 from wtforms import (
     validators,
     StringField,
@@ -102,9 +103,24 @@ class UKMobileNumber(TelField):
             raise ValidationError(str(e))
 
 
-def mobile_number():
-    return UKMobileNumber('Mobile number',
+class InternationalPhoneNumber(TelField):
+    def pre_validate(self, form):
+        try:
+            validate_phone_number(self.data, international=True)
+        except InvalidPhoneError as e:
+            raise ValidationError(str(e))
+
+
+def mobile_number(label='Mobile number'):
+    return UKMobileNumber(label,
                           validators=[DataRequired(message='Can’t be empty')])
+
+
+def international_phone_number(label='Mobile number'):
+    return InternationalPhoneNumber(
+        label,
+        validators=[DataRequired(message='Can’t be empty')]
+    )
 
 
 def password(label='Password'):
@@ -633,15 +649,25 @@ class PlaceholderForm(Form):
 def get_placeholder_form_instance(
     placeholder_name,
     dict_to_populate_from,
-    optional_placeholder=False
+    optional_placeholder=False,
+    allow_international_phone_numbers=False,
 ):
 
-    PlaceholderForm.placeholder_value = StringField(
-        placeholder_name,
-        validators=[
+    if Columns.make_key(placeholder_name) == 'emailaddress':
+        field = email_address(label=placeholder_name, gov_user=False)
+    elif Columns.make_key(placeholder_name) == 'phonenumber':
+        if allow_international_phone_numbers:
+            field = international_phone_number(label=placeholder_name)
+        else:
+            field = mobile_number(label=placeholder_name)
+    elif optional_placeholder:
+        field = StringField(placeholder_name)
+    else:
+        field = StringField(placeholder_name, validators=[
             DataRequired(message='Can’t be empty')
-        ] if not optional_placeholder else []
-    )
+        ])
+
+    PlaceholderForm.placeholder_value = field
 
     return PlaceholderForm(
         placeholder_value=dict_to_populate_from.get(placeholder_name, '')

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -302,6 +302,7 @@ def send_test_step(service_id, template_id, step_index):
         skip_link=skip_link,
         optional_placeholder=optional_placeholder,
         back_link=back_link,
+        help=get_help_argument(),
     )
 
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -245,6 +245,7 @@ def send_test_step(service_id, template_id, step_index):
         current_placeholder,
         dict_to_populate_from=get_normalised_send_test_values_from_session(),
         optional_placeholder=optional_placeholder,
+        allow_international_phone_numbers=current_service['can_send_international_sms'],
     )
 
     if form.validate_on_submit():

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -282,13 +282,25 @@ def send_test_step(service_id, template_id, step_index):
     template.values = get_normalised_send_test_values_from_session()
     template.values[current_placeholder] = None
 
+    if (
+        request.endpoint == 'main.send_one_off_step' and
+        step_index == 0 and
+        template.template_type != 'letter'
+    ):
+        skip_link = (
+            'Use my {}'.format(first_column_headings[template.template_type][0]),
+            url_for('.send_test', service_id=service_id, template_id=template.id),
+        )
+    else:
+        skip_link = None
+
     return render_template(
         'views/send-test.html',
-        page_title=get_send_test_page_title(template.template_type, request.endpoint),
+        page_title=get_send_test_page_title(template.template_type, get_help_argument()),
         template=template,
         form=form,
+        skip_link=skip_link,
         optional_placeholder=optional_placeholder,
-        help=get_help_argument(),
         back_link=back_link,
     )
 
@@ -549,12 +561,9 @@ def all_placeholders_in_session(placeholders):
     )
 
 
-def get_send_test_page_title(template_type, endpoint):
-    if get_help_argument():
+def get_send_test_page_title(template_type, help_argument):
+    if help_argument:
         return 'Example text message'
     if template_type == 'letter':
         return 'Print a test letter'
-    return {
-        'main.send_test_step': 'Send yourself a test',
-        'main.send_one_off_step': 'Send one-off message',
-    }[endpoint]
+    return 'Send one-off message'

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -566,4 +566,4 @@ def get_send_test_page_title(template_type, help_argument):
         return 'Example text message'
     if template_type == 'letter':
         return 'Print a test letter'
-    return 'Send one-off message'
+    return 'Send to one recipient'

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -284,6 +284,7 @@ def send_test_step(service_id, template_id, step_index):
 
     return render_template(
         'views/send-test.html',
+        page_title=get_send_test_page_title(template.template_type, request.endpoint),
         template=template,
         form=form,
         optional_placeholder=optional_placeholder,
@@ -546,3 +547,14 @@ def all_placeholders_in_session(placeholders):
         get_normalised_send_test_values_from_session().get(placeholder, False) not in (False, None)
         for placeholder in placeholders
     )
+
+
+def get_send_test_page_title(template_type, endpoint):
+    if get_help_argument():
+        return 'Example text message'
+    if template_type == 'letter':
+        return 'Print a test letter'
+    return {
+        'main.send_test_step': 'Send yourself a test',
+        'main.send_one_off_step': 'Send one-off message',
+    }[endpoint]

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -15,10 +15,20 @@
   </h1>
 
   <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus">
-    {{ textbox(
-      form.placeholder_value,
-      hint='Optional' if optional_placeholder else None
-    ) }}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        {{ textbox(
+          form.placeholder_value,
+          hint='Optional' if optional_placeholder else None,
+          width='1-1',
+        ) }}
+      </div>
+      {% if skip_link %}
+        <div class="column-one-third">
+          <a href="{{ skip_link[1] }}" class="top-gutter-4-3">{{ skip_link[0] }}</a>
+        </div>
+      {% endif %}
+    </div>
     {{ page_footer('Next', back_link=back_link) }}
   </form>
 

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -5,25 +5,13 @@
 {% from "components/table.html" import list_table, field, text_field, index_field, index_field_heading %}
 
 {% block service_page_title %}
-  {% if request.args['help'] %}
-    Example text message
-  {% else %}
-    Send yourself a test
-  {% endif %}
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-  {% if request.args['help'] %}
-    Example text message
-  {% else %}
-    {% if template.template_type == 'letter' %}
-      Print a test letter
-    {% else %}
-      Send yourself a test
-    {% endif %}
-  {% endif %}
+    {{ page_title }}
   </h1>
 
   <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus">

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -14,7 +14,7 @@
         </div>
         <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
           <a href="{{ url_for(".send_one_off", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-            {{ 'Print a test letter' if template.template_type == 'letter' else 'Send one-off message' }}
+            {{ 'Print a test letter' if template.template_type == 'letter' else 'Send to one recipient' }}
           </a>
         </div>
         {% endif %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -13,8 +13,8 @@
           </a>
         </div>
         <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
-          <a href="{{ url_for(".send_test", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-            {{ 'Print a test letter' if template.template_type == 'letter' else 'Send yourself a test' }}
+          <a href="{{ url_for(".send_one_off", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+            {{ 'Print a test letter' if template.template_type == 'letter' else 'Send one-off message' }}
           </a>
         </div>
         {% endif %}

--- a/tests/app/main/test_placeholder_form.py
+++ b/tests/app/main/test_placeholder_form.py
@@ -1,3 +1,4 @@
+import pytest
 from app.main.forms import get_placeholder_form_instance
 from wtforms import Label
 
@@ -16,3 +17,46 @@ def test_form_class_not_mutated(app_):
 
         assert str(form1.placeholder_value.label) == '<label for="placeholder_value">name</label>'
         assert str(form2.placeholder_value.label) == '<label for="placeholder_value">city</label>'
+
+
+@pytest.mark.parametrize('service_can_send_international_sms, placeholder_name, value, expected_error', [
+
+    (False, 'email address', '', 'Can’t be empty'),
+    (False, 'email address', '12345', 'Enter a valid email address'),
+    (False, 'email address', 'test@example.com', None),
+    (False, 'email address', 'test@example.gov.uk', None),
+
+    (False, 'phone number', '', 'Can’t be empty'),
+    (False, 'phone number', '+1-2345-678890', 'Not a UK mobile number'),
+    (False, 'phone number', '07900900123', None),
+    (False, 'phone number', '+44(0)7900 900-123', None),
+
+    (True, 'phone number', '+123', 'Not enough digits'),
+    (True, 'phone number', '+44(0)7900 900-123', None),
+    (True, 'phone number', '+1-2345-678890', None),
+
+    (False, 'anything else', '', 'Can’t be empty'),
+
+])
+def test_validates_recipients(
+    app_,
+    placeholder_name,
+    value,
+    service_can_send_international_sms,
+    expected_error,
+):
+    with app_.test_request_context(
+        method='POST',
+        data={'placeholder_value': value}
+    ):
+        form = get_placeholder_form_instance(
+            placeholder_name,
+            {},
+            allow_international_phone_numbers=service_can_send_international_sms,
+        )
+
+        if expected_error:
+            assert not form.validate_on_submit()
+            assert form.placeholder_value.errors[0] == expected_error
+        else:
+            assert form.validate_on_submit()

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -335,46 +335,54 @@ def test_send_test_step_redirects_if_session_not_setup(
         assert session['send_test_values'] == expected_session_contents
 
 
-@pytest.mark.parametrize('template_mock, partial_url, expected_h1', [
+@pytest.mark.parametrize('template_mock, partial_url, expected_h1, tour_shown', [
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_test'),
         'Send to one recipient',
+        False,
     ),
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_one_off'),
         'Send to one recipient',
+        False,
     ),
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_test', help=1),
         'Example text message',
+        True,
     ),
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_test', help=1),
         'Example text message',
+        True,
     ),
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_test'),
         'Send to one recipient',
+        False,
     ),
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_one_off'),
         'Send to one recipient',
+        False,
     ),
     (
         mock_get_service_letter_template,
         partial(url_for, 'main.send_test'),
         'Print a test letter',
+        False,
     ),
     (
         mock_get_service_letter_template,
         partial(url_for, 'main.send_one_off'),
         'Print a test letter',
+        False,
     ),
 ])
 def test_send_one_off_or_test_has_correct_page_titles(
@@ -385,6 +393,7 @@ def test_send_one_off_or_test_has_correct_page_titles(
     template_mock,
     partial_url,
     expected_h1,
+    tour_shown,
 ):
 
     template_mock(mocker)
@@ -398,6 +407,8 @@ def test_send_one_off_or_test_has_correct_page_titles(
 
     assert response.status_code == 200
     assert page.h1.text.strip() == expected_h1
+
+    assert (len(page.select('.banner-tour')) == 1) == tour_shown
 
 
 @pytest.mark.parametrize('template_mock, expected_link_text, expected_link_url', [

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -295,7 +295,7 @@ def test_send_test_sms_message(
     assert response.status_code == 200
     mock_s3_upload.assert_called_with(
         service_one['id'],
-        {'data': 'phone number\r\n07700 900762\r\n', 'file_name': 'One-off message'},
+        {'data': 'phone number\r\n07700 900762\r\n', 'file_name': 'Report'},
         'eu-west-1'
     )
 
@@ -339,12 +339,12 @@ def test_send_test_step_redirects_if_session_not_setup(
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_test'),
-        'Send one-off message',
+        'Send to one recipient',
     ),
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_one_off'),
-        'Send one-off message',
+        'Send to one recipient',
     ),
     (
         mock_get_service_template_with_placeholders,
@@ -359,12 +359,12 @@ def test_send_test_step_redirects_if_session_not_setup(
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_test'),
-        'Send one-off message',
+        'Send to one recipient',
     ),
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_one_off'),
-        'Send one-off message',
+        'Send to one recipient',
     ),
     (
         mock_get_service_letter_template,
@@ -603,7 +603,7 @@ def test_send_test_email_message_without_placeholders(
     assert response.status_code == 200
     mock_s3_upload.assert_called_with(
         service_one['id'],
-        {'data': 'email address\r\ntest@user.gov.uk\r\n', 'file_name': 'One-off message'},
+        {'data': 'email address\r\ntest@user.gov.uk\r\n', 'file_name': 'Report'},
         'eu-west-1'
     )
 
@@ -824,7 +824,7 @@ def test_send_test_sms_message_puts_submitted_data_in_session_and_file(
         service_one['id'],
         {
             'data': 'name,phone number\r\nJo,07700 900762\r\n',
-            'file_name': 'One-off message'
+            'file_name': 'Report'
         },
         'eu-west-1'
     )

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -44,11 +44,11 @@ def test_should_show_page_for_one_template(
     ),
     (
         ['send_texts', 'send_emails', 'send_letters'],
-        ['.send_messages', '.send_test']
+        ['.send_messages', '.send_one_off']
     ),
     (
         ['send_texts', 'send_emails', 'send_letters', 'manage_templates'],
-        ['.send_messages', '.send_test', '.edit_service_template']
+        ['.send_messages', '.send_one_off', '.edit_service_template']
     ),
 ])
 def test_should_be_able_to_view_a_template_with_links(


### PR DESCRIPTION
![one-off](https://cloud.githubusercontent.com/assets/355079/26450406/343ba10c-414f-11e7-9241-f73241cd3ce1.gif)

*** 

This pull request started off as making an extra feature to send individual messages, which would be invite-only for service teams that want it.

I think we should replace _Send yourself a test_ with this new feature for everyone. Reasons being:
- the service permissions stuff isn’t ready
- it keeps the proposition/feature set/surface of the app smaller and easier to understand

It adds:
- another page in the flow, for you to enter an email address phone number
- a link on that page to prefill the message with your own email address/phone number, so you still don’t ever have to type in your own phone number/email address
