### PR TITLE
add auth_type default to InvitedUser object

### DIFF
--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -141,7 +141,7 @@ class User(UserMixin):
 
 class InvitedUser(object):
 
-    def __init__(self, id, service, from_user, email_address, permissions, status, created_at):
+    def __init__(self, id, service, from_user, email_address, permissions, status, created_at, auth_type=None):
         self.id = id
         self.service = str(service)
         self.from_user = from_user


### PR DESCRIPTION
we unpack the api invited user rest endpoint results straight into the InvitedUser object, so we should make sure that any fields added to the api response are mentioned here