### PR TITLE
Updated runtime python version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.5.4


### PR DESCRIPTION
CloudFoundry pulled python 3.5.2.