### PR TITLE
Update SMS sender validation to reject senders starting with 00

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -32,6 +32,7 @@ from wtforms.validators import DataRequired, Length, Optional, Regexp
 from app.main.validators import (
     Blacklist,
     CsvFileValidator,
+    DoesNotStartWithDoubleZero,
     LettersNumbersAndFullStopsOnly,
     NoCommasInPlaceHolders,
     OnlyGSMCharacters,
@@ -594,6 +595,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
             Length(max=11, message="Enter 11 characters or fewer"),
             Length(min=3, message="Enter 3 characters or more"),
             LettersNumbersAndFullStopsOnly(),
+            DoesNotStartWithDoubleZero(),
         ]
     )
     is_default = BooleanField("Make this text message sender the default")

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -92,3 +92,13 @@ class LettersNumbersAndFullStopsOnly:
     def __call__(self, form, field):
         if field.data and not re.match(self.regex, field.data):
             raise ValidationError(self.message)
+
+
+class DoesNotStartWithDoubleZero:
+
+    def __init__(self, message="Can't start with 00"):
+        self.message = message
+
+    def __call__(self, form, field):
+        if field.data and field.data.startswith("00"):
+            raise ValidationError(self.message)

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -217,6 +217,10 @@ def test_sms_sender_form_validation(
     form.validate()
     assert 'Enter 3 characters or more' == form.errors['sms_sender'][0]
 
-    form.sms_sender.data = '000'
+    form.sms_sender.data = '111'
     form.validate()
     assert not form.errors
+
+    form.sms_sender.data = '00111222333'
+    form.validate()
+    assert "Can't start with 00" == form.errors['sms_sender'][0]

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -873,6 +873,7 @@ def test_incorrect_letter_contact_block_input(
     ('abcdefghijkhgkg', 'Enter 11 characters or fewer'),
     (' ¯\_(ツ)_/¯ ', 'Use letters and numbers only'),
     ('blood.co.uk', None),
+    ('00123', "Can't start with 00")
 ])
 def test_incorrect_sms_sender_input(
     sms_sender_input,


### PR DESCRIPTION
Having SMS senders that start with 00 can cause issues with Firetext due
to Firetext's validation rules, so we shouldn't allow SMS senders to start
with 00.

Firetext treats a double 00 at the start of the senderID as an international
prefix, so removes them. A sender of 00447876574016 would become 447876574016.

Under Firetext's validation rules, an SMS sender of five 0s (00000) would
become  4400. This is because the first 00 are removed (as the international
prefix). The third 0 is seen as the start of a phone number, and becomes 44,
leaving the final 00 = 4400.

[Pivotal story](https://www.pivotaltracker.com/story/show/155584129)