### PR TITLE
Remove dashboard from dashboard URL

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -51,6 +51,13 @@ def temp_service_history(service_id):
 @main.route("/services/<service_id>/dashboard")
 @login_required
 @user_has_permissions('view_activity', admin_override=True)
+def old_service_dashboard(service_id):
+    return redirect(url_for('.service_dashboard', service_id=service_id))
+
+
+@main.route("/services/<service_id>")
+@login_required
+@user_has_permissions('view_activity', admin_override=True)
 def service_dashboard(service_id):
 
     if session.get('invited_user'):

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -42,6 +42,19 @@ stub_template_stats = [
 ]
 
 
+def test_redirect_from_old_dashboard(
+    logged_in_client
+):
+
+    expected_location = 'http://localhost/services/{}'.format(SERVICE_ONE_ID)
+
+    response = logged_in_client.get('/services/{}/dashboard'.format(SERVICE_ONE_ID))
+
+    assert response.status_code == 302
+    assert response.location == expected_location
+    assert expected_location == url_for('main.service_dashboard', service_id=SERVICE_ONE_ID, _external=True)
+
+
 def test_get_started(
     logged_in_client,
     mocker,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -59,7 +59,7 @@ def test_should_login_user_and_should_redirect_to_next_url(
         session['user_details'] = {
             'id': api_user_active.id,
             'email': api_user_active.email_address}
-    response = client.post(url_for('main.two_factor', next='/services/{}/dashboard'.format(SERVICE_ONE_ID)),
+    response = client.post(url_for('main.two_factor', next='/services/{}'.format(SERVICE_ONE_ID)),
                            data={'sms_code': '12345'})
     assert response.status_code == 302
     assert response.location == url_for(


### PR DESCRIPTION
It’s weird that `/services/<service_id>` returns `404`. The home page for every service is the dashboard – should be possible to get there from any other page just by stemming the URL.

Also makes it consistent with organisations, which will have `/organisations/<org_id>`.