### PR TITLE
Fix bug with disappearing AJAX content in IE 9/10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "babel-core": "6.26.0",
     "babel-preset-es2015": "6.24.1",
-    "diff-dom": "2.3.0",
+    "diff-dom": "2.3.1",
     "govuk-elements-sass": "3.1.x",
     "govuk_frontend_toolkit": "7.2.0",
     "govuk_template_jinja": "0.23.0",


### PR DESCRIPTION
We had a user report that the ‘inbound messages’ part of their dashboard was appearing for a split second then disappearing.

This was caused by the Javascript on the page throwing an exception as it was trying to re-render this part of the page. This meant it gave up and rendered nothing.

The exception was caused by passing `undefined` as the second argument to `.insertBefore`. This is acceptable in most browsers, but not older versions of IE. This is fixed in the latest version of diffDOM (the 3rd party library we use to do the AJAX stuff) by defaulting the second argument to `.insertBefore` to `null`, which is acceptable in old IE versions.

See the fix here: https://github.com/fiduswriter/diffDOM/commit/8833d87e9d77d03ab94e792875697ab00712a714