### PR TITLE
Add handler for old feedback form

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -8,6 +8,11 @@ from app.main.forms import SupportType, Feedback, Problem, Triage
 from datetime import datetime
 
 
+@main.route('/feedback', methods=['GET'])
+def old_feedback():
+    return redirect(url_for('.support'))
+
+
 @main.route('/support', methods=['GET', 'POST'])
 def support():
     form = SupportType()

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -17,9 +17,18 @@ def no_redirect():
     return lambda _external=True: None
 
 
-def test_get_support_index_page(client):
-    resp = client.get(url_for('main.support'))
-    assert resp.status_code == 200
+@pytest.mark.parametrize('endpoint', [
+    'main.old_feedback',
+    'main.support',
+])
+def test_get_support_index_page(
+    client,
+    endpoint,
+):
+    response = client.get(url_for('main.support'), follow_redirects=True)
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Support'
 
 
 @freeze_time('2016-12-12 12:00:00.000000')


### PR DESCRIPTION
Cool URIs don’t change 😎

https://www.w3.org/Provider/Style/URI

We still have links to `/feedback` in our emails. These will live in people’s inboxes forever.