### PR TITLE
Make page titles match <h1> tags on static pages

### DIFF
--- a/app/templates/views/callbacks.html
+++ b/app/templates/views/callbacks.html
@@ -2,7 +2,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% block per_page_title %}
-  Callbacks
+  Callbacks for received text messages
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -3,7 +3,7 @@
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
-  Information risk management
+  Security
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -70,7 +70,7 @@
     <h2 class="heading-medium">Cabinet Office approval</h2>
     <p>Notify has been assessed and approved by the Cabinet Office Senior Information Risk Officer (SIRO). The SIRO checks this approval once a year.</p>
     <p>Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
-    
+
     <h2 class="heading-medium">Classifications and security vetting</h2>
     <p>Any information in Notify is classified as ‘OFFICIAL’ under the Government Security Classifications Policy.</p>
     <p>All system administration staff working on Notify are cleared to Security Check (SC) level by United Kingdom Security Vetting.</p>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -35,14 +35,10 @@ def test_logged_in_user_redirects_to_choose_service(
     'features', 'callbacks', 'documentation', 'security'
 ])
 def test_static_pages(
-    client,
+    client_request,
     view,
 ):
-    response = client.get(url_for('main.{}'.format(view)))
-    assert response.status_code == 200
-
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-
+    page = client_request.get('main.{}'.format(view))
     assert not page.select_one('meta[name=description]')
 
 


### PR DESCRIPTION
This commit fixes pages where this isn’t the case, and modifies the test to use the `client_request` fixture, which checks for this mismatch.