### PR TITLE
Allow Science & Technology Facilities Council

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -86,6 +86,7 @@ class Config(object):
         r"cjsm\.net",
         r"cqc\.org\.uk",
         r"bl\.uk",
+        r"stfc\.ac\.uk",
     ]
 
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -94,6 +94,7 @@ def _gen_mock_field(x):
     'test@cqc.org.uk',
     'test@digital.cqc.org.uk',
     'test@bl.uk',
+    'test@stfc.ac.uk',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
> STFC is an executive non-departmental public body, sponsored by the Department for Business, Energy & Industrial Strategy.
> http://www.stfc.ac.uk/

– https://www.gov.uk/government/organisations/science-and-technology-facilities-council