### PR TITLE
use new activate endpoint

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -148,9 +148,8 @@ class UserApiClient(NotifyAdminAPIClient):
 
     def activate_user(self, user):
         if user.state == 'pending':
-            user.state = 'active'
-            url = "/user/{}".format(user.id)
-            user_data = self.post(url, data={'state': 'active'})
+            url = "/user/{}/activate".format(user.id)
+            user_data = self.post(url)
             return User(user_data['data'], max_failed_login_count=self.max_failed_login_count)
         else:
             return user

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -33,3 +33,22 @@ def test_client_updates_password_separately(mocker, api_user_active):
 
     client.update_password(api_user_active.id, expected_params['_password'])
     mock_update_password.assert_called_once_with(expected_url, data=expected_params)
+
+
+def test_client_activates_if_pending(mocker, api_user_pending):
+    mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
+    client = UserApiClient()
+    client.max_failed_login_count = 1  # doesn't matter for this test
+
+    client.activate_user(api_user_pending)
+
+    mock_post.assert_called_once_with('/user/{}/activate'.format(api_user_pending.id))
+
+
+def test_client_doesnt_activate_if_already_active(mocker, api_user_active):
+    mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
+    client = UserApiClient()
+
+    client.activate_user(api_user_active)
+
+    assert not mock_post.called


### PR DESCRIPTION
to avoid mucking with the schema for update_user_attribute