### PR TITLE
Move jshint configuration to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,1 @@
+{"esversion": 6, "esnext": false}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -138,7 +138,7 @@ gulp.task('lint:sass', () => gulp
 
 gulp.task('lint:js', () => gulp
   .src(paths.src + 'javascripts/**/*.js')
-    .pipe(plugins.jshint({'esversion': 6, 'esnext': false}))
+    .pipe(plugins.jshint())
     .pipe(plugins.jshint.reporter(stylish))
     .pipe(plugins.jshint.reporter('fail'))
 );


### PR DESCRIPTION
When provided with inline configuration in a gulp task jshint will still try to load a configuration file from the current directory or the user's home directory. If user has a global .jshintrc file that sets different linting options this could lead to `npm test` output being different from the CI one.

jshint only uses the first file it finds, and .jshintrc in current directory or any parent of the current directory takes precedence over the user one, so moving jshint configuration from gulpfile to .jshintrc should make `npm test` produce the same outcome regardless of the user config.