### PR TITLE
Allow user to add multiple reply-to addresses

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -467,8 +467,9 @@ class ProviderForm(Form):
     priority = IntegerField('Priority', [validators.NumberRange(min=1, max=100, message="Must be between 1 and 100")])
 
 
-class ServiceReplyToEmailFrom(Form):
+class ServiceReplyToEmailForm(Form):
     email_address = email_address(label='Email reply to address')
+    is_default = BooleanField("Make this address the default")
 
 
 class ServiceSmsSender(Form):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -282,6 +282,42 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             )
         )['data']
 
+    def get_reply_to_email_addresses(self, service_id):
+        return self.get(
+            "/service/{}/email-reply-to".format(
+                service_id
+            )
+        )
+
+    def get_reply_to_email_address(self, service_id, reply_to_email_id):
+        return self.get(
+            "/service/{}/email-reply-to/{}".format(
+                service_id,
+                reply_to_email_id
+            )
+        )
+
+    def add_reply_to_email_address(self, service_id, email_address, is_default=False):
+        return self.post(
+            "/service/{}/email-reply-to".format(service_id),
+            data={
+                "email_address": email_address,
+                "is_default": is_default
+            }
+        )
+
+    def update_reply_to_email_address(self, service_id, reply_to_email_id, email_address, is_default=False):
+        return self.post(
+            "/service/{}/email-reply-to/{}".format(
+                service_id,
+                reply_to_email_id,
+            ),
+            data={
+                "email_address": email_address,
+                "is_default": is_default
+            }
+        )
+
 
 class ServicesBrowsableItem(BrowsableItem):
     @property

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -25,7 +25,6 @@
 {%- endmacro %}
 
 {% macro list_table(items, caption='', empty_message='', field_headings=[], field_headings_visible=True, caption_visible=True) -%}
-
   {% set parent_caller = caller %}
 
   {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible) %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -45,11 +45,15 @@
 
           {% call row() %}
             {{ text_field('Email reply to address') }}
-            {{ text_field(
-              current_service.reply_to_email_address,
-              status='' if current_service.reply_to_email_address else 'default'
-            ) }}
-            {{ edit_field('Change', url_for('.service_set_reply_to_email', service_id=current_service.id)) }}
+            {% call field() %}
+              {{ default_reply_to_email_address }}
+              {% if reply_to_email_address_count > 1 %}
+                <div class="hint">
+                  {{ '…and %d more' | format(reply_to_email_address_count - 1) }}
+                </div>
+              {% endif %}
+            {% endcall %}
+            {{ edit_field('Change', url_for('.service_email_reply_to', service_id=current_service.id)) }}
           {% endcall %}
 
         {% endif %}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -1,0 +1,33 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/checkbox.html" import checkbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Add email reply to address
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">
+    Add email reply to address
+  </h1>
+  <form method="post" novalidate>
+    {{ textbox(
+      form.email_address,
+      width='2-3',
+      safe_error_message=True
+    ) }}
+    {% if not first_email_address %}
+      <div class="form-group">
+        {{ checkbox(form.is_default) }}
+      </div>
+    {% endif %}
+    {{ page_footer(
+      'Add',
+      back_link=url_for('.service_email_reply_to', service_id=current_service.id),
+      back_link_text='Back'
+  ) }}
+  </form>
+
+{% endblock %}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -1,0 +1,35 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/checkbox.html" import checkbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+ Edit email reply to address
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">
+    Edit email reply to address
+  </h1>
+  <form method="post">
+    {{ textbox(
+      form.email_address,
+      width='2-3',
+      safe_error_message=True
+    ) }}
+    {% if form.is_default.data %}
+      <p> This email address is the default </p>
+    {% else %}
+      <div class="form-group">
+        {{ checkbox(form.is_default) }}
+      </div>
+    {% endif %}
+    {{ page_footer(
+      'Save',
+      back_link=url_for('.service_email_reply_to', service_id=current_service.id),
+      back_link_text='Back'
+  ) }}
+  </form>
+
+{% endblock %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -1,0 +1,45 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table %}
+
+{% block service_page_title %}
+  Email reply to addresses
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row bottom-gutter">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Email reply to addresses
+      </h1>
+    </div>
+	 <div class="column-one-third">
+	   <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
+	 </div>
+  </div>
+  <div class="bottom-gutter-3-2 body-copy-table">
+    {% call(item, row_number) list_table(
+      reply_to_email_addresses,
+      empty_message="You haven’t added any email addresses yet.",
+      caption="Reply to email addresses",
+      caption_visible=false,
+      field_headings=[
+        'Email addresses',
+        'Action'
+      ],
+      field_headings_visible=False
+    ) %}
+        {% call field() %}
+          {{ item.email_address }}
+          {% if item.is_default %}
+            <span class="hint">
+              {{ "(default)" }}
+            </span>
+          {% endif %}
+        {% endcall %}
+		{{ edit_field('Change', url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id)) }}        
+    {% endcall %}
+  </div>
+{% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2597,6 +2597,16 @@
         }
       }
     },
+    "govuk_frontend_toolkit": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-5.2.0.tgz",
+      "integrity": "sha1-9fbFrkjkMey5fYuAix6Nt3gqvH8="
+    },
+    "govuk_template_jinja": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/govuk_template_jinja/-/govuk_template_jinja-0.19.2.tgz",
+      "integrity": "sha1-oNCTHJrLnYgtXsRGvocyxWxTarU="
+    },
     "govuk-elements-sass": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/govuk-elements-sass/-/govuk-elements-sass-3.0.3.tgz",
@@ -2611,16 +2621,6 @@
           "integrity": "sha512-8N9uuzenxapzqgFHC6dMu6MpKTcKfpMKDDzxEW2xmgsSaBUgOnqBawo0aqeVWjz1CPEvWaDV+1M7fm4/UyZ6xg=="
         }
       }
-    },
-    "govuk_frontend_toolkit": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-5.2.0.tgz",
-      "integrity": "sha1-9fbFrkjkMey5fYuAix6Nt3gqvH8="
-    },
-    "govuk_template_jinja": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/govuk_template_jinja/-/govuk_template_jinja-0.19.2.tgz",
-      "integrity": "sha1-oNCTHJrLnYgtXsRGvocyxWxTarU="
     },
     "graceful-fs": {
       "version": "3.0.11",
@@ -5782,6 +5782,11 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -5800,11 +5805,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/tests/app/main/views/service_settings/test_inbound_sms_setting.py
+++ b/tests/app/main/views/service_settings/test_inbound_sms_setting.py
@@ -26,6 +26,7 @@ def test_get_inbound_number_in_service_settings(
         logged_in_client,
         mock_update_service,
         mock_get_letter_organisations,
+        single_reply_to_email_addresses,
         service_one,
         mocker
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,14 +50,105 @@ def service_one(api_user_active):
 
 
 @pytest.fixture(scope='function')
-def service_with_reply_to_addresses(api_user_active):
-    return service_json(
-        SERVICE_ONE_ID,
-        'service one',
-        [api_user_active.id],
-        reply_to_email_address='test@example.com',
-        sms_sender='elevenchars',
-    )
+def multiple_reply_to_email_addresses(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'email_address': 'test@example.com',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }, {
+                'id': '5678',
+                'service_id': service_id,
+                'email_address': 'test2@example.com',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }, {
+                'id': '9457',
+                'service_id': service_id,
+                'email_address': 'test3@example.com',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_reply_to_email_addresses', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def no_reply_to_email_addresses(mocker):
+    def _get(service_id):
+        return []
+
+    return mocker.patch('app.service_api_client.get_reply_to_email_addresses', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def single_reply_to_email_addresses(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'email_address': 'test@example.com',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_reply_to_email_addresses', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def get_default_reply_to_email_address(mocker):
+    def _get(service_id, reply_to_email_id):
+        return {
+            'id': '1234',
+            'service_id': service_id,
+            'email_address': 'test@example.com',
+            'is_default': True,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }
+
+    return mocker.patch('app.service_api_client.get_reply_to_email_address', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def get_non_default_reply_to_email_address(mocker):
+    def _get(service_id, reply_to_email_id):
+        return {
+            'id': '1234',
+            'service_id': service_id,
+            'email_address': 'test@example.com',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }
+
+    return mocker.patch('app.service_api_client.get_reply_to_email_address', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def mock_add_reply_to_email_address(mocker):
+    def _add_reply_to(service_id, email_address, is_default=False):
+        return
+
+    return mocker.patch('app.service_api_client.add_reply_to_email_address', side_effect=_add_reply_to)
+
+
+@pytest.fixture(scope='function')
+def mock_update_reply_to_email_address(mocker):
+    def _update_reply_to(service_id, reply_to_email_id, email_address, is_default=False):
+        return
+
+    return mocker.patch('app.service_api_client.update_reply_to_email_address', side_effect=_update_reply_to)
 
 
 @pytest.fixture(scope='function')
@@ -206,7 +297,6 @@ def mock_update_service(mocker):
                 'active',
                 'restricted',
                 'email_from',
-                'reply_to_email_address',
                 'sms_sender',
                 'permissions'
             ]}


### PR DESCRIPTION
Added new routes for email reply-to / edit / add
User can now create multiple reply to addresses
