### PR TITLE
New account verification emails no longer call API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from time import monotonic
 
 import itertools
 import ago
+from itsdangerous import BadSignature
 from flask import (
     Flask,
     session,
@@ -13,7 +14,8 @@ from flask import (
     current_app,
     request,
     g,
-    url_for
+    url_for,
+    flash
 )
 from flask._compat import string_types
 from flask.globals import _lookup_req_object, _request_ctx_stack
@@ -491,6 +493,12 @@ def register_errorhandlers(application):
         if current_app.config.get('DEBUG', None):
             raise error
         return _error_response(500)
+
+    @application.errorhandler(BadSignature)
+    def handle_bad_token(error):
+        # if someone has a malformed token
+        flash('There’s something wrong with the link you’ve used.')
+        return _error_response(404)
 
 
 def setup_event_handlers():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -440,7 +440,7 @@ def useful_headers_after_request(response):
     return response
 
 
-def register_errorhandlers(application):
+def register_errorhandlers(application):  # noqa (C901 too complex)
     def _error_response(error_code):
         application.logger.exception('Admin app errored with %s', error_code)
         resp = make_response(render_template("error/{0}.html".format(error_code)), error_code)

--- a/app/config.py
+++ b/app/config.py
@@ -41,7 +41,7 @@ class Config(object):
         'local': 25000,
         'nhs': 25000,
     }
-    EMAIL_EXPIRY_SECONDS = 3600 * 24 * 7  # one week
+    EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     HEADER_COLOUR = '#FFBF47'  # $yellow
     HTTP_PROTOCOL = 'http'
     MAX_FAILED_LOGIN_COUNT = 10
@@ -56,7 +56,6 @@ class Config(object):
     SHOW_STYLEGUIDE = True
     # TODO: move to utils
     SMS_CHAR_COUNT_LIMIT = 459
-    TOKEN_MAX_AGE_SECONDS = 3600
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -4,24 +4,29 @@ from flask import (
     session,
     flash,
     render_template,
-    abort
+    abort,
+    current_app
 )
 from markupsafe import Markup
+from notifications_utils.url_safe_token import check_token
+from flask_login import current_user
 
 from app.main import main
-
 from app import (
     invite_api_client,
     user_api_client,
     service_api_client
 )
 
-from flask_login import current_user
-
 
 @main.route("/invitation/<token>")
 def accept_invite(token):
-
+    check_token(
+        token,
+        current_app.config['SECRET_KEY'],
+        current_app.config['DANGEROUS_SALT'],
+        current_app.config['EMAIL_EXPIRY_SECONDS']
+    )
     invited_user = invite_api_client.check_token(token)
 
     if not current_user.is_anonymous and current_user.email_address != invited_user.email_address:

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -1,20 +1,20 @@
+from datetime import datetime
 import json
 
 from flask import (render_template, url_for, redirect, flash, session, current_app)
 from itsdangerous import SignatureExpired
+from notifications_utils.url_safe_token import check_token
 
+from app import user_api_client
 from app.main import main
 from app.main.forms import NewPasswordForm
-from datetime import datetime
-from app import user_api_client
 
 
 @main.route('/new-password/<path:token>', methods=['GET', 'POST'])
 def new_password(token):
-    from notifications_utils.url_safe_token import check_token
     try:
         token_data = check_token(token, current_app.config['SECRET_KEY'], current_app.config['DANGEROUS_SALT'],
-                                 current_app.config['TOKEN_MAX_AGE_SECONDS'])
+                                 current_app.config['EMAIL_EXPIRY_SECONDS'])
     except SignatureExpired:
         flash('The link in the email we sent you has expired. Enter your email address to resend.')
         return redirect(url_for('.forgot_password'))

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -1,3 +1,4 @@
+import pytest
 from bs4 import BeautifulSoup
 
 
@@ -6,3 +7,19 @@ def test_bad_url_returns_page_not_found(client):
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string.strip() == 'Page could not be found'
+
+
+@pytest.mark.parametrize('url', [
+    '/invitation/MALFORMED_TOKEN',
+    '/new-password/MALFORMED_TOKEN',
+    '/user-profile/email/confirm/MALFORMED_TOKEN',
+    '/verify-email/MALFORMED_TOKEN'
+])
+def test_malformed_token_returns_page_not_found(client, url):
+    response = client.get(url)
+
+    assert response.status_code == 404
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string.strip() == 'Page could not be found'
+    flash_banner = page.find('div', class_='banner-dangerous').string.strip()
+    assert flash_banner == "There’s something wrong with the link you’ve used."

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -15,8 +15,8 @@ def test_bad_url_returns_page_not_found(client):
     '/user-profile/email/confirm/MALFORMED_TOKEN',
     '/verify-email/MALFORMED_TOKEN'
 ])
-def test_malformed_token_returns_page_not_found(client, url):
-    response = client.get(url)
+def test_malformed_token_returns_page_not_found(logged_in_client, url):
+    response = logged_in_client.get(url)
 
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -13,14 +13,14 @@ def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     client,
     service_one,
     api_user_active,
-    sample_invite,
-    mock_get_service,
     mock_check_invite_token,
     mock_get_user_by_email,
     mock_get_users_by_service,
     mock_accept_invite,
     mock_add_user_to_service,
+    mocker,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     expected_service = service_one['id']
     expected_redirect_location = 'http://localhost/services/{}/dashboard'.format(expected_service)
@@ -47,8 +47,8 @@ def test_existing_user_with_no_permissions_accept_invite(
     mock_get_user_by_email,
     mock_get_users_by_service,
     mock_add_user_to_service,
-    mock_get_service,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     expected_service = service_one['id']
     sample_invite['permissions'] = ''
@@ -67,6 +67,7 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
     sample_invite,
     mock_get_service,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     sample_invite['status'] = 'accepted'
     invite = InvitedUser(**sample_invite)
@@ -93,6 +94,7 @@ def test_existing_user_of_service_get_redirected_to_signin(
     mock_get_user_by_email,
     mock_accept_invite,
 ):
+    mocker.patch('app.main.views.invites.check_token')
     sample_invite['email_address'] = api_user_active.email_address
     invite = InvitedUser(**sample_invite)
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
@@ -122,7 +124,9 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
     mock_add_user_to_service,
     mock_accept_invite,
     mock_get_service,
+    mocker,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     expected_service = service_one['id']
     expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
@@ -153,7 +157,9 @@ def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
     mock_add_user_to_service,
     mock_get_users_by_service,
     mock_get_service,
+    mocker,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     expected_redirect_location = 'http://localhost/register-from-invite'
 
@@ -174,7 +180,9 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(
     mock_add_user_to_service,
     mock_get_users_by_service,
     mock_get_service,
+    mocker,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
 
@@ -209,6 +217,7 @@ def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation
     mock_get_user,
     mock_get_service,
 ):
+    mocker.patch('app.main.views.invites.check_token')
     cancelled_invitation = create_sample_invite(mocker, service_one, status='cancelled')
     mock_check_token_invite(mocker, cancelled_invitation)
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
@@ -233,7 +242,9 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     mock_get_users_by_service,
     mock_add_user_to_service,
     mock_get_service,
+    mocker,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     expected_service = service_one['id']
     expected_email = sample_invite['email_address']
@@ -282,6 +293,7 @@ def test_signed_in_existing_user_cannot_use_anothers_invite(
     mock_accept_invite,
     mock_get_service,
 ):
+    mocker.patch('app.main.views.invites.check_token')
     invite = InvitedUser(**sample_invite)
     mocker.patch('app.invite_api_client.check_token', return_value=invite)
     mocker.patch('app.user_api_client.get_users_for_service', return_value=[api_user_active])
@@ -322,7 +334,9 @@ def test_new_invited_user_verifies_and_added_to_service(
     mock_get_users_by_service,
     mock_get_detailed_service,
     mock_get_usage,
+    mocker,
 ):
+    mocker.patch('app.main.views.invites.check_token')
 
     # visit accept token page
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))


### PR DESCRIPTION
This frees up the API call to be used for 2fa email auth

Also, catch malformed tokens, and show a little error page

 ![image](https://user-images.githubusercontent.com/5020841/32283339-f25c5d12-bf1b-11e7-8935-c55bae0f8c4a.png)
