### PR TITLE
Rename count from ‘departments’ to ’organisations’

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -121,14 +121,14 @@
           services
         </div>
         <div class="column-half">
-          <h3 class="visually-hidden">Departments</h3>
+          <h3 class="visually-hidden">Organisations</h3>
           <div class="product-page-big-number">40</div>
-          departments
+          organisations
         </div>
       </div>
       <p>
         See the
-        <a href="https://www.gov.uk/performance/govuk-notify/government-services">list of services and departments</a>.
+        <a href="https://www.gov.uk/performance/govuk-notify/government-services">list of services and organisations</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
They’re not all departments.

Could also say ‘departments and agencies’ as per the Performance Platform page. Which is more accurate?