### PR TITLE
Add letter counts to the platform admin page.

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -113,7 +113,6 @@ def create_global_stats(services):
             'requested': 0
         }
     }
-
     for service in services:
         for msg_type, status in itertools.product(('sms', 'email', 'letter'), ('delivered', 'failed', 'requested')):
             stats[msg_type][status] += service['statistics'][msg_type][status]

--- a/app/templates/views/platform-admin/_global_stats.html
+++ b/app/templates/views/platform-admin/_global_stats.html
@@ -23,8 +23,8 @@
   </div>
   <div class="column-third">
     {{ big_number_with_status(
-      global_stats.letter.delivered + global_stats.letter.failed,
-      message_count_label(global_stats.letter.delivered, 'letter'),
+      global_stats.letter.requested,
+      message_count_label(global_stats.letter.requested, 'letter'),
       global_stats.letter.failed,
       global_stats.letter.failure_rate,
       global_stats.letter.failure_rate|float > 3,

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -54,7 +54,7 @@
 
         {% call row() %}
           {% if not service['active'] %}
-            {% call field(status='default') %}
+            {% call field(status='default', border=False) %}
               <span class="heading-medium">archived</span>
             {% endcall %}
           {% elif service['research_mode'] %}
@@ -62,7 +62,7 @@
               <span class="research-mode">research mode</span>
             {% endcall %}
           {% elif not service['restricted'] %}
-            {% call field(status='error') %}
+            {% call field(status='error', border=False) %}
               <span class="heading-medium">Live</span>
             {% endcall %}
           {% else %}
@@ -70,6 +70,15 @@
           {% endif %}
 
           {{ stats_fields('sms', service['stats']) }}
+        {% endcall %}
+
+        {% call row() %}
+
+          {% call field(border=False) %}
+
+          {% endcall %}
+            {{ stats_fields('letter', service['stats']) }}
+
         {% endcall %}
 
       {% endcall %}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -97,7 +97,7 @@ def test_should_render_platform_admin_page(
     response = client.get(url_for(endpoint))
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert len(page.select('tbody tr')) == expected_services_shown * 2  # one row for SMS, one for email
+    assert len(page.select('tbody tr')) == expected_services_shown * 3  # one row for SMS, one for email, one for letter
     mock_get_detailed_services.assert_called_once_with({'detailed': True,
                                                         'include_from_test_key': True,
                                                         'only_active': False})
@@ -543,7 +543,7 @@ def test_should_show_correct_sent_totals_for_platform_admin(
 
     assert email_total == 60
     assert sms_total == 40
-    assert letter_total == 45
+    assert letter_total == 60
 
 
 @pytest.mark.parametrize('endpoint, restricted, research_mode', [


### PR DESCRIPTION
The big number counts are based on how many messages have been delivered. For letters we are using the requested count.