### PR TITLE
Update requirements.txt to fix html5lib issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ notifications-python-client==4.6.0
 awscli==1.14.2
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.2.1#egg=notifications-utils==23.3.1
+git+https://github.com/alphagov/notifications-utils.git@23.3.1#egg=notifications-utils==23.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ notifications-python-client==4.6.0
 awscli==1.14.2
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0
+git+https://github.com/alphagov/notifications-utils.git@23.2.1#egg=notifications-utils==23.3.1


### PR DESCRIPTION
## What

The latest version of html5lib breaks bleach which is used in notification utils. 

In order to fix this we have pinned html5lib to the last working version - 1.0b10