### PR TITLE
Call the correct endpoint to retrieve yearly billing usage

### DIFF
--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -20,6 +20,6 @@ class BillingAPIClient(NotifyAdminAPIClient):
 
     def get_service_usage(self, service_id, year=None):
         return self.get(
-            '/service/{0}/billing/yearly-usage'.format(service_id),
+            '/service/{0}/billing/yearly-usage-summary'.format(service_id),
             params=dict(year=year)
         )

--- a/tests/app/notify_client/test_billing_client.py
+++ b/tests/app/notify_client/test_billing_client.py
@@ -1,0 +1,27 @@
+import uuid
+
+from app.notify_client.billing_api_client import BillingAPIClient
+
+
+def test_get_billing_units_calls_correct_endpoint(mocker, api_user_active):
+    service_id = uuid.uuid4()
+    expected_url = '/service/{}/billing/monthly-usage'.format(service_id)
+
+    client = BillingAPIClient()
+
+    mock_get = mocker.patch('app.notify_client.billing_api_client.BillingAPIClient.get')
+
+    client.get_billable_units(service_id, 2017)
+    mock_get.assert_called_once_with(expected_url, params={'year': 2017})
+
+
+def test_get_get_service_usage_calls_correct_endpoint(mocker, api_user_active):
+    service_id = uuid.uuid4()
+    expected_url = '/service/{}/billing/yearly-usage-summary'.format(service_id)
+
+    client = BillingAPIClient()
+
+    mock_get = mocker.patch('app.notify_client.billing_api_client.BillingAPIClient.get')
+
+    client.get_service_usage(service_id, 2017)
+    mock_get.assert_called_once_with(expected_url, params={'year': 2017})


### PR DESCRIPTION
This adds a small fix to make admin call the correct billing yearly usage endpoint.

## Summary

Currently the usage page calls `/service/<service_id>/billing/yearly-usage` but this is incorrect. It should be calling `/service/<service_id>/billing/yearly-usage-summary` as shown here: https://github.com/alphagov/notifications-api/blob/953e2ae5bda97eae0f3a71bb1697debf89f0590c/app/billing/rest.py#L42.

This adds the fix and some tests.