### PR TITLE
Fix wrong permissions on dashboard pages

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -122,7 +122,7 @@ def usage(service_id):
 
 @main.route("/services/<service_id>/monthly")
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('view_activity', admin_override=True)
 def monthly(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
     return render_template(
@@ -140,7 +140,7 @@ def monthly(service_id):
 
 @main.route("/services/<service_id>/inbox")
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('view_activity', admin_override=True)
 def inbox(service_id):
 
     if 'inbound_sms' not in current_service['permissions']:

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -16,7 +16,7 @@ from app.main.views.dashboard import (
     get_tuples_of_financial_years
 )
 
-from tests import validate_route_permission
+from tests import validate_route_permission, validate_route_permission_with_client
 from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_inbound_sms_summary,
@@ -198,6 +198,28 @@ def test_inbox_not_accessible_to_service_without_permissions(
     assert response.status_code == 403
 
 
+def test_anyone_can_see_inbox(
+    client,
+    api_user_active,
+    service_one,
+    mocker,
+    mock_get_inbound_sms_with_no_messages,
+):
+
+    service_one['permissions'] = ['inbound_sms']
+
+    validate_route_permission_with_client(
+        mocker,
+        client,
+        'GET',
+        200,
+        url_for('main.inbox', service_id=service_one['id']),
+        ['view_activity'],
+        api_user_active,
+        service_one,
+    )
+
+
 def test_should_show_recent_templates_on_dashboard(
     logged_in_client,
     mocker,
@@ -262,6 +284,25 @@ def test_should_show_monthly_breakdown_of_template_usage(
 
     assert len(table_rows) == len(['April'])
     assert len(page.select('.table-no-data')) == len(['May', 'June', 'July'])
+
+
+def test_anyone_can_see_monthly_breakdown(
+    client,
+    api_user_active,
+    service_one,
+    mocker,
+    mock_get_monthly_notification_stats,
+):
+    validate_route_permission_with_client(
+        mocker,
+        client,
+        'GET',
+        200,
+        url_for('main.monthly', service_id=service_one['id']),
+        ['view_activity'],
+        api_user_active,
+        service_one,
+    )
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1410,6 +1410,27 @@ def mock_get_monthly_template_statistics(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def mock_get_monthly_notification_stats(mocker, service_one, fake_uuid):
+    def _stats(service_id, year):
+        return {'data': {
+            datetime.utcnow().strftime('%Y-%m'): {
+                "email": {
+                    "sending": 1,
+                    "delivered": 1,
+                },
+                "sms": {
+                    "sending": 1,
+                    "delivered": 1,
+                },
+            }
+        }}
+    return mocker.patch(
+        'app.service_api_client.get_monthly_notification_stats',
+        side_effect=_stats
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_template_statistics_for_template(mocker, service_one):
     def _get_stats(service_id, template_id):
         template = template_json(service_id, template_id, "Test template", "sms", "Something very interesting")


### PR DESCRIPTION
Anyone with access to a service should be able to see:
- monthly breakdown (non financial)
- incoming messages

Not sure how we test this better to stop it happening again?