### PR TITLE
Fix bug when editing letter contact block from letter template page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -58,7 +58,7 @@ def view_template(service_id, template_id):
     if template["template_type"] == "letter":
         letter_contact_details = service_api_client.get_letter_contacts(service_id)
         default_letter_contact_block_id = next(
-            (x['id'] for x in letter_contact_details if x['is_default']), "None"
+            (x['id'] for x in letter_contact_details if x['is_default']), None
         )
     else:
         default_letter_contact_block_id = None

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -29,7 +29,7 @@
       {% endif %}
       {{ page_footer(
         'Add',
-        back_link=url_for('.service_letter_contact_details', service_id=current_service.id),
+        back_link=None if request.args.get('from_template') else url_for('.service_letter_contact_details', service_id=current_service.id),
         back_link_text='Back'
       ) }}
     </form>

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -35,7 +35,11 @@
 <div class="column-whole template-container">
   {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) and template.template_type == 'letter' %}
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
-    <a href="{{ url_for(".service_edit_letter_contact", service_id=current_service.id, letter_contact_id=default_letter_contact_block_id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
+    {% if default_letter_contact_block_id %}
+      <a href="{{ url_for(".service_edit_letter_contact", service_id=current_service.id, letter_contact_id=default_letter_contact_block_id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
+    {% else %}
+      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
+    {% endif %}
   {% endif %}
   {{ template|string }}
 </div>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -198,6 +198,53 @@ def test_should_show_sms_template_with_downgraded_unicode_characters(
     assert rendered_msg in response.get_data(as_text=True)
 
 
+def test_should_let_letter_contact_block_be_edited_if_a_letter_contact_block_exists(
+    mocker,
+    mock_get_service_letter_template,
+    single_letter_contact_block,
+    client_request,
+    service_one,
+    fake_uuid,
+):
+    service_one['permissions'].append('letter')
+    mocker.patch('app.main.views.templates.get_page_count_for_letter', return_value=1)
+
+    page = client_request.get(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid
+    )
+
+    assert page.find('a', {'class': 'edit-template-link-letter-contact'})['href'] == url_for(
+        '.service_edit_letter_contact',
+        service_id=service_one['id'],
+        letter_contact_id='1234',
+        from_template=fake_uuid)
+
+
+def test_should_let_letter_contact_block_be_added_if_no_letter_contact_blocks_exist(
+    mocker,
+    mock_get_service_letter_template,
+    no_letter_contact_blocks,
+    client_request,
+    service_one,
+    fake_uuid,
+):
+    service_one['permissions'].append('letter')
+    mocker.patch('app.main.views.templates.get_page_count_for_letter', return_value=1)
+
+    page = client_request.get(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid
+    )
+
+    assert page.find('a', {'class': 'edit-template-link-letter-contact'})['href'] == url_for(
+        '.service_add_letter_contact',
+        service_id=service_one['id'],
+        from_template=fake_uuid)
+
+
 def test_should_show_page_template_with_priority_select_if_platform_admin(
     logged_in_platform_admin_client,
     platform_admin_user,


### PR DESCRIPTION
When viewing a letter template, there is a button to edit the letter
contact block. This should take the user to the page to edit the letter
contact block, but if a service has not set any letter contact blocks, the
button was returning a 404 error.

The code has now been changed so that if the service has no letter contact
blocks the edit button will link to the page to add a letter contact
block.

<img width="816" alt="screen shot 2017-12-12 at 16 24 35" src="https://user-images.githubusercontent.com/12881990/33896035-bd85004a-df59-11e7-826e-9cf497c158a4.png">


Pivotal story: https://www.pivotaltracker.com/story/show/152881444