### PR TITLE
Fix big numbers on new platform admin page

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -76,7 +76,7 @@ def sum_service_usage(service):
 
 
 def filter_and_sort_services(services, trial_mode_services=False):
-    return (
+    return [
         service for service in sorted(
             services,
             key=lambda service: (
@@ -87,7 +87,7 @@ def filter_and_sort_services(services, trial_mode_services=False):
             reverse=True,
         )
         if service['restricted'] == trial_mode_services
-    )
+    ]
 
 
 def create_global_stats(services):

--- a/app/templates/views/platform-admin/index.html
+++ b/app/templates/views/platform-admin/index.html
@@ -11,6 +11,10 @@
 
 {% block platform_admin_content %}
 
+  <h1 class="heading-large">
+    Summary
+  </h1>
+
   <details>
     <summary>Apply filters</summary>
     <form autocomplete="off" method="get">


### PR DESCRIPTION
Turns out the counts were all showing as zero because the generator had already been consumed by the time we were trying to do the stats. Making it a list comprehension means it can’t get exhausted.