### PR TITLE
Don’t let users in trial mode send letters

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -457,14 +457,15 @@ def check_messages(service_id, template_type, upload_id):
         data['recipients'].too_many_rows or
         not data['count_of_recipients'] or
         not data['recipients'].has_recipient_columns or
-        data['recipients'].missing_column_headers
+        data['recipients'].missing_column_headers or
+        data['trying_to_send_letters_in_trial_mode']
     ):
         return render_template('views/check/column-errors.html', **data)
 
     if data['row_errors']:
         return render_template('views/check/row-errors.html', **data)
 
-    if data['errors'] or data['trying_to_send_letters_in_trial_mode']:
+    if data['errors']:
         return render_template('views/check/column-errors.html', **data)
 
     return render_template('views/check/ok.html', **data)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -439,7 +439,10 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
         remaining_messages=remaining_messages,
         choose_time_form=choose_time_form,
         back_link=back_link,
-        help=get_help_argument()
+        help=get_help_argument(),
+        trying_to_send_letters_in_trial_mode=bool(
+            current_service['restricted'] and template.template_type == 'letter'
+        ),
     )
 
 
@@ -461,7 +464,7 @@ def check_messages(service_id, template_type, upload_id):
     if data['row_errors']:
         return render_template('views/check/row-errors.html', **data)
 
-    if data['errors']:
+    if data['errors'] or data['trying_to_send_letters_in_trial_mode']:
         return render_template('views/check/column-errors.html', **data)
 
     return render_template('views/check/ok.html', **data)

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -83,10 +83,6 @@
           {% include "partials/check/not-allowed-to-send-to.html" %}
         {% endwith %}
 
-      {% elif recipients.more_rows_than_can_send %}
-
-        {% include "partials/check/too-many-messages.html" %}
-
       {% elif trying_to_send_letters_in_trial_mode %}
 
         <h1 class='banner-title' data-module="track-error" data-error-type="Trying to send letters in trial mode" data-error-label="{{ upload_id }}">
@@ -97,6 +93,10 @@
           In <a href="{{ url_for('.trial_mode') }}">trial mode</a> you
           can only preview how your letters will look
         </p>
+
+      {% elif recipients.more_rows_than_can_send %}
+
+        {% include "partials/check/too-many-messages.html" %}
 
       {% endif %}
 

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -87,6 +87,17 @@
 
         {% include "partials/check/too-many-messages.html" %}
 
+      {% elif trying_to_send_letters_in_trial_mode %}
+
+        <h1 class='banner-title' data-module="track-error" data-error-type="Trying to send letters in trial mode" data-error-label="{{ upload_id }}">
+          You can’t send
+          {{ 'this letter' if count_of_recipients == 1 else 'these letters' }}
+        </h1>
+        <p>
+          In <a href="{{ url_for('.trial_mode') }}">trial mode</a> you
+          can only preview how your letters will look
+        </p>
+
       {% endif %}
 
       {{ skip_to_file_contents() }}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -75,14 +75,18 @@
         </p>
 
       {% elif not recipients.allowed_to_send_to %}
+
         {% with
           count_of_recipients=count_of_recipients,
           template_type_label=recipients.recipient_column_headers[0]
         %}
           {% include "partials/check/not-allowed-to-send-to.html" %}
         {% endwith %}
+
       {% elif recipients.more_rows_than_can_send %}
+
         {% include "partials/check/too-many-messages.html" %}
+
       {% endif %}
 
       {{ skip_to_file_contents() }}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -17,7 +17,7 @@
     </p>
     <ul class="list list-bullet">
       <li>
-        you can only send messages to yourself
+        you can only send text messages and emails to yourself
       </li>
       <li>
         you can add people to
@@ -26,10 +26,13 @@
         {% else %}
           your team,
         {% endif %}
-        then you can send messages to them too
+        then you can send text messages and emails to them too
       </li>
       <li>
-        you can only send 50 messages per day
+        you can only send 50 text messages or emails per day
+      </li>
+      <li>
+        you can’t send any letters
       </li>
     </ul>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/355079/29130559-29c34982-7d22-11e7-90ad-f005a2446262.png)

## Why we’re making this change

Users in trial mode haven’t signed the MOU. This means that they haven’t agreed to pay for any costs they incur.

Unlike text messages and emails, we don’t give you any free allowance of letters. Sending _any_ letters will cost the user money.

Therefore we shouldn’t let users who haven’t agreed that they will pay for the service to incur costs by sending letters.

Getting this in place means we can turn letters on for users in trial mode without worrying that they’ll accidentally send real letters, which would result in:
- us having to absorb those costs
- or some awkward conversations

## Implementation details

### The pattern

The pattern used for this is roughly the same as other trial mode errors that we have already, ie a red box that says you’re not allowed. Not sure if this is exactly right because it’s not exactly an error so the pattern might feel too heavy-handed.

### 50 recipients limit

We should also make sure that users trying to send letters don’t get told about the 50 recipients limit. The ‘can’t send to more than 50 recipients in trial mode’ error doesn’t apply for letters (they can’t send to _any_ recipients).  So we should make sure that the error message about not being able to send to any recipients always comes up instead of the 50 recipients one, whether you’re trying to upload a file with 1 or 111 rows.

### The trial mode page

The meaning of trial mode has evolved now that we’re adding letters. So this PR also updates the trial mode content page to make it clear:
- that the existing conditions only apply to texts and emails
- we need to explain what trial mode means for letters

