### PR TITLE
Don’t list all letter address cols if some missing

### DIFF
--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -48,7 +48,10 @@
       {% elif not recipients.has_recipient_columns %}
 
         <h1 class='banner-title' data-module="track-error" data-error-type="Missing recipient columns" data-error-label="{{ upload_id }}">
-          Your file needs {{ required_recipient_columns | formatted_list(
+          Your file needs {{ (
+            recipients.missing_column_headers
+            if template.template_type == 'letter' else required_recipient_columns
+          ) | formatted_list(
             prefix='a column called',
             prefix_plural='columns called'
           ) }}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1883,7 +1883,7 @@ def test_check_messages_column_error_doesnt_show_optional_columns(
     )
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
-        'Your file needs columns called ‘address line 1’, ‘address line 2’ and ‘postcode’ '
+        'Your file needs a column called ‘postcode’ '
         'Right now it has columns called ‘address_line_1’, ‘address_line_2’ and ‘foo’. '
         'Skip to file contents'
     )


### PR DESCRIPTION
If you’ve spelt ‘postcode’ wrong, or missed only ‘address_line_2’ then it’s pretty noisy to be told that your file needs columns called address line 1, address line 2, and postcode.

It’s better to be specific about which column you need to fix in order to get past this error. As a principle, we’ve found it better to tell get people to fix one error at a time, rather than overwhelm them with a list of errors to correct – this is why we split the recipient column errors out separately in the first place.