### PR TITLE
Add a link to download a PDF of a sent letter

### DIFF
--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -34,6 +34,9 @@
       <p>
         Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
       </p>
+      <p class="bottom-gutter">
+        <a href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download="download">Download as a PDF</a>
+      </p>
     {% endif %}
 
     {{ template|string }}


### PR DESCRIPTION
This is useful for service teams to keep a copy for their records. The letter won’t be available in Notify once the 7 day retention period has passed.

![image](https://user-images.githubusercontent.com/355079/32725352-a62a29e2-c86c-11e7-9d07-92f6fe8faf86.png)
