### PR TITLE
Add a non-GOV.UK banner option for email branding

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -511,7 +511,8 @@ class ServiceBrandingOrg(Form):
         choices=[
             ('govuk', 'GOV.UK only'),
             ('both', 'GOV.UK and organisation'),
-            ('org', 'Organisation only')
+            ('org', 'Organisation only'),
+            ('org_banner', 'Organisation banner')
         ],
         validators=[
             DataRequired()

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -187,6 +187,8 @@
               GOV.UK and {{ organisation.name if organisation else None }}
             {% elif current_service.branding == 'org' %}
               Only {{ organisation.name if organisation else None }}
+            {% elif current_service.branding == 'org_banner' %}
+              Only {{ organisation.name if organisation else None }} banner
             {% endif %}
           {% endcall %}
           {{ edit_field('Change', url_for('.service_set_branding_and_org', service_id=current_service.id)) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -922,10 +922,12 @@ def test_should_show_branding(
     assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
     assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
     assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
+    assert page.find('input', attrs={"id": "branding_type-3"})['value'] == 'org_banner'
 
     assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
     assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
     assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
+    assert 'checked' not in page.find('input', attrs={"id": "branding_type-3"}).attrs
 
     app.organisations_client.get_organisations.assert_called_once_with()
     app.service_api_client.get_service.assert_called_once_with(service_one['id'])
@@ -945,10 +947,12 @@ def test_should_show_organisations(
     assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
     assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
     assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
+    assert page.find('input', attrs={"id": "branding_type-3"})['value'] == 'org_banner'
 
     assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
     assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
     assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
+    assert 'checked' not in page.find('input', attrs={"id": "branding_type-3"}).attrs
 
     app.organisations_client.get_organisations.assert_called_once_with()
     app.service_api_client.get_service.assert_called_once_with(service_one['id'])


### PR DESCRIPTION
Added extra radio button for 'org_banner' option
Updated service setting template to display appropriate text when option is selected
Updated tests to also accomodate new radio option