### PR TITLE
Standardise Google Analytics tracking across GaaP

### DIFF
--- a/app/assets/error_pages/413.html
+++ b/app/assets/error_pages/413.html
@@ -134,6 +134,13 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-75215134-1', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'displayFeaturesTask', null);
+    ga('set', 'transport', 'beacon');
+    // strip UUIDs
+    page = (window.location.pathname + window.location.search).replace(
+      /[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}/g, '…'
+    )
     ga('send', 'pageview');
   </script>
 

--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -131,6 +131,13 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-75215134-1', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'displayFeaturesTask', null);
+    ga('set', 'transport', 'beacon');
+    // strip UUIDs
+    page = (window.location.pathname + window.location.search).replace(
+      /[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}/g, '…'
+    )
     ga('send', 'pageview');
   </script>
 

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -141,6 +141,9 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-75215134-1', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'displayFeaturesTask', null);
+    ga('set', 'transport', 'beacon');
     // strip UUIDs
     page = (window.location.pathname + window.location.search).replace(
       /[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}/g, '…'


### PR DESCRIPTION
These are the settings that our analytics person has said we should be using across all the GaaP products.

This commit also makes sure our tracking code is identical across all the templates that have it in (including the obfuscation of UUIDs). We may want to remove the ID obfuscation later on, but for now let’s make sure it’s happening consistently in all the places.