### PR TITLE
Open Notify to the wider public sector

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -24,8 +24,7 @@
             Send emails and text messages to your users
           </h1>
           <p>
-            Try GOV.UK Notify now if you work for a UK government
-            department or agency.
+            Try GOV.UK Notify now if you work for a UK government&nbsp;organisation.
           </p>
           <div class="button-container">
             <a class="button button-start" href='{{ url_for('.register' )}}'>


### PR DESCRIPTION
Notify is now available, as a pilot, to local government and the NHS. So
telling people that it’s only for government departments and agencies is
- wrong
- might stop them from signing up

The word ‘organisation’ matches what’s used on the list of services, and
on the hint text on the email field on the sign up page.

# Before 

![image](https://user-images.githubusercontent.com/355079/31608442-4a6af3d0-b268-11e7-88c1-f7a3f7c76403.png)

# After

![image](https://user-images.githubusercontent.com/355079/31608533-9114e8f4-b268-11e7-8c99-7b1c23cc9f81.png)

# Context 

![image](https://user-images.githubusercontent.com/355079/31608463-5b7b7956-b268-11e7-9c22-c6afc9cd47a3.png)

![image](https://user-images.githubusercontent.com/355079/31608494-6e3fa4a4-b268-11e7-9e12-6898fb9612ca.png)

