### PR TITLE
Don’t link to template in tour

### DIFF
--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -15,7 +15,11 @@
     </h1>
 
     <p>
-      <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+      {% if help %}
+        {{ template.name }}
+      {% else %}
+        <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+      {% endif %}
       sent
       {% if job and job.original_file_name != 'Report' %}
         from

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -9,7 +9,7 @@ from app.utils import (
 )
 
 from tests.app.test_utils import normalize_spaces
-from tests.conftest import mock_get_notification
+from tests.conftest import mock_get_notification, SERVICE_ONE_ID
 
 
 @pytest.mark.parametrize('notification_status, expected_status', [
@@ -91,3 +91,23 @@ def test_notification_status_page_respects_redaction(
         service_one['id'],
         fake_uuid,
     )
+
+
+@freeze_time("2012-01-01 01:01")
+def test_notification_page_doesnt_link_to_template_in_tour(
+    client_request,
+    fake_uuid,
+    mock_get_notification,
+):
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        help=3,
+    )
+
+    assert normalize_spaces(page.select('main p:nth-of-type(1)')[0].text) == (
+        'sample template sent by Test User on 1 January at 1:01am'
+    )
+    assert len(page.select('main p:nth-of-type(1) a')) == 0


### PR DESCRIPTION
We want people to go to the dashboard, not get distracted by clicking the tempting blue link.