### PR TITLE
Drop admin-paas.* route

### DIFF
--- a/manifest-preview.yml
+++ b/manifest-preview.yml
@@ -4,5 +4,4 @@ inherit: manifest-base.yml
 
 routes:
   - route: notify-admin-preview.cloudapps.digital
-  - route: admin-paas.notify.works
   - route: www.notify.works

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -4,7 +4,6 @@ inherit: manifest-base.yml
 
 routes:
   - route: notify-admin-production.cloudapps.digital
-  - route: admin-paas.notifications.service.gov.uk
   - route: www.notifications.service.gov.uk
 instances: 2
 memory: 1G

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -4,7 +4,6 @@ inherit: manifest-base.yml
 
 routes:
   - route: notify-admin-staging.cloudapps.digital
-  - route: admin-paas.staging-notify.works
   - route: www.staging-notify.works
 instances: 2
 memory: 1G


### PR DESCRIPTION
This was introduced during the migration and is no longer needed nor
should it be used.

Related to alphagov/notifications-api#1311.