### PR TITLE
Add a checklist to the request to go live page 

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -169,6 +169,9 @@ def request_to_go_live(service_id):
                 service_id, 'manage_settings'
             ) > 1
         ),
+        has_templates=(
+            service_api_client.count_service_templates(service_id) > 0
+        ),
     )
 
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -162,7 +162,14 @@ def service_name_change_confirm(service_id):
 @login_required
 @user_has_permissions('manage_settings', admin_override=True)
 def request_to_go_live(service_id):
-    return render_template('views/service-settings/request-to-go-live.html')
+    return render_template(
+        'views/service-settings/request-to-go-live.html',
+        has_team_members=(
+            user_api_client.get_count_of_users_with_permission(
+                service_id, 'manage_settings'
+            ) > 1
+        ),
+    )
 
 
 @main.route("/services/<service_id>/service-settings/submit-request-to-go-live", methods=['GET', 'POST'])

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -172,6 +172,12 @@ def request_to_go_live(service_id):
         has_templates=(
             service_api_client.count_service_templates(service_id) > 0
         ),
+        has_email_templates=(
+            service_api_client.count_service_templates(service_id, template_type='email') > 0
+        ),
+        has_email_reply_to_address=bool(
+            service_api_client.get_reply_to_email_addresses(service_id)
+        )
     )
 
 

--- a/app/templates/components/tick-cross.html
+++ b/app/templates/components/tick-cross.html
@@ -1,15 +1,20 @@
-{% macro tick_cross(yes, label) %}
+{% macro tick_cross(yes, label, truthy_hint='Can', falsey_hint='Can’t') %}
   <li>
     {% if yes %}
       <span class="tick-cross-tick">
-        <span class="visually-hidden">Can</span>
+        <span class="visually-hidden">{{ truthy_hint }}</span>
         {{ label}}
       </span>
     {% else %}
       <span class="tick-cross-cross">
-        <span class="visually-hidden">Can’t</span>
+        <span class="visually-hidden">{{ falsey_hint }}</span>
         {{ label}}
       </span>
     {% endif %}
   </li>
+{% endmacro %}
+
+
+{% macro tick_cross_done_not_done(yes, label) %}
+  {{ tick_cross(yes, label, truthy_hint='Done: ', falsey_hint='Not done: ') }}
 {% endmacro %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -4,6 +4,7 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/banner.html" import banner_wrapper %}
+{% from "components/tick-cross.html" import tick_cross_done_not_done %}
 
 {% block service_page_title %}
   Request to go live
@@ -14,21 +15,27 @@
     <div class="column-five-sixths">
       <h1 class="heading-large">Request to go live</h1>
       <p>
-        Before you request to go live, make sure you’ve:
+        Before you request to go live, make sure that:
+      </p>
+      <ul class='bottom-gutter'>
+        {{ tick_cross_done_not_done(
+          has_team_members,
+          'Another person in your team has the ‘Manage service’ permission',
+        ) }}
+      </ul>
+      <p>
+        You also need to:
       </p>
       <ul class="list list-bullet bottom-gutter">
         <li>
           read our <a href="{{ url_for('.terms') }}">terms of use</a>
         </li>
         <li>
-          added <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">team members</a> to your account
-        </li>
-        <li>
-          specified your reply to email address or text message sender in your
+          specify your reply to email address or text message sender in your
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page
         </li>
         <li>
-          added the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for
+          add the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for
           <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a>
         </li>
       </ul>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -26,6 +26,14 @@
           has_templates,
           'You’ve added some templates',
         ) }}
+        {% if has_email_templates %}
+          {{ tick_cross_done_not_done(
+            has_email_reply_to_address,
+            'You’ve added an email reply to address on the <a href="{}">settings</a> page'.format(
+              url_for('main.service_settings', service_id=current_service.id)
+            )|safe,
+          ) }}
+        {% endif %}
       </ul>
       <p>
         You also need to:
@@ -33,10 +41,6 @@
       <ul class="list list-bullet bottom-gutter">
         <li>
           read our <a href="{{ url_for('.terms') }}">terms of use</a>
-        </li>
-        <li>
-          specify your reply to email address or text message sender in your
-          <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page
         </li>
         <li>
           make sure your messages follow the GOV.UK Service Manual standards for

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -22,6 +22,10 @@
           has_team_members,
           'Another person in your team has the ‘Manage service’ permission',
         ) }}
+        {{ tick_cross_done_not_done(
+          has_templates,
+          'You’ve added some templates',
+        ) }}
       </ul>
       <p>
         You also need to:
@@ -35,7 +39,7 @@
           <a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">settings</a> page
         </li>
         <li>
-          add the templates you want to start with, making sure they follow the GOV.UK Service Manual standards for
+          make sure your messages follow the GOV.UK Service Manual standards for
           <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a>
         </li>
       </ul>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -455,30 +455,46 @@ def test_should_raise_duplicate_name_handled(
     assert mock_verify_password.called
 
 
-@pytest.mark.parametrize('count_of_users_with_manage_service, expected_checklist_item', [
+@pytest.mark.parametrize('count_of_users_with_manage_service, expected_user_checklist_item', [
     (1, 'Not done: Another person in your team has the ‘Manage service’ permission'),
     (2, 'Done: Another person in your team has the ‘Manage service’ permission'),
+])
+@pytest.mark.parametrize('count_of_templates, expected_templates_checklist_item', [
+    (0, 'Not done: You’ve added some templates'),
+    (1, 'Done: You’ve added some templates'),
+    (2, 'Done: You’ve added some templates'),
 ])
 def test_should_show_request_to_go_live_checklist(
     client_request,
     mocker,
     count_of_users_with_manage_service,
-    expected_checklist_item,
+    expected_user_checklist_item,
+    count_of_templates,
+    expected_templates_checklist_item,
 ):
     mock_count_users = mocker.patch(
         'app.main.views.service_settings.user_api_client.get_count_of_users_with_permission',
         return_value=count_of_users_with_manage_service
     )
+    mock_count_templates = mocker.patch(
+        'app.main.views.service_settings.service_api_client.count_service_templates',
+        return_value=count_of_templates
+    )
+
     page = client_request.get(
         'main.request_to_go_live', service_id=SERVICE_ONE_ID
     )
     assert page.h1.text == 'Request to go live'
-    assert normalize_spaces(page.select('main ul li')[0].text) == expected_checklist_item
+
+    assert normalize_spaces(page.select('main ul li')[0].text) == expected_user_checklist_item
+    assert normalize_spaces(page.select('main ul li')[1].text) == expected_templates_checklist_item
+
     assert page.select_one('main .button')['href'] == url_for(
         'main.submit_request_to_go_live',
         service_id=SERVICE_ONE_ID,
     )
     mock_count_users.assert_called_once_with(SERVICE_ONE_ID, 'manage_settings')
+    mock_count_templates.assert_called_once_with(SERVICE_ONE_ID)
 
 
 def test_should_show_request_to_go_live(
@@ -577,6 +593,7 @@ def test_route_permissions(
         single_sms_sender,
         route,
         mock_get_service_settings_page_common,
+        mock_get_service_templates,
 ):
     validate_route_permission(
         mocker,
@@ -606,6 +623,7 @@ def test_route_invalid_permissions(
         api_user_active,
         service_one,
         route,
+        mock_get_service_templates,
 ):
     validate_route_permission(
         mocker,
@@ -637,6 +655,7 @@ def test_route_for_platform_admin(
         single_sms_sender,
         route,
         mock_get_service_settings_page_common,
+        mock_get_service_templates,
 ):
     validate_route_permission(mocker,
                               app_,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -455,17 +455,30 @@ def test_should_raise_duplicate_name_handled(
     assert mock_verify_password.called
 
 
+@pytest.mark.parametrize('count_of_users_with_manage_service, expected_checklist_item', [
+    (1, 'Not done: Another person in your team has the ‘Manage service’ permission'),
+    (2, 'Done: Another person in your team has the ‘Manage service’ permission'),
+])
 def test_should_show_request_to_go_live_checklist(
     client_request,
+    mocker,
+    count_of_users_with_manage_service,
+    expected_checklist_item,
 ):
+    mock_count_users = mocker.patch(
+        'app.main.views.service_settings.user_api_client.get_count_of_users_with_permission',
+        return_value=count_of_users_with_manage_service
+    )
     page = client_request.get(
         'main.request_to_go_live', service_id=SERVICE_ONE_ID
     )
     assert page.h1.text == 'Request to go live'
+    assert normalize_spaces(page.select('main ul li')[0].text) == expected_checklist_item
     assert page.select_one('main .button')['href'] == url_for(
         'main.submit_request_to_go_live',
         service_id=SERVICE_ONE_ID,
     )
+    mock_count_users.assert_called_once_with(SERVICE_ONE_ID, 'manage_settings')
 
 
 def test_should_show_request_to_go_live(


### PR DESCRIPTION
We reckon that by making this list respond to what the user has done that it will be more effective than a static list.

We don‘t want to block anyone from making the request. The request to go live is essentially the end of our conversion funnel. So introducing a roadblock feels like a dangerous thing to do. These changes represent more of a speedbump.

## Check for team members

One of the things that we want to check before a service goes live is that they have at least two team members with the manage service permission. Anyone who can make a request to go live has this permission, so that means one additional user is needed. This is what we can automatically communicate to the user.

## Check for templates

We need users to have created some templates before they go live, so we can see what kind of messages they intend to send. This won’t catch users who only have ‘testing’ template(s) set up, but it will at least warn those who have none.

## Check for reply to email address

We require that a user has a real reply-to email address before going live. We can partially automate this by at least telling users who haven’t done this.

This only applies for users that have email templates; we shouldn’t bother users who aren’t going to send emails about this.

# Before 

![image](https://user-images.githubusercontent.com/355079/36737280-9aa66248-1bd2-11e8-9b72-31d018919a4a.png)

# After 

![image](https://user-images.githubusercontent.com/355079/36737252-878a7244-1bd2-11e8-86b5-b184a913a14e.png)

---

Addresses https://github.com/alphagov/notify-design-changes/issues/4