### PR TITLE
Change display of cancelled users, fix edit link

### DIFF
--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -184,6 +184,8 @@ class InvitedUser(object):
         self.auth_type = auth_type
 
     def has_permissions(self, *permissions):
+        if self.status == 'cancelled':
+            return False
         return set(self.permissions) > set(permissions)
 
     def __eq__(self, other):

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -54,7 +54,7 @@
               {{ user.email_address }} (invited)
             {%- elif user.status == 'cancelled' -%}
               {{ user.email_address }} (cancelled invite)
-            {%- elif user.email_address == current_user.email_address -%}
+            {%- elif user.id == current_user.id -%}
               (you)
             {% else %}
               {{ user.email_address }}
@@ -93,7 +93,7 @@
             <li class="tick-cross-list-edit-link">
               {% if user.status == 'pending' %}
                 <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
-              {% elif user.status == 'active' and current_user.id != user.id %}
+              {% elif user.state == 'active' and current_user.id != user.id %}
                 <a href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Edit permissions</a>
               {% endif %}
             </li>


### PR DESCRIPTION
It’s confusing showing green ticks for cancelled invites. This commit changes the appearance so that only pending or active users (ie those that could actually do some damage) get green ticks.

Also fixes missing edit links caused by instances of `User` having `.state` but instances of `InvitedUser` having `.status`.

---

![image](https://user-images.githubusercontent.com/355079/35518192-bb7c149e-0508-11e8-8133-c5d07f614536.png)
