### PR TITLE
use iget_array to reduce memory footprint. and removed useless import…

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -22,10 +22,6 @@ from flask import (
 )
 from flask_login import current_user
 import pyexcel
-import pyexcel_io
-import pyexcel_xls
-import pyexcel_xlsx
-import pyexcel_ods3
 
 from notifications_utils.template import (
     SMSPreviewTemplate,
@@ -246,12 +242,16 @@ class Spreadsheet():
             return cls(Spreadsheet.normalise_newlines(file_content), filename)
 
         if extension == 'tsv':
-            file_content = StringIO(Spreadsheet.normalise_newlines(file_content))
+            file_content = StringIO(
+                Spreadsheet.normalise_newlines(file_content))
 
-        return cls.from_rows(pyexcel.get_sheet(
-            file_type=extension,
-            file_content=file_content.read()
-        ).to_array(), filename)
+        instance = cls.from_rows(
+            pyexcel.iget_array(
+                file_type=extension,
+                file_stream=file_content),
+            filename)
+        pyexcel.free_resources()
+        return instance
 
 
 def get_help_argument():

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pyexcel==0.5.3
 pyexcel-io==0.4.4
 pyexcel-xls==0.4.0
 pyexcel-xlsx==0.4.1
-pyexcel-ods3==0.4.0
+pyexcel-ods3==0.4.1
 pytz==2017.2
 six==1.10.0
 gunicorn==19.7.1


### PR DESCRIPTION
I felt iget_array would be better suited for the use case. The benefit is that when dealing with large excel files, the memory footprint of pyexcel is reduced. Especially with csv, tsv, its memory consumption is constant. And if you would only read ods and if your ods file could be large, I would recommend that you choose pyexcel-odsr, which consumes less memory because it does not load everything into memory in one go.

Here is the documentation on iget_array:

http://pyexcel.readthedocs.io/en/latest/generated/pyexcel.iget_array.html#pyexcel.iget_array

Since version pyexcel 0.2.2, no longer the imports of pyexcel.ext.xls, pyexcel.ext.ods etc. are required. And here is the [plugin loading methodology](http://lml.readthedocs.io/en/latest/design.html).