### PR TITLE
Revert "Stop escaping special characters in inbound messages"

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -10,7 +10,7 @@ from notifications_utils.recipients import format_phone_number_human_readable
 from notifications_utils.template import SMSPreviewTemplate
 from app.main import main
 from app.main.forms import SearchTemplatesForm
-from app.utils import user_has_permissions, unescape_string
+from app.utils import user_has_permissions
 from app import notification_api_client, service_api_client
 from notifications_python_client.errors import HTTPError
 
@@ -120,7 +120,12 @@ def get_sms_thread(service_id, user_number):
         yield {
             'inbound': is_inbound,
             'content': SMSPreviewTemplate(
-                {'content': get_sms_content(notification, is_inbound)},
+                {
+                    'content': (
+                        notification['content'] if is_inbound else
+                        notification['template']['content']
+                    )
+                },
                 notification.get('personalisation'),
                 downgrade_non_gsm_characters=(not is_inbound),
                 redact_missing_personalisation=redact_personalisation,
@@ -129,10 +134,3 @@ def get_sms_thread(service_id, user_number):
             'status': notification.get('status'),
             'id': notification['id'],
         }
-
-
-def get_sms_content(notification, is_inbound):
-    return (
-        unescape_string(notification['content']) if is_inbound else
-        notification['template']['content']
-    )

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -31,7 +31,6 @@ from app.utils import (
     FAILURE_STATUSES,
     REQUESTED_STATUSES,
     Spreadsheet,
-    unescape_string,
 )
 
 
@@ -204,9 +203,6 @@ def get_inbox_partials(service_id):
             format_phone_number_human_readable(message['user_number'])
             for message in messages_to_show
         }:
-            message.update({
-                'content': unescape_string(message['content'])
-            })
             messages_to_show.append(message)
 
     if not inbound_messages:

--- a/app/utils.py
+++ b/app/utils.py
@@ -379,7 +379,3 @@ def get_cdn_domain():
     domain = parsed_uri.netloc[len(subdomain + '.'):]
 
     return "static-logos.{}".format(domain)
-
-
-def unescape_string(string):
-    return bytes(string, "utf-8").decode('unicode_escape')

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -161,29 +161,6 @@ def test_view_conversation(
         ) == expected
 
 
-def test_escaped_characters_in_inbound_messages(
-    client_request,
-    mock_get_notification,
-    mock_get_notifications,
-    mock_get_inbound_sms_with_special_characters,
-    fake_uuid,
-):
-
-    page = client_request.get(
-        'main.conversation',
-        service_id=SERVICE_ONE_ID,
-        notification_id=fake_uuid,
-    )
-
-    assert normalize_spaces(
-        str(page.select_one('.sms-message-inbound .sms-message-wrapper'))
-    ) == (
-        "<div class=\"sms-message-wrapper\"> "
-        "the first line's content<br/>the second line's content "
-        "</div>"
-    )
-
-
 def test_view_conversation_updates(
     logged_in_client,
     mocker,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -172,25 +172,6 @@ def test_inbox_showing_inbound_messages(
     )
 
 
-def test_inbox_handles_escaped_characters(
-    client_request,
-    service_one,
-    mock_get_inbound_sms_with_special_characters,
-):
-
-    service_one['permissions'] = ['inbound_sms']
-
-    page = client_request.get('main.inbox', service_id=SERVICE_ONE_ID)
-
-    assert normalize_spaces(
-        str(page.select_one('tbody tr .file-list-hint'))
-    ) == (
-        "<span class=\"file-list-hint\">"
-        "the first line's content the second line's content"
-        "</span>"
-    )
-
-
 def test_empty_inbox(
     logged_in_client,
     service_one,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1763,26 +1763,6 @@ def mock_get_inbound_sms(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_get_inbound_sms_with_special_characters(mocker):
-    def _get_inbound_sms(
-        service_id,
-        user_number=None,
-    ):
-        return [{
-            'user_number': '07900900001',
-            'notify_number': '07900000002',
-            'content': "the first line\\'s content\\nthe second line\\'s content",
-            'created_at': datetime.utcnow().isoformat(),
-            'id': sample_uuid(),
-        }]
-
-    return mocker.patch(
-        'app.service_api_client.get_inbound_sms',
-        side_effect=_get_inbound_sms,
-    )
-
-
-@pytest.fixture(scope='function')
 def mock_get_inbound_sms_with_no_messages(mocker):
     def _get_inbound_sms(
         service_id,


### PR DESCRIPTION
Reverts alphagov/notifications-admin#1614

Caused problems with emoji and curly quotes:

![image](https://user-images.githubusercontent.com/355079/32507769-5327eb02-c3e0-11e7-8d16-05d985be95d2.png)