### PR TITLE
Fix missing recipients on notification page

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -57,7 +57,7 @@ def view_notification(service_id, notification_id):
         ),
         show_recipient=True,
     )
-    template.values = notification['personalisation']
+    template.values = get_all_personalisation_from_notification(notification)
     if notification['job']:
         job = job_api_client.get_job(service_id, notification['job']['id'])['data']
     else:
@@ -106,3 +106,18 @@ def get_single_notification_partials(notification):
             notification=notification
         ),
     }
+
+
+def get_all_personalisation_from_notification(notification):
+    if notification['template']['template_type'] == 'email':
+        return dict(
+            email_address=notification['to'],
+            **notification['personalisation']
+        )
+    if notification['template']['template_type'] == 'sms':
+        return dict(
+            phone_number=notification['to'],
+            **notification['personalisation']
+        )
+    if notification['template']['template_type'] == 'letter':
+        return notification['personalisation']

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -43,6 +43,9 @@ def test_notification_status_page_shows_details(
         notification_id=fake_uuid
     )
 
+    assert normalize_spaces(page.select('.sms-message-recipient')[0].text) == (
+        'To: 07123456789'
+    )
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: hello Jo'
     )


### PR DESCRIPTION
For some reason:
- notifications sent from CSV files have the recipient as part of the personalisation
- notifications sent via the API don’t have the recipient as part of the personalisation

I’d only tested it locally with CSV-sent files so didn’t spot this. The `conftest.py` fixtures we set up like the API already, but we didn’t have an explicit test.

This commit adds a method to append the recipient to the personalisation, so we can populate the template with it.