### PR TITLE
Change the CSRF error from 400 to 403

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -151,7 +151,7 @@ def init_csrf(application):
             u'csrf.invalid_token: Aborting request, user_id: {user_id}',
             extra={'user_id': session['user_id']})
 
-        abort(400, reason)
+        abort(403, reason)
 
 
 def init_app(application):


### PR DESCRIPTION
All 400s are handled by a generic errorhandler which logs them and
converts them to 500.

We don't need to be alerted for CSRF problems.