### PR TITLE
Fix performance issue

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -47,11 +47,6 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
   {% endif %}
-    <p class="bottom-gutter">
-       <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
-       &emsp;
-       Data available for 7 days
-    </p>
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),


### PR DESCRIPTION
Gunicorn will timeout a process after 30 seconds.
The marshmallow schema takes too long, we need to fix the performance of that first.