### PR TITLE
Pass service_id through to API '/service/unique' endpoint

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -100,7 +100,7 @@ def service_name_change(service_id):
         form.name.data = current_service.get('name')
 
     if form.validate_on_submit():
-        unique_name = service_api_client.is_service_name_unique(form.name.data, email_safe(form.name.data))
+        unique_name = service_api_client.is_service_name_unique(service_id, form.name.data, email_safe(form.name.data))
         if not unique_name:
             form.name.errors.append("This service name is already in use")
             return render_template('views/service-settings/name.html', form=form)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -237,12 +237,12 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         data = _attach_current_user(data)
         return self.post(endpoint, data=data)
 
-    def is_service_name_unique(self, name, email_from):
+    def is_service_name_unique(self, service_id, name, email_from):
         """
         Check that the service name or email from are unique across all services.
         """
         endpoint = "/service/unique"
-        params = {"name": name, "email_from": email_from}
+        params = {"service_id": service_id, "name": name, "email_from": email_from}
         return self.get(url=endpoint, params=params)["result"]
 
     # Temp access of service history data. Includes service and api key history

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -357,7 +357,7 @@ def test_should_not_allow_duplicate_names(
     assert response.status_code == 200
     resp_data = response.get_data(as_text=True)
     assert 'This service name is already in use' in resp_data
-    app.service_api_client.is_service_name_unique.assert_called_once_with('SErvICE TWO', 'service.two')
+    app.service_api_client.is_service_name_unique.assert_called_once_with(service_id, 'SErvICE TWO', 'service.two')
 
 
 def test_should_show_service_name_confirmation(


### PR DESCRIPTION
Notifications-api now needs the `service_id` to check the uniqueness of
the service name when trying to change it. This is to allow a user to
successfully change the pluralization or the case of their service name.

This PR depends on https://github.com/alphagov/notifications-api/pull/1656

[Pivotal story](https://www.pivotaltracker.com/story/show/155127026)