### PR TITLE
Add British Museum to whitelist

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,7 @@ class Config(object):
         r"gov\.wales",
         r"biglotteryfund\.org\.uk",
         r"marinemanagement\.org\.uk",
+        r"britishmuseum\.org",
     ]
 
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -100,6 +100,7 @@ def _gen_mock_field(x):
     'test@acas.org.uk',
     'test@biglotteryfund.org.uk',
     'test@marinemanagement.org.uk',
+    'test@britishmuseum.org',
 ])
 def test_valid_list_of_white_list_email_domains(
     client,


### PR DESCRIPTION
> BM is an executive non-departmental public body, sponsored by the Department for Digital, Culture, Media & Sport.
>
> British Museum has a separate website (http://www.britishmuseum.org)

– https://www.gov.uk/government/organisations/british-museum