### PR TITLE
Add syslog drain service to preview and staging

### DIFF
--- a/manifest-preview.yml
+++ b/manifest-preview.yml
@@ -2,6 +2,14 @@
 
 inherit: manifest-base.yml
 
+services:
+  - notify-aws
+  - notify-config
+  - notify-template-preview
+  - hosted-graphite
+  - deskpro
+  - logit-ssl-syslog-drain
+
 routes:
   - route: notify-admin-preview.cloudapps.digital
   - route: www.notify.works

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -5,5 +5,14 @@ inherit: manifest-base.yml
 routes:
   - route: notify-admin-staging.cloudapps.digital
   - route: www.staging-notify.works
+
+services:
+  - notify-aws
+  - notify-config
+  - notify-template-preview
+  - hosted-graphite
+  - deskpro
+  - logit-ssl-syslog-drain
+
 instances: 2
 memory: 1G


### PR DESCRIPTION
This should and will be moved back to manifest-base.yml when
it is configured for production usage.