### PR TITLE
Add missing <form> on letters setting page

### DIFF
--- a/app/templates/views/service-settings/set-letters.html
+++ b/app/templates/views/service-settings/set-letters.html
@@ -18,12 +18,14 @@
         See <a href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for the list
         of rates.
       </p>
-      {{ radios(form.enabled) }}
-      {{ page_footer(
-        'Save',
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
+      <form method="post">
+        {{ radios(form.enabled) }}
+        {{ page_footer(
+          'Save',
+          back_link=url_for('.service_settings', service_id=current_service.id),
+          back_link_text='Back to settings'
+        ) }}
+      </form>
     </div>
   </div>
 


### PR DESCRIPTION
Pressing the big green button does nothing unless there’s a form on the page.