### PR TITLE
Allow services to turn international text messaging on and off

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -658,6 +658,16 @@ class ServiceInboundApiForm(Form):
                                                            Length(min=10, message='Must be at least 10 characters')])
 
 
+class InternationalSMSForm(Form):
+    enabled = RadioField(
+        'Send text messages to international phone numbers',
+        choices=[
+            ('on', 'On'),
+            ('off', 'Off'),
+        ],
+    )
+
+
 def get_placeholder_form_instance(
     placeholder_name,
     dict_to_populate_from,

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -232,11 +232,6 @@
         </li>
         {% if 'sms' in current_service.permissions %}
           <li class="bottom-gutter">
-            <a href="{{ url_for('.service_switch_can_send_international_sms', service_id=current_service.id) }}" class="button">
-              {{ 'Stop sending international sms' if 'international_sms' in current_service.permissions else 'Allow to send international sms' }}
-            </a>
-          </li>
-          <li class="bottom-gutter">
           {% if can_receive_inbound %}
             <a href="{{ url_for('.service_set_inbound_number', service_id=current_service.id, set_inbound_sms=False) }}" class="button">
               Stop inbound sms

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/textbox.html" import textbox %}
+{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -11,28 +11,21 @@
   <div class="grid-row">
     <div class="column-five-sixths">
       <h1 class="heading-large">International text messages</h1>
-      {% if 'international_sms' in current_service.permissions %}
-        <p>
-          Your service can send text messages to international phone numbers.
-        </p>
-        <p>
-          If you want to turn it off,
-          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
-        </p>
-      {% else %}
-        <p>
-          Sending text messages to international phone numbers is an
-          invitation&#8209;only feature.
-        </p>
-        <p>
-          If you want to try it out,
-          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
-        </p>
-      {% endif %}
-      {{ page_footer(
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
+      <p>
+        Messages to international mobile numbers are charged at 1, 2, or
+        3 times the cost of messages to UK mobile numbers.</p>
+      <p>
+        See <a href="{{ url_for(".pricing") }}">pricing</a> for the list
+        of rates.
+      </p>
+      <form method="post">
+        {{ radios(form.enabled) }}
+        {{ page_footer(
+          button_text="Save",
+          back_link=url_for('.service_settings', service_id=current_service.id),
+          back_link_text='Back to settings'
+        ) }}
+      </form>
     </div>
   </div>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1956,7 +1956,14 @@ def client_request(logged_in_client):
             return page
 
         @staticmethod
-        def post(endpoint, _data=None, _expected_status=None, _follow_redirects=False, **endpoint_kwargs):
+        def post(
+            endpoint,
+            _data=None,
+            _expected_status=None,
+            _follow_redirects=False,
+            _expected_redirect=None,
+            **endpoint_kwargs
+        ):
             if _expected_status is None:
                 _expected_status = 200 if _follow_redirects else 302
             resp = logged_in_client.post(
@@ -1965,6 +1972,8 @@ def client_request(logged_in_client):
                 follow_redirects=_follow_redirects,
             )
             assert resp.status_code == _expected_status
+            if _expected_redirect:
+                assert resp.location == _expected_redirect
             return BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
 
     return ClientRequest


### PR DESCRIPTION
We didn’t make this self-service before because the pricing information wasn’t published (ie we had to send it to services that asked for it). 

Now that we publish pricing information in the app, there’s no reason why services can’t make an informed decision about whether they want international SMS or not.

So this commit:
- removes the platform admin button
- adds some radio buttons that our users can click with their mice

***

![image](https://user-images.githubusercontent.com/355079/30862317-90fdf9b2-a2c5-11e7-9f82-50b074725db7.png)



