### PR TITLE
Select text message sender for one off notifications

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -192,7 +192,8 @@ def set_sender(service_id, template_id):
         sender_choices=sender_context['value_and_label'],
         sender_label=sender_context['description']
     )
-    option_hints = {sender_context['default_id']: 'Default'}
+    option_hints = {sender_context['default_id']: 'Default',
+                    sender_context['receives_text_message']: 'Receives replies'}
 
     if form.validate_on_submit():
         session['sender_id'] = form.sender.data
@@ -231,6 +232,9 @@ def get_sender_context(sender_details, template_type):
     sender_format = context['field_name']
 
     context['default_id'] = next(sender['id'] for sender in sender_details if sender['is_default'])
+    if template_type == 'sms':
+        context['receives_text_message'] = next(
+            sender['id'] for sender in sender_details if sender['inbound_number_id'])
     context['value_and_label'] = [(sender['id'], sender[sender_format]) for sender in sender_details]
     return context
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -590,7 +590,7 @@ def service_sms_senders(service_id):
         if sender['is_default']:
             hints += ["default"]
         if sender['inbound_number_id']:
-            hints += ["recieves replies"]
+            hints += ["receives replies"]
         if hints:
             sender['hint'] = "(" + " and ".join(hints) + ")"
 

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -61,7 +61,6 @@ class NotificationApiClient(NotifyAdminAPIClient):
             'personalisation': personalisation,
         }
         if sender_id:
-            print(sender_id)
             data['sender_id'] = sender_id
         data = _attach_current_user(data)
         return self.post(url='/service/{}/send-notification'.format(service_id), data=data)

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -61,6 +61,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
             'personalisation': personalisation,
         }
         if sender_id:
+            print(sender_id)
             data['sender_id'] = sender_id
         data = _attach_current_user(data)
         return self.post(url='/service/{}/send-notification'.format(service_id), data=data)

--- a/app/utils.py
+++ b/app/utils.py
@@ -272,6 +272,7 @@ def get_template(
     page_count=1,
     redact_missing_personalisation=False,
     email_reply_to=None,
+    sms_sender=None
 ):
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
@@ -287,7 +288,7 @@ def get_template(
         return SMSPreviewTemplate(
             template,
             prefix=service['name'],
-            sender=(service['sms_sender'] not in {'GOVUK', None}),
+            sender=sms_sender if sms_sender else (service['sms_sender'] not in {'GOVUK', None}),
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
         )

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -107,6 +107,25 @@ def test_default_sender_is_checked_and_has_hint(
     assert not page.select('.multiple-choice input')[2].has_attr('checked')
 
 
+def test_sms_sender_is_has_receives_replies_hint(
+    client_request,
+    service_one,
+    fake_uuid,
+    mock_get_service_template,
+    multiple_sms_senders
+):
+    page = client_request.get(
+        '.set_sender',
+        service_id=service_one['id'],
+        template_id=fake_uuid
+    )
+
+    assert page.select('.multiple-choice input')[0].has_attr('checked')
+    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "Receives replies"
+    assert not page.select('.multiple-choice input')[1].has_attr('checked')
+    assert not page.select('.multiple-choice input')[2].has_attr('checked')
+
+
 @pytest.mark.parametrize('template_mock, sender_data', [
     (
         mock_get_service_email_template,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -132,7 +132,7 @@ def test_default_inbound_sender_is_checked_and_has_hint_with_default_and_receive
     assert not page.select('.multiple-choice input')[2].has_attr('checked')
 
 
-def test_sms_sender_is_has_receives_replies_hint(
+def test_sms_sender_has_receives_replies_hint(
     client_request,
     service_one,
     fake_uuid,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -28,7 +28,9 @@ from tests.conftest import (
     multiple_reply_to_email_addresses,
     no_reply_to_email_addresses,
     multiple_sms_senders,
-    no_sms_senders
+    no_sms_senders,
+    multiple_sms_senders_with_diff_default,
+    multiple_sms_senders_no_inbound
 )
 
 template_types = ['email', 'sms']
@@ -82,7 +84,11 @@ def test_show_correct_title_and_description_for_sender_type(
     ),
     (
         mock_get_service_template,
-        multiple_sms_senders
+        multiple_sms_senders_with_diff_default
+    ),
+    (
+        mock_get_service_template,
+        multiple_sms_senders_no_inbound
     )
 ])
 def test_default_sender_is_checked_and_has_hint(
@@ -102,7 +108,26 @@ def test_default_sender_is_checked_and_has_hint(
     )
 
     assert page.select('.multiple-choice input')[0].has_attr('checked')
-    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "Default"
+    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "(Default)"
+    assert not page.select('.multiple-choice input')[1].has_attr('checked')
+
+
+def test_default_inbound_sender_is_checked_and_has_hint_with_default_and_receives_text(
+    client_request,
+    service_one,
+    fake_uuid,
+    mock_get_service_template,
+    multiple_sms_senders
+):
+    page = client_request.get(
+        '.set_sender',
+        service_id=service_one['id'],
+        template_id=fake_uuid
+    )
+
+    assert page.select('.multiple-choice input')[0].has_attr('checked')
+    assert normalize_spaces(
+        page.select_one('.multiple-choice label .block-label-hint').text) == "(Default and receives replies)"
     assert not page.select('.multiple-choice input')[1].has_attr('checked')
     assert not page.select('.multiple-choice input')[2].has_attr('checked')
 
@@ -121,7 +146,8 @@ def test_sms_sender_is_has_receives_replies_hint(
     )
 
     assert page.select('.multiple-choice input')[0].has_attr('checked')
-    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "Receives replies"
+    assert normalize_spaces(
+        page.select_one('.multiple-choice label .block-label-hint').text) == "(Default and receives replies)"
     assert not page.select('.multiple-choice input')[1].has_attr('checked')
     assert not page.select('.multiple-choice input')[2].has_attr('checked')
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -761,7 +761,7 @@ def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
     ), (
         'main.service_sms_senders',
         multiple_sms_senders,
-        'Example (default and recieves replies) Change 1234',
+        'Example (default and receives replies) Change 1234',
         'Example 2 Change 5678',
         'Example 3 Change 9457'
     ),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -335,13 +335,14 @@ def test_should_not_allow_creation_of_a_template_without_correct_permission(
 
 @pytest.mark.parametrize('fixture,  expected_status_code', [
     (mock_get_service_email_template, 200),
-    (mock_get_service_template, 302),
+    (mock_get_service_template, 200),
     (mock_get_service_letter_template, 302),
 ])
-def test_should_redirect_to_one_off_if_template_type_is_not_email(
+def test_should_redirect_to_one_off_if_template_type_is_letter(
     logged_in_client,
     active_user_with_permissions,
     multiple_reply_to_email_addresses,
+    multiple_sms_senders,
     service_one,
     fake_uuid,
     mocker,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,6 +305,66 @@ def multiple_sms_senders(mocker):
 
 
 @pytest.fixture(scope='function')
+def multiple_sms_senders_with_diff_default(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'sms_sender': 'Example',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'inbound_number_id': None,
+                'updated_at': None
+            }, {
+                'id': '5678',
+                'service_id': service_id,
+                'sms_sender': 'Example 2',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'inbound_number_id': None,
+                'updated_at': None
+            }, {
+                'id': '9457',
+                'service_id': service_id,
+                'sms_sender': 'Example 3',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'inbound_number_id': '12354',
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_sms_senders', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
+def multiple_sms_senders_no_inbound(mocker):
+    def _get(service_id):
+        return [
+            {
+                'id': '1234',
+                'service_id': service_id,
+                'sms_sender': 'Example',
+                'is_default': True,
+                'created_at': datetime.utcnow(),
+                'inbound_number_id': None,
+                'updated_at': None
+            }, {
+                'id': '5678',
+                'service_id': service_id,
+                'sms_sender': 'Example 2',
+                'is_default': False,
+                'created_at': datetime.utcnow(),
+                'inbound_number_id': None,
+                'updated_at': None
+            }
+        ]
+
+    return mocker.patch('app.service_api_client.get_sms_senders', side_effect=_get)
+
+
+@pytest.fixture(scope='function')
 def no_sms_senders(mocker):
     def _get(service_id):
         return []


### PR DESCRIPTION
This PR adds the ability to select a text message sender if more than one exist for the service.

If the service has more than one text message sender set then when `send to one recipient` will allow the user to select which text message sender to use for that notification.

<img width="927" alt="screen shot 2017-11-02 at 12 10 26" src="https://user-images.githubusercontent.com/4282990/32325474-0f651556-bfc7-11e7-9516-d6fa2ef638ad.png">
