### PR TITLE
Stop creating tour text messages as priority

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -55,7 +55,6 @@ def _create_example_template(service_id):
         'sms',
         'Hey ((name)), I’m trying out Notify. Today is ((day of week)) and my favourite colour is ((colour)).',
         service_id,
-        process_type='priority',
     )
     return example_sms_template
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -57,7 +57,6 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
             '((day of week)) and my favourite colour is ((colour)).'
         ),
         101,
-        process_type='priority',
     )
     assert session['service_id'] == 101
     assert response.status_code == 302


### PR DESCRIPTION
Since we send all one off messages as priority [now](https://github.com/alphagov/notifications-api/pull/1722), we don’t need to explicitly mark this template as being priority.

This stops the (potential) problem of people skipping the tour, still having this template and then modifying it to send other messages, potentially in high volumes from CSV files or the API. I don’t think this is a real problem now, but worth cleaning this up.

Currently:
- 827 priority templates in the database
- 195 of which are not deleted
- 18 of which are not called ‘Example text message template’
- 3 of which look like genuine use cases, not from services that we run

---

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/1722