### PR TITLE
Don’t link to one-off reports from activity

### DIFF
--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -21,7 +21,10 @@
           {{ item.to }}
         </p>
         <p class="hint">
-          {% if item.job %}
+          {% if item.job and item.job.original_file_name == 'Report' %}
+            <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=item.template.id, version=item.template_version) }}">{{ item.template.name }}</a>
+            sent to one recipient
+          {% elif item.job %}
             From <a href="{{ url_for(".view_job", service_id=current_service.id, job_id=item.job.id) }}">{{ item.job.original_file_name }}</a>
           {% else %}
             <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=item.template.id, version=item.template_version) }}">{{ item.template.name }}</a>


### PR DESCRIPTION
There’s no need to see the ‘Report’ page for a one-off message – pretty much all the info about the notification is there on the page. And ‘Sent from _Report_’ looks weird.

We should display it more like an API call instead.