### PR TITLE
Enable the download CSV file for notifications

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -157,7 +157,8 @@ def download_notifications_csv(service_id):
                 status=filter_args.get('status'),
                 page=request.args.get('page', 1),
                 page_size=5000,
-                format_for_csv=True
+                format_for_csv=True,
+                template_type=filter_args.get('message_type')
             )
         ),
         mimetype='text/csv',

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -47,11 +47,11 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
   {% endif %}
-    <!--<p class="bottom-gutter">-->
-       <!--<a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>-->
-       <!--&emsp;-->
-       <!--Data available for 7 days-->
-    <!--</p>-->
+    <p class="bottom-gutter">
+       <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+       &emsp;
+       Data available for 7 days
+    </p>
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),


### PR DESCRIPTION
The downloading of the CSV is working for as many as 190, 000 notifications.

This PR re-enables the download link and filters the notifications by templates type.

<img width="917" alt="screen shot 2018-01-15 at 12 34 25" src="https://user-images.githubusercontent.com/4282990/34942688-7abb8066-f9f0-11e7-8edf-7ad100eaafc1.png">


We do get latency cloudwatch alerts from this operation. Sakis is looking into this for me. 
