### PR TITLE
Fix page title on notification page

### DIFF
--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Page not found{% endblock %}
+{% block per_page_title %}Page could not be found{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/views/check.html
+++ b/app/templates/views/check.html
@@ -14,7 +14,7 @@
 {% endmacro %}
 
 {% block service_page_title %}
-  {{ "Error" if errors else "Preview" }}
+  {{ "Error" if errors else "Preview of {}".format(template.name) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -3,7 +3,7 @@
 {% from "components/message-count-label.html" import message_count_label %}
 
 {% block service_page_title %}
-  {{ "Error" if error else "Preview" }}
+  {{ "Error" if error else "Preview of {}".format(template.name) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -5,7 +5,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Report
+  {{ message_count_label(1, template.template_type, suffix='') | capitalize }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -8,8 +8,7 @@ from bs4 import BeautifulSoup
 
 from app.main.views.jobs import get_time_left, get_status_filters
 from tests import notification_json
-from tests.conftest import SERVICE_ONE_ID, mock_get_notifications
-from tests.app.test_utils import normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, mock_get_notifications, normalize_spaces
 from freezegun import freeze_time
 
 

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -8,7 +8,7 @@ from notifications_python_client.errors import HTTPError
 from tests.conftest import (
     SERVICE_ONE_ID,
 )
-from tests.app.test_utils import normalize_spaces
+from tests.conftest import normalize_spaces
 from freezegun import freeze_time
 from unittest import mock
 from app.main.views.conversation import get_user_number

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -21,8 +21,8 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_inbound_sms_summary,
     mock_get_inbound_sms_summary_with_no_messages,
+    normalize_spaces,
 )
-from tests.app.test_utils import normalize_spaces
 
 stub_template_stats = [
     {

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -8,8 +8,7 @@ from bs4 import BeautifulSoup
 
 from app.main.views.jobs import get_time_left, get_status_filters
 from tests import notification_json
-from tests.app.test_utils import normalize_spaces
-from tests.conftest import SERVICE_ONE_ID
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 from freezegun import freeze_time
 
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -8,8 +8,7 @@ from app.utils import (
     DELIVERED_STATUSES,
 )
 
-from tests.app.test_utils import normalize_spaces
-from tests.conftest import mock_get_notification, SERVICE_ONE_ID
+from tests.conftest import mock_get_notification, SERVICE_ONE_ID, normalize_spaces
 
 
 @pytest.mark.parametrize('notification_status, expected_status', [

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -15,7 +15,6 @@ from notifications_utils.template import LetterPreviewTemplate, LetterImageTempl
 from notifications_utils.recipients import RecipientCSV
 
 from tests import validate_route_permission, validate_route_permission_with_client
-from tests.app.test_utils import normalize_spaces
 from tests.conftest import (
     mock_get_service_template,
     mock_get_service_template_with_placeholders,
@@ -23,6 +22,7 @@ from tests.conftest import (
     mock_get_service,
     mock_get_international_service,
     mock_get_service_email_template,
+    normalize_spaces,
     SERVICE_ONE_ID,
 )
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -10,7 +10,7 @@ import app
 from app.main.views.service_settings import dummy_bearer_token
 from app.utils import email_safe
 from tests import validate_route_permission, service_json
-from tests.app.test_utils import normalize_spaces
+from tests.conftest import normalize_spaces
 
 from tests.conftest import active_user_with_permissions, platform_admin_user
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -7,9 +7,13 @@ from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from tests.conftest import service_one as create_sample_service
-from tests.conftest import mock_get_service_email_template, mock_get_service_letter_template, SERVICE_ONE_ID
+from tests.conftest import (
+    mock_get_service_email_template,
+    mock_get_service_letter_template,
+    normalize_spaces,
+    SERVICE_ONE_ID,
+)
 from tests import validate_route_permission, template_json, single_notification_json
-from tests.app.test_utils import normalize_spaces
 
 from app.main.views.templates import get_last_use_message, get_human_readable_delta
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -154,9 +154,3 @@ def test_generate_notifications_csv_calls_twice_if_next_link(mocker):
     # mock_calls[0][2] is the kwargs from first call
     assert mock_get_notifications.mock_calls[0][2]['page'] == 1
     assert mock_get_notifications.mock_calls[1][2]['page'] == 2
-
-
-def normalize_spaces(input):
-    if isinstance(input, str):
-        return ' '.join(input.split())
-    return normalize_spaces(' '.join(item.text for item in input))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1778,3 +1778,9 @@ def client_request(logged_in_client):
             return BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
 
     return ClientRequest
+
+
+def normalize_spaces(input):
+    if isinstance(input, str):
+        return ' '.join(input.split())
+    return normalize_spaces(' '.join(item.text for item in input))


### PR DESCRIPTION
Also:
- adds some tests to try to stop this reoccurring on other pages…
- …which caught some other pages where the `<title>` didn’t match the `<h1>`