### PR TITLE
Open links to client documentation in a new tab

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -10,14 +10,14 @@
   <div class="column-two-thirds">
 
 	<h1 class="heading-large"> Documentation </h1>
-	<p>Use our API documentation to integrate with GOV.UK Notify using the following clients:</p>
+	<p>Integrate with the GOV.UK Notify API using one of our clients (links open in a new tab):</p>
 	<ul class="list list-bullet">
-      <li><a href="https://github.com/alphagov/notifications-java-client">Java</a></li>
-      <li><a href="https://github.com/alphagov/notifications-net-client">.NET</a></li>
-      <li><a href="https://github.com/alphagov/notifications-node-client">Node JS</a></li>
-      <li><a href="https://github.com/alphagov/notifications-php-client">PHP</a></li>
-      <li><a href="https://github.com/alphagov/notifications-python-client">Python</a></li>
-      <li><a href="https://github.com/alphagov/notifications-ruby-client">Ruby</a></li>
+      <li><a href="https://github.com/alphagov/notifications-java-client" target="_blank" rel="noopener">Java</a></li>
+      <li><a href="https://github.com/alphagov/notifications-net-client" target="_blank" rel="noopener">.NET</a></li>
+      <li><a href="https://github.com/alphagov/notifications-node-client" target="_blank" rel="noopener">Node JS</a></li>
+      <li><a href="https://github.com/alphagov/notifications-php-client" target="_blank" rel="noopener">PHP</a></li>
+      <li><a href="https://github.com/alphagov/notifications-python-client" target="_blank" rel="noopener">Python</a></li>
+      <li><a href="https://github.com/alphagov/notifications-ruby-client" target="_blank" rel="noopener">Ruby</a></li>
     </ul>
     <p>You can also find out about <a href="{{ url_for('main.integration_testing')}}">integration testing</a> and the different types of API keys that you can use.</p>
   </div>


### PR DESCRIPTION
In research we saw developers having difficulty getting back to Notify once they’d  navigated to the documentation.

One way we think this might be alleviated is by keeping Notify open in the same tab, and having the documentation open in a new tab.

It’s polite to tell users that this is going to happen.

`rel=noopener` stops the site we’re redirecting people to (Github) have script  access to the orginal Notify tab (see https://mathiasbynens.github.io/rel-noopener/).