### PR TITLE
Update the usage page to use new billing endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -54,6 +54,7 @@ from app.notify_client.provider_client import ProviderClient
 from app.notify_client.organisations_client import OrganisationsClient
 from app.notify_client.models import AnonymousUser
 from app.notify_client.letter_jobs_client import LetterJobsClient
+from app.notify_client.billing_api_client import BillingAPIClient
 from app.utils import get_cdn_domain
 
 from app.utils import gmt_timezones
@@ -75,6 +76,7 @@ organisations_client = OrganisationsClient()
 asset_fingerprinter = AssetFingerprinter()
 statsd_client = StatsdClient()
 letter_jobs_client = LetterJobsClient()
+billing_api_client = BillingAPIClient()
 
 # The current service attached to the request stack.
 current_service = LocalProxy(partial(_lookup_req_object, 'service'))
@@ -107,6 +109,7 @@ def create_app():
     provider_client.init_app(application)
     organisations_client.init_app(application)
     letter_jobs_client.init_app(application)
+    billing_api_client.init_app(application)
 
     login_manager.init_app(application)
     login_manager.login_view = 'main.sign_in'

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -15,6 +15,7 @@ from notifications_utils.recipients import format_phone_number_human_readable
 from app.main import main
 from app import (
     current_service,
+    billing_api_client,
     job_api_client,
     service_api_client,
     template_statistics_client
@@ -105,10 +106,11 @@ def template_history(service_id):
 @user_has_permissions('manage_settings', admin_override=True)
 def usage(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
+
     return render_template(
         'views/usage.html',
         months=list(get_free_paid_breakdown_for_billable_units(
-            year, service_api_client.get_billable_units(service_id, year)
+            year, billing_api_client.get_billable_units(service_id, year)
         )),
         selected_year=year,
         years=get_tuples_of_financial_years(
@@ -116,7 +118,7 @@ def usage(service_id):
             start=current_financial_year - 1,
             end=current_financial_year + 1,
         ),
-        **calculate_usage(service_api_client.get_service_usage(service_id, year))
+        **calculate_usage(billing_api_client.get_service_usage(service_id, year))
     )
 
 

--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -1,0 +1,25 @@
+from app.notify_client import NotifyAdminAPIClient
+
+
+class BillingAPIClient(NotifyAdminAPIClient):
+    # Fudge assert in the super __init__ so
+    # we can set those variables later.
+    def __init__(self):
+        super().__init__("a" * 73, "b")
+
+    def init_app(self, application):
+        self.base_url = application.config['API_HOST_NAME']
+        self.service_id = application.config['ADMIN_CLIENT_USER_NAME']
+        self.api_key = application.config['ADMIN_CLIENT_SECRET']
+
+    def get_billable_units(self, service_id, year):
+        return self.get(
+            '/service/{0}/billing/monthly-usage'.format(service_id),
+            params=dict(year=year)
+        )
+
+    def get_service_usage(self, service_id, year=None):
+        return self.get(
+            '/service/{0}/billing/yearly-usage'.format(service_id),
+            params=dict(year=year)
+        )

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -224,12 +224,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_service_history(self, service_id):
         return self.get('/service/{0}/history'.format(service_id))
 
-    def get_service_usage(self, service_id, year=None):
-        return self.get(
-            '/service/{0}/yearly-usage'.format(service_id),
-            params=dict(year=year)
-        )
-
     def get_yearly_sms_unit_count_and_cost(self, service_id, year=None):
         return self.get(
             '/service/{0}/yearly-sms-billable-units'.format(service_id),
@@ -244,12 +238,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     def update_whitelist(self, service_id, data):
         return self.put(url='/service/{}/whitelist'.format(service_id), data=data)
-
-    def get_billable_units(self, service_id, year):
-        return self.get(
-            '/service/{0}/monthly-usage'.format(service_id),
-            params=dict(year=year)
-        )
 
     def get_inbound_sms(self, service_id, user_number=''):
         return self.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1490,7 +1490,7 @@ def mock_get_usage(mocker, service_one, fake_uuid):
         ]
 
     return mocker.patch(
-        'app.service_api_client.get_service_usage', side_effect=_get_usage)
+        'app.billing_api_client.get_service_usage', side_effect=_get_usage)
 
 
 @pytest.fixture(scope='function')
@@ -1590,7 +1590,7 @@ def mock_get_billable_units(mocker):
         ]
 
     return mocker.patch(
-        'app.service_api_client.get_billable_units', side_effect=_get_usage)
+        'app.billing_api_client.get_billable_units', side_effect=_get_usage)
 
 
 @pytest.fixture(scope='function')
@@ -1608,7 +1608,7 @@ def mock_get_future_usage(mocker, service_one, fake_uuid):
         ]
 
     return mocker.patch(
-        'app.service_api_client.get_service_usage', side_effect=_get_usage)
+        'app.billing_api_client.get_service_usage', side_effect=_get_usage)
 
 
 @pytest.fixture(scope='function')
@@ -1617,7 +1617,7 @@ def mock_get_future_billable_units(mocker):
         return []
 
     return mocker.patch(
-        'app.service_api_client.get_billable_units', side_effect=_get_usage)
+        'app.billing_api_client.get_billable_units', side_effect=_get_usage)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
This makes the Usage page use the new billing endpoints. 

## Summary

https://github.com/alphagov/notifications-api/pull/1181 introduces new endpoints that retrieve billing data from the new `MonthlyBilling` table. This will make use of those endpoints on the Usage page.

## Dependencies 

- [x] - https://github.com/alphagov/notifications-api/pull/1181
- [x] - Backfill billing data for all services.