### PR TITLE
Content style fixes on request to go live page

### DIFF
--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -42,8 +42,8 @@
         ]) }}
         <div class="form-group">
           {{ textbox(form.start_date, width='1-1') }}
-          {{ textbox(form.start_volume, width='1-1', hint='For example, ‘1000 a month’.') }}
-          {{ textbox(form.peak_volume, width='1-1', hint='For example, ‘Messages will increase to 20,000 a month in January’.') }}
+          {{ textbox(form.start_volume, width='1-1', hint='For example, ‘1,000 per month’.') }}
+          {{ textbox(form.peak_volume, width='1-1', hint='For example, ‘Messages will increase to 20,000 per month in January’.') }}
         </div>
         {{ checkbox_group('How are you going to send messages?', [
           form.method_one_off,


### PR DESCRIPTION
It’s ‘per month’ – ‘a month’ is a colloquialism.

Large numbers should be chunked using commas; ‘20,000’ already is, this commit makes ‘1000’ consistent.