### PR TITLE
Only mandate mandatory address columns

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1,6 +1,7 @@
 import itertools
 from string import ascii_uppercase
 
+from orderedset import OrderedSet
 from contextlib import suppress
 from zipfile import BadZipFile
 from xlrd.biffh import XLRDError
@@ -445,6 +446,7 @@ def _check_messages(service_id, template_type, upload_id, letters_as_pdf=False):
             template.template_type == 'letter',
             not request.args.get('from_test'),
         )),
+        required_recipient_columns=OrderedSet(recipients.recipient_column_headers) - optional_address_columns
     )
 
 

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -48,7 +48,7 @@
       {% elif not recipients.has_recipient_columns %}
 
         <h1 class='banner-title' data-module="track-error" data-error-type="Missing recipient columns" data-error-label="{{ upload_id }}">
-          Your file needs {{ recipients.recipient_column_headers | formatted_list(
+          Your file needs {{ required_recipient_columns | formatted_list(
             prefix='a column called',
             prefix_plural='columns called'
           ) }}


### PR DESCRIPTION
If you miss ‘postcode’ from your file then you get told that you need ‘address_line_1’, ‘address_line_2’, ‘address_line_3’, etc.

This is incorrect – the only required address columns are lines 1 and 2, plus the postcode. So this commit corrects the error message to be factually accurate.

We had a user report this to Fajer as a bug.

Hopefully we deal with this in a more generic way once users can edit the address block.