### PR TITLE
Fix order of nav when signed out

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -45,8 +45,8 @@
         <ul id="proposition-links">
           <li><a href="{{ url_for('main.support') }}">Support</a></li>
           <li><a href="{{ url_for('main.features') }}">Features</a></li>
-          <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
           {% if current_user.is_authenticated %}
+            <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
             <li><a href="{{ url_for('main.user_profile') }}">{{ current_user.name }}</a></li>
             {% if current_user.has_permissions(admin_override=True) %}
               <li><a href="{{ url_for('main.platform_admin') }}">Platform admin</a></li>
@@ -54,6 +54,7 @@
             <li><a href="{{ url_for('main.sign_out')}}">Sign out</a></li>
           {% else %}
             <li><a href="{{ url_for('main.pricing' )}}">Pricing</a></li>
+            <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
             <li><a href="{{ url_for('main.sign_in' )}}">Sign in</a></li>
           {% endif %}
         </ul>


### PR DESCRIPTION
Got this wrong in a previous commit. Now it matches the footer (which is the right order).

# Signed in

![image](https://user-images.githubusercontent.com/355079/33486491-2fbf4758-d6a2-11e7-9887-9634e4bb10df.png)

# Signed out, before 

![image](https://user-images.githubusercontent.com/355079/33486521-4d454516-d6a2-11e7-8b0b-a1287adf5ef5.png)

# Signed out, after 

![image](https://user-images.githubusercontent.com/355079/33486509-3dc00752-d6a2-11e7-88a4-8d9d9ea25502.png)
