### PR TITLE
Send one off messages without jobs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -447,7 +447,10 @@ def register_errorhandlers(application):
         ))
         error_code = error.status_code
         if error_code == 400:
-            msg = list(itertools.chain(*[error.message[x] for x in error.message.keys()]))
+            if isinstance(error.message, str):
+                msg = [error.message]
+            else:
+                msg = list(itertools.chain(*[error.message[x] for x in error.message.keys()]))
             resp = make_response(render_template("error/400.html", message=msg))
             return useful_headers_after_request(resp)
         elif error_code not in [401, 404, 403, 410, 500]:

--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,8 @@ class Config(object):
     SESSION_COOKIE_SECURE = True
     SESSION_REFRESH_EACH_REQUEST = True
     SHOW_STYLEGUIDE = True
+    # TODO: move to utils
+    SMS_CHAR_COUNT_LIMIT = 459
     TOKEN_MAX_AGE_SECONDS = 3600
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -601,12 +601,6 @@ def get_back_link(service_id, template_id, step_index):
 @login_required
 @user_has_permissions('manage_templates')
 def check_notification(service_id, template_id):
-    # go back to start of process
-    back_link = get_back_link(service_id, template_id, 0)
-
-    if {'recipient', 'placeholders'} - set(session.keys()) and back_link:
-        return redirect(back_link)
-
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
 
     template = get_template(
@@ -614,6 +608,19 @@ def check_notification(service_id, template_id):
         current_service,
         show_recipient=True
     )
+
+    # go back to start of process
+    back_link = get_back_link(service_id, template_id, 0)
+
+    if (
+        (
+            not session.get('recipient') or
+            not all_placeholders_in_session(template.placeholders)
+        )
+        and back_link
+    ):
+        return redirect(back_link)
+
     template.values = get_receipient_and_placeholders_from_session(template.template_type)
 
     return render_template(

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 
 
 class NotificationApiClient(NotifyAdminAPIClient):
@@ -54,6 +54,15 @@ class NotificationApiClient(NotifyAdminAPIClient):
                 url='/service/{}/notifications'.format(service_id),
                 params=params
             )
+
+    def send_notification(self, service_id, *, template_id, recipient, personalisation=None):
+        data = {
+            'template_id': template_id,
+            'to': recipient,
+            'personalisation': personalisation,
+        }
+        data = _attach_current_user(data)
+        return self.post(url='/service/{}/send-notification'.format(service_id), data=data)
 
     def get_notification(self, service_id, notification_id):
         return self.get(url='/service/{}/notifications/{}'.format(service_id, notification_id))

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -55,7 +55,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
                 params=params
             )
 
-    def send_notification(self, service_id, *, template_id, recipient, personalisation=None):
+    def send_notification(self, service_id, *, template_id, recipient, personalisation):
         data = {
             'template_id': template_id,
             'to': recipient,

--- a/app/templates/partials/check/message-too-long.html
+++ b/app/templates/partials/check/message-too-long.html
@@ -4,7 +4,8 @@
       Message too long
     </h1>
     <p>
-      Text messages can’t be longer than {{ template|string|length }} characters. Your message is {{message_length}} characters.
+      Text messages can’t be longer than {{ SMS_CHAR_COUNT_LIMIT }} characters.
+      Your message is {{ template.content_count }} characters.
     </p>
   {% endcall %}
 </div>

--- a/app/templates/partials/check/message-too-long.html
+++ b/app/templates/partials/check/message-too-long.html
@@ -1,0 +1,10 @@
+<div class="bottom-gutter">
+  {% call banner_wrapper(type='dangerous') %}
+    <h1 class='banner-title'>
+      Message too long
+    </h1>
+    <p>
+      Text messages can’t be longer than {{ template|string|length }} characters. Your message is {{message_length}} characters.
+    </p>
+  {% endcall %}
+</div>

--- a/app/templates/partials/check/message-too-long.html
+++ b/app/templates/partials/check/message-too-long.html
@@ -1,3 +1,5 @@
+{% from "components/banner.html" import banner_wrapper %}
+
 <div class="bottom-gutter">
   {% call banner_wrapper(type='dangerous') %}
     <h1 class='banner-title'>

--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -1,0 +1,17 @@
+<div class="bottom-gutter">
+  {% call banner_wrapper(type='dangerous') %}
+    <h1 class='banner-title'>
+      You can’t send to
+      {{ 'this' if count_of_recipients == 1 else 'these' }}
+      {{ recipients.recipient_column_headers[0] }}
+      {%- if count_of_recipients != 1 -%}
+        {{ 'es' if 'email address' == recipients.recipient_column_headers[0] else 's' }}
+      {%- endif %}
+    </h1>
+    <p>
+      In <a href="{{ url_for('.trial_mode') }}">trial mode</a> you can only
+      send to yourself and members of your team
+    </p>
+    {{ skip_to_file_contents() }}
+  {% endcall %}
+</div>

--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -1,11 +1,19 @@
+{% from "components/banner.html" import banner_wrapper %}
+
+{% macro skip_to_file_contents() %}
+  <p class="visually-hidden">
+    <a href="#{{ file_contents_header_id }}">Skip to file contents</a>
+  </p>
+{% endmacro %}
+
 <div class="bottom-gutter">
   {% call banner_wrapper(type='dangerous') %}
     <h1 class='banner-title'>
       You can’t send to
       {{ 'this' if count_of_recipients == 1 else 'these' }}
-      {{ recipients.recipient_column_headers[0] }}
+      {{ template_type_label }}
       {%- if count_of_recipients != 1 -%}
-        {{ 'es' if 'email address' == recipients.recipient_column_headers[0] else 's' }}
+        {{ 'es' if 'email address' == template_type_label else 's' }}
       {%- endif %}
     </h1>
     <p>

--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -1,3 +1,5 @@
+{% from "components/banner.html" import banner_wrapper %}
+
 <div class="bottom-gutter">
   {% call banner_wrapper(type='dangerous') %}
     <h1 class='banner-title'>

--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -1,7 +1,11 @@
 <div class="bottom-gutter">
   {% call banner_wrapper(type='dangerous') %}
     <h1 class='banner-title'>
-      Too many recipients
+      {% if original_file_name %}
+        Too many recipients
+      {% else %}
+        Daily limit reached
+      {% endif %}
     </h1>
     <p>
       You can only send {{ current_service.message_limit }} messages per day
@@ -10,29 +14,31 @@
       {%- endif -%}
       .
     </p>
-    <p>
-      {% if current_service.message_limit != remaining_messages %}
-        You can still send {{ remaining_messages }} messages today, but
-      {% endif %}
-      ‘{{ original_file_name }}’ contains
-      {{ count_of_recipients }}
-      {% if count_of_recipients == 1 -%}
-        {%- if template.template_type == 'email' -%}
-          email address
-        {%- elif template.template_type == 'sms' -%}
-          phone number
-        {%- elif template.template_type == 'letter' -%}
-          address
-        {%- endif -%}
-      {%- else -%}
-        {%- if template.template_type == 'email' -%}
-          email addresses
-        {%- elif template.template_type == 'sms' -%}
-          phone numbers
-        {%- elif template.template_type == 'letter' -%}
-          addresses
-        {%- endif -%}
-      {%- endif -%}.
-    </p>
+    {% if original_file_name %}
+      <p>
+        {% if current_service.message_limit != remaining_messages %}
+          You can still send {{ remaining_messages }} messages today, but
+        {% endif %}
+        ‘{{ original_file_name }}’ contains
+        {{ count_of_recipients }}
+        {% if count_of_recipients == 1 -%}
+          {%- if template.template_type == 'email' -%}
+            email address
+          {%- elif template.template_type == 'sms' -%}
+            phone number
+          {%- elif template.template_type == 'letter' -%}
+            address
+          {%- endif -%}
+        {%- else -%}
+          {%- if template.template_type == 'email' -%}
+            email addresses
+          {%- elif template.template_type == 'sms' -%}
+            phone numbers
+          {%- elif template.template_type == 'letter' -%}
+            addresses
+          {%- endif -%}
+        {%- endif -%}.
+      </p>
+    {% endif %}
   {% endcall %}
 </div>

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -120,7 +120,12 @@
     </div>
 
   {% elif not recipients.allowed_to_send_to %}
-    {% include "partials/check/not-allowed-to-send-to.html" %}
+    {% with
+      count_of_recipients=count_of_recipients,
+      template_type_label=recipients.recipient_column_headers[0]
+    %}
+      {% include "partials/check/not-allowed-to-send-to.html" %}
+    {% endwith %}
   {% elif recipients.more_rows_than_can_send %}
     {% include "partials/check/too-many-messages.html" %}
   {% else %}

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -120,25 +120,7 @@
     </div>
 
   {% elif not recipients.allowed_to_send_to %}
-
-    <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous') %}
-        <h1 class='banner-title'>
-          You can’t send to
-          {{ 'this' if count_of_recipients == 1 else 'these' }}
-          {{ recipients.recipient_column_headers[0] }}
-          {%- if count_of_recipients != 1 -%}
-            {{ 'es' if 'email address' == recipients.recipient_column_headers[0] else 's' }}
-          {%- endif %}
-        </h1>
-        <p>
-          In <a href="{{ url_for('.trial_mode') }}">trial mode</a> you can only
-          send to yourself and members of your team
-        </p>
-        {{ skip_to_file_contents() }}
-      {% endcall %}
-    </div>
-
+    {% include "partials/check/not-allowed-to-send-to.html" %}
   {% elif recipients.more_rows_than_can_send %}
     {% include "partials/check/too-many-messages.html" %}
   {% else %}

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -14,9 +14,9 @@
     %}
       {% include "partials/check/not-allowed-to-send-to.html" %}
     {% endwith %}
-  {% elif error == 'more_rows_than_can_send' %}
+  {% elif error == 'too-many-messages' %}
     {% include "partials/check/too-many-messages.html" %}
-  {% elif error == 'row_errors' %}
+  {% elif error == 'message-too-long' %}
     {# the only row_errors we can get when sending one off messages is that the message is too long #}
     {% include "partials/check/message-too-long.html" %}
   {% else %}

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -1,0 +1,34 @@
+{% extends "withnav_template.html" %}
+<!-- {% from "components/banner.html" import banner_wrapper %} -->
+<!-- {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %} -->
+<!-- {% from "components/file-upload.html" import file_upload %} -->
+<!-- {% from "components/page-footer.html" import page_footer %} -->
+{% from "components/radios.html" import radio_select %}
+{% from "components/message-count-label.html" import message_count_label %}
+
+{% block service_page_title %}
+  {{ "Error" if errors else "Preview" }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">
+    Preview of {{ template.name }}
+  </h1>
+
+  {{ template|string }}
+
+  <div class="bottom-gutter-3-2">
+    <form method="post" enctype="multipart/form-data" action="{{url_for('main.send_notification', service_id=current_service.id, template_id=template.id)}}" class='page-footer'>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="help" value="{{ '3' if help else 0 }}" />
+      {% if template.template_type != 'letter' or not request.args.from_test %}
+      <input type="submit" class="button" value="Send 1 {{ message_count_label(1, template.template_type, suffix='') }}" />
+      {% else %}
+        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="button">Download as a printable PDF</a>
+      {% endif %}
+      <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
+    </form>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -1,20 +1,29 @@
 {% extends "withnav_template.html" %}
-<!-- {% from "components/banner.html" import banner_wrapper %} -->
-<!-- {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %} -->
-<!-- {% from "components/file-upload.html" import file_upload %} -->
-<!-- {% from "components/page-footer.html" import page_footer %} -->
 {% from "components/radios.html" import radio_select %}
 {% from "components/message-count-label.html" import message_count_label %}
 
 {% block service_page_title %}
-  {{ "Error" if errors else "Preview" }}
+  {{ "Error" if error else "Preview" }}
 {% endblock %}
 
 {% block maincolumn_content %}
-
-  <h1 class="heading-large">
-    Preview of {{ template.name }}
-  </h1>
+  {% if error == 'not-allowed-to-send-to' %}
+    {% with
+      count_of_recipients=1,
+      template_type_label='phone number'
+    %}
+      {% include "partials/check/not-allowed-to-send-to.html" %}
+    {% endwith %}
+  {% elif error == 'more_rows_than_can_send' %}
+    {% include "partials/check/too-many-messages.html" %}
+  {% elif error == 'row_errors' %}
+    {# the only row_errors we can get when sending one off messages is that the message is too long #}
+    {% include "partials/check/message-too-long.html" %}
+  {% else %}
+    <h1 class="heading-large">
+      Preview of {{ template.name }}
+    </h1>
+  {% endif %}
 
   {{ template|string }}
 
@@ -22,10 +31,12 @@
     <form method="post" enctype="multipart/form-data" action="{{url_for('main.send_notification', service_id=current_service.id, template_id=template.id)}}" class='page-footer'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="help" value="{{ '3' if help else 0 }}" />
-      {% if template.template_type != 'letter' or not request.args.from_test %}
-      <input type="submit" class="button" value="Send 1 {{ message_count_label(1, template.template_type, suffix='') }}" />
-      {% else %}
-        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="button">Download as a printable PDF</a>
+      {% if not error %}
+        {% if template.template_type != 'letter' or not request.args.from_test %}
+        <input type="submit" class="button" value="Send 1 {{ message_count_label(1, template.template_type, suffix='') }}" />
+        {% else %}
+          <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="button">Download as a printable PDF</a>
+        {% endif %}
       {% endif %}
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
     </form>

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -37,7 +37,7 @@ def test_client_gets_notifications_for_service_and_job_by_page(mocker, arguments
 
 def test_send_notification(mocker, logged_in_client, active_user_with_permissions):
     mock_post = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.post')
-    NotificationApiClient().send_notification('foo', template_id='bar', recipient='07700900001')
+    NotificationApiClient().send_notification('foo', template_id='bar', recipient='07700900001', personalisation=None)
     mock_post.assert_called_once_with(
         url='/service/foo/send-notification',
         data={

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -35,6 +35,20 @@ def test_client_gets_notifications_for_service_and_job_by_page(mocker, arguments
     mock_get.assert_called_once_with(**expected_call)
 
 
+def test_send_notification(mocker, logged_in_client, active_user_with_permissions):
+    mock_post = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.post')
+    NotificationApiClient().send_notification('foo', template_id='bar', recipient='07700900001')
+    mock_post.assert_called_once_with(
+        url='/service/foo/send-notification',
+        data={
+            'template_id': 'bar',
+            'to': '07700900001',
+            'personalisation': None,
+            'created_by': active_user_with_permissions.id
+        }
+    )
+
+
 def test_get_notification(mocker):
     mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
     NotificationApiClient().get_notification('foo', 'bar')


### PR DESCRIPTION
Lots of code change here (sorry!), but this PR changes the one off / send a test flow to, instead of creating a one-line CSV file and submitting a job, instead post a notification to a new endpoint. This is complicated. Three main reasons:

* Letters should still go via CSV because they aren't actually submitted as notifications
* In CSV files, the recipient is just another column. When sending as an API request, recipient is another field altogether, so we need to unpick that.
* The send_test_step function is already pretty long and complicated


![image](https://user-images.githubusercontent.com/5020841/27549367-9d5a52e8-5a93-11e7-9e34-2ae5232bb3d0.png)
