### PR TITLE
Add Biotechnology and Biological Sciences Research Council to email domain list

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -87,6 +87,7 @@ class Config(object):
         r"bl\.uk",
         r"stfc\.ac\.uk",
         r"wmfs\.net",
+        r"bbsrc\.ac\.uk",
     ]
 
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -96,6 +96,7 @@ def _gen_mock_field(x):
     'test@bl.uk',
     'test@stfc.ac.uk',
     'test@wmfs.net',
+    'test@bbsrc.ac.uk',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
> BBSRC is an executive non-departmental public body, sponsored by the Department for Business, Energy & Industrial Strategy.

– https://www.gov.uk/government/organisations/biotechnology-biological-sciences-research-council