### PR TITLE
Lint for print statements

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -4,7 +4,7 @@ from flask import current_app
 def list_routes():
     """List URLs of all application routes."""
     for rule in sorted(current_app.url_map.iter_rules(), key=lambda r: r.rule):
-        print("{:10} {}".format(", ".join(rule.methods - set(['OPTIONS', 'HEAD'])), rule.rule))
+        print("{:10} {}".format(", ".join(rule.methods - set(['OPTIONS', 'HEAD'])), rule.rule))  # noqa
 
 
 def setup_commands(application):

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -8,3 +8,4 @@ httpretty==0.8.14
 beautifulsoup4==4.6.0
 freezegun==0.3.9
 flake8==3.5.0
+flake8-print==3.0.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,7 +28,7 @@ if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
 
-flake8 .
+flake8 --enable=T .
 display_result $? 1 "Code style check"
 
 npm test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -368,7 +368,6 @@ def validate_route_permission(mocker,
             else:
                 pytest.fail("Invalid method call {}".format(method))
             if resp.status_code != response_code:
-                print(resp.status_code)
                 pytest.fail("Invalid permissions set for endpoint {}".format(route))
     return resp
 
@@ -403,6 +402,5 @@ def validate_route_permission_with_client(mocker,
     else:
         pytest.fail("Invalid method call {}".format(method))
     if resp.status_code != response_code:
-        print(resp.status_code)
         pytest.fail("Invalid permissions set for endpoint {}".format(route))
     return resp


### PR DESCRIPTION
flake8-print is a flake8 plugin that checks for `print()` statements in Python files.

This should save us having to manually spot these when reviewing pull requests.

The `--enable=T` flag needs to be set until this bug is fixed: https://github.com/JBKahn/flake8-print/issues/27