### PR TITLE
Remove error-handling code from OK page

### DIFF
--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -80,11 +80,7 @@
 
   {% if count_of_displayed_recipients < count_of_recipients %}
     <p class="table-show-more-link">
-      {% if row_errors and not recipients.missing_column_headers %}
-        Only showing the first {{ count_of_displayed_recipients }} rows with errors
-      {% else %}
-        Only showing the first {{ count_of_displayed_recipients }} rows
-      {% endif %}
+      Only showing the first {{ count_of_displayed_recipients }} rows
     </p>
   {% endif %}
 


### PR DESCRIPTION
`ok.html` is only used when there’s a spreadsheet which doesn’t have any errors in it.