### PR TITLE
Stop putting phone numbers and email addresses in URLs

### DIFF
--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -19,10 +19,14 @@
 
   var clearQueue = queue => (queue.length = 0);
 
-  var poll = function(renderer, resource, queue, interval) {
+  var poll = function(renderer, resource, queue, interval, form) {
 
     if (queue.push(renderer) === 1) $.ajax(
-      resource
+      resource,
+      {
+        'method': form ? 'post' : 'get',
+        'data': form ? $('#' + form).serialize() : {}
+      }
     ).done(
       response => flushQueue(queue, response)
     ).fail(
@@ -41,7 +45,8 @@
       getRenderer($(component)),
       $(component).data('resource'),
       getQueue($(component).data('resource')),
-      ($(component).data('interval-seconds') || 1.5) * 1000
+      ($(component).data('interval-seconds') || 1.5) * 1000,
+      $(component).data('form')
     );
 
   };

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -190,7 +190,7 @@ def view_job_updates(service_id, job_id):
     ))
 
 
-@main.route('/services/<service_id>/notifications/<message_type>')
+@main.route('/services/<service_id>/notifications/<message_type>', methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('view_activity', admin_override=True)
 def view_notifications(service_id, message_type):
@@ -200,8 +200,8 @@ def view_notifications(service_id, message_type):
         message_type=message_type,
         status=request.args.get('status') or 'sending,delivered,failed',
         page=request.args.get('page', 1),
-        to=request.args.get('to'),
-        search_form=SearchNotificationsForm(to=request.args.get('to')),
+        to=request.form.get('to', ''),
+        search_form=SearchNotificationsForm(to=request.form.get('to', '')),
     )
 
 
@@ -245,7 +245,7 @@ def get_notifications(service_id, message_type, status_override=None):
         template_type=[message_type],
         status=filter_args.get('status'),
         limit_days=current_app.config['ACTIVITY_STATS_LIMIT_DAYS'],
-        to=request.args.get('to'),
+        to=request.form.get('to', ''),
     )
 
     url_args = {

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -205,7 +205,7 @@ def view_notifications(service_id, message_type):
     )
 
 
-@main.route('/services/<service_id>/notifications/<message_type>.json')
+@main.route('/services/<service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
 @user_has_permissions('view_activity', admin_override=True)
 def get_notifications_as_json(service_id, message_type):
     return jsonify(get_notifications(

--- a/app/templates/components/ajax-block.html
+++ b/app/templates/components/ajax-block.html
@@ -1,10 +1,11 @@
-{% macro ajax_block(partials, url, key, interval=2, finished=False) %}
+{% macro ajax_block(partials, url, key, interval=2, finished=False, form='') %}
   {% if not finished %}
     <div
       data-module="update-content"
       data-resource="{{ url }}"
       data-key="{{ key }}"
       data-interval-seconds="{{ interval }}"
+      data-form="{{ form }}"
       aria-live="polite"
     >
   {% endif %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -24,9 +24,9 @@
     method="post"
     action="{{ url_for('.view_notifications', service_id=current_service.id, message_type=message_type) }}"
     class="grid-row"
+    id="search-form"
   >
     <div class="column-three-quarters">
-      <input type="hidden" name="status" value="{{ status }}">
       {{ textbox(
         search_form.to,
         width='1-1',
@@ -41,8 +41,9 @@
 
   {{ ajax_block(
     partials,
-    url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page, to=to),
-    'notifications'
+    url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),
+    'notifications',
+    form='search-form'
   ) }}
 
 {% endblock %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -21,7 +21,7 @@
   ) }}
 
   <form
-    method="get"
+    method="post"
     action="{{ url_for('.view_notifications', service_id=current_service.id, message_type=message_type) }}"
     class="grid-row"
   >
@@ -34,6 +34,7 @@
       ) }}
     </div>
     <div class="column-one-quarter align-button-with-textbox">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="submit" class="button" value="Search">
     </div>
   </form>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -24,7 +24,6 @@
     method="post"
     action="{{ url_for('.view_notifications', service_id=current_service.id, message_type=message_type) }}"
     class="grid-row"
-    id="search-form"
   >
     <div class="column-three-quarters">
       {{ textbox(
@@ -34,9 +33,14 @@
       ) }}
     </div>
     <div class="column-one-quarter align-button-with-textbox">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="submit" class="button" value="Search">
     </div>
+  </form>
+
+  <form id="search-form" method="post">
+    <input type="hidden" name="to" value="{{ search_form.to.data }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   </form>
 
   {{ ajax_block(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -110,8 +110,7 @@ def test_can_show_notifications(
         assert query_dict['status'] == [status_argument]
     if expected_page_argument:
         assert query_dict['page'] == [str(expected_page_argument)]
-    if to_argument:
-        assert query_dict['to'] == [to_argument]
+    assert 'to' not in query_dict
 
     mock_get_notifications.assert_called_with(
         limit_days=7,
@@ -135,7 +134,6 @@ def test_can_show_notifications(
 @pytest.mark.parametrize((
     'initial_query_arguments,'
     'form_post_data,'
-    'expected_status_field_value,'
     'expected_search_box_contents'
 ), [
     (
@@ -143,7 +141,6 @@ def test_can_show_notifications(
             'message_type': 'sms',
         },
         {},
-        'sending,delivered,failed',
         '',
     ),
     (
@@ -153,7 +150,6 @@ def test_can_show_notifications(
         {
             'to': '+33(0)5-12-34-56-78',
         },
-        'sending,delivered,failed',
         '+33(0)5-12-34-56-78',
     ),
     (
@@ -165,7 +161,6 @@ def test_can_show_notifications(
         {
             'to': 'test@example.com',
         },
-        'failed',
         'test@example.com',
     ),
 ])
@@ -175,7 +170,6 @@ def test_search_recipient_form(
     mock_get_detailed_service,
     initial_query_arguments,
     form_post_data,
-    expected_status_field_value,
     expected_search_box_contents,
 ):
     response = logged_in_client.post(
@@ -199,7 +193,6 @@ def test_search_recipient_form(
     query_dict = parse_qs(url.query)
     assert query_dict == {}
 
-    assert page.find("input", {'name': 'status'})['value'] == expected_status_field_value
     assert page.find("input", {'name': 'to'})['value'] == expected_search_box_contents
 
 

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -193,7 +193,11 @@ def test_search_recipient_form(
     query_dict = parse_qs(url.query)
     assert query_dict == {}
 
-    assert page.find("input", {'name': 'to'})['value'] == expected_search_box_contents
+    recipient_inputs = page.select("input[name=to]")
+    assert(len(recipient_inputs) == 2)
+
+    for field in recipient_inputs:
+        assert field['value'] == expected_search_box_contents
 
 
 def test_should_show_notifications_for_a_service_with_next_previous(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -70,14 +70,27 @@ def test_can_show_notifications(
     to_argument,
     expected_to_argument,
 ):
-    response = logged_in_client.get(url_for(
-        'main.view_notifications',
-        service_id=service_one['id'],
-        message_type=message_type,
-        status=status_argument,
-        page=page_argument,
-        to=to_argument,
-    ))
+    if expected_to_argument:
+        response = logged_in_client.post(
+            url_for(
+                'main.view_notifications',
+                service_id=service_one['id'],
+                message_type=message_type,
+                status=status_argument,
+                page=page_argument,
+            ),
+            data={
+                'to': to_argument
+            }
+        )
+    else:
+        response = logged_in_client.get(url_for(
+            'main.view_notifications',
+            service_id=service_one['id'],
+            message_type=message_type,
+            status=status_argument,
+            page=page_argument,
+        ))
     assert response.status_code == 200
     content = response.get_data(as_text=True)
     notifications = notification_json(service_one['id'])
@@ -119,17 +132,25 @@ def test_can_show_notifications(
     assert json_content.keys() == {'counts', 'notifications'}
 
 
-@pytest.mark.parametrize("initial_query_arguments, expected_status_field_value, expected_search_box_contents", [
+@pytest.mark.parametrize((
+    'initial_query_arguments,'
+    'form_post_data,'
+    'expected_status_field_value,'
+    'expected_search_box_contents'
+), [
     (
         {
             'message_type': 'sms',
         },
+        {},
         'sending,delivered,failed',
         '',
     ),
     (
         {
             'message_type': 'sms',
+        },
+        {
             'to': '+33(0)5-12-34-56-78',
         },
         'sending,delivered,failed',
@@ -140,6 +161,8 @@ def test_can_show_notifications(
             'status': 'failed',
             'message_type': 'email',
             'page': '99',
+        },
+        {
             'to': 'test@example.com',
         },
         'failed',
@@ -151,17 +174,22 @@ def test_search_recipient_form(
     mock_get_notifications,
     mock_get_detailed_service,
     initial_query_arguments,
+    form_post_data,
     expected_status_field_value,
     expected_search_box_contents,
 ):
-    response = logged_in_client.get(url_for(
-        'main.view_notifications',
-        service_id=SERVICE_ONE_ID,
-        **initial_query_arguments
-    ))
+    response = logged_in_client.post(
+        url_for(
+            'main.view_notifications',
+            service_id=SERVICE_ONE_ID,
+            **initial_query_arguments
+        ),
+        data=form_post_data
+    )
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
+    assert page.find("form")['method'] == 'post'
     action_url = page.find("form")['action']
     url = urlparse(action_url)
     assert url.path == '/services/{}/notifications/{}'.format(


### PR DESCRIPTION
# Problem

Phone numbers and email addresses are showing up in URLs where we let users search for sent notifications by phone number or email address.

# It’s happening because we’re using `GET` requests

`GET` requests put the form data as a query string in the URL. This is problematic when people are searching by a recipient’s phone number or email address, because the URL may show up:
- in our server logs
- in our analytics
- in the user’s browser history

This is bad because these are all places where we don’t want people’s personal information. It’s not too bad when this is happening a handful of times. But it would be bad if we kept aggregating this information because it would allow us to track users across services.

# We can stop it happening by changing to using `POST` requests

While it’s not especially RESTful, it’s better for the search form to submit as a `POST` request. This way the phone number or email address goes in the body of the request and does not show up in the URL.

# It also means changing our AJAX code to support both `GET` and `POST`

Currently our AJAX requests only work as `GET` requests. So this commit does a bit of work to make them work as `POST` requests.

This is optional behaviour, and will only happen when the element in the page that should be updated with AJAX has the `data-form` attribute set. It will take the form that has the corresponding `id`, serialise it, and use that data as the body of the post request. If `data-form` is not specified it will not do the serialisation, and submit as a `GET` request as before.

# Encryption is not an option here

Encrypting the phone number before putting it in the URL is not a good solution because:
- it would be reliant on doing the encryption client-side, which means the key needs to be in the page on the client side (asymmetric encryption would partially solve this)
- but it would still be reliant on doing the encryption in Javascript before submitting the form, so either the form would have to only work with Javascript (bad) or still leak people’s information into the URL if Javascript failed (also bad)
- we’d also have to reimplement the encryption as part of doing our AJAX requests, which would be result in some very messy code