### PR TITLE
Allow full stops in SMS senders

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -35,7 +35,7 @@ from app.main.validators import (
     ValidGovEmail,
     NoCommasInPlaceHolders,
     OnlyGSMCharacters,
-    LettersAndNumbersOnly,
+    LettersNumbersAndFullStopsOnly,
 )
 
 
@@ -560,7 +560,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Can’t be empty"),
             Length(max=11, message="Enter 11 characters or fewer"),
-            LettersAndNumbersOnly(),
+            LettersNumbersAndFullStopsOnly(),
         ]
     )
     is_default = BooleanField("Make this text message sender the default")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,4 +1,3 @@
-import re
 import pytz
 import weakref
 
@@ -30,7 +29,14 @@ from wtforms.fields.html5 import EmailField, TelField, SearchField
 from wtforms.validators import (DataRequired, Email, Length, Regexp, Optional)
 from flask_wtf.file import FileField as FileField_wtf, FileAllowed
 
-from app.main.validators import (Blacklist, CsvFileValidator, ValidGovEmail, NoCommasInPlaceHolders, OnlyGSMCharacters)
+from app.main.validators import (
+    Blacklist,
+    CsvFileValidator,
+    ValidGovEmail,
+    NoCommasInPlaceHolders,
+    OnlyGSMCharacters,
+    LettersAndNumbersOnly,
+)
 
 
 def get_time_value_and_label(future_time):
@@ -553,14 +559,11 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
         'Text message sender',
         validators=[
             DataRequired(message="Can’t be empty"),
-            Length(max=11, message="Enter 11 characters or fewer")
+            Length(max=11, message="Enter 11 characters or fewer"),
+            LettersAndNumbersOnly(),
         ]
     )
     is_default = BooleanField("Make this text message sender the default")
-
-    def validate_sms_sender(self, field):
-        if field.data and not re.match(r'^[a-zA-Z0-9\s]+$', field.data):
-            raise ValidationError('Use letters and numbers only')
 
 
 class ServiceEditInboundNumberForm(StripWhitespaceForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,3 +1,4 @@
+import re
 from wtforms import ValidationError
 from notifications_utils.field import Field
 from notifications_utils.gsm import get_non_gsm_compatible_characters
@@ -63,3 +64,15 @@ class OnlyGSMCharacters:
                     ('It' if len(non_gsm_characters) == 1 else 'They')
                 )
             )
+
+
+class LettersAndNumbersOnly:
+
+    regex = re.compile(r'^[a-zA-Z0-9\s]+$')
+
+    def __init__(self, message='Use letters and numbers only'):
+        self.message = message
+
+    def __call__(self, form, field):
+        if field.data and not re.match(self.regex, field.data):
+            raise ValidationError(self.message)

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -66,9 +66,9 @@ class OnlyGSMCharacters:
             )
 
 
-class LettersAndNumbersOnly:
+class LettersNumbersAndFullStopsOnly:
 
-    regex = re.compile(r'^[a-zA-Z0-9\s]+$')
+    regex = re.compile(r'^[a-zA-Z0-9\s\.]+$')
 
     def __init__(self, message='Use letters and numbers only'):
         self.message = message

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -810,6 +810,7 @@ def test_incorrect_letter_contact_block_input(
 
 @pytest.mark.parametrize('sms_sender_input, expected_error', [
     ('elevenchars', None),
+    ('11 chars', None),
     ('', 'Can’t be empty'),
     ('abcdefghijkhgkg', 'Enter 11 characters or fewer'),
     (' ¯\_(ツ)_/¯ ', 'Use letters and numbers only'),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -814,7 +814,7 @@ def test_incorrect_letter_contact_block_input(
     ('', 'Can’t be empty'),
     ('abcdefghijkhgkg', 'Enter 11 characters or fewer'),
     (' ¯\_(ツ)_/¯ ', 'Use letters and numbers only'),
-    ('blood.co.uk', 'Use letters and numbers only'),
+    ('blood.co.uk', None),
 ])
 def test_incorrect_sms_sender_input(
     sms_sender_input,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -810,7 +810,8 @@ def test_incorrect_letter_contact_block_input(
 
 @pytest.mark.parametrize('sms_sender_input, expected_error', [
     ('', 'Can’t be empty'),
-    ('abcdefghijkhgkg', 'Enter 11 characters or fewer')
+    ('abcdefghijkhgkg', 'Enter 11 characters or fewer'),
+    (' ¯\_(ツ)_/¯ ', 'Use letters and numbers only'),
 ])
 def test_incorrect_sms_sender_input(
     sms_sender_input,


### PR DESCRIPTION
_First three commits in this PR are just refactoring. Substantive change detailed below._

---

We have a team who want their (short) web address as the text message sender. This pull request updates the validation of text message senders to allow `.` as a valid character, which is currently blocking them from doing this.

We can be fairly confident this works because:

- the team are sending large volumes of messages already with their existing provider
- we’ve tested it with all combinations of
  - both our text message providers
  - an Android phone and n iPhone