### PR TITLE
Make dashboard totals smaller if numbers are big

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -85,7 +85,8 @@
       outline: 3px solid $yellow;
     }
 
-    .big-number {
+    .big-number,
+    .big-number-smaller {
       background: transparent;
     }
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -10,7 +10,7 @@ from flask import (
     Response,
 )
 from flask_login import login_required
-
+from math import pow
 from notifications_utils.recipients import format_phone_number_human_readable
 
 from app.main import main
@@ -244,7 +244,10 @@ def get_dashboard_partials(service_id):
         for job in job_api_client.get_jobs(service_id, limit_days=7, statuses=statuses_to_display)['data']
     ]
     service = service_api_client.get_detailed_service(service_id)
-    column_width = 'column-third' if 'letter' in current_service['permissions'] else 'column-half'
+    number_of_columns = 3 if 'letter' in current_service['permissions'] else 2
+    column_width = 'column-{}'.format(
+        {2: 'half', 3: 'third'}.get(number_of_columns)
+    )
 
     return {
         'upcoming': render_template(

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -244,7 +244,9 @@ def get_dashboard_partials(service_id):
     ]
     service = service_api_client.get_detailed_service(service_id)
     column_width, max_notifiction_count = get_column_properties(
-        3 if 'letter' in current_service['permissions'] else 2
+        number_of_columns=(
+            3 if 'letter' in current_service['permissions'] else 2
+        )
     )
     dashboard_totals = get_dashboard_totals(service['data']['statistics']),
     highest_notification_count = max(

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -11,7 +11,8 @@
         statistics['email']['failed_percentage'],
         statistics['email']['show_warning'],
         failure_link=url_for(".view_notifications", service_id=service_id, message_type='email', status='failed'),
-        link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed')
+        link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed'),
+        smaller=smaller_font_size
       ) }}
     </div>
     <div id="total-sms" class="{{column_width}}">
@@ -22,7 +23,8 @@
         statistics['sms']['failed_percentage'],
         statistics['sms']['show_warning'],
         failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
-        link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed')
+        link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed'),
+        smaller=smaller_font_size
       ) }}
     </div>
     {% if 'letter' in current_service['permissions'] %}
@@ -34,7 +36,8 @@
           statistics['letter']['failed_percentage'],
           statistics['letter']['show_warning'],
           failure_link=url_for(".view_notifications", service_id=service_id, message_type='letter', status='failed'),
-          link=url_for(".view_notifications", service_id=service_id, message_type='letter', status='')
+          link=url_for(".view_notifications", service_id=service_id, message_type='letter', status=''),
+          smaller=smaller_font_size
         ) }}
       </div>
     {% endif %}


### PR DESCRIPTION
Numbers over a billion overflow the two column layout. Numbers over one hundred thousand overflow the three column layout.

This commit makes the type size smaller in these cases, so that the numbers still fit in the boxes.

![image](https://user-images.githubusercontent.com/355079/32620511-ddd77056-c575-11e7-9d27-fbfb1a98ad3a.png)

![image](https://user-images.githubusercontent.com/355079/32620542-f0758efa-c575-11e7-8c3a-8e895813980f.png)

<img width="769" alt="screen shot 2017-11-09 at 17 31 05" src="https://user-images.githubusercontent.com/355079/32620359-75895672-c575-11e7-8000-856bd6ef6f5d.png">

<img width="783" alt="screen shot 2017-11-09 at 17 30 48" src="https://user-images.githubusercontent.com/355079/32620432-a820cf5c-c575-11e7-8e40-d2202adbb40d.png">

