### PR TITLE
show letters as accepted, not created or sending, on the api page

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -13,13 +13,18 @@ from app.notify_client.api_key_api_client import KEY_TYPE_NORMAL, KEY_TYPE_TEST,
 def api_integration(service_id):
     return render_template(
         'views/api/index.html',
-        api_notifications=notification_api_client.get_notifications_for_service(
+        api_notifications=map_letters_to_accepted(notification_api_client.get_notifications_for_service(
             service_id=service_id,
             include_jobs=False,
             include_from_test_key=True
-        )
+        ))
     )
 
+def map_letters_to_accepted(notifications):
+    for notification in notifications['notifications']:
+        if notification['notification_type'] == 'letter' and notification['status'] in ('created', 'sending'):
+            notification['status'] = 'accepted'
+    return notifications
 
 @main.route("/services/<service_id>/api/documentation")
 @login_required

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -13,18 +13,9 @@ from app.notify_client.api_key_api_client import KEY_TYPE_NORMAL, KEY_TYPE_TEST,
 def api_integration(service_id):
     return render_template(
         'views/api/index.html',
-        api_notifications=map_letters_to_accepted(notification_api_client.get_notifications_for_service(
-            service_id=service_id,
-            include_jobs=False,
-            include_from_test_key=True
-        ))
+        api_notifications=notification_api_client.get_api_notifications_for_service(service_id)
     )
 
-def map_letters_to_accepted(notifications):
-    for notification in notifications['notifications']:
-        if notification['notification_type'] == 'letter' and notification['status'] in ('created', 'sending'):
-            notification['status'] = 'accepted'
-    return notifications
 
 @main.route("/services/<service_id>/api/documentation")
 @login_required

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -66,3 +66,14 @@ class NotificationApiClient(NotifyAdminAPIClient):
 
     def get_notification(self, service_id, notification_id):
         return self.get(url='/service/{}/notifications/{}'.format(service_id, notification_id))
+
+    def get_api_notifications_for_service(self, service_id):
+        ret = self.get_notifications_for_service(service_id, include_jobs=False, include_from_test_key=True)
+        return self.map_letters_to_accepted(ret)
+
+    @staticmethod
+    def map_letters_to_accepted(notifications):
+        for notification in notifications['notifications']:
+            if notification['notification_type'] == 'letter' and notification['status'] in ('created', 'sending'):
+                notification['status'] = 'accepted'
+        return notifications

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -266,6 +266,7 @@ def notification_json(
             'service': service_id,
             'template_version': template['version'],
             'personalisation': personalisation or {},
+            'notification_type': 'sms',
         } for i in range(rows)],
         'total': rows,
         'page_size': 50,
@@ -281,7 +282,8 @@ def single_notification_json(
     status=None,
     sent_at=None,
     created_at=None,
-    updated_at=None
+    updated_at=None,
+    notification_type='sms'
 ):
     if template is None:
         template = template_json(service_id, str(generate_uuid()))
@@ -310,7 +312,7 @@ def single_notification_json(
         'id': '29441662-17ce-4ffe-9502-fcaed73b2826',
         'template': template,
         'job_row_number': 0,
-        'notification_type': 'sms',
+        'notification_type': notification_type,
         'api_key': None,
         'job': job_payload,
         'sent_by': 'mmg'


### PR DESCRIPTION
- [ ] https://github.com/alphagov/notifications-api/pull/1241

Letters are shown as `accepted`, emails and sms are still shown as `created` or `sending`