### PR TITLE
Stop escaping special characters in inbound messages, version 2

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -10,7 +10,7 @@ from notifications_utils.recipients import format_phone_number_human_readable
 from notifications_utils.template import SMSPreviewTemplate
 from app.main import main
 from app.main.forms import SearchTemplatesForm
-from app.utils import user_has_permissions
+from app.utils import user_has_permissions, unescape_string
 from app import notification_api_client, service_api_client
 from notifications_python_client.errors import HTTPError
 
@@ -120,12 +120,7 @@ def get_sms_thread(service_id, user_number):
         yield {
             'inbound': is_inbound,
             'content': SMSPreviewTemplate(
-                {
-                    'content': (
-                        notification['content'] if is_inbound else
-                        notification['template']['content']
-                    )
-                },
+                {'content': get_sms_content(notification, is_inbound)},
                 notification.get('personalisation'),
                 downgrade_non_gsm_characters=(not is_inbound),
                 redact_missing_personalisation=redact_personalisation,
@@ -134,3 +129,10 @@ def get_sms_thread(service_id, user_number):
             'status': notification.get('status'),
             'id': notification['id'],
         }
+
+
+def get_sms_content(notification, is_inbound):
+    return (
+        unescape_string(notification['content']) if is_inbound else
+        notification['template']['content']
+    )

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -31,6 +31,7 @@ from app.utils import (
     FAILURE_STATUSES,
     REQUESTED_STATUSES,
     Spreadsheet,
+    unescape_string,
 )
 
 
@@ -203,6 +204,9 @@ def get_inbox_partials(service_id):
             format_phone_number_human_readable(message['user_number'])
             for message in messages_to_show
         }:
+            message.update({
+                'content': unescape_string(message['content'])
+            })
             messages_to_show.append(message)
 
     if not inbound_messages:

--- a/app/utils.py
+++ b/app/utils.py
@@ -382,4 +382,4 @@ def get_cdn_domain():
 
 
 def unescape_string(string):
-    return bytes(string, "utf-8").decode('unicode_escape')
+    return string.encode('raw_unicode_escape').decode('unicode_escape')

--- a/app/utils.py
+++ b/app/utils.py
@@ -379,3 +379,7 @@ def get_cdn_domain():
     domain = parsed_uri.netloc[len(subdomain + '.'):]
 
     return "static-logos.{}".format(domain)
+
+
+def unescape_string(string):
+    return bytes(string, "utf-8").decode('unicode_escape')

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -161,6 +161,29 @@ def test_view_conversation(
         ) == expected
 
 
+def test_escaped_characters_in_inbound_messages(
+    client_request,
+    mock_get_notification,
+    mock_get_notifications,
+    mock_get_inbound_sms_with_special_characters,
+    fake_uuid,
+):
+
+    page = client_request.get(
+        'main.conversation',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    assert normalize_spaces(
+        str(page.select_one('.sms-message-inbound .sms-message-wrapper'))
+    ) == (
+        "<div class=\"sms-message-wrapper\"> "
+        "the first line's content<br/>the second line's content "
+        "</div>"
+    )
+
+
 def test_view_conversation_updates(
     logged_in_client,
     mocker,

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -179,7 +179,7 @@ def test_escaped_characters_in_inbound_messages(
         str(page.select_one('.sms-message-inbound .sms-message-wrapper'))
     ) == (
         "<div class=\"sms-message-wrapper\"> "
-        "the first line's content<br/>the second line's content "
+        "the first line's content<br/>the second line's content<br/>a fire truck 🚒 "
         "</div>"
     )
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -186,7 +186,7 @@ def test_inbox_handles_escaped_characters(
         str(page.select_one('tbody tr .file-list-hint'))
     ) == (
         "<span class=\"file-list-hint\">"
-        "the first line's content the second line's content"
+        "the first line's content the second line's content a fire truck 🚒"
         "</span>"
     )
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -172,6 +172,25 @@ def test_inbox_showing_inbound_messages(
     )
 
 
+def test_inbox_handles_escaped_characters(
+    client_request,
+    service_one,
+    mock_get_inbound_sms_with_special_characters,
+):
+
+    service_one['permissions'] = ['inbound_sms']
+
+    page = client_request.get('main.inbox', service_id=SERVICE_ONE_ID)
+
+    assert normalize_spaces(
+        str(page.select_one('tbody tr .file-list-hint'))
+    ) == (
+        "<span class=\"file-list-hint\">"
+        "the first line's content the second line's content"
+        "</span>"
+    )
+
+
 def test_empty_inbox(
     logged_in_client,
     service_one,

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -13,7 +13,8 @@ from app.utils import (
     generate_next_dict,
     Spreadsheet,
     get_letter_timings,
-    get_cdn_domain
+    get_cdn_domain,
+    unescape_string,
 )
 
 
@@ -300,3 +301,33 @@ def test_get_cdn_domain_on_non_localhost(client, mocker):
     mocker.patch.dict('app.current_app.config', values={'ADMIN_BASE_URL': 'https://some.admintest.com'})
     domain = get_cdn_domain()
     assert domain == 'static-logos.admintest.com'
+
+
+@pytest.mark.parametrize('raw, expected', [
+    (
+        '😬',
+        '😬',
+    ),
+    (
+        '1\\n2',
+        '1\n2',
+    ),
+    (
+        '\\\'"\\\'',
+        '\'"\'',
+    ),
+    (
+        """
+
+        """,
+        """
+
+        """,
+    ),
+    (
+        '\x79 \\x79 \\\\x79',  # we should never see the middle one
+        'y y \\x79',
+    ),
+])
+def test_unescape_string(raw, expected):
+    assert unescape_string(raw) == expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1771,7 +1771,7 @@ def mock_get_inbound_sms_with_special_characters(mocker):
         return [{
             'user_number': '07900900001',
             'notify_number': '07900000002',
-            'content': "the first line\\'s content\\nthe second line\\'s content",
+            'content': "the first line\\'s content\\nthe second line\\'s content\\na fire truck 🚒",
             'created_at': datetime.utcnow().isoformat(),
             'id': sample_uuid(),
         }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1763,6 +1763,26 @@ def mock_get_inbound_sms(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_inbound_sms_with_special_characters(mocker):
+    def _get_inbound_sms(
+        service_id,
+        user_number=None,
+    ):
+        return [{
+            'user_number': '07900900001',
+            'notify_number': '07900000002',
+            'content': "the first line\\'s content\\nthe second line\\'s content",
+            'created_at': datetime.utcnow().isoformat(),
+            'id': sample_uuid(),
+        }]
+
+    return mocker.patch(
+        'app.service_api_client.get_inbound_sms',
+        side_effect=_get_inbound_sms,
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_inbound_sms_with_no_messages(mocker):
     def _get_inbound_sms(
         service_id,


### PR DESCRIPTION
This PR reimplements https://github.com/alphagov/notifications-admin/pull/1614, but with a bug around handling unicode characters fixed (see ed3f6fb for just the new changes).

---

Our previous, reverted, attempt at handling escaped strings (https://github.com/alphagov/notifications-admin/pull/1614) was too naïve and didn’t play well with characters outside the normal ASCII range. We have examples of real inbound messages containing `👍` and `’`, so we should definitely handle them.

It’s a bit tricky, because the strings we get from our providers are a mixture of escape sequences (eg `\n`) and unicode bytes (eg `😨`). So we have to first convert the unicode bytes `😨` into an escape sequence, for example `\U0001f628`. We do this using the `raw_unicode_escape` encoding:

> Latin-1 encoding with \uXXXX and \UXXXXXXXX for other code points. Existing backslashes are not escaped in any way.

– https://docs.python.org/3/library/codecs.html#text-encodings

Then, as before, we turn this back into a string using the `unicode_escape` codec, which transforms all escape sequences into their literal representations (eg `\U0001f628` becomes `😨` and `\n` becomes a newline).