### PR TITLE
Remove yearly usage from dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -219,14 +219,7 @@ def get_dashboard_partials(service_id):
             'views/dashboard/_jobs.html',
             jobs=immediate_jobs
         ),
-        'has_jobs': bool(immediate_jobs),
-        'usage': render_template(
-            'views/dashboard/_usage.html',
-            **calculate_free_tier_usage(service_api_client.get_yearly_sms_unit_count_and_cost(
-                service_id,
-                get_current_financial_year(),
-            ), service)
-        ),
+        'has_jobs': bool(immediate_jobs)
     }
 
 
@@ -235,16 +228,6 @@ def get_dashboard_totals(statistics):
         msg_type['failed_percentage'] = get_formatted_percentage(msg_type['failed'], msg_type['requested'])
         msg_type['show_warning'] = float(msg_type['failed_percentage']) > 3
     return statistics
-
-
-def calculate_free_tier_usage(usage, service):
-    sms_free_allowance = service['data']['free_sms_fragment_limit']
-    return({
-        'sms_chargeable': max(0, usage['billable_sms_units'] - sms_free_allowance),
-        'total_sms_bill': usage['billable_sms_units'],
-        'total_sms_cost': usage['total_cost'],
-        'sms_allowance_remaining': sms_free_allowance - int(usage['billable_sms_units'])
-    })
 
 
 def calculate_usage(usage):

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -53,15 +53,6 @@
       ) }}
     {% endif %}
 
-    {% if current_user.has_permissions(['manage_settings'], admin_override=True) %}
-      <h2 class='heading-medium'>This year</h2>
-      {{ ajax_block(partials, updates_url, 'usage') }}
-      {{ show_more(
-        url_for(".usage", service_id=current_service['id']),
-        'See usage breakdown'
-      ) }}
-    {% endif %}
-
   </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -5,7 +5,6 @@ from unittest.mock import call, ANY
 from flask import url_for
 import pytest
 from bs4 import BeautifulSoup
-from datetime import datetime, timedelta
 from freezegun import freeze_time
 
 from app.main.views.dashboard import (
@@ -14,8 +13,7 @@ from app.main.views.dashboard import (
     get_free_paid_breakdown_for_billable_units,
     aggregate_status_types,
     format_template_stats_to_list,
-    get_tuples_of_financial_years,
-    get_dashboard_partials
+    get_tuples_of_financial_years
 )
 
 from tests import validate_route_permission
@@ -833,45 +831,3 @@ def test_should_show_all_jobs_with_valid_statuses(
         'ready to send',
         'sent to dvla'
     })
-
-
-def test_should_show_remaining_free_tier_count(
-    logged_in_client,
-    mock_get_service_templates,
-    mock_get_template_statistics,
-    mock_get_detailed_service,
-    mock_get_jobs,
-    mock_get_usage,
-    mocker
-):
-    mocker.patch(
-        'app.service_api_client.get_yearly_sms_unit_count_and_cost',
-        return_value={"billable_sms_units": 100, "total_cost": 200.0}
-    )
-
-    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
-
-    assert response.status_code == 200
-    assert '249,900' in response.get_data(as_text=True)
-    assert 'free text messages left' in response.get_data(as_text=True)
-
-
-def test_should_show_cost_if_exceeded_free_tier_count(
-    logged_in_client,
-    mock_get_service_templates,
-    mock_get_template_statistics,
-    mock_get_detailed_service,
-    mock_get_jobs,
-    mock_get_usage,
-    mocker
-):
-    mocker.patch(
-        'app.service_api_client.get_yearly_sms_unit_count_and_cost',
-        return_value={"billable_sms_units": 300000, "total_cost": 1500.50}
-    )
-
-    response = logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
-
-    assert response.status_code == 200
-    assert '£1,500.50' in response.get_data(as_text=True)
-    assert 'spent on text messages' in response.get_data(as_text=True)


### PR DESCRIPTION
The yearly usage section on the dashboard page takes too log as a result services with large yearly stats are timing out.

As a short term fix we have taken the yearly stats off the dashboard.

There is a plan to create permanent statistic tables to warehouse the data.