### PR TITLE
remove free sms fragment limit from go live flow

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -162,7 +162,7 @@ def service_request_to_go_live(service_id):
             'message': (
                 'On behalf of {} ({})\n'
                 '\n---'
-                '\nOrganisation type: {} ({:,} free text messages)'
+                '\nOrganisation type: {}'
                 '\nMOU in place: {}'
                 '\nChannel: {}\nStart date: {}\nStart volume: {}'
                 '\nPeak volume: {}'
@@ -171,7 +171,6 @@ def service_request_to_go_live(service_id):
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 current_service['organisation_type'],
-                current_service['free_sms_fragment_limit'],
                 form.mou.data,
                 formatted_list(filter(None, (
                     'email' if form.channel_email.data else None,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,7 +56,6 @@ def service_json(
     service_callback_api=None,
     permissions=None,
     organisation_type='central',
-    free_sms_fragment_limit=250000,
     prefix_sms=True,
 ):
     if users is None:
@@ -70,7 +69,6 @@ def service_json(
         'name': name,
         'users': users,
         'message_limit': message_limit,
-        'free_sms_fragment_limit': free_sms_fragment_limit,
         'active': active,
         'restricted': restricted,
         'email_from': email_from,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -488,7 +488,7 @@ def test_should_redirect_after_request_to_go_live(
 
     returned_message = mock_post.call_args[1]['data']['message']
     assert 'On behalf of service one' in returned_message
-    assert 'Organisation type: central (250,000 free text messages)' in returned_message
+    assert 'Organisation type: central' in returned_message
     assert 'Channel: email and text messages' in returned_message
     assert 'Start date: 01/01/2017' in returned_message
     assert 'Start volume: 100,000' in returned_message


### PR DESCRIPTION
it's no longer a field on the service