### PR TITLE
Bump utils to count characters in SMS properly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@17.5.0#egg=notifications-utils==17.5.0
+git+https://github.com/alphagov/notifications-utils.git@17.5.1#egg=notifications-utils==17.5.1

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1819,7 +1819,7 @@ SERVICE_DAILY_LIMIT_MSG = 'Exceeded send limits (1000) for today'
     (
         TOO_LONG_MSG,
         'Message too long',
-        'Text messages can’t be longer than 459 characters. Your message is 678 characters.'
+        'Text messages can’t be longer than 459 characters. Your message is 554 characters.'
     ),
     (
         SERVICE_DAILY_LIMIT_MSG,


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/172