### PR TITLE
Never say ‘report is 100% complete…’ on job page

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -26,7 +26,7 @@
 
       {% if percentage_complete < 100 %}
         <p class="bottom-gutter hint">
-          Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
+          Report is {{ "{:.0f}%".format(percentage_complete * 0.99) }} complete…
         </p>
       {% elif notifications %}
         <p class="bottom-gutter">


### PR DESCRIPTION
This message is meant to indicate that generating the report is still in progress. Saying 100% contradicts this because 100% sounds like ‘complete’.

Reason this is happening is because rounding 99.5 to 0 decimal places gives you 100.

So let’s make sure it never gets above 99.0