### PR TITLE
Don’t add newlines to DVLA markup view of template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -162,7 +162,7 @@ def view_template_as_dvla_markup(service_id, template_id):
         str(LetterDVLATemplate(
             template,
             notification_reference=1,
-        )).replace('<cr>', '<cr>\n'),
+        )),
         mimetype='text/plain',
     )
 


### PR DESCRIPTION
It’s more confusing than helpful.