### PR TITLE
Add British Library to email domain whitelist

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,6 +85,7 @@ class Config(object):
         r"assembly\.wales",
         r"cjsm\.net",
         r"cqc\.org\.uk",
+        r"bl\.uk",
     ]
 
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -93,6 +93,7 @@ def _gen_mock_field(x):
     'test@cjsm.net',
     'test@cqc.org.uk',
     'test@digital.cqc.org.uk',
+    'test@bl.uk',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,
@@ -126,7 +127,8 @@ def test_valid_list_of_white_list_email_domains(
     'test@ukpolice.uk',
     'test@police.uk.uk',
     'test@police.test.uk',
-    'test@ucds.com'
+    'test@ucds.com',
+    'test@123bl.uk',
 ])
 def test_invalid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
I think that British Library can use Notify. Need to double check though.

> BL is an executive non-departmental public body, sponsored by the Department for Digital, Culture, Media & Sport.
> https://www.bl.uk/

– https://www.gov.uk/government/organisations/british-library