### PR TITLE
Add undocumented support for <hr>s in emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ notifications-python-client==4.6.0
 awscli==1.14.2
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.3.1#egg=notifications-utils==23.3.1
+git+https://github.com/alphagov/notifications-utils.git@23.3.4#egg=notifications-utils==23.3.4
 
 # required by utils
 git+https://github.com/leohemsted/smartypants.py.git@regex-speedup#egg=smartypants==2.1.0


### PR DESCRIPTION
Implements:
- [x] https://github.com/alphagov/notifications-utils/pull/275

Should be merged not long before/after: https://github.com/alphagov/notifications-api/pull/1481