### PR TITLE
Add view link in message log for letter notifications

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -71,6 +71,9 @@
               <dt>{{ key }}:</dt>
               <dd class="api-notifications-item-data-item">{{ notification[key] }}</dd>
             {% endfor %}
+            {% if notification['notification_type'] == 'letter' %}
+              <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=notification.id) }}">View letter</a>
+            {% endif %}
           </dl>
         </div>
       </details>

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -11,6 +11,7 @@ from tests.conftest import (
     mock_get_service,
     mock_get_live_service,
     mock_get_service_with_letters,
+    mock_get_notifications,
     normalize_spaces,
     SERVICE_ONE_ID,
     mock_get_valid_service_callback_api,
@@ -64,6 +65,29 @@ def test_should_show_api_page_with_no_notifications(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     rows = page.find_all('div', {'class': 'api-notifications-item'})
     assert 'When you send messages via the API they’ll appear here.' in rows[len(rows) - 1].text.strip()
+
+
+@pytest.mark.parametrize('template_type, has_links', [
+    ('sms', False),
+    ('letter', True),
+])
+def test_letter_notifications_should_have_link_to_view_letter(
+    client_request,
+    api_user_active,
+    fake_uuid,
+    mock_has_permissions,
+    mocker,
+    template_type,
+    has_links
+):
+    mock_get_notifications(mocker, api_user_active, diff_template_type=template_type)
+
+    page = client_request.get(
+        'main.api_integration',
+        service_id=fake_uuid,
+    )
+
+    assert (page.select_one('details a') is not None) == has_links
 
 
 def test_should_show_api_page_for_live_service(


### PR DESCRIPTION
Adds a link into the letter notifications in the message log on API Integration page. 

![image](https://user-images.githubusercontent.com/31617728/34988000-188cc646-fab5-11e7-844b-908cc6765fb7.png)
