### PR TITLE
Add feature to mark a template as redacted

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -252,3 +252,7 @@ details .arrow {
   color: $secondary-text-colour;
   cursor: default;
 }
+
+.heading-inline {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -76,6 +76,10 @@
 
   }
 
+  .list {
+    margin-bottom: 0;
+  }
+
 }
 
 .banner-tour {

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -42,6 +42,7 @@
   &-delete-link-without-button {
     @include core-19;
     padding-left: 0;
+    display: inline-block;
   }
 
   &-secondary-link {

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -40,6 +40,7 @@
   }
 
   &-delete-link-without-button {
+    @include core-19;
     padding-left: 0;
   }
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -383,26 +383,10 @@ def delete_service_template(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET', 'POST'])
+@main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET'])
 @login_required
 @user_has_permissions('manage_templates', admin_override=True)
-def redact_template(service_id, template_id):
-
-    if request.method == 'POST':
-
-        service_api_client.redact_service_template(service_id, template_id)
-
-        flash(
-            'Personalised content will be hidden for messages sent with this template',
-            'default_with_tick'
-        )
-
-        return redirect(url_for(
-            '.view_template',
-            service_id=service_id,
-            template_id=template_id,
-        ))
-
+def confirm_redact_template(service_id, template_id):
     return render_template(
         'views/templates/template.html',
         template=get_template(
@@ -419,6 +403,25 @@ def redact_template(service_id, template_id):
         ),
         show_redaction_message=True,
     )
+
+
+@main.route("/services/<service_id>/templates/<template_id>/redact", methods=['POST'])
+@login_required
+@user_has_permissions('manage_templates', admin_override=True)
+def redact_template(service_id, template_id):
+
+    service_api_client.redact_service_template(service_id, template_id)
+
+    flash(
+        'Personalised content will be hidden for messages sent with this template',
+        'default_with_tick'
+    )
+
+    return redirect(url_for(
+        '.view_template',
+        service_id=service_id,
+        template_id=template_id,
+    ))
 
 
 @main.route('/services/<service_id>/templates/<template_id>/versions')

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -383,6 +383,44 @@ def delete_service_template(service_id, template_id):
     )
 
 
+@main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET', 'POST'])
+@login_required
+@user_has_permissions('manage_templates', admin_override=True)
+def redact_template(service_id, template_id):
+
+    if request.method == 'POST':
+
+        service_api_client.redact_service_template(service_id, template_id)
+
+        flash(
+            'Personalised content will be hidden for messages sent with this template',
+            'default_with_tick'
+        )
+
+        return redirect(url_for(
+            '.view_template',
+            service_id=service_id,
+            template_id=template_id,
+        ))
+
+    return render_template(
+        'views/templates/template.html',
+        template=get_template(
+            service_api_client.get_service_template(service_id, template_id)['data'],
+            current_service,
+            expand_emails=True,
+            letter_preview_url=url_for(
+                '.view_letter_template_preview',
+                service_id=service_id,
+                template_id=template_id,
+                filetype='png',
+            ),
+            show_recipient=True,
+        ),
+        show_redaction_message=True,
+    )
+
+
 @main.route('/services/<service_id>/templates/<template_id>/versions')
 @login_required
 @user_has_permissions(

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -171,7 +171,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def redact_service_template(self, service_id, id_):
         return self.post(
             "/service/{}/template/{}".format(service_id, id_),
-            {'redact_personalisation': True}
+            _attach_current_user(
+                {'redact_personalisation': True}
+            ),
         )
 
     def get_service_template(self, service_id, template_id, version=None, *params):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -168,6 +168,12 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         endpoint = "/service/{0}/template/{1}".format(service_id, id_)
         return self.post(endpoint, data)
 
+    def redact_service_template(self, service_id, id_):
+        return self.post(
+            "/service/{}/template/{}".format(service_id, id_),
+            {'redact_personalisation': True}
+        )
+
     def get_service_template(self, service_id, template_id, version=None, *params):
         """
         Retrieve a service template.

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -50,14 +50,16 @@
       <br/>
     {% endif %}
     {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
-      <span class="page-footer-delete-link page-footer-delete-link-without-button">
+      <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
         <a href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
       </span>
       &emsp;
-      {% if not template.redact_personalisation %}
+      {% if not template._template.redact_personalisation %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
           <a href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
         </span>
+      {% else %}
+        <p class="hint">Personalisation is hidden after sending</p>
       {% endif %}
     {% endif %}
   </div>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/api-key.html" import api_key %}
@@ -9,6 +10,24 @@
 
 {% block maincolumn_content %}
 
+  {% if show_redaction_message %}
+    <div class="bottom-gutter">
+      {% call banner_wrapper(type='dangerous', subhead='Are you sure you want to hide personalisation after sending?') %}
+        <ul class="list list-bullet">
+          <li>
+            You won’t be able to see personalised content in Notify for this template
+          </li>
+          <li>
+            You can’t undo this
+          </li>
+        </ul>
+        <form method='post'>
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          <input type="submit" class="button" name="delete" value="Confirm" />
+        </form>
+      {% endcall %}
+    </div>
+  {% endif %}
 
   <h1 class="heading-large">{{ template.name }}</h1>
 
@@ -18,26 +37,29 @@
     {% endwith %}
   </div>
 
-  <div class="bottom-gutter">
+  <div class="bottom-gutter-1-2">
     {{ api_key(template.id, name="Template ID", thing='template ID') }}
   </div>
 
-  {% if template._template.updated_at %}
-    <div class="bottom-gutter-1-2">
-      <h2 class="heading-small">Last edited {{ template._template.updated_at|format_delta }}</h2>
-      <p>
-        <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
-      </p>
-    </div>
-  {% endif %}
-
-  {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
-    <div class="bottom-gutter">
-      {{ page_footer(
-        delete_link=url_for('.delete_service_template', service_id=current_service.id, template_id=template.id),
-        delete_link_text='Delete this template'
-      ) }}
-    </div>
-  {% endif %}
+  <div class="bottom-gutter-1-2">
+    {% if template._template.updated_at %}
+      <h2 class="heading-small bottom-gutter-2-3 heading-inline">Last edited {{ template._template.updated_at|format_delta }}</h2>
+      &emsp;
+      <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
+      &emsp;
+      <br/>
+    {% endif %}
+    {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
+      <span class="page-footer-delete-link page-footer-delete-link-without-button">
+        <a href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
+      </span>
+      &emsp;
+      {% if not template.redact_personalisation %}
+        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+          <a href="{{ url_for('.redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
+        </span>
+      {% endif %}
+    {% endif %}
+  </div>
 
 {% endblock %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -56,7 +56,7 @@
       &emsp;
       {% if not template.redact_personalisation %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a href="{{ url_for('.redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
+          <a href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
         </span>
       {% endif %}
     {% endif %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,7 +91,9 @@ def template_json(service_id,
                   subject=None,
                   version=1,
                   archived=False,
-                  process_type='normal'):
+                  process_type='normal',
+                  redact_personalisation=False,
+                  ):
     template = {
         'id': id_,
         'name': name,
@@ -101,10 +103,12 @@ def template_json(service_id,
         'version': version,
         'updated_at': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f'),
         'archived': archived,
-        'process_type': process_type
+        'process_type': process_type,
     }
     if subject is not None:
         template['subject'] = subject
+    if redact_personalisation is not None:
+        template['redact_personalisation'] = redact_personalisation
     return template
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -987,3 +987,21 @@ def test_should_show_redact_template(
     )
 
     mock_redact_template.assert_called_once_with(SERVICE_ONE_ID, fake_uuid)
+
+
+def test_should_show_hint_once_template_redacted(
+    client_request,
+    mocker,
+    service_one,
+    fake_uuid,
+):
+
+    mock_get_service_email_template(mocker, redact_personalisation=True)
+
+    page = client_request.get(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert page.select('.hint')[0].text == 'Personalisation is hidden after sending'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -519,6 +519,11 @@ def mock_delete_service_template(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_redact_template(mocker):
+    return mocker.patch('app.service_api_client.redact_service_template')
+
+
+@pytest.fixture(scope='function')
 def api_user_pending(fake_uuid):
     from app.notify_client.user_api_client import User
     user_data = {'id': fake_uuid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,7 +351,7 @@ def mock_get_service_template_with_placeholders(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_get_service_email_template(mocker, content=None, subject=None):
+def mock_get_service_email_template(mocker, content=None, subject=None, redact_personalisation=False):
     def _get(service_id, template_id, version=None):
         template = template_json(
             service_id,
@@ -360,6 +360,7 @@ def mock_get_service_email_template(mocker, content=None, subject=None):
             "email",
             content or "Your vehicle tax expires on ((date))",
             subject or "Your ((thing)) is due soon",
+            redact_personalisation=redact_personalisation,
         )
         return {'data': template}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1716,7 +1716,9 @@ def client_request(logged_in_client):
             return BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
 
         @staticmethod
-        def post(endpoint, _data=None, _expected_status=302, _follow_redirects=False, **endpoint_kwargs):
+        def post(endpoint, _data=None, _expected_status=None, _follow_redirects=False, **endpoint_kwargs):
+            if _expected_status is None:
+                _expected_status = 200 if _follow_redirects else 302
             resp = logged_in_client.post(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 data=_data,


### PR DESCRIPTION
Works similarly to the delete template flow, because it’s a destructive, one-way action.

Not on the edit template page, because it’s not something you want to be considering every time you’re editing a template. And we saw that people couldn’t find the delete button when it was on this page.

Adds a bit more CSS for the `dangerous` banner type, because the content here is quite complicated. Breaking it into a list helps, but the spacing didn’t look right, so needed some tweaking.

Can ship independently of the code that shows the redaction, but needs the API first.

***

**Wording needs work:**

![image](https://user-images.githubusercontent.com/355079/27576988-f15b081e-5b16-11e7-83f5-99f85d8160c0.png)


![image](https://user-images.githubusercontent.com/355079/27577002-f99bf59c-5b16-11e7-8a4d-46a28490018e.png)
