### PR TITLE
Allow page headings to word-wrap

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -82,6 +82,7 @@ a {
   .heading-large,
   > .heading-medium {
     margin: 10px 0 15px 0;
+    word-wrap: break-word;
   }
 
   > .grid-row:first-child  {
@@ -89,6 +90,7 @@ a {
     .heading-large,
     .heading-medium {
       margin: 10px 0 15px 0;
+      word-wrap: break-word;
     }
 
   }


### PR DESCRIPTION
This is mostly for template names, which can be very long, unbroken strings, especially if developers have been naming them.

# Before 

<img width="961" alt="screen shot 2018-01-26 at 14 43 05" src="https://user-images.githubusercontent.com/355079/35445006-3107caf4-02a8-11e8-8f61-ad5191c6d675.png">

# After 

<img width="962" alt="screen shot 2018-01-26 at 14 43 17" src="https://user-images.githubusercontent.com/355079/35445012-348ab1b4-02a8-11e8-89f5-a05a3804dcbd.png">
