### PR TITLE
Fix error message for missing cells in CSV file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ notifications-python-client>=3.1,<3.2
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@17.5.1#egg=notifications-utils==17.5.1
+git+https://github.com/alphagov/notifications-utils.git@17.5.6#egg=notifications-utils==17.5.6

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -185,6 +185,32 @@ def test_upload_csvfile_with_errors_shows_check_page_with_errors(
             'Skip to file contents'
         )
     ),
+    (
+        """
+            phone number, name
+            +447700900986, example
+            , example
+            +447700900986, example
+        """,
+        (
+            'There is a problem with your data '
+            'You need to enter missing data in 1 row '
+            'Skip to file contents'
+        )
+    ),
+    (
+        """
+            phone number, name
+            +447700900986, example
+            +447700900986,
+            +447700900986, example
+        """,
+        (
+            'There is a problem with your data '
+            'You need to enter missing data in 1 row '
+            'Skip to file contents'
+        )
+    ),
 ])
 def test_upload_csvfile_with_missing_columns_shows_error(
     logged_in_client,


### PR DESCRIPTION
This was causing a `500` because of a bug in utils. It only occurred when there was missing data for a cell in the recipient column. I’ve also added a test for missing data in a non-recipient column just in case.