### PR TITLE
Stop pytest on 10th failing test

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,5 +35,5 @@ npm test
 display_result $? 2 "Front end code style check"
 
 ## Code coverage
-py.test -n4 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
+py.test -n4 -x --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
 display_result $? 3 "Code coverage"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,5 +35,5 @@ npm test
 display_result $? 2 "Front end code style check"
 
 ## Code coverage
-py.test -n4 -x --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
+py.test -n4 --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
 display_result $? 3 "Code coverage"


### PR DESCRIPTION
If a PR is going to fail because tests aren’t passing then you:
- should know about it as quick as possible
- shouldn’t waste precious Jenkins CPU running subsequent tests

This commit adds the `-maxfail=10` flag to pytest, which stops the test run once an unacceptable number of tests have failed.