### PR TITLE
Rremove awscli and boto3 from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Flask==0.12.2
 Flask-WTF==0.14.2
 Flask-Login==0.4.1
 
-boto3==1.5.12
 blinker==1.4
 pyexcel==0.5.7
 pyexcel-io==0.5.6
@@ -17,7 +16,6 @@ eventlet==0.22.1
 notifications-python-client==4.7.2
 
 # PaaS
-awscli==1.14.22
 awscli-cwlogs>=1.4,<1.5
 
 git+https://github.com/alphagov/notifications-utils.git@23.6.2#egg=notifications-utils==23.6.2


### PR DESCRIPTION
They're both brought in by utils, and are generating a lot of PR noise by being on every repo.

Closes #1905 

Closes #1906 