### PR TITLE
Fix invisible focused item text

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -80,7 +80,9 @@
       text-decoration: underline;
     }
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:link:focus {
       color: $light-blue-25;
     }
 


### PR DESCRIPTION
GOV.UK Template hanged the colour of text in focused links in https://github.com/alphagov/govuk_template/commit/79466a489c38b0b82f4cb95daa2baba41b375a81

It was done with greater specificity than before. This means that the way we were previously overriding the focus colour (for links with a dark background) no longer works.

This commit makes our override more specific, so that it works again.

# Before

<img width="520" alt="screen shot 2017-10-17 at 16 31 47" src="https://user-images.githubusercontent.com/355079/31674437-b8c269f2-b359-11e7-915c-ce635316ab14.png">

# After 

![image](https://user-images.githubusercontent.com/355079/31674491-d539a104-b359-11e7-8104-4054aeffcbed.png)
