### PR TITLE
Add settings page for inbound SMS

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -303,6 +303,15 @@ def service_set_international_sms(service_id):
     )
 
 
+@main.route("/services/<service_id>/service-settings/set-inbound-sms", methods=['GET'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_inbound_sms(service_id):
+    return render_template(
+        'views/service-settings/set-inbound-sms.html',
+    )
+
+
 @main.route("/services/<service_id>/service-settings/set-letters", methods=['GET'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -105,10 +105,8 @@
   {% endcall %}
 {%- endmacro %}
 
-{% macro boolean_field(yes) -%}
-  {% call field(status='yes' if yes else 'no') %}
-    {{ "Yes" if yes else "No" }}
-  {% endcall %}
+{% macro boolean_field(value) -%}
+  {{ text_field('On' if value else 'Off') }}
 {%- endmacro %}
 
 {% macro right_aligned_field_heading(text) %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, row, field, boolean_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, row, field, hidden_field_heading %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/tick-cross.html" import tick_cross %}
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -52,6 +52,12 @@
         {% endcall %}
 
         {% call row() %}
+          {{ text_field('Receive text messages') }}
+          {{ text_field('On' if 'inbound_sms' in current_service.permissions else 'Off') }}
+          {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
+        {% endcall %}
+
+        {% call row() %}
           {{ text_field('Letters') }}
           {{ text_field('On' if current_service.can_send_letters else 'Off') }}
           {{ edit_field('Change', url_for('.service_set_letters', service_id=current_service.id)) }}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/browse-list.html" import browse_list %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field, boolean_field %}
 
 {% block service_page_title %}
   Settings
@@ -47,19 +47,19 @@
 
         {% call row() %}
           {{ text_field('International text messages') }}
-          {{ text_field('On' if current_service.can_send_international_sms else 'Off') }}
+          {{ boolean_field(current_service.can_send_international_sms) }}
           {{ edit_field('Change', url_for('.service_set_international_sms', service_id=current_service.id)) }}
         {% endcall %}
 
         {% call row() %}
           {{ text_field('Receive text messages') }}
-          {{ text_field('On' if 'inbound_sms' in current_service.permissions else 'Off') }}
+          {{ boolean_field('inbound_sms' in current_service.permissions) }}
           {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
         {% endcall %}
 
         {% call row() %}
           {{ text_field('Letters') }}
-          {{ text_field('On' if current_service.can_send_letters else 'Off') }}
+          {{ boolean_field(current_service.can_send_letters) }}
           {{ edit_field('Change', url_for('.service_set_letters', service_id=current_service.id)) }}
         {% endcall %}
 

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -1,0 +1,43 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Receive text messages
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">Receive text messages</h1>
+      {% if 'inbound_sms' in current_service.permissions %}
+        <p>
+          Your service can receive text messages sent to {{ current_service.sms_sender }}.
+        </p>
+        <p>
+          If you want to turn this feature off,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% else %}
+        <p>
+          Receiving text messages from your users is an
+          invitation&#8209;only feature.
+        </p>
+        <p>
+          If you want to try it out,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+        <p>
+          We’ll set you up with a special phone number, and you’ll be able to see
+          the messages on your dashboard, or get them using the API.
+        </p>
+      {% endif %}
+      {{ page_footer(
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Text message sender
+  International text messages
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -21,6 +21,7 @@ from tests.conftest import active_user_with_permissions, platform_admin_user
         'Email reply to address None Change',
         'Text message sender GOVUK Change',
         'International text messages Off Change',
+        'Receive text messages Off Change',
         'Letters Off Change',
     ]),
     (platform_admin_user, [
@@ -29,6 +30,7 @@ from tests.conftest import active_user_with_permissions, platform_admin_user
         'Email reply to address None Change',
         'Text message sender GOVUK Change',
         'International text messages Off Change',
+        'Receive text messages Off Change',
         'Letters Off Change',
         'Label Value Action',
         'Email branding GOV.UK Change',
@@ -67,6 +69,8 @@ def test_should_show_overview_for_service_with_more_things_set(
     mock_get_letter_organisations,
 ):
     client.login(active_user_with_permissions, mocker, service_with_reply_to_addresses)
+    service_with_reply_to_addresses['permissions'] = ['inbound_sms']
+    service_with_reply_to_addresses['can_send_international_sms'] = True
     response = client.get(url_for(
         'main.service_settings', service_id=service_with_reply_to_addresses['id']
     ))
@@ -74,8 +78,9 @@ def test_should_show_overview_for_service_with_more_things_set(
     for index, row in enumerate([
         'Service name service one Change',
         'Email reply to address test@example.com Change',
-        'Text message sender elevenchars Change',
-        'International text messages Off Change',
+        'Text message sender elevenchars',
+        'International text messages On Change',
+        'Receive text messages On Change',
         'Letters Off Change',
     ]):
         assert row == " ".join(page.find_all('tr')[index + 1].text.split())
@@ -120,7 +125,7 @@ def test_letter_contact_block_shows_none_if_not_set(
     ))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    div = page.find_all('tr')[6].find_all('td')[1].div
+    div = page.find_all('tr')[7].find_all('td')[1].div
     assert div.text.strip() == 'None'
     assert 'default' in div.attrs['class'][0]
 
@@ -138,7 +143,7 @@ def test_escapes_letter_contact_block(
     ))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    div = str(page.find_all('tr')[6].find_all('td')[1].div)
+    div = str(page.find_all('tr')[7].find_all('td')[1].div)
     assert 'foo<br>bar' in div
     assert '<script>' not in div
 


### PR DESCRIPTION
Users might be interested in inbound SMS. And when it’s fully available, they’ll probably be able to control whether it’s on/off for their service.

Until they point, the only way of getting it is to ask us. So let’s make an in-the-meantime page that directs them to ask us, from the place where they’d be able to do it themselves.

![image](https://user-images.githubusercontent.com/355079/26880310-f00b01c0-4b8b-11e7-9595-25032f50c39a.png)

***

![image](https://user-images.githubusercontent.com/355079/26880332-029ab2ae-4b8c-11e7-95e2-f422d80db6c1.png)
