### PR TITLE
(reverse #1506) admin to api not passing trial_mode_service para

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -22,7 +22,6 @@ def platform_admin():
     api_args = {'detailed': True,
                 'only_active': False,     # specifically DO get inactive services
                 'include_from_test_key': form.include_from_test_key.data,
-                'trial_mode_services': None
                 }
 
     if form.start_date.data:
@@ -48,7 +47,6 @@ def platform_admin_services():
     api_args = {'detailed': True,
                 'only_active': False,    # specifically DO get inactive services
                 'include_from_test_key': form.include_from_test_key.data,
-                'trial_mode_services': request.endpoint == 'main.trial_services'
                 }
 
     if form.start_date.data:

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -72,8 +72,7 @@ def test_should_show_research_and_restricted_mode(
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'include_from_test_key': True,
-                                                        'only_active': False,
-                                                        'trial_mode_services': ANY})
+                                                        'only_active': False})
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     # get first column in second row, which contains flags as text.
     table_body = page.find_all('table')[0].find_all('tbody')[0]
@@ -81,9 +80,9 @@ def test_should_show_research_and_restricted_mode(
     assert service_mode == displayed
 
 
-@pytest.mark.parametrize('endpoint, expected_services_shown, trial_mode_services', [
-    ('main.live_services', 1, False),
-    ('main.trial_services', 1, True),
+@pytest.mark.parametrize('endpoint, expected_services_shown', [
+    ('main.live_services', 1),
+    ('main.trial_services', 1),
 ])
 def test_should_render_platform_admin_page(
     client,
@@ -91,8 +90,7 @@ def test_should_render_platform_admin_page(
     mocker,
     mock_get_detailed_services,
     endpoint,
-    expected_services_shown,
-    trial_mode_services,
+    expected_services_shown
 ):
     mock_get_user(mocker, user=platform_admin_user)
     client.login(platform_admin_user)
@@ -102,14 +100,13 @@ def test_should_render_platform_admin_page(
     assert len(page.select('tbody tr')) == expected_services_shown * 2  # one row for SMS, one for email
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'include_from_test_key': True,
-                                                        'only_active': False,
-                                                        'trial_mode_services': trial_mode_services})
+                                                        'only_active': False})
 
 
-@pytest.mark.parametrize('endpoint, trial_mode_services', [
-    ('main.platform_admin', None),
-    ('main.live_services', False),
-    ('main.trial_services', True),
+@pytest.mark.parametrize('endpoint', [
+    ('main.platform_admin'),
+    ('main.live_services'),
+    ('main.trial_services'),
 ])
 @pytest.mark.parametrize('include_from_test_key, inc', [
     ("Y", True),
@@ -122,7 +119,6 @@ def test_platform_admin_toggle_including_from_test_key(
     mocker,
     mock_get_detailed_services,
     endpoint,
-    trial_mode_services,
     inc
 ):
     mock_get_user(mocker, user=platform_admin_user)
@@ -132,21 +128,19 @@ def test_platform_admin_toggle_including_from_test_key(
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'only_active': False,
-                                                        'trial_mode_services': trial_mode_services,
                                                         'include_from_test_key': inc})
 
 
-@pytest.mark.parametrize('endpoint, trial_mode_services', [
-    ('main.platform_admin', None),
-    ('main.live_services', False),
-    ('main.trial_services', True)
+@pytest.mark.parametrize('endpoint', [
+    'main.platform_admin',
+    'main.live_services',
+    'main.trial_services'
 ])
 def test_platform_admin_with_date_filter(
     client,
     platform_admin_user,
     mocker,
     mock_get_detailed_services,
-    trial_mode_services,
     endpoint
 ):
     mock_get_user(mocker, user=platform_admin_user)
@@ -162,7 +156,6 @@ def test_platform_admin_with_date_filter(
         'start_date': datetime.date(2016, 12, 20),
         'detailed': True,
         'only_active': False,
-        'trial_mode_services': trial_mode_services,
     })
 
 
@@ -308,15 +301,14 @@ def test_format_stats_by_service_returns_correct_values(fake_uuid):
     assert ret[0]['stats']['sms']['failed'] == 11
 
 
-@pytest.mark.parametrize('endpoint, restricted, research_mode, trial_mode_services', [
-    ('main.trial_services', True, False, True),
-    ('main.live_services', False, False, False)
+@pytest.mark.parametrize('endpoint, restricted, research_mode', [
+    ('main.trial_services', True, False),
+    ('main.live_services', False, False)
 ])
 def test_should_show_email_and_sms_stats_for_all_service_types(
     endpoint,
     restricted,
     research_mode,
-    trial_mode_services,
     client,
     platform_admin_user,
     mocker,
@@ -341,7 +333,6 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'include_from_test_key': True,
-                                                        'trial_mode_services': trial_mode_services,
                                                         'only_active': ANY})
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
@@ -360,13 +351,12 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     assert sms_failed == 11
 
 
-@pytest.mark.parametrize('endpoint, restricted, trial_mode_services', [
-    ('main.live_services', False, False),
-    ('main.trial_services', True, True)
+@pytest.mark.parametrize('endpoint, restricted', [
+    ('main.live_services', False),
+    ('main.trial_services', True)
 ], ids=['live', 'trial'])
 def test_should_show_archived_services_last(
     endpoint,
-    trial_mode_services,
     client,
     platform_admin_user,
     mocker,
@@ -390,8 +380,7 @@ def test_should_show_archived_services_last(
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'include_from_test_key': True,
-                                                        'only_active': ANY,
-                                                        'trial_mode_services': trial_mode_services})
+                                                        'only_active': ANY})
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     table_body = page.find_all('table')[0].find_all('tbody')[0]
@@ -462,15 +451,14 @@ def test_should_show_correct_sent_totals_for_platform_admin(
     assert sms_total == 40
 
 
-@pytest.mark.parametrize('endpoint, restricted, research_mode, trial_mode_services', [
-    ('main.trial_services', True, False, True),
-    ('main.live_services', False, False, False)
+@pytest.mark.parametrize('endpoint, restricted, research_mode', [
+    ('main.trial_services', True, False),
+    ('main.live_services', False, False)
 ])
 def test_should_order_services_by_usage_with_inactive_last(
     endpoint,
     restricted,
     research_mode,
-    trial_mode_services,
     client,
     platform_admin_user,
     mocker,
@@ -517,8 +505,7 @@ def test_should_order_services_by_usage_with_inactive_last(
     assert response.status_code == 200
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'include_from_test_key': True,
-                                                        'only_active': ANY,
-                                                        'trial_mode_services': trial_mode_services})
+                                                        'only_active': ANY})
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     table_body = page.find_all('table')[0].find_all('tbody')[0]


### PR DESCRIPTION
**Why**
This is to reverse part of the pull request in #1506. Passing trial_mode_service parameter requires joining the service schema, which creates extra delay in loading the data.
https://github.com/alphagov/notifications-admin/pull/1506

**Change** 
Do not pass trial_mode_service to api. 

**Pivotal Story**
Platform Admin performance issue
#151371820