### PR TITLE
Fix broken link in support process

### DIFF
--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -33,7 +33,7 @@
         </p>
         <h2 class="heading-medium">Any other problems</h2>
         <p class="bottom-gutter-2">
-          <a href="{{ url_for('main.feedback', ticket_type='problem', severe=False)}}">Fill in this form</a>
+          <a href="{{ url_for('main.feedback', ticket_type='problem', severe='no') }}">Fill in this form</a>
           and we’ll get back to you by the next working day.
         </p>
         <p>

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -449,6 +449,13 @@ def test_bat_email_page(
     response = client.get(bat_phone_page)
     assert response.status_code == 200
 
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.select('main a')[1].text == 'Fill in this form'
+    assert page.select('main a')[1]['href'] == url_for('main.feedback', ticket_type='problem', severe='no')
+    next_page_response = client.get(page.select('main a')[1]['href'])
+    next_page = BeautifulSoup(next_page_response.data.decode('utf-8'), 'html.parser')
+    assert next_page.h1.text.strip() == 'Report a problem'
+
     client.login(active_user_with_permissions, mocker, service_one)
     logged_in_response = client.get(bat_phone_page)
     assert logged_in_response.status_code == 302


### PR DESCRIPTION
The idea is if you decide your problem isn’t such an emergency after all, we direct you to the form where you can report it as such. This link wasn’t working because it didn’t understand `False` to mean ‘not severe’. Only ‘no’ means not severe.

The result was that users got sent in a bit of a convoluted loop where they were asked again if their problem was an emergency or not.

Testing this by making sure that both:
- the URL in the link is what we expected
- when visited it gives the page title we expect

Because even if we had had the first test only, it wouldn’t have caught this bug.