### PR TITLE
Add API client method to count templates

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -226,6 +226,16 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             service_id=service_id)
         return self.get(endpoint, *params)
 
+    def count_service_templates(self, service_id, template_type=None):
+        return len([
+            template for template in
+            self.get_service_templates(service_id)['data']
+            if (
+                not template_type
+                or template['template_type'] == template_type
+            )
+        ])
+
     def delete_service_template(self, service_id, template_id):
         """
         Set a service template's archived flag to True

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -1,7 +1,8 @@
 import pytest
 
+from app import service_api_client
 from app.notify_client.service_api_client import ServiceAPIClient
-from tests.conftest import fake_uuid
+from tests.conftest import fake_uuid, SERVICE_ONE_ID
 
 
 def test_client_posts_archived_true_when_deleting_template(mocker):
@@ -78,3 +79,57 @@ def test_client_creates_service_with_correct_data(
             email_from='test@example.com',
         ),
     )
+
+
+@pytest.mark.parametrize('template_data, extra_args, expected_count', (
+    (
+        [],
+        {},
+        0,
+    ),
+    (
+        [],
+        {'template_type': 'email'},
+        0,
+    ),
+    (
+        [
+            {'template_type': 'email'},
+            {'template_type': 'sms'},
+        ],
+        {},
+        2,
+    ),
+    (
+        [
+            {'template_type': 'email'},
+            {'template_type': 'sms'},
+        ],
+        {'template_type': 'email'},
+        1,
+    ),
+    (
+        [
+            {'template_type': 'email'},
+            {'template_type': 'sms'},
+        ],
+        {'template_type': 'letter'},
+        0,
+    ),
+))
+def test_client_returns_count_of_service_templates(
+    app_,
+    mocker,
+    template_data,
+    extra_args,
+    expected_count,
+):
+
+    mocker.patch(
+        'app.service_api_client.get_service_templates',
+        return_value={'data': template_data}
+    )
+
+    assert service_api_client.count_service_templates(
+        SERVICE_ONE_ID, **extra_args
+    ) == expected_count


### PR DESCRIPTION
When users request to go live we check stuff like:
- if they’ve added templates
- if they have email templates (then we can check their reply to address)

This commit adds a method to do this programatically rather than manually.

We _could_ do this in SQL, but for page that’s used intermittently it doesn’t feel worth the work/optimisation (and the client method is at least in place now if we do ever need to lean on this code more heavily).