### PR TITLE
Use more processors when running tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,5 +35,5 @@ npm test
 display_result $? 2 "Front end code style check"
 
 ## Code coverage
-py.test -n2 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
+py.test -n4 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
 display_result $? 3 "Code coverage"


### PR DESCRIPTION
Back on my old 2013 Macbook Pro, 2 was the optimum number of cores for the fastest test runs. Which is why I chose `-n2` when I originally introduced this flag (see 9ced677ec7547ae23aea589983aa13c1d50d4fec).

Now I have a faster Macbook (same as every other developer), which has more cores to take advantage of.

We also use 4 cores when running the API tests.

Cores | Time taken to run tests
--- | ---
1 | 28.31s
2 (current) | 18.15s
3 | 14.33s
4 (proposed) | 12.32s
5 | 12.98s
6 | 13.49s
8 | 15.37s