### PR TITLE
Tell local government folk that they can sign up

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -36,7 +36,7 @@ class ValidGovEmail:
     def __call__(self, form, field):
         from flask import url_for
         message = (
-            'Enter a central government email address.'
+            'Enter a government email address.'
             ' If you think you should have access'
             ' <a href="{}">contact us</a>').format(url_for('main.support'))
         if not is_gov_user(field.data.lower()):

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -13,7 +13,7 @@ Create an account
     <h1 class="heading-large">Create an account</h1>
     <form method="post" novalidate>
       {{ textbox(form.name, width='3-4') }}
-      {{ textbox(form.email_address, hint="Must be from a central government organisation", width='3-4', safe_error_message=True) }}
+      {{ textbox(form.email_address, hint="Must be from a government organisation", width='3-4', safe_error_message=True) }}
       {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       <input class="visually-hidden" aria-hidden="true" tabindex="-1" id="defeat-chrome-autocomplete">
       {{ textbox(form.password, hint="At least 8 characters", width='3-4') }}

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -28,7 +28,7 @@ def test_valid_email_not_in_valid_domains(
 ):
     form = RegisterUserForm(email_address="test@test.com", mobile_number='441231231231')
     assert not form.validate()
-    assert "Enter a central government email address" in form.errors['email_address'][0]
+    assert "Enter a government email address" in form.errors['email_address'][0]
 
 
 def test_valid_email_in_valid_domains(

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -96,7 +96,7 @@ def test_should_return_200_when_email_is_not_gov_uk(
                                  'password': 'validPassword!'})
 
     assert response.status_code == 200
-    assert 'Enter a central government email address' in response.get_data(as_text=True)
+    assert 'Enter a government email address' in response.get_data(as_text=True)
 
 
 def test_should_add_user_details_to_session(


### PR DESCRIPTION
Notify is now available to local government: https://gds.blog.gov.uk/2017/08/10/local-government-services-to-start-using-gov-uk-notify/

So registration isn’t only for users with central government email addresses now.