### PR TITLE
Tidy up layout of letter contact blocks

### DIFF
--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -1,3 +1,5 @@
+$item-top-padding: $gutter-half;
+
 .user-list {
 
   @include core-19;
@@ -5,13 +7,21 @@
 
   &-item {
 
-    padding: $gutter-half 150px $gutter-half 0;
+    padding: $item-top-padding 150px $gutter-half 0;
     border-top: 1px solid $border-colour;
+    position: relative;
 
     &:last-child {
       border-bottom: 1px solid $border-colour;
     }
 
+  }
+
+  &-edit-link {
+    text-align: right;
+    position: absolute;
+    top: $item-top-padding;
+    right: 0px;
   }
 
 }

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -27,18 +27,16 @@
     {% endif %}
     {% for item in letter_contact_details %}
       <div class="user-list-item">
-        <h3>
-          <span class="heading-small">{{ item.contact_block }}</span>&ensp;<span class="hint">
-            {%- if item.is_default -%}
-              (default)
-            {% endif %}
-          </span>
-        </h3>
-        <ul class="tick-cross-list">
-          <li class="tick-cross-list-edit-link">
-            <a href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
-          </li>
-        </ul>
+        <p>
+          {{ item.contact_block | nl2br | safe }}
+        </p>
+        <p class="hint">
+          {%- if item.is_default -%}
+            (default)
+          {% endif %}
+        </p>
+
+        <a class="user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
         {% if letter_contact_details|length  > 1 %}
           {{ api_key(item.id, thing="ID") }}
         {% endif %}


### PR DESCRIPTION
Linebreaks are an important part of the letter contact block, and make it easier to read.

Bold text works for short pieces of info like email addresses or phone numbers, but is too heavy for the letter contact blocks because they tend to be longer.

## Before

<img width="766" alt="screen shot 2017-10-25 at 11 43 49" src="https://user-images.githubusercontent.com/355079/31995031-abd5eecc-b97a-11e7-84ae-977719406d45.png">

## After 

<img width="760" alt="screen shot 2017-10-25 at 11 44 00" src="https://user-images.githubusercontent.com/355079/31995026-a6ecac16-b97a-11e7-8cdc-e040ff8b8826.png">
