### PR TITLE
Let users reply to an inbound message with an existing template

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -1,5 +1,7 @@
 from flask import (
     jsonify,
+    session,
+    redirect,
     render_template,
     url_for,
 )
@@ -60,7 +62,28 @@ def conversation_reply(
         show_search_box=(len(templates) > 7),
         template_type='sms',
         search_form=SearchTemplatesForm(),
+        notification_id=notification_id,
     )
+
+
+@main.route("/services/<service_id>/conversation/<notification_id>/reply-with/<template_id>")
+@login_required
+@user_has_permissions('send_texts', admin_override=True)
+def conversation_reply_with_template(
+    service_id,
+    notification_id,
+    template_id,
+):
+
+    session['recipient'] = get_user_number(service_id, notification_id)
+    session['placeholders'] = {'phone number': session['recipient']}
+
+    return redirect(url_for(
+        'main.send_one_off_step',
+        service_id=service_id,
+        template_id=template_id,
+        step_index=1,
+    ))
 
 
 def get_conversation_partials(service_id, user_number):

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -82,6 +82,8 @@ def view_notification(service_id, notification_id):
         created_at=notification['created_at'],
         help=get_help_argument(),
         estimated_letter_delivery_date=get_letter_timings(notification['created_at']).earliest_delivery,
+        notification_id=notification['id'],
+        can_receive_inbound=('inbound_sms' in current_service['permissions']),
     )
 
 

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -22,6 +22,12 @@
       'messages',
     ) }}
 
+    {% if current_user.has_permissions(['send_texts'], admin_override=True) %}
+      <p>
+        <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
+      </p>
+    {% endif %}
+
   </div>
 
 {% endblock %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -42,4 +42,10 @@
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}
 
+    {% if current_user.has_permissions(['send_texts'], admin_override=True) and template.template_type == 'sms' and can_receive_inbound %}
+      <p>
+        <a href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
+      </p>
+    {% endif %}
+
 {% endblock %}

--- a/app/templates/views/templates/_search-box.html
+++ b/app/templates/views/templates/_search-box.html
@@ -1,0 +1,10 @@
+    {% if show_search_box %}
+      <div data-module="autofocus">
+        <div class="live-search" data-module="live-search" data-targets="#template-list .column-whole">
+          {{ textbox(
+            search_form.search,
+            width='1-1'
+          ) }}
+        </div>
+      </div>
+    {% endif %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -28,16 +28,7 @@
 
   {% else %}
 
-    {% if show_search_box %}
-      <div data-module="autofocus">
-        <div class="live-search" data-module="live-search" data-targets="#template-list .column-whole">
-          {{ textbox(
-            search_form.search,
-            width='1-1'
-          ) }}
-        </div>
-      </div>
-    {% endif %}
+    {% include "views/templates/_search-box.html" %}
 
     <nav class="grid-row" id=template-list>
       {% for template in templates %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -43,7 +43,7 @@
       {% for template in templates %}
         <div class="column-whole">
           <h2 class="message-name">
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+            <a href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=template.id, notification_id=notification_id) }}">{{ template.name }}</a>
           </h2>
           <p class="message-type">
             {{ message_count_label(1, template.template_type, suffix='')|capitalize }} template

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -1,0 +1,56 @@
+{% from "components/pill.html" import pill %}
+{% from "components/message-count-label.html" import message_count_label %}
+{% from "components/textbox.html" import textbox %}
+
+{% extends "withnav_template.html" %}
+
+{% block service_page_title %}
+  Choose a template
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-large">Choose a template</h1>
+
+  {% if not templates %}
+
+    {% if current_user.has_permissions(permissions=['manage_templates'], any_=True) %}
+       <p class="bottom-gutter">
+         You need a template before you can send text messages.
+       </p>
+      <a href="{{ url_for('.add_template_by_type', service_id=current_service.id) }}" class="button">Add a new template</a>
+    {% else %}
+      <p>
+        You need to ask your service manager to add templates before you
+        can send text messages.
+      </p>
+    {% endif %}
+
+  {% else %}
+
+    {% if show_search_box %}
+      <div data-module="autofocus">
+        <div class="live-search" data-module="live-search" data-targets="#template-list .column-whole">
+          {{ textbox(
+            search_form.search,
+            width='1-1'
+          ) }}
+        </div>
+      </div>
+    {% endif %}
+
+    <nav class="grid-row" id=template-list>
+      {% for template in templates %}
+        <div class="column-whole">
+          <h2 class="message-name">
+            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+          </h2>
+          <p class="message-type">
+            {{ message_count_label(1, template.template_type, suffix='')|capitalize }} template
+          </p>
+        </div>
+      {% endfor %}
+    </nav>
+  {% endif %}
+
+{% endblock %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -54,16 +54,7 @@
       </div>
     {% endif %}
 
-    {% if show_search_box %}
-      <div data-module="autofocus">
-        <div class="live-search" data-module="live-search" data-targets="#template-list .column-whole">
-          {{ textbox(
-            search_form.search,
-            width='1-1'
-          ) }}
-        </div>
-      </div>
-    {% endif %}
+    {% include "views/templates/_search-box.html" %}
 
     <nav class="grid-row" id=template-list>
       {% for template in templates %}

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -214,3 +214,51 @@ def test_view_conversation_with_empty_inbound(
 
     messages = page.select('.sms-message-wrapper')
     assert len(messages) == 1
+
+
+def test_conversation_links_to_reply(
+    client_request,
+    fake_uuid,
+    mock_get_notification,
+    mock_get_notifications,
+    mock_get_inbound_sms,
+):
+    page = client_request.get(
+        'main.conversation',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    assert page.select('main p')[-1].select_one('a')['href'] == (
+        url_for(
+            '.conversation_reply',
+            service_id=SERVICE_ONE_ID,
+            notification_id=fake_uuid,
+        )
+    )
+
+
+def test_conversation_reply_shows_templates(
+    client_request,
+    fake_uuid,
+    mock_get_service_templates,
+):
+    page = client_request.get(
+        'main.conversation_reply',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    for index, expected in enumerate([
+        'sms_template_one',
+        'sms_template_two',
+    ]):
+        link = page.select('.message-name')[index]
+        assert normalize_spaces(link.text) == expected
+        assert link.select_one('a')['href'].startswith(
+            url_for(
+                'main.view_template',
+                service_id=SERVICE_ONE_ID,
+                template_id='',
+            )
+        )

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -257,8 +257,32 @@ def test_conversation_reply_shows_templates(
         assert normalize_spaces(link.text) == expected
         assert link.select_one('a')['href'].startswith(
             url_for(
-                'main.view_template',
+                'main.conversation_reply_with_template',
                 service_id=SERVICE_ONE_ID,
+                notification_id=fake_uuid,
                 template_id='',
             )
         )
+
+
+def test_conversation_reply_redirects_with_phone_number_from_notification(
+    client_request,
+    fake_uuid,
+    mock_get_notification,
+    mock_get_service_template,
+):
+
+    page = client_request.get(
+        'main.conversation_reply_with_template',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        template_id=fake_uuid,
+        _follow_redirects=True,
+    )
+
+    for element, expected_text in [
+        ('h1', 'Preview of Two week reminder'),
+        ('.sms-message-recipient', 'To: 07123 456789'),
+        ('.sms-message-wrapper', 'service one: Template <em>content</em> with & entity'),
+    ]:
+        assert normalize_spaces(page.select_one(element).text) == expected_text


### PR DESCRIPTION
![inbound-reply](https://user-images.githubusercontent.com/355079/31605527-5c946bea-b25e-11e7-85ba-c2213dd19d96.gif)

---

If your service is receiving inbound messages, you might want to reply to them. Without an API integration, the only way to do this is by doing the send one off flow. But currently this means copying the phone number, navigating to the template you want, then pasting the phone number into the send one-off flow.

We saw people doing this in user research last week. They were sending a second message after having sent a first, so this commit also adds a link so they can get from the page where you’ve sent a message up to the conversation view.