### PR TITLE
Update requirements to get latest utils for address validation

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -333,6 +333,7 @@ def send_test_preview(service_id, template_id, filetype):
 
 
 def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
+
     if not session.get('upload_data'):
         # if we just return a `redirect` (302) object here, we'll get errors when we try and unpack in the
         # check_messages route - so raise a werkzeug.routing redirect to ensure that doesn't happen.

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -112,17 +112,9 @@ def send_messages(service_id, template_id):
     form = CsvUploadForm()
     if form.validate_on_submit():
         try:
-            file_data = Spreadsheet.from_file(form.file.data, filename=form.file.data.filename).as_dict
-            if template.template_type == 'letter':
-                def is_ascii(s):
-                    return all(ord(c) < 128 for c in s)
-
-                if is_ascii(str(file_data)) is False:
-                    raise ValueError("Invalid characters in {}".format(form.file.data.filename))
-
             upload_id = s3upload(
                 service_id,
-                file_data,
+                Spreadsheet.from_file(form.file.data, filename=form.file.data.filename).as_dict,
                 current_app.config['AWS_REGION']
             )
             session['upload_data'] = {
@@ -135,10 +127,6 @@ def send_messages(service_id, template_id):
                                     template_type=template.template_type))
         except (UnicodeDecodeError, BadZipFile, XLRDError):
             flash('Couldn’t read {}. Try using a different file format.'.format(
-                form.file.data.filename
-            ))
-        except ValueError:
-            flash('Invalid characters in the address fields within {}.'.format(
                 form.file.data.filename
             ))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@17.3.1#egg=notifications-utils==17.3.1
+git+https://github.com/alphagov/notifications-utils.git@17.3.2#egg=notifications-utils==17.3.2

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1544,7 +1544,7 @@ def test_non_ascii_characters_in_letter_recipients_file_shows_error(
     mock_recipients.as_dict = {
             'file_name': 'invalid_characters.csv', 'data':
             'address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode\r\n'
-            'Fran\u00e7oise Fr\u00e9d\u00e9rich,345 Example Street,,,,,ZM4 6HQ'
+            '\u041F\u0435\u0442\u044F,345 Example Street,,,,,ZM4 6HQ'
         }
 
     response = logged_in_client.post(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1529,7 +1529,7 @@ def test_check_messages_shows_over_max_row_error(
     )
 
 
-def test_special_characters_in_letter_recipients_file_shows_error(
+def test_non_ascii_characters_in_letter_recipients_file_shows_error(
     logged_in_client,
     mock_get_users_by_service,
     mock_get_service,
@@ -1544,7 +1544,7 @@ def test_special_characters_in_letter_recipients_file_shows_error(
     mock_recipients.as_dict = {
             'file_name': 'invalid_characters.csv', 'data':
             'address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode\r\n'
-            'B. √Name,345 Example Street,,,,,ZM4 6HQ©'
+            'Fran\u00e7oise Fr\u00e9d\u00e9rich,345 Example Street,,,,,ZM4 6HQ'
         }
 
     response = logged_in_client.post(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import uuid
 from io import BytesIO
 from os import path
@@ -1546,7 +1547,7 @@ def test_non_ascii_characters_in_letter_recipients_file_shows_error(
         mocker,
         content=u"""
         address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode
-        \u041F\u0435\u0442\u044F,345 Example Street,,,,,AA1 6BB
+        Петя,345 Example Street,,,,,AA1 6BB
         """
     )
 
@@ -1568,10 +1569,7 @@ def test_non_ascii_characters_in_letter_recipients_file_shows_error(
             'You need to fix 1 address '
             'Skip to file contents'
         )
-    assert page.select_one(
-        '#content > div.grid-row > main > table > tbody > '
-        'tr:nth-of-type(1) > td:nth-of-type(2) > div > span > span'
-        ).get_text(strip=True) == u'Can\u2019t include \u041F, \u0435, \u0442 or \u044F'
+    assert page.find('span', class_='table-field-error-label').text == u'Can’t include П, е, т or я'
 
 
 def test_check_messages_redirects_if_no_upload_data(logged_in_client, service_one, mocker):

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1568,6 +1568,10 @@ def test_non_ascii_characters_in_letter_recipients_file_shows_error(
             'You need to fix 1 address '
             'Skip to file contents'
         )
+    assert page.select_one(
+        '#content > div.grid-row > main > table > tbody > '
+        'tr:nth-of-type(1) > td:nth-of-type(2) > div > span > span'
+        ).get_text(strip=True) == u'Can\u2019t include \u041F, \u0435, \u0442 or \u044F'
 
 
 def test_check_messages_redirects_if_no_upload_data(logged_in_client, service_one, mocker):

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1529,6 +1529,36 @@ def test_check_messages_shows_over_max_row_error(
     )
 
 
+def test_special_characters_in_dvla_recipients_file_shows_error(
+    logged_in_client,
+    mock_get_users_by_service,
+    mock_get_service,
+    mock_get_service_letter_template,
+    mock_get_detailed_service_for_today,
+    fake_uuid,
+    mocker
+):
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=1)
+
+    mock_recipients = mocker.patch('app.utils.Spreadsheet.from_file').return_value
+    mock_recipients.as_dict = {
+            'file_name': 'invalid_characters.csv', 'data':
+            'address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode\r\n'\
+            'B. √Name,345 Example Street,,,,,ZM4 6HQ©'
+        }
+
+    response = logged_in_client.post(
+        url_for('main.send_messages', service_id=SERVICE_ONE_ID, template_id=fake_uuid),
+        data={'file': (None, 'invalid_characters.csv')},
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert ' '.join(
+        page.find('div', class_='banner-dangerous').text.split()
+    ) == 'Invalid characters in the address fields within invalid_characters.csv.'
+
+
 def test_check_messages_redirects_if_no_upload_data(logged_in_client, service_one, mocker):
     checker = mocker.patch('app.main.views.send.get_check_messages_back_url', return_value='foo')
     response = logged_in_client.get(url_for(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1529,7 +1529,7 @@ def test_check_messages_shows_over_max_row_error(
     )
 
 
-def test_special_characters_in_dvla_recipients_file_shows_error(
+def test_special_characters_in_letter_recipients_file_shows_error(
     logged_in_client,
     mock_get_users_by_service,
     mock_get_service,
@@ -1543,20 +1543,25 @@ def test_special_characters_in_dvla_recipients_file_shows_error(
     mock_recipients = mocker.patch('app.utils.Spreadsheet.from_file').return_value
     mock_recipients.as_dict = {
             'file_name': 'invalid_characters.csv', 'data':
-            'address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode\r\n'\
+            'address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode\r\n'
             'B. √Name,345 Example Street,,,,,ZM4 6HQ©'
         }
 
     response = logged_in_client.post(
         url_for('main.send_messages', service_id=SERVICE_ONE_ID, template_id=fake_uuid),
         data={'file': (None, 'invalid_characters.csv')},
+        follow_redirects=True
     )
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert ' '.join(
         page.find('div', class_='banner-dangerous').text.split()
-    ) == 'Invalid characters in the address fields within invalid_characters.csv.'
+    ) == (
+            'There is a problem with your data '
+            'You need to fix 1 address '
+            'Skip to file contents'
+        )
 
 
 def test_check_messages_redirects_if_no_upload_data(logged_in_client, service_one, mocker):

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1549,7 +1549,7 @@ def test_non_ascii_characters_in_letter_recipients_file_shows_error(
 
     response = logged_in_client.post(
         url_for('main.send_messages', service_id=SERVICE_ONE_ID, template_id=fake_uuid),
-        data={'file': (None, 'invalid_characters.csv')},
+        data={'file': (BytesIO(''.encode('utf-8')), 'invalid_characters.csv')},
         follow_redirects=True
     )
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1531,13 +1531,24 @@ def test_check_messages_shows_over_max_row_error(
 
 def test_non_ascii_characters_in_letter_recipients_file_shows_error(
     logged_in_client,
+    api_user_active,
+    mock_login,
     mock_get_users_by_service,
     mock_get_service,
+    mock_has_permissions,
     mock_get_service_letter_template,
     mock_get_detailed_service_for_today,
     fake_uuid,
     mocker
 ):
+    from tests.conftest import mock_s3_download
+    mock_s3_download(
+        mocker,
+        content=u"""
+        address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode
+        \u041F\u0435\u0442\u044F,345 Example Street,,,,,AA1 6BB
+        """
+    )
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=1)
 
     mock_recipients = mocker.patch('app.utils.Spreadsheet.from_file').return_value

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1544,7 +1544,7 @@ def test_non_ascii_characters_in_letter_recipients_file_shows_error(
     mock_recipients.as_dict = {
             'file_name': 'invalid_characters.csv', 'data':
             'address line 1,address line 2,address line 3,address line 4,address line 5,address line 6,postcode\r\n'
-            '\u041F\u0435\u0442\u044F,345 Example Street,,,,,ZM4 6HQ'
+            '\u041F\u0435\u0442\u044F,345 Example Street,,,,,AA1 6BB'
         }
 
     response = logged_in_client.post(


### PR DESCRIPTION
Updated requirements to get latest utils for improved address validation to accept ascii only characters and added a test to ensure that an error message is displayed when an invalid address is uploaded.