### PR TITLE
Remove cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ago==0.0.9
-cffi==1.11.1
 Flask==0.12.2
 Flask-Script==2.0.5
 Flask-WTF==0.14.2


### PR DESCRIPTION
It doesn’t seem to be used; tests pass without it being installed.

Was added in 10950bb8a683fb9845aec134bb849be731860aff with no explanation as to why it’s needed…