### PR TITLE
Add letters to the request to go live page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -431,15 +431,9 @@ class RequestToGoLiveForm(Form):
         ],
         validators=[DataRequired()]
     )
-    channel = RadioField(
-        'What kind of messages will you be sending?',
-        choices=[
-            ('emails', 'Emails'),
-            ('text messages', 'Text messages'),
-            ('emails and text messages', 'Both')
-        ],
-        validators=[DataRequired()]
-    )
+    channel_email = BooleanField('Emails')
+    channel_sms = BooleanField('Text messages')
+    channel_letter = BooleanField('Letters')
     start_date = StringField(
         'When will you be ready to start sending messages?',
         validators=[DataRequired(message='Can’t be empty')]

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -34,6 +34,7 @@ from app.main.forms import (
     LetterBranding,
     ServiceInboundApiForm)
 from app import user_api_client, current_service, organisations_client, inbound_number_client
+from notifications_utils.formatters import formatted_list
 
 
 dummy_bearer_token = 'bearer_token_set'
@@ -166,7 +167,11 @@ def service_request_to_go_live(service_id):
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 form.mou.data,
-                form.channel.data,
+                formatted_list(filter(None, (
+                    'email' if form.channel_email.data else None,
+                    'text messages' if form.channel_sms.data else None,
+                    'letters' if form.channel_letter.data else None,
+                )), before_each='', after_each=''),
                 form.start_date.data,
                 form.start_volume.data,
                 form.peak_volume.data,

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -20,3 +20,18 @@
     </label>
   </div>
 {% endmacro %}
+
+
+{% macro checkbox_group(
+  legend,
+  fields
+) %}
+  <fieldset class="form-group">
+    <legend class="form-label">
+      {{ legend }}
+    </legend>
+    {% for field in fields %}
+      {{ checkbox(field) }}
+    {% endfor %}
+  </fieldset>
+{% endmacro %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/checkbox.html" import checkbox_group %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
@@ -38,8 +39,12 @@
             'don’t know': 'We’ll check for you',
           }) }}
         </div>
+        {{ checkbox_group('What kind of messages will you be sending?', [
+          form.channel_email,
+          form.channel_sms,
+          form.channel_letter
+        ]) }}
         <div class="form-group">
-          {{ radios(form.channel) }}
           {{ textbox(form.start_date, width='1-1') }}
           {{ textbox(form.start_volume, width='1-1', hint='For example, ‘1000 a month’.') }}
           {{ textbox(form.peak_volume, width='1-1', hint='For example, ‘Messages will increase to 20,000 a month in January’.') }}


### PR DESCRIPTION
It’s not either text messages, or emails, or both now – it’s any combination of the three channels.

This commit adds ‘letters’ as an option on the request to go live page by changing the radio buttons to a group of checkboxes, so the user can choose as many or as few as they want.

This commit also does a bunch of housekeeping stuff around the tests for this page, because they haven’t been touched in quite some time.

## Before

![image](https://user-images.githubusercontent.com/355079/30907506-bea23146-a372-11e7-96fc-853c32e96b93.png)

## After

![image](https://user-images.githubusercontent.com/355079/30907491-b2d36588-a372-11e7-9a1c-08d78ac20568.png)
