### PR TITLE
Remove allow/stop send pdf letters button

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -265,14 +265,6 @@ def update_service_permissions(service_id, permissions, sms_sender=None):
     service_api_client.update_service_with_properties(service_id, data)
 
 
-@main.route("/services/<service_id>/service-settings/send-letters-as-pdf")
-@login_required
-@user_has_permissions(admin_override=True)
-def service_switch_send_letters_as_pdf(service_id):
-    switch_service_permissions(service_id, 'letters_as_pdf')
-    return redirect(url_for('.service_settings', service_id=service_id))
-
-
 @main.route("/services/<service_id>/service-settings/can-send-email")
 @login_required
 @user_has_permissions(admin_override=True)

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -310,13 +310,6 @@
             {{ 'Stop sending emails' if 'email' in current_service.permissions else 'Allow to send emails' }}
           </a>
         </li>
-        {% if 'letter' in current_service.permissions %}
-          <li class="bottom-gutter">
-            <a href="{{ url_for('.service_switch_send_letters_as_pdf', service_id=current_service.id) }}" class="button">
-              {{ 'Stop sending letters as PDF' if 'letters_as_pdf' in current_service.permissions else 'Send letters as PDF' }}
-            </a>
-          </li>
-        {% endif %}
         <li class="bottom-gutter">
           <a href="{{ url_for('.service_switch_can_send_sms', service_id=current_service.id) }}" class="button">
             {{ 'Stop sending sms' if 'sms' in current_service.permissions else 'Allow to send sms' }}

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -37,12 +37,6 @@ def get_service_settings_page(
 
     ({'permissions': ['sms']}, '.service_set_inbound_number', {'set_inbound_sms': True}, 'Allow inbound sms'),
 
-    (
-        {'permissions': ['letter', 'letters_as_pdf']},
-        '.service_switch_send_letters_as_pdf', {}, 'Stop sending letters as PDF'
-    ),
-    ({'permissions': ['letter']}, '.service_switch_send_letters_as_pdf', {}, 'Send letters as PDF'),
-
     ({'active': True}, '.archive_service', {}, 'Archive service'),
     ({'active': True}, '.suspend_service', {}, 'Suspend service'),
     ({'active': False}, '.resume_service', {}, 'Resume service'),


### PR DESCRIPTION
Now that we only use the pdf letter flow, we can remove the button for the platform admin users.