### PR TITLE
Add extra letter spacing to phone number search

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -25,7 +25,7 @@
       action="{{ url_for('.view_notifications', service_id=current_service.id, message_type=message_type) }}"
       class="grid-row"
     >
-      <div class="column-three-quarters">
+      <div class="column-three-quarters {% if message_type == 'sms' %}extra-tracking{% endif %}">
         {{ textbox(
           search_form.to,
           width='1-1',


### PR DESCRIPTION
This is another place where you might be transcribing a phone number and having it spaced out will make it easier for you to spot errors.

# Before 

![image](https://user-images.githubusercontent.com/355079/32240324-f68b7114-be64-11e7-8a5b-ae5733b87e1e.png)

# After 

![image](https://user-images.githubusercontent.com/355079/32240286-e03decf2-be64-11e7-8eec-31b9f2636921.png)
