### PR TITLE
Right-align reply link in conversation view

### DIFF
--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -73,3 +73,7 @@ $tail-angle: 20deg;
   }
 
 }
+
+.sms-message-reply-link {
+  text-align: right;
+}

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -23,7 +23,7 @@
     ) }}
 
     {% if current_user.has_permissions(['send_texts'], admin_override=True) %}
-      <p>
+      <p class="sms-message-reply-link">
         <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
       </p>
     {% endif %}


### PR DESCRIPTION
So that it lines up with the outbpund messages.

Also the ‘send’ button is usually right-aligned when using Whatsapp, iMessage, etc.

## Before

<img width="773" alt="screen shot 2017-10-24 at 12 00 11" src="https://user-images.githubusercontent.com/355079/31939676-3511e650-b8b3-11e7-84c7-f2ed1e529592.png">

## After 

<img width="785" alt="screen shot 2017-10-24 at 11 59 52" src="https://user-images.githubusercontent.com/355079/31939683-39b1998a-b8b3-11e7-91aa-d64fe32b6cbe.png">
