### PR TITLE
Show row errors before trial mode errors

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -459,15 +459,17 @@ def check_messages(service_id, template_type, upload_id):
         data['recipients'].too_many_rows or
         not data['count_of_recipients'] or
         not data['recipients'].has_recipient_columns or
-        data['recipients'].missing_column_headers or
-        data['trying_to_send_letters_in_trial_mode']
+        data['recipients'].missing_column_headers
     ):
         return render_template('views/check/column-errors.html', **data)
 
     if data['row_errors']:
         return render_template('views/check/row-errors.html', **data)
 
-    if data['errors']:
+    if (
+        data['errors'] or
+        data['trying_to_send_letters_in_trial_mode']
+    ):
         return render_template('views/check/column-errors.html', **data)
 
     return render_template('views/check/ok.html', **data)


### PR DESCRIPTION
It’s useful to be able to play with the CSV upload thing and find out how it works before you’re interrupted by the error telling you that you’ve got as far as you can in trial mode.