### PR TITLE
Make team members list easier to manage

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -735,6 +735,11 @@ class SearchTemplatesForm(StripWhitespaceForm):
     search = SearchField('Search by name')
 
 
+class SearchUsersForm(StripWhitespaceForm):
+
+    search = SearchField('Search by name or email address')
+
+
 class SearchNotificationsForm(StripWhitespaceForm):
 
     to = SearchField('Search by phone number or email address')

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -17,7 +17,8 @@ from notifications_python_client.errors import HTTPError
 from app.main import main
 from app.main.forms import (
     InviteUserForm,
-    PermissionsForm
+    PermissionsForm,
+    SearchUsersForm,
 )
 from app import (user_api_client, current_service, service_api_client, invite_api_client)
 from app.notify_client.models import roles
@@ -40,6 +41,8 @@ def manage_users(service_id):
         'views/manage-users.html',
         users=users,
         current_user=current_user,
+        show_search_box=(len(users) > 7),
+        form=SearchUsersForm(),
     )
 
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -28,15 +28,18 @@ from app.utils import user_has_permissions
 @login_required
 @user_has_permissions('view_activity', admin_override=True)
 def manage_users(service_id):
-    users = user_api_client.get_users_for_service(service_id=service_id)
-    invited_users = [invite for invite in invite_api_client.get_invites_for_service(service_id=service_id)
-                     if invite.status != 'accepted']
+    users = (
+        user_api_client.get_users_for_service(service_id=service_id) +
+        [
+            invite for invite in invite_api_client.get_invites_for_service(service_id=service_id)
+            if invite.status != 'accepted'
+        ]
+    )
 
     return render_template(
         'views/manage-users.html',
         users=users,
         current_user=current_user,
-        invited_users=invited_users
     )
 
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -28,12 +28,12 @@ from app.utils import user_has_permissions
 @login_required
 @user_has_permissions('view_activity', admin_override=True)
 def manage_users(service_id):
-    users = (
-        user_api_client.get_users_for_service(service_id=service_id) +
-        [
+    users = sorted(
+        user_api_client.get_users_for_service(service_id=service_id) + [
             invite for invite in invite_api_client.get_invites_for_service(service_id=service_id)
             if invite.status != 'accepted'
-        ]
+        ],
+        key=lambda user: user.email_address,
     )
 
     return render_template(

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -2,6 +2,7 @@
 {% from "components/table.html" import list_table, row, field, hidden_field_heading %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/tick-cross.html" import tick_cross %}
+{% from "components/textbox.html" import textbox %}
 
 {% set table_options = {
   'field_headings': [
@@ -29,6 +30,17 @@
       </div>
     {% endif %}
   </div>
+
+  {% if show_search_box %}
+    <div data-module="autofocus">
+      <div class="live-search" data-module="live-search" data-targets=".user-list-item">
+        {{ textbox(
+          form.search,
+          width='1-1'
+        ) }}
+      </div>
+    </div>
+  {% endif %}
 
   <div class="user-list">
     {% for user in users %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -39,7 +39,7 @@
           {%- endif -%}
           <span class="hint">
             {%- if user.status == 'pending' -%}
-              {{ user.email_address }} (pending)
+              {{ user.email_address }} (invited)
             {%- elif user.status == 'cancelled' -%}
               {{ user.email_address }} (cancelled invite)
             {%- elif user.email_address == current_user.email_address -%}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -30,15 +30,19 @@
     {% endif %}
   </div>
 
-  <h2 class="visually-hidden">
-    Active
-  </h2>
   <div class="user-list">
     {% for user in users %}
       <div class="user-list-item">
         <h3>
-          <span class="heading-small">{{ user.name }}</span>&ensp;<span class="hint">
-            {%- if user.email_address == current_user.email_address -%}
+          {%- if user.name -%}
+            <span class="heading-small">{{ user.name }}</span>&ensp;
+          {%- endif -%}
+          <span class="hint">
+            {%- if user.status == 'pending' -%}
+              {{ user.email_address }} (pending)
+            {%- elif user.status == 'cancelled' -%}
+              {{ user.email_address }} (cancelled invite)
+            {%- elif user.email_address == current_user.email_address -%}
               (you)
             {% else %}
               {{ user.email_address }}
@@ -74,66 +78,17 @@
             {% endif %}
           </div>
           {% if current_user.has_permissions('manage_users', admin_override=True) %}
-            {% if current_user.id != user.id %}
-              <li class="tick-cross-list-edit-link">
+            <li class="tick-cross-list-edit-link">
+              {% if user.status == 'pending' %}
+                <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
+              {% elif user.status == 'active' and current_user.id != user.id %}
                 <a href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Edit permissions</a>
-              </li>
-            {% endif %}
+              {% endif %}
+            </li>
           {% endif %}
         </ul>
       </div>
     {% endfor %}
   </div>
-
-  {% if invited_users %}
-    <h2 class="heading-medium">
-      Invited
-    </h2>
-    <div class="user-list">
-      {% for user in invited_users %}
-        <div class="user-list-item">
-          <h3>
-            <span style="font-weight: bold">{{ user.email_address }}</span>
-          </h3>
-          <ul class="tick-cross-list">
-            <div class="tick-cross-list-permissions">
-              {{ tick_cross(
-                user.has_permissions('send_texts', 'send_emails', 'send_letters'),
-                'Send messages'
-              ) }}
-              {{ tick_cross(
-                user.has_permissions('manage_templates'),
-                'Add and edit templates'
-              ) }}
-              {{ tick_cross(
-                user.has_permissions('manage_users', 'manage_settings'),
-                'Manage service'
-              ) }}
-              {{ tick_cross(
-                user.has_permissions('manage_api_keys'),
-                'Access API keys'
-              ) }}
-            {% if 'email_auth' in current_service['permissions'] %}
-              <div class="tick-cross-list-hint">
-                {% if user.auth_type == 'sms_auth' %}
-                  Signs in with a text message code
-                {% else %}
-                  Signs in with an email link
-                {% endif %}
-              </div>
-            {% endif %}
-            </div>
-            <li class="tick-cross-list-edit-link">
-              {% if user.status == 'pending' and current_user.has_permissions('manage_users') %}
-                <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
-              {% else %}
-                {{ user.status|title }}
-              {% endif %}
-            </li>
-          </ul>
-        </div>
-      {% endfor %}
-    </div>
-  {% endif %}
 
 {% endblock %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -461,8 +461,8 @@ def test_manage_users_shows_invited_user(
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
 
     assert page.h1.string.strip() == 'Team members'
-    assert normalize_spaces(page.select('.user-list')[1].text) == (
-        'invited_user@test.gov.uk '
+    assert normalize_spaces(page.select('.user-list-item')[1].text) == (
+        'invited_user@test.gov.uk (pending) '
         'Can’t Send messages Can’t Add and edit templates Can’t Manage service Can Access API keys '
         'Cancel invitation'
     )

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -461,7 +461,7 @@ def test_manage_users_shows_invited_user(
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
 
     assert page.h1.string.strip() == 'Team members'
-    assert normalize_spaces(page.select('.user-list-item')[1].text) == (
+    assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'invited_user@test.gov.uk (invited) '
         'Can’t Send messages Can’t Add and edit templates Can’t Manage service Can Access API keys '
         'Cancel invitation'

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -462,7 +462,7 @@ def test_manage_users_shows_invited_user(
 
     assert page.h1.string.strip() == 'Team members'
     assert normalize_spaces(page.select('.user-list-item')[1].text) == (
-        'invited_user@test.gov.uk (pending) '
+        'invited_user@test.gov.uk (invited) '
         'Can’t Send messages Can’t Add and edit templates Can’t Manage service Can Access API keys '
         'Cancel invitation'
     )


### PR DESCRIPTION
Some teams have a lot of users now (the record is 172 last time we looked). So we should make it easier for teams to manage large numbers of users.

# Combine invited and active team members, rename pending to invited and sort list by email address 

Right now these are two separate lists. Which makes it harder to add improvements that will make large numbers of users easier to manage.

Pending is a bit of a technical word. Pending what? Invited is clear enough, and doesn’t introduce a new concept.

Sorting alphabetially is the same change we made for templates (changed from most recent sort) when the number of templates was getting unmanageable.

Sorted on email address because invited users don’t have a name (and not sorted on both, because a lot of departments have a `lastname.firstname` scheme for email addresses, but people generally enter their names as `Firstname Lastname`).

![image](https://user-images.githubusercontent.com/355079/35452737-82c27ac6-02bf-11e8-8ee2-90e8a6c14e93.png)

# Add search bar to team member list

Another thing we did for templates, when they started to get unmanageable, was add a find-as-you type search. We’ve observed real users interacting with this to great effect, so I think it makes sense for users too.

Like for templates, it only shows up when there are more than 7, so that it’s not clutter for teams who don’t have a lot of members.

![find-team](https://user-images.githubusercontent.com/355079/35452715-6483aae4-02bf-11e8-8ed1-d97bac860203.gif)
