### PR TITLE
Refactor user permissions decorator

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -20,15 +20,8 @@ from app.main.forms import (
     PermissionsForm
 )
 from app import (user_api_client, current_service, service_api_client, invite_api_client)
+from app.notify_client.models import roles
 from app.utils import user_has_permissions
-
-
-roles = {
-    'send_messages': ['send_texts', 'send_emails', 'send_letters'],
-    'manage_templates': ['manage_templates'],
-    'manage_service': ['manage_users', 'manage_settings'],
-    'manage_api_keys': ['manage_api_keys']
-}
 
 
 @main.route("/services/<service_id>/users")

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -92,10 +92,9 @@ def edit_user_permissions(service_id, user_id):
     user_has_no_mobile_number = user.mobile_number is None
 
     form = PermissionsForm(
-        **{role: user.has_permissions(permissions=permissions) for role, permissions in roles.items()},
+        **{role: user.has_permissions(*permissions) for role, permissions in roles.items()},
         login_authentication=user.auth_type
     )
-
     if form.validate_on_submit():
         user_api_client.set_user_permissions(
             user_id, service_id,
@@ -122,7 +121,7 @@ def remove_user_from_service(service_id, user_id):
     # Need to make the email address read only, or a disabled field?
     # Do it through the template or the form class?
     form = PermissionsForm(**{
-        role: user.has_permissions(permissions=permissions) for role, permissions in roles.items()
+        role: user.has_permissions(*permissions) for role, permissions in roles.items()
     })
 
     if request.method == 'POST':

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -354,7 +354,7 @@ def add_service_template(service_id, template_type):
 
 
 def abort_403_if_not_admin_user():
-    if not current_user.has_permissions([], admin_override=True):
+    if not current_user.has_permissions(admin_override=True):
         abort(403)
 
 

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -91,7 +91,8 @@ class User(UserMixin):
     def permissions(self, permissions):
         raise AttributeError("Read only property")
 
-    def has_permissions(self, permissions=[], any_=False, admin_override=False):
+    def has_permissions(self, *permissions, any_=False, admin_override=False):
+
         # Only available to the platform admin user
         if admin_override and self.platform_admin:
             return True
@@ -166,7 +167,7 @@ class InvitedUser(object):
         self.created_at = created_at
         self.auth_type = auth_type
 
-    def has_permissions(self, permissions):
+    def has_permissions(self, *permissions):
         return set(self.permissions) > set(permissions)
 
     def __eq__(self, other):

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from flask_login import UserMixin, AnonymousUserMixin
 from flask import session
 
@@ -8,6 +9,8 @@ roles = {
     'manage_service': ['manage_users', 'manage_settings'],
     'manage_api_keys': ['manage_api_keys']
 }
+
+all_permissions = set(chain.from_iterable(roles.values())) | {'view_activity'}
 
 
 class User(UserMixin):
@@ -100,6 +103,11 @@ class User(UserMixin):
         raise AttributeError("Read only property")
 
     def has_permissions(self, *permissions, any_=False, admin_override=False):
+
+        unknown_permissions = set(permissions) - all_permissions
+
+        if unknown_permissions:
+            raise TypeError('{} are not valid permissions'.format(unknown_permissions))
 
         # Only available to the platform admin user
         if admin_override and self.platform_admin:

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -2,6 +2,14 @@ from flask_login import UserMixin, AnonymousUserMixin
 from flask import session
 
 
+roles = {
+    'send_messages': ['send_texts', 'send_emails', 'send_letters'],
+    'manage_templates': ['manage_templates'],
+    'manage_service': ['manage_users', 'manage_settings'],
+    'manage_api_keys': ['manage_api_keys']
+}
+
+
 class User(UserMixin):
     def __init__(self, fields, max_failed_login_count=3):
         self._id = fields.get('id')

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -44,17 +44,17 @@
 <nav class="navigation">
   <ul>
     <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
-  {% if current_user.has_permissions(['view_activity', 'manage_templates', 'manage_api_keys'], admin_override=True, any_=True) %}
+  {% if current_user.has_permissions('view_activity', 'manage_templates', 'manage_api_keys', admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
   {% endif %}
-  {% if current_user.has_permissions(['manage_users', 'manage_settings'], admin_override=True) %}
+  {% if current_user.has_permissions('manage_users', 'manage_settings', admin_override=True) %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
-  {% elif current_user.has_permissions(['view_activity']) %}
+  {% elif current_user.has_permissions('view_activity') %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
-  {% if current_user.has_permissions(['manage_api_keys'], admin_override=True) %}
+  {% if current_user.has_permissions('manage_api_keys', admin_override=True) %}
     <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
   {% endif %}
   </ul>

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -22,7 +22,7 @@
       'messages',
     ) }}
 
-    {% if current_user.has_permissions(['send_texts'], admin_override=True) %}
+    {% if current_user.has_permissions('send_texts', admin_override=True) %}
       <p class="sms-message-reply-link">
         <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
       </p>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -15,11 +15,11 @@
   <div class="dashboard">
 
     <h1 class="visuallyhidden">Dashboard</h1>
-    {% if current_user.has_permissions(['manage_templates'], admin_override=True) %}
+    {% if current_user.has_permissions('manage_templates', admin_override=True) %}
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}
       {% endif %}
-    {% elif not current_user.has_permissions(['send_texts', 'send_emails', 'send_letters', 'manage_api_keys'], any_=True) %}
+    {% elif not current_user.has_permissions('send_texts', 'send_emails', 'send_letters', 'manage_api_keys', any_=True) %}
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -19,7 +19,7 @@
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
-          {% if current_user.has_permissions([], admin_override=True) %}
+          {% if current_user.has_permissions(admin_override=True) %}
              {{ radios(form.process_type) }}
           {% endif %}
           {{ page_footer(

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -20,7 +20,7 @@
         </div>
         <div class="column-two-thirds">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=5) }}
-          {% if current_user.has_permissions([], admin_override=True) %}
+          {% if current_user.has_permissions(admin_override=True) %}
             {{ radios(form.process_type) }}
           {% endif %}
           {{ page_footer(

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -23,7 +23,7 @@
         Team members
       </h1>
     </div>
-    {% if current_user.has_permissions(['manage_users'], admin_override=True) %}
+    {% if current_user.has_permissions('manage_users', admin_override=True) %}
       <div class="column-one-third">
         <a href="{{ url_for('.invite_user', service_id=current_service.id) }}" class="button align-with-heading">Invite team member</a>
       </div>
@@ -48,19 +48,19 @@
         <ul class="tick-cross-list">
           <div class="tick-cross-list-permissions">
             {{ tick_cross(
-              user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']),
+              user.has_permissions('send_texts', 'send_emails', 'send_letters'),
               'Send messages'
             ) }}
             {{ tick_cross(
-              user.has_permissions(permissions=['manage_templates']),
+              user.has_permissions('manage_templates'),
               'Add and edit templates'
             ) }}
             {{ tick_cross(
-              user.has_permissions(permissions=['manage_users', 'manage_settings']),
+              user.has_permissions('manage_users', 'manage_settings'),
               'Manage service'
             ) }}
             {{ tick_cross(
-              user.has_permissions(permissions=['manage_api_keys']),
+              user.has_permissions('manage_api_keys'),
               'Access API keys'
             ) }}
             {% if 'email_auth' in current_service['permissions'] %}
@@ -73,7 +73,7 @@
               </div>
             {% endif %}
           </div>
-          {% if current_user.has_permissions(['manage_users'], admin_override=True) %}
+          {% if current_user.has_permissions('manage_users', admin_override=True) %}
             {% if current_user.id != user.id %}
               <li class="tick-cross-list-edit-link">
                 <a href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Edit permissions</a>
@@ -98,19 +98,19 @@
           <ul class="tick-cross-list">
             <div class="tick-cross-list-permissions">
               {{ tick_cross(
-                user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']),
+                user.has_permissions('send_texts', 'send_emails', 'send_letters'),
                 'Send messages'
               ) }}
               {{ tick_cross(
-                user.has_permissions(permissions=['manage_templates']),
+                user.has_permissions('manage_templates'),
                 'Add and edit templates'
               ) }}
               {{ tick_cross(
-                user.has_permissions(permissions=['manage_users', 'manage_settings']),
+                user.has_permissions('manage_users', 'manage_settings'),
                 'Manage service'
               ) }}
               {{ tick_cross(
-                user.has_permissions(permissions=['manage_api_keys']),
+                user.has_permissions('manage_api_keys'),
                 'Access API keys'
               ) }}
             {% if 'email_auth' in current_service['permissions'] %}
@@ -124,7 +124,7 @@
             {% endif %}
             </div>
             <li class="tick-cross-list-edit-link">
-              {% if user.status == 'pending' and current_user.has_permissions(['manage_users']) %}
+              {% if user.status == 'pending' and current_user.has_permissions('manage_users') %}
                 <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
               {% else %}
                 {{ user.status|title }}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -45,7 +45,7 @@
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}
 
-    {% if current_user.has_permissions(['send_texts'], admin_override=True) and template.template_type == 'sms' and can_receive_inbound %}
+    {% if current_user.has_permissions('send_texts', admin_override=True) and template.template_type == 'sms' and can_receive_inbound %}
       <p>
         <a href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
       </p>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -183,7 +183,7 @@
 
     {% endif %}
 
-    {% if current_user.has_permissions([], admin_override=True) %}
+    {% if current_user.has_permissions(admin_override=True) %}
 
       <h2 class="heading-medium">Platform admin settings</h2>
 

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -19,7 +19,7 @@
           If you want to turn this feature off,
           <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
         </p>
-        {% if current_user.has_permissions(['manage_api_keys'], admin_override=True) %}
+        {% if current_user.has_permissions('manage_api_keys', admin_override=True) %}
           <p>
             You can set up callbacks for received text messages on the
             <a href="{{ url_for('.api_callbacks', service_id=current_service.id) }}">API integration page</a>.

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -6,7 +6,7 @@
   {% else %}
     <div class="bottom-gutter-2-3">
       <div class="grid-row">
-        {% if current_user.has_permissions(permissions=['send_texts', 'send_emails', 'send_letters']) %}
+        {% if current_user.has_permissions('send_texts', 'send_emails', 'send_letters') %}
         <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
           <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
             Upload recipients
@@ -19,7 +19,7 @@
         </div>
         {% endif %}
         {% if
-          current_user.has_permissions(permissions=['manage_templates'], admin_override=True) and
+          current_user.has_permissions('manage_templates', admin_override=True) and
           template.template_type != 'letter'
         %}
         <div class="column-one-third">
@@ -33,7 +33,7 @@
   {% endif %}
 </div>
 <div class="column-whole template-container">
-  {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) and template.template_type == 'letter' %}
+  {% if current_user.has_permissions('manage_templates', admin_override=True) and template.template_type == 'letter' %}
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
     <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
   {% endif %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -14,7 +14,7 @@
 
   {% if not templates %}
 
-    {% if current_user.has_permissions(permissions=['manage_templates'], any_=True) %}
+    {% if current_user.has_permissions('manage_templates', any_=True) %}
        <p class="bottom-gutter">
          You need a template before you can send text messages.
        </p>

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -14,7 +14,7 @@
 
     <h1 class="heading-large">Templates</h1>
 
-    {% if current_user.has_permissions(permissions=['manage_templates'], any_=True) %}
+    {% if current_user.has_permissions('manage_templates', any_=True) %}
        <p class="bottom-gutter">
          You need a template before you can send
          {% if 'letter' in current_service.permissions %}
@@ -41,7 +41,7 @@
       <div class="column-two-thirds">
         <h1 class="heading-large">Templates</h1>
       </div>
-      {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
+      {% if current_user.has_permissions('manage_templates', admin_override=True) %}
         <div class="column-one-third">
           <a href="{{ url_for('.add_template_by_type', service_id=current_service.id) }}" class="button align-with-heading">Add new template</a>
         </div>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -63,7 +63,7 @@
       &emsp;
       <br/>
     {% endif %}
-    {% if current_user.has_permissions(permissions=['manage_templates'], admin_override=True) %}
+    {% if current_user.has_permissions('manage_templates', admin_override=True) %}
       {% if not template._template.archived %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
           <a href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>

--- a/app/utils.py
+++ b/app/utils.py
@@ -71,7 +71,7 @@ def user_has_permissions(*permissions, admin_override=False, any_=False):
         def wrap_func(*args, **kwargs):
             if current_user and current_user.is_authenticated:
                 if current_user.has_permissions(
-                    permissions=permissions,
+                    *permissions,
                     admin_override=admin_override,
                     any_=any_
                 ):

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -38,7 +38,7 @@ def test_user_has_permissions_on_endpoint_fail(
     _test_permissions(
         client,
         user,
-        ['something'],
+        ['send_texts'],
         '',
         False)
 
@@ -66,7 +66,7 @@ def test_user_has_permissions_or(
     _test_permissions(
         client,
         user,
-        ['something', 'manage_users'],
+        ['send_texts', 'manage_users'],
         '',
         True,
         any_=True)

--- a/tests/app/main/test_user.py
+++ b/tests/app/main/test_user.py
@@ -1,3 +1,4 @@
+import pytest
 from app.notify_client.user_api_client import User
 
 
@@ -25,3 +26,6 @@ def test_user():
     # set failed logins to threshold
     user.failed_login_count = 3
     assert user.is_locked()
+
+    with pytest.raises(TypeError):
+        user.has_permissions('to_do_bad_things')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1880,7 +1880,7 @@ def mock_no_inbound_number_for_service(mocker):
 
 @pytest.fixture(scope='function')
 def mock_has_permissions(mocker):
-    def _has_permission(permissions=None, any_=False, admin_override=False):
+    def _has_permission(*permissions, any_=False, admin_override=False):
         return True
 
     return mocker.patch(


### PR DESCRIPTION
Found this random refactoring in a 3-month-old branch on my other computer, might as well PR it `¯\_(ツ)_/¯`


# Refactor user permissions to use args, not list

This makes the interface a bit cleaner and less verbose.

# Check for unknown permissions

This guards against anyone misspelling or using the wrong words for a permission, which could introduce unexpected or hard to catch errors.