### PR TITLE
Don’t show trial mode error if making test letter

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -440,9 +440,11 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
         choose_time_form=choose_time_form,
         back_link=back_link,
         help=get_help_argument(),
-        trying_to_send_letters_in_trial_mode=bool(
-            current_service['restricted'] and template.template_type == 'letter'
-        ),
+        trying_to_send_letters_in_trial_mode=all((
+            current_service['restricted'],
+            template.template_type == 'letter',
+            not request.args.get('from_test'),
+        )),
     )
 
 


### PR DESCRIPTION
We don’t want users in trial mode sending real letters. So we’ve introduced an error message. This error message is also showing up when users in trial mode and making a test letter (and having the knock on effect of hiding the download button).

They should be able to make a test letter in trial mode, because it doesn’t cost anything.

# Before

![image](https://user-images.githubusercontent.com/355079/29715928-4623e4fc-89a1-11e7-9564-904ba74f5ae6.png)

***

![image](https://user-images.githubusercontent.com/355079/29715932-4d70ff60-89a1-11e7-8736-80acb9a1e9a2.png)


# After

![image](https://user-images.githubusercontent.com/355079/29715892-25af6ff2-89a1-11e7-8ca3-ea1d407c9477.png)
***
![image](https://user-images.githubusercontent.com/355079/29715902-33c9bf84-89a1-11e7-99c6-d7922ab04471.png)


