### PR TITLE
Tell people they can close tab once email auth’d

### DIFF
--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
-  Email verification
+  {{ title }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -10,7 +10,8 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
-    <p> We’ve sent you an email with your login link</p>
+    <p>We’ve emailed you a link to sign in to Notify.</p>
+    <p>Clicking the link will open Notify in a new browser window, so you can close this one.</p>
     {{ page_footer(
       secondary_link=url_for('main.email_not_received'),
       secondary_link_text='Not received an email?'


### PR DESCRIPTION
We’ve seen people come back to this page once signed in and be confused what it’s for and how they get back to Notify.

The best way to avoid confusion is (we think) getting people to close this tab.

This PR also makes the page `<title>` match the `<h1>`. This is what we do as convention, unless there’s a good reason not to, and is better than ’Email verification’.