### PR TITLE
Letters on usage page

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -137,8 +137,12 @@ def usage(service_id):
     free_sms_allowance = billing_api_client.get_free_sms_fragment_limit_for_year(service_id, year)
     units = billing_api_client.get_billable_units(service_id, year)
     yearly_usage = billing_api_client.get_service_usage(service_id, year)
+
+    usage_template = 'views/usage.html'
+    if 'letter' in current_service['permissions']:
+        usage_template = 'views/usage-with-letters.html'
     return render_template(
-        'views/usage.html',
+        usage_template,
         months=list(get_free_paid_breakdown_for_billable_units(
             year,
             free_sms_allowance,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -337,6 +337,11 @@ def calculate_usage(usage, free_sms_fragment_limit):
     emails = [breakdown["billing_units"] for breakdown in usage if breakdown['notification_type'] == 'email']
     emails_sent = 0 if len(emails) == 0 else emails[0]
 
+    letters = [(breakdown["billing_units"], breakdown['letter_total']) for breakdown in usage if
+               breakdown['notification_type'] == 'letter']
+    letter_sent = 0 if len(letters) == 0 else letters[0][0]
+    letter_cost = 0 if len(letters) == 0 else letters[0][1]
+
     return {
         'emails_sent': emails_sent,
         'sms_free_allowance': sms_free_allowance,
@@ -344,6 +349,8 @@ def calculate_usage(usage, free_sms_fragment_limit):
         'sms_allowance_remaining': max(0, (sms_free_allowance - sms_sent)),
         'sms_chargeable': max(0, sms_sent - sms_free_allowance),
         'sms_rate': sms_rate,
+        'letter_sent': letter_sent,
+        'letter_cost': letter_cost
     }
 
 
@@ -409,10 +416,16 @@ def get_free_paid_breakdown_for_billable_units(year, free_sms_fragment_limit, bi
             free_sms_fragment_limit, cumulative, previous_cumulative,
             [billing_month for billing_month in sms_units if billing_month['month'] == month]
         )
-        letter_billing = [(x['billing_units'], x['rate']) for x in letter_units if x['month'] == month]
+        letter_billing = [(x['billing_units'], x['rate'], (x['billing_units'] * x['rate']))
+                          for x in letter_units if x['month'] == month]
+        letter_total = 0
+        for x in letter_billing:
+            letter_total += x[2]
+            letter_cumulative += letter_total
         yield {
             'name': month,
-            # 'total': sms + letter
+            'letter_total': letter_total,
+            'letter_cumulative': letter_cumulative,
             'paid': breakdown['paid'],
             'free': breakdown['free'],
             'letters': letter_billing

--- a/app/templates/views/usage-with-letters.html
+++ b/app/templates/views/usage-with-letters.html
@@ -17,14 +17,14 @@
     </div>
     <div id='pill-selected-item'>
       <div class='grid-row'>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
             {{ big_number(emails_sent, 'sent', smaller=True) }}
             {{ big_number("Unlimited", 'free allowance', smaller=True) }}
           </div>
         </div>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <h2 class='heading-small'>Text messages</h2>
           <div class="keyline-block">
             {{ big_number(sms_sent, 'sent', smaller=True) }}
@@ -39,15 +39,21 @@
             {% endif %}
           </div>
         </div>
+        <div class='column-one-third'>
+          <h2 class='heading-small'>Letters</h2>
+          <div class="keyline-block">
+            {{ big_number(letter_sent, 'sent', smaller=True) }}
+          </div>
+        </div>
       </div>
 
       <div class='grid-row'>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <div class="keyline-block">
             &nbsp;
           </div>
         </div>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <div class="keyline-block">
             {{ big_number(
               (sms_chargeable * sms_rate),
@@ -57,6 +63,17 @@
             ) }}
           </div>
         </div>
+        <div class='column-one-third'>
+          <div class="keyline-block">
+            {{ big_number(
+                letter_cost,
+                'spent',
+                currency="£",
+                smaller=True
+              ) }}
+          </div>
+        </div>
+
       </div>
 
       {% if months %}
@@ -77,11 +94,11 @@
             {% endcall %}
             {% call field(align='left') %}
               {{ big_number(
-                sms_rate * month.paid,
+                (sms_rate * month.paid) + month.letter_total,
                 currency="£",
                 smallest=True
               ) }}
-              <ul>
+          <ul>
               {% if month.free %}
                 <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
               {% endif %}
@@ -93,6 +110,14 @@
                 <li aria-hidden="true">–</li>
               {% endif %}
               </ul>
+             <ul>
+              {% for letter in month.letters%}
+                {% if letter[0] %}
+                <li class="tabular-numbers">{{ "{:,}".format(letter[0])}} letters at {{ '{:.0f}p'.format(letter[1] * 100) }}
+                </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
             {% endcall %}
           {% endcall %}
         </div>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -81,7 +81,7 @@
                 currency="£",
                 smallest=True
               ) }}
-              <ul>
+          <ul>
               {% if month.free %}
                 <li class="tabular-numbers">{{ "{:,}".format(month.free) }} free text messages</li>
               {% endif %}
@@ -93,6 +93,15 @@
                 <li aria-hidden="true">–</li>
               {% endif %}
               </ul>
+             <ul>
+               {{ month.letters }}
+              {% for letter in month.letters%}
+                {% if letter[0] %}
+                <li class="tabular-numbers">{{ letter[0]}} letters at {{ ' {:.0f}p'.format(letter[1] * 100) }}
+                </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
             {% endcall %}
           {% endcall %}
         </div>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -17,14 +17,14 @@
     </div>
     <div id='pill-selected-item'>
       <div class='grid-row'>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
             {{ big_number(emails_sent, 'sent', smaller=True) }}
             {{ big_number("Unlimited", 'free allowance', smaller=True) }}
           </div>
         </div>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <h2 class='heading-small'>Text messages</h2>
           <div class="keyline-block">
             {{ big_number(sms_sent, 'sent', smaller=True) }}
@@ -39,15 +39,21 @@
             {% endif %}
           </div>
         </div>
+        <div class='column-one-third'>
+          <h2 class='heading-small'>Letters</h2>
+          <div class="keyline-block">
+            {{ big_number(letter_sent, 'sent', smaller=True) }}
+          </div>
+        </div>
       </div>
 
       <div class='grid-row'>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <div class="keyline-block">
             &nbsp;
           </div>
         </div>
-        <div class='column-half'>
+        <div class='column-one-third'>
           <div class="keyline-block">
             {{ big_number(
               (sms_chargeable * sms_rate),
@@ -57,6 +63,17 @@
             ) }}
           </div>
         </div>
+        <div class='column-one-third'>
+          <div class="keyline-block">
+            {{ big_number(
+                letter_cost,
+                'spent',
+                currency="£",
+                smaller=True
+              ) }}
+          </div>
+        </div>
+
       </div>
 
       {% if months %}
@@ -77,7 +94,7 @@
             {% endcall %}
             {% call field(align='left') %}
               {{ big_number(
-                sms_rate * month.paid,
+                (sms_rate * month.paid) + month.letter_total,
                 currency="£",
                 smallest=True
               ) }}
@@ -94,10 +111,9 @@
               {% endif %}
               </ul>
              <ul>
-               {{ month.letters }}
               {% for letter in month.letters%}
                 {% if letter[0] %}
-                <li class="tabular-numbers">{{ letter[0]}} letters at {{ ' {:.0f}p'.format(letter[1] * 100) }}
+                <li class="tabular-numbers">{{ "{:,}".format(letter[0])}} letters at {{ '{:.0f}p'.format(letter[1] * 100) }}
                 </li>
                 {% endif %}
               {% endfor %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -601,7 +601,7 @@ def test_usage_page(
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-    cols = page.find_all('div', {'class': 'column-half'})
+    cols = page.find_all('div', {'class': 'column-one-third'})
     nav = page.find('ul', {'class': 'pill', 'role': 'tablist'})
     nav_links = nav.find_all('a')
 
@@ -616,14 +616,14 @@ def test_usage_page(
     assert '249,860 free text messages' in table
     assert '40 free text messages' in table
     assert '960 text messages at 1.65p' in table
-
     assert 'April' in table
     assert 'February' in table
     assert 'March' in table
-    assert '£15.84' in table
+    assert '£18.94' in table
     assert '140 free text messages' in table
     assert '£20.30' in table
     assert '1,230 text messages at 1.65p' in table
+    assert '10 letters at 31p' in table
 
 
 def test_usage_page_with_year_argument(
@@ -986,18 +986,18 @@ def test_get_free_paid_breakdown_for_billable_units(now, expected_number_of_mont
             ]
         )
         assert list(billing_units) == [
-            {'free': 100000, 'name': 'April', 'paid': 0},
-            {'free': 100000, 'name': 'May', 'paid': 0},
-            {'free': 50000, 'name': 'June', 'paid': 50000},
-            {'free': 0, 'name': 'July', 'paid': 0},
-            {'free': 0, 'name': 'August', 'paid': 0},
-            {'free': 0, 'name': 'September', 'paid': 0},
-            {'free': 0, 'name': 'October', 'paid': 0},
-            {'free': 0, 'name': 'November', 'paid': 0},
-            {'free': 0, 'name': 'December', 'paid': 0},
-            {'free': 0, 'name': 'January', 'paid': 0},
-            {'free': 0, 'name': 'February', 'paid': 2000},
-            {'free': 0, 'name': 'March', 'paid': 0}
+            {'free': 100000, 'name': 'April', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 100000, 'name': 'May', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 50000, 'name': 'June', 'paid': 50000, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'July', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'August', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'September', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'October', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'November', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'December', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'January', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'February', 'paid': 2000, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 0, 'name': 'March', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0}
         ][:expected_number_of_months]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2155,7 +2155,14 @@ def mock_get_billable_units(mocker):
                 'rate': 0.0165,
                 'billing_units': 100
             },
-
+            {
+                'month': 'February',
+                'international': False,
+                'rate_multiplier': 1,
+                'notification_type': 'letter',
+                'rate': 0.31,
+                'billing_units': 10
+            }
         ]
 
     return mocker.patch(


### PR DESCRIPTION
This PR add the letter data on the usage page. 
Monthly billing now contains letter data. 
If the service has the letter permission the usage page will show the letter usage data. Otherwise the letter data will not show up on the page. 
