### PR TITLE
Allow email and sms to be disabled

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -93,6 +93,16 @@ def send_messages(service_id, template_id):
 
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
 
+    if (db_template['template_type'] in ['email', 'sms']) \
+            and (db_template['template_type'] not in current_service['permissions']):
+        return redirect(url_for(
+            '.action_blocked',
+            service_id=service_id,
+            notification_type=db_template['template_type'],
+            return_to='view_template',
+            template_id=template_id
+        ))
+
     template = get_template(
         db_template,
         current_service,
@@ -163,6 +173,18 @@ def send_test(service_id, template_id):
     session['recipient'] = None
     session['placeholders'] = {}
     session['send_test_letter_page_count'] = None
+
+    db_template = service_api_client.get_service_template(service_id, template_id)['data']
+
+    if (db_template['template_type'] in ['email', 'sms']) \
+            and (db_template['template_type'] not in current_service['permissions']):
+        return redirect(url_for(
+            '.action_blocked',
+            service_id=service_id,
+            notification_type=db_template['template_type'],
+            return_to='view_template',
+            template_id=template_id))
+
     return redirect(url_for(
         {
             'main.send_test': '.send_test_step',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -43,7 +43,8 @@ from app.utils import (
     get_errors_for_csv,
     Spreadsheet,
     get_help_argument,
-    get_template
+    get_template,
+    email_or_sms_not_enabled,
 )
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 
@@ -93,8 +94,7 @@ def send_messages(service_id, template_id):
 
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
 
-    if (db_template['template_type'] in ['email', 'sms']) \
-            and (db_template['template_type'] not in current_service['permissions']):
+    if email_or_sms_not_enabled(db_template['template_type'], current_service['permissions']):
         return redirect(url_for(
             '.action_blocked',
             service_id=service_id,
@@ -176,8 +176,7 @@ def send_test(service_id, template_id):
 
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
 
-    if (db_template['template_type'] in ['email', 'sms']) \
-            and (db_template['template_type'] not in current_service['permissions']):
+    if email_or_sms_not_enabled(db_template['template_type'], current_service['permissions']):
         return redirect(url_for(
             '.action_blocked',
             service_id=service_id,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -247,6 +247,14 @@ def service_switch_can_send_email(service_id):
     return redirect(url_for('.service_settings', service_id=service_id))
 
 
+@main.route("/services/<service_id>/service-settings/can-send-sms")
+@login_required
+@user_has_permissions(admin_override=True)
+def service_switch_can_send_sms(service_id):
+    switch_service_permissions(service_id, 'sms')
+    return redirect(url_for('.service_settings', service_id=service_id))
+
+
 @main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
@@ -333,6 +341,15 @@ def service_set_sms_sender(service_id):
     return render_template(
         'views/service-settings/set-sms-sender.html',
         form=form)
+
+
+@main.route("/services/<service_id>/service-settings/set-sms", methods=['GET'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_sms(service_id):
+    return render_template(
+        'views/service-settings/set-sms.html',
+    )
 
 
 @main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET'])

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -239,6 +239,14 @@ def service_switch_can_send_international_sms(service_id):
     return redirect(url_for('.service_settings', service_id=service_id))
 
 
+@main.route("/services/<service_id>/service-settings/can-send-email")
+@login_required
+@user_has_permissions(admin_override=True)
+def service_switch_can_send_email(service_id):
+    switch_service_permissions(service_id, 'email')
+    return redirect(url_for('.service_settings', service_id=service_id))
+
+
 @main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
@@ -274,6 +282,15 @@ def resume_service(service_id):
     else:
         flash("This will resume the service. New api key are required for this service to use the API.", 'resume')
         return service_settings(service_id)
+
+
+@main.route("/services/<service_id>/service-settings/set-email", methods=['GET'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_email(service_id):
+    return render_template(
+        'views/service-settings/set-email.html',
+    )
 
 
 @main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET', 'POST'])

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -26,13 +26,23 @@
         {% endcall %}
 
         {% call row() %}
-          {{ text_field('Email reply to address') }}
-          {{ text_field(
-            current_service.reply_to_email_address,
-            status='' if current_service.reply_to_email_address else 'default'
-          ) }}
-          {{ edit_field('Change', url_for('.service_set_reply_to_email', service_id=current_service.id)) }}
+          {{ text_field('Send emails') }}
+          {{ boolean_field('email' in current_service.permissions) }}
+          {{ edit_field('Change', url_for('.service_set_email', service_id=current_service.id)) }}
         {% endcall %}
+
+        {% if 'email' in current_service.permissions %}
+
+          {% call row() %}
+            {{ text_field('Email reply to address') }}
+            {{ text_field(
+              current_service.reply_to_email_address,
+              status='' if current_service.reply_to_email_address else 'default'
+            ) }}
+            {{ edit_field('Change', url_for('.service_set_reply_to_email', service_id=current_service.id)) }}
+          {% endcall %}
+
+        {% endif %}
 
         {% call row() %}
           {{ text_field('Text message sender') }}
@@ -154,6 +164,11 @@
         <li class="bottom-gutter">
           <a href="{{ url_for('.service_switch_research_mode', service_id=current_service.id) }}" class="button">
             {{ 'Take service out of research mode' if current_service.research_mode else 'Put into research mode' }}
+          </a>
+        </li>
+        <li class="bottom-gutter">
+          <a href="{{ url_for('.service_switch_can_send_email', service_id=current_service.id) }}" class="button">
+            {{ 'Stop sending emails' if 'email' in current_service.permissions else 'Allow to send emails' }}
           </a>
         </li>
         <li class="bottom-gutter">

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -45,37 +45,47 @@
         {% endif %}
 
         {% call row() %}
-          {{ text_field('Text message sender') }}
-          {{ text_field(current_service.sms_sender) }}
-          {% if current_user.has_permissions([], admin_override=True) or not can_receive_inbound %}
-            {{ edit_field('Change', url_for('.service_set_sms_sender', service_id=current_service.id, set_inbound_sms=False)) }}
-          {% else %}
-               {{ text_field('') }}
+          {{ text_field('Send text messages') }}
+          {{ boolean_field('sms' in current_service.permissions) }}
+          {{ edit_field('Change', url_for('.service_set_sms', service_id=current_service.id)) }}
+        {% endcall %}
+
+        {% if 'sms' in current_service.permissions %}
+
+          {% call row() %}
+            {{ text_field('Text message sender') }}
+            {{ text_field(current_service.sms_sender) }}
+            {% if current_user.has_permissions([], admin_override=True) or not can_receive_inbound %}
+              {{ edit_field('Change', url_for('.service_set_sms_sender', service_id=current_service.id, set_inbound_sms=False)) }}
+            {% else %}
+                 {{ text_field('') }}
+            {% endif %}
+
+          {% endcall %}
+
+          {% call row() %}
+            {{ text_field('International text messages') }}
+            {{ boolean_field('international_sms' in current_service.permissions) }}
+            {{ edit_field('Change', url_for('.service_set_international_sms', service_id=current_service.id)) }}
+          {% endcall %}
+
+          {% call row() %}
+            {{ text_field('Receive text messages') }}
+            {{ boolean_field('inbound_sms' in current_service.permissions) }}
+            {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
+          {% endcall %}
+
+          {% if can_receive_inbound %}
+            {% call row() %}
+              {{ text_field('API endpoint for received text messages') }}
+              {{ text_field(
+                'None' if not inbound_api_url else inbound_api_url,
+                status='' if inbound_api_url else 'default'
+              ) }}
+              {{ edit_field('Change', url_for('.service_set_inbound_api', service_id=current_service.id)) }}
+            {% endcall %}
           {% endif %}
 
-        {% endcall %}
-
-        {% call row() %}
-          {{ text_field('International text messages') }}
-          {{ boolean_field('international_sms' in current_service.permissions) }}
-          {{ edit_field('Change', url_for('.service_set_international_sms', service_id=current_service.id)) }}
-        {% endcall %}
-
-        {% call row() %}
-          {{ text_field('Receive text messages') }}
-          {{ boolean_field('inbound_sms' in current_service.permissions) }}
-          {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
-        {% endcall %}
-
-        {% if can_receive_inbound %}
-          {% call row() %}
-            {{ text_field('API endpoint for received text messages') }}
-            {{ text_field(
-              'None' if not inbound_api_url else inbound_api_url,
-              status='' if inbound_api_url else 'default'
-            ) }}
-            {{ edit_field('Change', url_for('.service_set_inbound_api', service_id=current_service.id)) }}
-          {% endcall %}
         {% endif %}
 
         {% call row() %}
@@ -177,10 +187,22 @@
           </a>
         </li>
         <li class="bottom-gutter">
-          <a href="{{ url_for('.service_switch_can_send_international_sms', service_id=current_service.id) }}" class="button">
-            {{ 'Stop sending international sms' if 'international_sms' in current_service.permissions else 'Allow international sms' }}
+          <a href="{{ url_for('.service_switch_can_send_sms', service_id=current_service.id) }}" class="button">
+            {{ 'Stop sending sms' if 'sms' in current_service.permissions else 'Allow to send sms' }}
           </a>
         </li>
+        {% if 'sms' in current_service.permissions %}
+          <li class="bottom-gutter">
+            <a href="{{ url_for('.service_switch_can_send_international_sms', service_id=current_service.id) }}" class="button">
+              {{ 'Stop sending international sms' if 'international_sms' in current_service.permissions else 'Allow to send international sms' }}
+            </a>
+          </li>
+          <li class="bottom-gutter">
+            <a href="{{ url_for('.service_set_sms_sender', service_id=current_service.id, set_inbound_sms=True) }}" class="button">
+              {{ 'Stop inbound sms' if can_receive_inbound else 'Allow inbound sms' }}
+            </a>
+          </li>
+        {% endif %}
         {% if current_service.active %}
           <li class="bottom-gutter">
             <a href="{{ url_for('.archive_service', service_id=current_service.id) }}" class="button">
@@ -200,11 +222,6 @@
             </a>
           </li>
         {% endif %}
-        <li class="bottom-gutter">
-          <a href="{{ url_for('.service_set_sms_sender', service_id=current_service.id, set_inbound_sms=True) }}" class="button">
-            {{ 'Stop inbound sms' if can_receive_inbound else 'Allow inbound sms' }}
-          </a>
-        </li>
       </ul>
 
     {% endif %}

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -1,0 +1,38 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Emails
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">Emails</h1>
+      {% if 'email' in current_service.permissions %}
+        <p>
+          Your service can send emails.
+        </p>
+        <p>
+          If you want to turn it off,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% else %}
+        <p>
+          Sending emails is an invitation&#8209;only feature.
+        </p>
+        <p>
+          If you want to try it out,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% endif %}
+      {{ page_footer(
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -1,0 +1,38 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Text messages
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">Text messages</h1>
+      {% if 'sms' in current_service.permissions %}
+        <p>
+          Your service can send text messages.
+        </p>
+        <p>
+          If you want to turn it off,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% else %}
+        <p>
+          Sending text messages is an invitation&#8209;only feature.
+        </p>
+        <p>
+          If you want to try it out,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        </p>
+      {% endif %}
+      {{ page_footer(
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -1,0 +1,47 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Emails
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">{{ notification_type.capitalize() }}</h1>
+      <p>
+        Sending {{ notification_type }} is an invitation&#8209;only feature.
+      </p>
+      <p>
+        If you want to try it out,
+        <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+      </p>
+
+      {% set
+        back_link_dict = {
+          'add_new_template': {
+            'url' : '.add_template_by_type', 'text': 'Back to add new template'
+          },
+          'templates': {
+            'url' : '.choose_template', 'text' : 'Back to templates'
+          },
+          'view_template': {
+            'url' :'.view_template', 'text' : 'Back to the template'
+          }
+        }
+      %}
+
+      {{ page_footer(
+        back_link=url_for(
+          back_link_dict[return_to]['url'],
+          service_id=current_service.id,
+          template_id=template_id),
+        back_link_text=back_link_dict[return_to]['text']
+        ) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -10,12 +10,12 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">{{ notification_type.capitalize() }}</h1>
+      <h1 class="heading-large">{{ notification_type.capitalize() }} are disabled</h1>
       <p>
-        Sending {{ notification_type }} is an invitation&#8209;only feature.
+        Sending {{ notification_type }} has been disabled for your service.
       </p>
       <p>
-        If you want to try it out,
+        If you need to send {{ notification_type }} 
         <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
       </p>
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -320,3 +320,7 @@ def get_time_left(created_at):
         past_tense='Data no longer available',  # No-one should ever see this
         precision=1
     )
+
+
+def email_or_sms_not_enabled(template_type, permissions):
+    return (template_type in ['email', 'sms']) and (template_type not in permissions)

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -55,7 +55,7 @@ def test_should_not_allow_files_to_be_uploaded_without_the_correct_permission(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     assert response.status_code == 200
-    assert page.select('main p')[0].text.strip() == "Sending text messages is an invitation‑only feature."
+    assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
     assert page.select(".page-footer-back-link")[0].text == "Back to the template"
     assert page.select(".page-footer-back-link")[0]['href'] == url_for(
         '.view_template',
@@ -353,7 +353,7 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     assert response.status_code == 200
-    assert page.select('main p')[0].text.strip() == "Sending text messages is an invitation‑only feature."
+    assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
     assert page.select(".page-footer-back-link")[0].text == "Back to the template"
     assert page.select(".page-footer-back-link")[0]['href'] == url_for(
         '.view_template',

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -38,6 +38,32 @@ def test_that_test_files_exist():
     assert len(test_non_spreadsheet_files) == 6
 
 
+def test_should_not_allow_files_to_be_uploaded_without_the_correct_permission(
+    logged_in_client,
+    mock_get_service_template,
+    service_one,
+    fake_uuid,
+):
+    template_id = fake_uuid
+    service_one['permissions'] = []
+
+    response = logged_in_client.get(url_for(
+        '.send_messages',
+        service_id=service_one['id'],
+        template_id=template_id),
+        follow_redirects=True)
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert page.select('main p')[0].text.strip() == "Sending text messages is an invitation‑only feature."
+    assert page.select(".page-footer-back-link")[0].text == "Back to the template"
+    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+        '.view_template',
+        service_id=service_one['id'],
+        template_id=template_id,
+    )
+
+
 @pytest.mark.parametrize(
     "filename, acceptable_file",
     list(zip(
@@ -310,6 +336,32 @@ def test_send_test_step_redirects_if_session_not_setup(
         assert session['recipient'] == expected_recipient
 
 
+def test_send_one_off_does_not_send_without_the_correct_permissions(
+    logged_in_client,
+    mock_get_service_template,
+    service_one,
+    fake_uuid,
+):
+    template_id = fake_uuid
+    service_one['permissions'] = []
+
+    response = logged_in_client.get(url_for(
+        '.send_one_off',
+        service_id=service_one['id'],
+        template_id=template_id),
+        follow_redirects=True)
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert page.select('main p')[0].text.strip() == "Sending text messages is an invitation‑only feature."
+    assert page.select(".page-footer-back-link")[0].text == "Back to the template"
+    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+        '.view_template',
+        service_id=service_one['id'],
+        template_id=template_id,
+    )
+
+
 @pytest.mark.parametrize('template_mock, partial_url, expected_h1, tour_shown', [
     (
         mock_get_service_template_with_placeholders,
@@ -542,11 +594,15 @@ def test_send_test_redirects_to_start_if_index_out_of_bounds_and_some_placeholde
 ])
 def _redirects_with_help_argument(
     logged_in_client,
+    mocker,
     service_one,
     fake_uuid,
     endpoint,
     expected_redirect,
 ):
+    template = {'data': {'template_type': 'sms'}}
+    mocker.patch('app.service_api_client.get_service_template', return_value=template)
+
     response = logged_in_client.get(
         url_for(endpoint, service_id=service_one['id'], template_id=fake_uuid, help=1)
     )
@@ -848,6 +904,8 @@ def test_send_test_clears_session(
     service_one,
     fake_uuid,
 ):
+    template = {'data': {'template_type': 'sms'}}
+    mocker.patch('app.service_api_client.get_service_template', return_value=template)
 
     with logged_in_client.session_transaction() as session:
         session['recipient'] = '07700900001'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -286,7 +286,7 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
 
     assert response.status_code == 200
     assert page.select('main p')[0].text.strip() == \
-        "Sending {} is an invitation‑only feature.".format(template_description[type_of_template])
+        "Sending {} has been disabled for your service.".format(template_description[type_of_template])
     assert page.select(".page-footer-back-link")[0].text == "Back to add new template"
     assert page.select(".page-footer-back-link")[0]['href'] == url_for(
         '.add_template_by_type',
@@ -315,7 +315,7 @@ def test_should_not_allow_creation_of_a_template_without_correct_permission(
 
     assert response.status_code == 200
     assert page.select('main p')[0].text.strip() == \
-        "Sending {} is an invitation‑only feature.".format(template_description[type_of_template])
+        "Sending {} has been disabled for your service.".format(template_description[type_of_template])
     assert page.select(".page-footer-back-link")[0].text == "Back to templates"
     assert page.select(".page-footer-back-link")[0]['href'] == url_for(
         '.choose_template',
@@ -411,7 +411,7 @@ def test_should_not_allow_template_edits_without_correct_permission(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     assert response.status_code == 200
-    assert page.select('main p')[0].text.strip() == "Sending text messages is an invitation‑only feature."
+    assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
     assert page.select(".page-footer-back-link")[0].text == "Back to the template"
     assert page.select(".page-footer-back-link")[0]['href'] == url_for(
         '.view_template',

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -266,6 +266,64 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
     assert mock_get_service_template.called is False
 
 
+@pytest.mark.parametrize('type_of_template', ['email', 'sms'])
+def test_should_not_allow_creation_of_template_through_form_without_correct_permission(
+    logged_in_client,
+    service_one,
+    mocker,
+    type_of_template,
+):
+    service_one['permissions'] = []
+    template_description = {'sms': 'text messages', 'email': 'emails'}
+
+    response = logged_in_client.post(url_for(
+        '.add_template_by_type',
+        service_id=service_one['id']),
+        data={'template_type': type_of_template},
+        follow_redirects=True)
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert page.select('main p')[0].text.strip() == \
+        "Sending {} is an invitation‑only feature.".format(template_description[type_of_template])
+    assert page.select(".page-footer-back-link")[0].text == "Back to add new template"
+    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+        '.add_template_by_type',
+        service_id=service_one['id'],
+        template_id='0',
+    )
+
+
+@pytest.mark.parametrize('type_of_template', ['email', 'sms'])
+def test_should_not_allow_creation_of_a_template_without_correct_permission(
+    logged_in_client,
+    service_one,
+    mocker,
+    type_of_template,
+):
+    service_one['permissions'] = []
+    template_description = {'sms': 'text messages', 'email': 'emails'}
+
+    response = logged_in_client.get(url_for(
+        '.add_service_template',
+        service_id=service_one['id'],
+        template_type=type_of_template),
+        follow_redirects=True)
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert page.select('main p')[0].text.strip() == \
+        "Sending {} is an invitation‑only feature.".format(template_description[type_of_template])
+    assert page.select(".page-footer-back-link")[0].text == "Back to templates"
+    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+        '.choose_template',
+        service_id=service_one['id'],
+        template_id='0',
+    )
+
+
 def test_should_redirect_when_saving_a_template(
     logged_in_client,
     active_user_with_permissions,
@@ -333,6 +391,32 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
         service['id'],
         None,
         'priority'
+    )
+
+
+def test_should_not_allow_template_edits_without_correct_permission(
+    logged_in_client,
+    mock_get_service_template,
+    service_one,
+    fake_uuid,
+):
+    template_id = fake_uuid
+    service_one['permissions'] = ['email']
+
+    response = logged_in_client.get(url_for(
+        '.edit_service_template',
+        service_id=service_one['id'],
+        template_id=template_id),
+        follow_redirects=True)
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert page.select('main p')[0].text.strip() == "Sending text messages is an invitation‑only feature."
+    assert page.select(".page-footer-back-link")[0].text == "Back to the template"
+    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+        '.view_template',
+        service_id=service_one['id'],
+        template_id=template_id,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def mock_get_service(mocker, api_user_active):
 @pytest.fixture(scope='function')
 def mock_get_international_service(mocker, api_user_active):
     def _get(service_id):
-        service = service_json(service_id, users=[api_user_active.id], permissions=['international_sms'])
+        service = service_json(service_id, users=[api_user_active.id], permissions=['sms', 'international_sms'])
         return {'data': service}
 
     return mocker.patch('app.service_api_client.get_service', side_effect=_get)


### PR DESCRIPTION
Email and SMS can now be enabled and disabled by Platform Admin. If email or SMS are disabled for a service, then users will not be able to edit or add a new template.