### PR TITLE
Fix spacing of table footers

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -149,6 +149,8 @@ details summary {
 
 .spreadsheet {
 
+  margin-bottom: -$gutter;
+
   th,
   .table-field-index {
     background: $grey-4;

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -130,9 +130,16 @@
   }
 
   &-shim {
+
     width: 100%;
     position: relative;
     z-index: 9;
+    margin-bottom: 30px;
+
+    & + .table-show-more-link {
+      margin-top: -28px;
+    }
+
   }
 
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -230,12 +230,18 @@
 }
 
 .table-show-more-link {
+
   @include core-16;
   color: $secondary-text-colour;
   margin-bottom: $gutter * 1.3333;
   border-bottom: 1px solid $border-colour;
   padding: 10px 0 10px 0;
   text-align: center;
+
+  .table + & {
+    margin-top: -$gutter;
+  }
+
 }
 
 a.table-show-more-link {


### PR DESCRIPTION
When implementing the horizontally scrollable tables I messed up the spacing above the text that says “Only showing the first 50 rows”, where it’s displayed below a table that doesn’t have horizontal scrolling.

This PR makes the spacing correct in all these cases:

# Example spreadsheet

![image](https://user-images.githubusercontent.com/355079/35447595-082fb436-02b0-11e8-912f-d396061daad1.png)

# Uploaded file with no horizontal overflow

![image](https://user-images.githubusercontent.com/355079/35447668-347faffa-02b0-11e8-8b7b-c675e73ee22f.png)

# Uploaded file with horizontal overflow

![image](https://user-images.githubusercontent.com/355079/35447699-463446fc-02b0-11e8-8d73-20ec2201fcec.png)

