### PR TITLE
Tweak email reply to pages, add IDs

### DIFF
--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -42,12 +42,12 @@
   &-list {
 
     @extend %grid-row;
-    margin-top: 5px;
     position: relative;
 
     &-permissions {
 
       @include grid-column(3/4);
+      margin-top: 5px;
 
       li {
         display: block;
@@ -59,7 +59,7 @@
     &-edit-link {
       text-align: right;
       position: absolute;
-      top: -1.6em;
+      top: -25px;
       right: -135px;
     }
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -469,7 +469,7 @@ class ProviderForm(Form):
 
 class ServiceReplyToEmailForm(Form):
     email_address = email_address(label='Email reply to address')
-    is_default = BooleanField("Make this address the default")
+    is_default = BooleanField("Make this email address the default")
 
 
 class ServiceSmsSender(Form):

--- a/app/templates/components/api-key.html
+++ b/app/templates/components/api-key.html
@@ -1,7 +1,9 @@
-{% macro api_key(key, name, thing="API key") %}
-  <h2 class="api-key-name">
-    {{ name }}
-  </h2>
+{% macro api_key(key, name=None, thing="API key") %}
+  {% if name %}
+    <h2 class="api-key-name">
+      {{ name }}
+    </h2>
+  {% endif %}
   <div data-module="api-key" data-key="{{ key }}" data-thing="{{ thing }}" aria-live="assertive">
     <span class="api-key-key">{{ key }}</span>
   </div>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -45,7 +45,8 @@
 
           {% call row() %}
             {{ text_field('Email reply to address') }}
-            {% call field() %}
+            {% call field(status='default' if default_reply_to_email_address == "None" else '') %}
+
               {{ default_reply_to_email_address }}
               {% if reply_to_email_address_count > 1 %}
                 <div class="hint">

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -44,7 +44,7 @@
         {% if 'email' in current_service.permissions %}
 
           {% call row() %}
-            {{ text_field('Email reply to address') }}
+            {{ text_field('Email reply to addresses') }}
             {% call field(status='default' if default_reply_to_email_address == "None" else '') %}
 
               {{ default_reply_to_email_address }}
@@ -54,7 +54,10 @@
                 </div>
               {% endif %}
             {% endcall %}
-            {{ edit_field('Change', url_for('.service_email_reply_to', service_id=current_service.id)) }}
+            {{ edit_field(
+              'Manage' if reply_to_email_address_count else 'Change',
+              url_for('.service_email_reply_to', service_id=current_service.id))
+            }}
           {% endcall %}
 
         {% endif %}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -27,7 +27,7 @@
       'Add',
       back_link=url_for('.service_email_reply_to', service_id=current_service.id),
       back_link_text='Back'
-  ) }}
+    ) }}
   </form>
 
 {% endblock %}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -20,7 +20,7 @@
     ) }}
     {% if form.is_default.data %}
       <p class="form-group">
-        This email address is the default
+        This is the default reply to address for {{ current_service.name }} emails
       </p>
     {% else %}
       <div class="form-group">

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -19,7 +19,9 @@
       safe_error_message=True
     ) }}
     {% if form.is_default.data %}
-      <p> This email address is the default </p>
+      <p>
+        This email address is the default
+      </p>
     {% else %}
       <div class="form-group">
         {{ checkbox(form.is_default) }}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -19,7 +19,7 @@
       safe_error_message=True
     ) }}
     {% if form.is_default.data %}
-      <p>
+      <p class="form-group">
         This email address is the default
       </p>
     {% else %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -39,7 +39,9 @@
             <a href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
           </li>
         </ul>
-        {{ api_key(item.id, thing="ID") }}
+        {% if reply_to_email_addresses|length  > 1 %}
+          {{ api_key(item.id, thing="ID") }}
+        {% endif %}
       </div>
     {% endfor %}
   </div>

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -22,7 +22,7 @@
   <div class="bottom-gutter-3-2 body-copy-table">
     {% call(item, row_number) list_table(
       reply_to_email_addresses,
-      empty_message="You haven’t added any email addresses yet.",
+      empty_message="You haven’t added any email reply to addresses yet",
       caption="Reply to email addresses",
       caption_visible=false,
       field_headings=[
@@ -39,7 +39,27 @@
             </span>
           {% endif %}
         {% endcall %}
-		{{ edit_field('Change', url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id)) }}        
+		{{ edit_field('Change', url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id)) }}
     {% endcall %}
+  </div>
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <p>
+        Your emails will be sent from
+        {{ current_service.email_from }}@notifications.service.gov.uk
+      </p>
+      <p>
+        This is so they have the best chance of being delivered.
+        This email address can’t receive replies.
+      </p>
+      <p>
+        Set up separate email addresses to receive replies
+        from your users.
+        {% if current_service.restricted and not reply_to_email_addresses %}
+          Your service can’t go live until you’ve added at least one
+          reply to address.
+        {% endif %}
+      </p>
+    </div>
   </div>
 {% endblock %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/textbox.html" import textbox %}
+{% from "components/api-key.html" import api_key %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table %}
 
@@ -19,28 +19,29 @@
 	   <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
 	 </div>
   </div>
-  <div class="bottom-gutter-3-2 body-copy-table">
-    {% call(item, row_number) list_table(
-      reply_to_email_addresses,
-      empty_message="You haven’t added any email reply to addresses yet",
-      caption="Reply to email addresses",
-      caption_visible=false,
-      field_headings=[
-        'Email addresses',
-        'Action'
-      ],
-      field_headings_visible=False
-    ) %}
-        {% call field() %}
-          {{ item.email_address }}
-          {% if item.is_default %}
-            <span class="hint">
-              {{ "(default)" }}
-            </span>
-          {% endif %}
-        {% endcall %}
-		{{ edit_field('Change', url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id)) }}
-    {% endcall %}
+  <div class="user-list">
+    {% if not reply_to_email_addresses %}
+      <div class="user-list-item">
+        <span class="hint">You haven’t added any email reply to addresses yet</span>
+      </div>
+    {% endif %}
+    {% for item in reply_to_email_addresses %}
+      <div class="user-list-item">
+        <h3>
+          <span class="heading-small">{{ item.email_address }}</span>&ensp;<span class="hint">
+            {%- if item.is_default -%}
+              (default)
+            {% endif %}
+          </span>
+        </h3>
+        <ul class="tick-cross-list">
+          <li class="tick-cross-list-edit-link">
+            <a href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
+          </li>
+        </ul>
+        {{ api_key(item.id, thing="ID") }}
+      </div>
+    {% endfor %}
   </div>
   <div class="grid-row">
     <div class="column-five-sixths">

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -713,7 +713,7 @@ def test_no_reply_to_email_addresses_message_shows(
         service_id=SERVICE_ONE_ID
     )
 
-    assert normalize_spaces(page.select('tbody tr')[0].text) == "You haven’t added any email addresses yet."
+    assert normalize_spaces(page.select('tbody tr')[0].text) == "You haven’t added any email reply to addresses yet"
     assert len(page.select('tbody tr')) == 1
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -31,7 +31,7 @@ from tests.conftest import (
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply to address None Change',
+        'Email reply to addresses None Change',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -50,7 +50,7 @@ from tests.conftest import (
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply to address None Change',
+        'Email reply to addresses None Change',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -102,7 +102,7 @@ def test_should_show_overview(
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply to address test@example.com Change',
+        'Email reply to addresses test@example.com Manage',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -121,7 +121,7 @@ def test_should_show_overview(
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply to address test@example.com Change',
+        'Email reply to addresses test@example.com Manage',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -686,7 +686,7 @@ def test_reply_to_hint_appears_when_service_has_multiple_reply_to_addresses(
 
     assert normalize_spaces(
         page.select('tbody tr')[2].text
-    ) == "Email reply to address test@example.com …and 2 more Change"
+    ) == "Email reply to addresses test@example.com …and 2 more Manage"
 
 
 def test_default_email_reply_to_address_has_default_hint(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -838,7 +838,9 @@ def test_default_box_shows_on_non_default_email_addresses_while_editing(
     if checkbox_present:
         assert page.select_one('[name=is_default]')
     else:
-        assert normalize_spaces(page.select_one('form p').text) == "This email address is the default"
+        assert normalize_spaces(page.select_one('form p').text) == (
+            'This is the default reply to address for service one emails'
+        )
 
 
 def test_switch_service_to_research_mode(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -693,28 +693,32 @@ def test_default_email_reply_to_address_has_default_hint(
     client_request,
     multiple_reply_to_email_addresses
 ):
-    page = client_request.get(
+    rows = client_request.get(
         'main.service_email_reply_to',
         service_id=SERVICE_ONE_ID
+    ).select(
+        '.user-list-item'
     )
 
-    assert normalize_spaces(page.select('tbody tr')[0].text) == "test@example.com (default) Change"
-    assert normalize_spaces(page.select('tbody tr')[1].text) == "test2@example.com Change"
-    assert normalize_spaces(page.select('tbody tr')[2].text) == "test3@example.com Change"
-    assert len(page.select('tbody tr')) == 3
+    assert normalize_spaces(rows[0].text) == "test@example.com (default) Change 1234"
+    assert normalize_spaces(rows[1].text) == "test2@example.com Change 5678"
+    assert normalize_spaces(rows[2].text) == "test3@example.com Change 9457"
+    assert len(rows) == 3
 
 
 def test_no_reply_to_email_addresses_message_shows(
     client_request,
     no_reply_to_email_addresses
 ):
-    page = client_request.get(
+    rows = client_request.get(
         'main.service_email_reply_to',
         service_id=SERVICE_ONE_ID
+    ).select(
+        '.user-list-item'
     )
 
-    assert normalize_spaces(page.select('tbody tr')[0].text) == "You haven’t added any email reply to addresses yet"
-    assert len(page.select('tbody tr')) == 1
+    assert normalize_spaces(rows[0].text) == "You haven’t added any email reply to addresses yet"
+    assert len(rows) == 1
 
 
 @pytest.mark.parametrize('reply_to_input, expected_error', [

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -689,6 +689,21 @@ def test_reply_to_hint_appears_when_service_has_multiple_reply_to_addresses(
     ) == "Email reply to addresses test@example.com …and 2 more Manage"
 
 
+def test_single_reply_to_address_shows_default_but_without_id(
+    client_request,
+    single_reply_to_email_addresses
+):
+    rows = client_request.get(
+        'main.service_email_reply_to',
+        service_id=SERVICE_ONE_ID
+    ).select(
+        '.user-list-item'
+    )
+
+    assert normalize_spaces(rows[0].text) == "test@example.com (default) Change"
+    assert len(rows) == 1
+
+
 def test_default_email_reply_to_address_has_default_hint(
     client_request,
     multiple_reply_to_email_addresses


### PR DESCRIPTION
This pull request makes a few small design tweaks to the email reply to pages, and adds one major new thing, showing the IDs of the reply to addresses on these pages.

***

The first users of multiple email reply to addresses will be using the API. This means that the need to be able to specify the ID of the reply to address they want.

We chose to implement it like this instead of by passing the address in directly because that means deploying code. For some teams deploying code can take weeks, and we’d like to let teams have the flexibility to make changes faster than this.

Same as for templates, you shouldn’t have to go to the _edit_ page in order to get the ID. This means listing them on the page where you see all the reply to addresses.

Listing the IDs like this means that it’s not really a table any more, because the information isn’t organised in columns. So I think it makes sense to reuse the pattern from the manage team page, which has a similar relationship between the information.

***

<img width="1007" alt="screen shot 2017-09-26 at 15 59 42" src="https://user-images.githubusercontent.com/355079/30868364-513de786-a2d6-11e7-84ea-9e79d3d19d21.png">

<img width="1003" alt="screen shot 2017-09-26 at 15 56 18" src="https://user-images.githubusercontent.com/355079/30868375-5558c340-a2d6-11e7-903a-6920366718c6.png">


