### PR TITLE
Revert "Re-add IDs for each notification to the jobs page"

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -50,7 +50,7 @@
         field_headings_visible=False
       ) %}
         {% call row_heading() %}
-          <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}" id="{{ item.id }}">{{ item.to }}</a>
+          <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
           <p class="file-list-hint">
             {{ item.preview_of_content }}
           </p>

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -17,7 +17,7 @@
     ) %}
 
       {% call row_heading() %}
-        <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}" id="{{ item.id }}">{{ item.to }}</a>
+        <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to }}</a>
         <p class="file-list-hint">
           {{ item.preview_of_content }}
         </p>


### PR DESCRIPTION
Reverts alphagov/notifications-admin#1329

This wasn’t the problem. ID was on the table row already.