### PR TITLE
Add Care Quality Commission to email whitelist

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -82,6 +82,7 @@ class Config(object):
         r"scotent\.co\.uk",
         r"assembly\.wales",
         r"cjsm\.net",
+        r"cqc\.org\.uk",
     ]
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -90,7 +90,9 @@ def _gen_mock_field(x):
     'test@hmcts.net',
     'test@scotent.co.uk',
     'test@assembly.wales',
-    'test@cjsm.net'
+    'test@cjsm.net',
+    'test@cqc.org.uk',
+    'test@digital.cqc.org.uk',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
CQC is an executive non-departmental public body, sponsored by the Department of Health.

They have asked to be allowed to register for Notify using the `cqc.org.uk` and `digital.cqc.org.uk` domains. We know that this really is there domain because it’s linked to from here:

https://www.gov.uk/government/organisations/care-quality-commission