### PR TITLE
Add a page for each notification and start linking to it

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -66,6 +66,7 @@ $path: '/static/images/';
 @import 'views/api';
 @import 'views/product-page';
 @import 'views/template';
+@import 'views/notification';
 
 // TODO: break this up
 @import 'app';

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -96,5 +96,6 @@
 }
 
 .align-with-message-body {
+  display: block;
   margin-top: $gutter * 5 / 6;
 }

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -46,17 +46,6 @@
     transition: width 0.6s ease-in-out;
   }
 
-  &-label {
-    @include bold-19;
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: $govuk-blue;
-    max-width: 100%;
-    background: $white;
-  }
-
 }
 
 .file-list {
@@ -67,12 +56,17 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    padding-bottom: 30px;
+    padding-top: 10px;
+    margin-bottom: -30px;
+    margin-top: -10px;
   }
 
   &-hint {
     @include core-16;
     display: block;
     color: $secondary-text-colour;
+    pointer-events: none;
   }
 
 }

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -1,0 +1,18 @@
+.notification-status {
+
+  @include core-16;
+  color: $secondary-text-colour;
+  margin-top: -$gutter-half;
+
+  &.error {
+
+    color: $error-colour;
+    font-weight: bold;
+
+    a {
+      color: $error-colour;
+    }
+
+  }
+
+}

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -114,21 +114,7 @@ def view_job(service_id, job_id):
         'views/jobs/job.html',
         finished=(total_notifications == processed_notifications),
         uploaded_file_name=job['original_file_name'],
-        template=get_template(
-            service_api_client.get_service_template(
-                service_id=service_id,
-                template_id=job['template'],
-                version=job['template_version']
-            )['data'],
-            current_service,
-            letter_preview_url=url_for(
-                '.view_template_version_preview',
-                service_id=service_id,
-                template_id=job['template'],
-                version=job['template_version'],
-                filetype='png',
-            ),
-        ),
+        template_id=job['template'],
         status=request.args.get('status', ''),
         updates_url=url_for(
             ".view_job_updates",

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -350,6 +350,11 @@ def get_job_partials(job):
     notifications = notification_api_client.get_notifications_for_service(
         job['service'], job['id'], status=filter_args['status']
     )
+    template = service_api_client.get_service_template(
+        service_id=current_service['id'],
+        template_id=job['template'],
+        version=job['template_version']
+    )['data']
     return {
         'counts': render_template(
             'partials/count.html',
@@ -369,7 +374,9 @@ def get_job_partials(job):
             ),
             help=get_help_argument(),
             time_left=get_time_left(job['created_at']),
-            job=job
+            job=job,
+            template=template,
+            template_version=job['template_version'],
         ),
         'status': render_template(
             'partials/jobs/status.html',

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -39,7 +39,7 @@ def get_status_arg(filter_args):
         return REQUESTED_STATUSES
 
 
-@main.route("/services/<service_id>/one-off-notification/<notification_id>")
+@main.route("/services/<service_id>/notification/<notification_id>")
 @login_required
 @user_has_permissions('view_activity', admin_override=True)
 def view_notification(service_id, notification_id):
@@ -72,7 +72,7 @@ def view_notification(service_id, notification_id):
     )
 
 
-@main.route("/services/<service_id>/one-off-notification/<notification_id>.json")
+@main.route("/services/<service_id>/notification/<notification_id>.json")
 @user_has_permissions('view_activity', admin_override=True)
 def view_notification_updates(service_id, notification_id):
     return jsonify(**get_single_notification_partials(

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -59,7 +59,6 @@ def view_notification(service_id, notification_id):
                 filetype='png',
             ),
         ),
-        status=request.args.get('status'),
         updates_url=url_for(
             ".view_notification_updates",
             service_id=service_id,
@@ -80,49 +79,10 @@ def view_notification_updates(service_id, notification_id):
     ))
 
 
-def _get_single_notification_counts(notification, help_argument):
-    return [
-        (
-            label,
-            query_param,
-            url_for(
-                ".view_notification",
-                service_id=notification['service'],
-                notification_id=notification['id'],
-                status=query_param,
-                help=help_argument
-            ),
-            count
-        ) for label, query_param, count in [
-            [
-                'total', '',
-                1
-            ],
-            [
-                'sending', 'sending',
-                int(notification['status'] in SENDING_STATUSES)
-            ],
-            [
-                'delivered', 'delivered',
-                int(notification['status'] in DELIVERED_STATUSES)
-            ],
-            [
-                'failed', 'failed',
-                int(notification['status'] in FAILURE_STATUSES)
-            ]
-        ]
-    ]
-
-
 def get_single_notification_partials(notification):
     status_args = get_status_arg(request.args)
 
     return {
-        'counts': render_template(
-            'partials/count.html',
-            counts=_get_single_notification_counts(notification, request.args.get('help', 0)),
-            status=status_args
-        ),
         'notifications': render_template(
             'partials/notifications/notifications.html',
             notification=notification,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -44,22 +44,24 @@ def get_status_arg(filter_args):
 @user_has_permissions('view_activity', admin_override=True)
 def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, notification_id)
+    template = get_template(
+        notification['template'],
+        current_service,
+        letter_preview_url=url_for(
+            '.view_template_version_preview',
+            service_id=service_id,
+            template_id=notification['template']['id'],
+            version=notification['template_version'],
+            filetype='png',
+        ),
+        show_recipient=True,
+    )
+    template.values = notification['personalisation']
     return render_template(
         'views/notifications/notification.html',
         finished=(notification['status'] in (DELIVERED_STATUSES + FAILURE_STATUSES)),
         uploaded_file_name='Report',
-        template=get_template(
-            notification['template'],
-            current_service,
-            letter_preview_url=url_for(
-                '.view_template_version_preview',
-                service_id=service_id,
-                template_id=notification['template']['id'],
-                version=notification['template_version'],
-                filetype='png',
-            ),
-            show_recipient=True,
-        ),
+        template=template,
         updates_url=url_for(
             ".view_notification_updates",
             service_id=service_id,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -10,6 +10,7 @@ from flask_login import login_required
 
 from app import (
     notification_api_client,
+    job_api_client,
     current_service
 )
 from app.main import main
@@ -57,11 +58,16 @@ def view_notification(service_id, notification_id):
         show_recipient=True,
     )
     template.values = notification['personalisation']
+    if notification['job']:
+        job = job_api_client.get_job(service_id, notification['job']['id'])['data']
+    else:
+        job = None
     return render_template(
         'views/notifications/notification.html',
         finished=(notification['status'] in (DELIVERED_STATUSES + FAILURE_STATUSES)),
         uploaded_file_name='Report',
         template=template,
+        job=job,
         updates_url=url_for(
             ".view_notification_updates",
             service_id=service_id,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -70,6 +70,8 @@ def view_notification(service_id, notification_id):
             help=get_help_argument()
         ),
         partials=get_single_notification_partials(notification),
+        created_by=notification.get('created_by'),
+        created_at=notification['created_at'],
         help=get_help_argument()
     )
 

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -58,6 +58,7 @@ def view_notification(service_id, notification_id):
                 version=notification['template_version'],
                 filetype='png',
             ),
+            show_recipient=True,
         ),
         updates_url=url_for(
             ".view_notification_updates",

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -120,6 +120,7 @@
 
 {% macro notification_status_field(notification) %}
   {% call field(status=notification.status|format_notification_status_as_field_status, align='right') %}
+    {% if notification.status in ['created', 'sending', 'delivered'] %}<span class="align-with-message-body">{% endif %}
     {% if notification.status|format_notification_status_as_url %}
       <a href="{{ notification.status|format_notification_status_as_url }}">
     {% endif %}
@@ -135,6 +136,7 @@
         (notification.updated_at or notification.created_at)|format_datetime_short
       ) }}
     </span>
+    {% if notification.status in ['created', 'sending', 'delivered'] %}</span>{% endif %}
   {% endcall %}
 {% endmacro %}
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -32,7 +32,7 @@
             Notify delivers the message
           </p>
           {% if help == '3' %}
-            <a href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
+            <a href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template_id) }}'>
               Now go to your dashboard
             </a>
           {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -48,7 +48,9 @@
         field_headings_visible=False
       ) %}
         {% call row_heading() %}
-          <p>{{ item.to }}</p>
+          <p>
+            <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
+          </p>
         {% endcall %}
         {{ notification_status_field(item) }}
       {% endcall %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -50,8 +50,8 @@
         field_headings_visible=False
       ) %}
         {% call row_heading() %}
-          <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
-          <p>
+          <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
+          <p class="file-list-hint">
             {{ item.preview_of_content }}
           </p>
         {% endcall %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -48,8 +48,9 @@
         field_headings_visible=False
       ) %}
         {% call row_heading() %}
+          <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
           <p>
-            <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
+            {{ item.preview_of_content }}
           </p>
         {% endcall %}
         {{ notification_status_field(item) }}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -5,7 +5,9 @@
   {% if job.job_status == 'scheduled' %}
 
     <p>
-      Sending will start {{ job.scheduled_for|format_datetime_relative }}
+      Sending
+      <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=template.id, version=template_version) }}">{{ template.name }}</a>
+      {{ job.scheduled_for|format_datetime_relative }}
     </p>
     <div class="page-footer">
       <form method="post">

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,5 +1,5 @@
 <div class="ajax-block-container">
-  <p class='heading-small bottom-gutter'>
+  <p class='bottom-gutter'>
     {% if job.scheduled_for %}
       {% if job.processing_started %}
         Sent by {{ job.created_by.name }} on {{ job.processing_started|format_datetime_short }}

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -1,6 +1,13 @@
 <div class="ajax-block-container">
-  <p class='heading-small bottom-gutter'>
-    Sent {% if notification.created_by %}by {{ notification.created_by.name }} {% endif %}
-    on {{ notification.created_at|format_datetime_short }}
+  <p class="notification-status {{ notification.status|format_notification_status_as_field_status }}">
+    {% if notification.status|format_notification_status_as_url %}
+      <a href="{{ notification.status|format_notification_status_as_url }}">
+    {% endif %}
+    {{ notification.status|format_notification_status(
+      notification.template.template_type
+    ) }}
+    {% if notification.status|format_notification_status_as_url %}
+      </a>
+    {% endif %}
   </p>
 </div>

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -20,16 +20,8 @@
         <p>
           <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
         </p>
-        <p class="hint">
-          {% if item.job and item.job.original_file_name == 'Report' %}
-            <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=item.template.id, version=item.template_version) }}">{{ item.template.name }}</a>
-            sent to one recipient
-          {% elif item.job %}
-            From <a href="{{ url_for(".view_job", service_id=current_service.id, job_id=item.job.id) }}">{{ item.job.original_file_name }}</a>
-          {% else %}
-            <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=item.template.id, version=item.template_version) }}">{{ item.template.name }}</a>
-            from an API call
-          {% endif %}
+        <p>
+          {{ item.preview_of_content }}
         </p>
       {% endcall %}
 

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -17,10 +17,8 @@
     ) %}
 
       {% call row_heading() %}
-        <p>
-          <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
-        </p>
-        <p>
+        <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
+        <p class="file-list-hint">
           {{ item.preview_of_content }}
         </p>
       {% endcall %}

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -18,7 +18,7 @@
 
       {% call row_heading() %}
         <p>
-          {{ item.to }}
+          <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
         </p>
         <p class="hint">
           {% if item.job and item.job.original_file_name == 'Report' %}

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -41,11 +41,9 @@
             field_headings_visible=False
           ) %}
             {% call row_heading() %}
-              <span class="spark-bar-label">
-                <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
-                <span class="file-list-hint">
-                  {{ message_count_label(1, item.type, suffix='template')|capitalize }}
-                </span>
+              <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
+              <span class="file-list-hint">
+                {{ message_count_label(1, item.type, suffix='template')|capitalize }}
               </span>
             {% endcall %}
             {{ spark_bar_field(item.requested_count, most_used_template_count) }}

--- a/app/templates/views/dashboard/inbox.html
+++ b/app/templates/views/dashboard/inbox.html
@@ -31,10 +31,10 @@
         >
           {{ item.user_number | format_phone_number_human_readable }}
         </a>
-        <span class="wide-left-hand-column">{{ item.content }}</span>
+        <span class="file-list-hint">{{ item.content }}</span>
       {% endcall %}
       {% call field(align='right') %}
-        <span class="file-list-hint align-with-message-body">
+        <span class="align-with-message-body">
           {{ item.created_at | format_delta }}
         </span>
       {% endcall %}

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -17,11 +17,9 @@
   ) %}
 
     {% call row_heading() %}
-      <span class="spark-bar-label">
-        <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
-        <span class="file-list-hint">
-          {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
-        </span>
+      <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
+      <span class="file-list-hint">
+        {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
       </span>
     {% endcall %}
     {% if template_statistics|length > 1 %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -13,17 +13,8 @@
       {{ uploaded_file_name }}
     </h1>
 
-    {{ template|string }}
-
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
-
-    {% if not help %}
-      {{ page_footer(
-        secondary_link=url_for('.view_template', service_id=current_service.id, template_id=template.id),
-        secondary_link_text='Back to {}'.format(template.name)
-      ) }}
-    {% endif %}
 
 {% endblock %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -16,7 +16,6 @@
     {{ template|string }}
 
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
-    {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
 
     {{ page_footer(
       secondary_link=url_for('.view_template', service_id=current_service.id, template_id=template.id),

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -14,6 +14,11 @@
       {{ message_count_label(1, template.template_type, suffix='') | capitalize }}
     </h1>
 
+    <p>
+      Sent {% if created_by %}by {{ created_by.name }} {% endif %}
+      on {{ created_at|format_datetime_short }}
+    </p>
+
     {{ template|string }}
 
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -16,7 +16,6 @@
     {{ template|string }}
 
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
-    {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
 
     {{ page_footer(

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
+{% from "components/message-count-label.html" import message_count_label %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -10,7 +11,7 @@
 {% block maincolumn_content %}
 
     <h1 class="heading-large">
-      Report
+      {{ message_count_label(1, template.template_type, suffix='') | capitalize }}
     </h1>
 
     {{ template|string }}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -15,17 +15,19 @@
     </h1>
 
     <p>
-      Sent {% if created_by %}by {{ created_by.name }} {% endif %}
+      <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+      sent
+      {% if job %}
+        from
+        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>
+      {% elif created_by %}
+        by {{ created_by.name }}
+      {% endif %}
       on {{ created_at|format_datetime_short }}
     </p>
 
     {{ template|string }}
 
     {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
-
-    {{ page_footer(
-      secondary_link=url_for('.view_template', service_id=current_service.id, template_id=template.id),
-      secondary_link_text='Back to {}'.format(template.name)
-    ) }}
 
 {% endblock %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -17,7 +17,7 @@
     <p>
       <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
       sent
-      {% if job %}
+      {% if job and job.original_file_name != 'Report' %}
         from
         <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>
       {% elif created_by %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,6 +103,8 @@ def template_json(service_id,
         'archived': archived,
         'process_type': process_type
     }
+    if subject is None and type_ != 'sms':
+        template['subject'] = "template subject"
     if subject is not None:
         template['subject'] = subject
     return template
@@ -216,7 +218,8 @@ def notification_json(
     created_at=None,
     updated_at=None,
     with_links=False,
-    rows=5
+    rows=5,
+    personalisation=None,
 ):
     if template is None:
         template = template_json(service_id, str(generate_uuid()))
@@ -255,7 +258,8 @@ def notification_json(
             'updated_at': updated_at,
             'job_row_number': job_row_number,
             'service': service_id,
-            'template_version': template['version']
+            'template_version': template['version'],
+            'personalisation': personalisation or {},
         } for i in range(rows)],
         'total': rows,
         'page_size': 50,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -182,7 +182,7 @@ def job_json(
     if job_id is None:
         job_id = str(generate_uuid())
     if template_id is None:
-        template_id = str(generate_uuid())
+        template_id = "5d729fbd-239c-44ab-b498-75a985f3198f"
     if created_at is None:
         created_at = str(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z'))
     data = {

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -92,13 +92,17 @@ def test_can_show_notifications(
             page=page_argument,
         ))
     assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     content = response.get_data(as_text=True)
     notifications = notification_json(service_one['id'])
     notification = notifications['notifications'][0]
-    assert notification['to'] in content
-    assert notification['status'] in content
-    assert notification['template']['name'] in content
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    text_of_first_row = page.select('tbody tr')[0].text
+    assert '07123456789' in text_of_first_row
+    assert (
+        'template content' in text_of_first_row or
+        'template subject' in text_of_first_row
+    )
+    assert 'Delivered' in text_of_first_row
     assert page_title in page.h1.text.strip()
 
     path_to_json = page.find("div", {'data-key': 'notifications'})['data-resource']

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -80,6 +80,7 @@ def test_should_show_page_for_one_job(
     status_argument,
     expected_api_call,
 ):
+
     response = logged_in_client.get(url_for(
         'main.view_job',
         service_id=service_one['id'],
@@ -94,7 +95,7 @@ def test_should_show_page_for_one_job(
         '{}: Template <em>content</em> with & entity'.format(service_one['name'])
     )
     assert ' '.join(page.find('tbody').find('tr').text.split()) == (
-        '07123456789 Delivered 1 January at 11:10am'
+        '07123456789 template content Delivered 1 January at 11:10am'
     )
     assert page.find('div', {'data-key': 'notifications'})['data-resource'] == url_for(
         'main.view_job_updates',

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -91,9 +91,6 @@ def test_should_show_page_for_one_job(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.text.strip() == 'thisisatest.csv'
-    assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == (
-        '{}: Template <em>content</em> with & entity'.format(service_one['name'])
-    )
     assert ' '.join(page.find('tbody').find('tr').text.split()) == (
         '07123456789 template content Delivered 1 January at 11:10am'
     )

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -44,7 +44,7 @@ def test_notification_status_page_shows_details(
     )
 
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
-        'service one: template content'
+        'service one: hello Jo'
     )
     assert normalize_spaces(page.select('.ajax-block-container p')[0].text) == (
         expected_status

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -1,8 +1,6 @@
 from freezegun import freeze_time
 import pytest
-from werkzeug.datastructures import MultiDict
 
-from app.main.views.notifications import get_status_arg
 from app.utils import (
     REQUESTED_STATUSES,
     FAILURE_STATUSES,
@@ -14,13 +12,31 @@ from tests.app.test_utils import normalize_spaces
 from tests.conftest import mock_get_notification
 
 
+@pytest.mark.parametrize('notification_status, expected_status', [
+    ('created', 'Sending'),
+    ('sending', 'Sending'),
+    ('delivered', 'Delivered'),
+    ('failed', 'Failed'),
+    ('temporary-failure', 'Phone not accepting messages right now'),
+    ('permanent-failure', 'Phone number doesn’t exist'),
+    ('technical-failure', 'Technical failure'),
+])
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_notification_status_page_shows_details(
     client_request,
-    mock_get_notification,
+    mocker,
     service_one,
     fake_uuid,
+    notification_status,
+    expected_status,
 ):
+
+    _mock_get_notification = mock_get_notification(
+        mocker,
+        fake_uuid,
+        notification_status=notification_status
+    )
+
     page = client_request.get(
         'main.view_notification',
         service_id=service_one['id'],
@@ -29,10 +45,10 @@ def test_notification_status_page_shows_details(
 
     assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == 'service one: template content'
     assert normalize_spaces(page.select('.ajax-block-container p')[0].text) == (
-        'Sent by Test User on 1 January at 11:09am'
+        expected_status
     )
 
-    mock_get_notification.assert_called_with(
+    _mock_get_notification.assert_called_with(
         service_one['id'],
         fake_uuid
     )

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -10,6 +10,7 @@ from app.utils import (
     DELIVERED_STATUSES,
 )
 
+from tests.app.test_utils import normalize_spaces
 from tests.conftest import mock_get_notification
 
 
@@ -27,7 +28,9 @@ def test_notification_status_page_shows_details(
     )
 
     assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == 'service one: template content'
-    assert ' '.join(page.find('tbody').find('tr').text.split()) == '07123456789 Delivered 1 January at 11:10am'
+    assert normalize_spaces(page.select('.ajax-block-container p')[0].text) == (
+        'Sent by Test User on 1 January at 11:09am'
+    )
 
     mock_get_notification.assert_called_with(
         service_one['id'],

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -43,7 +43,9 @@ def test_notification_status_page_shows_details(
         notification_id=fake_uuid
     )
 
-    assert page.find('div', {'class': 'sms-message-wrapper'}).text.strip() == 'service one: template content'
+    assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
+        'service one: template content'
+    )
     assert normalize_spaces(page.select('.ajax-block-container p')[0].text) == (
         expected_status
     )

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -13,23 +13,6 @@ from app.utils import (
 from tests.conftest import mock_get_notification
 
 
-@pytest.mark.parametrize('multidict_args, expected_statuses', [
-    ([], REQUESTED_STATUSES),
-    ([('status', '')], REQUESTED_STATUSES),
-    ([('status', 'garbage')], REQUESTED_STATUSES),
-    ([('status', 'sending')], SENDING_STATUSES),
-    ([('status', 'delivered')], DELIVERED_STATUSES),
-    ([('status', 'failed')], FAILURE_STATUSES),
-])
-def test_status_filters(mocker, multidict_args, expected_statuses):
-    mocker.patch('app.main.views.notifications.current_app')
-
-    args = MultiDict(multidict_args)
-    args['status'] = get_status_arg(args)
-
-    assert sorted(args['status']) == sorted(expected_statuses)
-
-
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_notification_status_page_shows_details(
     client_request,
@@ -50,29 +33,3 @@ def test_notification_status_page_shows_details(
         service_one['id'],
         fake_uuid
     )
-
-
-@pytest.mark.parametrize('notification_status, expected_big_number_vals', [
-    ('created', [1, 1, 0, 0]),
-    ('sending', [1, 1, 0, 0]),
-    ('delivered', [1, 0, 1, 0]),
-    ('temporary-failure', [1, 0, 0, 1]),
-])
-def test_notification_status_page_shows_correct_numbers(
-    client_request,
-    mocker,
-    service_one,
-    fake_uuid,
-    notification_status,
-    expected_big_number_vals
-):
-    mock_get_notification(mocker, fake_uuid, notification_status=notification_status)
-
-    page = client_request.get(
-        'main.view_notification',
-        service_id=service_one['id'],
-        notification_id=fake_uuid
-    )
-
-    big_numbers = page.find_all('div', {'class': 'big-number-number'})
-    assert expected_big_number_vals == [int(num.text.strip()) for num in big_numbers]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1635,7 +1635,8 @@ def mock_get_notification(mocker, fake_uuid, notification_status='delivered'):
             'name': 'Test User',
             'email_address': 'test@user.gov.uk'
         }
-        noti['template'] = template_json(service_id, str(generate_uuid()))
+        noti['personalisation'] = {'name': 'Jo'}
+        noti['template'] = template_json(service_id, str(generate_uuid()), content='hello ((name))')
         return noti
 
     return mocker.patch(


### PR DESCRIPTION
Detailed changes in each commit, but:

# Activity and job pages…

Before | After 
--- | ---
![image](https://user-images.githubusercontent.com/355079/27392548-ddd79cf2-569e-11e7-99d2-7772b2c1d82d.png) | ![image](https://user-images.githubusercontent.com/355079/27392431-9397d2a6-569e-11e7-9c97-81f131952897.png)


Before | After 
--- | ---
![image](https://user-images.githubusercontent.com/355079/27392488-b89261ac-569e-11e7-9faf-c860e90dc36e.png) | ![image](https://user-images.githubusercontent.com/355079/27392525-cebf101a-569e-11e7-8ca9-1c720df04523.png)



# …now link to the notification page

![image](https://user-images.githubusercontent.com/355079/27392620-08ea8364-569f-11e7-855d-a7e133cb195f.png)

***

![image](https://user-images.githubusercontent.com/355079/27392644-124cc48a-569f-11e7-87c7-b6bac1f5d9bb.png)

# Caveat

This won’t work perfectly until we start returning the correct version of the template with each notification. So if you edit a template you might get a mismatch, and start thinking that your messages were sent out with <span class="placeholder"… 😬