### PR TITLE
Strip spaces from email addresses when signing in

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -30,6 +30,9 @@ def sign_in():
         return redirect(url_for('main.choose_service'))
 
     form = LoginForm()
+    if form.email_address.data:
+        form.email_address.data = form.email_address.data.strip()
+
     if form.validate_on_submit():
 
         user = user_api_client.get_user_by_email_or_none(form.email_address.data)

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -77,6 +77,10 @@ def test_logged_in_user_redirects_to_choose_service(
     assert response.location == url_for('main.choose_service', _external=True)
 
 
+@pytest.mark.parametrize('email_address', [
+    'valid@example.gov.uk',
+    ' valid@example.gov.uk  ',
+])
 def test_process_sms_auth_sign_in_return_2fa_template(
     client,
     api_user_active,
@@ -84,14 +88,16 @@ def test_process_sms_auth_sign_in_return_2fa_template(
     mock_get_user,
     mock_get_user_by_email,
     mock_verify_password,
+    email_address,
 ):
     response = client.post(
         url_for('main.sign_in'), data={
-            'email_address': 'valid@example.gov.uk',
+            'email_address': email_address,
             'password': 'val1dPassw0rd!'})
     assert response.status_code == 302
     assert response.location == url_for('.two_factor', _external=True)
     mock_verify_password.assert_called_with(api_user_active.id, 'val1dPassw0rd!')
+    mock_get_user_by_email.assert_called_with('valid@example.gov.uk')
 
 
 def test_process_email_auth_sign_in_return_2fa_template(


### PR DESCRIPTION
If you copy and paste an email address into the sign in box, there’s a chance you’ll also copy some leading or trailing spaces. This is especially likely to happen if you’re doing this while using your
computer upside down.

If this happens, it never even gets as far as looking up the user, because the form validation doesn’t consider a string with a leading space to be a valid email address.

This commit makes sure that accidental spaces are handled, by removing them before doing any validation or hitting the API to look up the user.

---

This isn’t going to stop anyone signing in; no-one on production is relying on having a space in their email address:

```
select created_at, email_address from users where email_address ilike '% %';
         created_at         |                  email_address
----------------------------+-------------------------------------------------
 2017-12-04 11:20:18.467762 |  chris.hill-scott@digital.cabinet-office.gov.uk
(1 row)
```