### PR TITLE
Revert vendoring dependencies for cloundfoundry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ var/
 .installed.cfg
 *.egg
 venv/
-vendor/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,6 @@ generate-version-file: ## Generates the app version file
 build: dependencies generate-version-file ## Build project
 	npm run build
 	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel install -r requirements.txt
-	mkdir -p vendor/
-	cp ${PIP_ACCEL_CACHE}/sources/* vendor/
 
 .PHONY: cf-build
 cf-build: dependencies generate-version-file ## Build project
@@ -201,7 +199,7 @@ clean-docker-containers: ## Clean up any remaining docker containers
 
 .PHONY: clean
 clean:
-	rm -rf node_modules cache target venv .coverage vendor
+	rm -rf node_modules cache target venv .coverage
 
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,7 @@ generate-version-file: ## Generates the app version file
 build: dependencies generate-version-file ## Build project
 	npm run build
 	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel install -r requirements.txt
-	rm -rf vendor
-	mkdir -p vendor
+	mkdir -p vendor/
 	cp ${PIP_ACCEL_CACHE}/sources/* vendor/
 
 .PHONY: cf-build


### PR DESCRIPTION
Despite following the instructions described here for vendoring dependencies: http://docs.cloudfoundry.org/buildpacks/python/#vendoring, it doesn't seem to work and instead runs `pip install -r requirements.txt` as opposed to with `--find-links --no-index` (https://github.com/cloudfoundry/python-buildpack/blob/1588bd4099b9b2f75448c62bcea80e38dd5795a8/bin/steps/pipenv). 

Reverting for now until we have some time to look later.