### PR TITLE
Fix Receive text message bug

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -66,10 +66,7 @@ def service_settings(service_id):
         inbound_api_url = ''
 
     inbound_number = inbound_number_client.get_inbound_sms_number_for_service(service_id)
-    if inbound_number['data'] == {}:
-        disp_inbound_number = ''
-    else:
-        disp_inbound_number = inbound_number['data']['number']
+    disp_inbound_number = inbound_number['data'].get('number', '')
 
     return render_template(
         'views/service-settings.html',
@@ -392,9 +389,10 @@ def service_set_international_sms(service_id):
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
 def service_set_inbound_sms(service_id):
+    number = inbound_number_client.get_inbound_sms_number_for_service(service_id)['data'].get('number', '')
     return render_template(
         'views/service-settings/set-inbound-sms.html',
-        inbound_number=inbound_number_client.get_inbound_sms_number_for_service(service_id)['data']['number'],
+        inbound_number=number,
     )
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1356,3 +1356,31 @@ def test_invitation_pages(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert normalize_spaces(page.select('main p')[0].text) == expected_p
+
+
+def test_service_settings_when_inbound_number_is_not_set(
+    logged_in_client,
+    service_one,
+    mocker,
+    mock_get_letter_organisations,
+):
+    mocker.patch('app.inbound_number_client.get_inbound_sms_number_for_service',
+                 return_value={'data': {}})
+    response = logged_in_client.get(url_for(
+        'main.service_settings', service_id=service_one['id']
+    ))
+    assert response.status_code == 200
+
+
+def test_set_inbound_sms_when_inbound_number_is_not_set(
+    logged_in_client,
+    service_one,
+    mocker,
+    mock_get_letter_organisations,
+):
+    mocker.patch('app.inbound_number_client.get_inbound_sms_number_for_service',
+                 return_value={'data': {}})
+    response = logged_in_client.get(url_for(
+        'main.service_set_inbound_sms', service_id=service_one['id']
+    ))
+    assert response.status_code == 200


### PR DESCRIPTION
If a service does not have an inbound number and they click `change` on Receive text messages, they should see a message saying contact the Notify team to enable this feature.

That will now happens again.

https://www.pivotaltracker.com/story/show/150781643