### PR TITLE
Update utils to fix Deskpro empty user_email error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ notifications-python-client==4.7.1
 awscli==1.14.22
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.5.0#egg=notifications-utils==23.5.0
+git+https://github.com/alphagov/notifications-utils.git@23.5.1#egg=notifications-utils==23.5.1


### PR DESCRIPTION
Deskpro user_email will now use the default address from the app
configuration if `user_email` argument was set to an empty string.