### PR TITLE
Remove references to computed column

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,7 @@ from flask_wtf.csrf import CSRFError
 from functools import partial
 
 from notifications_python_client.errors import HTTPError
-from notifications_utils import logging, request_id, formatters
+from notifications_utils import logging, request_helper, formatters
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.recipients import (
     validate_phone_number,
@@ -93,7 +93,7 @@ def create_app(application):
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
     init_csrf(application)
-    request_id.init_app(application)
+    request_helper.init_app(application)
 
     service_api_client.init_app(application)
     user_api_client.init_app(application)

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -48,6 +48,12 @@ $tail-angle: 20deg;
 
 }
 
+.sms-message-sender {
+  @include copy-19;
+  color: $secondary-text-colour;
+  margin: 0 0 -10px 0;
+}
+
 .sms-message-recipient {
   @include copy-19;
   color: $secondary-text-colour;

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -109,8 +109,7 @@ def service_settings(service_id):
         default_sms_sender=default_sms_sender,
         sms_sender_count=sms_sender_count,
         free_sms_fragment_limit=free_sms_fragment_limit,
-        prefix_sms_with_service_name=current_service['prefix_sms_with_service_name'],
-
+        prefix_sms=current_service['prefix_sms'],
     )
 
 
@@ -477,7 +476,7 @@ def service_set_sms(service_id):
 def service_set_sms_prefix(service_id):
 
     form = SMSPrefixForm(enabled=(
-        'on' if current_service['prefix_sms_with_service_name'] else 'off'
+        'on' if current_service['prefix_sms'] else 'off'
     ))
 
     form.enabled.label.text = 'Start all text messages with ‘{}:’'.format(current_service['name'])

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -94,7 +94,7 @@
 
           {% call row() %}
             {{ text_field('Text messages start with service name') }}
-            {{ boolean_field(prefix_sms_with_service_name) }}
+            {{ boolean_field(prefix_sms) }}
             {{ edit_field('Change', url_for('.service_set_sms_prefix', service_id=current_service.id)) }}
           {% endcall %}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -288,7 +288,7 @@ def get_template(
         return SMSPreviewTemplate(
             template,
             prefix=service['name'],
-            sender=not service['prefix_sms_with_service_name'],
+            sender=not service['prefix_sms'],
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -288,7 +288,8 @@ def get_template(
         return SMSPreviewTemplate(
             template,
             prefix=service['name'],
-            sender=not service['prefix_sms'],
+            show_prefix=service['prefix_sms'],
+            sender=sms_sender,
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -272,7 +272,7 @@ def get_template(
     page_count=1,
     redact_missing_personalisation=False,
     email_reply_to=None,
-    sms_sender=None
+    sms_sender=None,
 ):
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
@@ -290,6 +290,7 @@ def get_template(
             prefix=service['name'],
             show_prefix=service['prefix_sms'],
             sender=sms_sender,
+            show_sender=bool(sms_sender),
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ notifications-python-client==4.6.0
 awscli>=1.11,<1.12
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@21.5.0#egg=notifications-utils==21.5.0
+git+https://github.com/alphagov/notifications-utils.git@23.0.0#egg=notifications-utils==23.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,7 +56,7 @@ def service_json(
     permissions=None,
     organisation_type='central',
     free_sms_fragment_limit=250000,
-    prefix_sms_with_service_name='Treat as None',
+    prefix_sms=True,
 ):
     if users is None:
         users = []
@@ -64,8 +64,6 @@ def service_json(
         permissions = ['email', 'sms']
     if inbound_api is None:
         inbound_api = []
-    if prefix_sms_with_service_name == 'Treat as None':
-        prefix_sms_with_service_name = (sms_sender == 'GOVUK')
     return {
         'id': id_,
         'name': name,
@@ -86,7 +84,7 @@ def service_json(
         'dvla_organisation': '001',
         'permissions': permissions,
         'inbound_api': inbound_api,
-        'prefix_sms_with_service_name': prefix_sms_with_service_name,
+        'prefix_sms': prefix_sms,
     }
 
 


### PR DESCRIPTION
`prefix_sms` is the real database column, which should be referred to from now on.

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/1372

---

Also rolls in showing the text message sender in the send one-off flow

If you’ve chosen a text message sender then it’s good to see confirmation of your choice.

This replicates what we do when you choose an email reply-to address.

Couldn’t do this before because the interface to the method was a bit of a mess.

![image](https://user-images.githubusercontent.com/355079/32903554-3083972c-caed-11e7-8e1f-4ef6c5de8bb3.png)

![image](https://user-images.githubusercontent.com/355079/32903546-2901d338-caed-11e7-9338-aae1baa450a3.png)
