### PR TITLE
Add send letters as PDF service setting

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -293,6 +293,14 @@ def service_switch_can_send_letters(service_id):
     return redirect(url_for('.service_settings', service_id=service_id))
 
 
+@main.route("/services/<service_id>/service-settings/send-letters-as-pdf")
+@login_required
+@user_has_permissions(admin_override=True)
+def service_switch_send_letters_as_pdf(service_id):
+    switch_service_permissions(service_id, 'letters_as_pdf')
+    return redirect(url_for('.service_settings', service_id=service_id))
+
+
 @main.route("/services/<service_id>/service-settings/can-send-international-sms")
 @login_required
 @user_has_permissions(admin_override=True)

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -256,6 +256,13 @@
             {{ 'Stop sending letters' if 'letter' in current_service.permissions else 'Allow to send letters' }}
           </a>
         </li>
+        {% if 'letter' in current_service.permissions %}
+          <li class="bottom-gutter">
+            <a href="{{ url_for('.service_switch_send_letters_as_pdf', service_id=current_service.id) }}" class="button">
+              {{ 'Stop sending letters as PDF' if 'letters_as_pdf' in current_service.permissions else 'Send letters as PDF' }}
+            </a>
+          </li>
+        {% endif %}
         <li class="bottom-gutter">
           <a href="{{ url_for('.service_switch_can_send_sms', service_id=current_service.id) }}" class="button">
             {{ 'Stop sending sms' if 'sms' in current_service.permissions else 'Allow to send sms' }}

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -39,6 +39,12 @@ def get_service_settings_page(
 
     ({'permissions': ['sms']}, '.service_set_inbound_number', {'set_inbound_sms': True}, 'Allow inbound sms'),
 
+    (
+        {'permissions': ['letter', 'letters_as_pdf']},
+        '.service_switch_send_letters_as_pdf', {}, 'Stop sending letters as PDF'
+    ),
+    ({'permissions': ['letter']}, '.service_switch_send_letters_as_pdf', {}, 'Send letters as PDF'),
+
     ({'active': True}, '.archive_service', {}, 'Archive service'),
     ({'active': True}, '.suspend_service', {}, 'Suspend service'),
     ({'active': False}, '.resume_service', {}, 'Resume service'),
@@ -62,6 +68,20 @@ def test_service_settings_doesnt_show_inbound_options_if_sms_disabled(
     page = get_service_settings_page()
     toggles = page.find_all('a', {'class': 'button'})
     assert not any(button for button in toggles if 'inbound sms' in button.text)
+
+
+@pytest.mark.parametrize('permissions', [
+    ['letters_as_pdf'], []
+])
+def test_service_settings_doesnt_show_letters_as_pdf_options_if_letters_disabled(
+    get_service_settings_page,
+    service_one,
+    permissions
+):
+    service_one['permissions'] = permissions
+    page = get_service_settings_page()
+    toggles = page.find_all('a', {'class': 'button'})
+    assert not any(button for button in toggles if 'letters as PDF' in button.text)
 
 
 @pytest.mark.parametrize('service_fields, hidden_button_text', [


### PR DESCRIPTION
## What

Added toggle for switching on service permission `letters_as_pdf` so that we can set specified services to produce pdf letters.

## Reference

https://www.pivotaltracker.com/story/show/151511579