### PR TITLE
Fix error messages on one off sending

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -668,11 +668,11 @@ def _check_notification(service_id, template_id, exception=None):
 
 def get_template_error_dict(exception):
     # TODO: Make API return some computer-friendly identifier as well as the end user error messages
-    if 'service is in trial mode' in exception._message:
+    if 'service is in trial mode' in exception.message:
         error = 'not-allowed-to-send-to'
-    elif 'Exceeded send limits' in exception._message:
+    elif 'Exceeded send limits' in exception.message:
         error = 'too-many-messages'
-    elif 'Content for template has a character count greater than the limit of' in exception._message:
+    elif 'Content for template has a character count greater than the limit of' in exception.message:
         error = 'message-too-long'
     else:
         raise exception

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1922,9 +1922,13 @@ def test_send_notification_shows_error_if_400(
     expected_h1,
     expected_err_details
 ):
+
+    class MockHTTPError(HTTPError):
+        message = exception_msg
+
     mocker.patch(
         'app.notification_api_client.send_notification',
-        side_effect=HTTPError(response=Mock(status_code=400), message=exception_msg)
+        side_effect=MockHTTPError(),
     )
     with client_request.session_transaction() as session:
         session['recipient'] = '07700900001'
@@ -1948,9 +1952,13 @@ def test_send_notification_shows_email_error_in_trial_mode(
     mocker,
     mock_get_service_email_template,
 ):
+    class MockHTTPError(HTTPError):
+        message = TRIAL_MODE_MSG
+        status_code = 400
+
     mocker.patch(
         'app.notification_api_client.send_notification',
-        side_effect=HTTPError(response=Mock(status_code=400), message=TRIAL_MODE_MSG)
+        side_effect=MockHTTPError(),
     )
     with client_request.session_transaction() as session:
         session['recipient'] = 'test@example.com'


### PR DESCRIPTION
This was causing a 500 in production.

This commit:
- reverts the code the working state it was before 68a1426e58475965a052d511c61e4ca2230b0e17
- figures out a way to make the tests pass without breaking the actual app
- confirms that mocking things is hard