### PR TITLE
Fix misleading wording on choose text message sender/email reply to pages 

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -218,17 +218,17 @@ def get_sender_context(sender_details, template_type):
     context = {
         'email': {
             'title': "Choose where to send replies",
-            'description': "Select an email address that recipients can reply to",
+            'description': 'Where should replies go?',
             'field_name': 'email_address'
         },
         'letter': {
             'title': 'Choose sender address',
-            'description': 'Select an address that recipients can reply to',
+            'description': 'What should appear in the top right of the letter?',
             'field_name': 'contact_block'
         },
         'sms': {
             'title': 'Chose text message sender',
-            'description': 'Select a text message sender that the recipients can reply to',
+            'description': 'Who should the message come from?',
             'field_name': 'sms_sender'
         }
     }[template_type]

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -217,17 +217,17 @@ def set_sender(service_id, template_id):
 def get_sender_context(sender_details, template_type):
     context = {
         'email': {
-            'title': "Choose where to send replies",
+            'title': 'Send to one recipient',
             'description': 'Where should replies go?',
             'field_name': 'email_address'
         },
         'letter': {
-            'title': 'Choose sender address',
+            'title': 'Send to one recipient',
             'description': 'What should appear in the top right of the letter?',
             'field_name': 'contact_block'
         },
         'sms': {
-            'title': 'Chose text message sender',
+            'title': 'Send to one recipient',
             'description': 'Who should the message come from?',
             'field_name': 'sms_sender'
         }

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -44,13 +44,13 @@ test_non_spreadsheet_files = glob(path.join('tests', 'non_spreadsheet_files', '*
     (
         mock_get_service_email_template,
         multiple_reply_to_email_addresses,
-        'Choose where to send replies',
+        'Send to one recipient',
         'Where should replies go?',
     ),
     (
         mock_get_service_template,
         multiple_sms_senders,
-        'Chose text message sender',
+        'Send to one recipient',
         'Who should the message come from?'
     )
 ])

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -45,13 +45,13 @@ test_non_spreadsheet_files = glob(path.join('tests', 'non_spreadsheet_files', '*
         mock_get_service_email_template,
         multiple_reply_to_email_addresses,
         'Choose where to send replies',
-        'Select an email address that recipients can reply to'
+        'Where should replies go?',
     ),
     (
         mock_get_service_template,
         multiple_sms_senders,
         'Chose text message sender',
-        'Select a text message sender that the recipients can reply to'
+        'Who should the message come from?'
     )
 ])
 def test_show_correct_title_and_description_for_sender_type(


### PR DESCRIPTION
Make it clear that:

- In the case of text messages, it’s about who the message comes from
- In the case of emails, it’s about where the user will reply to

This commit also changes the `<h1>` of these pages to ‘Send to one recipient’. We have a sort of principle that when clicking a link, the page you land on should be titled the same as the link you clicked. And the link people click to get to these pages is ‘Send to one recipient’. This also reduces unnecessary repetition between the page title and the form label.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/32724792-96cbb954-c86a-11e7-94a0-e0a5e435e5fa.png) |  <img  alt="screen shot 2017-11-13 at 11 42 34" src="https://user-images.githubusercontent.com/355079/32724816-aa92d1a2-c86a-11e7-8025-14c4fbf09a04.png">
![image](https://user-images.githubusercontent.com/355079/32724800-9cc7b74a-c86a-11e7-9a2f-afb228bd8964.png) | <img alt="screen shot 2017-11-13 at 11 43 16" src="https://user-images.githubusercontent.com/355079/32724824-b0a37bb4-c86a-11e7-85b4-4300153c8e6c.png">

