### PR TITLE
Add note about relationship between team API key and letters

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -69,14 +69,15 @@ def create_api_key(service_id):
         (KEY_TYPE_TEAM, 'Team and whitelist – limits who you can send to'),
         (KEY_TYPE_TEST, 'Test – pretends to send messages'),
     ]
+    disabled_options, option_hints = [], {}
     if current_service['restricted']:
         disabled_options = [KEY_TYPE_NORMAL]
-        option_hints = {KEY_TYPE_NORMAL: Markup(
+        option_hints[KEY_TYPE_NORMAL] = Markup(
             'This option is not available because your service is in '
             '<a href="{}#trial-mode">trial mode</a>'.format(url_for(".using_notify"))
-        )}
-    else:
-        disabled_options, option_hints = [], {}
+        )
+    if 'letter' in current_service['permissions']:
+        option_hints[KEY_TYPE_TEAM] = 'Can’t be used to send letters'
     if form.validate_on_submit():
         if form.key_type.data in disabled_options:
             abort(400)

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -73,7 +73,7 @@ def create_api_key(service_id):
     if current_service['restricted']:
         disabled_options = [KEY_TYPE_NORMAL]
         option_hints[KEY_TYPE_NORMAL] = Markup(
-            'This option is not available because your service is in '
+            'Not available because your service is in '
             '<a href="{}#trial-mode">trial mode</a>'.format(url_for(".using_notify"))
         )
     if 'letter' in current_service['permissions']:

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -7,7 +7,12 @@ from bs4 import BeautifulSoup
 from unittest.mock import call
 
 from tests import validate_route_permission
-from tests.conftest import normalize_spaces, SERVICE_ONE_ID
+from tests.conftest import (
+    mock_get_service,
+    mock_get_live_service,
+    normalize_spaces,
+    SERVICE_ONE_ID,
+)
 
 
 def test_should_show_api_page(
@@ -120,20 +125,41 @@ def test_should_show_api_keys_page(
     mock_get_api_keys.assert_called_once_with(service_id=fake_uuid)
 
 
+@pytest.mark.parametrize('service_mock, expected_options', [
+    (
+        mock_get_service,
+        [
+            (
+                'Live – sends to anyone '
+                'This option is not available because your service is in trial mode'
+            ),
+            'Team and whitelist – limits who you can send to',
+            'Test – pretends to send messages',
+        ]
+    ),
+    (
+        mock_get_live_service,
+        [
+            'Live – sends to anyone',
+            'Team and whitelist – limits who you can send to',
+            'Test – pretends to send messages',
+        ]
+    ),
+])
 def test_should_show_create_api_key_page(
-    logged_in_client,
+    client_request,
+    mocker,
     api_user_active,
-    mock_login,
     mock_get_api_keys,
-    mock_get_service,
-    mock_has_permissions,
-    fake_uuid,
+    service_mock,
+    expected_options,
 ):
-    logged_in_client.login(api_user_active)
-    service_id = fake_uuid
-    response = logged_in_client.get(url_for('main.create_api_key', service_id=fake_uuid))
+    service_mock(mocker, api_user_active)
 
-    assert response.status_code == 200
+    page = client_request.get('main.create_api_key', service_id=SERVICE_ONE_ID)
+
+    for index, option in enumerate(expected_options):
+        assert normalize_spaces(page.select('.block-label')[index].text) == option
 
 
 def test_should_create_api_key_with_type_normal(

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -132,7 +132,7 @@ def test_should_show_api_keys_page(
         [
             (
                 'Live – sends to anyone '
-                'This option is not available because your service is in trial mode'
+                'Not available because your service is in trial mode'
             ),
             'Team and whitelist – limits who you can send to',
             'Test – pretends to send messages',

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -127,36 +127,27 @@ def test_should_show_api_keys_page(
 
 
 @pytest.mark.parametrize('service_mock, expected_options', [
-    (
-        mock_get_service,
-        [
-            (
-                'Live – sends to anyone '
-                'Not available because your service is in trial mode'
-            ),
-            'Team and whitelist – limits who you can send to',
-            'Test – pretends to send messages',
-        ]
-    ),
-    (
-        mock_get_live_service,
-        [
-            'Live – sends to anyone',
-            'Team and whitelist – limits who you can send to',
-            'Test – pretends to send messages',
-        ]
-    ),
-    (
-        mock_get_service_with_letters,
-        [
-            'Live – sends to anyone',
-            (
-                'Team and whitelist – limits who you can send to '
-                'Can’t be used to send letters'
-            ),
-            'Test – pretends to send messages',
-        ]
-    ),
+    (mock_get_service, [
+        (
+            'Live – sends to anyone '
+            'Not available because your service is in trial mode'
+        ),
+        'Team and whitelist – limits who you can send to',
+        'Test – pretends to send messages',
+    ]),
+    (mock_get_live_service, [
+        'Live – sends to anyone',
+        'Team and whitelist – limits who you can send to',
+        'Test – pretends to send messages',
+    ]),
+    (mock_get_service_with_letters, [
+        'Live – sends to anyone',
+        (
+            'Team and whitelist – limits who you can send to '
+            'Can’t be used to send letters'
+        ),
+        'Test – pretends to send messages',
+    ]),
 ])
 def test_should_show_create_api_key_page(
     client_request,

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -10,6 +10,7 @@ from tests import validate_route_permission
 from tests.conftest import (
     mock_get_service,
     mock_get_live_service,
+    mock_get_service_with_letters,
     normalize_spaces,
     SERVICE_ONE_ID,
 )
@@ -142,6 +143,17 @@ def test_should_show_api_keys_page(
         [
             'Live – sends to anyone',
             'Team and whitelist – limits who you can send to',
+            'Test – pretends to send messages',
+        ]
+    ),
+    (
+        mock_get_service_with_letters,
+        [
+            'Live – sends to anyone',
+            (
+                'Team and whitelist – limits who you can send to '
+                'Can’t be used to send letters'
+            ),
             'Test – pretends to send messages',
         ]
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,19 @@ def mock_get_live_service(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_get_service_with_letters(mocker, api_user_active):
+    def _get(service_id):
+        return {'data': service_json(
+            service_id,
+            users=[api_user_active.id],
+            restricted=False,
+            permissions=['email', 'sms', 'letter']
+        )}
+
+    return mocker.patch('app.service_api_client.get_service', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
 def mock_create_service(mocker):
     def _create(service_name, message_limit, restricted, user_id, email_from):
         service = service_json(


### PR DESCRIPTION
When trying to send letters using the API, the ‘team and whitelist’ key is confusing. We don’t have addresses for your team members, nor is there a whitelist for letter addresses. The actual behaviour is that you’ll get an error if you try to use this key to send letters.

So, for services who have letters available, we should add a hint telling users that team and whitelist is probably not the key they’re looking for.

***

## Before

![image](https://user-images.githubusercontent.com/355079/31125337-de231ce8-a83f-11e7-8e5a-e464acd01597.png)

## After

![image](https://user-images.githubusercontent.com/355079/31125316-cef3a6e8-a83f-11e7-8d62-1e9b5910c644.png)
