### PR TITLE
Change text style of default banner

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -2,8 +2,8 @@
 .banner,
 .banner-default {
 
-  @include core-19;
-  color: $text-colour;
+  @include bold-19;
+  color: $button-colour;
   display: block;
   padding: $gutter-half;
   margin: $gutter-half 0 $gutter 0;


### PR DESCRIPTION
# Before

<img width="755" alt="screen shot 2017-09-25 at 15 04 31" src="https://user-images.githubusercontent.com/355079/30812830-b836280a-a203-11e7-94a6-fac4705d8b50.png">

<img width="764" alt="screen shot 2017-09-25 at 15 06 29" src="https://user-images.githubusercontent.com/355079/30812833-bab24d0c-a203-11e7-81b6-910f476c4929.png">

## After 

<img width="771" alt="screen shot 2017-09-25 at 15 03 42" src="https://user-images.githubusercontent.com/355079/30812848-c2f3b064-a203-11e7-81d1-df6e53dd1d3b.png">

<img width="748" alt="screen shot 2017-09-25 at 15 06 43" src="https://user-images.githubusercontent.com/355079/30812852-c4b7a130-a203-11e7-9be1-6b648eb37695.png">

***

Thanks, @soniaturcotte