### PR TITLE
Add information about pricing to inbound SMS page

### DIFF
--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -27,16 +27,15 @@
         {% endif %}
       {% else %}
         <p>
-          Receiving text messages from your users is an
-          invitation&#8209;only feature.
+          If you want to be able to receive text messages from your users, please
+          <a href="{{ url_for('.support') }}">get in touch</a>.
         </p>
         <p>
-          If you want to try it out,
-          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
-        </p>
-        <p>
-          We’ll set you up with a special phone number, and you’ll be able to see
+          We’ll create a special phone number for your users to contact. You'll be able to see
           the messages on your dashboard, or get them using the API.
+        </p>
+          It doesn’t cost you anything to receive messages. Users will pay their normal rate for
+          messaging a mobile number.
         </p>
       {% endif %}
       {{ page_footer(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1821,7 +1821,7 @@ def test_cant_resume_active_service(
         'main.service_set_inbound_sms',
         ['sms'],
         (
-            'Receiving text messages from your users is an invitation‑only feature.'
+            'If you want to be able to receive text messages from your users, please get in touch.'
         )
     ),
     (


### PR DESCRIPTION
One of the things that came out of the support analysis was that people were asking how much inbound SMS costs. There wasn’t a significant volume of these requests, but the fix seems low-effort and non-disruptive enough that we should do it.

Content by Thom.

# After 

![image](https://user-images.githubusercontent.com/355079/35222871-4b144f50-ff77-11e7-8f9f-88278ade0ae3.png)

# Before 

![image](https://user-images.githubusercontent.com/355079/35222883-587b1ade-ff77-11e7-9e6f-5a525fba8c3d.png)
