### PR TITLE
Use ‘Continue’ not ‘Next’ for button text

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -29,7 +29,7 @@
         </div>
       {% endif %}
     </div>
-    {{ page_footer('Next', back_link=back_link) }}
+    {{ page_footer('Continue', back_link=back_link) }}
   </form>
 
   {{ template|string }}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -87,7 +87,7 @@
   </p>
 
   {{ page_footer(
-    button_text='Next step'
+    button_text='Continue'
   ) }}
 
   {{ page_footer(

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -17,7 +17,7 @@
 
         <form method="post" class="bottom-gutter-2">
           {{ radios(form.support_type) }}
-          {{ page_footer('Next') }}
+          {{ page_footer('Continue') }}
         </form>
 
         <h2 class="heading-medium">

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -15,7 +15,7 @@
       </h1>
       <form method="post">
         {{ radios(form.severe) }}
-        {{ page_footer('Next') }}
+        {{ page_footer('Continue') }}
       </form>
       <h2 class="heading-small">
         It’s only an emergency if:

--- a/app/templates/views/templates/add.html
+++ b/app/templates/views/templates/add.html
@@ -14,7 +14,7 @@
     <form method="post">
       {{ radios(form.template_type) }}
       {{ page_footer(
-        'Next'
+        'Continue'
       ) }}
     </form>
 

--- a/app/templates/views/templates/start-tour.html
+++ b/app/templates/views/templates/start-tour.html
@@ -15,7 +15,7 @@
   {{ template|string }}
 
   <div class="page-footer">
-    <a href="{{ url_for('.send_test', service_id=current_service.id, template_id=template.id, help=2) }}" class="button">Next</a>
+    <a href="{{ url_for('.send_test', service_id=current_service.id, template_id=template.id, help=2) }}" class="button">Continue</a>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
The service manual recommends to:

> Make sure your ‘Continue’ button is:
>
> - labelled ‘Continue’, not ‘Next’
> - aligned to the left so users don’t miss it

– https://www.gov.uk/service-manual/design/question-pages