### PR TITLE
Track form validation errors in Google analytics

### DIFF
--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -18,7 +18,7 @@
             </span>
           {% endif %}
           {% if field.errors %}
-            <span class="error-message">
+            <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0][0] }}" data-error-label="{{ field.name }}">
               {{ field.errors[0][0] }}
             </span>
           {% endif %}

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -9,7 +9,7 @@
       <legend class="form-label">
         {{ field.label.text|safe }}
         {% if field.errors %}
-          <span class="error-message">
+          <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
             {{ field.errors[0] }}
           </span>
         {% endif %}
@@ -50,7 +50,7 @@
      <legend class="form-label">
        {{ field.label.text }}
        {% if field.errors %}
-         <span class="error-message">
+         <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
            {{ field.errors[0] }}
          </span>
        {% endif %}
@@ -89,7 +89,7 @@
           {{ field.label.text }}
         {% endif %}
         {% if field.errors %}
-            <span class="error-message">
+            <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
               {{ field.errors[0] }}
             </span>
         {% endif %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -24,7 +24,7 @@
         </span>
       {% endif %}
       {% if field.errors %}
-        <span class="error-message">
+        <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
           {% if not safe_error_message %}{{ field.errors[0] }}{% else %}{{ field.errors[0]|safe }}{% endif %}
         </span>
       {% endif %}


### PR DESCRIPTION
We started tracking upload errors in eb264f34b766d92ce79cb116b6093698de593caf

This has been useful.

This commit adds tracking of other form validation errors, so we can pick up if there’s a form field that’s causing people particular trouble.