### PR TITLE
Fix 500 on two-way conversation page

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -254,7 +254,6 @@ def notification_json(
         'notifications': [{
             'id': uuid.uuid4(),
             'to': to,
-            'body': template['content'],
             'template': template,
             'job': job_payload,
             'sent_at': sent_at,

--- a/tests/app/main/test_asset_fingerprinter.py
+++ b/tests/app/main/test_asset_fingerprinter.py
@@ -6,9 +6,9 @@ from unittest import mock
 from app.asset_fingerprinter import AssetFingerprinter
 
 
-@mock.patch.object(AssetFingerprinter, 'get_asset_file_contents')
 class TestAssetFingerprint(object):
-    def test_url_format(self, get_file_content_mock):
+    def test_url_format(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, 'get_asset_file_contents')
         get_file_content_mock.return_value = """
             body {
                 font-family: nta;
@@ -26,7 +26,8 @@ class TestAssetFingerprint(object):
             '/suppliers/static/application-ie6.css?418e6f4a6cdf1142e45c072ed3e1c90a'  # noqa
         )
 
-    def test_building_file_path(self, get_file_content_mock):
+    def test_building_file_path(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, 'get_asset_file_contents')
         get_file_content_mock.return_value = """
             document.write('Hello world!');
         """
@@ -36,7 +37,8 @@ class TestAssetFingerprint(object):
             'app/static/javascripts/application.js'
         )
 
-    def test_hashes_are_consistent(self, get_file_content_mock):
+    def test_hashes_are_consistent(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, 'get_asset_file_contents')
         get_file_content_mock.return_value = """
             body {
                 font-family: nta;
@@ -49,8 +51,9 @@ class TestAssetFingerprint(object):
         )
 
     def test_hashes_are_different_for_different_files(
-        self, get_file_content_mock
+        self, mocker
     ):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, 'get_asset_file_contents')
         asset_fingerprinter = AssetFingerprinter()
         get_file_content_mock.return_value = """
             body {
@@ -66,7 +69,8 @@ class TestAssetFingerprint(object):
             js_hash != css_hash
         )
 
-    def test_hash_gets_cached(self, get_file_content_mock):
+    def test_hash_gets_cached(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, 'get_asset_file_contents')
         get_file_content_mock.return_value = """
             body {
                 font-family: nta;


### PR DESCRIPTION
We changed the schema used by the endpoint that searches for notifications by recipient. So the admin app was looking for the wrong thing in the JSON.

This is hard to catch in tests because it relies on our fixtures matching what the API really returns.

This commit fixes the code to use the correct key to lookup the template content from the JSON.

This also exposed the fact that we weren’t passing in the personalisation any more (perhaps got lost in the re-reverts somehow) so users were only seeing the template in the inbound view, not the
full message content.