### PR TITLE
Hide ‘request to go live’ from API only users

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -227,9 +227,14 @@
       </ul>
 
       <p>
-        To remove these restrictions
-        <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
-      </p>
+        {% if current_user.has_permissions('manage_settings') %}
+          To remove these restrictions
+          <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+        {% else %}
+          Your service manager can ask to have these restrictions removed.
+        {% endif %}
+        </p>
+
     {% else %}
       <h2 class="heading-medium">Your service is live</h2>
 
@@ -328,7 +333,7 @@
             <a href="{{ url_for('.service_switch_can_send_precompiled_letter', service_id=current_service.id) }}" class="button">
               {{ 'Stop sending precompiled letters' if 'precompiled_letter' in current_service.permissions else 'Allow to send precompiled letters' }}
             </a>
-          </li>  
+          </li>
         {% endif %}
         <li class="bottom-gutter">
           <a href="{{ url_for('.service_switch_email_auth', service_id=current_service.id) }}" class="button">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1261,6 +1261,31 @@ def active_user_no_api_key_permission(fake_uuid):
     return user
 
 
+@pytest.fixture
+def active_user_no_settings_permission(fake_uuid):
+    from app.notify_client.user_api_client import User
+
+    user_data = {
+        'id': fake_uuid,
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'manage_templates',
+            'manage_api_keys',
+            'view_activity',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth'
+    }
+    user = User(user_data)
+    return user
+
+
 @pytest.fixture(scope='function')
 def api_user_locked(fake_uuid):
     from app.notify_client.user_api_client import User


### PR DESCRIPTION
Users who have the ‘manage API keys’ permission can see the settings page. But they don’t have permission to request to go live.

At the moment they can still see the link, though clicking it gives them a 403 error. This commit changes it so that they can’t see the link, and tells them who they should speak to about going live (their manager).