### PR TITLE
Moving performance link to the support column in the footer

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -88,6 +88,7 @@
           <ul>
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="{{ url_for('main.support') }}">Support</a></li>
+            <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
             <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Chat with the Notify team</a></li>
           </ul>
         </div>
@@ -100,7 +101,6 @@
             <li><a href="{{ url_for("main.trial_mode") }}">Trial mode</a></li>
             <li><a href="{{ url_for("main.pricing") }}">Pricing</a></li>
             <li><a href="{{ url_for("main.delivery_and_failure") }}">Delivery and failure</a></li>
-            <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
           </ul>
         </div>
         <div class="column-one-third">


### PR DESCRIPTION
Feels more appropriate here - these are all the live things the about is all the static things.