### PR TITLE
Disable autofill on one-off messages

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -14,7 +14,7 @@
     {{ page_title }}
   </h1>
 
-  <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus">
+  <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus" autocomplete="off">
     <div class="grid-row">
       <div class="column-two-thirds">
         {{ textbox(


### PR DESCRIPTION
Not good to be storing people’s phone numbers in browser autocomplete.

And increases the chance of accidentally sending the wrong thing to the wrong person.