### PR TITLE
Create inbound api

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -657,9 +657,9 @@ class ServiceInboundApiForm(Form):
                                   Regexp(regex="^https.*",
                                          message='Must be a valid https url')]
                       )
-    bearer_token = StringField("Bearer token",
-                               validators=[DataRequired(message='Can’t be empty'),
-                                           Length(min=5, message='Must be at least 10 characters')])
+    bearer_token = PasswordField("Bearer token",
+                                 validators=[DataRequired(message='Can’t be empty'),
+                                             Length(min=10, message='Must be at least 10 characters')])
 
 
 def get_placeholder_form_instance(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -9,6 +9,7 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.columns import Columns
 from wtforms import (
+    widgets,
     validators,
     StringField,
     PasswordField,
@@ -651,15 +652,19 @@ class PlaceholderForm(Form):
     pass
 
 
+class PasswordFieldShowHasContent(StringField):
+    widget = widgets.PasswordInput(hide_value=False)
+
+
 class ServiceInboundApiForm(Form):
     url = StringField("Inbound sms url",
                       validators=[DataRequired(message='Can’t be empty'),
                                   Regexp(regex="^https.*",
                                          message='Must be a valid https url')]
                       )
-    bearer_token = PasswordField("Bearer token",
-                                 validators=[DataRequired(message='Can’t be empty'),
-                                             Length(min=10, message='Must be at least 10 characters')])
+    bearer_token = PasswordFieldShowHasContent("Bearer token",
+                                               validators=[DataRequired(message='Can’t be empty'),
+                                                           Length(min=10, message='Must be at least 10 characters')])
 
 
 def get_placeholder_form_instance(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -651,6 +651,17 @@ class PlaceholderForm(Form):
     pass
 
 
+class ServiceInboundApiForm(Form):
+    url = StringField("Inbound sms url",
+                      validators=[DataRequired(message='Can’t be empty'),
+                                  Regexp(regex="^https.*",
+                                         message='Must be a valid https url')]
+                      )
+    bearer_token = StringField("Bearer token",
+                               validators=[DataRequired(message='Can’t be empty'),
+                                           Length(min=5, message='Must be at least 10 characters')])
+
+
 def get_placeholder_form_instance(
     placeholder_name,
     dict_to_populate_from,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -30,7 +30,7 @@ from app.main.forms import (
     ServiceLetterContactBlock,
     ServiceBrandingOrg,
     LetterBranding,
-)
+    ServiceInboundApiForm)
 from app import user_api_client, current_service, organisations_client
 
 
@@ -38,6 +38,7 @@ from app import user_api_client, current_service, organisations_client
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
 def service_settings(service_id):
+    print(current_service)
     letter_branding_organisations = organisations_client.get_letter_organisations()
     if current_service['organisation']:
         organisation = organisations_client.get_organisation(current_service['organisation'])['organisation']
@@ -410,3 +411,24 @@ def get_branding_as_dict(organisations):
             'colour': organisation['colour']
         } for organisation in organisations
     }
+
+
+@main.route("/services/<service_id>/service-settings/set-inbound-api", methods=['GET', 'POST'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_inbound_api(service_id):
+    form = ServiceInboundApiForm()
+
+    if form.validate_on_submit():
+        service_api_client.update_service_inbound_api(
+            service_id,
+            url=form.url.data,
+            bearer_token=form.bearer_token.data,
+            user_id=current_user.id
+        )
+        return redirect(url_for('.service_settings', service_id=service_id))
+
+    return render_template(
+        'views/service-settings/set-inbound-api.html',
+        form=form,
+    )

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -449,13 +449,21 @@ def service_set_inbound_api(service_id):
     form = ServiceInboundApiForm(url=inbound_api.get('url') if inbound_api else '')
 
     if form.validate_on_submit():
-        service_api_client.update_service_inbound_api(
-            service_id,
-            url=form.url.data,
-            bearer_token=form.bearer_token.data,
-            user_id=current_user.id,
-            inbound_api_id=inbound_api.get('id') if inbound_api else ''
-        )
+        if inbound_api:
+            service_api_client.update_service_inbound_api(
+                service_id,
+                url=form.url.data,
+                bearer_token=form.bearer_token.data,
+                user_id=current_user.id,
+                inbound_api_id=inbound_api.get('id') if inbound_api else ''
+            )
+        else:
+            service_api_client.create_service_inbound_api(
+                service_id,
+                url=form.url.data,
+                bearer_token=form.bearer_token.data,
+                user_id=current_user.id
+            )
         return redirect(url_for('.service_settings', service_id=service_id))
 
     return render_template(

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -38,7 +38,6 @@ from app import user_api_client, current_service, organisations_client
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
 def service_settings(service_id):
-    print(current_service)
     letter_branding_organisations = organisations_client.get_letter_organisations()
     if current_service['organisation']:
         organisation = organisations_client.get_organisation(current_service['organisation'])['organisation']

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -36,6 +36,9 @@ from app.main.forms import (
 from app import user_api_client, current_service, organisations_client
 
 
+dummy_bearer_token = 'bearer_token_set'
+
+
 def get_inbound_api():
     if current_service['inbound_api']:
         return service_api_client.get_service_inbound_api(
@@ -441,17 +444,21 @@ def service_set_inbound_api(service_id):
         abort(403)
 
     inbound_api = get_inbound_api()
-    form = ServiceInboundApiForm(url=inbound_api.get('url') if inbound_api else '')
+    form = ServiceInboundApiForm(
+        url=inbound_api.get('url') if inbound_api else '',
+        bearer_token=dummy_bearer_token if inbound_api else ''
+    )
 
     if form.validate_on_submit():
         if inbound_api:
-            service_api_client.update_service_inbound_api(
-                service_id,
-                url=form.url.data,
-                bearer_token=form.bearer_token.data,
-                user_id=current_user.id,
-                inbound_api_id=inbound_api.get('id')
-            )
+            if inbound_api.get('url') != form.url.data or form.bearer_token.data != dummy_bearer_token:
+                service_api_client.update_service_inbound_api(
+                    service_id,
+                    url=form.url.data,
+                    bearer_token=form.bearer_token.data if form.bearer_token.data != dummy_bearer_token else '',
+                    user_id=current_user.id,
+                    inbound_api_id=inbound_api.get('id')
+                )
         else:
             service_api_client.create_service_inbound_api(
                 service_id,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import requests
 from flask import (
     render_template,
@@ -34,6 +36,14 @@ from app.main.forms import (
 from app import user_api_client, current_service, organisations_client
 
 
+def get_inbound_api():
+    if current_service['inbound_api']:
+        return service_api_client.get_service_inbound_api(
+            current_service['id'],
+            current_service.get('inbound_api')[0]
+        )
+
+
 @main.route("/services/<service_id>/service-settings")
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
@@ -43,6 +53,15 @@ def service_settings(service_id):
         organisation = organisations_client.get_organisation(current_service['organisation'])['organisation']
     else:
         organisation = None
+
+    inbound_api = get_inbound_api()
+    if inbound_api:
+        parsed_url = urlparse(inbound_api.get('url')) if inbound_api else ''
+        inbound_api_url = '{uri.scheme}://{uri.netloc}{elide_token}'.format(
+            uri=parsed_url, elide_token='...' if parsed_url.path else '')
+    else:
+        inbound_api_url = ''
+
     return render_template(
         'views/service-settings.html',
         organisation=organisation,
@@ -50,6 +69,7 @@ def service_settings(service_id):
             current_service.get('dvla_organisation', '001')
         ),
         can_receive_inbound=('inbound_sms' in current_service['permissions']),
+        inbound_api_url=inbound_api_url,
         letter_contact_block=Field(current_service['letter_contact_block'], html='escape')
     )
 
@@ -268,19 +288,25 @@ def service_set_reply_to_email(service_id):
 @user_has_permissions('manage_settings', admin_override=True)
 def service_set_sms_sender(service_id):
     form = ServiceSmsSender()
+
+    def update_service(permissions, sms_sender):
+        service_api_client.update_service_with_properties(
+            current_service['id'],
+            {'permissions': permissions, 'sms_sender': sms_sender}
+        )
+
+    set_inbound_sms = request.args.get('set_inbound_sms')
+    if set_inbound_sms == 'True':
+        if 'inbound_sms' in current_service['permissions']:
+            current_service['permissions'].remove('inbound_sms')
+            update_service(current_service['permissions'], current_service['sms_sender'])
+            return redirect(url_for('.service_settings', service_id=service_id))
+
     if form.validate_on_submit():
-        set_inbound_sms = request.args.get('set_inbound_sms', False)
         if set_inbound_sms == 'True':
             permissions = current_service['permissions']
-            if 'inbound_sms' in permissions:
-                permissions.remove('inbound_sms')
-            else:
-                permissions.append('inbound_sms')
-            service_api_client.update_service_with_properties(
-                current_service['id'],
-                {'permissions': permissions,
-                 'sms_sender': form.sms_sender.data or None}
-            )
+            permissions.append('inbound_sms')
+            update_service(permissions, form.sms_sender.data)
         else:
             service_api_client.update_service(
                 current_service['id'],
@@ -416,14 +442,19 @@ def get_branding_as_dict(organisations):
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
 def service_set_inbound_api(service_id):
-    form = ServiceInboundApiForm()
+    if 'inbound_sms' not in current_service['permissions']:
+        abort(403)
+
+    inbound_api = get_inbound_api()
+    form = ServiceInboundApiForm(url=inbound_api.get('url') if inbound_api else '')
 
     if form.validate_on_submit():
         service_api_client.update_service_inbound_api(
             service_id,
             url=form.url.data,
             bearer_token=form.bearer_token.data,
-            user_id=current_user.id
+            user_id=current_user.id,
+            inbound_api_id=inbound_api.get('id') if inbound_api else ''
         )
         return redirect(url_for('.service_settings', service_id=service_id))
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -277,9 +277,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def update_service_inbound_api(self, service_id, url, bearer_token, user_id, inbound_api_id):
         data = {
             "url": url,
-            "bearer_token": bearer_token,
             "updated_by_id": user_id
         }
+        if bearer_token:
+            data['bearer_token'] = bearer_token
         return self.post("/service/{}/inbound-api/{}".format(service_id, inbound_api_id), data)
 
     def get_service_inbound_api(self, service_id, inbound_sms_api_id):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -266,13 +266,21 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             '/service/{}/inbound-sms/summary'.format(service_id)
         )
 
-    def update_service_inbound_api(self, service_id, url, bearer_token, user_id):
+    def update_service_inbound_api(self, service_id, url, bearer_token, user_id, inbound_api_id):
         data = {
-            "url":url,
+            "url": url,
             "bearer_token": bearer_token,
             "updated_by_id": user_id
         }
-        return self.post("/service/{}/inbound-api".format(service_id), data)
+        update_inbound_api_path = '/{}'.format(inbound_api_id) if inbound_api_id else ''
+        return self.post("/service/{}/inbound-api{}".format(service_id, update_inbound_api_path), data)
+
+    def get_service_inbound_api(self, service_id, inbound_sms_api_id):
+        return self.get(
+            "/service/{}/inbound-api/{}".format(
+                service_id, inbound_sms_api_id
+            )
+        )['data']
 
 
 class ServicesBrowsableItem(BrowsableItem):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -266,14 +266,21 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             '/service/{}/inbound-sms/summary'.format(service_id)
         )
 
+    def create_service_inbound_api(self, service_id, url, bearer_token, user_id):
+        data = {
+            "url": url,
+            "bearer_token": bearer_token,
+            "updated_by_id": user_id
+        }
+        return self.post("/service/{}/inbound-api".format(service_id), data)
+
     def update_service_inbound_api(self, service_id, url, bearer_token, user_id, inbound_api_id):
         data = {
             "url": url,
             "bearer_token": bearer_token,
             "updated_by_id": user_id
         }
-        update_inbound_api_path = '/{}'.format(inbound_api_id) if inbound_api_id else ''
-        return self.post("/service/{}/inbound-api{}".format(service_id, update_inbound_api_path), data)
+        return self.post("/service/{}/inbound-api/{}".format(service_id, inbound_api_id), data)
 
     def get_service_inbound_api(self, service_id, inbound_sms_api_id):
         return self.get(

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -266,6 +266,14 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             '/service/{}/inbound-sms/summary'.format(service_id)
         )
 
+    def update_service_inbound_api(self, service_id, url, bearer_token, user_id):
+        data = {
+            "url":url,
+            "bearer_token": bearer_token,
+            "updated_by_id": user_id
+        }
+        return self.post("/service/{}/inbound-api".format(service_id), data)
+
 
 class ServicesBrowsableItem(BrowsableItem):
     @property

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -72,6 +72,13 @@
             {{ edit_field('Change', url_for('.service_set_letter_contact_block', service_id=current_service.id)) }}
           {% endcall %}
         {% endif %}
+
+        {% call row() %}
+          {{ text_field('Inbound API') }}
+             {{ boolean_field(current_service.can_send_letters) }}
+            {{ edit_field('Change', url_for('.service_set_inbound_api', service_id=current_service.id)) }}
+          {% endcall %}
+
       {% endcall %}
     </div>
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -57,6 +57,17 @@
           {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
         {% endcall %}
 
+        {% if 'inbound_sms' in current_service.permissions %}
+          {% call row() %}
+            {{ text_field('API endpoint for received text messages') }}
+            {{ text_field(
+              'None' if not inbound_api_url else inbound_api_url,
+              status='' if inbound_api_url else 'default'
+            ) }}
+            {{ edit_field('Change', url_for('.service_set_inbound_api', service_id=current_service.id)) }}
+          {% endcall %}
+        {% endif %}
+
         {% call row() %}
           {{ text_field('Letters') }}
           {{ boolean_field(current_service.can_send_letters) }}
@@ -72,12 +83,6 @@
             {{ edit_field('Change', url_for('.service_set_letter_contact_block', service_id=current_service.id)) }}
           {% endcall %}
         {% endif %}
-
-        {% call row() %}
-          {{ text_field('Inbound API') }}
-             {{ boolean_field(current_service.can_send_letters) }}
-            {{ edit_field('Change', url_for('.service_set_inbound_api', service_id=current_service.id)) }}
-          {% endcall %}
 
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -57,7 +57,7 @@
           {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
         {% endcall %}
 
-        {% if 'inbound_sms' in current_service.permissions %}
+        {% if can_receive_inbound %}
           {% call row() %}
             {{ text_field('API endpoint for received text messages') }}
             {{ text_field(

--- a/app/templates/views/service-settings/set-inbound-api.html
+++ b/app/templates/views/service-settings/set-inbound-api.html
@@ -1,0 +1,35 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Inbound api
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">Inbound API</h1>
+  <p>
+    This is the https url that the inbound SMS messages will be posted to
+      and the bearer token used in the authorisation header of the request.
+  </p>
+
+  <form method="post">
+    {{ textbox(
+      form.url,
+      width='1-4',
+      hint='Valid https url'
+    ) }}
+    {{ textbox(
+      form.bearer_token,
+      width='1-4',
+      hint='At least 10 characters'
+    ) }}
+      {{ page_footer(
+      'Save',
+      back_link=url_for('.service_settings', service_id=current_service.id),
+      back_link_text='Back to settings'
+  ) }}
+  </form>
+
+{% endblock %}

--- a/app/templates/views/service-settings/set-inbound-api.html
+++ b/app/templates/views/service-settings/set-inbound-api.html
@@ -7,29 +7,32 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">API endpoint for received text messages</h1>
+      <p>
+        This is the https url that the inbound SMS messages will be posted to
+          and the bearer token used in the authorisation header of the request.
+      </p>
 
-  <h1 class="heading-large">Inbound API</h1>
-  <p>
-    This is the https url that the inbound SMS messages will be posted to
-      and the bearer token used in the authorisation header of the request.
-  </p>
-
-  <form method="post">
-    {{ textbox(
-      form.url,
-      width='1-4',
-      hint='Valid https url'
-    ) }}
-    {{ textbox(
-      form.bearer_token,
-      width='1-4',
-      hint='At least 10 characters'
-    ) }}
-      {{ page_footer(
-      'Save',
-      back_link=url_for('.service_settings', service_id=current_service.id),
-      back_link_text='Back to settings'
-  ) }}
-  </form>
+      <form method="post">
+        {{ textbox(
+          form.url,
+          width='2-3',
+          hint='Valid https url'
+        ) }}
+        {{ textbox(
+          form.bearer_token,
+          width='1-4',
+          hint='At least 10 characters'
+        ) }}
+          {{ page_footer(
+          'Save',
+          back_link=url_for('.service_settings', service_id=current_service.id),
+          back_link_text='Back to settings'
+      ) }}
+      </form>
+    </div>
+  </div>
 
 {% endblock %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,11 +56,14 @@ def service_json(
     created_at=None,
     letter_contact_block=None,
     permissions=None,
+    inbound_api=None,
 ):
     if users is None:
         users = []
     if permissions is None:
         permissions = []
+    if inbound_api is None:
+        inbound_api = []
     return {
         'id': id_,
         'name': name,
@@ -80,6 +83,7 @@ def service_json(
         'letter_contact_block': letter_contact_block,
         'dvla_organisation': '001',
         'permissions': permissions,
+        'inbound_api': inbound_api,
     }
 
 


### PR DESCRIPTION
## What 

Added service settings to manage inbound api which are shown when `inbound sms` permissions are on.

## How to review

Execute `pytest tests/app/main/views/test_service_settings.py`

Also you can manually check it by logging into admin and navigating to the service settings under a platform admin log in to ensure that -

- the API endpoint is shown when inbound sms are allowed and hidden when not allowed. 
- check that you can set the API endpoint, and can also see updates to it.
- check that only the domain is shown on the service settings screen and not the full url.
- check that you can update url / bearer token or both
