### PR TITLE
Rationalise top navigation and footer 

### DIFF
--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -13,11 +13,6 @@ def features_nav():
             "link": "main.security",
         },
         {
-            "name": "Performance",
-            "link": "https://www.gov.uk/performance/govuk-notify",
-            "external_link": True,
-        },
-        {
             "name": "Terms of use",
             "link": "main.terms",
         },

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -87,11 +87,11 @@
         <div class="column-one-third">
           <h2>About</h2>
           <ul>
-            <li><a href="{{ url_for("main.using_notify") }}">Using Notify</a></li>
             <li><a href="{{ url_for("main.features") }}">Features</a></li>
             <li><a href="{{ url_for("main.roadmap") }}">Roadmap</a></li>
+            <li><a href="{{ url_for("main.security") }}">Security</a></li>
             <li><a href="{{ url_for("main.terms") }}">Terms of use</a></li>
-            <li><a href="{{ url_for("main.pricing") }}">Pricing</a></li>
+            <li><a href="{{ url_for("main.using_notify") }}">Using Notify</a></li>
           </ul>
         </div>
         <div class="column-one-third">

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -76,16 +76,14 @@
     <div class="footer-categories-wrapper">
       <div class="grid-row">
         <div class="column-one-quarter">
-          <h2>Support</h2>
           <ul>
-            <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="{{ url_for('main.support') }}">Support</a></li>
+            <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
             <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Chat with the Notify team</a></li>
           </ul>
         </div>
         <div class="column-one-quarter">
-          <h2>About</h2>
           <ul>
             <li><a href="{{ url_for("main.features") }}">Features</a></li>
             <li><a href="{{ url_for("main.roadmap") }}">Roadmap</a></li>
@@ -100,19 +98,8 @@
           </ul>
         </div>
         <div class="column-one-quarter">
-          <h2>API documentation</h2>
           <ul>
-            {% for language, url in [
-              ('Java', 'https://github.com/alphagov/notifications-java-client'),
-              ('.NET', 'https://github.com/alphagov/notifications-net-client'),
-              ('Node JS', 'https://github.com/alphagov/notifications-node-client'),
-              ('PHP', 'https://github.com/alphagov/notifications-php-client'),
-              ('Python', 'https://github.com/alphagov/notifications-python-client'),
-              ('Ruby', 'https://github.com/alphagov/notifications-ruby-client')
-            ] %}
-            <li><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ language }} client</a></li>
-            {% endfor %}
-            <li><a href="{{ url_for("main.integration_testing") }}">Integration testing</a></li>
+            <li><a href="{{ url_for("main.documentation") }}">Documentation</a></li>
           </ul>
         </div>
       </div>

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -44,6 +44,8 @@
       <nav id="proposition-menu">
         <ul id="proposition-links">
           <li><a href="{{ url_for('main.support') }}">Support</a></li>
+          <li><a href="{{ url_for('main.features') }}">Features</a></li>
+          <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
           {% if current_user.is_authenticated %}
             <li><a href="{{ url_for('main.user_profile') }}">{{ current_user.name }}</a></li>
             {% if current_user.has_permissions(admin_override=True) %}
@@ -51,9 +53,7 @@
             {% endif %}
             <li><a href="{{ url_for('main.sign_out')}}">Sign out</a></li>
           {% else %}
-            <li><a href="{{ url_for('main.features' )}}">Features</a></li>
             <li><a href="{{ url_for('main.pricing' )}}">Pricing</a></li>
-            <li><a href="{{ url_for('main.documentation' )}}">Documentation</a></li>
             <li><a href="{{ url_for('main.sign_in' )}}">Sign in</a></li>
           {% endif %}
         </ul>

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -80,7 +80,7 @@
             <li><a href="{{ url_for('main.support') }}">Support</a></li>
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
-            <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Chat with the Notify team</a></li>
+            <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Slack channel</a></li>
           </ul>
         </div>
         <div class="column-one-quarter">

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -75,7 +75,7 @@
   <div class="footer-categories">
     <div class="footer-categories-wrapper">
       <div class="grid-row">
-        <div class="column-one-third">
+        <div class="column-one-quarter">
           <h2>Support</h2>
           <ul>
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
@@ -84,7 +84,7 @@
             <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Chat with the Notify team</a></li>
           </ul>
         </div>
-        <div class="column-one-third">
+        <div class="column-one-quarter">
           <h2>About</h2>
           <ul>
             <li><a href="{{ url_for("main.features") }}">Features</a></li>
@@ -94,7 +94,12 @@
             <li><a href="{{ url_for("main.using_notify") }}">Using Notify</a></li>
           </ul>
         </div>
-        <div class="column-one-third">
+        <div class="column-one-quarter">
+          <ul>
+            <li><a href="{{ url_for("main.pricing") }}">Pricing</a></li>
+          </ul>
+        </div>
+        <div class="column-one-quarter">
           <h2>API documentation</h2>
           <ul>
             {% for language, url in [

--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -3,18 +3,13 @@
 ) %}
   <nav class="sub-navigation">
     <ol itemscope itemtype="http://schema.org/ItemList">
-      {% for item in item_set %}        
-        <li class="sub-navigation__item {% if item['link'] == request.endpoint %} sub-navigation__item--active {% endif %}" 
-            itemprop="itemListElement" 
-            itemscope 
+      {% for item in item_set %}
+        <li class="sub-navigation__item {% if item['link'] == request.endpoint %} sub-navigation__item--active {% endif %}"
+            itemprop="itemListElement"
+            itemscope
             itemtype="http://schema.org/ListItem"
         >
-          <a href="{%- if item['external_link'] -%} 
-                     {{ item['link'] }} 
-                   {%- else -%} 
-                     {{ url_for(item['link']) }} 
-                   {%- endif -%}" 
-             itemprop="item">
+          <a href="{{ url_for(item['link']) }}" itemprop="item">
             <span itemprop="name">{{item['name']}}</span>
           </a>
         </li>


### PR DESCRIPTION
# Signed out

## Before

![image](https://user-images.githubusercontent.com/355079/33446761-fd02811c-d5f8-11e7-8303-b7dceb99a2fa.png)

## After 

![image](https://user-images.githubusercontent.com/355079/33446774-0996cc44-d5f9-11e7-86ab-bd8e635e6d55.png)

# Signed in

## Before 

![image](https://user-images.githubusercontent.com/355079/33446812-298ebc50-d5f9-11e7-957b-db2adb296a65.png)

## After 

![image](https://user-images.githubusercontent.com/355079/33446791-1e7bcb96-d5f9-11e7-9413-4aed75a9e046.png)

# Footer

## Before 

![image](https://user-images.githubusercontent.com/355079/33446867-500f8422-d5f9-11e7-904c-1f22f758531f.png)

## After 

![image](https://user-images.githubusercontent.com/355079/33478293-b5b229ce-d680-11e7-8f3d-1009b8e6a2e5.png)

# Individual changes 

## Make features and documentation always visible

These links should always appear in the header, because they’re useful to both signed in and signed out users.

## Remove performance link from features nav

The features nav is supposed to navigate your between pages in the app. It’s very unexpected to have it open an external link.

Performance isn’t strictly a part of Support, but it’s worked having it there for long enough that it’s probably not a bother.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/355079/33446981-b6a65a58-d5f9-11e7-8ae0-282ba9b126e2.png) | ![image](https://user-images.githubusercontent.com/355079/33447014-d00d65d6-d5f9-11e7-8294-9cadb71f8f2e.png)


## Make order of About links match features sidebar

The links in the footer should be in the same order as those in the sidebar of the features page. That’s the order that’s been thought about more.

## Make pricing its own column in footer

This makes the footer match the order and grouping of links in the top navigation.

## Remove headings from footer

It doesn’t make sense to have a section called ‘Support’ which has a link called ‘Support’ in it.

And by splitting up, and reducing the number of links in the footer, they don’t _need_ headers – hopefully they’re self explanatory.

## Rename Slack link

It was quite long, and Thom wasn’t a fan of the wording.