### PR TITLE
Fix 500 error from notifications/letter.json page

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -42,6 +42,10 @@
       <input type="hidden" name="to" value="{{ search_form.to.data }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     </form>
+  {% else %}
+    <form id="search-form" method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    </form>
   {% endif %}
     <!--<p class="bottom-gutter">-->
        <!--<a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>-->


### PR DESCRIPTION
The letters notification page makes ajax calls to update the status - these
were failing because it's making a POST request without a CSRF token.
(The email and SMS notification pages contain a search form that includes
the hidden CSRF input, so this was only occurring with the letters
page.)

This commit adds a hidden form for the letters page which just contains
the CSRF token.