### PR TITLE
Fixed typo

### DIFF
--- a/app/templates/views/service-settings/set-letters.html
+++ b/app/templates/views/service-settings/set-letters.html
@@ -16,7 +16,7 @@
           Your service can send letters.
         </p>
         <p>
-          If you want to stop your sending from sending letters,
+          If you want to stop your service from sending letters,
           <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
         </p>
       {% else %}


### PR DESCRIPTION
Typo in the 'set-letters' page, changed word 'sending' to 'service'