### PR TITLE
Change step 1 of tour to only show the template

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -88,8 +88,9 @@
   background: $govuk-blue;
   color: $white;
   margin-top: 10px;
+  margin-bottom: 0;
   padding: $gutter;
-  height: 475px;
+  height: 425px;
   overflow: hidden;
   box-shadow: inset 0 -1em 1.6em 0 rgba(0, 0, 0, 0.05);
 

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -80,10 +80,9 @@ def add_service():
         )
 
         return redirect(url_for(
-            'main.send_test',
+            'main.start_tour',
             service_id=service_id,
             template_id=example_sms_template['data']['id'],
-            help=1
         ))
     else:
         return render_template(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -18,7 +18,7 @@ from notifications_utils.recipients import first_column_headings
 from notifications_python_client.errors import HTTPError
 
 from app.main import main
-from app.utils import user_has_permissions, get_template
+from app.utils import user_has_permissions, get_template, get_help_argument
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.main.forms import (
     ChooseTemplateType,
@@ -70,6 +70,34 @@ def view_template(service_id, template_id):
             show_recipient=True,
             page_count=get_page_count_for_letter(template),
         ),
+    )
+
+
+@main.route("/services/<service_id>/start-tour/<uuid:template_id>")
+@login_required
+@user_has_permissions(
+    'view_activity',
+    'send_texts',
+    'send_emails',
+    'manage_templates',
+    'manage_api_keys',
+    admin_override=True, any_=True
+)
+def start_tour(service_id, template_id):
+
+    template = service_api_client.get_service_template(service_id, str(template_id))['data']
+
+    if template['template_type'] != 'sms':
+        abort(404)
+
+    return render_template(
+        'views/templates/start-tour.html',
+        template=get_template(
+            template,
+            current_service,
+            show_recipient=True,
+        ),
+        help='1',
     )
 
 

--- a/app/templates/views/templates/start-tour.html
+++ b/app/templates/views/templates/start-tour.html
@@ -1,0 +1,21 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/api-key.html" import api_key %}
+
+{% block service_page_title %}
+  {{ template.name }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+
+  <h1 class="heading-large">{{ template.name }}</h1>
+
+  {{ template|string }}
+
+  <div class="page-footer">
+    <a href="{{ url_for('.send_test', service_id=current_service.id, template_id=template.id, help=2) }}" class="button">Next</a>
+  </div>
+
+{% endblock %}

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -59,10 +59,9 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
     assert session['service_id'] == 101
     assert response.status_code == 302
     assert response.location == url_for(
-        'main.send_test',
+        'main.start_tour',
         service_id=101,
-        template_id="Example text message template",
-        help=1,
+        template_id="Example%20text%20message%20template",
         _external=True
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -944,6 +944,57 @@ def test_should_create_sms_template_without_downgrading_unicode_characters(
     assert resp.status_code == 302
 
 
+def test_should_show_template_as_first_page_of_tour(
+    client_request,
+    mock_get_service_template,
+    service_one,
+    fake_uuid,
+):
+
+    page = client_request.get(
+        'main.start_tour',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+
+    assert normalize_spaces(
+        page.select('.banner-tour .heading-medium')[0].text
+    ) == (
+        'Try sending yourself this example'
+    )
+
+    assert normalize_spaces(
+        page.select('.sms-message-wrapper')[0].text
+    ) == (
+        'service one: Template <em>content</em> with & entity'
+    )
+
+    assert page.select('a.button')[0]['href'] == url_for(
+        '.send_test', service_id=SERVICE_ONE_ID, template_id=fake_uuid, help=2
+    )
+
+
+@pytest.mark.parametrize('template_mock', [
+    mock_get_service_email_template,
+    mock_get_service_letter_template,
+])
+def test_cant_see_email_template_in_tour(
+    client_request,
+    fake_uuid,
+    mocker,
+    template_mock,
+):
+
+    template_mock(mocker)
+
+    client_request.get(
+        'main.start_tour',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _expected_status=404,
+    )
+
+
 def test_should_show_message_before_redacting_template(
     client_request,
     mock_get_service_template,


### PR DESCRIPTION
We’ve made a few changes to the tour recently, without changing the help text on the left hand side of the screen. So the stuff you see on the right side of the screen doesn’t quite sync up any more. But the text on the left is still good.

This commit adds an extra, introductory page that just shows the template and a next button, which better matches the ‘every message starts with a template’ help text.

# Before 

Step 1. | …continued | Step 2. | Step 3.
---|---|---|---
![image](https://user-images.githubusercontent.com/355079/27680644-5bfe6fbe-5cb4-11e7-9876-9189b4faa8a9.png) | ![image](https://user-images.githubusercontent.com/355079/27680680-79f754b8-5cb4-11e7-9231-6b1c9f47dfba.png) | ![image](https://user-images.githubusercontent.com/355079/27680668-692b25d8-5cb4-11e7-9a63-662437fa5027.png) | ![image](https://user-images.githubusercontent.com/355079/27681194-441a384a-5cb6-11e7-9236-933b45c1a069.png)




# After

Step 1. | Step 2. | …continued | Step 3.
---|---|---|---
![image](https://user-images.githubusercontent.com/355079/27680522-e8118988-5cb3-11e7-87bd-51109fb90e2c.png) | ![image](https://user-images.githubusercontent.com/355079/27680534-f3f606de-5cb3-11e7-8e6a-a25cc615673e.png) | ![image](https://user-images.githubusercontent.com/355079/27680551-089e78dc-5cb4-11e7-806e-2f794906a4b6.png) | ![image](https://user-images.githubusercontent.com/355079/27680566-131117b6-5cb4-11e7-8838-194409a7e38a.png)


