### PR TITLE
Add links to navigate to/from callbacks page

### DIFF
--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -30,4 +30,8 @@
 	    {% endcall %}
 	  {% endcall %}
 	</div>
+  {{ page_footer(
+    secondary_link=url_for('.api_integration', service_id=current_service.id),
+    secondary_link_text='Back to API integration'
+  ) }}
 {% endblock %}

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -19,6 +19,12 @@
           If you want to turn this feature off,
           <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
         </p>
+        {% if current_user.has_permissions(['manage_api_keys'], admin_override=True) %}
+          <p>
+            You can set up callbacks for received text messages on the
+            <a href="{{ url_for('.api_callbacks', service_id=current_service.id) }}">API integration page</a>.
+          </p>
+        {% endif %}
       {% else %}
         <p>
           Receiving text messages from your users is an

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -11,6 +11,7 @@ from app.utils import email_safe
 from tests import validate_route_permission, service_json
 from tests.conftest import (
     active_user_with_permissions,
+    active_user_no_api_key_permission,
     platform_admin_user,
     normalize_spaces,
     multiple_reply_to_email_addresses,
@@ -1925,6 +1926,41 @@ def test_set_inbound_sms_when_inbound_number_is_not_set(
         'main.service_set_inbound_sms', service_id=service_one['id']
     ))
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize('user, expected_paragraphs', [
+    (active_user_with_permissions, [
+        'Your service can receive text messages sent to 07700900123.',
+        'If you want to turn this feature off, get in touch with the GOV.UK Notify team.',
+        'You can set up callbacks for received text messages on the API integration page.',
+    ]),
+    (active_user_no_api_key_permission, [
+        'Your service can receive text messages sent to 07700900123.',
+        'If you want to turn this feature off, get in touch with the GOV.UK Notify team.',
+    ]),
+])
+def test_set_inbound_sms_when_inbound_number_is_set(
+    client,
+    service_one,
+    mocker,
+    fake_uuid,
+    user,
+    expected_paragraphs,
+):
+    service_one['permissions'] = ['inbound_sms']
+    mocker.patch('app.inbound_number_client.get_inbound_sms_number_for_service', return_value={
+        'data': {'number': '07700900123'}
+    })
+    client.login(user(fake_uuid), mocker, service_one)
+    response = client.get(url_for(
+        'main.service_set_inbound_sms', service_id=SERVICE_ONE_ID
+    ))
+    paragraphs = BeautifulSoup(response.data.decode('utf-8'), 'html.parser').select('main p')
+
+    assert len(paragraphs) == len(expected_paragraphs)
+
+    for index, p in enumerate(expected_paragraphs):
+        assert normalize_spaces(paragraphs[index].text) == p
 
 
 def test_empty_letter_contact_block_returns_error(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1236,6 +1236,31 @@ def active_user_manage_template_permission(fake_uuid):
     return user
 
 
+@pytest.fixture
+def active_user_no_api_key_permission(fake_uuid):
+    from app.notify_client.user_api_client import User
+
+    user_data = {
+        'id': fake_uuid,
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'manage_templates',
+            'manage_settings',
+            'view_activity',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth'
+    }
+    user = User(user_data)
+    return user
+
+
 @pytest.fixture(scope='function')
 def api_user_locked(fake_uuid):
     from app.notify_client.user_api_client import User


### PR DESCRIPTION
# Link to callbacks from inbound page

If you’ve got an inbound number and are using the API you’ll probably be interested in this new feature we’ve got. And if you do know about it, you might not be able to find it because we’ve moved it.

# Add link back to API integration from callbacks 

Matches what we do on the API keys and whitelist pages.