### PR TITLE
Tell API what URL to use for email auth links 

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -20,6 +20,7 @@ class UserApiClient(NotifyAdminAPIClient):
         self.service_id = app.config['ADMIN_CLIENT_USER_NAME']
         self.api_key = app.config['ADMIN_CLIENT_SECRET']
         self.max_failed_login_count = app.config["MAX_FAILED_LOGIN_COUNT"]
+        self.admin_url = app.config['ADMIN_BASE_URL']
 
     def register_user(self, name, email_address, mobile_number, password, auth_type):
         data = {
@@ -93,6 +94,8 @@ class UserApiClient(NotifyAdminAPIClient):
         data = {'to': to}
         if next_string:
             data['next'] = next_string
+        if code_type == 'email':
+            data['email_auth_link_host'] = self.admin_url
         endpoint = '/user/{0}/{1}-code'.format(user_id, code_type)
         self.post(endpoint, data=data)
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -117,6 +117,7 @@ def test_process_email_auth_sign_in_return_2fa_template(
             'password': 'val1dPassw0rd!'})
     assert response.status_code == 302
     assert response.location == url_for('.two_factor_email_sent', _external=True)
+    mock_send_verify_code.assert_called_with(api_user_active_email_auth.id, 'email', None)
     mock_verify_password.assert_called_with(api_user_active_email_auth.id, 'val1dPassw0rd!')
 
 

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app import user_api_client
 from app.notify_client.user_api_client import UserApiClient
 
 
@@ -52,3 +53,21 @@ def test_client_doesnt_activate_if_already_active(mocker, api_user_active):
     client.activate_user(api_user_active)
 
     assert not mock_post.called
+
+
+def test_client_passes_admin_url_when_sending_email_auth(
+    app_,
+    mocker,
+    fake_uuid,
+):
+    mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
+
+    user_api_client.send_verify_code(fake_uuid, 'email', 'ignored@example.com')
+
+    mock_post.assert_called_once_with(
+        '/user/{}/email-code'.format(fake_uuid),
+        data={
+            'to': 'ignored@example.com',
+            'email_auth_link_host': 'http://localhost:6012',
+        }
+    )

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -1,7 +1,6 @@
 import pytest
 
 from app import user_api_client
-from app.notify_client.user_api_client import UserApiClient
 
 
 def test_client_uses_correct_find_by_email(mocker, api_user_active):
@@ -9,11 +8,10 @@ def test_client_uses_correct_find_by_email(mocker, api_user_active):
     expected_url = '/user/email'
     expected_params = {'email': api_user_active.email_address}
 
-    client = UserApiClient()
-    client.max_failed_login_count = 1  # doesn't matter for this test
+    user_api_client.max_failed_login_count = 1  # doesn't matter for this test
     mock_get = mocker.patch('app.notify_client.user_api_client.UserApiClient.get')
 
-    client.get_user_by_email(api_user_active.email_address)
+    user_api_client.get_user_by_email(api_user_active.email_address)
 
     mock_get.assert_called_once_with(expected_url, params=expected_params)
 
@@ -21,36 +19,33 @@ def test_client_uses_correct_find_by_email(mocker, api_user_active):
 def test_client_only_updates_allowed_attributes(mocker):
     mocker.patch('app.notify_client.current_user', id='1')
     with pytest.raises(TypeError) as error:
-        UserApiClient().update_user_attribute('user_id', id='1')
+        user_api_client.update_user_attribute('user_id', id='1')
     assert str(error.value) == 'Not allowed to update user attributes: id'
 
 
 def test_client_updates_password_separately(mocker, api_user_active):
     expected_url = '/user/{}/update-password'.format(api_user_active.id)
     expected_params = {'_password': 'newpassword'}
-    client = UserApiClient()
-    client.max_failed_login_count = 1  # doesn't matter for this test
+    user_api_client.max_failed_login_count = 1  # doesn't matter for this test
     mock_update_password = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
 
-    client.update_password(api_user_active.id, expected_params['_password'])
+    user_api_client.update_password(api_user_active.id, expected_params['_password'])
     mock_update_password.assert_called_once_with(expected_url, data=expected_params)
 
 
 def test_client_activates_if_pending(mocker, api_user_pending):
     mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
-    client = UserApiClient()
-    client.max_failed_login_count = 1  # doesn't matter for this test
+    user_api_client.max_failed_login_count = 1  # doesn't matter for this test
 
-    client.activate_user(api_user_pending)
+    user_api_client.activate_user(api_user_pending)
 
     mock_post.assert_called_once_with('/user/{}/activate'.format(api_user_pending.id), data=None)
 
 
 def test_client_doesnt_activate_if_already_active(mocker, api_user_active):
     mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
-    client = UserApiClient()
 
-    client.activate_user(api_user_active)
+    user_api_client.activate_user(api_user_active)
 
     assert not mock_post.called
 


### PR DESCRIPTION
So that we can keep people on the prototype URL when doing user research.

Depends on:
- [ ] alphagov/notifications-api#1645