### PR TITLE
Fix empty table message

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -386,7 +386,7 @@ def get_job_partials(job):
 
 
 def add_preview_of_content_to_notifications(notifications):
-    return (
+    return [
         dict(
             preview_of_content=(
                 str(Template(notification['template'], notification['personalisation']))
@@ -396,4 +396,4 @@ def add_preview_of_content_to_notifications(notifications):
             **notification
         )
         for notification in notifications
-    )
+    ]

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from app.main.views.jobs import get_time_left, get_status_filters
 from tests import notification_json
 from tests.conftest import SERVICE_ONE_ID
+from tests.app.test_utils import normalize_spaces
 from freezegun import freeze_time
 
 
@@ -133,6 +134,23 @@ def test_can_show_notifications(
     ))
     json_content = json.loads(json_response.get_data(as_text=True))
     assert json_content.keys() == {'counts', 'notifications'}
+
+
+def test_shows_message_when_no_notifications(
+    client_request,
+    mock_get_detailed_service,
+    mock_get_notifications_with_no_notifications,
+):
+
+    page = client_request.get(
+        'main.view_notifications',
+        service_id=SERVICE_ONE_ID,
+        message_type='sms',
+    )
+
+    assert normalize_spaces(page.select('tbody tr')[0].text) == (
+        'No messages found'
+    )
 
 
 @pytest.mark.parametrize((

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1128,7 +1128,9 @@ def mock_get_notifications_with_no_notifications(mocker):
                            status=None,
                            limit_days=None,
                            include_jobs=None,
-                           include_from_test_key=None):
+                           include_from_test_key=None,
+                           to=None,
+                           ):
         return notification_json(service_id, rows=0)
 
     return mocker.patch(


### PR DESCRIPTION
Bug was happening because:

```python
bool(list())
>>> False
```

```python
bool((item for item in list()))
>>> True
```

i.e. generator expressions cast to boolean are `True`, even if they’re empty – Python doesn’t evaluate them.

This was causing the functional tests to fail because it was taking too long for any table rows to appear on the page.