### PR TITLE
Remove features from top nav when signed in

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -44,7 +44,6 @@
       <nav id="proposition-menu">
         <ul id="proposition-links">
           <li><a href="{{ url_for('main.support') }}">Support</a></li>
-          <li><a href="{{ url_for('main.features') }}">Features</a></li>
           {% if current_user.is_authenticated %}
             <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
             <li><a href="{{ url_for('main.user_profile') }}">{{ current_user.name }}</a></li>
@@ -53,6 +52,7 @@
             {% endif %}
             <li><a href="{{ url_for('main.sign_out')}}">Sign out</a></li>
           {% else %}
+            <li><a href="{{ url_for('main.features') }}">Features</a></li>
             <li><a href="{{ url_for('main.pricing' )}}">Pricing</a></li>
             <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
             <li><a href="{{ url_for('main.sign_in' )}}">Sign in</a></li>


### PR DESCRIPTION
Features is a sales tool. Once you’re using the product already there’s less of a need to see it. The pages are still accessible from the footer, and for users who aren’t signed in.

# Signed out (unchanged)

![image](https://user-images.githubusercontent.com/355079/33549419-4e88974c-d8e2-11e7-94a8-59499e8abaa3.png)

# Signed in

![image](https://user-images.githubusercontent.com/355079/33549396-35675276-d8e2-11e7-997c-fa5017e9d835.png)
