### PR TITLE
Don’t set combined API on Notify python client

### DIFF
--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -12,10 +12,8 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_api_keys(self, service_id, key_id=None):
         if key_id:

--- a/app/notify_client/events_api_client.py
+++ b/app/notify_client/events_api_client.py
@@ -7,10 +7,8 @@ class EventsApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def create_event(self, event_type, event_data):
         data = {

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -9,10 +9,8 @@ class InviteApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def create_invite(self, invite_from_id, service_id, email_address, permissions):
         data = {

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -21,10 +21,8 @@ class JobApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     @staticmethod
     def __convert_statistics(job):

--- a/app/notify_client/letter_jobs_client.py
+++ b/app/notify_client/letter_jobs_client.py
@@ -8,10 +8,8 @@ class LetterJobsClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_letter_jobs(self):
         return self.get(url='/letter-jobs')['data']

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -7,10 +7,8 @@ class NotificationApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_notifications_for_service(
         self,

--- a/app/notify_client/organisations_client.py
+++ b/app/notify_client/organisations_client.py
@@ -8,10 +8,8 @@ class OrganisationsClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_organisation(self, id):
         return self.get(url='/organisation/{}'.format(id))

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -8,10 +8,8 @@ class ProviderClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_all_providers(self):
         return self.get(

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -14,10 +14,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     def init_app(self, application):
         self.base_url = application.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            application.config['ADMIN_CLIENT_USER_NAME'],
-            application.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = application.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = application.config['ADMIN_CLIENT_SECRET']
 
     def create_service(self, service_name, message_limit, restricted, user_id, email_from):
         """

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -8,10 +8,8 @@ class StatusApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_status(self, *params):
         return self.get(url='/_status', *params)

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -7,10 +7,8 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
     def get_template_statistics_for_service(self, service_id, limit_days=None):
         params = {}

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -19,10 +19,8 @@ class UserApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
-        self.api_key = '{}-{}'.format(
-            app.config['ADMIN_CLIENT_USER_NAME'],
-            app.config['ADMIN_CLIENT_SECRET'],
-        )
+        self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = app.config['ADMIN_CLIENT_SECRET']
         self.max_failed_login_count = app.config["MAX_FAILED_LOGIN_COUNT"]
 
     def register_user(self, name, email_address, mobile_number, password):


### PR DESCRIPTION
Because we’re setting the API key and service ID after calling the `__init__` method of the client it wasn’t doing the thing where it splits the combined key into the two individual UUIDs. So we still need to set them directly, individually on the client.