### PR TITLE
Updated link to for browsing to financial years

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -116,23 +116,25 @@ def template_usage(service_id):
 
     stats = sorted(stats, key=lambda x: (x['count']), reverse=True)
 
-    months = [
-        {
-            'name': yyyy_mm_to_datetime(month).strftime('%B'),
-            'templates_used': [],
-        }
-        for month in get_months_for_financial_year(year, time_format='%Y-%m')
-    ]
-
-    for i, d in enumerate(months):
-        for stat in stats:
-            if d['name'] == calendar.month_name[int(stat['month'])]:
-                d['templates_used'].append({
+    def get_monthly_template_stats(month_name, stats):
+        return {
+            'name': month_name,
+            'templates_used': [
+                {
                     'id': stat['template_id'],
                     'name': stat['name'],
                     'type': stat['type'],
                     'requested_count': stat['count']
-                })
+                }
+                for stat in stats
+                if calendar.month_name[int(stat['month'])] == month_name
+            ],
+        }
+
+    months = [
+        get_monthly_template_stats(month, stats)
+        for month in get_months_for_financial_year(year, time_format='%B')
+    ]
 
     return render_template(
         'views/dashboard/all-template-statistics.html',

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -142,7 +142,7 @@ def template_usage(service_id):
             for month in months
         ),
         years=get_tuples_of_financial_years(
-            partial(url_for, '.template_history', service_id=service_id),
+            partial(url_for, '.template_usage', service_id=service_id),
             end=current_financial_year,
         ),
         selected_year=year

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -120,24 +120,20 @@ def template_usage(service_id):
     months = [
         {
             'name': yyyy_mm_to_datetime(month).strftime('%B'),
-            'templates_used': {},
+            'templates_used': [],
         }
         for month in get_months_for_financial_year(year, time_format='%Y-%m')
     ]
 
-    templates_by_month = defaultdict(list)
-    for stat in stats:
-        templates_by_month[int(stat['month'])].append({
-            'id': stat['template_id'],
-            'name': stat['name'],
-            'type': stat['type'],
-            'requested_count': stat['count']
-        })
-        months = [{
-            'name': calendar.month_name[k],
-            'templates_used': v
-        } for k, v in templates_by_month.items()
-        ]
+    for i, d in enumerate(months):
+        for stat in stats:
+            if d['name'] == calendar.month_name[int(stat['month'])]:
+                d['templates_used'].append({
+                    'id': stat['template_id'],
+                    'name': stat['name'],
+                    'type': stat['type'],
+                    'requested_count': stat['count']
+                })
 
     return render_template(
         'views/dashboard/all-template-statistics.html',

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -117,9 +117,18 @@ def template_usage(service_id):
 
     stats = sorted(stats, key=lambda x: (x['count']), reverse=True)
 
+    months = [
+        {
+            'name': yyyy_mm_to_datetime(month).strftime('%B'),
+            'templates_used': {},
+        }
+        for month in get_months_for_financial_year(year, time_format='%Y-%m')
+    ]
+
     templates_by_month = defaultdict(list)
     for stat in stats:
         templates_by_month[int(stat['month'])].append({
+            'id': stat['template_id'],
             'name': stat['name'],
             'type': stat['type'],
             'requested_count': stat['count']

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,5 +1,4 @@
 import calendar
-from collections import defaultdict
 from datetime import datetime
 from functools import partial
 from flask import (


### PR DESCRIPTION
- The link which when clicked allows the user to view different financial years was pointing to the template_activity page
- Added Template id so that the link through to the template is maintained
- Handled empty data sets from API, so empty months are displayed to the user