### PR TITLE
Reduce spacing before button on invite page

### DIFF
--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -9,7 +9,7 @@
   {{ checkbox(form.manage_api_keys) }}
 </fieldset>
 
-<div class="form-group">
+<div class="bottom-gutter">
   <p class="form-label">
     All team members can see
   </p>


### PR DESCRIPTION
It was too much, the button looked adrift.

# Before

![image](https://user-images.githubusercontent.com/355079/28172571-d1fbf62a-67e3-11e7-9461-9f13b94d61a9.png)

# After

![image](https://user-images.githubusercontent.com/355079/28172548-bc6c90b2-67e3-11e7-8414-54d5127c48ca.png)
