### PR TITLE
Catch exceptions caused by ambiguous Excel files

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -22,6 +22,7 @@ from notifications_utils.recipients import (
 from orderedset import OrderedSet
 from werkzeug.routing import RequestRedirect
 from xlrd.biffh import XLRDError
+from xlrd.xldate import XLDateError
 
 from app import (
     current_service,
@@ -135,6 +136,13 @@ def send_messages(service_id, template_id):
                                     template_type=template.template_type))
         except (UnicodeDecodeError, BadZipFile, XLRDError):
             flash('Couldn’t read {}. Try using a different file format.'.format(
+                form.file.data.filename
+            ))
+        except (XLDateError):
+            flash((
+                '{} contains numbers or dates that Notify can’t understand. '
+                'Try formatting all columns as ‘text’ or export your file as CSV.'
+            ).format(
                 form.file.data.filename
             ))
 


### PR DESCRIPTION
Excel stores dates as floating point numbers, counting the days (or fraction thereof) since 1900 (except when it counts from 1904).

However it also, incorrectly, recognises 1900 as a leap year. This means that it’s ambiguous whether day 59 is February 28th, or February 27th, depending if you’re counting up or down. In fact any number less than 60 is, therefore, ambiguous.

This shouldn’t really matter since no-one is going to be using dates in the year 1900 in Notify messages. _Except_ when Excel misidentifies a cell as containing a date. For example, if you have the number `9` inside a cell, it means _house number 9_ if the next cell contains _Example street_. but Excel is all like ‘oh they must want January 9th 1900!’ No. Bad Excel.

There’s not much we can do about this, but we can at least give people an error message with the workaround, which is what this commit does.

Most of this commit message is paraphrased from http://xlrd.readthedocs.io/en/latest/dates.html