### PR TITLE
Link to create account page from features page

### DIFF
--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -18,7 +18,7 @@
 
     <div class="panel panel-border-wide">
       <p>
-          You can <a href="{{ url_for('main.index') }}">create yourself a trial account now</a> to see all
+          You can <a href="{{ url_for('main.register') }}">create yourself a trial account now</a> to see all
           of these features in action.
       </p>
     </div>


### PR DESCRIPTION
Doesn’t make sense to make people click through the product page in order to get to the create account page.

Thanks Paola.