### PR TITLE
Make click areas bigger on choose template page

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -3,6 +3,19 @@
   &-name {
     @include bold-24;
     margin: 20px 0 5px 0;
+
+    a {
+      display: block;
+      margin-bottom: -$gutter;
+      padding-bottom: $gutter;
+    }
+
+  }
+
+  &-type {
+    color: $secondary-text-colour;
+    margin-bottom: $gutter / 3;
+    pointer-events: none;
   }
 
   &-updated-at {

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -18,30 +18,4 @@
     pointer-events: none;
   }
 
-  &-updated-at {
-    @include copy-16;
-    color: $secondary-text-colour;
-    margin: 0 0 5px 0;
-  }
-
-  &-use-links {
-
-    @include copy-16;
-    margin-top: -7px;
-    color: $secondary-text-colour;
-
-    a {
-      @include core-19;
-      display: block;
-      margin-bottom: 5px;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
-
-    }
-
-  }
-
 }

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -64,7 +64,7 @@
           <h2 class="message-name">
             <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
           </h2>
-          <p class="hint bottom-gutter-1-3">
+          <p class="message-type">
             {{ message_count_label(1, template.template_type, suffix='')|capitalize }} template
           </p>
         </div>


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/355079/27325399-373dd324-55a0-11e7-9b72-153a13b43549.png)

# The change

Generally, [bigger click areas are better](https://en.wikipedia.org/wiki/Fitts%27s_law), as long as they don’t cause ambiguity.

This commit expands the clickable area of links to templates to include hint text underneath which states the type of template.

# After

![image](https://user-images.githubusercontent.com/355079/27325384-29b41baa-55a0-11e7-9b4b-fa093404d4dc.png)
