### PR TITLE
Updated service manual link on using-notify page

### DIFF
--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -24,10 +24,10 @@
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
         <li>
           added the templates you want to start with, making sure they follow our
-          <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ" rel="external">design patterns</a>,
-          <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing" rel="external">style guide</a>
+          <a href="https://www.gov.uk/service-manual/design/using-adapting-and-creating-patterns" rel="external">design patterns</a>,
+          <a href="https://www.gov.uk/guidance/style-guide" rel="external">style guide</a>
           and
-          <a href="https://docs.google.com/document/d/15-OjaEqDBy31uDU7nLZCpYIQOnzSCJR63-cp3cQI9G8" rel="external">information security guidelines</a>
+          <a href="https://www.gov.uk/service-manual/technology/securing-your-information" rel="external">information security guidelines</a>
           </li>
       </ul>
 

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -39,7 +39,7 @@ Terms of use
       <li>get the right levels of consent (to send messages and to use data)</li>
       <li>not send unsolicited messages, only ones related to a transaction or something the user has subscribed to be updated about (<a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">check the Service Manual</a> if you’re not sure)</li>
       <li>
-        send messages that meet the GOV.UK <a href="https://designpatterns.hackpad.com/Notifications-5vuitmNqIjZ">design patterns</a>, <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing">style guide</a> and <a href="https://www.notifications.service.gov.uk/information-security">information security guidelines</a></li>
+        send messages that meet the GOV.UK <a href="https://www.gov.uk/service-manual/design/using-adapting-and-creating-patterns">design patterns</a>, <a href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a href="https://www.gov.uk/service-manual/technology/securing-your-information">information security guidelines</a></li>
       <li>not send messages containing any personally or commercially sensitive information</li>
       <li>check that the data you add to Notify is accurate and complies with Data Protection Act principles</li>
     </ul>

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -16,10 +16,10 @@
     <h1 class="heading-large">Using Notify</h1>
 
     <h2 class="heading-medium">Writing and sending text messages, emails and letters</h2>
-    <p>Check the Service Manual for guidance on how to:</p>
+    <p><a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">Check the Service Manual</a> for guidance on how to:</p>
     <ul class="list list-bullet">
-      <li><a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">plan and write text messages and emails</a></li>
-      <li><a href=""><a href="https://www.gov.uk/service-manual/technology/how-to-email-your-users"></a>send emails in a way that protects users from spam and phishing</a></li>
+      <li>plan and write text messages and emails</li>
+      <li><a href="https://www.gov.uk/service-manual/technology/how-to-email-your-users">send emails</a> in a way that protects users from spam and phishing</li>
     </ul>
 
     <h2 id="trial-mode" class="heading-medium">Trial mode</h2>


### PR DESCRIPTION
Changes the link on the using-notify page to be on the 'Service Manual' text, rather than the bullet point.