### PR TITLE
Remove Github-Flavored Markdown dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask-WTF==0.14.2
 Flask-Login==0.4.0
 
 boto3==1.4.7
-py-gfm==0.1.3
 blinker==1.4
 lxml==3.8.0
 pyexcel==0.5.3


### PR DESCRIPTION
This was used when we used to publish technical documentation in the app.