### PR TITLE
Remove six dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pyexcel-xls==0.5.0
 pyexcel-xlsx==0.5.0.1
 pyexcel-ods3==0.5.0
 pytz==2017.2
-six==1.10.0
 gunicorn==19.7.1
 whitenoise==3.3.0  #manages static assets
 


### PR DESCRIPTION
six is used for Python 2/3 compatibility. We never run under Python 2.

Closes #1495