### PR TITLE
Add a meta description tag to the product page

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -18,6 +18,8 @@
   <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main-ie8.css') }}" />
   <![endif]-->
   <meta name="google-site-verification" content="niWnSqImOWz6mVQTYqNb5tFK8HaKSB4b3ED4Z9gtUQ0" />
+  {% block meta %}
+  {% endblock %}
 {% endblock %}
 
 {% block page_title %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -1,5 +1,9 @@
 {% extends "fullwidth_template.html" %}
 
+{% block meta %}
+  <meta name="description" content="GOV.UK Notify lets your send emails and text messages to your users. Try it now if you work in central government, a local authority, or the NHS.">
+{% endblock %}
+
 {% block page_title %}
   GOV.UK Notify
 {% endblock %}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -1,5 +1,19 @@
 import pytest
+from bs4 import BeautifulSoup
 from flask import url_for
+
+
+def test_non_logged_in_user_can_see_homepage(
+    client,
+):
+    response = client.get(url_for('main.index'))
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert page.select_one('meta[name=description]')['content'].startswith(
+        'GOV.UK Notify lets your send emails and text messages'
+    )
 
 
 def test_logged_in_user_redirects_to_choose_service(
@@ -26,6 +40,10 @@ def test_static_pages(
 ):
     response = client.get(url_for('main.{}'.format(view)))
     assert response.status_code == 200
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert not page.select_one('meta[name=description]')
 
 
 @pytest.mark.parametrize('view, expected_anchor', [


### PR DESCRIPTION
Google tries to auto-generate a snippet of a site’s content to show in search results. Currently it’s not doing a great job of this for Notify.

There’s a chance that if we give it better content in the site’s meta description then it will use that instead. Worth a go…

The content is adapted from the blue box on the product page.

It’s 145 characters, which is within the 160 characters recommended[1].

It matches the content in the page, and contains words that users are likely to be searching for (GOV.UK Notify, emails, text messages).

It’s only on the homepage, because it shouldn’t be duplicated across multiple pages.

1. https://yoast.com/meta-descriptions/

# Before 

<img width="669" alt="screen shot 2017-11-14 at 17 20 13" src="https://user-images.githubusercontent.com/355079/32794786-c10e0ca6-c961-11e7-9fa6-7ff63a4e2217.png">

# After 

Let’s see what Google does with it…