### PR TITLE
Ease fixed-position elements into place

### DIFF
--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -5,8 +5,12 @@
 
   overflow: hidden;
   margin-left: -$gutter-half;
-  margin-top: -10px;
+  margin-top: 5px;
+  margin-bottom: 5px;
   padding: 10px 0 0 $gutter-half;
+  position: relative;
+  top: -10px;
+  transition: top 0.1s ease-out, box-shadow 1s ease-in-out;
 
   .form-group {
     margin-bottom: 20px;
@@ -23,6 +27,7 @@
   padding-right: $gutter-half;
   border-bottom: 1px solid $border-colour;
   box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
+  transition: background 0.6s ease-in-out, top 0.4s ease-out, margin-top 0.4s ease-out;
 }
 
 .shim {


### PR DESCRIPTION
The transition between something being static in the page and fixed to the top of the viewport is a bit jarring.

This commit adds a bit of animation so that, as elements become fixed, they appear to catch up with the scrolling of the page.

Doesn’t GIF very well, but:

# Before

![scroll-without-ease](https://user-images.githubusercontent.com/355079/27174654-c5a60b1c-51b4-11e7-9767-5a285a012b1a.gif)


# After

![scroll-with-ease](https://user-images.githubusercontent.com/355079/27174662-cb5eb310-51b4-11e7-9983-3f7dd5551fe2.gif)
