### PR TITLE
Enforce order and style of imports

### DIFF
--- a/app/asset_fingerprinter.py
+++ b/app/asset_fingerprinter.py
@@ -1,5 +1,5 @@
-import hashlib
 import codecs
+import hashlib
 
 
 class AssetFingerprinter(object):

--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -3,8 +3,8 @@ Extracts cloudfoundry config from its json and populates the environment variabl
 on local/aws boxes
 """
 
-import os
 import json
+import os
 
 
 def extract_cloudfoundry_config():

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,5 @@
 import os
 
-
 if os.environ.get('VCAP_APPLICATION'):
     # on cloudfoundry, config is a json blob in VCAP_APPLICATION - unpack it, and populate
     # standard environment variables from it

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,42 +1,42 @@
-import pytz
 import weakref
-
-from flask_wtf import FlaskForm as Form
 from datetime import datetime, timedelta
 from itertools import chain
 
-from notifications_utils.recipients import (
-    validate_phone_number,
-    InvalidPhoneError
-)
+import pytz
+from flask_wtf import FlaskForm as Form
+from flask_wtf.file import FileAllowed
+from flask_wtf.file import FileField as FileField_wtf
 from notifications_utils.columns import Columns
+from notifications_utils.recipients import (
+    InvalidPhoneError,
+    validate_phone_number,
+)
 from wtforms import (
-    widgets,
-    validators,
-    StringField,
-    PasswordField,
-    ValidationError,
-    TextAreaField,
-    FileField,
     BooleanField,
+    DateField,
+    FieldList,
+    FileField,
     HiddenField,
     IntegerField,
+    PasswordField,
     RadioField,
-    FieldList,
-    DateField,
+    StringField,
+    TextAreaField,
+    ValidationError,
+    validators,
+    widgets,
 )
-from wtforms.fields.html5 import EmailField, TelField, SearchField
-from wtforms.validators import (DataRequired, Length, Regexp, Optional)
-from flask_wtf.file import FileField as FileField_wtf, FileAllowed
+from wtforms.fields.html5 import EmailField, SearchField, TelField
+from wtforms.validators import DataRequired, Length, Optional, Regexp
 
 from app.main.validators import (
     Blacklist,
     CsvFileValidator,
-    ValidGovEmail,
+    LettersNumbersAndFullStopsOnly,
     NoCommasInPlaceHolders,
     OnlyGSMCharacters,
-    LettersNumbersAndFullStopsOnly,
-    ValidEmail
+    ValidEmail,
+    ValidGovEmail,
 )
 
 

--- a/app/main/s3_client.py
+++ b/app/main/s3_client.py
@@ -1,4 +1,5 @@
 import uuid
+
 import botocore
 from boto3 import resource
 from flask import current_app

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,17 +1,17 @@
 import re
 
-from wtforms import ValidationError
-from wtforms.validators import Email
 from notifications_utils.field import Field
 from notifications_utils.gsm import get_non_gsm_compatible_characters
-from notifications_utils.recipients import validate_email_address, InvalidEmailError
+from notifications_utils.recipients import (
+    InvalidEmailError,
+    validate_email_address,
+)
+from wtforms import ValidationError
+from wtforms.validators import Email
 
 from app import formatted_list
 from app.main._blacklisted_passwords import blacklisted_passwords
-from app.utils import (
-    Spreadsheet,
-    is_gov_user
-)
+from app.utils import Spreadsheet, is_gov_user
 
 
 class Blacklist:

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,33 +1,18 @@
-from flask import (
-    render_template,
-    redirect,
-    session,
-    url_for,
-    current_app
-)
-
-from flask_login import (
-    current_user,
-    login_required
-)
+from flask import current_app, redirect, render_template, session, url_for
+from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
 from werkzeug.exceptions import abort
 
+from app import (
+    billing_api_client,
+    invite_api_client,
+    service_api_client,
+    user_api_client,
+)
 from app.main import main
 from app.main.forms import CreateServiceForm
 from app.notify_client.models import InvitedUser
-
-from app import (
-    invite_api_client,
-    user_api_client,
-    service_api_client,
-    billing_api_client
-)
-
-from app.utils import (
-    email_safe,
-    is_gov_user
-)
+from app.utils import email_safe, is_gov_user
 
 
 def _add_invited_user_to_service(invited_user):

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -1,15 +1,33 @@
-from flask import request, render_template, redirect, url_for, flash, Markup, abort
-from flask_login import login_required, current_user
+from flask import (
+    Markup,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import current_user, login_required
+
+from app import (
+    api_key_api_client,
+    current_service,
+    notification_api_client,
+    service_api_client,
+)
 from app.main import main
 from app.main.forms import (
     CreateKeyForm,
-    Whitelist,
+    ServiceDeliveryStatusCallbackForm,
     ServiceReceiveMessagesCallbackForm,
-    ServiceDeliveryStatusCallbackForm
+    Whitelist,
 )
-from app import api_key_api_client, service_api_client, notification_api_client, current_service
-from app.utils import user_has_permissions, email_safe
-from app.notify_client.api_key_api_client import KEY_TYPE_NORMAL, KEY_TYPE_TEST, KEY_TYPE_TEAM
+from app.notify_client.api_key_api_client import (
+    KEY_TYPE_NORMAL,
+    KEY_TYPE_TEAM,
+    KEY_TYPE_TEST,
+)
+from app.utils import email_safe, user_has_permissions
 
 dummy_bearer_token = 'bearer_token_set'
 

--- a/app/main/views/choose_service.py
+++ b/app/main/views/choose_service.py
@@ -1,7 +1,8 @@
-from flask import (render_template, redirect, url_for, session)
-from flask_login import login_required, current_user
-from app.main import main
+from flask import redirect, render_template, session, url_for
+from flask_login import current_user, login_required
+
 from app import service_api_client
+from app.main import main
 from app.notify_client.service_api_client import ServicesBrowsableItem
 from app.utils import is_gov_user
 

--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -1,9 +1,4 @@
-from flask import (
-    render_template,
-    redirect,
-    session,
-    url_for
-)
+from flask import redirect, render_template, session, url_for
 
 from app import user_api_client
 from app.main import main

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -1,18 +1,13 @@
-from flask import (
-    jsonify,
-    session,
-    redirect,
-    render_template,
-    url_for,
-)
+from flask import jsonify, redirect, render_template, session, url_for
 from flask_login import login_required
+from notifications_python_client.errors import HTTPError
 from notifications_utils.recipients import format_phone_number_human_readable
 from notifications_utils.template import SMSPreviewTemplate
+
+from app import notification_api_client, service_api_client
 from app.main import main
 from app.main.forms import SearchTemplatesForm
 from app.utils import user_has_permissions
-from app import notification_api_client, service_api_client
-from notifications_python_client.errors import HTTPError
 
 
 @main.route("/services/<service_id>/conversation/<notification_id>")

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,37 +1,38 @@
 import calendar
 from datetime import datetime
 from functools import partial
+
 from flask import (
-    render_template,
-    url_for,
-    session,
-    jsonify,
-    request,
-    abort,
     Response,
+    abort,
+    jsonify,
+    render_template,
+    request,
+    session,
+    url_for,
 )
 from flask_login import login_required
 from notifications_utils.recipients import format_phone_number_human_readable
 from werkzeug.utils import redirect
 
-from app.main import main
 from app import (
-    current_service,
     billing_api_client,
+    current_service,
+    format_date_numeric,
+    format_datetime_numeric,
+    inbound_number_client,
     job_api_client,
     service_api_client,
     template_statistics_client,
-    inbound_number_client,
-    format_date_numeric,
-    format_datetime_numeric,
 )
-from app.statistics_utils import get_formatted_percentage, add_rate_to_job
+from app.main import main
+from app.statistics_utils import add_rate_to_job, get_formatted_percentage
 from app.utils import (
-    user_has_permissions,
-    get_current_financial_year,
     FAILURE_STATUSES,
     REQUESTED_STATUSES,
     Spreadsheet,
+    get_current_financial_year,
+    user_has_permissions,
 )
 
 

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -4,19 +4,22 @@ from flask_login import login_required
 from app import email_branding_client
 from app.main import main
 from app.main.forms import (
+    ServiceCreateEmailBranding,
     ServiceSelectEmailBranding,
     ServiceUpdateEmailBranding,
-    ServiceCreateEmailBranding
 )
-from app.utils import user_has_permissions, get_cdn_domain
 from app.main.s3_client import (
     TEMP_TAG,
-    upload_logo,
     delete_temp_file,
     delete_temp_files_created_by,
-    persist_logo
+    persist_logo,
+    upload_logo,
 )
-from app.main.views.service_settings import get_branding_as_value_and_label, get_branding_as_dict
+from app.main.views.service_settings import (
+    get_branding_as_dict,
+    get_branding_as_value_and_label,
+)
+from app.utils import get_cdn_domain, user_has_permissions
 
 
 @main.route("/email-branding", methods=['GET', 'POST'])

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,13 +1,18 @@
+from datetime import datetime
+
 import pytz
-from flask import render_template, url_for, redirect, abort, request, session
+from flask import abort, redirect, render_template, request, session, url_for
 from flask_login import current_user
 from notifications_utils.clients import DeskproError
 
-from app import convert_to_boolean, current_service, service_api_client, deskpro_client
+from app import (
+    convert_to_boolean,
+    current_service,
+    deskpro_client,
+    service_api_client,
+)
 from app.main import main
-from app.main.forms import SupportType, Feedback, Problem, Triage
-from datetime import datetime
-
+from app.main.forms import Feedback, Problem, SupportType, Triage
 
 QUESTION_TICKET_TYPE = 'ask-question-give-feedback'
 PROBLEM_TICKET_TYPE = "report-problem"

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -1,11 +1,9 @@
-from flask import (
-    render_template,
-)
+from flask import render_template
 from notifications_python_client.errors import HTTPError
 
+from app import user_api_client
 from app.main import main
 from app.main.forms import ForgotPasswordForm
-from app import user_api_client
 
 
 @main.route('/forgot-password', methods=['GET', 'POST'])

--- a/app/main/views/inbound_number.py
+++ b/app/main/views/inbound_number.py
@@ -1,7 +1,8 @@
 from flask import render_template
 from flask_login import login_required
-from app.main import main
+
 from app import inbound_number_client
+from app.main import main
 from app.utils import user_has_permissions
 
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,12 +1,13 @@
-from flask import (render_template, url_for, redirect, request)
-from app.main import main
-from app import convert_to_boolean
-from app.main.forms import SearchTemplatesForm
-from flask_login import (login_required, current_user)
-
+from flask import redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+from notifications_utils.international_billing_rates import (
+    INTERNATIONAL_BILLING_RATES,
+)
 from notifications_utils.template import HTMLEmailTemplate
-from notifications_utils.international_billing_rates import INTERNATIONAL_BILLING_RATES
 
+from app import convert_to_boolean
+from app.main import main
+from app.main.forms import SearchTemplatesForm
 from app.main.views.sub_navigation_dictionaries import features_nav
 
 

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -1,22 +1,15 @@
-from flask import (
-    redirect,
-    url_for,
-    session,
-    flash,
-    render_template,
-    abort
-)
-from markupsafe import Markup
+from flask import abort, flash, redirect, render_template, session, url_for
 from flask_login import current_user
+from markupsafe import Markup
 
-from app.main import main
 from app import (
     invite_api_client,
     org_invite_api_client,
-    user_api_client,
     organisations_client,
-    service_api_client
+    service_api_client,
+    user_api_client,
 )
+from app.main import main
 
 
 @main.route("/invitation/<token>")

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -1,41 +1,40 @@
 # -*- coding: utf-8 -*-
 
 from flask import (
-    render_template,
-    abort,
-    jsonify,
-    request,
-    url_for,
-    current_app,
-    redirect,
     Response,
-    stream_with_context
+    abort,
+    current_app,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    stream_with_context,
+    url_for,
 )
 from flask_login import login_required
-from notifications_utils.template import (
-    Template,
-    WithSubjectTemplate,
-)
+from notifications_utils.template import Template, WithSubjectTemplate
 
 from app import (
+    current_service,
+    format_datetime_short,
     job_api_client,
     notification_api_client,
     service_api_client,
-    current_service,
-    format_datetime_short)
+)
 from app.main import main
 from app.main.forms import SearchNotificationsForm
-from app.utils import (
-    get_page_from_request,
-    generate_next_dict,
-    generate_previous_dict,
-    user_has_permissions,
-    generate_notifications_csv,
-    get_time_left,
-    get_letter_timings,
-    parse_filter_args, set_status_filters
-)
 from app.statistics_utils import add_rate_to_job
+from app.utils import (
+    generate_next_dict,
+    generate_notifications_csv,
+    generate_previous_dict,
+    get_letter_timings,
+    get_page_from_request,
+    get_time_left,
+    parse_filter_args,
+    set_status_filters,
+    user_has_permissions,
+)
 
 
 @main.route("/services/<service_id>/jobs")

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -1,26 +1,17 @@
 from itertools import chain
-from flask import (
-    request,
-    render_template,
-    redirect,
-    url_for,
-    flash,
-    abort
-)
 
-from flask_login import (
-    login_required,
-    current_user
-)
-
+from flask import abort, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
-from app.main import main
-from app.main.forms import (
-    InviteUserForm,
-    PermissionsForm,
-    SearchUsersForm,
+
+from app import (
+    current_service,
+    invite_api_client,
+    service_api_client,
+    user_api_client,
 )
-from app import (user_api_client, current_service, service_api_client, invite_api_client)
+from app.main import main
+from app.main.forms import InviteUserForm, PermissionsForm, SearchUsersForm
 from app.notify_client.models import roles
 from app.utils import user_has_permissions
 

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -1,7 +1,14 @@
-from datetime import datetime
 import json
+from datetime import datetime
 
-from flask import (render_template, url_for, redirect, flash, session, current_app)
+from flask import (
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    session,
+    url_for,
+)
 from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import check_token
 

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -2,30 +2,36 @@
 from datetime import datetime
 
 from flask import (
+    Response,
     abort,
-    render_template,
     jsonify,
+    render_template,
     request,
+    stream_with_context,
     url_for,
-    Response, stream_with_context)
+)
 from flask_login import login_required
 
 from app import (
-    notification_api_client,
-    job_api_client,
     current_service,
-    format_date_numeric)
+    format_date_numeric,
+    job_api_client,
+    notification_api_client,
+)
 from app.main import main
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
-    user_has_permissions,
+    DELIVERED_STATUSES,
+    FAILURE_STATUSES,
+    generate_notifications_csv,
     get_help_argument,
+    get_letter_timings,
     get_template,
     get_time_left,
-    get_letter_timings,
-    FAILURE_STATUSES,
-    DELIVERED_STATUSES,
-    generate_notifications_csv, parse_filter_args, set_status_filters)
+    parse_filter_args,
+    set_status_filters,
+    user_has_permissions,
+)
 
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>")

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -1,30 +1,16 @@
-from flask import (
-    redirect,
-    render_template,
-    url_for,
-    flash,
-    request
-)
-from flask_login import (
-    login_required,
-    current_user
-)
-
-from app import (
-    organisations_client,
-    org_invite_api_client,
-    user_api_client,
-)
-from app.main.forms import (
-    SearchUsersForm,
-    InviteOrgUserForm,
-)
-from app.main import main
-from app.main.forms import CreateOrUpdateOrganisation
-from app.utils import user_has_permissions
-
+from flask import flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
 from werkzeug.exceptions import abort
+
+from app import org_invite_api_client, organisations_client, user_api_client
+from app.main import main
+from app.main.forms import (
+    CreateOrUpdateOrganisation,
+    InviteOrgUserForm,
+    SearchUsersForm,
+)
+from app.utils import user_has_permissions
 
 
 @main.route("/organisations", methods=['GET'])

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -1,17 +1,14 @@
 import itertools
-
 from datetime import datetime
-from flask import (
-    render_template,
-    request
-)
+
+from flask import render_template, request
 from flask_login import login_required
 
 from app import service_api_client
 from app.main import main
 from app.main.forms import DateFilterForm
-from app.utils import user_has_permissions
 from app.statistics_utils import get_formatted_percentage
+from app.utils import user_has_permissions
 
 
 @main.route("/platform-admin")

--- a/app/main/views/providers.py
+++ b/app/main/views/providers.py
@@ -1,14 +1,11 @@
-from flask import (
-    render_template,
-    url_for
-)
-
+from flask import render_template, url_for
 from flask_login import login_required
 from werkzeug.utils import redirect
+
+from app import provider_client
 from app.main import main
 from app.main.forms import ProviderForm
 from app.utils import user_has_permissions
-from app import provider_client
 
 
 @main.route("/providers")

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,32 +1,16 @@
-from datetime import (
-    datetime,
-    timedelta
-)
+from datetime import datetime, timedelta
 
-from flask import (
-    render_template,
-    redirect,
-    session,
-    abort,
-    url_for
-)
-
+from flask import abort, redirect, render_template, session, url_for
 from flask_login import current_user
 
+from app import invite_api_client, org_invite_api_client, user_api_client
 from app.main import main
-
 from app.main.forms import (
     RegisterUserForm,
     RegisterUserFromInviteForm,
-    RegisterUserFromOrgInviteForm
+    RegisterUserFromOrgInviteForm,
 )
 from app.main.views.verify import activate_user
-
-from app import (
-    user_api_client,
-    invite_api_client,
-    org_invite_api_client
-)
 
 
 @main.route('/register', methods=['GET', 'POST'])

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1,52 +1,52 @@
 import itertools
 from string import ascii_uppercase
-
-from orderedset import OrderedSet
 from zipfile import BadZipFile
-from xlrd.biffh import XLRDError
-from werkzeug.routing import RequestRedirect
 
 from flask import (
-    request,
-    render_template,
-    redirect,
-    url_for,
-    flash,
     abort,
-    session,
     current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
 )
-
-from flask_login import login_required, current_user
-
+from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
 from notifications_utils.recipients import (
     RecipientCSV,
     first_column_headings,
     optional_address_columns,
 )
+from orderedset import OrderedSet
+from werkzeug.routing import RequestRedirect
+from xlrd.biffh import XLRDError
 
+from app import (
+    current_service,
+    job_api_client,
+    notification_api_client,
+    service_api_client,
+    user_api_client,
+)
 from app.main import main
 from app.main.forms import (
-    CsvUploadForm,
     ChooseTimeForm,
+    CsvUploadForm,
     SetSenderForm,
-    get_placeholder_form_instance
+    get_placeholder_form_instance,
 )
-from app.main.s3_client import (
-    s3upload,
-    s3download
-)
-from app import job_api_client, service_api_client, current_service, user_api_client, notification_api_client
+from app.main.s3_client import s3download, s3upload
+from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
-    user_has_permissions,
-    get_errors_for_csv,
     Spreadsheet,
+    email_or_sms_not_enabled,
+    get_errors_for_csv,
     get_help_argument,
     get_template,
-    email_or_sms_not_enabled,
+    user_has_permissions,
 )
-from app.template_previews import TemplatePreview, get_page_count_for_letter
 
 
 def get_page_headings(template_type):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1,53 +1,48 @@
 from flask import (
-    render_template,
-    redirect,
-    request,
-    url_for,
-    session,
-    flash,
     abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
 )
-
-from flask_login import (
-    login_required,
-    current_user
-)
-
-from notifications_utils.field import Field
-from notifications_utils.clients import DeskproError
+from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
+from notifications_utils.clients import DeskproError
+from notifications_utils.field import Field
+from notifications_utils.formatters import formatted_list
 
-from app.main import main
-from app.utils import user_has_permissions, email_safe, get_cdn_domain
-from app.main.forms import (
-    ConfirmPasswordForm,
-    RenameServiceForm,
-    RequestToGoLiveForm,
-    ServiceReplyToEmailForm,
-    ServiceInboundNumberForm,
-    ServiceSmsSenderForm,
-    ServiceLetterContactBlockForm,
-    ServiceSetBranding,
-    LetterBranding,
-    InternationalSMSForm,
-    OrganisationTypeForm,
-    FreeSMSAllowance,
-    ServiceEditInboundNumberForm,
-    SMSPrefixForm,
-    ServiceSwitchLettersForm,
-    LinkOrganisationsForm,
-)
 from app import (
-    service_api_client,
-    deskpro_client,
-    user_api_client,
+    billing_api_client,
     current_service,
+    deskpro_client,
     email_branding_client,
     inbound_number_client,
-    billing_api_client,
     organisations_client,
+    service_api_client,
+    user_api_client,
 )
-from notifications_utils.formatters import formatted_list
+from app.main import main
+from app.main.forms import (
+    ConfirmPasswordForm,
+    FreeSMSAllowance,
+    InternationalSMSForm,
+    LetterBranding,
+    LinkOrganisationsForm,
+    OrganisationTypeForm,
+    RenameServiceForm,
+    RequestToGoLiveForm,
+    ServiceEditInboundNumberForm,
+    ServiceInboundNumberForm,
+    ServiceLetterContactBlockForm,
+    ServiceReplyToEmailForm,
+    ServiceSetBranding,
+    ServiceSmsSenderForm,
+    ServiceSwitchLettersForm,
+    SMSPrefixForm,
+)
+from app.utils import email_safe, get_cdn_domain, user_has_permissions
 
 
 @main.route("/services/<service_id>/service-settings")

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -1,25 +1,16 @@
 from flask import (
-    render_template,
-    redirect,
-    url_for,
-    session,
-    flash,
-    request,
+    Markup,
     abort,
-    Markup
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
 )
+from flask_login import current_user
 
-from flask_login import (
-    current_user,
-)
-
-from app import (
-    login_manager,
-    user_api_client,
-    invite_api_client
-)
-
-
+from app import invite_api_client, login_manager, user_api_client
 from app.main import main
 from app.main.forms import LoginForm
 

--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -1,9 +1,4 @@
-from flask import (
-    redirect,
-    url_for,
-    session
-)
-
+from flask import redirect, session, url_for
 from flask_login import logout_user
 
 from app.main import main

--- a/app/main/views/styleguide.py
+++ b/app/main/views/styleguide.py
@@ -1,7 +1,14 @@
-from flask import render_template, current_app, abort
+from flask import abort, current_app, render_template
 from flask_wtf import FlaskForm as Form
-from wtforms import StringField, PasswordField, TextAreaField, FileField, validators
 from notifications_utils.template import Template
+from wtforms import (
+    FileField,
+    PasswordField,
+    StringField,
+    TextAreaField,
+    validators,
+)
+
 from app.main import main
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1,38 +1,40 @@
 from datetime import datetime, timedelta
 from string import ascii_uppercase
 
-from flask import (
-    request,
-    render_template,
-    redirect,
-    url_for,
-    flash,
-    abort,
-    Response,
-)
-from flask_login import login_required, current_user
 from dateutil.parser import parse
+from flask import (
+    Response,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import current_user, login_required
 from markupsafe import Markup
-
+from notifications_python_client.errors import HTTPError
 from notifications_utils.formatters import nl2br
 from notifications_utils.recipients import first_column_headings
 from notifications_utils.template import LetterDVLATemplate
-from notifications_python_client.errors import HTTPError
 
+from app import current_service, service_api_client, template_statistics_client
 from app.main import main
-from app.utils import user_has_permissions, get_template, email_or_sms_not_enabled
-from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.main.forms import (
     ChooseTemplateType,
-    SMSTemplateForm,
     EmailTemplateForm,
     LetterTemplateForm,
     SearchTemplatesForm,
     SetTemplateSenderForm,
+    SMSTemplateForm,
 )
 from app.main.views.send import get_example_csv_rows, get_sender_details
-from app import service_api_client, current_service, template_statistics_client
-
+from app.template_previews import TemplatePreview, get_page_count_for_letter
+from app.utils import (
+    email_or_sms_not_enabled,
+    get_template,
+    user_has_permissions,
+)
 
 form_objects = {
     'email': EmailTemplateForm,

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -1,20 +1,22 @@
 import json
+
 from flask import (
-    render_template,
+    current_app,
+    flash,
     redirect,
+    render_template,
+    request,
     session,
     url_for,
-    request,
-    current_app,
-    flash
 )
-from flask_login import login_user, current_user
+from flask_login import current_user, login_user
+from itsdangerous import SignatureExpired
+from notifications_utils.url_safe_token import check_token
+
+from app import service_api_client, user_api_client
 from app.main import main
 from app.main.forms import TwoFactorForm
-from app import service_api_client, user_api_client
 from app.utils import redirect_to_sign_in
-from notifications_utils.url_safe_token import check_token
-from itsdangerous import SignatureExpired
 
 
 @main.route('/two-factor-email-sent', methods=['GET'])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -2,29 +2,26 @@ import json
 
 from flask import (
     abort,
-    render_template,
+    current_app,
     redirect,
-    url_for,
+    render_template,
     session,
-    current_app)
-
-from flask_login import login_required, current_user
+    url_for,
+)
+from flask_login import current_user, login_required
 from notifications_utils.url_safe_token import check_token
 
+from app import user_api_client
 from app.main import main
-
 from app.main.forms import (
-    ChangePasswordForm,
-    ChangeNameForm,
     ChangeEmailForm,
     ChangeMobileNumberForm,
+    ChangeNameForm,
+    ChangePasswordForm,
     ConfirmMobileNumberForm,
-    ConfirmPasswordForm
+    ConfirmPasswordForm,
 )
-
 from app.utils import is_gov_user
-
-from app import user_api_client
 
 NEW_EMAIL = 'new-email'
 NEW_MOBILE = 'new-mob'

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -1,26 +1,22 @@
 import json
 
 from flask import (
-    render_template,
-    redirect,
-    session,
-    url_for,
+    abort,
     current_app,
     flash,
-    abort
+    redirect,
+    render_template,
+    session,
+    url_for,
 )
-
-from itsdangerous import SignatureExpired
-
 from flask_login import login_user
-
+from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import check_token
 
+from app import user_api_client
 from app.main import main
 from app.main.forms import TwoFactorForm
 from app.utils import redirect_to_sign_in
-
-from app import user_api_client
 
 
 @main.route('/verify', methods=['GET', 'POST'])

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 # must match key types in notifications-api/app/models.py
 KEY_TYPE_NORMAL = 'normal'

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -1,5 +1,5 @@
 
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 from app.notify_client.models import InvitedUser
 
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 
 class JobApiClient(NotifyAdminAPIClient):

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -1,7 +1,7 @@
 from itertools import chain
-from flask_login import UserMixin, AnonymousUserMixin
-from flask import request, session
 
+from flask import request, session
+from flask_login import AnonymousUserMixin, UserMixin
 
 roles = {
     'send_messages': ['send_texts', 'send_emails', 'send_letters'],

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 
 class NotificationApiClient(NotifyAdminAPIClient):

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 from app.notify_client.models import InvitedOrgUser
 
 

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 
 class OrganisationsClient(NotifyAdminAPIClient):

--- a/app/notify_client/provider_client.py
+++ b/app/notify_client/provider_client.py
@@ -1,5 +1,5 @@
 
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 
 
 class ProviderClient(NotifyAdminAPIClient):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 
 from flask import url_for
+
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user
 from app.utils import BrowsableItem
-from app.notify_client import _attach_current_user, NotifyAdminAPIClient
 
 
 class ServiceAPIClient(NotifyAdminAPIClient):

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from dateutil import parser
 from functools import reduce
+
+from dateutil import parser
 
 
 def sum_of_statistics(delivery_statistics):

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -1,7 +1,8 @@
-from flask import jsonify, request, current_app
-from app import (version, status_api_client)
-from app.status import status
+from flask import current_app, jsonify, request
 from notifications_python_client.errors import HTTPError
+
+from app import status_api_client, version
+from app.status import status
 
 
 @status.route('/_status', methods=['GET'])

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -1,5 +1,5 @@
-from flask import current_app, json
 import requests
+from flask import current_app, json
 
 from app import current_service
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,37 +1,27 @@
+import csv
 import os
 import re
-import csv
-import yaml
-
-from itertools import chain
-
-import pytz
-from io import StringIO
-from os import path
-from functools import wraps
 import unicodedata
-from urllib.parse import urlparse
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
+from functools import wraps
+from io import StringIO
+from itertools import chain
+from os import path
+from urllib.parse import urlparse
 
-import dateutil
 import ago
-from flask import (
-    abort,
-    current_app,
-    redirect,
-    request,
-    session,
-    url_for
-)
-from flask_login import current_user
+import dateutil
 import pyexcel
-
+import pytz
+import yaml
+from flask import abort, current_app, redirect, request, session, url_for
+from flask_login import current_user
 from notifications_utils.template import (
-    SMSPreviewTemplate,
     EmailPreviewTemplate,
     LetterImageTemplate,
     LetterPreviewTemplate,
+    SMSPreviewTemplate,
 )
 from orderedset._orderedset import OrderedSet
 from werkzeug.datastructures import MultiDict

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+isort==4.3.4
 pytest==3.4.1
 pytest-env==0.6.2
 pytest-mock==1.7.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,9 +27,12 @@ fi
 flake8 .
 display_result $? 1 "Code style check"
 
+isort --check-only -rc ./app ./tests
+display_result $? 2 "Import order check"
+
 npm test
-display_result $? 2 "Front end code style check"
+display_result $? 3 "Front end code style check"
 
 ## Code coverage
 py.test -n4 --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
-display_result $? 3 "Code coverage"
+display_result $? 4 "Code coverage"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
 [tool:pytest]
 norecursedirs = node_modules bower_components
 xfail_strict=true
+
+[isort]
+line_length=80
+indent='    '
+multi_line_output=3
+known_third_party = notifications_utils, notifications_python_client
+include_trailing_comma = True

--- a/tests/app/main/test_choose_time_form.py
+++ b/tests/app/main/test_choose_time_form.py
@@ -1,7 +1,7 @@
 import pytest
+from freezegun import freeze_time
 
 from app.main.forms import ChooseTimeForm
-from freezegun import freeze_time
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -1,5 +1,4 @@
 import pytest
-
 from werkzeug.datastructures import MultiDict
 
 from app.main.forms import CreateKeyForm

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -1,7 +1,7 @@
-from flask import Response, url_for
-from flask_wtf.csrf import CSRFError
 import pytest
 from bs4 import BeautifulSoup
+from flask import Response, url_for
+from flask_wtf.csrf import CSRFError
 from notifications_python_client.errors import HTTPError
 
 

--- a/tests/app/main/test_errors_for_csv.py
+++ b/tests/app/main/test_errors_for_csv.py
@@ -4,7 +4,6 @@ import pytest
 
 from app.utils import get_errors_for_csv
 
-
 MockRecipients = namedtuple(
     'RecipientCSV',
     [

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -1,8 +1,9 @@
 import pytest
-from app.utils import user_has_permissions
-from app.main.views.index import index
-from werkzeug.exceptions import Forbidden, Unauthorized
 from flask import request
+from werkzeug.exceptions import Forbidden, Unauthorized
+
+from app.main.views.index import index
+from app.utils import user_has_permissions
 
 
 def _test_permissions(

--- a/tests/app/main/test_placeholder_form.py
+++ b/tests/app/main/test_placeholder_form.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app.main.forms import get_placeholder_form_instance
 
 

--- a/tests/app/main/test_request_header.py
+++ b/tests/app/main/test_request_header.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.conftest import set_config_values
 
 

--- a/tests/app/main/test_s3_client.py
+++ b/tests/app/main/test_s3_client.py
@@ -1,15 +1,16 @@
 from collections import namedtuple
 from unittest.mock import call
+
 import pytest
 
 from app.main.s3_client import (
-    upload_logo,
-    persist_logo,
+    LOGO_LOCATION_STRUCTURE,
+    TEMP_TAG,
     delete_temp_file,
     delete_temp_files_created_by,
     get_temp_truncated_filename,
-    LOGO_LOCATION_STRUCTURE,
-    TEMP_TAG
+    persist_logo,
+    upload_logo,
 )
 
 bucket = 'test_bucket'

--- a/tests/app/main/test_two_factor_form.py
+++ b/tests/app/main/test_two_factor_form.py
@@ -1,5 +1,5 @@
-from app.main.forms import TwoFactorForm
 from app import user_api_client
+from app.main.forms import TwoFactorForm
 
 
 def test_form_is_valid_returns_no_errors(

--- a/tests/app/main/test_user.py
+++ b/tests/app/main/test_user.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app.notify_client.user_api_client import User
 
 

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -1,8 +1,14 @@
-import pytest
-from app.main.forms import RegisterUserForm, ServiceSmsSenderForm
-from app.main.validators import ValidGovEmail, NoCommasInPlaceHolders, OnlyGSMCharacters
-from wtforms import ValidationError
 from unittest.mock import Mock
+
+import pytest
+from wtforms import ValidationError
+
+from app.main.forms import RegisterUserForm, ServiceSmsSenderForm
+from app.main.validators import (
+    NoCommasInPlaceHolders,
+    OnlyGSMCharacters,
+    ValidGovEmail,
+)
 
 
 @pytest.mark.parametrize('password', [

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -2,7 +2,6 @@ import functools
 
 import pytest
 from flask import url_for
-
 from tests.conftest import client_request as client_request_factory
 
 

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -1,12 +1,12 @@
-from flask import url_for
-from bs4 import BeautifulSoup
 from unittest.mock import ANY
+
+from bs4 import BeautifulSoup
+from flask import url_for
+from tests.conftest import mock_check_invite_token as mock_check_token_invite
+from tests.conftest import sample_invite as create_sample_invite
 
 import app
 from app.notify_client.models import InvitedUser
-
-from tests.conftest import sample_invite as create_sample_invite
-from tests.conftest import mock_check_invite_token as mock_check_token_invite
 
 
 def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -1,18 +1,18 @@
 import json
 import uuid
-from urllib.parse import urlparse, quote, parse_qs
+from urllib.parse import parse_qs, quote, urlparse
 
 import pytest
-from flask import url_for
 from bs4 import BeautifulSoup
-
-from app.main.views.jobs import get_time_left, get_status_filters
+from flask import url_for
+from freezegun import freeze_time
 from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_notifications,
     normalize_spaces,
 )
-from freezegun import freeze_time
+
+from app.main.views.jobs import get_status_filters, get_time_left
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -1,5 +1,5 @@
 import pytest
-from flask import url_for, session
+from flask import session, url_for
 
 from app.utils import is_gov_user
 

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -1,21 +1,20 @@
 import uuid
 from collections import OrderedDict
-
-import pytest
-from flask import url_for
-from bs4 import BeautifulSoup
 from unittest.mock import call
 
+import pytest
+from bs4 import BeautifulSoup
+from flask import url_for
 from tests import validate_route_permission
 from tests.conftest import (
-    mock_get_service,
-    mock_get_live_service,
-    mock_get_service_with_letters,
-    mock_get_notifications,
-    normalize_spaces,
     SERVICE_ONE_ID,
+    mock_get_live_service,
+    mock_get_notifications,
+    mock_get_service,
+    mock_get_service_with_letters,
     mock_get_valid_service_callback_api,
     mock_get_valid_service_inbound_api,
+    normalize_spaces,
 )
 
 

--- a/tests/app/main/views/test_api_keys.py
+++ b/tests/app/main/views/test_api_keys.py
@@ -1,21 +1,20 @@
 import uuid
 from collections import OrderedDict
-
-import pytest
-from flask import url_for
-from bs4 import BeautifulSoup
 from unittest.mock import call
 
+import pytest
+from bs4 import BeautifulSoup
+from flask import url_for
 from tests import validate_route_permission
 from tests.conftest import (
-    fake_uuid,
-    mock_get_service,
-    mock_get_live_service,
-    mock_get_service_with_letters,
-    normalize_spaces,
     SERVICE_ONE_ID,
+    fake_uuid,
+    mock_get_live_service,
+    mock_get_service,
+    mock_get_service_with_letters,
     mock_get_valid_service_callback_api,
     mock_get_valid_service_inbound_api,
+    normalize_spaces,
 )
 
 

--- a/tests/app/main/views/test_choose_services.py
+++ b/tests/app/main/views/test_choose_services.py
@@ -1,5 +1,5 @@
-from flask import url_for
 from bs4 import BeautifulSoup
+from flask import url_for
 
 
 def test_should_show_choose_services_page(

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -1,6 +1,6 @@
 import pytest
-from flask import url_for
 from bs4 import BeautifulSoup
+from flask import url_for
 
 
 def test_should_render_email_verification_resend_show_email_address_and_resend_verify_email(

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -1,18 +1,16 @@
-from datetime import datetime
 import json
+from datetime import datetime
+
 import pytest
-
-from flask import (
-    url_for,
-)
-from notifications_python_client.errors import HTTPError
+from flask import url_for
 from freezegun import freeze_time
-
+from notifications_python_client.errors import HTTPError
 from tests.conftest import (
     SERVICE_ONE_ID,
-    normalize_spaces,
     mock_get_notifications,
+    normalize_spaces,
 )
+
 from app.main.views.conversation import get_user_number
 
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1,29 +1,31 @@
-import json
-from functools import partial
 import copy
-from unittest.mock import call, ANY
+import json
+from datetime import datetime
+from functools import partial
+from unittest.mock import ANY, call
 
-from flask import url_for
 import pytest
 from bs4 import BeautifulSoup
+from flask import url_for
 from freezegun import freeze_time
-from datetime import datetime
-
-from app.main.views.dashboard import (
-    get_dashboard_totals,
-    format_monthly_stats_to_list,
-    get_free_paid_breakdown_for_billable_units,
-    aggregate_status_types,
-    format_template_stats_to_list,
-    get_tuples_of_financial_years
+from tests import (
+    validate_route_permission,
+    validate_route_permission_with_client,
 )
-
-from tests import validate_route_permission, validate_route_permission_with_client
 from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_inbound_sms_summary,
     mock_get_inbound_sms_summary_with_no_messages,
     normalize_spaces,
+)
+
+from app.main.views.dashboard import (
+    aggregate_status_types,
+    format_monthly_stats_to_list,
+    format_template_stats_to_list,
+    get_dashboard_totals,
+    get_free_paid_breakdown_for_billable_units,
+    get_tuples_of_financial_years,
 )
 
 stub_template_stats = [

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -1,16 +1,12 @@
 from io import BytesIO
 from unittest.mock import call
 
+import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
-import pytest
+from tests.conftest import mock_get_email_branding, normalize_spaces
 
-from tests.conftest import (
-    mock_get_email_branding,
-    normalize_spaces
-)
-
-from app.main.s3_client import TEMP_TAG, LOGO_LOCATION_STRUCTURE
+from app.main.s3_client import LOGO_LOCATION_STRUCTURE, TEMP_TAG
 
 
 def test_email_branding_page_shows_full_branding_list(

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -1,17 +1,24 @@
-from bs4 import BeautifulSoup, element
 from functools import partial
-import pytest
-from flask import url_for
-from werkzeug.exceptions import InternalServerError
 from unittest.mock import ANY
+
+import pytest
+from bs4 import BeautifulSoup, element
+from flask import url_for
 from freezegun import freeze_time
 from notifications_utils.clients import DeskproError
 from tests.conftest import (
     mock_get_services,
     mock_get_services_with_no_services,
-    mock_get_services_with_one_service
+    mock_get_services_with_one_service,
 )
-from app.main.views.feedback import has_live_services, in_business_hours, PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE
+from werkzeug.exceptions import InternalServerError
+
+from app.main.views.feedback import (
+    PROBLEM_TICKET_TYPE,
+    QUESTION_TICKET_TYPE,
+    has_live_services,
+    in_business_hours,
+)
 
 
 def no_redirect():

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -1,6 +1,5 @@
 import pytest
-
-from flask import url_for, Response
+from flask import Response, url_for
 from notifications_python_client.errors import HTTPError
 from tests.conftest import api_user_active as create_active_user
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -1,12 +1,16 @@
 import json
 
 import pytest
-from flask import url_for
 from bs4 import BeautifulSoup
+from flask import url_for
+from freezegun import freeze_time
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    mock_get_notifications,
+    normalize_spaces,
+)
 
 from app.main.views.jobs import get_time_left
-from tests.conftest import SERVICE_ONE_ID, normalize_spaces, mock_get_notifications
-from freezegun import freeze_time
 
 
 def test_get_jobs_should_return_list_of_all_real_jobs(

--- a/tests/app/main/views/test_letter_jobs.py
+++ b/tests/app/main/views/test_letter_jobs.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
-from flask import url_for
+
 from bs4 import BeautifulSoup
+from flask import url_for
 
 from app import format_datetime_short
 

--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -1,7 +1,8 @@
+from functools import partial
+
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
-from functools import partial
 
 letters_urls = [
     partial(url_for, 'main.add_service_template', template_type='letter'),

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1,19 +1,21 @@
 import copy
+
 import pytest
-from flask import url_for
 from bs4 import BeautifulSoup
+from flask import url_for
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    active_user_manage_template_permission,
+    active_user_no_mobile,
+    active_user_view_permissions,
+    active_user_with_permissions,
+    normalize_spaces,
+)
+from tests.conftest import service_one as create_sample_service
+
 import app
 from app.notify_client.models import InvitedUser
 from app.utils import is_gov_user
-from tests.conftest import service_one as create_sample_service
-from tests.conftest import (
-    normalize_spaces,
-    SERVICE_ONE_ID,
-    active_user_with_permissions,
-    active_user_view_permissions,
-    active_user_no_mobile,
-    active_user_manage_template_permission,
-)
 
 
 @pytest.mark.parametrize('user, expected_self_text, expected_coworker_text', [

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -1,8 +1,8 @@
 import json
 from datetime import datetime
 
-from itsdangerous import SignatureExpired
 from flask import url_for
+from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import generate_token
 
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -1,10 +1,14 @@
-from freezegun import freeze_time
-from flask import url_for
 from functools import partial
-import pytest
 
+import pytest
+from flask import url_for
+from freezegun import freeze_time
 from notifications_utils.template import LetterImageTemplate
-from tests.conftest import mock_get_notification, SERVICE_ONE_ID, normalize_spaces
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    mock_get_notification,
+    normalize_spaces,
+)
 
 
 @pytest.mark.parametrize('notification_status, expected_status', [

--- a/tests/app/main/views/test_organisations.py
+++ b/tests/app/main/views/test_organisations.py
@@ -1,17 +1,11 @@
-import pytest
+from datetime import datetime, timedelta
+from unittest.mock import ANY
 
+import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from tests.conftest import normalize_spaces
 
-from datetime import (
-    datetime,
-    timedelta
-)
-
-from tests.conftest import (
-    normalize_spaces
-)
-from unittest.mock import ANY
 from app.notify_client.models import InvitedOrgUser
 
 

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1,15 +1,17 @@
 import datetime
+from unittest.mock import ANY
 
-from flask import url_for
 import pytest
 from bs4 import BeautifulSoup
-
-from tests.conftest import mock_get_user, normalize_spaces
+from flask import url_for
 from tests import service_json
+from tests.conftest import mock_get_user, normalize_spaces
 
-from app.main.views.platform_admin import format_stats_by_service, create_global_stats, sum_service_usage
-
-from unittest.mock import ANY
+from app.main.views.platform_admin import (
+    create_global_stats,
+    format_stats_by_service,
+    sum_service_usage,
+)
 
 
 @pytest.mark.parametrize('endpoint', [

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -1,14 +1,11 @@
-import pytest
-
 from datetime import datetime
-from bs4 import BeautifulSoup
 from unittest.mock import ANY
 
-from flask import (
-    url_for,
-    session
-)
+import pytest
+from bs4 import BeautifulSoup
+from flask import session, url_for
 from flask_login import current_user
+
 from app.notify_client.models import InvitedUser
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1,36 +1,41 @@
 # -*- coding: utf-8 -*-
 import uuid
-from io import BytesIO
-from os import path
-from glob import glob
-from itertools import repeat
 from functools import partial
+from glob import glob
+from io import BytesIO
+from itertools import repeat
+from os import path
 
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 from notifications_python_client.errors import HTTPError
-from notifications_utils.template import LetterPreviewTemplate, LetterImageTemplate
 from notifications_utils.recipients import RecipientCSV
-
-from tests import validate_route_permission, validate_route_permission_with_client
+from notifications_utils.template import (
+    LetterImageTemplate,
+    LetterPreviewTemplate,
+)
+from tests import (
+    validate_route_permission,
+    validate_route_permission_with_client,
+)
 from tests.conftest import (
+    SERVICE_ONE_ID,
     fake_uuid,
+    mock_get_international_service,
+    mock_get_live_service,
+    mock_get_service,
+    mock_get_service_email_template,
+    mock_get_service_letter_template,
     mock_get_service_template,
     mock_get_service_template_with_placeholders,
-    mock_get_service_letter_template,
-    mock_get_service,
-    mock_get_international_service,
-    mock_get_service_email_template,
-    normalize_spaces,
-    SERVICE_ONE_ID,
-    mock_get_live_service,
     multiple_reply_to_email_addresses,
-    no_reply_to_email_addresses,
     multiple_sms_senders,
-    no_sms_senders,
+    multiple_sms_senders_no_inbound,
     multiple_sms_senders_with_diff_default,
-    multiple_sms_senders_no_inbound
+    no_reply_to_email_addresses,
+    no_sms_senders,
+    normalize_spaces,
 )
 
 template_types = ['email', 'sms']

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1,35 +1,35 @@
 import uuid
-from unittest.mock import call, ANY
+from unittest.mock import ANY, call
 
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from freezegun import freeze_time
+from tests import service_json, validate_route_permission
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    active_user_no_api_key_permission,
+    active_user_no_settings_permission,
+    active_user_with_permissions,
+    get_default_letter_contact_block,
+    get_default_reply_to_email_address,
+    get_default_sms_sender,
+    get_inbound_number_sms_sender,
+    get_non_default_letter_contact_block,
+    get_non_default_reply_to_email_address,
+    get_non_default_sms_sender,
+    multiple_letter_contact_blocks,
+    multiple_reply_to_email_addresses,
+    multiple_sms_senders,
+    no_letter_contact_blocks,
+    no_reply_to_email_addresses,
+    no_sms_senders,
+    normalize_spaces,
+    platform_admin_user,
+)
 
 import app
 from app.utils import email_safe
-from tests import validate_route_permission, service_json
-from tests.conftest import (
-    active_user_with_permissions,
-    active_user_no_api_key_permission,
-    active_user_no_settings_permission,
-    platform_admin_user,
-    normalize_spaces,
-    multiple_reply_to_email_addresses,
-    multiple_letter_contact_blocks,
-    multiple_sms_senders,
-    no_reply_to_email_addresses,
-    no_letter_contact_blocks,
-    no_sms_senders,
-    get_default_reply_to_email_address,
-    get_non_default_reply_to_email_address,
-    get_default_letter_contact_block,
-    get_non_default_letter_contact_block,
-    get_default_sms_sender,
-    get_non_default_sms_sender,
-    get_inbound_number_sms_sender,
-    SERVICE_ONE_ID
-)
-from freezegun import freeze_time
 
 
 @pytest.fixture

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -1,8 +1,8 @@
 import uuid
 
 import pytest
-from flask import url_for
 from bs4 import BeautifulSoup
+from flask import url_for
 
 
 def test_render_sign_in_template_for_new_user(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1,26 +1,33 @@
 from datetime import datetime
-from unittest.mock import Mock, ANY
+from unittest.mock import ANY, Mock
 
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
-from tests.conftest import service_one as create_sample_service
+from tests import (
+    single_notification_json,
+    template_json,
+    validate_route_permission,
+)
 from tests.conftest import (
+    SERVICE_ONE_ID,
+    active_user_with_permissions,
     mock_get_service_email_template,
     mock_get_service_letter_template,
     mock_get_service_template,
     no_letter_contact_blocks,
-    single_letter_contact_block,
     normalize_spaces,
-    SERVICE_ONE_ID,
-    active_user_with_permissions,
     platform_admin_user,
 )
-from tests import validate_route_permission, template_json, single_notification_json
+from tests.conftest import service_one as create_sample_service
+from tests.conftest import single_letter_contact_block
 
-from app.main.views.templates import get_last_use_message, get_human_readable_delta
+from app.main.views.templates import (
+    get_human_readable_delta,
+    get_last_use_message,
+)
 
 
 @pytest.mark.parametrize('extra_args, expected_nav_links, expected_templates', [

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -1,8 +1,7 @@
 from unittest.mock import ANY
 
-from flask import url_for
 from bs4 import BeautifulSoup
-
+from flask import url_for
 from tests.conftest import SERVICE_ONE_ID, normalize_spaces, set_config
 
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -1,10 +1,9 @@
-import pytest
-import uuid
 import json
+import uuid
 
+import pytest
 from flask import url_for
 from notifications_utils.url_safe_token import generate_token
-
 from tests.conftest import api_user_active as create_user
 
 

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -1,10 +1,9 @@
-import uuid
 import json
+import uuid
 
-from itsdangerous import SignatureExpired
-from flask import url_for
 from bs4 import BeautifulSoup
-
+from flask import url_for
+from itsdangerous import SignatureExpired
 from tests.conftest import normalize_spaces
 
 

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -1,4 +1,5 @@
 from unittest.mock import ANY
+
 from app import invite_api_client
 
 

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -1,10 +1,9 @@
 import uuid
 
 import pytest
+from tests import notification_json, single_notification_json
 
 from app.notify_client.notification_api_client import NotificationApiClient
-
-from tests import single_notification_json, notification_json
 
 
 @pytest.mark.parametrize("arguments,expected_call", [

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -1,13 +1,12 @@
 import uuid
-import pytest
 from unittest.mock import patch
 
+import pytest
 import werkzeug
-
 from tests import service_json
 from tests.conftest import api_user_active, platform_admin_user
-from app.notify_client import NotifyAdminAPIClient
 
+from app.notify_client import NotifyAdminAPIClient
 
 SAMPLE_API_KEY = '{}-{}'.format('a' * 36, 's' * 36)
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -1,8 +1,8 @@
 import pytest
+from tests.conftest import SERVICE_ONE_ID, fake_uuid
 
 from app import service_api_client
 from app.notify_client.service_api_client import ServiceAPIClient
-from tests.conftest import fake_uuid, SERVICE_ONE_ID
 
 
 def test_client_posts_archived_true_when_deleting_template(mocker):

--- a/tests/app/notify_client/test_template_statistics_client.py
+++ b/tests/app/notify_client/test_template_statistics_client.py
@@ -1,6 +1,8 @@
 import uuid
 
-from app.notify_client.template_statistics_api_client import TemplateStatisticsApiClient
+from app.notify_client.template_statistics_api_client import (
+    TemplateStatisticsApiClient,
+)
 
 
 def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocker, api_user_active):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -1,8 +1,10 @@
-import pytest
 from unittest.mock import call
+
+import pytest
+from tests.conftest import SERVICE_ONE_ID
+
 from app import user_api_client
 from app.notify_client.models import User
-from tests.conftest import SERVICE_ONE_ID
 
 
 def test_client_gets_all_users_for_service(

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -1,5 +1,5 @@
-import os
 import importlib
+import os
 from unittest import mock
 
 import pytest

--- a/tests/app/test_statistics_utils.py
+++ b/tests/app/test_statistics_utils.py
@@ -1,6 +1,11 @@
 import pytest
 
-from app.statistics_utils import sum_of_statistics, add_rates_to, add_rate_to_job, statistics_by_state
+from app.statistics_utils import (
+    add_rate_to_job,
+    add_rates_to,
+    statistics_by_state,
+    sum_of_statistics,
+)
 
 
 @pytest.mark.parametrize('delivery_statistics', [

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -1,7 +1,7 @@
-import pytest
-
 from functools import partial
 from unittest.mock import Mock
+
+import pytest
 from notifications_utils.template import LetterPreviewTemplate
 
 from app.template_previews import TemplatePreview, get_page_count_for_letter

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,22 +1,22 @@
-from pathlib import Path
-from io import StringIO
 from collections import OrderedDict
 from csv import DictReader
+from io import StringIO
+from pathlib import Path
 
-from freezegun import freeze_time
 import pytest
+from freezegun import freeze_time
+from tests.conftest import fake_uuid
 
 from app.utils import (
+    GovernmentDomain,
+    Spreadsheet,
     email_safe,
+    generate_next_dict,
     generate_notifications_csv,
     generate_previous_dict,
-    generate_next_dict,
-    Spreadsheet,
-    get_letter_timings,
     get_cdn_domain,
-    GovernmentDomain,
+    get_letter_timings,
 )
-from tests.conftest import fake_uuid
 
 
 def _get_notifications_csv(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,40 +1,35 @@
-from contextlib import contextmanager
+import json
 import os
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
-from notifications_python_client.errors import HTTPError
-from flask import url_for, Flask
 from bs4 import BeautifulSoup
+from flask import Flask, url_for
+from notifications_python_client.errors import HTTPError
+from notifications_utils.url_safe_token import generate_token
 
 from app import create_app
-from app.notify_client.models import (
-    User,
-    InvitedUser,
-    InvitedOrgUser
-)
+from app.notify_client.models import InvitedOrgUser, InvitedUser, User
 
 from . import (
-    service_json,
-    organisation_json,
-    user_json,
-    invited_user,
     TestClient,
-    template_json,
-    template_version_json,
     api_key_json,
+    generate_uuid,
+    invite_json,
+    invited_user,
     job_json,
     notification_json,
-    invite_json,
+    org_invite_json,
+    organisation_json,
     sample_uuid,
-    generate_uuid,
+    service_json,
     single_notification_json,
-    org_invite_json
+    template_json,
+    template_version_json,
+    user_json,
 )
-
-from notifications_utils.url_safe_token import generate_token
-import json
 
 
 @pytest.fixture


### PR DESCRIPTION
Done using isort<sup>1</sup>, with the following command:
```
isort -rc ./app ./tests
```

Adds linting to the `run_tests.sh` script to stop badly-sorted imports getting re-introduced.

Chosen style is ‘Vertical Hanging Indent’ with trailing commas, because I think it gives the cleanest diffs, eg:
```python
from third_party import (
    lib1,
    lib2,
    lib3,
)
```
to
```python
from third_party import (
    lib1,
    lib2,
    lib3,
    lib4,
)
```

Gives a diff of:
```diff
+    lib4,
```

1. https://pypi.python.org/pypi/isort