### PR TITLE
[DONT MERGE] Add multiple letter contact blocks for services from Admin app

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -480,13 +480,14 @@ class ServiceSmsSender(Form):
             raise ValidationError('Use letters and numbers only')
 
 
-class ServiceLetterContactBlock(Form):
+class ServiceLetterContactBlockForm(Form):
     letter_contact_block = TextAreaField(
         validators=[
             DataRequired(message="Can’t be empty"),
             NoCommasInPlaceHolders()
         ]
     )
+    is_default = BooleanField("Set as your default address")
 
     def validate_letter_contact_block(form, field):
         line_count = field.data.strip().count('\n')

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -57,6 +57,13 @@ page_headings = {
 )
 def view_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, str(template_id))['data']
+    if template["template_type"] == "letter":
+        letter_contact_details = service_api_client.get_letter_contacts(service_id)
+        default_letter_contact_block_id = next(
+            (x['id'] for x in letter_contact_details if x['is_default']), "None"
+            )
+    else:
+        default_letter_contact_block_id = None
     return render_template(
         'views/templates/template.html',
         template=get_template(
@@ -72,6 +79,7 @@ def view_template(service_id, template_id):
             show_recipient=True,
             page_count=get_page_count_for_letter(template),
         ),
+        default_letter_contact_block_id=default_letter_contact_block_id
     )
 
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -318,6 +318,42 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             }
         )
 
+    def get_letter_contacts(self, service_id):
+        return self.get(
+            "/service/{}/letter-contact".format(
+                service_id
+            )
+        )
+
+    def get_letter_contact(self, service_id, letter_contact_id):
+        return self.get(
+            "/service/{}/letter-contact/{}".format(
+                service_id,
+                letter_contact_id
+            )
+        )
+
+    def add_letter_contact(self, service_id, contact_block, is_default=False):
+        return self.post(
+            "/service/{}/letter-contact".format(service_id),
+            data={
+                "contact_block": contact_block,
+                "is_default": is_default
+            }
+        )
+
+    def update_letter_contact(self, service_id, letter_contact_id, contact_block, is_default=False):
+        return self.post(
+            "/service/{}/letter-contact/{}".format(
+                service_id,
+                letter_contact_id,
+            ),
+            data={
+                "contact_block": contact_block,
+                "is_default": is_default
+            }
+        )
+
 
 class ServicesBrowsableItem(BrowsableItem):
     @property

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -137,11 +137,16 @@
 
         {% if 'letter' in current_service.permissions %}
           {% call row() %}
-            {{ text_field('Letter contact details') }}
-            {% call field(status='' if current_service.letter_contact_block else 'default') %}
-              {{ letter_contact_block | string | nl2br | safe if current_service.letter_contact_block else 'None'}}
+            {{ text_field('Sender addresses') }}
+            {% call field(status='default' if default_letter_contact_block == "None" else '') %}
+              {{ default_letter_contact_block | string | nl2br | safe if default_letter_contact_block else 'None'}}
+              {% if letter_contact_details_count > 1 %}
+                <div class="hint">
+                  {{ '…and %d more' | format(letter_contact_details_count - 1) }}
+                </div>
+              {% endif %}
             {% endcall %}
-            {{ edit_field('Change', url_for('.service_set_letter_contact_block', service_id=current_service.id)) }}
+            {{ edit_field('Manage' if letter_contact_details_count else 'Change', url_for('.service_letter_contact_details', service_id=current_service.id)) }}
           {% endcall %}
         {% endif %}
 

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -1,0 +1,48 @@
+{% extends "withnav_template.html" %}
+{% from "components/api-key.html" import api_key %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table %}
+
+{% block service_page_title %}
+  Sender addresses
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row bottom-gutter">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Sender addresses
+      </h1>
+    </div>
+   <div class="column-one-third">
+     <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id) }}" class="button align-with-heading">Add a new address</a>
+   </div>
+  </div>
+  <div class="user-list">
+    {% if not letter_contact_details %}
+      <div class="user-list-item">
+        <span class="hint">You haven’t added any letter contact details yet</span>
+      </div>
+    {% endif %}
+    {% for item in letter_contact_details %}
+      <div class="user-list-item">
+        <h3>
+          <span class="heading-small">{{ item.contact_block }}</span>&ensp;<span class="hint">
+            {%- if item.is_default -%}
+              (default)
+            {% endif %}
+          </span>
+        </h3>
+        <ul class="tick-cross-list">
+          <li class="tick-cross-list-edit-link">
+            <a href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
+          </li>
+        </ul>
+        {% if letter_contact_details|length  > 1 %}
+          {{ api_key(item.id, thing="ID") }}
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -1,0 +1,38 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/checkbox.html" import checkbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Add a new address
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">
+    Add a new address
+  </h1>
+  <div class="grid-row">
+    <form method="post" class="column-half" novalidate>
+      {{ textbox(
+          form.letter_contact_block,
+          label='This will appear as the ‘sender’ address on your letters.'|safe,
+          hint='10 lines maximum',
+          width='1-1',
+          rows=10,
+          highlight_tags=True
+        ) }}
+      {% if not first_contact_block %}
+        <div class="form-group">
+          {{ checkbox(form.is_default) }}
+        </div>
+      {% endif %}
+      {{ page_footer(
+        'Add',
+        back_link=url_for('.service_letter_contact_details', service_id=current_service.id),
+        back_link_text='Back'
+      ) }}
+    </form>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -1,0 +1,42 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/checkbox.html" import checkbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Edit an address
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">
+    Edit an address
+  </h1>
+  <div class="grid-row">
+    <form method="post" class="column-half">
+      {{ textbox(
+        form.letter_contact_block,
+        label='This will appear as the ‘sender’ address on your letters.'|safe,
+        hint='10 lines maximum',
+        width='1-1',
+        rows=10,
+        highlight_tags=True
+      ) }}
+      {% if form.is_default.data %}
+        <p class="form-group">
+          This is currently your default address for {{ current_service.name }}
+        </p>
+      {% else %}
+        <div class="form-group">
+          {{ checkbox(form.is_default) }}
+        </div>
+      {% endif %}
+      {{ page_footer(
+        'Save',
+        back_link=None if request.args.get('from_template') else url_for('.service_letter_contact_details', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </form>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -35,7 +35,7 @@
 <div class="column-whole template-container">
   {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) and template.template_type == 'letter' %}
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
-    <a href="{{ url_for(".service_set_letter_contact_block", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
+    <a href="{{ url_for(".service_edit_letter_contact", service_id=current_service.id, letter_contact_id=default_letter_contact_block_id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
   {% endif %}
   {{ template|string }}
 </div>

--- a/tests/app/main/views/service_settings/test_inbound_sms_setting.py
+++ b/tests/app/main/views/service_settings/test_inbound_sms_setting.py
@@ -26,7 +26,8 @@ def test_get_inbound_number_in_service_settings(
         logged_in_client,
         mock_update_service,
         mock_get_letter_organisations,
-        single_reply_to_email_addresses,
+        single_reply_to_email_address,
+        single_letter_contact_block,
         service_one,
         mocker
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -127,6 +127,7 @@ def test_should_be_able_to_view_a_template_with_links(
     client,
     mock_get_service_template,
     active_user_with_permissions,
+    single_letter_contact_block,
     mocker,
     service_one,
     fake_uuid,
@@ -178,6 +179,7 @@ def test_should_show_sms_template_with_downgraded_unicode_characters(
     logged_in_client,
     mocker,
     service_one,
+    single_letter_contact_block,
     fake_uuid,
 ):
     msg = 'here:\tare some “fancy quotes” and zero\u200Bwidth\u200Bspaces'
@@ -813,6 +815,7 @@ def test_should_show_page_for_a_deleted_template(
     mock_login,
     mock_get_service,
     mock_get_deleted_template,
+    single_letter_contact_block,
     mock_get_user,
     mock_get_user_by_email,
     mock_has_permissions,
@@ -1132,6 +1135,7 @@ def test_should_show_redact_template(
     client_request,
     mock_get_service_template,
     mock_redact_template,
+    single_letter_contact_block,
     service_one,
     fake_uuid,
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def no_reply_to_email_addresses(mocker):
 
 
 @pytest.fixture(scope='function')
-def single_reply_to_email_addresses(mocker):
+def single_reply_to_email_address(mocker):
     def _get(service_id):
         return [
             {
@@ -149,6 +149,125 @@ def mock_update_reply_to_email_address(mocker):
         return
 
     return mocker.patch('app.service_api_client.update_reply_to_email_address', side_effect=_update_reply_to)
+
+
+@pytest.fixture(scope='function')
+def multiple_letter_contact_blocks(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'contact_block': '1 Example Street',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }, {
+                'id': '5678',
+                'service_id': service_id,
+                'contact_block': '2 Example Street',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }, {
+                'id': '9457',
+                'service_id': service_id,
+                'contact_block': '3 Example Street',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_letter_contacts', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def no_letter_contact_blocks(mocker):
+    def _get(service_id):
+        return []
+
+    return mocker.patch('app.service_api_client.get_letter_contacts', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def single_letter_contact_block(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'contact_block': '1 Example Street',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_letter_contacts', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def injected_letter_contact_block(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'contact_block': 'foo\nbar<script>alert(1);</script>',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_letter_contacts', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def get_default_letter_contact_block(mocker):
+    def _get(service_id, letter_contact_id):
+        return {
+            'id': '1234',
+            'service_id': service_id,
+            'contact_block': '1 Example Street',
+            'is_default': True,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }
+
+    return mocker.patch('app.service_api_client.get_letter_contact', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def get_non_default_letter_contact_block(mocker):
+    def _get(service_id, letter_contact_id):
+        return {
+            'id': '1234',
+            'service_id': service_id,
+            'contact_block': '1 Example Street',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }
+
+    return mocker.patch('app.service_api_client.get_letter_contact', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def mock_add_letter_contact(mocker):
+    def _add_letter_contact(service_id, contact_block, is_default=False):
+        return
+
+    return mocker.patch('app.service_api_client.add_letter_contact', side_effect=_add_letter_contact)
+
+
+@pytest.fixture(scope='function')
+def mock_update_letter_contact(mocker):
+    def _update_letter_contact(service_id, letter_contact_id, contact_block, is_default=False):
+        return
+
+    return mocker.patch('app.service_api_client.update_letter_contact', side_effect=_update_letter_contact)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Summary

Task to allow users to have multiple letter contact blocks, that they could choose the default from, similar to how email-reply-tos work currently. 

Edit route from letter template now redirects straight to the edit  page for the default letter contact block.


## Screenshots

![image](https://user-images.githubusercontent.com/31617728/31238145-e0377896-a9f0-11e7-9877-15cf5beb8cc7.png)

![image](https://user-images.githubusercontent.com/31617728/31238206-2b3acb40-a9f1-11e7-9fde-2f1d25eac728.png)

![image](https://user-images.githubusercontent.com/31617728/31238244-4c483dcc-a9f1-11e7-91b3-11570f439702.png)

![image](https://user-images.githubusercontent.com/31617728/31238171-fadae52a-a9f0-11e7-9e6f-089f8989ceac.png)