### PR TITLE
make sure old invites get the proper err message

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -42,6 +42,7 @@ class Config(object):
         'nhs': 25000,
     }
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
+    INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api
     HEADER_COLOUR = '#FFBF47'  # $yellow
     HTTP_PROTOCOL = 'http'
     MAX_FAILED_LOGIN_COUNT = 10


### PR DESCRIPTION
we were accidentally covering up the expiry message with a more
generic one