### PR TITLE
Remove beta badge from header

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -45,12 +45,6 @@
 
 }
 
-.beta-badge {
-  @include phase-tag();
-  margin: 10px 0 0 0;
-}
-
-
 @include media(desktop) {
   #proposition-menu {
     float: right;
@@ -170,11 +164,6 @@ details summary {
     border-top: 0;
   }
 
-}
-
-.phase-banner-beta {
-  border: 0;
-  margin-bottom: -$gutter + 2px;
 }
 
 .body-copy-table {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -13,7 +13,6 @@ $path: '/static/images/';
 @import 'helpers';
 @import 'url-helpers';
 @import 'design-patterns/buttons';
-@import 'design-patterns/alpha-beta';
 
 // Dependencies from GOV.UK Elements
 // https://github.com/alphagov/govuk_elements
@@ -28,7 +27,6 @@ $path: '/static/images/';
 @import 'elements/layout';
 @import 'elements/lists';
 @import 'elements/panels';
-@import 'elements/phase-banner';
 @import 'elements/tables';
 
 

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -33,9 +33,6 @@
   </p>
 {% endblock %}
 
-{% block inside_header %}
-  <strong class='beta-badge'>Beta</strong>
-{% endblock %}
 {% block header_class %}with-proposition{% endblock %}
 {% block proposition_header %}
   <div class="header-proposition">

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -16,7 +16,7 @@
 
     <h1 class="heading-large">Roadmap</h1>
     <p>The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
-    <p class="panel panel-border-wide">This roadmap is a only a guide and things might change.</p>
+    <p>Notify is in public beta. This means it’s fully operational and supported, but we’re regularly adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
     <p>You can <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> for more detail about these features, or to suggest something else you’d like Notify to offer.</p>
 
     <h2 class="heading-medium">Sending and receiving messages</h2>


### PR DESCRIPTION
We have found repeatedly in research that our users don’t know what ‘beta’ means. In this situation they come up with their own interpretation of what it means, for example that:
- certain features are not available to them
- Notify as a whole is not available to them
- they are using a ‘different’ version of Notify to those using it for real

In the most severe cases this ambiguity actively dissuades users from adopting Notify. We know this from support tickets and user research; there are probably a host of other teams we haven’t spoken to.

---

Here’s a quote from a user research session just last week:

> Once we’ve got the facility to receive inbound messages […] that’s not available to us at the moment with a beta account

---

From support tickets:

> We see that the service is still in beta mode – can we assume uninterrupted service reliability and performance?

> we do not have a .gov.uk email address any longer but I was wondering if we would be able to utilize the notify system which is currently in beta

> We are currently using the BETA version, are we able to switch to the TEST version so we can add other numbers to send SMS to?

> I have previously enquired about this option [receiving text messages], but thought it was still at Beta stage. If we can set it up so that notify handles the responses that would be great.

> [after going live] Should I see the wording LIVE on the login screen as I still see BETA.,....

> Also I note that you are a BETA service just now and that to use the service we would need a .gov.uk email address. We don't have this, is there any way that [redacted] could use the service as I note that one of the teams have an account?

> Morning, Our Notify account is still in Beta mode which is preventing us from creating additional services. We are keen to go live ASAP as we have multiple services waiting to use the service.

---

This pull request removes the beta badge from Notify, and hopefully with it the confusion it’s causing our users.

---  

# Before

![image](https://user-images.githubusercontent.com/355079/35812478-f5a5327e-0a88-11e8-984c-af67df83bc55.png)

# After 

![image](https://user-images.githubusercontent.com/355079/35812457-e2dbc306-0a88-11e8-830a-9e8933a9a231.png)
