### PR TITLE
Fix overlapping text on settings page

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -180,6 +180,7 @@ details summary {
     th,
     td {
       @include core-19;
+      word-wrap: break-word;
     }
 
     thead {


### PR DESCRIPTION
Think this broke when we split the setting page up into three sections. This forces the text to wrap onto multiple lines even if it doesn’t contain spaces (for example an email address).

# Before 

![screen shot 2017-09-14 at 13 10 41](https://user-images.githubusercontent.com/355079/30429156-5903c1c0-994e-11e7-907d-8fbbe6f3509f.png)

# After 

![screen shot 2017-09-14 at 13 10 02](https://user-images.githubusercontent.com/355079/30429162-5d2940fe-994e-11e7-8feb-e2f15cda47e0.png)
