### PR TITLE
Improve the performance of /platform-admin

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -123,36 +123,6 @@ def create_global_stats(services):
     return stats
 
 
-def platform_failure_percentages(services):
-    stats = {
-        'email': {
-            'delivered': 0,
-            'failed': 0,
-            'requested': 0
-        },
-        'sms': {
-            'delivered': 0,
-            'failed': 0,
-            'requested': 0
-        },
-        'letter': {
-            'delivered': 0,
-            'failed': 0,
-            'requested': 0
-        }
-    }
-
-    for service in services:
-        for msg_type, status in itertools.product(('sms', 'email', 'letter'), ('delivered', 'failed', 'requested')):
-            import pdb
-            pdb.set_trace()
-            stats[msg_type][status] += service[msg_type][status]
-
-    for stat in stats.values():
-        stat['failure_rate'] = get_formatted_percentage(stat['failed'], stat['requested'])
-    return stats
-
-
 def format_stats_by_service(services):
     for service in services:
         yield {

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -353,6 +353,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             }
         )
 
+    def get_aggregate_platform_stats(self, params_dict=None):
+        return self.get("/service/platform-stats", params=params_dict)
+
 
 class ServicesBrowsableItem(BrowsableItem):
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2213,3 +2213,14 @@ def normalize_spaces(input):
     if isinstance(input, str):
         return ' '.join(input.split())
     return normalize_spaces(' '.join(item.text for item in input))
+
+
+@pytest.fixture(scope='function')
+def mock_get_aggregate_platform_stats(mocker):
+    stats = {
+        'email': {'requested': 0, 'delivered': 0, 'failed': 0},
+        'sms': {'requested': 0, 'delivered': 0, 'failed': 0},
+        'letter': {'requested': 0, 'delivered': 0, 'failed': 0}
+
+    }
+    return mocker.patch('app.service_api_client.get_aggregate_platform_stats', return_value=stats)


### PR DESCRIPTION
Using a new endpoint in API to get the aggregate platform admin stats.

- [x]  https://github.com/alphagov/notifications-api/pull/1332