### PR TITLE
Force example CSV to download, not open in browser

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -31,7 +31,7 @@
           </p>
         {% elif notifications %}
           <p class="bottom-gutter">
-            <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+            <a href="{{ download_link }}" download class="heading-small">Download this report</a>
             &emsp;
             <span id="time-left">{{ time_left }}</span>
           </p>

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -39,7 +39,7 @@
       {% if template.template_type != 'letter' or not request.args.from_test %}
       <input type="submit" class="button" value="Send {{ count_of_recipients }} {{ message_count_label(count_of_recipients, template.template_type, suffix='') }}" />
       {% else %}
-        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="button">Download as a printable PDF</a>
+        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download class="button">Download as a printable PDF</a>
       {% endif %}
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
     </form>

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -4,7 +4,7 @@
 <div class="ajax-block-container">
   {% if messages %}
     <p class="bottom-gutter-2-3 top-gutter-2-3">
-      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download="download" class="heading-small">Download these messages</a>
+      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="heading-small">Download these messages</a>
     </p>
   {% endif %}
   {% call(item, row_number) list_table(

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -53,7 +53,7 @@
         {% if template.template_type != 'letter' or not request.args.from_test %}
         <input type="submit" class="button" value="Send 1 {{ message_count_label(1, template.template_type, suffix='') }}" />
         {% else %}
-          <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download="download" class="button">Download as a printable PDF</a>
+          <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, filetype='pdf') }}" download class="button">Download as a printable PDF</a>
         {% endif %}
       {% endif %}
       <a href="{{ back_link }}" class="page-footer-back-link">Back</a>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -35,7 +35,7 @@
         Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
       </p>
       <p class="bottom-gutter">
-        <a href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download="download">Download as a PDF</a>
+        <a href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download>Download as a PDF</a>
       </p>
     {% endif %}
 

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -40,7 +40,7 @@
     {% endcall %}
   </div>
   <p class="table-show-more-link">
-    <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}">Download this example</a>
+    <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download="download">Download this example</a>
   </p>
 
   <h2 class="heading-medium">Your file will populate this template ({{ template.name }})</h2>

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -40,7 +40,7 @@
     {% endcall %}
   </div>
   <p class="table-show-more-link">
-    <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download="download">Download this example</a>
+    <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download>Download this example</a>
   </p>
 
   <h2 class="heading-medium">Your file will populate this template ({{ template.name }})</h2>

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -97,7 +97,7 @@ def test_should_show_page_for_one_job(
         job_id=fake_uuid,
         status=status_argument,
     )
-    csv_link = page.find('a', {'download': 'download'})
+    csv_link = page.select_one('a[download]')
     assert csv_link['href'] == url_for(
         'main.view_job_csv',
         service_id=service_one['id'],


### PR DESCRIPTION
We wouldn’t wan’t anyone just seeing the raw CSV data in their browser – it isn’t clear what a user would do with it at that point. And we wouldn’t want it navigating them away from the send page, because this might cause them to lose their place.

This commit forces the file to download using the HTML5 `download` attribute:

> This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. 

– https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download