### PR TITLE
Update last used message when deleting a template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -428,12 +428,13 @@ def delete_service_template(service_id, template_id):
         last_used_notification = template_statistics_client.get_template_statistics_for_template(
             service_id, template['id']
         )
-        message = 'It was last used {} ago.'.format(
-            get_human_readable_delta(
+        message = 'It was last used {} ago'.format(
+            'more than seven days' if not last_used_notification else get_human_readable_delta(
                 parse(last_used_notification['created_at']).replace(tzinfo=None),
                 datetime.utcnow()
             )
         )
+
     except HTTPError as e:
         if e.status_code == 404:
             message = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1760,7 +1760,7 @@ def logged_in_client(
     active_user_with_permissions,
     mocker,
     service_one,
-    mock_login,
+    mock_login
 ):
     client.login(active_user_with_permissions, mocker, service_one)
     yield client


### PR DESCRIPTION
This will now show a generic message in the case that a given template to be deleted has been used more than seven days ago.

This can be merged before the API change that will ensure we no longer query the `NotificationHistory` table get the last usage of a template.