### PR TITLE
Platform admin Timeout problem

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -44,7 +44,8 @@ def platform_admin():
 def platform_admin_services():
     form = DateFilterForm(request.args)
     api_args = {'detailed': True,  # specifically DO get inactive services
-                'include_from_test_key': form.include_from_test_key.data
+                'include_from_test_key': form.include_from_test_key.data,
+                'trial_mode_services' : request.endpoint == 'main.trial_services'
                 }
 
     if form.start_date.data:


### PR DESCRIPTION
When viewing platform admin services, we do an sql queries and whether it's trial mode or live services is filtered at the admin views.

This PR pass the filtered live/trial mode service to the query and reduce query time.

This is in relation to PR https://github.com/alphagov/notifications-api/pull/1257