### PR TITLE
Make email addresses case insensitive when inviting users to services

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -38,7 +38,7 @@ def accept_invite(token):
 
     invited_user = invite_api_client.check_token(token)
 
-    if not current_user.is_anonymous and current_user.email_address != invited_user.email_address:
+    if not current_user.is_anonymous and current_user.email_address.lower() != invited_user.email_address.lower():
         message = Markup("""
             You’re signed in as {}.
             This invite is for another email address.

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -40,7 +40,7 @@ def sign_in():
 
         if user and session.get('invited_user'):
             invited_user = session.get('invited_user')
-            if user.email_address != invited_user['email_address']:
+            if user.email_address.lower() != invited_user['email_address'].lower():
                 flash("You can't accept an invite for another person.")
                 session.pop('invited_user', None)
                 abort(403)


### PR DESCRIPTION
Email addresses in invites should be case insensitive. This is to stop
the bug where a user creates their account using a lower case email
address (e.g. user1@gov.uk), but is then invited to a service using
their email address in a different case (e.g. USER1.gov.uk) and sees
an error message telling them that they can't accept an invite for a
different email address.

[Pivotal story](https://www.pivotaltracker.com/n/projects/1443052/stories/153825749)