### PR TITLE
Fix bug horizontal scrollbar being pushed off page

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -62,7 +62,7 @@
     this.maintainHeight = () => {
 
       let height = Math.min(
-        $(window).height() - this.topOffset + $('html, body').scrollTop() + 5,
+        $(window).height() - this.topOffset + $('html, body').scrollTop(),
         this.nativeHeight
       );
 

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -53,4 +53,5 @@
 
 .shim {
   display: block;
+  margin-bottom: 5px;
 }


### PR DESCRIPTION
We weren’t calculating the height quite right; we were trying to compensate for something that should have been compensated for in the `stick-at-top-when-scrolling` code.

Add the 5px to the shim there is required because we’re adding it to the element that the shim in replacing.

# Before 

![screen shot 2017-12-20 at 15 37 16](https://user-images.githubusercontent.com/355079/34214974-e3410430-e59b-11e7-811a-dd49d3313b62.png)

# After 

![screen shot 2017-12-20 at 15 36 54](https://user-images.githubusercontent.com/355079/34214977-e81a9af2-e59b-11e7-99da-e1f79b82c20b.png)
