### PR TITLE
Improve page <h1>s in send one off flow

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -421,7 +421,11 @@ def send_test_step(service_id, template_id, step_index):
         skip_link = None
     return render_template(
         'views/send-test.html',
-        page_title=get_send_test_page_title(template.template_type, get_help_argument()),
+        page_title=get_send_test_page_title(
+            template.template_type,
+            get_help_argument(),
+            entering_recipient=not session['recipient']
+        ),
         template=template,
         form=form,
         skip_link=skip_link,
@@ -711,12 +715,14 @@ def all_placeholders_in_session(placeholders):
     )
 
 
-def get_send_test_page_title(template_type, help_argument):
+def get_send_test_page_title(template_type, help_argument, entering_recipient):
     if help_argument:
         return 'Example text message'
     if template_type == 'letter':
         return 'Print a test letter'
-    return 'Send to one recipient'
+    if entering_recipient:
+        return 'Who should this message be sent to?'
+    return 'Personalise this message'
 
 
 def get_back_link(service_id, template_id, step_index):

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -217,7 +217,7 @@ def set_sender(service_id, template_id):
 def get_sender_context(sender_details, template_type):
     context = {
         'email': {
-            'title': 'Send to one recipient',
+            'title': 'Where should replies go?',
             'description': 'Where should replies go?',
             'field_name': 'email_address'
         },
@@ -227,7 +227,7 @@ def get_sender_context(sender_details, template_type):
             'field_name': 'contact_block'
         },
         'sms': {
-            'title': 'Send to one recipient',
+            'title': 'Who should the message come from?',
             'description': 'Who should the message come from?',
             'field_name': 'sms_sender'
         }

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -217,8 +217,8 @@ def set_sender(service_id, template_id):
 def get_sender_context(sender_details, template_type):
     context = {
         'email': {
-            'title': 'Where should replies go?',
-            'description': 'Where should replies go?',
+            'title': 'Where should replies come back to?',
+            'description': 'Where should replies come back to?',
             'field_name': 'email_address'
         },
         'letter': {

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -2,12 +2,15 @@
   field,
   hint=None,
   disable=[],
-  option_hints={}
+  option_hints={},
+  hide_legend=False
 ) %}
   <div class="form-group {% if field.errors %} form-group-error{% endif %}">
     <fieldset>
       <legend class="form-label">
-        {{ field.label.text|safe }}
+        {% if hide_legend %}<span class="visually-hidden">{% endif %}
+          {{ field.label.text|safe }}
+        {% if hide_legend %}</span>{% endif %}
         {% if field.errors %}
           <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
             {{ field.errors[0] }}

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -13,10 +13,10 @@
     <div class="column-three-quarters">
       <form method="post">
         {{ radios(
-          form.sender, 
-          option_hints=option_hints
-          ) 
-        }}
+          form.sender,
+          option_hints=option_hints,
+          hide_legend=True
+        ) }}
         {{ page_footer(
           'Continue',
           back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id),

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -74,7 +74,9 @@ def test_show_correct_title_and_description_for_sender_type(
     )
 
     assert page.select_one('h1').text == expected_title
-    assert normalize_spaces(page.select_one('legend').text) == expected_description
+
+    for element in ('legend', 'legend .visually-hidden'):
+        assert normalize_spaces(page.select_one(element).text) == expected_description
 
 
 @pytest.mark.parametrize('template_mock, sender_data', [

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -575,13 +575,13 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_test'),
-        'Send to one recipient',
+        'Personalise this message',
         False,
     ),
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_one_off'),
-        'Send to one recipient',
+        'Who should this message be sent to?',
         False,
     ),
     (
@@ -599,13 +599,13 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_test'),
-        'Send to one recipient',
+        'Personalise this message',
         False,
     ),
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_one_off'),
-        'Send to one recipient',
+        'Who should this message be sent to?',
         False,
     ),
     (

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -44,8 +44,8 @@ test_non_spreadsheet_files = glob(path.join('tests', 'non_spreadsheet_files', '*
     (
         mock_get_service_email_template,
         multiple_reply_to_email_addresses,
-        'Where should replies go?',
-        'Where should replies go?',
+        'Where should replies come back to?',
+        'Where should replies come back to?',
     ),
     (
         mock_get_service_template,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -44,14 +44,14 @@ test_non_spreadsheet_files = glob(path.join('tests', 'non_spreadsheet_files', '*
     (
         mock_get_service_email_template,
         multiple_reply_to_email_addresses,
-        'Send to one recipient',
+        'Where should replies go?',
         'Where should replies go?',
     ),
     (
         mock_get_service_template,
         multiple_sms_senders,
-        'Send to one recipient',
-        'Who should the message come from?'
+        'Who should the message come from?',
+        'Who should the message come from?',
     )
 ])
 def test_show_correct_title_and_description_for_sender_type(


### PR DESCRIPTION
# Description of changes

## Fix misleading `<h1>` in one-off flow

Changing the `<h1>` in #1638 turned out to be quite confusing. The combination of the word
"recipient" and a selection of email addresses on the page was confusing.

This commit changes the page title to be much more explicit about what is expected from the page, rather than what is consistent with the text of the link that the user clicked.

## Hide form legend on choose reply page

The `<h1>` on this page says all the user needs to know. In research we saw that users didn’t even read the legend, even when prompted to!

## Improve page titles later on in the one off flow

Now that the page title for picking a sender/reply to has been improved, I think these pages are also less clear than they could be.

This commit changes the page titles to (I hope) be clearer about what is needed from the user on these pages.

# Changes to the email flow 

<img width="753" alt="screen shot 2017-11-20 at 16 49 03" src="https://user-images.githubusercontent.com/355079/33030727-fdb196b2-ce13-11e7-8907-351c0aa3254e.png">
<img width="759" alt="screen shot 2017-11-20 at 16 49 09" src="https://user-images.githubusercontent.com/355079/33030728-fdce1ce2-ce13-11e7-9405-9157644f4ce9.png">
<img width="757" alt="screen shot 2017-11-20 at 16 49 16" src="https://user-images.githubusercontent.com/355079/33030729-fde87006-ce13-11e7-8f64-feed2baaa8bf.png">
<img width="751" alt="screen shot 2017-11-20 at 16 49 25" src="https://user-images.githubusercontent.com/355079/33030730-fdfd6c36-ce13-11e7-8a5c-0456b62c1340.png">

## Changes to the text message flow 

<img width="758" alt="screen shot 2017-11-20 at 16 49 36" src="https://user-images.githubusercontent.com/355079/33030731-fe18bffe-ce13-11e7-9cc8-d64a8b60e04e.png">
<img width="751" alt="screen shot 2017-11-20 at 16 49 44" src="https://user-images.githubusercontent.com/355079/33030732-fe33feae-ce13-11e7-99ce-4a6bb8109c2e.png">
<img width="759" alt="screen shot 2017-11-20 at 16 49 49" src="https://user-images.githubusercontent.com/355079/33030733-fe4a8566-ce13-11e7-94aa-5285dcaa3358.png">
<img width="746" alt="screen shot 2017-11-20 at 16 49 56" src="https://user-images.githubusercontent.com/355079/33030734-fe637350-ce13-11e7-873b-32d56852746c.png">

# Pages that don’t change 

## The tour

<img width="1009" alt="screen shot 2017-11-20 at 16 51 26" src="https://user-images.githubusercontent.com/355079/33030735-fe85b4d8-ce13-11e7-92f6-e2de01f8695f.png">

## Printing a test letter 

![image](https://user-images.githubusercontent.com/355079/33030818-3a68aaf0-ce14-11e7-85a7-43319ea17857.png)


