### PR TITLE
Update error message about commas in placeholders

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -45,7 +45,7 @@ class ValidGovEmail:
 
 class NoCommasInPlaceHolders:
 
-    def __init__(self, message='You can’t put commas inbetween double brackets'):
+    def __init__(self, message='You can’t put commas between double brackets'):
         self.message = message
 
     def __call__(self, form, field):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,5 +1,5 @@
 from wtforms import ValidationError
-from notifications_utils.template import Template
+from notifications_utils.field import Field
 from notifications_utils.gsm import get_non_gsm_compatible_characters
 
 from app import formatted_list
@@ -45,11 +45,11 @@ class ValidGovEmail:
 
 class NoCommasInPlaceHolders:
 
-    def __init__(self, message='You can’t have commas in your fields'):
+    def __init__(self, message='You can’t put commas inbetween double brackets'):
         self.message = message
 
     def __call__(self, form, field):
-        if ',' in ''.join(Template({'content': field.data}).placeholders):
+        if ',' in ''.join(Field(field.data).placeholders):
             raise ValidationError(self.message)
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -149,7 +149,7 @@ def test_for_commas_in_placeholders(
 ):
     with pytest.raises(ValidationError) as error:
         NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name,date))'))
-    assert str(error.value) == 'You can’t put commas inbetween double brackets'
+    assert str(error.value) == 'You can’t put commas between double brackets'
     NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name))'))
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -149,7 +149,7 @@ def test_for_commas_in_placeholders(
 ):
     with pytest.raises(ValidationError) as error:
         NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name,date))'))
-    assert str(error.value) == 'You can’t have commas in your fields'
+    assert str(error.value) == 'You can’t put commas inbetween double brackets'
     NoCommasInPlaceHolders()(None, _gen_mock_field('Hello ((name))'))
 
 


### PR DESCRIPTION
We call the yellow things ‘double brackets’ on the frontend, not fields or placeholders. This error message was a bit out of date.

Also refactored it to use the `Field` class; this code was probably written before `Field` was factored out of `Template`.