### PR TITLE
Fix link to dashboard from end of tour

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -34,7 +34,6 @@ from app.utils import (
     generate_previous_dict,
     user_has_permissions,
     generate_notifications_csv,
-    get_help_argument,
     get_template,
     get_time_left,
     REQUESTED_STATUSES,
@@ -121,10 +120,8 @@ def view_job(service_id, job_id):
             service_id=service_id,
             job_id=job['id'],
             status=request.args.get('status', ''),
-            help=get_help_argument()
         ),
         partials=get_job_partials(job),
-        help=get_help_argument()
     )
 
 
@@ -307,7 +304,7 @@ def get_status_filters(service, message_type, statistics):
     ]
 
 
-def _get_job_counts(job, help_argument):
+def _get_job_counts(job):
     sending = 0 if job['job_status'] == 'scheduled' else (
         job.get('notification_count', 0) -
         job.get('notifications_delivered', 0) -
@@ -322,7 +319,6 @@ def _get_job_counts(job, help_argument):
                 service_id=job['service'],
                 job_id=job['id'],
                 status=query_param,
-                help=help_argument
             ),
             count
         ) for label, query_param, count in [
@@ -360,7 +356,7 @@ def get_job_partials(job):
     return {
         'counts': render_template(
             'partials/count.html',
-            counts=_get_job_counts(job, request.args.get('help', 0)),
+            counts=_get_job_counts(job),
             status=filter_args['status']
         ),
         'notifications': render_template(
@@ -376,7 +372,6 @@ def get_job_partials(job):
                 job_id=job['id'],
                 status=request.args.get('status')
             ),
-            help=get_help_argument(),
             time_left=get_time_left(job['created_at']),
             job=job,
             template=template,

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -32,7 +32,7 @@
             Notify delivers the message
           </p>
           {% if help == '3' %}
-            <a href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template_id) }}'>
+            <a href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
               Now go to your dashboard
             </a>
           {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -24,18 +24,16 @@
       <div class="dashboard-table bottom-gutter-3-2">
     {% endif %}
 
-      {% if not help %}
-        {% if percentage_complete < 100 %}
-          <p class="bottom-gutter hint">
-            Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
-          </p>
-        {% elif notifications %}
-          <p class="bottom-gutter">
-            <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
-            &emsp;
-            <span id="time-left">{{ time_left }}</span>
-          </p>
-        {% endif %}
+      {% if percentage_complete < 100 %}
+        <p class="bottom-gutter hint">
+          Report is {{ "{:.0f}%".format(percentage_complete) }} complete…
+        </p>
+      {% elif notifications %}
+        <p class="bottom-gutter">
+          <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+          &emsp;
+          <span id="time-left">{{ time_left }}</span>
+        </p>
       {% endif %}
 
       {% call(item, row_number) list_table(

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -224,38 +224,6 @@ def test_should_not_show_cancelled_job(
     assert response.status_code == 404
 
 
-def test_should_show_not_show_csv_download_in_tour(
-    logged_in_client,
-    service_one,
-    active_user_with_permissions,
-    mock_get_service_template,
-    mock_get_job,
-    mocker,
-    mock_get_notifications,
-    fake_uuid,
-):
-    response = logged_in_client.get(url_for(
-        'main.view_job',
-        service_id=service_one['id'],
-        job_id=fake_uuid,
-        help=3
-    ))
-
-    assert response.status_code == 200
-    assert url_for(
-        'main.view_job_updates',
-        service_id=service_one['id'],
-        job_id=fake_uuid,
-        status='',
-        help=3
-    ).replace('&', '&amp;') in response.get_data(as_text=True)
-    assert url_for(
-        'main.view_job_csv',
-        service_id=service_one['id'],
-        job_id=fake_uuid
-    ) not in response.get_data(as_text=True)
-
-
 @freeze_time("2016-01-01 00:00:00.000001")
 def test_should_show_updates_for_one_job_as_json(
     logged_in_client,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1334,7 +1334,27 @@ def test_check_messages_back_link(
     ) == expected_url(service_id=fake_uuid, template_id=fake_uuid)
 
 
-def test_go_to_dashboard_after_tour(
+def test_shows_link_to_end_tour(
+    client_request,
+    mock_get_notification,
+    fake_uuid,
+):
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        help=3,
+    )
+
+    assert page.select(".banner-tour a")[0]['href'] == url_for(
+        'main.go_to_dashboard_after_tour',
+        service_id=SERVICE_ONE_ID,
+        example_template_id='5407f4db-51c7-4150-8758-35412d42186a',
+    )
+
+
+def test_go_to_dashboard_after_tour_link(
     logged_in_client,
     mocker,
     api_user_active,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1678,7 +1678,7 @@ def mock_get_notification(
         noti['personalisation'] = {'name': 'Jo'}
         noti['template'] = template_json(
             service_id,
-            str(generate_uuid()),
+            '5407f4db-51c7-4150-8758-35412d42186a',
             content='hello ((name))',
             redact_personalisation=redact_personalisation,
         )


### PR DESCRIPTION
The notification page was different to the job page in that it passed through the whole template, not just the ID.