### PR TITLE
Show email reply to address if one’s been selected

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -272,6 +272,7 @@ def get_template(
     letter_preview_url=None,
     page_count=1,
     redact_missing_personalisation=False,
+    email_reply_to=None,
 ):
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
@@ -281,6 +282,7 @@ def get_template(
             expanded=expand_emails,
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
+            reply_to=email_reply_to,
         )
     if 'sms' == template['template_type']:
         return SMSPreviewTemplate(

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ notifications-python-client==4.4.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@21.2.0#egg=notifications-utils==21.2.0
+git+https://github.com/alphagov/notifications-utils.git@21.5.0#egg=notifications-utils==21.5.0


### PR DESCRIPTION
![multi-reply](https://user-images.githubusercontent.com/355079/31673887-40d69518-b358-11e7-93b1-0523e3781ac4.gif)

***

If you’ve picked an email reply to address, it’s good UI design to have your choice played back to you, so you can be confident it’s worked. This commit does that by making it part of the email preview.

This works for both uploading files and sending one off messages, although you can’t actually pick a reply to address when uploading a file yet.

The reply to address is only previewed when you’ve been given the option to choose one.

***

Uses:
- [x] https://github.com/alphagov/notifications-utils/pull/227

