### PR TITLE
Invite users to choose how team members sign in

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -536,6 +536,15 @@ def service_set_letters(service_id):
     )
 
 
+@main.route("/services/<service_id>/service-settings/set-auth-type", methods=['GET'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def service_set_auth_type(service_id):
+    return render_template(
+        'views/service-settings/set-auth-type.html',
+    )
+
+
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -26,6 +26,16 @@
           {{ edit_field('Change', url_for('.service_name_change', service_id=current_service.id)) }}
         {% endcall %}
 
+        {% call row() %}
+          {{ text_field('Sign-in method') }}
+          {{ text_field(
+            'Email link or text message code'
+            if 'email_auth' in current_service.permissions
+            else 'Text message code'
+          ) }}
+          {{ edit_field('Change', url_for('.service_set_auth_type', service_id=current_service.id)) }}
+        {% endcall %}
+
       {% endcall %}
 
       {% call mapping_table(

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -1,0 +1,44 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Text message sender
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">Sign-in method</h1>
+      {% if 'email_auth' in current_service.permissions %}
+        <p class="heading-small bottom-gutter-2-3">
+          Email link or text message code
+        </p>
+        <p>
+          Your team members can sign in with either a text message code
+          or an email link.
+        </p>
+        <p>
+          You can <a href="{{ url_for('.manage_users', service_id=current_service.id) }}">set the sign-in method for individual team members</a>.
+        </p>
+      {% else %}
+        <p class="heading-small bottom-gutter-2-3">
+          Text message code
+        </p>
+        <p>
+          Your team members sign in with a text message code.
+        </p>
+        <p>
+          If signing in with a text message is a problem for your team,
+          please <a href="{{ url_for('.support') }}">contact us</a>.
+        </p>
+      {% endif %}
+      {{ page_footer(
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
+    </div>
+  </div>
+
+{% endblock %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -46,6 +46,7 @@ def mock_get_service_settings_page_common(
 
         'Label Value Action',
         'Service name service one Change',
+        'Sign-in method Text message code Change',
 
         'Label Value Action',
         'Send emails On Change',
@@ -66,6 +67,7 @@ def mock_get_service_settings_page_common(
 
         'Label Value Action',
         'Service name service one Change',
+        'Sign-in method Text message code Change',
 
         'Label Value Action',
         'Send emails On Change',
@@ -122,6 +124,7 @@ def test_should_show_overview(
     (['email', 'sms', 'inbound_sms', 'international_sms'], [
 
         'Service name service one Change',
+        'Sign-in method Text message code Change',
 
         'Label Value Action',
         'Send emails On Change',
@@ -139,9 +142,10 @@ def test_should_show_overview(
         'Send letters Off Change',
 
     ]),
-    (['email', 'sms'], [
+    (['email', 'sms', 'email_auth'], [
 
         'Service name service one Change',
+        'Sign-in method Email link or text message code Change',
 
         'Label Value Action',
         'Send emails On Change',
@@ -249,7 +253,7 @@ def test_letter_contact_block_shows_none_if_not_set(
     ))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    div = page.find_all('tr')[8].find_all('td')[1].div
+    div = page.find_all('tr')[9].find_all('td')[1].div
     assert div.text.strip() == 'Not set'
     assert 'default' in div.attrs['class'][0]
 
@@ -269,7 +273,7 @@ def test_escapes_letter_contact_block(
     ))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    div = str(page.find_all('tr')[8].find_all('td')[1].div)
+    div = str(page.find_all('tr')[9].find_all('td')[1].div)
     assert 'foo<br/>bar' in div
     assert '<script>' not in div
 
@@ -713,9 +717,9 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
             page.select('tbody tr')[index].text
         )
 
-    assert get_row(page, 2) == "Email reply to addresses test@example.com …and 2 more Manage"
-    assert get_row(page, 4) == "Text message sender Example …and 2 more Manage"
-    assert get_row(page, 9) == "Sender addresses 1 Example Street …and 2 more Manage"
+    assert get_row(page, 3) == "Email reply to addresses test@example.com …and 2 more Manage"
+    assert get_row(page, 5) == "Text message sender Example …and 2 more Manage"
+    assert get_row(page, 10) == "Sender addresses 1 Example Street …and 2 more Manage"
 
 
 @pytest.mark.parametrize('sender_list_page, expected_output', [
@@ -2001,6 +2005,20 @@ def test_cant_resume_active_service(
         ['sms', 'inbound_sms'],
         (
             'Your service can receive text messages sent to 0781239871.'
+        )
+    ),
+    (
+        'main.service_set_auth_type',
+        [],
+        (
+            'Text message code'
+        )
+    ),
+    (
+        'main.service_set_auth_type',
+        ['email_auth'],
+        (
+            'Email link or text message code'
         )
     ),
 ])


### PR DESCRIPTION
Email auth is a new feature that currently we’ve only given to teams who have contact us with a problem.

At the moment, we’re aware of all the teams that are sharing phone numbers when they sign in. We think that in the future there will be other teams who encounter this problem. So we should let them know that they should contact us if they are having the problem.

At the moment we want to talk to teams before giving them access to the feature, so that we’re confident it’s only going to teams from whom it’s more secure than using a text message code.


![image](https://user-images.githubusercontent.com/355079/33439085-7eb9defe-d5e4-11e7-8c00-1d39c22c84eb.png)

![image](https://user-images.githubusercontent.com/355079/33439095-872b64f4-d5e4-11e7-8ce9-f93d44fcd390.png)

![image](https://user-images.githubusercontent.com/355079/33439141-9e6f7e52-d5e4-11e7-8697-688d66ccc165.png)

![image](https://user-images.githubusercontent.com/355079/33439108-9134fbe0-d5e4-11e7-8e67-25fffa8f6572.png)

