### PR TITLE
Added new template usage page which will replace template-activity

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -108,7 +108,7 @@ def template_history(service_id):
 
 @main.route("/services/<service_id>/template-usage")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions(admin_override=True)
 def template_usage(service_id):
 
     year, current_financial_year = requested_and_current_financial_year(request)

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -26,6 +26,12 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
             url='/service/{}/notifications/templates/monthly?year={}'.format(service_id, year)
         )['data']
 
+    def get_monthly_template_usage_for_service(self, service_id, year):
+
+        return self.get(
+            url='/service/{}/notifications/templates_usage/monthly?year={}'.format(service_id, year)
+        )['stats']
+
     def get_template_statistics_for_template(self, service_id, template_id):
 
         return self.get(


### PR DESCRIPTION
The current template-activity page is slow as it is using the end point which uses notification_history  and hence is timing out. This adds a new pages (so that they can be compared side by side) which will be hidden until is is approved with the larger data set and tested.