### PR TITLE
Bump utils to 21.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ notifications-python-client==4.4.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@21.0.0#egg=notifications-utils==21.0.0
+git+https://github.com/alphagov/notifications-utils.git@21.2.0#egg=notifications-utils==21.2.0


### PR DESCRIPTION
This will stop logging the request, as it is logged by nginx-access logs