### PR TITLE
Allow creation of an organisation without a logo

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -71,7 +71,9 @@ def manage_org(logo=None):
             return redirect(
                 url_for('.manage_org', logo=upload_filename))
 
-        logo = persist_logo(logo, session["user_id"])
+        if logo:
+            logo = persist_logo(logo, session["user_id"])
+
         delete_temp_files_created_by(session["user_id"])
 
         if org:

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -6,13 +6,12 @@
   secondary_link=False,
   secondary_link_text=None,
   delete_link=False,
-  delete_link_text="delete",
-  button_disabled=False
+  delete_link_text="delete"
 ) %}
   <div class="page-footer">
     {% if button_text %}
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <input type="submit" class="button{% if destructive %}-destructive{% endif %}" value="{{ button_text }}"{% if button_disabled %} disabled{% endif %}/>
+      <input type="submit" class="button{% if destructive %}-destructive{% endif %}" value="{{ button_text }}" />
     {% endif %}
     {% if back_link %}
       <a class="page-footer-back-link" href="{{ back_link }}">{{ back_link_text }}</a>

--- a/app/templates/views/organisations/manage-org.html
+++ b/app/templates/views/organisations/manage-org.html
@@ -26,14 +26,13 @@
       <form method="post">
         <div class="form-group">
           <div style='margin-top:15px;'>{{textbox(form.name)}}</div>
-          <div>{{textbox(form.colour, width='1-4')}} 
+          <div>{{textbox(form.colour, width='1-4')}}
             <span id='colour_span' style="background: {{ organisation.colour }}; {% if not organisation.colour %}visibility:hidden; {% endif %}border:1px black solid; width: 3px; height: 25px;position:absolute;margin-top:138px;margin-left:135px;display:block;"></span>
           </div>
         {{ page_footer(
           'Save',
           back_link=url_for('.organisations', organisation_id=organisation.id if organisation else 'None'),
           back_link_text='Back to organisation selection',
-          button_disabled=True if not logo else False
         ) }}
         </div>
       </form>


### PR DESCRIPTION
Now we have the org banner branding, not all organisations need a logo. So it shouldn’t be an error to not provide one.

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/1265