### PR TITLE
Alter login flow to allow for email auth login

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -43,6 +43,7 @@ class Config(object):
     }
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api
+    EMAIL_2FA_EXPIRY_SECONDS = 1800  # 30 Minutes
     HEADER_COLOUR = '#FFBF47'  # $yellow
     HTTP_PROTOCOL = 'http'
     MAX_FAILED_LOGIN_COUNT = 10

--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -46,3 +46,17 @@ def check_and_resend_verification_code():
         return redirect(url_for('main.verify'))
     else:
         return redirect(url_for('main.two_factor'))
+
+
+@main.route('/email-not-received', methods=['GET'])
+@redirect_to_sign_in
+def email_not_received():
+    return render_template('views/email-not-received.html')
+
+
+@main.route('/send-new-email-token', methods=['GET'])
+@redirect_to_sign_in
+def resend_email_link():
+    user_api_client.send_verify_code(session['user_details']['id'], 'email', None)
+    session.pop('user_details')
+    return redirect(url_for('main.two_factor_email_sent', email_resent=True))

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -410,7 +410,8 @@ def send_test_step(service_id, template_id, step_index):
     if (
         request.endpoint == 'main.send_one_off_step' and
         step_index == 0 and
-        template.template_type != 'letter'
+        template.template_type != 'letter' and
+        not (template.template_type == 'sms' and current_user.mobile_number is None)
     ):
         skip_link = (
             'Use my {}'.format(first_column_headings[template.template_type][0]),

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -1,16 +1,64 @@
+import json
 from flask import (
     render_template,
     redirect,
     session,
     url_for,
-    request
+    request,
+    current_app,
+    flash
 )
-
 from flask_login import login_user, current_user
 from app.main import main
 from app.main.forms import TwoFactorForm
 from app import service_api_client, user_api_client
 from app.utils import redirect_to_sign_in
+from notifications_utils.url_safe_token import check_token
+from itsdangerous import SignatureExpired
+
+
+@main.route('/two-factor-email-sent', methods=['GET'])
+def two_factor_email_sent():
+    title = 'Email resent' if request.args.get('email_resent') else 'Check your email'
+    return render_template(
+        'views/two-factor-email.html',
+        title=title
+    )
+
+
+@main.route('/email-auth/<token>', methods=['GET'])
+def two_factor_email(token):
+    if current_user.is_authenticated:
+        return redirect_when_logged_in(current_user.id)
+
+    # checks url is valid, and hasn't timed out
+    try:
+        token_data = json.loads(check_token(
+            token,
+            current_app.config['SECRET_KEY'],
+            current_app.config['DANGEROUS_SALT'],
+            current_app.config['EMAIL_2FA_EXPIRY_SECONDS']
+        ))
+    except SignatureExpired as exc:
+        # lets decode again, without the expiry, to get the user id out
+        orig_data = json.loads(check_token(
+            token,
+            current_app.config['SECRET_KEY'],
+            current_app.config['DANGEROUS_SALT'],
+            None
+        ))
+        session['user_details'] = {'id': orig_data['user_id']}
+        flash("The link in the email we sent you has expired. We’ve sent you a new one.")
+        return redirect(url_for('.resend_email_link'))
+
+    user_id = token_data['user_id']
+    # checks if code was already used
+    logged_in, msg = user_api_client.check_verify_code(user_id, token_data['secret_code'], "email")
+
+    if not logged_in:
+        flash("There’s something wrong with the code")
+        return redirect(url_for('.two_factor_email_sent'))
+    return log_in_user(user_id)
 
 
 @main.route('/two-factor', methods=['GET', 'POST'])
@@ -24,29 +72,7 @@ def two_factor():
     form = TwoFactorForm(_check_code)
 
     if form.validate_on_submit():
-        try:
-            user = user_api_client.get_user(user_id)
-            # the user will have a new current_session_id set by the API - store it in the cookie for future requests
-            session['current_session_id'] = user.current_session_id
-            services = service_api_client.get_active_services({'user_id': str(user_id)}).get('data', [])
-            # Check if coming from new password page
-            if 'password' in session['user_details']:
-                user = user_api_client.update_password(user.id, password=session['user_details']['password'])
-            activated_user = user_api_client.activate_user(user)
-            login_user(activated_user)
-        finally:
-            del session['user_details']
-
-        next_url = request.args.get('next')
-        if next_url and _is_safe_redirect_url(next_url):
-            return redirect(next_url)
-
-        if current_user.platform_admin:
-            return redirect(url_for('main.platform_admin'))
-        if len(services) == 1:
-            return redirect(url_for('main.service_dashboard', service_id=services[0]['id']))
-        else:
-            return redirect(url_for('main.choose_service'))
+        return log_in_user(user_id)
 
     return render_template('views/two-factor.html', form=form)
 
@@ -58,3 +84,34 @@ def _is_safe_redirect_url(target):
     redirect_url = urlparse(urljoin(request.host_url, target))
     return redirect_url.scheme in ('http', 'https') and \
         host_url.netloc == redirect_url.netloc
+
+
+def log_in_user(user_id):
+    try:
+        user = user_api_client.get_user(user_id)
+        # the user will have a new current_session_id set by the API - store it in the cookie for future requests
+        session['current_session_id'] = user.current_session_id
+        # Check if coming from new password page
+        if 'password' in session.get('user_details', {}):
+            user = user_api_client.update_password(user.id, password=session['user_details']['password'])
+        activated_user = user_api_client.activate_user(user)
+        login_user(activated_user)
+    finally:
+        session.pop("user_details", None)
+
+    return redirect_when_logged_in(user_id)
+
+
+def redirect_when_logged_in(user_id):
+    next_url = request.args.get('next')
+    if next_url and _is_safe_redirect_url(next_url):
+        return redirect(next_url)
+    if current_user.platform_admin:
+        return redirect(url_for('main.platform_admin'))
+
+    services = service_api_client.get_active_services({'user_id': str(user_id)}).get('data', [])
+
+    if len(services) == 1:
+        return redirect(url_for('main.service_dashboard', service_id=services[0]['id']))
+    else:
+        return redirect(url_for('main.choose_service'))

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -88,8 +88,10 @@ class UserApiClient(NotifyAdminAPIClient):
             if e.status_code == 400 or e.status_code == 404:
                 return False
 
-    def send_verify_code(self, user_id, code_type, to):
+    def send_verify_code(self, user_id, code_type, to, next_string=None):
         data = {'to': to}
+        if next_string:
+            data['next'] = next_string
         endpoint = '/user/{0}/{1}-code'.format(user_id, code_type)
         self.post(endpoint, data=data)
 

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -1,0 +1,24 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block per_page_title %}
+  Resend email link
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Resend email link</h1>
+
+    <p> Email messages sometimes take a few minutes to arrive. If you do not recieve the email, you can resend it.</p>
+    <p> If you no longer have access to the email address you registered for this service, speak to your service manager to reset the email.</p>
+
+    <p>
+  		<a class="button" href="{{url_for('main.resend_email_link')}}" role="button">Resend email link</a>
+  	</p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -1,0 +1,21 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block per_page_title %}
+  Email verification
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">{{ title }}</h1>
+    <p> We’ve sent you an email with your login link</p>
+    {{ page_footer(
+      secondary_link=url_for('main.email_not_received'),
+      secondary_link_text='Not received an email?'
+    ) }}
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -660,7 +660,6 @@ def test_send_one_off_has_skip_link(
     expected_link_text,
     expected_link_url,
 ):
-
     template_mock(mocker)
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
 
@@ -681,6 +680,23 @@ def test_send_one_off_has_skip_link(
         )
     else:
         assert not skip_links
+
+
+def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(
+    logged_in_client,
+    service_one,
+    fake_uuid,
+    mock_get_service_template,
+    active_user_with_permissions
+):
+    active_user_with_permissions.mobile_number = None
+    response = logged_in_client.get(
+        url_for('main.send_one_off_step', service_id=service_one['id'], template_id=fake_uuid, step_index=0),
+        follow_redirects=True
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    skip_links = page.select('a.top-gutter-4-3')
+    assert not skip_links
 
 
 @pytest.mark.parametrize('endpoint, expected_redirect, placeholders', [

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -77,7 +77,7 @@ def test_logged_in_user_redirects_to_choose_service(
     assert response.location == url_for('main.choose_service', _external=True)
 
 
-def test_process_sign_in_return_2fa_template(
+def test_process_sms_auth_sign_in_return_2fa_template(
     client,
     api_user_active,
     mock_send_verify_code,
@@ -92,6 +92,25 @@ def test_process_sign_in_return_2fa_template(
     assert response.status_code == 302
     assert response.location == url_for('.two_factor', _external=True)
     mock_verify_password.assert_called_with(api_user_active.id, 'val1dPassw0rd!')
+
+
+def test_process_email_auth_sign_in_return_2fa_template(
+    client,
+    api_user_active_email_auth,
+    mock_send_verify_code,
+    mock_verify_password,
+    mocker
+):
+    mocker.patch('app.user_api_client.get_user', return_value=api_user_active_email_auth)
+    mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_active_email_auth)
+
+    response = client.post(
+        url_for('main.sign_in'), data={
+            'email_address': 'valid@example.gov.uk',
+            'password': 'val1dPassw0rd!'})
+    assert response.status_code == 302
+    assert response.location == url_for('.two_factor_email_sent', _external=True)
+    mock_verify_password.assert_called_with(api_user_active_email_auth.id, 'val1dPassw0rd!')
 
 
 def test_should_return_locked_out_true_when_user_is_locked(

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -1,7 +1,9 @@
-from flask import url_for
-from tests.conftest import SERVICE_ONE_ID
-
 from unittest.mock import ANY
+
+from flask import url_for
+from bs4 import BeautifulSoup
+
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces, set_config
 
 
 def test_should_render_two_factor_page(
@@ -213,3 +215,108 @@ def test_two_factor_should_activate_pending_user(
 
     assert mock_activate_user.called
     assert api_user_pending.is_active
+
+
+def test_valid_two_factor_email_link_logs_in_user(
+    client,
+    valid_token,
+    mock_get_user,
+    mock_get_services_with_one_service,
+    mocker
+):
+    mocker.patch('app.user_api_client.check_verify_code', return_value=(True, ''))
+
+    response = client.get(
+        url_for('main.two_factor_email', token=valid_token),
+    )
+
+    assert response.status_code == 302
+    assert response.location == url_for('main.service_dashboard', service_id=SERVICE_ONE_ID, _external=True)
+
+
+def test_two_factor_email_link_has_expired(
+    app_,
+    valid_token,
+    client,
+    mock_send_verify_code,
+    fake_uuid
+):
+
+    with set_config(app_, 'EMAIL_2FA_EXPIRY_SECONDS', -1):
+        response = client.get(
+            url_for('main.two_factor_email', token=valid_token),
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert normalize_spaces(
+        page.select_one('.banner-dangerous').text
+    ) == "The link in the email we sent you has expired. We’ve sent you a new one."
+    assert page.h1.text.strip() == 'Email resent'
+    mock_send_verify_code.assert_called_once_with(fake_uuid, 'email', None)
+
+
+def test_two_factor_email_link_is_invalid(
+    client
+):
+    token = 12345
+    response = client.get(
+        url_for('main.two_factor_email', token=token),
+        follow_redirects=True
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert normalize_spaces(
+        page.select_one('.banner-dangerous').text
+    ) == "There’s something wrong with the link you’ve used."
+    assert response.status_code == 404
+
+
+def test_two_factor_email_link_is_already_used(
+    client,
+    valid_token,
+    mocker
+):
+    mocker.patch('app.user_api_client.check_verify_code', return_value=(False, 'Code has expired'))
+
+    response = client.get(
+        url_for('main.two_factor_email', token=valid_token),
+        follow_redirects=True
+    )
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert normalize_spaces(
+        page.select_one('.banner-dangerous').text
+    ) == "There’s something wrong with the code"
+    assert response.status_code == 200
+
+
+def test_two_factor_email_link_when_user_is_locked_out(
+    client,
+    valid_token,
+    mocker
+):
+    mocker.patch('app.user_api_client.check_verify_code', return_value=(False, 'Code not found'))
+
+    response = client.get(
+        url_for('main.two_factor_email', token=valid_token),
+        follow_redirects=True
+    )
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert normalize_spaces(
+        page.select_one('.banner-dangerous').text
+    ) == "There’s something wrong with the code"
+    assert response.status_code == 200
+
+
+def test_two_factor_email_link_used_when_user_already_logged_in(
+    logged_in_client,
+    valid_token
+):
+    response = logged_in_client.get(
+        url_for('main.two_factor_email', token=valid_token)
+    )
+    assert response.status_code == 302
+    assert response.location == url_for('main.choose_service', _external=True)


### PR DESCRIPTION
# Summary
Added the login functionality for a user currently on email auth. If they log in correctly, they will be sent an email with a token inside it (with 'next' query string appended to it if they came to the log-in from a different notify request). The user will then be able to click the link to log into the platform. 

## :o: Two factor email sent 
![image](https://user-images.githubusercontent.com/31617728/32505330-d57e35cc-c3d9-11e7-8d59-91c7a38ca891.png)
## :o: Resend email 
![image](https://user-images.githubusercontent.com/31617728/32505361-e6852f2e-c3d9-11e7-8c72-6778ac98b02d.png)
## :o: Two factor email
![image](https://user-images.githubusercontent.com/31617728/32505468-2fda99e8-c3da-11e7-9777-558f3a3ec621.png)

