### PR TITLE
manage api keys permission should be able to see senders

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,7 +18,7 @@ from flask import (
 )
 from flask._compat import string_types
 from flask.globals import _lookup_req_object, _request_ctx_stack
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 from flask_wtf import CSRFProtect
 from flask_wtf.csrf import CSRFError
 from functools import partial
@@ -152,6 +152,10 @@ def init_app(application):
     @application.context_processor
     def _attach_current_service():
         return {'current_service': current_service}
+
+    @application.context_processor
+    def _attach_current_user():
+        return{'current_user': current_user}
 
     @application.before_request
     def record_start_time():

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -43,7 +43,7 @@ from notifications_utils.formatters import formatted_list
 
 @main.route("/services/<service_id>/service-settings")
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
 def service_settings(service_id):
     letter_branding_organisations = email_branding_client.get_letter_email_branding()
     if current_service['email_branding']:
@@ -340,7 +340,7 @@ def service_set_reply_to_email(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
 def service_email_reply_to(service_id):
     reply_to_email_addresses = service_api_client.get_reply_to_email_addresses(service_id)
     return render_template(
@@ -520,7 +520,7 @@ def service_set_auth_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
     return render_template(
@@ -576,7 +576,7 @@ def service_edit_letter_contact(service_id, letter_contact_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
 def service_sms_senders(service_id):
 
     def attach_hint(sender):

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -105,9 +105,11 @@
   {% endcall %}
 {%- endmacro %}
 
-{% macro edit_field(text, link) -%}
+{% macro edit_field(text, link, permissions=[]) -%}
   {% call field(align='right') %}
-    <a href="{{ link }}">{{ text }}</a>
+    {% if current_user.has_permissions(*permissions, **{'any_':True, 'admin_override': True}) or not permissions %}
+      <a href="{{ link }}">{{ text }}</a>
+    {% endif %}
   {% endcall %}
 {%- endmacro %}
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -50,9 +50,11 @@
   {% if current_user.has_permissions('manage_users', 'manage_settings', admin_override=True) %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
-    <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
   {% elif current_user.has_permissions('view_activity') %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
+  {% endif %}
+  {% if current_user.has_permissions('manage_api_keys', 'manage_settings', admin_override=True, any_=True) %}
+    <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
   {% endif %}
   {% if current_user.has_permissions('manage_api_keys', admin_override=True) %}
     <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field with context %}
 
 
 {% block service_page_title %}
@@ -25,8 +25,8 @@
 
 	    {% call row() %}
 	      {{ text_field('Callbacks for received text messages') }}
-        {{ optional_text_field(received_text_messages_callback) }}
-	    	{{ edit_field('Change', url_for('.received_text_messages_callback', service_id=current_service.id)) }}
+          {{ optional_text_field(received_text_messages_callback) }}
+	   	  {{ edit_field('Change', url_for('.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 	  {% endcall %}
 	</div>

--- a/app/templates/views/callbacks.html
+++ b/app/templates/views/callbacks.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field, row_heading%}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field, row_heading with context %}
 {% extends "withoutnav_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
@@ -81,5 +81,5 @@
 
     <h2 class="heading-medium">Reliable and resilient</h2>
     <p>Notify sends messages through multiple providers. If one provider fails, Notify automatically switches to another so that your messages aren’t affected.</p>
-    
+
 {% endblock %}

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% extends "withoutnav_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
 {% extends "withoutnav_template.html" %}
 

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/browse-list.html" import browse_list %}
-{% from "components/table.html" import mapping_table, row, text_field, optional_text_field, edit_field, field, boolean_field %}
+{% from "components/table.html" import mapping_table, row, text_field, optional_text_field, edit_field, field, boolean_field with context %}
 
 {% block service_page_title %}
   Settings
@@ -23,7 +23,12 @@
         {% call row() %}
           {{ text_field('Service name') }}
           {{ text_field(current_service.name) }}
-          {{ edit_field('Change', url_for('.service_name_change', service_id=current_service.id)) }}
+          {{ edit_field(
+              'Change',
+              url_for('.service_name_change', service_id=current_service.id),
+              permissions=['manage_settings']
+            )
+          }}
         {% endcall %}
 
         {% call row() %}
@@ -33,7 +38,13 @@
             if 'email_auth' in current_service.permissions
             else 'Text message code'
           ) }}
-          {{ edit_field('Change', url_for('.service_set_auth_type', service_id=current_service.id)) }}
+          {{ edit_field(
+              'Change',
+              url_for('.service_set_auth_type',
+              service_id=current_service.id),
+              permissions=['manage_settings']
+            )
+          }}
         {% endcall %}
 
       {% endcall %}
@@ -48,7 +59,13 @@
         {% call row() %}
           {{ text_field('Send emails') }}
           {{ boolean_field('email' in current_service.permissions) }}
-          {{ edit_field('Change', url_for('.service_set_email', service_id=current_service.id)) }}
+          {{ edit_field(
+              'Change',
+              url_for('.service_set_email',
+              service_id=current_service.id),
+              permissions=['manage_settings']
+              )
+          }}
         {% endcall %}
 
         {% if 'email' in current_service.permissions %}
@@ -65,8 +82,11 @@
               {% endif %}
             {% endcall %}
             {{ edit_field(
-              'Manage' if reply_to_email_address_count else 'Change',
-              url_for('.service_email_reply_to', service_id=current_service.id))
+                'Manage' if reply_to_email_address_count else 'Change',
+                url_for('.service_email_reply_to',
+                service_id=current_service.id),
+                permissions=['manage_settings','manage_api_keys']
+              )
             }}
           {% endcall %}
 
@@ -84,7 +104,13 @@
         {% call row() %}
           {{ text_field('Send text messages') }}
           {{ boolean_field('sms' in current_service.permissions) }}
-          {{ edit_field('Change', url_for('.service_set_sms', service_id=current_service.id)) }}
+          {{ edit_field(
+              'Change',
+              url_for('.service_set_sms',
+              service_id=current_service.id),
+              permissions=['manage_settings']
+            )
+          }}
         {% endcall %}
 
         {% if 'sms' in current_service.permissions %}
@@ -99,25 +125,49 @@
                 </div>
               {% endif %}
             {% endcall %}
-            {{ edit_field('Manage' if sms_sender_count else 'Change', url_for('.service_sms_senders', service_id=current_service.id)) }}
+            {{ edit_field(
+                'Manage' if sms_sender_count else 'Change',
+                url_for('.service_sms_senders',
+                service_id=current_service.id),
+                permissions=['manage_settings','manage_api_keys']
+            )
+            }}
           {% endcall %}
 
           {% call row() %}
             {{ text_field('Text messages start with service name') }}
             {{ boolean_field(prefix_sms) }}
-            {{ edit_field('Change', url_for('.service_set_sms_prefix', service_id=current_service.id)) }}
+            {{ edit_field(
+                'Change',
+                url_for('.service_set_sms_prefix',
+                service_id=current_service.id),
+                permissions=['manage_settings']
+            )
+            }}
           {% endcall %}
 
           {% call row() %}
             {{ text_field('International text messages') }}
             {{ boolean_field('international_sms' in current_service.permissions) }}
-            {{ edit_field('Change', url_for('.service_set_international_sms', service_id=current_service.id)) }}
+            {{ edit_field(
+                'Change',
+                url_for('.service_set_international_sms',
+                service_id=current_service.id),
+                permissions=['manage_settings']
+            )
+            }}
           {% endcall %}
 
           {% call row() %}
             {{ text_field('Receive text messages') }}
             {{ boolean_field('inbound_sms' in current_service.permissions) }}
-            {{ edit_field('Change', url_for('.service_set_inbound_sms', service_id=current_service.id)) }}
+            {{ edit_field(
+                'Change',
+                url_for('.service_set_inbound_sms',
+                service_id=current_service.id),
+                permissions=['manage_settings']
+            )
+            }}
           {% endcall %}
 
         {% endif %}
@@ -134,7 +184,13 @@
         {% call row() %}
           {{ text_field('Send letters') }}
           {{ boolean_field('letter' in current_service.permissions) }}
-          {{ edit_field('Change', url_for('.service_set_letters', service_id=current_service.id)) }}
+          {{ edit_field(
+              'Change',
+              url_for('.service_set_letters',
+              service_id=current_service.id),
+              permissions=['manage_settings']
+          )
+          }}
         {% endcall %}
 
         {% if 'letter' in current_service.permissions %}
@@ -148,7 +204,13 @@
                 </div>
               {% endif %}
             {% endcall %}
-            {{ edit_field('Manage' if letter_contact_details_count else 'Change', url_for('.service_letter_contact_details', service_id=current_service.id)) }}
+            {{ edit_field(
+                'Manage' if letter_contact_details_count else 'Change',
+                url_for('.service_letter_contact_details',
+                service_id=current_service.id),
+                permissions=['manage_settings','manage_api_keys']
+            )
+            }}
           {% endcall %}
         {% endif %}
 

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/api-key.html" import api_key %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table %}
+{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
 {% block service_page_title %}
   Email reply to addresses
@@ -15,9 +15,11 @@
         Email reply to addresses
       </h1>
     </div>
-	 <div class="column-one-third">
-	   <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
-	 </div>
+  {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+	  <div class="column-one-third">
+	    <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
+	  </div>
+  {% endif %}
   </div>
   <div class="user-list">
     {% if not reply_to_email_addresses %}
@@ -34,11 +36,9 @@
             {% endif %}
           </span>
         </h3>
-        <ul class="tick-cross-list">
-          <li class="tick-cross-list-edit-link">
-            <a href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
-          </li>
-        </ul>
+        {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+          <a class="user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
+        {% endif %}
         {% if reply_to_email_addresses|length  > 1 %}
           {{ api_key(item.id, thing="ID") }}
         {% endif %}

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/api-key.html" import api_key %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table %}
+{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
 {% block service_page_title %}
   Sender addresses
@@ -15,9 +15,11 @@
         Sender addresses
       </h1>
     </div>
-   <div class="column-one-third">
-     <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id) }}" class="button align-with-heading">Add a new address</a>
-   </div>
+    {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+      <div class="column-one-third">
+        <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id) }}" class="button align-with-heading">Add a new address</a>
+      </div>
+    {% endif %}
   </div>
   <div class="user-list">
     {% if not letter_contact_details %}
@@ -35,8 +37,9 @@
             (default)
           {% endif %}
         </p>
-
+        {% if current_user.has_permissions('manage_settings', admin_override=True) %}
         <a class="user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
+        {% endif %}
         {% if letter_contact_details|length  > 1 %}
           {{ api_key(item.id, thing="ID") }}
         {% endif %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/api-key.html" import api_key %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table %}
+{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context%}
 
 {% block service_page_title %}
   Text message senders
@@ -14,16 +14,18 @@
         Text message senders
       </h1>
     </div>
-	 <div class="column-one-third">
-	   <a href="{{ url_for('.service_add_sms_sender', service_id=current_service.id) }}" class="button align-with-heading">Add text message sender</a>
-	 </div>
+    {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+  	<div class="column-one-third">
+  	  <a href="{{ url_for('.service_add_sms_sender', service_id=current_service.id) }}" class="button align-with-heading">Add text message sender</a>
+  	</div>
+    {% endif %}
   </div>
   <div class="user-list">
     {% if not sms_senders %}
       <div class="user-list-item">
         <span class="hint">You haven’t added any sms senders yet</span>
       </div>
-    {% endif %} 
+    {% endif %}
     {% for item in sms_senders %}
       <div class="user-list-item">
         <h3>
@@ -35,11 +37,9 @@
             </span>
           {% endif %}
         </h3>
-        <ul class="tick-cross-list">
-          <li class="tick-cross-list-edit-link">
-            <a href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
-          </li>
-        </ul>
+        {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+          <a class="user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
+        {% endif %}
         {% if sms_senders|length  > 1 %}
           {{ api_key(item.id, thing="ID") }}
         {% endif %}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -1,6 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/table.html" import list_table, row, field %}
-{% from "components/table.html" import mapping_table, row, text_field, optional_text_field, edit_field, field, boolean_field %}
+{% from "components/table.html" import mapping_table, row, text_field, optional_text_field, edit_field, field, boolean_field with context %}
 
 {% block per_page_title %}
   Your profile

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -827,14 +827,12 @@ def test_menu_manage_api_keys(
             api_user_active,
             service_one,
             ['view_activity', 'manage_api_keys'])
-        page = resp.get_data(as_text=True)
-        assert url_for(
-            'main.choose_template',
-            service_id=service_one['id'],
-        ) in page
-        assert url_for('main.manage_users', service_id=service_one['id']) in page
-        assert url_for('main.service_settings', service_id=service_one['id']) not in page
 
+        page = resp.get_data(as_text=True)
+
+        assert url_for('main.choose_template', service_id=service_one['id'],) in page
+        assert url_for('main.manage_users', service_id=service_one['id']) in page
+        assert url_for('main.service_settings', service_id=service_one['id']) in page
         assert url_for('main.api_integration', service_id=service_one['id']) in page
 
 


### PR DESCRIPTION
PR to allow api users to see senders. On live, the settings page and manage pages are locked behind permissions for user's with 'manage_settings', this has been opened up to allow api users to now view, but the edit pages are still hidden behind permission blocks.

## Notes:
- 'or not permissions' clause had to be added onto edit_field conditional, given that admin_override had to remain true, it never would have passed the conditionals within the has_permissions method in models. 
- 'attach_current_user' and 'with context' were added because the view had no knowledge of the user and we didn't want to be passing it into each method, with context allows the user to also exist within sub-templates.

## Screenshots: 
![screencapture-localhost-6012-services-29d27c6a-1020-41e0-baf5-f240ad13a94f-service-settings-1517230132225](https://user-images.githubusercontent.com/31617728/35511182-e0127548-04f2-11e8-9f25-1c652863a523.png)

![image](https://user-images.githubusercontent.com/31617728/35511179-dcd73d1e-04f2-11e8-9542-9054d904c88e.png)
