### PR TITLE
Separate ‘manage service’ and ‘manage templates’ permissions

### DIFF
--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -4,8 +4,8 @@
   display: inline-block;
   background-size: 19px 19px;
   background-repeat: no-repeat;
-  background-position: 0 0;
-  padding: 1px 0 0 25px;
+  background-position: 0 6px;
+  padding: 6px 0 5px 25px;
 
   @include ie-lte(8) {
     background-position: 0 3px;
@@ -31,6 +31,7 @@
     @extend %tick-cross;
     color: $secondary-text-colour;
     background-image: file-url('cross-grey.png');
+    box-shadow: inset 20px 0 0 0 rgba(255, 255, 255, 0.6);
 
     @include ie-lte(8) {
       background-image: file-url('cross-grey-16px.png');
@@ -42,21 +43,24 @@
 
     @extend %grid-row;
     margin-top: 5px;
+    position: relative;
 
     &-permissions {
 
       @include grid-column(3/4);
 
       li {
-        display: inline-block;
+        display: block;
         margin-right: 0.5em;
       }
 
     }
 
     &-edit-link {
-      @include grid-column(1/4);
       text-align: right;
+      position: absolute;
+      top: -1.6em;
+      right: -135px;
     }
 
   }

--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -5,7 +5,7 @@
 
   &-item {
 
-    padding: $gutter-half 0;
+    padding: $gutter-half 150px $gutter-half 0;
     border-top: 1px solid $border-colour;
 
     &:last-child {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -171,7 +171,8 @@ class RegisterUserFromInviteForm(Form):
 
 class PermissionsForm(Form):
     send_messages = BooleanField("Send messages from existing templates")
-    manage_service = BooleanField("Modify this service, its team, and its templates")
+    manage_templates = BooleanField("Add and edit templates")
+    manage_service = BooleanField("Modify this service and its team")
     manage_api_keys = BooleanField("Create and revoke API keys")
 
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -25,7 +25,8 @@ from app.utils import user_has_permissions
 
 roles = {
     'send_messages': ['send_texts', 'send_emails', 'send_letters'],
-    'manage_service': ['manage_users', 'manage_templates', 'manage_settings'],
+    'manage_templates': ['manage_templates'],
+    'manage_service': ['manage_users', 'manage_settings'],
     'manage_api_keys': ['manage_api_keys']
 }
 

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-Manage users
+  {{ user.name or user.email_localpart }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -4,13 +4,13 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-Manage users
+  Invite a team member
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    {{ "Invite a team member" }}
+    Invite a team member
   </h1>
 
   <div class="grid-row">

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -37,7 +37,7 @@
     {% for user in users %}
       <div class="user-list-item">
         <h3>
-          {{ user.name }}&ensp;<span class="hint">
+          <span class="heading-small">{{ user.name }}</span>&ensp;<span class="hint">
             {%- if user.email_address == current_user.email_address -%}
               (you)
             {% else %}
@@ -84,7 +84,7 @@
       {% for user in invited_users %}
         <div class="user-list-item">
           <h3>
-            {{ user.email_address }}
+            <span style="font-weight: bold">{{ user.email_address }}</span>
           </h3>
           <ul class="tick-cross-list">
             <div class="tick-cross-list-permissions">

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -52,7 +52,11 @@
               'Send messages'
             ) }}
             {{ tick_cross(
-              user.has_permissions(permissions=['manage_users', 'manage_templates', 'manage_settings']),
+              user.has_permissions(permissions=['manage_templates']),
+              'Manage templates'
+            ) }}
+            {{ tick_cross(
+              user.has_permissions(permissions=['manage_users', 'manage_settings']),
               'Manage service'
             ) }}
             {{ tick_cross(
@@ -89,7 +93,11 @@
                 'Send messages'
               ) }}
               {{ tick_cross(
-                user.has_permissions(permissions=['manage_users', 'manage_templates', 'manage_settings']),
+                user.has_permissions(permissions=['manage_templates']),
+                'Edit templates'
+              ) }}
+              {{ tick_cross(
+                user.has_permissions(permissions=['manage_users', 'manage_settings']),
                 'Manage service'
               ) }}
               {{ tick_cross(

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -12,7 +12,7 @@
 } %}
 
 {% block service_page_title %}
-Manage users
+  Team members
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -5,6 +5,7 @@
     Permissions
   </legend>
   {{ checkbox(form.send_messages) }}
+  {{ checkbox(form.manage_templates) }}
   {{ checkbox(form.manage_service) }}
   {{ checkbox(form.manage_api_keys) }}
 </fieldset>

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -10,6 +10,7 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     active_user_with_permissions,
     active_user_view_permissions,
+    active_user_manage_template_permission,
 )
 
 
@@ -18,14 +19,21 @@ from tests.conftest import (
         active_user_with_permissions,
         (
             'Test User (you) '
-            'Can Send messages Can Manage service Can Access API keys'
+            'Can Send messages Can Manage templates Can Manage service Can Access API keys'
         ),
     ),
     (
         active_user_view_permissions,
         (
             'Test User With Permissions (you) '
-            'Can’t Send messages Can’t Manage service Can’t Access API keys'
+            'Can’t Send messages Can’t Manage templates Can’t Manage service Can’t Access API keys'
+        ),
+    ),
+    (
+        active_user_manage_template_permission,
+        (
+            'Test User With Permissions (you) '
+            'Can’t Send messages Can Manage templates Can’t Manage service Can’t Access API keys'
         ),
     ),
 ])
@@ -53,6 +61,7 @@ def test_should_show_overview_page(
         {'user_id': 0},
         [
             ('send_messages', True),
+            ('manage_templates', True),
             ('manage_service', True),
             ('manage_api_keys', True),
         ]
@@ -62,6 +71,7 @@ def test_should_show_overview_page(
         {},
         [
             ('send_messages', False),
+            ('manage_templates', False),
             ('manage_service', False),
             ('manage_api_keys', False),
         ]
@@ -76,7 +86,7 @@ def test_should_show_page_for_one_user(
     page = client_request.get(endpoint, service_id=SERVICE_ONE_ID, **extra_args)
     checkboxes = page.select('input[type=checkbox]')
 
-    assert len(checkboxes) == 3
+    assert len(checkboxes) == 4
 
     for index, expected in enumerate(expected_checkboxes):
         expected_input_name, expected_checked = expected
@@ -96,6 +106,7 @@ def test_edit_user_permissions(
         'main.edit_user_permissions', service_id=service['id'], user_id=active_user_with_permissions.id
     ), data={'email_address': active_user_with_permissions.email_address,
              'send_messages': 'y',
+             'manage_templates': 'y',
              'manage_service': 'y',
              'manage_api_keys': 'y'})
 
@@ -192,6 +203,7 @@ def test_invite_user(
         url_for('main.invite_user', service_id=service['id']),
         data={'email_address': email_address,
               'send_messages': 'y',
+              'manage_templates': 'y',
               'manage_service': 'y',
               'manage_api_keys': 'y'},
         follow_redirects=True
@@ -243,7 +255,7 @@ def test_manage_users_shows_invited_user(
     assert page.h1.string.strip() == 'Team members'
     assert normalize_spaces(page.select('.user-list')[1].text) == (
         'invited_user@test.gov.uk '
-        'Can’t Send messages Can’t Manage service Can Access API keys '
+        'Can’t Send messages Can’t Edit templates Can’t Manage service Can Access API keys '
         'Cancel invitation'
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -682,6 +682,29 @@ def active_user_view_permissions(fake_uuid):
     return user
 
 
+@pytest.fixture
+def active_user_manage_template_permission(fake_uuid):
+    from app.notify_client.user_api_client import User
+
+    user_data = {
+        'id': fake_uuid,
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'manage_templates',
+            'view_activity',
+        ]},
+        'platform_admin': False
+    }
+    user = User(user_data)
+    return user
+
+
 @pytest.fixture(scope='function')
 def api_user_locked(fake_uuid):
     from app.notify_client.user_api_client import User


### PR DESCRIPTION
Paired with @klssmith.

The substantive changes in this PR are explained in d591b9a and 0092c8b. The other commits are just cleaning up, or improving test coverage of existing functionality.

# Before

![screen shot 2017-08-17 at 17 36 14](https://user-images.githubusercontent.com/355079/29423956-9e99aca2-8375-11e7-953f-9fc2944c0e95.png)

# After 

![screen shot 2017-08-17 at 17 35 53](https://user-images.githubusercontent.com/355079/29423964-a378d3b0-8375-11e7-84b7-0035e589ab42.png)

---

https://www.pivotaltracker.com/story/show/149806592