### PR TITLE
Add original file data to job downloads

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -126,7 +126,8 @@ def view_job_csv(service_id, job_id):
                 status=filter_args.get('status'),
                 page=request.args.get('page', 1),
                 page_size=5000,
-                format_for_csv=True
+                format_for_csv=True,
+                template_type=template['template_type'],
             )
         ),
         mimetype='text/csv',

--- a/app/utils.py
+++ b/app/utils.py
@@ -141,27 +141,21 @@ def generate_notifications_csv(**kwargs):
 
     while kwargs['page']:
         notifications_resp = notification_api_client.get_notifications_for_service(**kwargs)
-        notifications = notifications_resp['notifications']
-
-        if kwargs.get('job_id'):
-            for notification in notifications:
-                original_row = original_upload[notification['row_number'] - 1]
+        for notification in notifications_resp['notifications']:
+            if kwargs.get('job_id'):
                 values = [
                     notification['row_number'],
                 ] + [
-                    original_row.get(header)
+                    original_upload[notification['row_number'] - 1].get(header)
                     for header in original_column_headers
                 ] + [
                     notification['template_name'],
                     notification['template_type'],
                     notification['job_name'],
                     notification['status'],
-                    notification['created_at']
+                    notification['created_at'],
                 ]
-                yield ','.join(map(str, values)) + '\n'
-        else:
-            # Change here
-            for notification in notifications:
+            else:
                 values = [
                     notification['to'],
                     notification['template']['name'],
@@ -171,8 +165,8 @@ def generate_notifications_csv(**kwargs):
                     notification['created_at'],
                     notification['updated_at']
                 ]
-                line = ','.join(str(i) for i in values) + '\n'
-                yield line
+            yield ','.join(map(str, values)) + '\n'
+
         if notifications_resp['links'].get('next'):
             kwargs['page'] += 1
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ notifications-python-client==4.7.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.6.2#egg=notifications-utils==23.6.2
+git+https://github.com/alphagov/notifications-utils.git@23.8.0#egg=notifications-utils==23.8.0


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/347

---

When downloading a report of a which messages from a job have been delivered and which have failed we currently only include the Notify data. This makes it hard to reconcile or do analysis on these reports, because often the thing that people want to reconcile on is in the data they’ve uploaded (eg a reference number).

Here’s an example of a user talking about this problem:

> It would also be helpful if the format of the delivery and failure reports could include the fields from the recipient's file. While I can, of course,  cross-reference one report with the other it would be easier if I did not have to. We send emails to individuals within organisations and it is not always easy to establish the organisation from a recipient's email address. This is particularly important when emails fail to be delivered as we need to contact the organisation to establish a new contact.

– Deskpro ticket 677

We’ve also seen it when doing research with a local council.

---

This commit takes the original file, the data from the API, and munges them together.