### PR TITLE
Simplified to links to guidance in the service manual

### DIFF
--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -23,7 +23,7 @@
           specified your reply to email address or text message sender in your
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
         <li>
-          added the templates you want to start with, making sure they follow the GOV.UK service maunal standards for 
+          added the templates you want to start with, making sure they follow the GOV.UK service manual standards for 
           <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
       </ul>
 

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -23,12 +23,8 @@
           specified your reply to email address or text message sender in your
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
         <li>
-          added the templates you want to start with, making sure they follow our
-          <a href="https://www.gov.uk/service-manual/design/using-adapting-and-creating-patterns" rel="external">design patterns</a>,
-          <a href="https://www.gov.uk/guidance/style-guide" rel="external">style guide</a>
-          and
-          <a href="https://www.gov.uk/service-manual/technology/securing-your-information" rel="external">information security guidelines</a>
-          </li>
+          added the templates you want to start with, making sure they follow the GOV.UK service maunal standards for 
+          <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
       </ul>
 
       <form method="post">

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -23,7 +23,7 @@
           specified your reply to email address or text message sender in your
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
         <li>
-          added the templates you want to start with, making sure they follow the GOV.UK service manual standards for 
+          added the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for 
           <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
       </ul>
 

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -39,7 +39,7 @@ Terms of use
       <li>get the right levels of consent (to send messages and to use data)</li>
       <li>not send unsolicited messages, only ones related to a transaction or something the user has subscribed to be updated about (<a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">check the Service Manual</a> if you’re not sure)</li>
       <li>
-        send messages that meet the GOV.UK <a href="https://www.gov.uk/service-manual/design/using-adapting-and-creating-patterns">design patterns</a>, <a href="https://www.gov.uk/guidance/style-guide">style guide</a> and <a href="https://www.gov.uk/service-manual/technology/securing-your-information">information security guidelines</a></li>
+        send messages that meet the GOV.UK service maunal standards for <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
       <li>not send messages containing any personally or commercially sensitive information</li>
       <li>check that the data you add to Notify is accurate and complies with Data Protection Act principles</li>
     </ul>

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -39,7 +39,7 @@ Terms of use
       <li>get the right levels of consent (to send messages and to use data)</li>
       <li>not send unsolicited messages, only ones related to a transaction or something the user has subscribed to be updated about (<a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">check the Service Manual</a> if you’re not sure)</li>
       <li>
-        send messages that meet the GOV.UK service maunal standards for <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
+        send messages that meet the GOV.UK Service Manual standards for <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
       <li>not send messages containing any personally or commercially sensitive information</li>
       <li>check that the data you add to Notify is accurate and complies with Data Protection Act principles</li>
     </ul>


### PR DESCRIPTION
Some strange pages to be linking to. Most of the things we are trying to say are now covered on this page https://www.gov.uk/service-manual/design/sending-emails-and-text-messages, so much tidier and more effective to link just to that.