### PR TITLE
Add another prototyping app on PaaS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,11 @@ cf-deploy-prototype: cf-target ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	cf push -f <(make -s CF_MANIFEST_FILE=manifest-prototype-${CF_SPACE}.yml generate-manifest)
 
+.PHONY: cf-deploy-prototype-2
+cf-deploy-prototype-2: cf-target ## Deploys the app to Cloud Foundry
+	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	cf push -f <(make -s CF_MANIFEST_FILE=manifest-prototype-2-${CF_SPACE}.yml generate-manifest)
+
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release
 	@cf app --guid notify-admin-rollback || exit 1

--- a/Makefile
+++ b/Makefile
@@ -192,12 +192,16 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 .PHONY: cf-deploy-prototype
 cf-deploy-prototype: cf-target ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	cf push -f <(make -s CF_MANIFEST_FILE=manifest-prototype-${CF_SPACE}.yml generate-manifest)
+	(make -s CF_MANIFEST_FILE=manifest-prototype-${CF_SPACE}.yml generate-manifest) > /tmp/admin_manifest.yml
+	cf push -f /tmp/admin_manifest.yml
+	rm /tmp/admin_manifest.yml
 
 .PHONY: cf-deploy-prototype-2
 cf-deploy-prototype-2: cf-target ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
-	cf push -f <(make -s CF_MANIFEST_FILE=manifest-prototype-2-${CF_SPACE}.yml generate-manifest)
+	(make -s CF_MANIFEST_FILE=manifest-prototype-2-${CF_SPACE}.yml generate-manifest) > /tmp/admin_manifest.yml
+	cf push -f /tmp/admin_manifest.yml
+	rm /tmp/admin_manifest.yml
 
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release

--- a/manifest-prototype-2-base.yml
+++ b/manifest-prototype-2-base.yml
@@ -1,0 +1,31 @@
+---
+
+buildpack: python_buildpack
+command: scripts/run_app_paas.sh gunicorn -w 5 -b 0.0.0.0:$PORT application
+instances: 1
+memory: 1G
+env:
+  NOTIFY_APP_NAME: admin
+
+  # Credentials variables
+  ADMIN_CLIENT_SECRET: null
+  ADMIN_BASE_URL: null
+  API_HOST_NAME: null
+  DANGEROUS_SALT: null
+  SECRET_KEY: null
+  ROUTE_SECRET_KEY_1: null
+  ROUTE_SECRET_KEY_2: null
+
+  AWS_ACCESS_KEY_ID: null
+  AWS_SECRET_ACCESS_KEY: null
+
+  STATSD_PREFIX: null
+
+  DESKPRO_API_HOST: null
+  DESKPRO_API_KEY: null
+
+  TEMPLATE_PREVIEW_API_HOST: null
+  TEMPLATE_PREVIEW_API_KEY: null
+
+applications:
+  - name: notify-admin-prototype-2

--- a/manifest-prototype-2-preview.yml
+++ b/manifest-prototype-2-preview.yml
@@ -1,0 +1,6 @@
+---
+
+inherit: manifest-prototype-2-base.yml
+
+routes:
+  - route: notify-admin-prototype-2-preview.cloudapps.digital

--- a/manifest-prototype-2-production.yml
+++ b/manifest-prototype-2-production.yml
@@ -1,0 +1,6 @@
+---
+
+inherit: manifest-prototype-2-base.yml
+
+routes:
+  - route: notify-admin-prototype-2-production.cloudapps.digital


### PR DESCRIPTION
Just a copy/paste of the existing prototype. 

Bit of a gotcha with how we run the deploy command though:

---

Some time between version 6.32 and 6.34 of the Cloudfoundry CLI the ability to redirect the output of a command into `cf push -f` was broken.

The only alternative we can think of is writing the file to disk, doing the deploy, and then deleting it.

We’re careful to write to a directory outside the current repo to avoid:
- including secrets in the deployed package
- accidentally checking the secrets into source control

Right now this only applies to people deploying from their local machines. At some point it will affect Jenkins too, but isn’t now. So this commit only fixes the problem for the commands that developers run locally.