### PR TITLE
Talk about time of last password change relatively

### DIFF
--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -14,7 +14,7 @@
       {'label': 'Name', 'value': current_user.name, 'url': url_for('.user_profile_name')},
       {'label': 'Email address', 'value': current_user.email_address, 'url': url_for('.user_profile_email')},
       {'label': 'Mobile number', 'value': current_user.mobile_number, 'url': url_for('.user_profile_mobile_number')},
-      {'label': 'Password', 'value': 'Last changed ' + current_user.password_changed_at |format_datetime_short, 'url': url_for('.user_profile_password')},
+      {'label': 'Password', 'value': 'Last changed ' + current_user.password_changed_at|format_delta, 'url': url_for('.user_profile_password')},
     ],
     caption='Account settings',
     field_headings=['Setting', 'Value', 'Link to change'],


### PR DESCRIPTION
People don’t talk about having last changed their password ‘on 15 July’; they talk about having changed it ‘two weeks ago’.

Interfaces are usually clearer when they employ the same language as the people using them.