### PR TITLE
Fix overridden padding on email subject

### DIFF
--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -26,9 +26,15 @@ $email-message-gutter: $gutter * 2;
     }
 
     td {
+
       width: 99%;
       padding-right: $email-message-gutter;
       word-break: break-word;
+
+      &:first-child {
+        padding-right: $email-message-gutter;
+      }
+
     }
 
   }


### PR DESCRIPTION
Something in a new version of GOV.UK Elements, Template, or Frontend Toolkit has introduced a rules which removes padding for the last column in a table.

This is undesirable in the case of email message previews.

## Before

<img width="732" alt="screen shot 2017-09-28 at 10 46 59" src="https://user-images.githubusercontent.com/355079/30960296-85c3cd94-a43a-11e7-860b-3bf319ccf242.png">

## After 

<img width="729" alt="screen shot 2017-09-28 at 10 45 24" src="https://user-images.githubusercontent.com/355079/30960302-89df7e50-a43a-11e7-8ccd-8ecf3fc3e10a.png">
