### PR TITLE
Remove HTML5 validation

### DIFF
--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -42,7 +42,7 @@
     are included in the whitelist automatically.
   </p>
 
-  <form method="post">
+  <form method="post" autocomplete="off" novalidate>
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -14,7 +14,7 @@ Create a new password
 
     <p>We’ll send you an email to create a new password.</p>
 
-    <form autocomplete="off" method="post">
+    <form autocomplete="off" method="post" novalidate>
       {{ textbox(form.email_address, safe_error_message=True) }}
       {{ page_footer("Send email") }}
     </form>

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -14,7 +14,7 @@
   </h1>
 
   <div class="grid-row">
-    <form method="post" class="column-three-quarters">
+    <form method="post" class="column-three-quarters" novalidate>
 
       {{ textbox(form.email_address, width='1-1', safe_error_message=True) }}
 

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -14,7 +14,7 @@
     {{ page_title }}
   </h1>
 
-  <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus" autocomplete="off">
+  <form method="post" class="js-stick-at-top-when-scrolling" data-module="autofocus" autocomplete="off" novalidate>
     <div class="grid-row">
       <div class="column-two-thirds">
         {{ textbox(

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -30,7 +30,7 @@
       </p>
     {% endif %}
 
-    <form method="post" autocomplete="off">
+    <form method="post" autocomplete="off" novalidate>
       {{ textbox(form.email_address) }}
       {{ textbox(form.password) }}
       {{ page_footer("Continue", secondary_link=url_for('.forgot_password'), secondary_link_text="Forgot your password?") }}

--- a/app/templates/views/support/problem.html
+++ b/app/templates/views/support/problem.html
@@ -20,7 +20,7 @@
             page to see if there are any known issues with GOV.UK Notify.
           </p>
         </div>
-        <form method="post">
+        <form method="post" autocomplete="off" novalidate>
             {{ textbox(form.feedback, width='1-1', hint='', rows=10) }}
             {% if not current_user.is_authenticated %}
               {{ textbox(form.name, width='1-1') }}

--- a/app/templates/views/support/question.html
+++ b/app/templates/views/support/question.html
@@ -13,7 +13,7 @@
     </h1>
     <div class="grid-row">
       <div class="column-two-thirds">
-        <form method="post">
+        <form method="post" autocomplete="off" novalidate>
             {{ textbox(form.feedback, width='1-1', hint='', rows=10) }}
             {% if not current_user.is_authenticated %}
               <h3 class="heading-medium">Do you want a reply?</h3>

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -17,7 +17,7 @@
       </p>
     {% endif %}
     <div class="column-three-quarters">
-      <form method="post">
+      <form method="post" autocomplete="off" novalidate>
         {{ textbox(form_field, safe_error_message=True) }}
         {{ page_footer(
           'Save',


### PR DESCRIPTION
This commit:
- uses WTForms email fields wherever we collect email addresses
- makes sure we don’t let the default HTML5 form validation get trigged (using `novalidate`[1])

We don’t want to use the default validation because:
- it looks out of place
- it’s not well supported by assistive technology

1. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate