### PR TITLE
Speed up deployment (cleanup wheels/vendor dependencies for cf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ var/
 .installed.cfg
 *.egg
 venv/
-wheelhouse/
+vendor/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,9 @@ generate-version-file: ## Generates the app version file
 .PHONY: build
 build: dependencies generate-version-file ## Build project
 	npm run build
-	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel wheel --wheel-dir=wheelhouse -r requirements.txt
+	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel install -r requirements.txt
+	mkdir -p vendor/
+	cp -r ${PIP_ACCEL_CACHE}/sources/ vendor/
 
 .PHONY: cf-build
 cf-build: dependencies generate-version-file ## Build project
@@ -199,7 +201,7 @@ clean-docker-containers: ## Clean up any remaining docker containers
 
 .PHONY: clean
 clean:
-	rm -rf node_modules cache target venv .coverage wheelhouse
+	rm -rf node_modules cache target venv .coverage vendor
 
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry

--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -2,4 +2,4 @@
 
 echo "Install dependencies"
 cd /home/notify-app/notifications-admin;
-pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-admin/requirements.txt
+pip3 install --find-links=vendor -r /home/notify-app/notifications-admin/requirements.txt


### PR DESCRIPTION
This removes the action of creating python wheels for our dependencies (previously used to support offline installation on AWS) but adds functionality to package our requirements for CloudFoundry.

## Summary

1. Previously we used AWS which meant that we could create wheels from our requirements and then install them offline making our deployments quicker. We're no longer using AWS so let's remove that.

2. CloudFoundry supports installing dependencies in an offline environment as documented here:
http://docs.cloudfoundry.org/buildpacks/python/#vendoring. To achieve this we create a vendor/ directory containing the python packages to install. This uses `--no-index` and `--find-links` and as a result will not attempt to resolve any dependencies from pypi. For this reason there is
assumed confidence that the vendor/ directory will contain all of the dependencies we need.