### PR TITLE
validate email addresses in one-off flow

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -26,7 +26,7 @@ from wtforms import (
     DateField,
 )
 from wtforms.fields.html5 import EmailField, TelField, SearchField
-from wtforms.validators import (DataRequired, Email, Length, Regexp, Optional)
+from wtforms.validators import (DataRequired, Length, Regexp, Optional)
 from flask_wtf.file import FileField as FileField_wtf, FileAllowed
 
 from app.main.validators import (
@@ -36,6 +36,7 @@ from app.main.validators import (
     NoCommasInPlaceHolders,
     OnlyGSMCharacters,
     LettersNumbersAndFullStopsOnly,
+    ValidEmail
 )
 
 
@@ -98,7 +99,7 @@ def email_address(label='Email address', gov_user=True):
     validators = [
         Length(min=5, max=255),
         DataRequired(message='Can’t be empty'),
-        Email(message='Enter a valid email address')
+        ValidEmail()
     ]
 
     if gov_user:
@@ -196,7 +197,7 @@ class LoginForm(StripWhitespaceForm):
     email_address = StringField('Email address', validators=[
         Length(min=5, max=255),
         DataRequired(message='Can’t be empty'),
-        Email(message='Enter a valid email address')
+        ValidEmail()
     ])
     password = PasswordField('Password', validators=[
         DataRequired(message='Enter your password')
@@ -707,7 +708,7 @@ class Whitelist(StripWhitespaceForm):
             '',
             validators=[
                 Optional(),
-                Email(message='Enter valid email addresses')
+                ValidEmail()
             ],
             default=''
         ),

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,7 +1,10 @@
 import re
+
 from wtforms import ValidationError
+from wtforms.validators import Email
 from notifications_utils.field import Field
 from notifications_utils.gsm import get_non_gsm_compatible_characters
+from notifications_utils.recipients import validate_email_address, InvalidEmailError
 
 from app import formatted_list
 from app.main._blacklisted_passwords import blacklisted_passwords
@@ -42,6 +45,19 @@ class ValidGovEmail:
             ' <a href="{}">contact us</a>').format(url_for('main.support'))
         if not is_gov_user(field.data.lower()):
             raise ValidationError(message)
+
+
+class ValidEmail(Email):
+
+    def __init__(self):
+        super().__init__('Enter a valid email address')
+
+    def __call__(self, form, field):
+        try:
+            validate_email_address(field.data)
+        except InvalidEmailError:
+            raise ValidationError(self.message)
+        return super().__call__(form, field)
 
 
 class NoCommasInPlaceHolders:

--- a/tests/app/main/test_placeholder_form.py
+++ b/tests/app/main/test_placeholder_form.py
@@ -22,6 +22,7 @@ def test_form_class_not_mutated(app_):
 
     (False, 'email address', '', 'Can’t be empty'),
     (False, 'email address', '12345', 'Enter a valid email address'),
+    (False, 'email address', '“bad”@email-address.com', 'Enter a valid email address'),
     (False, 'email address', 'test@example.com', None),
     (False, 'email address', 'test@example.gov.uk', None),
 


### PR DESCRIPTION
previously we were just using the wtforms builtin email validator, which is much more relaxed than our own one. But we'd still catch bad emails when POSTing to the API, resulting in an ugly error message. It's easy work to make sure we validate email addresses as soon as they're entered.

![image](https://user-images.githubusercontent.com/5020841/36210144-95f7118a-1195-11e8-8a18-4153dab35f80.png)
