### PR TITLE
Automatically set environment vars before tests

### DIFF
--- a/environment_test.sh
+++ b/environment_test.sh
@@ -1,8 +1,0 @@
-export NOTIFY_ENVIRONMENT='test'
-export ADMIN_CLIENT_SECRET='dev-notify-secret-key'
-export API_HOST_NAME=''
-export DANGEROUS_SALT='dev-notify-salt'
-export SECRET_KEY='dev-notify-secret-key'
-export DESKPRO_API_HOST=""
-export DESKPRO_API_KEY=""
-export STATSD_PREFIX="stats-prefix"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+testpaths = tests
+env =
+    NOTIFY_ENVIRONMENT=test
+    ADMIN_CLIENT_SECRET=dev-notify-secret-key
+    API_HOST_NAME=test
+    DANGEROUS_SALT=dev-notify-salt
+    SECRET_KEY=dev-notify-secret-key
+    DESKPRO_API_HOST=test
+    DESKPRO_API_KEY=test
+    STATSD_PREFIX=stats-prefix

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest==3.4.0
+pytest-env==0.6.2
 pytest-mock==1.6.3
 pytest-cov==2.5.1
 pytest-xdist==1.22.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,11 +5,7 @@
 # NOTE: This script expects to be run from the project root with
 # ./scripts/run_tests.sh
 
-# Use default environment vars for localhost if not already set
-
 set -o pipefail
-
-source environment_test.sh
 
 function display_result {
   RESULT=$1


### PR DESCRIPTION
Sometimes you just wanna run some tests directly using the `pytest` command. But you’re in a new shell, and have forgotten to do `source environment_test.sh`. The screen fills with red, and your day just got a little bit worse.

This commit will stop this from ever happening again, by making the setting environment variables part of running Pytest. It does this with a plugin called pytest-env<sup>1</sup>.

pytest.ini is the standard way of configuring pytest. Creating this file where it didn’t exist before changes the behaviour of pytest, in that it will now look for tests in the same directory as the file, rather than defaulting to the `tests/` directory. So we also have to explicitly configure pytest<sup>2</sup> to tell it that it should only look in this directory. Otherwise it gets lost in the weeds of `node_modules`.

1. https://github.com/MobileDynasty/pytest-env
2. https://docs.pytest.org/en/latest/customize.html#confval-testpaths