### PR TITLE
Add Marine Management Organisation as email domain

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,7 @@ class Config(object):
         r"acas\.org\.uk",
         r"gov\.wales",
         r"biglotteryfund\.org\.uk",
+        r"marinemanagement\.org\.uk",
     ]
 
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -99,6 +99,7 @@ def _gen_mock_field(x):
     'test@bbsrc.ac.uk',
     'test@acas.org.uk',
     'test@biglotteryfund.org.uk',
+    'test@marinemanagement.org.uk',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
Seems like sometimes they use a Defra email address, sometimes their own .org.uk one.