### PR TITLE
Update request to go live flow with new features

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -534,15 +534,9 @@ class RequestToGoLiveForm(StripWhitespaceForm):
         'Will the number of messages increase and when will that start?',
         validators=[DataRequired(message='Can’t be empty')]
     )
-    upload_or_api = RadioField(
-        'How are you going to send messages?',
-        choices=[
-            ('File upload', 'Upload a spreadsheet of recipients'),
-            ('API', 'Integrate with the GOV.UK Notify API'),
-            ('API and file upload', 'Both')
-        ],
-        validators=[DataRequired()]
-    )
+    method_one_off = BooleanField('One at a time')
+    method_upload = BooleanField('Upload a spreadsheet of recipients')
+    method_api = BooleanField('Integrate with the GOV.UK Notify API')
 
 
 class ProviderForm(StripWhitespaceForm):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -153,7 +153,6 @@ def service_request_to_go_live(service_id):
     form = RequestToGoLiveForm()
 
     if form.validate_on_submit():
-
         data = {
             'person_email': current_user.email_address,
             'person_name': current_user.name,
@@ -161,13 +160,17 @@ def service_request_to_go_live(service_id):
             'agent_team_id': current_app.config.get('DESKPRO_ASSIGNED_AGENT_TEAM_ID'),
             'subject': 'Request to go live - {}'.format(current_service['name']),
             'message': (
-                'On behalf of {} ({})\n\nExpected usage\n---'
+                'On behalf of {} ({})\n'
+                '\n---'
+                '\nOrganisation type: {} ({:,} free text messages)'
                 '\nMOU in place: {}'
                 '\nChannel: {}\nStart date: {}\nStart volume: {}'
                 '\nPeak volume: {}\nUpload or API: {}'
             ).format(
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
+                current_service['organisation_type'],
+                current_service['free_sms_fragment_limit'],
                 form.mou.data,
                 formatted_list(filter(None, (
                     'email' if form.channel_email.data else None,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -165,7 +165,8 @@ def service_request_to_go_live(service_id):
                 '\nOrganisation type: {} ({:,} free text messages)'
                 '\nMOU in place: {}'
                 '\nChannel: {}\nStart date: {}\nStart volume: {}'
-                '\nPeak volume: {}\nUpload or API: {}'
+                '\nPeak volume: {}'
+                '\nFeatures: {}'
             ).format(
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
@@ -180,7 +181,11 @@ def service_request_to_go_live(service_id):
                 form.start_date.data,
                 form.start_volume.data,
                 form.peak_volume.data,
-                form.upload_or_api.data
+                formatted_list(filter(None, (
+                    'one off' if form.method_one_off.data else None,
+                    'file upload' if form.method_upload.data else None,
+                    'API' if form.method_api.data else None,
+                )), before_each='', after_each='')
 
             )
         }

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -44,9 +44,12 @@
           {{ textbox(form.start_date, width='1-1') }}
           {{ textbox(form.start_volume, width='1-1', hint='For example, ‘1000 a month’.') }}
           {{ textbox(form.peak_volume, width='1-1', hint='For example, ‘Messages will increase to 20,000 a month in January’.') }}
-          {{ radios(form.upload_or_api) }}
         </div>
-
+        {{ checkbox_group('How are you going to send messages?', [
+          form.method_one_off,
+          form.method_upload,
+          form.method_api
+        ]) }}
         <p>
           Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.
         </p>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -434,6 +434,14 @@ def test_should_show_request_to_go_live(
         assert normalize_spaces(
             page.select_one('label[for=channel_{}]'.format(channel)).text
         ) == label
+    for feature, label in (
+        ('one_off', 'One at a time'),
+        ('upload', 'Upload a spreadsheet of recipients'),
+        ('api', 'Integrate with the GOV.UK Notify API'),
+    ):
+        assert normalize_spaces(
+            page.select_one('label[for=method_{}]'.format(feature)).text
+        ) == label
 
 
 def test_should_redirect_after_request_to_go_live(
@@ -459,7 +467,9 @@ def test_should_redirect_after_request_to_go_live(
             'start_date': '01/01/2017',
             'start_volume': '100,000',
             'peak_volume': '2,000,000',
-            'upload_or_api': 'API'
+            'method_one_off': 'y',
+            'method_upload': 'y',
+            'method_api': 'y',
         },
         _follow_redirects=True
     )
@@ -483,7 +493,7 @@ def test_should_redirect_after_request_to_go_live(
     assert 'Start date: 01/01/2017' in returned_message
     assert 'Start volume: 100,000' in returned_message
     assert 'Peak volume: 2,000,000' in returned_message
-    assert 'Upload or API: API' in returned_message
+    assert 'Features: one off, file upload and API' in returned_message
 
     assert normalize_spaces(page.select_one('.banner-default').text) == (
         'We’ve received your request to go live'

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -477,6 +477,8 @@ def test_should_redirect_after_request_to_go_live(
     )
 
     returned_message = mock_post.call_args[1]['data']['message']
+    assert 'On behalf of service one' in returned_message
+    assert 'Organisation type: central (250,000 free text messages)' in returned_message
     assert 'Channel: email and text messages' in returned_message
     assert 'Start date: 01/01/2017' in returned_message
     assert 'Start volume: 100,000' in returned_message


### PR DESCRIPTION
# Include organisation type in request to go live tickets

This is so we can catch organisations that are going live with the wrong free text message allowance. Organisation type wasn’t a thing until recently.

#  Add option for one off sending in request to go live

When we first made this form you couldn’t send one off messages with Notify. It’s interesting to us because it might help identity teams who would benefit from email auth, or other features that we build in the future for caseworkers.

---

![image](https://user-images.githubusercontent.com/355079/34868645-5b1fafa0-f77c-11e7-9677-8ef2aa97d3de.png)
