### PR TITLE
Don’t hit template preview app when running tests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -98,6 +98,7 @@ class Test(Development):
     WTF_CSRF_ENABLED = False
     CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
     NOTIFY_ENVIRONMENT = 'test'
+    TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
 
 
 class Preview(Config):

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -29,15 +29,15 @@ def test_from_utils_template_calls_through(
 @pytest.mark.parametrize('partial_call, expected_url', [
     (
         partial(TemplatePreview.from_database_object, filetype='bar'),
-        'http://localhost:6013/preview.bar',
+        'http://localhost:9999/preview.bar',
     ),
     (
         partial(TemplatePreview.from_database_object, filetype='baz'),
-        'http://localhost:6013/preview.baz',
+        'http://localhost:9999/preview.baz',
     ),
     (
         partial(TemplatePreview.from_database_object, filetype='bar', page=99),
-        'http://localhost:6013/preview.bar?page=99',
+        'http://localhost:9999/preview.bar?page=99',
     ),
 ])
 def test_from_database_object_makes_request(


### PR DESCRIPTION
It’s annoying for tests to pass locally because the template preview app is running locally, but fail on Jenkins because the template preview app doesn’t exist.

This commit changes it’s hostname to use a dummy port in tests.