### PR TITLE
Remove lxml package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Flask-Login==0.4.0
 boto3==1.4.7
 py-gfm==0.1.3
 blinker==1.4
-lxml==3.8.0
 pyexcel==0.5.3
 pyexcel-io==0.5.1
 pyexcel-xls==0.5.0


### PR DESCRIPTION
We don’t use lxml directly. Our dependencies (eg html5lib) do, but we should just install whatever version they specify.

Closes #1494