### PR TITLE
Specify domain to use for invite links

### DIFF
--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -9,6 +9,7 @@ class InviteApiClient(NotifyAdminAPIClient):
 
     def init_app(self, app):
         self.base_url = app.config['API_HOST_NAME']
+        self.admin_url = app.config['ADMIN_BASE_URL']
         self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
         self.api_key = app.config['ADMIN_CLIENT_SECRET']
 
@@ -18,7 +19,8 @@ class InviteApiClient(NotifyAdminAPIClient):
             'email_address': email_address,
             'from_user': invite_from_id,
             'permissions': permissions,
-            'auth_type': auth_type
+            'auth_type': auth_type,
+            'invite_link_host': self.admin_url,
         }
         data = _attach_current_user(data)
         resp = self.post(url='/service/{}/invite'.format(service_id), data=data)

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -1,4 +1,40 @@
-from app.notify_client.invite_api_client import InviteApiClient
+from unittest.mock import ANY
+from app import invite_api_client
+
+
+def test_client_creates_invite(
+    app_,
+    mocker,
+    fake_uuid,
+    sample_invite,
+):
+
+    mocker.patch('app.notify_client.current_user')
+
+    mock_post = mocker.patch(
+        'app.invite_api_client.post',
+        return_value={'data': dict.fromkeys({
+            'id', 'service', 'from_user', 'email_address',
+            'permissions', 'status', 'created_at', 'auth_type'
+        })}
+    )
+
+    invite_api_client.create_invite(
+        '12345', '67890', 'test@example.com', 'send_messages', 'sms_auth'
+    )
+
+    mock_post.assert_called_once_with(
+        url='/service/{}/invite'.format('67890'),
+        data={
+            'auth_type': 'sms_auth',
+            'email_address': 'test@example.com',
+            'from_user': '12345',
+            'service': '67890',
+            'created_by': ANY,
+            'permissions': 'send_messages',
+            'invite_link_host': 'http://localhost:6012',
+        }
+    )
 
 
 def test_client_returns_invite(mocker, sample_invite):
@@ -10,10 +46,9 @@ def test_client_returns_invite(mocker, sample_invite):
 
     expected_url = '/service/{}/invite'.format(service_id)
 
-    client = InviteApiClient()
     mock_get = mocker.patch('app.notify_client.invite_api_client.InviteApiClient.get', return_value=expected_data)
 
-    invites = client.get_invites_for_service(service_id)
+    invites = invite_api_client.get_invites_for_service(service_id)
 
     mock_get.assert_called_once_with(expected_url)
     assert len(invites) == 1


### PR DESCRIPTION
When we’re doing user research we often:
- start the task by inviting the participant to a service on Notify
- have them use a prototype version of the admin app, hosted on a different domain

Currently we can’t do both of these things together, because the invite emails always send people to notifications.service.gov.uk (because it’s the API that sends the emails, and the prototype admin app points at the production API).

This commit changes the admin app to tell the API which host to use when creating the invite links.

---

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/1515