### PR TITLE
Link to previews of each recipient in a spreadsheet

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -52,7 +52,8 @@
             'height': this.nativeHeight,
             'top': this.topOffset
           })
-        );
+        )
+        .css('position', 'absolute');
 
       this.$scrollableTable = this.$component.find('.fullscreen-scrollable-table');
       this.$fixedTable = this.$component.find('.fullscreen-fixed-table');
@@ -99,6 +100,11 @@
           'visible',
           this.$scrollableTable.scrollLeft() < (this.$table.width() - this.$scrollableTable.width())
         );
+
+      setTimeout(
+        () => this.$component.find('.fullscreen-right-shadow').addClass('with-transition'),
+        3000
+      );
 
     };
 

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -6,8 +6,7 @@
     z-index: 10;
     overflow-y: hidden;
     box-sizing: border-box;
-    position: absolute;
-    margin: 5px 0 $gutter 0;
+    margin: 0 0 $gutter 0;
     padding: 0 0 0 0;
     overflow: hidden;
     border-bottom: 1px solid $border-colour;
@@ -42,8 +41,13 @@
     z-index: 200;
 
     &.visible {
-      transition: box-shadow 0.3s ease-in-out;
+
+      &.with-transition {
+        transition: box-shadow 0.6s ease-out;
+      }
+
       box-shadow: inset -1px 0 0 0 $border-colour, inset -3px 0 0 0 rgba($border-colour, 0.2);
+
     }
 
   }

--- a/app/assets/stylesheets/components/radio-select.scss
+++ b/app/assets/stylesheets/components/radio-select.scss
@@ -1,5 +1,7 @@
 .radio-select {
 
+  min-height: 39px;
+
   &-column {
 
     display: inline-block;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -129,8 +129,31 @@
   }
 
   &-index {
+
     @include bold-16;
     width: 15px;
+
+    a {
+
+      &:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
+
+      &:focus {
+
+        &:before {
+          background: $yellow;
+          z-index: -1;
+        }
+
+      }
+
+    }
   }
 
   p {

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -523,9 +523,12 @@ def _check_messages(service_id, template_type, upload_id, preview_row, letters_a
 
     count_of_recipients = len(list(recipients.rows))
 
-    if preview_row < count_of_recipients:
-        template.values = recipients[preview_row]
-    elif preview_row > 0:
+    if preview_row < 2:
+        abort(404)
+
+    if preview_row < count_of_recipients + 2:
+        template.values = recipients[preview_row - 2]
+    elif preview_row > 2:
         abort(404)
 
     session['upload_data']['notification_count'] = count_of_recipients
@@ -562,7 +565,7 @@ def _check_messages(service_id, template_type, upload_id, preview_row, letters_a
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>", methods=['GET'])
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
-def check_messages(service_id, template_type, upload_id, row_index=0):
+def check_messages(service_id, template_type, upload_id, row_index=2):
 
     data = _check_messages(service_id, template_type, upload_id, row_index)
 
@@ -590,7 +593,7 @@ def check_messages(service_id, template_type, upload_id, row_index=0):
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>.<filetype>", methods=['GET'])
 @login_required
 @user_has_permissions('send_texts', 'send_emails', 'send_letters')
-def check_messages_preview(service_id, template_type, upload_id, filetype, row_index=0):
+def check_messages_preview(service_id, template_type, upload_id, filetype, row_index=2):
     if filetype not in ('pdf', 'png'):
         abort(404)
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -553,7 +553,8 @@ def _check_messages(service_id, template_type, upload_id, preview_row, letters_a
             template.template_type == 'letter',
             not request.args.get('from_test'),
         )),
-        required_recipient_columns=OrderedSet(recipients.recipient_column_headers) - optional_address_columns
+        required_recipient_columns=OrderedSet(recipients.recipient_column_headers) - optional_address_columns,
+        preview_row=preview_row,
     )
 
 

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -60,10 +60,10 @@
       ) %}
         {% call index_field() %}
           <span>
-            {% if item.index == preview_row %}
+            {% if (item.index + 2) == preview_row %}
               {{ item.index + 2 }}
             {% else %}
-              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, row_index=(item.index)) }}">{{ item.index + 2 }}</a>
+              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, row_index=(item.index + 2)) }}">{{ item.index + 2 }}</a>
             {% endif %}
           </span>
         {% endcall %}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -60,7 +60,11 @@
       ) %}
         {% call index_field() %}
           <span>
-            {{ item.index + 2 }}
+            {% if item.index == preview_row %}
+              {{ item.index + 2 }}
+            {% else %}
+              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_type=template.template_type, upload_id=upload_id, row_index=(item.index)) }}">{{ item.index + 2 }}</a>
+            {% endif %}
           </span>
         {% endcall %}
         {% for column in recipients.column_headers %}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -59,7 +59,7 @@
         ] + recipients.column_headers
       ) %}
         {% call index_field() %}
-          <span class="{% if item.index in recipients.rows_with_errors %}table-field-error{% endif %}">
+          <span>
             {{ item.index + 2 }}
           </span>
         {% endcall %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -472,13 +472,13 @@ def test_upload_valid_csv_redirects_to_check_page(
         'Test Service: A, Template <em>content</em> with & entity',
     ),
     (
-        {'row_index': 0},
+        {'row_index': 2},
         None,
         'To: 07700900001',
         'Test Service: A, Template <em>content</em> with & entity',
     ),
     (
-        {'row_index': 2},
+        {'row_index': 4},
         True,
         'To: 07700900003',
         'Test Service: C, Template <em>content</em> with & entity',
@@ -524,7 +524,7 @@ def test_upload_valid_csv_shows_preview_and_table(
 
     if expected_link_in_first_row:
         assert page.select_one('.table-field-index a')['href'] == url_for(
-            'main.check_messages', service_id=SERVICE_ONE_ID, template_type='sms', upload_id=fake_uuid, row_index=0
+            'main.check_messages', service_id=SERVICE_ONE_ID, template_type='sms', upload_id=fake_uuid, row_index=2
         )
     else:
         assert not page.select_one('.table-field-index').select_one('a')
@@ -546,9 +546,12 @@ def test_upload_valid_csv_shows_preview_and_table(
 
 
 @pytest.mark.parametrize('row_index, expected_status', [
-    (0, 200),
+    (0, 404),
+    (1, 404),
     (2, 200),
-    (3, 404),
+    (3, 200),
+    (4, 200),
+    (5, 404),
 ])
 def test_404_for_previewing_a_row_out_of_range(
     client_request,
@@ -1480,11 +1483,11 @@ def test_can_start_letters_job(
         {'postcode': 'abc123', 'addressline1': '123 street'},
     ),
     (
-        {'row_index': 0},
+        {'row_index': 2},
         {'postcode': 'abc123', 'addressline1': '123 street'},
     ),
     (
-        {'row_index': 1},
+        {'row_index': 3},
         {'postcode': 'cba321', 'addressline1': '321 avenue'},
     ),
 ])

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -517,7 +517,7 @@ def test_upload_valid_csv_shows_preview_and_table(
     assert page.select_one('.sms-message-wrapper').text.strip() == expected_message
 
     for index, cell in enumerate([
-        '<td class="table-field-index"> <span class=""> 2 </span> </td>',
+        '<td class="table-field-index"> <span> 2 </span> </td>',
         '<td class="table-field-center-aligned "> <div class=""> 07700900001 </div> </td>',
         '<td class="table-field-center-aligned "> <div class=""> A </div> </td>',
         (

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -464,19 +464,22 @@ def test_upload_valid_csv_redirects_to_check_page(
     )
 
 
-@pytest.mark.parametrize('extra_args, expected_recipient, expected_message', [
+@pytest.mark.parametrize('extra_args, expected_link_in_first_row, expected_recipient, expected_message', [
     (
         {},
+        None,
         'To: 07700900001',
         'Test Service: A, Template <em>content</em> with & entity',
     ),
     (
         {'row_index': 0},
+        None,
         'To: 07700900001',
         'Test Service: A, Template <em>content</em> with & entity',
     ),
     (
         {'row_index': 2},
+        True,
         'To: 07700900003',
         'Test Service: C, Template <em>content</em> with & entity',
     ),
@@ -490,6 +493,7 @@ def test_upload_valid_csv_shows_preview_and_table(
     mock_get_detailed_service_for_today,
     fake_uuid,
     extra_args,
+    expected_link_in_first_row,
     expected_recipient,
     expected_message,
 ):
@@ -516,8 +520,16 @@ def test_upload_valid_csv_shows_preview_and_table(
     assert page.select_one('.sms-message-recipient').text.strip() == expected_recipient
     assert page.select_one('.sms-message-wrapper').text.strip() == expected_message
 
+    assert page.select_one('.table-field-index').text.strip() == '2'
+
+    if expected_link_in_first_row:
+        assert page.select_one('.table-field-index a')['href'] == url_for(
+            'main.check_messages', service_id=SERVICE_ONE_ID, template_type='sms', upload_id=fake_uuid, row_index=0
+        )
+    else:
+        assert not page.select_one('.table-field-index').select_one('a')
+
     for index, cell in enumerate([
-        '<td class="table-field-index"> <span> 2 </span> </td>',
         '<td class="table-field-center-aligned "> <div class=""> 07700900001 </div> </td>',
         '<td class="table-field-center-aligned "> <div class=""> A </div> </td>',
         (
@@ -530,7 +542,7 @@ def test_upload_valid_csv_shows_preview_and_table(
             '</td>'
         ),
     ]):
-        assert normalize_spaces(str(page.select('table tbody td')[index])) == cell
+        assert normalize_spaces(str(page.select('table tbody td')[index + 1])) == cell
 
 
 @pytest.mark.parametrize('row_index, expected_status', [


### PR DESCRIPTION
![pick-a-row](https://user-images.githubusercontent.com/355079/34945225-7a282ad2-f9fa-11e7-8510-2a073d5d2539.gif)

---

We’ve heard from some users, especially those sending letters, that they’d like to check that a spreadsheet they’ve uploaded has populated the template correctly.

My reckon is that seeing just one row of the spreadsheet populate the template isn’t enough to give people confidence that everything’s working properly.

This commit adds links to all but the currently-previewed row. Clicking that link will populate the preview with values from that row. These pages already exist; they were created in this PR:
#1696

---

More implementation detail in individual commits…