### PR TITLE
Use service setting to determine prefixing of SMSs

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -288,7 +288,7 @@ def get_template(
         return SMSPreviewTemplate(
             template,
             prefix=service['name'],
-            sender=sms_sender if sms_sender else (service['sms_sender'] not in {'GOVUK', None}),
+            sender=not service['prefix_sms_with_service_name'],
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
         )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,6 +56,7 @@ def service_json(
     permissions=['email', 'sms'],
     organisation_type='central',
     free_sms_fragment_limit=250000,
+    prefix_sms_with_service_name=None,
 ):
     if users is None:
         users = []
@@ -63,6 +64,8 @@ def service_json(
         permissions = []
     if inbound_api is None:
         inbound_api = []
+    if prefix_sms_with_service_name is None:
+        prefix_sms_with_service_name = (sms_sender == 'GOVUK')
     return {
         'id': id_,
         'name': name,
@@ -83,6 +86,7 @@ def service_json(
         'dvla_organisation': '001',
         'permissions': permissions,
         'inbound_api': inbound_api,
+        'prefix_sms_with_service_name': prefix_sms_with_service_name,
     }
 
 


### PR DESCRIPTION
Rather than doing this nasty `if` statement, let the API work out what to do. Also means that the logic is not repeated between the two apps.

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/1364

---

The arguments to `SMSPreviewTemplate` are super badly named – sender isn’t really used as a string, it’s a boolean that effectively means ‘is this a custom sender (`True`) or the platform default (`False`)’. We should rename it once this bug is fixed.