### PR TITLE
Add a hint to explain why SMS auth is unavailable

### DIFF
--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -23,5 +23,13 @@
 </div>
 
 {% if service_has_email_auth %}
-  {{ radios(form.login_authentication, disable=['sms_auth' if user_has_no_mobile_number]) }}
+  {% if user_has_no_mobile_number %}
+    {{ radios(
+      form.login_authentication,
+      disable=['sms_auth'],
+      option_hints={'sms_auth': 'Not available because this team member hasn’t added a phone&nbsp;number to their profile'|safe}
+    ) }}
+  {% else %}
+    {{ radios(form.login_authentication) }}
+  {% endif %}
 {% endif %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -114,20 +114,29 @@ def test_manage_users_page_shows_member_auth_type_if_service_has_email_auth_acti
     assert bool(page.select_one('.tick-cross-list-hint')) == displays_auth_type
 
 
-@pytest.mark.parametrize('user, sms_option_disabled', [
+@pytest.mark.parametrize('user, sms_option_disabled, expected_label', [
     (
         active_user_no_mobile,
         True,
+        """
+            Text message code
+            Not available because this team member hasn’t added a
+            phone number to their profile
+        """,
     ),
     (
         active_user_with_permissions,
         False,
+        """
+            Text message code
+        """,
     ),
 ])
 def test_user_with_no_mobile_number_cant_be_set_to_sms_auth(
     client_request,
     user,
     sms_option_disabled,
+    expected_label,
     service_one,
     mocker
 ):
@@ -142,6 +151,9 @@ def test_user_with_no_mobile_number_cant_be_set_to_sms_auth(
 
     sms_auth_radio_button = page.select_one('input[value="sms_auth"]')
     assert sms_auth_radio_button.has_attr("disabled") == sms_option_disabled
+    assert normalize_spaces(
+        page.select_one('label[for=login_authentication-0]').text
+    ) == normalize_spaces(expected_label)
 
 
 @pytest.mark.parametrize('endpoint, extra_args, expected_checkboxes', [


### PR DESCRIPTION
If we’re going to ‘disable’ radio buttons then we should always tell users why the radio button is disabled.

This is what we found with the API key choices anyway.

---

![image](https://user-images.githubusercontent.com/355079/32847118-0395a114-ca21-11e7-98cb-25ba90ce2041.png)
