### PR TITLE
Split request to go live into two pages 

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -161,7 +161,7 @@ def service_name_change_confirm(service_id):
 @main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
-def service_request_to_go_live(service_id):
+def request_to_go_live(service_id):
     form = RequestToGoLiveForm()
 
     if form.validate_on_submit():

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -158,10 +158,17 @@ def service_name_change_confirm(service_id):
         form=form)
 
 
-@main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['GET', 'POST'])
+@main.route("/services/<service_id>/service-settings/request-to-go-live")
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
 def request_to_go_live(service_id):
+    return render_template('views/service-settings/request-to-go-live.html')
+
+
+@main.route("/services/<service_id>/service-settings/submit-request-to-go-live", methods=['GET', 'POST'])
+@login_required
+@user_has_permissions('manage_settings', admin_override=True)
+def submit_request_to_go_live(service_id):
     form = RequestToGoLiveForm()
 
     if form.validate_on_submit():
@@ -204,7 +211,7 @@ def request_to_go_live(service_id):
         flash('We’ve received your request to go live', 'default')
         return redirect(url_for('.service_settings', service_id=service_id))
 
-    return render_template('views/service-settings/request-to-go-live.html', form=form)
+    return render_template('views/service-settings/submit-request-to-go-live.html', form=form)
 
 
 @main.route("/services/<service_id>/service-settings/switch-live")

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -228,7 +228,7 @@
 
       <p>
         To remove these restrictions
-        <a href="{{ url_for('.service_request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+        <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
       </p>
     {% else %}
       <h2 class="heading-medium">Your service is live</h2>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -33,6 +33,9 @@
       </li>
     </ul>
     <p>
+      Once you’ve made the request, we’ll put your service live within one working day.
+    </p>
+    <p>
       <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Next</a>
     </p>
 

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -11,54 +11,29 @@
 
 {% block maincolumn_content %}
 
-      <h1 class="heading-large">Request to go live</h1>
+    <h1 class="heading-large">Request to go live</h1>
 
-      <p>
-        Before you request to go live, make sure you’ve:
-      </p>
-      <ul class="list list-bullet bottom-gutter">
-        <li>read our <a href="{{ url_for('.terms') }}">terms of use</a></li>
-        <li>added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account</li>
-        <li>
-          specified your reply to email address or text message sender in your
-          <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page</li>
-        <li>
-          added the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for 
-          <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
-      </ul>
-
-      <form method="post">
-        <div class="form-group">
-          <p>We need permission to process your data before we can make your service live.</p>
-          {{ radios(form.mou, option_hints={
-            'no': 'We’ll send you a copy',
-            'don’t know': 'We’ll check for you',
-          }) }}
-        </div>
-        {{ checkbox_group('What kind of messages will you be sending?', [
-          form.channel_email,
-          form.channel_sms,
-          form.channel_letter
-        ]) }}
-        <div class="form-group">
-          {{ textbox(form.start_date, width='1-1') }}
-          {{ textbox(form.start_volume, width='1-1', hint='For example, ‘1,000 per month’.') }}
-          {{ textbox(form.peak_volume, width='1-1', hint='For example, ‘Messages will increase to 20,000 per month in January’.') }}
-        </div>
-        {{ checkbox_group('How are you going to send messages?', [
-          form.method_one_off,
-          form.method_upload,
-          form.method_api
-        ]) }}
-        <p>
-          Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.
-        </p>
-        <p>
-          By requesting to go live you’re agreeing to our <a href="{{ url_for('.terms') }}">terms of use</a>.
-        </p>
-
-        {{ page_footer('Request to go live') }}
-      </form>
-
+    <p>
+      Before you request to go live, make sure you’ve:
+    </p>
+    <ul class="list list-bullet bottom-gutter">
+      <li>
+        read our <a href="{{ url_for('.terms') }}">terms of use</a>
+      </li>
+      <li>
+        added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account
+      </li>
+      <li>
+        specified your reply to email address or text message sender in your
+        <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page
+      </li>
+      <li>
+        added the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for
+        <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a>
+      </li>
+    </ul>
+    <p>
+      <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Next</a>
+    </p>
 
 {% endblock %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -10,33 +10,34 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-
-    <h1 class="heading-large">Request to go live</h1>
-
-    <p>
-      Before you request to go live, make sure you’ve:
-    </p>
-    <ul class="list list-bullet bottom-gutter">
-      <li>
-        read our <a href="{{ url_for('.terms') }}">terms of use</a>
-      </li>
-      <li>
-        added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account
-      </li>
-      <li>
-        specified your reply to email address or text message sender in your
-        <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page
-      </li>
-      <li>
-        added the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for
-        <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a>
-      </li>
-    </ul>
-    <p>
-      Once you’ve made the request, we’ll put your service live within one working day.
-    </p>
-    <p>
-      <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Next</a>
-    </p>
-
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      <h1 class="heading-large">Request to go live</h1>
+      <p>
+        Before you request to go live, make sure you’ve:
+      </p>
+      <ul class="list list-bullet bottom-gutter">
+        <li>
+          read our <a href="{{ url_for('.terms') }}">terms of use</a>
+        </li>
+        <li>
+          added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account
+        </li>
+        <li>
+          specified your reply to email address or text message sender in your
+          <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page
+        </li>
+        <li>
+          added the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for
+          <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a>
+        </li>
+      </ul>
+      <p>
+        Once you’ve made the request, we’ll put your service live within one working day.
+      </p>
+      <p>
+        <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Next</a>
+      </p>
+    </div>
+  </div>
 {% endblock %}

--- a/app/templates/views/service-settings/submit-request-to-go-live.html
+++ b/app/templates/views/service-settings/submit-request-to-go-live.html
@@ -37,9 +37,6 @@
           form.method_api
         ]) }}
         <p>
-          Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.
-        </p>
-        <p>
           By requesting to go live you’re agreeing to our <a href="{{ url_for('.terms') }}">terms of use</a>.
         </p>
 

--- a/app/templates/views/service-settings/submit-request-to-go-live.html
+++ b/app/templates/views/service-settings/submit-request-to-go-live.html
@@ -1,0 +1,50 @@
+{% extends "withnav_template.html" %}
+{% from "components/checkbox.html" import checkbox_group %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/radios.html" import radios %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/banner.html" import banner_wrapper %}
+
+{% block service_page_title %}
+  Request to go live
+{% endblock %}
+
+{% block maincolumn_content %}
+
+      <h1 class="heading-large">Request to go live</h1>
+
+      <form method="post">
+        <div class="form-group">
+          <p>We need permission to process your data before we can make your service live.</p>
+          {{ radios(form.mou, option_hints={
+            'no': 'We’ll send you a copy',
+            'don’t know': 'We’ll check for you',
+          }) }}
+        </div>
+        {{ checkbox_group('What kind of messages will you be sending?', [
+          form.channel_email,
+          form.channel_sms,
+          form.channel_letter
+        ]) }}
+        <div class="form-group">
+          {{ textbox(form.start_date, width='1-1') }}
+          {{ textbox(form.start_volume, width='1-1', hint='For example, ‘1,000 per month’.') }}
+          {{ textbox(form.peak_volume, width='1-1', hint='For example, ‘Messages will increase to 20,000 per month in January’.') }}
+        </div>
+        {{ checkbox_group('How are you going to send messages?', [
+          form.method_one_off,
+          form.method_upload,
+          form.method_api
+        ]) }}
+        <p>
+          Once you’ve completed the tasks needed to set up, we’ll make your service live. We’ll do this within one working day.
+        </p>
+        <p>
+          By requesting to go live you’re agreeing to our <a href="{{ url_for('.terms') }}">terms of use</a>.
+        </p>
+
+        {{ page_footer('Request to go live') }}
+      </form>
+
+
+{% endblock %}

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -25,7 +25,13 @@
     <h2 id="trial-mode" class="heading-medium">Trial mode</h2>
     <p>When you sign up to GOV.UK Notify, you’ll start in trial mode. In trial mode, you can send up to 50 text messages and emails a day. You can only send them to yourself and other people in your team.</p>
     <p>You can’t send letters in trial mode.</p>
-    <p>When you request to go live on Notify, we’ll remove these restrictions.</p>
+    <p>When you
+      {% if current_service and current_service.restricted %}
+        <a href="{{ url_for('main.request_to_go_live', service_id=current_service.id) }}">request to go live</a>
+      {% else %}
+        request to go live
+      {% endif %}
+    on Notify, we’ll remove these restrictions.</p>
 
     <h2 id="messagedeliveryandfailure" class="heading-medium">Sending messages</h2>
     <p>When you send a message, it moves through different states in Notify.</p>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -425,11 +425,24 @@ def test_should_raise_duplicate_name_handled(
     assert mock_verify_password.called
 
 
-def test_should_show_request_to_go_live(
+def test_should_show_request_to_go_live_checklist(
     client_request,
 ):
     page = client_request.get(
         'main.request_to_go_live', service_id=SERVICE_ONE_ID
+    )
+    assert page.h1.text == 'Request to go live'
+    assert page.select_one('main .button')['href'] == url_for(
+        'main.submit_request_to_go_live',
+        service_id=SERVICE_ONE_ID,
+    )
+
+
+def test_should_show_request_to_go_live(
+    client_request,
+):
+    page = client_request.get(
+        'main.submit_request_to_go_live', service_id=SERVICE_ONE_ID
     )
     assert page.h1.text == 'Request to go live'
     for channel, label in (
@@ -462,7 +475,7 @@ def test_should_redirect_after_request_to_go_live(
 ):
     mock_post = mocker.patch('app.main.views.service_settings.deskpro_client.create_ticket')
     page = client_request.post(
-        'main.request_to_go_live',
+        'main.submit_request_to_go_live',
         service_id=SERVICE_ONE_ID,
         _data={
             'mou': 'yes',
@@ -506,6 +519,7 @@ def test_should_redirect_after_request_to_go_live(
     'main.service_name_change',
     'main.service_name_change_confirm',
     'main.request_to_go_live',
+    'main.submit_request_to_go_live',
     'main.archive_service'
 ])
 def test_route_permissions(
@@ -537,6 +551,7 @@ def test_route_permissions(
     'main.service_name_change',
     'main.service_name_change_confirm',
     'main.request_to_go_live',
+    'main.submit_request_to_go_live',
     'main.service_switch_live',
     'main.service_switch_research_mode',
     'main.archive_service',
@@ -565,6 +580,7 @@ def test_route_invalid_permissions(
     'main.service_name_change',
     'main.service_name_change_confirm',
     'main.request_to_go_live',
+    'main.submit_request_to_go_live',
 ])
 def test_route_for_platform_admin(
         mocker,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -429,7 +429,7 @@ def test_should_show_request_to_go_live(
     client_request,
 ):
     page = client_request.get(
-        'main.service_request_to_go_live', service_id=SERVICE_ONE_ID
+        'main.request_to_go_live', service_id=SERVICE_ONE_ID
     )
     assert page.h1.text == 'Request to go live'
     for channel, label in (
@@ -462,7 +462,7 @@ def test_should_redirect_after_request_to_go_live(
 ):
     mock_post = mocker.patch('app.main.views.service_settings.deskpro_client.create_ticket')
     page = client_request.post(
-        'main.service_request_to_go_live',
+        'main.request_to_go_live',
         service_id=SERVICE_ONE_ID,
         _data={
             'mou': 'yes',
@@ -505,7 +505,7 @@ def test_should_redirect_after_request_to_go_live(
     'main.service_settings',
     'main.service_name_change',
     'main.service_name_change_confirm',
-    'main.service_request_to_go_live',
+    'main.request_to_go_live',
     'main.archive_service'
 ])
 def test_route_permissions(
@@ -536,7 +536,7 @@ def test_route_permissions(
     'main.service_settings',
     'main.service_name_change',
     'main.service_name_change_confirm',
-    'main.service_request_to_go_live',
+    'main.request_to_go_live',
     'main.service_switch_live',
     'main.service_switch_research_mode',
     'main.archive_service',
@@ -564,7 +564,7 @@ def test_route_invalid_permissions(
     'main.service_settings',
     'main.service_name_change',
     'main.service_name_change_confirm',
-    'main.service_request_to_go_live',
+    'main.request_to_go_live',
 ])
 def test_route_for_platform_admin(
         mocker,


### PR DESCRIPTION
# Split into two pages

A lot of users aren’t reading or paying attention to the checklist on the request to go live page. We think that we can get more people to read it by putting it on its own page, where users won’t jump straight to filling in the form.

This will, later on, let us make this page smarter by automatically detecting if they’ve done the necessary things.

# Move expectation-setting text to initial page

We have tickets from people asking how long the process takes. I suspect that this is because they’re not getting to the bottom of the form before they’re ready to go live.

# Link to request to go live from the guidance

If we know what service someone has been using, we can take them to the right place. This should increase the findability of the page. We used to do this, back when trial mode had its own page.

# Screenshots

## Before 

![localhost-6012-services-905e65d1-a816-4f48-b595-d37eabfe19d9-service-settings-request-to-go-live ipad pro 1](https://user-images.githubusercontent.com/355079/36424294-b64808b4-163a-11e8-88d3-fea429dd3a00.png)

## After 

![localhost-6012-services-905e65d1-a816-4f48-b595-d37eabfe19d9-service-settings-request-to-go-live ipad pro](https://user-images.githubusercontent.com/355079/36424300-bbc45e00-163a-11e8-8fa0-b9b678742bf5.png)
![localhost-6012-services-905e65d1-a816-4f48-b595-d37eabfe19d9-service-settings-submit-request-to-go-live ipad pro](https://user-images.githubusercontent.com/355079/36424301-bbdbcdba-163a-11e8-9dd3-a60e567b9f93.png)

---

Addresses https://github.com/alphagov/notify-design-changes/issues/4 and https://github.com/alphagov/notify-design-changes/issues/5