### PR TITLE
Permissions refactor

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -418,19 +418,17 @@ def load_organisation_before_request():
         _request_ctx_stack.top.organisation = None
 
         if request.view_args:
-            org_id = request.view_args.get('org_id', session.get('org_id'))
-        else:
-            org_id = session.get('org_id')
+            org_id = request.view_args.get('org_id')
 
-        if org_id:
-            try:
-                _request_ctx_stack.top.organisation = organisations_client.get_organisation(org_id)
-            except HTTPError as exc:
-                # if org id isn't real, then 404 rather than 500ing later because we expect org to be set
-                if exc.status_code == 404:
-                    abort(404)
-                else:
-                    raise
+            if org_id:
+                try:
+                    _request_ctx_stack.top.organisation = organisations_client.get_organisation(org_id)
+                except HTTPError as exc:
+                    # if org id isn't real, then 404 rather than 500ing later because we expect org to be set
+                    if exc.status_code == 404:
+                        abort(404)
+                    else:
+                        raise
 
 
 def save_service_after_request(response):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -4,8 +4,8 @@ from itertools import chain
 
 import pytz
 from flask_wtf import FlaskForm as Form
-from flask_wtf.file import FileAllowed
 from flask_wtf.file import FileField as FileField_wtf
+from flask_wtf.file import FileAllowed
 from notifications_utils.columns import Columns
 from notifications_utils.recipients import (
     InvalidPhoneError,

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -4,8 +4,8 @@ from itertools import chain
 
 import pytz
 from flask_wtf import FlaskForm as Form
-from flask_wtf.file import FileField as FileField_wtf
 from flask_wtf.file import FileAllowed
+from flask_wtf.file import FileField as FileField_wtf
 from notifications_utils.columns import Columns
 from notifications_utils.recipients import (
     InvalidPhoneError,

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -34,7 +34,7 @@ dummy_bearer_token = 'bearer_token_set'
 
 @main.route("/services/<service_id>/api")
 @login_required
-@user_has_permissions('manage_api_keys', admin_override=True)
+@user_has_permissions('manage_api_keys')
 def api_integration(service_id):
     callbacks_link = (
         '.api_callbacks' if 'inbound_sms' in current_service['permissions']
@@ -49,14 +49,14 @@ def api_integration(service_id):
 
 @main.route("/services/<service_id>/api/documentation")
 @login_required
-@user_has_permissions('manage_api_keys', admin_override=True)
+@user_has_permissions('manage_api_keys')
 def api_documentation(service_id):
     return redirect(url_for('.documentation'), code=301)
 
 
 @main.route("/services/<service_id>/api/whitelist", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_api_keys', admin_override=True)
+@user_has_permissions('manage_api_keys')
 def whitelist(service_id):
     form = Whitelist()
     if form.validate_on_submit():
@@ -76,7 +76,7 @@ def whitelist(service_id):
 
 @main.route("/services/<service_id>/api/keys")
 @login_required
-@user_has_permissions('manage_api_keys', admin_override=True)
+@user_has_permissions('manage_api_keys')
 def api_keys(service_id):
     return render_template(
         'views/api/keys.html',
@@ -130,7 +130,7 @@ def create_api_key(service_id):
 
 @main.route("/services/<service_id>/api/keys/revoke/<key_id>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_api_keys', admin_override=True)
+@user_has_permissions('manage_api_keys')
 def revoke_api_key(service_id, key_id):
     key_name = api_key_api_client.get_api_keys(service_id=service_id, key_id=key_id)['apiKeys'][0]['name']
     if request.method == 'GET':

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -86,7 +86,7 @@ def api_keys(service_id):
 
 @main.route("/services/<service_id>/api/keys/create", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_api_keys')
+@user_has_permissions('manage_api_keys', restrict_admin_usage=True)
 def create_api_key(service_id):
     key_names = [
         key['name'] for key in api_key_api_client.get_api_keys(service_id=service_id)['apiKeys']

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -39,7 +39,7 @@ def conversation_updates(service_id, notification_id):
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with")
 @login_required
-@user_has_permissions('send_texts', admin_override=True)
+@user_has_permissions('send_messages', admin_override=True)
 def conversation_reply(
     service_id,
     notification_id,
@@ -63,7 +63,7 @@ def conversation_reply(
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with/<template_id>")
 @login_required
-@user_has_permissions('send_texts', admin_override=True)
+@user_has_permissions('send_messages', admin_override=True)
 def conversation_reply_with_template(
     service_id,
     notification_id,

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -12,7 +12,7 @@ from app.utils import user_has_permissions
 
 @main.route("/services/<service_id>/conversation/<notification_id>")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def conversation(service_id, notification_id):
 
     user_number = get_user_number(service_id, notification_id)
@@ -28,7 +28,7 @@ def conversation(service_id, notification_id):
 
 @main.route("/services/<service_id>/conversation/<notification_id>.json")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def conversation_updates(service_id, notification_id):
 
     return jsonify(get_conversation_partials(
@@ -39,7 +39,7 @@ def conversation_updates(service_id, notification_id):
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with")
 @login_required
-@user_has_permissions('send_messages', admin_override=True)
+@user_has_permissions('send_messages')
 def conversation_reply(
     service_id,
     notification_id,
@@ -63,7 +63,7 @@ def conversation_reply(
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with/<template_id>")
 @login_required
-@user_has_permissions('send_messages', admin_override=True)
+@user_has_permissions('send_messages')
 def conversation_reply_with_template(
     service_id,
     notification_id,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -138,7 +138,7 @@ def template_usage(service_id):
 
 @main.route("/services/<service_id>/usage")
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def usage(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -51,14 +51,14 @@ def temp_service_history(service_id):
 
 @main.route("/services/<service_id>/dashboard")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def old_service_dashboard(service_id):
     return redirect(url_for('.service_dashboard', service_id=service_id))
 
 
 @main.route("/services/<service_id>")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def service_dashboard(service_id):
 
     if session.get('invited_user'):
@@ -74,14 +74,14 @@ def service_dashboard(service_id):
 
 
 @main.route("/services/<service_id>/dashboard.json")
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def service_dashboard_updates(service_id):
     return jsonify(**get_dashboard_partials(service_id))
 
 
 @main.route("/services/<service_id>/template-activity")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def template_history(service_id):
 
     return redirect(url_for('main.template_usage', service_id=service_id), code=301)
@@ -89,7 +89,7 @@ def template_history(service_id):
 
 @main.route("/services/<service_id>/template-usage")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def template_usage(service_id):
 
     year, current_financial_year = requested_and_current_financial_year(request)
@@ -138,7 +138,7 @@ def template_usage(service_id):
 
 @main.route("/services/<service_id>/usage")
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def usage(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
 
@@ -169,7 +169,7 @@ def usage(service_id):
 
 @main.route("/services/<service_id>/monthly")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def monthly(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
     return render_template(
@@ -187,7 +187,7 @@ def monthly(service_id):
 
 @main.route("/services/<service_id>/inbox")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def inbox(service_id):
 
     return render_template(
@@ -199,7 +199,7 @@ def inbox(service_id):
 
 @main.route("/services/<service_id>/inbox.json")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def inbox_updates(service_id):
 
     return jsonify(get_inbox_partials(service_id))
@@ -207,7 +207,7 @@ def inbox_updates(service_id):
 
 @main.route("/services/<service_id>/inbox.csv")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def inbox_download(service_id):
     return Response(
         Spreadsheet.from_rows(

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -19,12 +19,12 @@ from app.main.views.service_settings import (
     get_branding_as_dict,
     get_branding_as_value_and_label,
 )
-from app.utils import get_cdn_domain, user_has_permissions
+from app.utils import get_cdn_domain, user_is_platform_admin
 
 
 @main.route("/email-branding", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def email_branding():
     brandings = email_branding_client.get_all_email_branding()
 
@@ -47,7 +47,7 @@ def email_branding():
 @main.route("/email-branding/<branding_id>/edit", methods=['GET', 'POST'])
 @main.route("/email-branding/<branding_id>/edit/<logo>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def update_email_branding(branding_id, logo=None):
     email_branding = email_branding_client.get_email_branding(branding_id)['email_branding']
 
@@ -98,7 +98,7 @@ def update_email_branding(branding_id, logo=None):
 @main.route("/email-branding/create", methods=['GET', 'POST'])
 @main.route("/email-branding/create/<logo>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def create_email_branding(logo=None):
     form = ServiceCreateEmailBranding()
 

--- a/app/main/views/inbound_number.py
+++ b/app/main/views/inbound_number.py
@@ -3,12 +3,12 @@ from flask_login import login_required
 
 from app import inbound_number_client
 from app.main import main
-from app.utils import user_has_permissions
+from app.utils import user_is_platform_admin
 
 
 @main.route('/inbound-sms-admin', methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def inbound_sms_admin():
     data = inbound_number_client.get_all_inbound_sms_number_service()
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,8 +1,7 @@
 from flask import redirect, render_template, request, url_for
 from flask_login import current_user, login_required
-from notifications_utils.international_billing_rates import (
-    INTERNATIONAL_BILLING_RATES,
-)
+from notifications_utils.international_billing_rates import \
+    INTERNATIONAL_BILLING_RATES
 from notifications_utils.template import HTMLEmailTemplate
 
 from app import convert_to_boolean

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,7 +1,8 @@
 from flask import redirect, render_template, request, url_for
 from flask_login import current_user, login_required
-from notifications_utils.international_billing_rates import \
-    INTERNATIONAL_BILLING_RATES
+from notifications_utils.international_billing_rates import (
+    INTERNATIONAL_BILLING_RATES,
+)
 from notifications_utils.template import HTMLEmailTemplate
 
 from app import convert_to_boolean

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -39,7 +39,7 @@ from app.utils import (
 
 @main.route("/services/<service_id>/jobs")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_jobs(service_id):
     page = int(request.args.get('page', 1))
     # all but scheduled and cancelled
@@ -67,7 +67,7 @@ def view_jobs(service_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_job(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     if job['job_status'] == 'cancelled':
@@ -107,7 +107,7 @@ def view_job(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>.csv")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_job_csv(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     template = service_api_client.get_service_template(
@@ -142,14 +142,14 @@ def view_job_csv(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>", methods=['POST'])
 @login_required
-@user_has_permissions('send_messages', admin_override=True)
+@user_has_permissions('send_messages')
 def cancel_job(service_id, job_id):
     job_api_client.cancel_job(service_id, job_id)
     return redirect(url_for('main.service_dashboard', service_id=service_id))
 
 
 @main.route("/services/<service_id>/jobs/<job_id>.json")
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_job_updates(service_id, job_id):
 
     job = job_api_client.get_job(service_id, job_id)['data']
@@ -166,7 +166,7 @@ def view_job_updates(service_id, job_id):
 
 @main.route('/services/<service_id>/notifications/<message_type>', methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_notifications(service_id, message_type):
     return render_template(
         'views/notifications.html',
@@ -186,7 +186,7 @@ def view_notifications(service_id, message_type):
 
 
 @main.route('/services/<service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def get_notifications_as_json(service_id, message_type):
     return jsonify(get_notifications(
         service_id, message_type, status_override=request.args.get('status')
@@ -194,7 +194,7 @@ def get_notifications_as_json(service_id, message_type):
 
 
 @main.route('/services/<service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def get_notifications(service_id, message_type, status_override=None):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -142,7 +142,7 @@ def view_job_csv(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>", methods=['POST'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters', admin_override=True)
+@user_has_permissions('send_messages', admin_override=True)
 def cancel_job(service_id, job_id):
     job_api_client.cancel_job(service_id, job_id)
     return redirect(url_for('main.service_dashboard', service_id=service_id))

--- a/app/main/views/letter_jobs.py
+++ b/app/main/views/letter_jobs.py
@@ -3,12 +3,12 @@ from flask_login import login_required
 
 from app import letter_jobs_client
 from app.main import main
-from app.utils import user_has_permissions
+from app.utils import user_is_platform_admin
 
 
 @main.route("/letter-jobs", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def letter_jobs():
     letter_jobs_list = letter_jobs_client.get_letter_jobs()
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -37,7 +37,7 @@ def manage_users(service_id):
 
 @main.route("/services/<service_id>/users/invite", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_users', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def invite_user(service_id):
 
     form = InviteUserForm(
@@ -71,7 +71,7 @@ def invite_user(service_id):
 
 @main.route("/services/<service_id>/users/<user_id>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_users', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def edit_user_permissions(service_id, user_id):
     service_has_email_auth = 'email_auth' in current_service['permissions']
     # TODO we should probably using the service id here in the get user
@@ -103,7 +103,7 @@ def edit_user_permissions(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<user_id>/delete", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_users', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def remove_user_from_service(service_id, user_id):
     user = user_api_client.get_user(user_id)
     # Need to make the email address read only, or a disabled field?
@@ -139,7 +139,7 @@ def remove_user_from_service(service_id, user_id):
 
 
 @main.route("/services/<service_id>/cancel-invited-user/<invited_user_id>", methods=['GET'])
-@user_has_permissions('manage_users', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def cancel_invited_user(service_id, invited_user_id):
     invite_api_client.cancel_invited_user(service_id=service_id, invited_user_id=invited_user_id)
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -80,7 +80,7 @@ def edit_user_permissions(service_id, user_id):
     user_has_no_mobile_number = user.mobile_number is None
 
     form = PermissionsForm(
-        **{role: user.has_permissions(role) for role in roles.keys()},
+        **{role: user.has_permission_for_service(service_id, role) for role in roles.keys()},
         login_authentication=user.auth_type
     )
     if form.validate_on_submit():
@@ -109,7 +109,7 @@ def remove_user_from_service(service_id, user_id):
     # Need to make the email address read only, or a disabled field?
     # Do it through the template or the form class?
     form = PermissionsForm(**{
-        role: user.has_permissions(role) for role in roles.keys()
+        role: user.has_permission_for_service(service_id, role) for role in roles.keys()
     })
 
     if request.method == 'POST':

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -16,7 +16,7 @@ from app.utils import user_has_permissions
 
 @main.route("/services/<service_id>/users")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def manage_users(service_id):
     users = sorted(
         user_api_client.get_users_for_service(service_id=service_id) + [
@@ -37,7 +37,7 @@ def manage_users(service_id):
 
 @main.route("/services/<service_id>/users/invite", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def invite_user(service_id):
 
     form = InviteUserForm(
@@ -71,7 +71,7 @@ def invite_user(service_id):
 
 @main.route("/services/<service_id>/users/<user_id>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def edit_user_permissions(service_id, user_id):
     service_has_email_auth = 'email_auth' in current_service['permissions']
     # TODO we should probably using the service id here in the get user
@@ -103,7 +103,7 @@ def edit_user_permissions(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<user_id>/delete", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def remove_user_from_service(service_id, user_id):
     user = user_api_client.get_user(user_id)
     # Need to make the email address read only, or a disabled field?
@@ -139,7 +139,7 @@ def remove_user_from_service(service_id, user_id):
 
 
 @main.route("/services/<service_id>/cancel-invited-user/<invited_user_id>", methods=['GET'])
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def cancel_invited_user(service_id, invited_user_id):
     invite_api_client.cancel_invited_user(service_id=service_id, invited_user_id=invited_user_id)
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 from flask import abort, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
@@ -52,7 +50,7 @@ def invite_user(service_id):
 
     if form.validate_on_submit():
         email_address = form.email_address.data
-        permissions = ','.join(sorted(get_permissions_from_form(form)))
+        permissions = get_permissions_from_form(form)
         invited_user = invite_api_client.create_invite(
             current_user.id,
             service_id,
@@ -82,7 +80,7 @@ def edit_user_permissions(service_id, user_id):
     user_has_no_mobile_number = user.mobile_number is None
 
     form = PermissionsForm(
-        **{role: user.has_permissions(*permissions) for role, permissions in roles.items()},
+        **{role: user.has_permissions(role) for role in roles.keys()},
         login_authentication=user.auth_type
     )
     if form.validate_on_submit():
@@ -111,7 +109,7 @@ def remove_user_from_service(service_id, user_id):
     # Need to make the email address read only, or a disabled field?
     # Do it through the template or the form class?
     form = PermissionsForm(**{
-        role: user.has_permissions(*permissions) for role, permissions in roles.items()
+        role: user.has_permissions(role) for role in roles.keys()
     })
 
     if request.method == 'POST':
@@ -152,11 +150,6 @@ def get_permissions_from_form(form):
     # view_activity is a default role to be added to all users.
     # All users will have at minimum view_activity to allow users to see notifications,
     # templates, team members but no update privileges
-    selected_permissions = [
-        permissions
-        for role, permissions in roles.items()
-        if form[role].data is True
-    ]
-    selected_permissions = list(chain.from_iterable(selected_permissions))
-    selected_permissions.append('view_activity')
-    return selected_permissions
+    selected_roles = {role for role in roles.keys() if form[role].data is True}
+    selected_roles.add('view_activity')
+    return selected_roles

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -39,7 +39,7 @@ from app.utils import (
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
     notification['template'].update({'reply_to_text': notification['reply_to_text']})
@@ -94,7 +94,7 @@ def get_preview_error_image():
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>.<filetype>")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_letter_notification_as_preview(service_id, notification_id, filetype):
 
     if filetype not in ('pdf', 'png'):
@@ -116,7 +116,7 @@ def view_letter_notification_as_preview(service_id, notification_id, filetype):
 
 
 @main.route("/services/<service_id>/notification/<notification_id>.json")
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_notification_updates(service_id, notification_id):
     return jsonify(**get_single_notification_partials(
         notification_api_client.get_notification(service_id, notification_id)
@@ -155,7 +155,7 @@ def get_all_personalisation_from_notification(notification):
 
 @main.route("/services/<service_id>/download-notifications.csv")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def download_notifications_csv(service_id):
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -10,12 +10,12 @@ from app.main.forms import (
     InviteOrgUserForm,
     SearchUsersForm,
 )
-from app.utils import user_has_permissions
+from app.utils import user_is_platform_admin
 
 
 @main.route("/organisations", methods=['GET'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def organisations():
     orgs = organisations_client.get_organisations()
 
@@ -27,7 +27,7 @@ def organisations():
 
 @main.route("/organisations/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def add_organisation():
     form = CreateOrUpdateOrganisation()
 
@@ -46,7 +46,7 @@ def add_organisation():
 
 @main.route("/organisations/<org_id>", methods=['GET'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def organisation_dashboard(org_id):
     organisation_services = organisations_client.get_organisation_services(org_id)
 
@@ -58,7 +58,7 @@ def organisation_dashboard(org_id):
 
 @main.route("/organisations/<org_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def update_organisation(org_id):
     org = organisations_client.get_organisation(org_id)
 
@@ -83,7 +83,7 @@ def update_organisation(org_id):
 
 @main.route("/organisations/<org_id>/users", methods=['GET'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def manage_org_users(org_id):
     users = sorted(
         user_api_client.get_users_for_organisation(org_id=org_id) + [
@@ -103,7 +103,7 @@ def manage_org_users(org_id):
 
 @main.route("/organisations/<org_id>/users/invite", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def invite_org_user(org_id):
     form = InviteOrgUserForm(
         invalid_email_address=current_user.email_address
@@ -127,7 +127,7 @@ def invite_org_user(org_id):
 
 @main.route("/organisations/<org_id>/users/<user_id>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def edit_user_org_permissions(org_id, user_id):
     user = user_api_client.get_user(user_id)
 
@@ -139,7 +139,7 @@ def edit_user_org_permissions(org_id, user_id):
 
 @main.route("/organisations/<org_id>/users/<user_id>/delete", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def remove_user_from_organisation(org_id, user_id):
     user = user_api_client.get_user(user_id)
     if request.method == 'POST':
@@ -169,7 +169,7 @@ def remove_user_from_organisation(org_id, user_id):
 
 @main.route("/organisations/<org_id>/cancel-invited-user/<invited_user_id>", methods=['GET'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def cancel_invited_org_user(org_id, invited_user_id):
     org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
 

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -8,12 +8,12 @@ from app import service_api_client
 from app.main import main
 from app.main.forms import DateFilterForm
 from app.statistics_utils import get_formatted_percentage
-from app.utils import user_has_permissions
+from app.utils import user_is_platform_admin
 
 
 @main.route("/platform-admin")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def platform_admin():
     form = DateFilterForm(request.args)
     api_args = {'detailed': True,
@@ -41,7 +41,7 @@ def platform_admin():
 @main.route("/platform-admin/live-services", endpoint='live_services')
 @main.route("/platform-admin/trial-services", endpoint='trial_services')
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def platform_admin_services():
     form = DateFilterForm(request.args)
     api_args = {'detailed': True,

--- a/app/main/views/providers.py
+++ b/app/main/views/providers.py
@@ -5,12 +5,12 @@ from werkzeug.utils import redirect
 from app import provider_client
 from app.main import main
 from app.main.forms import ProviderForm
-from app.utils import user_has_permissions
+from app.utils import user_is_platform_admin
 
 
 @main.route("/providers")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def view_providers():
     providers = provider_client.get_all_providers()['provider_details']
     domestic_email_providers, domestic_sms_providers, intl_sms_providers = [], [], []
@@ -32,7 +32,7 @@ def view_providers():
 
 @main.route("/provider/<provider_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def edit_provider(provider_id):
     provider = provider_client.get_provider_by_id(provider_id)['provider_details']
     form = ProviderForm(active=provider['active'], priority=provider['priority'])
@@ -46,7 +46,7 @@ def edit_provider(provider_id):
 
 @main.route("/provider/<provider_id>")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def view_provider(provider_id):
     versions = provider_client.get_provider_versions(provider_id)
     return render_template('views/providers/provider.html', provider_versions=versions['data'])

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -159,7 +159,7 @@ def send_messages(service_id, template_id):
 
 @main.route("/services/<service_id>/send/<template_id>.csv", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages', 'manage_templates', any_=True)
+@user_has_permissions('send_messages', 'manage_templates')
 def get_example_csv(service_id, template_id):
     template = get_template(
         service_api_client.get_service_template(service_id, template_id)['data'], current_service

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -601,7 +601,7 @@ def check_messages(service_id, template_type, upload_id, row_index=2):
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>.<filetype>", methods=['GET'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>.<filetype>", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_messages_preview(service_id, template_type, upload_id, filetype, row_index=2):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -615,7 +615,7 @@ def check_messages_preview(service_id, template_type, upload_id, filetype, row_i
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['POST'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>", methods=['POST'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def recheck_messages(service_id, template_type, upload_id, row_index=0):
 
     if not session.get('upload_data'):
@@ -626,7 +626,7 @@ def recheck_messages(service_id, template_type, upload_id, row_index=0):
 
 @main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def start_job(service_id, upload_id):
     upload_data = session['upload_data']
 
@@ -658,7 +658,7 @@ def start_job(service_id, upload_id):
 
 @main.route("/services/<service_id>/end-tour/<example_template_id>")
 @login_required
-@user_has_permissions('manage_templates')
+@user_has_permissions('manage_templates', admin_override=True)
 def go_to_dashboard_after_tour(service_id, example_template_id):
 
     service_api_client.delete_service_template(service_id, example_template_id)
@@ -767,7 +767,7 @@ def get_back_link(service_id, template_id, step_index):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', admin_override=True)
 def check_notification(service_id, template_id):
     return _check_notification(service_id, template_id)
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -658,7 +658,7 @@ def start_job(service_id, upload_id):
 
 @main.route("/services/<service_id>/end-tour/<example_template_id>")
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def go_to_dashboard_after_tour(service_id, example_template_id):
 
     service_api_client.delete_service_template(service_id, example_template_id)
@@ -767,7 +767,7 @@ def get_back_link(service_id, template_id, step_index):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages', admin_override=True)
+@user_has_permissions('send_messages')
 def check_notification(service_id, template_id):
     return _check_notification(service_id, template_id)
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -90,7 +90,7 @@ def get_example_letter_address(key):
 
 @main.route("/services/<service_id>/send/<template_id>/csv", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def send_messages(service_id, template_id):
     session['sender_id'] = None
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
@@ -159,7 +159,7 @@ def send_messages(service_id, template_id):
 
 @main.route("/services/<service_id>/send/<template_id>.csv", methods=['GET'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters', 'manage_templates', any_=True)
+@user_has_permissions('send_messages', 'manage_templates', any_=True)
 def get_example_csv(service_id, template_id):
     template = get_template(
         service_api_client.get_service_template(service_id, template_id)['data'], current_service
@@ -175,7 +175,7 @@ def get_example_csv(service_id, template_id):
 
 @main.route("/services/<service_id>/send/<template_id>/set-sender", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def set_sender(service_id, template_id):
     session['sender_id'] = None
     redirect_to_one_off = redirect(
@@ -265,7 +265,7 @@ def get_sender_details(service_id, template_type):
 @main.route("/services/<service_id>/send/<template_id>/test", endpoint='send_test')
 @main.route("/services/<service_id>/send/<template_id>/one-off", endpoint='send_one_off')
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def send_test(service_id, template_id):
     session['recipient'] = None
     session['placeholders'] = {}
@@ -319,7 +319,7 @@ def get_notification_check_endpoint(service_id, template):
     endpoint='send_one_off_step',
 )
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def send_test_step(service_id, template_id, step_index):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(
@@ -443,7 +443,7 @@ def send_test_step(service_id, template_id, step_index):
 
 @main.route("/services/<service_id>/send/<template_id>/test.<filetype>", methods=['GET'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def send_test_preview(service_id, template_id, filetype):
 
     if filetype not in ('pdf', 'png'):
@@ -572,7 +572,7 @@ def _check_messages(service_id, template_type, upload_id, preview_row, letters_a
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['GET'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>", methods=['GET'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def check_messages(service_id, template_type, upload_id, row_index=2):
 
     data = _check_messages(service_id, template_type, upload_id, row_index)
@@ -601,7 +601,7 @@ def check_messages(service_id, template_type, upload_id, row_index=2):
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>.<filetype>", methods=['GET'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>.<filetype>", methods=['GET'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def check_messages_preview(service_id, template_type, upload_id, filetype, row_index=2):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -615,7 +615,7 @@ def check_messages_preview(service_id, template_type, upload_id, filetype, row_i
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['POST'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>", methods=['POST'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def recheck_messages(service_id, template_type, upload_id, row_index=0):
 
     if not session.get('upload_data'):
@@ -626,7 +626,7 @@ def recheck_messages(service_id, template_type, upload_id, row_index=0):
 
 @main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def start_job(service_id, upload_id):
     upload_data = session['upload_data']
 
@@ -767,7 +767,7 @@ def get_back_link(service_id, template_id, step_index):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def check_notification(service_id, template_id):
     return _check_notification(service_id, template_id)
 
@@ -831,7 +831,7 @@ def get_template_error_dict(exception):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['POST'])
 @login_required
-@user_has_permissions('send_texts', 'send_emails', 'send_letters')
+@user_has_permissions('send_messages')
 def send_notification(service_id, template_id):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -90,7 +90,7 @@ def get_example_letter_address(key):
 
 @main.route("/services/<service_id>/send/<template_id>/csv", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_messages(service_id, template_id):
     session['sender_id'] = None
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
@@ -175,7 +175,7 @@ def get_example_csv(service_id, template_id):
 
 @main.route("/services/<service_id>/send/<template_id>/set-sender", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def set_sender(service_id, template_id):
     session['sender_id'] = None
     redirect_to_one_off = redirect(
@@ -198,8 +198,7 @@ def set_sender(service_id, template_id):
         sender_choices=sender_context['value_and_label'],
         sender_label=sender_context['description']
     )
-    option_hints = {sender_context['default_id']: '(Default)',
-                    }
+    option_hints = {sender_context['default_id']: '(Default)'}
     if sender_context.get('receives_text_message', None):
         option_hints.update({sender_context['receives_text_message']: '(Receives replies)'})
     if sender_context.get('default_and_receives', None):
@@ -265,7 +264,7 @@ def get_sender_details(service_id, template_type):
 @main.route("/services/<service_id>/send/<template_id>/test", endpoint='send_test')
 @main.route("/services/<service_id>/send/<template_id>/one-off", endpoint='send_one_off')
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_test(service_id, template_id):
     session['recipient'] = None
     session['placeholders'] = {}
@@ -319,7 +318,7 @@ def get_notification_check_endpoint(service_id, template):
     endpoint='send_one_off_step',
 )
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_test_step(service_id, template_id, step_index):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(
@@ -572,7 +571,7 @@ def _check_messages(service_id, template_type, upload_id, preview_row, letters_a
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>", methods=['GET'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_messages(service_id, template_type, upload_id, row_index=2):
 
     data = _check_messages(service_id, template_type, upload_id, row_index)
@@ -601,7 +600,7 @@ def check_messages(service_id, template_type, upload_id, row_index=2):
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>.<filetype>", methods=['GET'])
 @main.route("/services/<service_id>/<template_type>/check/<upload_id>/row-<int:row_index>.<filetype>", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages')
 def check_messages_preview(service_id, template_type, upload_id, filetype, row_index=2):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -767,7 +766,7 @@ def get_back_link(service_id, template_id, step_index):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_notification(service_id, template_id):
     return _check_notification(service_id, template_id)
 
@@ -831,7 +830,7 @@ def get_template_error_dict(exception):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['POST'])
 @login_required
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_notification(service_id, template_id):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -53,7 +53,7 @@ from app.utils import (
 
 @main.route("/services/<service_id>/service-settings")
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
 def service_settings(service_id):
     letter_branding_organisations = email_branding_client.get_letter_email_branding()
     organisation = organisations_client.get_service_organisation(service_id).get('name', None)
@@ -105,7 +105,7 @@ def service_settings(service_id):
 
 @main.route("/services/<service_id>/service-settings/name", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_name_change(service_id):
     form = RenameServiceForm()
 
@@ -127,7 +127,7 @@ def service_name_change(service_id):
 
 @main.route("/services/<service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_name_change_confirm(service_id):
     # Validate password for form
     def _check_password(pwd):
@@ -161,14 +161,14 @@ def service_name_change_confirm(service_id):
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live")
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def request_to_go_live(service_id):
     return render_template('views/service-settings/request-to-go-live.html')
 
 
 @main.route("/services/<service_id>/service-settings/submit-request-to-go-live", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def submit_request_to_go_live(service_id):
     form = RequestToGoLiveForm()
 
@@ -307,7 +307,7 @@ def service_switch_can_send_precompiled_letter(service_id):
 
 @main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def archive_service(service_id):
     if request.method == 'POST':
         service_api_client.archive_service(service_id)
@@ -319,7 +319,7 @@ def archive_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/suspend", methods=["GET", "POST"])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def suspend_service(service_id):
     if request.method == 'POST':
         service_api_client.suspend_service(service_id)
@@ -332,7 +332,7 @@ def suspend_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/resume", methods=["GET", "POST"])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def resume_service(service_id):
     if request.method == 'POST':
         service_api_client.resume_service(service_id)
@@ -344,7 +344,7 @@ def resume_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-email", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_email(service_id):
     return render_template(
         'views/service-settings/set-email.html',
@@ -353,14 +353,14 @@ def service_set_email(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_reply_to_email(service_id):
     return redirect(url_for('.service_email_reply_to', service_id=service_id))
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
 def service_email_reply_to(service_id):
     reply_to_email_addresses = service_api_client.get_reply_to_email_addresses(service_id)
     return render_template(
@@ -370,7 +370,7 @@ def service_email_reply_to(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_add_email_reply_to(service_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address_count = len(service_api_client.get_reply_to_email_addresses(service_id))
@@ -390,7 +390,7 @@ def service_add_email_reply_to(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = service_api_client.get_reply_to_email_address(service_id, reply_to_email_id)
@@ -413,7 +413,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
 
 @main.route("/services/<service_id>/service-settings/set-inbound-number", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_inbound_number(service_id):
     available_inbound_numbers = inbound_number_client.get_available_inbound_sms_numbers()
     service_has_inbound_number = inbound_number_client.get_inbound_sms_number_for_service(service_id)['data'] != {}
@@ -443,7 +443,7 @@ def service_set_inbound_number(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-sms", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_sms(service_id):
     return render_template(
         'views/service-settings/set-sms.html',
@@ -452,7 +452,7 @@ def service_set_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-prefix", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_sms_prefix(service_id):
 
     form = SMSPrefixForm(enabled=(
@@ -476,7 +476,7 @@ def service_set_sms_prefix(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_international_sms(service_id):
     form = InternationalSMSForm(
         enabled='on' if 'international_sms' in current_service['permissions'] else 'off'
@@ -498,7 +498,7 @@ def service_set_international_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-inbound-sms", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_inbound_sms(service_id):
     number = inbound_number_client.get_inbound_sms_number_for_service(service_id)['data'].get('number', '')
     return render_template(
@@ -509,7 +509,7 @@ def service_set_inbound_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-letters", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_letters(service_id):
     form = ServiceSwitchLettersForm(
         enabled='on' if 'letter' in current_service['permissions'] else 'off'
@@ -531,7 +531,7 @@ def service_set_letters(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-auth-type", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_auth_type(service_id):
     return render_template(
         'views/service-settings/set-auth-type.html',
@@ -540,7 +540,7 @@ def service_set_auth_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
     return render_template(
@@ -550,7 +550,7 @@ def service_letter_contact_details(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contact/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_add_letter_contact(service_id):
     form = ServiceLetterContactBlockForm()
     letter_contact_blocks_count = len(service_api_client.get_letter_contacts(service_id))
@@ -574,7 +574,7 @@ def service_add_letter_contact(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_edit_letter_contact(service_id, letter_contact_id):
     letter_contact_block = service_api_client.get_letter_contact(service_id, letter_contact_id)
     form = ServiceLetterContactBlockForm(letter_contact_block=letter_contact_block['contact_block'])
@@ -596,7 +596,7 @@ def service_edit_letter_contact(service_id, letter_contact_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
 def service_sms_senders(service_id):
 
     def attach_hint(sender):
@@ -621,7 +621,7 @@ def service_sms_senders(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
     sms_sender_count = len(service_api_client.get_sms_senders(service_id))
@@ -641,7 +641,7 @@ def service_add_sms_sender(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender/<sms_sender_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_edit_sms_sender(service_id, sms_sender_id):
     sms_sender = service_api_client.get_sms_sender(service_id, sms_sender_id)
     is_inbound_number = sms_sender['inbound_number_id']
@@ -670,7 +670,7 @@ def service_edit_sms_sender(service_id, sms_sender_id):
 
 @main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_service', admin_override=True)
+@user_has_permissions('manage_service')
 def service_set_letter_contact_block(service_id):
 
     if 'letter' not in current_service['permissions']:

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -53,7 +53,7 @@ from app.utils import (
 
 @main.route("/services/<service_id>/service-settings")
 @login_required
-@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
 def service_settings(service_id):
     letter_branding_organisations = email_branding_client.get_letter_email_branding()
     organisation = organisations_client.get_service_organisation(service_id).get('name', None)
@@ -105,7 +105,7 @@ def service_settings(service_id):
 
 @main.route("/services/<service_id>/service-settings/name", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_name_change(service_id):
     form = RenameServiceForm()
 
@@ -127,7 +127,7 @@ def service_name_change(service_id):
 
 @main.route("/services/<service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_name_change_confirm(service_id):
     # Validate password for form
     def _check_password(pwd):
@@ -161,14 +161,14 @@ def service_name_change_confirm(service_id):
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live")
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def request_to_go_live(service_id):
     return render_template('views/service-settings/request-to-go-live.html')
 
 
 @main.route("/services/<service_id>/service-settings/submit-request-to-go-live", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def submit_request_to_go_live(service_id):
     form = RequestToGoLiveForm()
 
@@ -307,7 +307,7 @@ def service_switch_can_send_precompiled_letter(service_id):
 
 @main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def archive_service(service_id):
     if request.method == 'POST':
         service_api_client.archive_service(service_id)
@@ -319,7 +319,7 @@ def archive_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/suspend", methods=["GET", "POST"])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def suspend_service(service_id):
     if request.method == 'POST':
         service_api_client.suspend_service(service_id)
@@ -332,7 +332,7 @@ def suspend_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/resume", methods=["GET", "POST"])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def resume_service(service_id):
     if request.method == 'POST':
         service_api_client.resume_service(service_id)
@@ -344,7 +344,7 @@ def resume_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-email", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_email(service_id):
     return render_template(
         'views/service-settings/set-email.html',
@@ -353,14 +353,14 @@ def service_set_email(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_reply_to_email(service_id):
     return redirect(url_for('.service_email_reply_to', service_id=service_id))
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
 def service_email_reply_to(service_id):
     reply_to_email_addresses = service_api_client.get_reply_to_email_addresses(service_id)
     return render_template(
@@ -370,7 +370,7 @@ def service_email_reply_to(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_add_email_reply_to(service_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address_count = len(service_api_client.get_reply_to_email_addresses(service_id))
@@ -390,7 +390,7 @@ def service_add_email_reply_to(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = service_api_client.get_reply_to_email_address(service_id, reply_to_email_id)
@@ -413,7 +413,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
 
 @main.route("/services/<service_id>/service-settings/set-inbound-number", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_inbound_number(service_id):
     available_inbound_numbers = inbound_number_client.get_available_inbound_sms_numbers()
     service_has_inbound_number = inbound_number_client.get_inbound_sms_number_for_service(service_id)['data'] != {}
@@ -443,7 +443,7 @@ def service_set_inbound_number(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-sms", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_sms(service_id):
     return render_template(
         'views/service-settings/set-sms.html',
@@ -452,7 +452,7 @@ def service_set_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-prefix", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_sms_prefix(service_id):
 
     form = SMSPrefixForm(enabled=(
@@ -476,7 +476,7 @@ def service_set_sms_prefix(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_international_sms(service_id):
     form = InternationalSMSForm(
         enabled='on' if 'international_sms' in current_service['permissions'] else 'off'
@@ -498,7 +498,7 @@ def service_set_international_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-inbound-sms", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_inbound_sms(service_id):
     number = inbound_number_client.get_inbound_sms_number_for_service(service_id)['data'].get('number', '')
     return render_template(
@@ -509,7 +509,7 @@ def service_set_inbound_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-letters", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_letters(service_id):
     form = ServiceSwitchLettersForm(
         enabled='on' if 'letter' in current_service['permissions'] else 'off'
@@ -531,7 +531,7 @@ def service_set_letters(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-auth-type", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_auth_type(service_id):
     return render_template(
         'views/service-settings/set-auth-type.html',
@@ -540,7 +540,7 @@ def service_set_auth_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
     return render_template(
@@ -550,7 +550,7 @@ def service_letter_contact_details(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contact/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_add_letter_contact(service_id):
     form = ServiceLetterContactBlockForm()
     letter_contact_blocks_count = len(service_api_client.get_letter_contacts(service_id))
@@ -574,7 +574,7 @@ def service_add_letter_contact(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_edit_letter_contact(service_id, letter_contact_id):
     letter_contact_block = service_api_client.get_letter_contact(service_id, letter_contact_id)
     form = ServiceLetterContactBlockForm(letter_contact_block=letter_contact_block['contact_block'])
@@ -596,7 +596,7 @@ def service_edit_letter_contact(service_id, letter_contact_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
 @login_required
-@user_has_permissions('manage_settings', 'manage_api_keys', admin_override=True, any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys', admin_override=True, any_=True)
 def service_sms_senders(service_id):
 
     def attach_hint(sender):
@@ -621,7 +621,7 @@ def service_sms_senders(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
     sms_sender_count = len(service_api_client.get_sms_senders(service_id))
@@ -641,7 +641,7 @@ def service_add_sms_sender(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender/<sms_sender_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_edit_sms_sender(service_id, sms_sender_id):
     sms_sender = service_api_client.get_sms_sender(service_id, sms_sender_id)
     is_inbound_number = sms_sender['inbound_number_id']
@@ -670,7 +670,7 @@ def service_edit_sms_sender(service_id, sms_sender_id):
 
 @main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_settings', admin_override=True)
+@user_has_permissions('manage_service', admin_override=True)
 def service_set_letter_contact_block(service_id):
 
     if 'letter' not in current_service['permissions']:

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -43,7 +43,12 @@ from app.main.forms import (
     ServiceSwitchLettersForm,
     SMSPrefixForm,
 )
-from app.utils import email_safe, get_cdn_domain, user_has_permissions
+from app.utils import (
+    email_safe,
+    get_cdn_domain,
+    user_has_permissions,
+    user_is_platform_admin,
+)
 
 
 @main.route("/services/<service_id>/service-settings")
@@ -212,7 +217,7 @@ def submit_request_to_go_live(service_id):
 
 @main.route("/services/<service_id>/service-settings/switch-live")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_switch_live(service_id):
     service_api_client.update_service(
         current_service['id'],
@@ -226,7 +231,7 @@ def service_switch_live(service_id):
 
 @main.route("/services/<service_id>/service-settings/research-mode")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_switch_research_mode(service_id):
     service_api_client.update_service_with_properties(
         service_id,
@@ -270,7 +275,7 @@ def update_service_permissions(service_id, permissions, sms_sender=None):
 
 @main.route("/services/<service_id>/service-settings/can-send-email")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_switch_can_send_email(service_id):
     switch_service_permissions(service_id, 'email')
     return redirect(url_for('.service_settings', service_id=service_id))
@@ -278,7 +283,7 @@ def service_switch_can_send_email(service_id):
 
 @main.route("/services/<service_id>/service-settings/can-send-sms")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_switch_can_send_sms(service_id):
     switch_service_permissions(service_id, 'sms')
     return redirect(url_for('.service_settings', service_id=service_id))
@@ -286,7 +291,7 @@ def service_switch_can_send_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-auth")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_switch_email_auth(service_id):
     switch_service_permissions(service_id, 'email_auth')
     return redirect(url_for('.service_settings', service_id=service_id))
@@ -294,7 +299,7 @@ def service_switch_email_auth(service_id):
 
 @main.route("/services/<service_id>/service-settings/can-send-precompiled-letter")
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_switch_can_send_precompiled_letter(service_id):
     switch_service_permissions(service_id, 'precompiled_letter')
     return redirect(url_for('.service_settings', service_id=service_id))
@@ -690,7 +695,7 @@ def service_set_letter_contact_block(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-organisation-type", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def set_organisation_type(service_id):
 
     form = OrganisationTypeForm(organisation_type=current_service.get('organisation_type'))
@@ -715,7 +720,7 @@ def set_organisation_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-free-sms-allowance", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def set_free_sms_allowance(service_id):
 
     form = FreeSMSAllowance(free_sms_allowance=billing_api_client.get_free_sms_fragment_limit_for_year(service_id))
@@ -733,7 +738,7 @@ def set_free_sms_allowance(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-email-branding", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def service_set_email_branding(service_id):
     email_branding = email_branding_client.get_all_email_branding()
 
@@ -762,7 +767,7 @@ def service_set_email_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-letter-branding", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def set_letter_branding(service_id):
 
     form = LetterBranding(choices=email_branding_client.get_letter_email_branding().items())
@@ -784,7 +789,7 @@ def set_letter_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/link-service-to-organisation", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions(admin_override=True)
+@user_is_platform_admin
 def link_service_to_organisation(service_id):
 
     organisations = organisations_client.get_organisations()

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -53,7 +53,7 @@ from app.utils import (
 
 @main.route("/services/<service_id>/service-settings")
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys')
 def service_settings(service_id):
     letter_branding_organisations = email_branding_client.get_letter_email_branding()
     organisation = organisations_client.get_service_organisation(service_id).get('name', None)
@@ -360,7 +360,7 @@ def service_set_reply_to_email(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys')
 def service_email_reply_to(service_id):
     reply_to_email_addresses = service_api_client.get_reply_to_email_addresses(service_id)
     return render_template(
@@ -540,7 +540,7 @@ def service_set_auth_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys')
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
     return render_template(
@@ -596,7 +596,7 @@ def service_edit_letter_contact(service_id, letter_contact_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
 @login_required
-@user_has_permissions('manage_service', 'manage_api_keys', any_=True)
+@user_has_permissions('manage_service', 'manage_api_keys')
 def service_sms_senders(service_id):
 
     def attach_hint(sender):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -41,10 +41,7 @@ page_headings = {
 
 @main.route("/services/<service_id>/templates/<uuid:template_id>")
 @login_required
-@user_has_permissions(
-    'view_activity',
-    admin_override=True,
-)
+@user_has_permissions('view_activity')
 def view_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, str(template_id))['data']
     if template["template_type"] == "letter":
@@ -75,10 +72,7 @@ def view_template(service_id, template_id):
 
 @main.route("/services/<service_id>/start-tour/<uuid:template_id>")
 @login_required
-@user_has_permissions(
-    'view_activity',
-    admin_override=True,
-)
+@user_has_permissions('view_activity')
 def start_tour(service_id, template_id):
 
     template = service_api_client.get_service_template(service_id, str(template_id))['data']
@@ -100,10 +94,7 @@ def start_tour(service_id, template_id):
 @main.route("/services/<service_id>/templates")
 @main.route("/services/<service_id>/templates/<template_type>")
 @login_required
-@user_has_permissions(
-    'view_activity',
-    admin_override=True,
-)
+@user_has_permissions('view_activity')
 def choose_template(service_id, template_type='all'):
     templates = service_api_client.get_service_templates(service_id)['data']
 
@@ -139,7 +130,7 @@ def choose_template(service_id, template_type='all'):
 
 @main.route("/services/<service_id>/templates/<template_id>.<filetype>")
 @login_required
-@user_has_permissions('view_activity', admin_override=True)
+@user_has_permissions('view_activity')
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -166,10 +157,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")
 @login_required
-@user_has_permissions(
-    'view_activity',
-    admin_override=True,
-)
+@user_has_permissions('view_activity')
 def view_template_version(service_id, template_id, version):
     return render_template(
         'views/templates/template_history.html',
@@ -179,10 +167,7 @@ def view_template_version(service_id, template_id, version):
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.<filetype>")
 @login_required
-@user_has_permissions(
-    'view_activity',
-    admin_override=True,
-)
+@user_has_permissions('view_activity')
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = service_api_client.get_service_template(service_id, template_id, version=version)['data']
     return TemplatePreview.from_database_object(db_template, filetype)
@@ -190,7 +175,7 @@ def view_template_version_preview(service_id, template_id, version, filetype):
 
 @main.route("/services/<service_id>/templates/add", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def add_template_by_type(service_id):
 
     form = ChooseTemplateType(
@@ -234,7 +219,7 @@ def add_template_by_type(service_id):
 
 @main.route("/services/<service_id>/templates/action-blocked/<notification_type>/<return_to>/<template_id>")
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def action_blocked(service_id, notification_type, return_to, template_id):
     if notification_type == 'sms':
         notification_type = 'text messages'
@@ -252,7 +237,7 @@ def action_blocked(service_id, notification_type, return_to, template_id):
 
 @main.route("/services/<service_id>/templates/add-<template_type>", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def add_service_template(service_id, template_type):
 
     if template_type not in ['sms', 'email', 'letter']:
@@ -311,7 +296,7 @@ def abort_403_if_not_admin_user():
 
 @main.route("/services/<service_id>/templates/<template_id>/edit", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def edit_service_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, template_id)['data']
     template['template_content'] = template['content']
@@ -396,7 +381,7 @@ def edit_service_template(service_id, template_id):
 
 @main.route("/services/<service_id>/templates/<template_id>/delete", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def delete_service_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, template_id)['data']
 
@@ -447,7 +432,7 @@ def delete_service_template(service_id, template_id):
 
 @main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def confirm_redact_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, template_id)['data']
 
@@ -471,7 +456,7 @@ def confirm_redact_template(service_id, template_id):
 
 @main.route("/services/<service_id>/templates/<template_id>/redact", methods=['POST'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def redact_template(service_id, template_id):
 
     service_api_client.redact_service_template(service_id, template_id)
@@ -490,10 +475,7 @@ def redact_template(service_id, template_id):
 
 @main.route('/services/<service_id>/templates/<template_id>/versions')
 @login_required
-@user_has_permissions(
-    'view_activity',
-    admin_override=True,
-)
+@user_has_permissions('view_activity')
 def view_template_versions(service_id, template_id):
     return render_template(
         'views/templates/choose_history.html',
@@ -517,7 +499,7 @@ def view_template_versions(service_id, template_id):
 
 @main.route('/services/<service_id>/templates/<template_id>/set-template-sender', methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('manage_templates', admin_override=True)
+@user_has_permissions('manage_templates')
 def set_template_sender(service_id, template_id):
     template = service_api_client.get_service_template(service_id, template_id)['data']
     sender_details = get_template_sender_form_dict(service_id, template)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -43,11 +43,7 @@ page_headings = {
 @login_required
 @user_has_permissions(
     'view_activity',
-    'send_texts',
-    'send_emails',
-    'manage_templates',
-    'manage_api_keys',
-    admin_override=True, any_=True
+    admin_override=True,
 )
 def view_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, str(template_id))['data']
@@ -81,11 +77,7 @@ def view_template(service_id, template_id):
 @login_required
 @user_has_permissions(
     'view_activity',
-    'send_texts',
-    'send_emails',
-    'manage_templates',
-    'manage_api_keys',
-    admin_override=True, any_=True
+    admin_override=True,
 )
 def start_tour(service_id, template_id):
 
@@ -110,12 +102,7 @@ def start_tour(service_id, template_id):
 @login_required
 @user_has_permissions(
     'view_activity',
-    'send_texts',
-    'send_emails',
-    'manage_templates',
-    'manage_api_keys',
     admin_override=True,
-    any_=True,
 )
 def choose_template(service_id, template_type='all'):
     templates = service_api_client.get_service_templates(service_id)['data']
@@ -181,12 +168,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
 @login_required
 @user_has_permissions(
     'view_activity',
-    'send_texts',
-    'send_emails',
-    'manage_templates',
-    'manage_api_keys',
     admin_override=True,
-    any_=True
 )
 def view_template_version(service_id, template_id, version):
     return render_template(
@@ -199,12 +181,7 @@ def view_template_version(service_id, template_id, version):
 @login_required
 @user_has_permissions(
     'view_activity',
-    'send_texts',
-    'send_emails',
-    'manage_templates',
-    'manage_api_keys',
     admin_override=True,
-    any_=True
 )
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = service_api_client.get_service_template(service_id, template_id, version=version)['data']
@@ -515,12 +492,7 @@ def redact_template(service_id, template_id):
 @login_required
 @user_has_permissions(
     'view_activity',
-    'send_texts',
-    'send_emails',
-    'manage_templates',
-    'manage_api_keys',
     admin_override=True,
-    any_=True
 )
 def view_template_versions(service_id, template_id):
     return render_template(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -328,7 +328,7 @@ def add_service_template(service_id, template_type):
 
 
 def abort_403_if_not_admin_user():
-    if not current_user.has_permissions(admin_override=True):
+    if not current_user.platform_admin:
         abort(403)
 
 

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -1,6 +1,8 @@
-
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user
-from app.notify_client.models import InvitedUser
+from app.notify_client.models import (
+    InvitedUser,
+    translate_permissions_from_admin_roles_to_db,
+)
 
 
 class InviteApiClient(NotifyAdminAPIClient):
@@ -17,7 +19,7 @@ class InviteApiClient(NotifyAdminAPIClient):
             'service': str(service_id),
             'email_address': email_address,
             'from_user': invite_from_id,
-            'permissions': permissions,
+            'permissions': ','.join(sorted(translate_permissions_from_admin_roles_to_db(permissions))),
             'auth_type': auth_type,
             'invite_link_host': self.admin_url,
         }

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -159,7 +159,7 @@ class User(UserMixin):
     def permissions(self, permissions):
         raise AttributeError("Read only property")
 
-    def has_permissions(self, *permissions, any_=False, admin_override=None, restrict_admin_usage=False):
+    def has_permissions(self, *permissions, any_=False, restrict_admin_usage=False):
         unknown_permissions = set(permissions) - all_permissions
 
         if unknown_permissions:

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -159,7 +159,7 @@ class User(UserMixin):
     def permissions(self, permissions):
         raise AttributeError("Read only property")
 
-    def has_permissions(self, *permissions, any_=False, restrict_admin_usage=False):
+    def has_permissions(self, *permissions, restrict_admin_usage=False):
         unknown_permissions = set(permissions) - all_permissions
 
         if unknown_permissions:
@@ -172,12 +172,7 @@ class User(UserMixin):
         # Service id is always set on the request for service specific views.
         service_id = _get_service_id_from_view_args()
         if service_id in self._permissions:
-            if any_:
-                has_permissions = any(x in self._permissions[service_id] for x in permissions)
-            else:
-                has_permissions = set(self._permissions[service_id]) >= set(permissions)
-
-            return has_permissions
+            return any(x in self._permissions[service_id] for x in permissions)
         return False
 
     def has_permission_for_service(self, service_id, permission):

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -183,6 +183,7 @@ class InvitedUser(object):
         self.status = status
         self.created_at = created_at
         self.auth_type = auth_type
+        self.permissions = translate_permissions_from_db_to_admin_roles(self.permissions)
 
     def has_permissions(self, *permissions):
         if self.status == 'cancelled':
@@ -217,7 +218,7 @@ class InvitedUser(object):
         if permissions_as_string:
             data['permissions'] = ','.join(self.permissions)
         else:
-            data['permissions'] = self.permissions
+            data['permissions'] = sorted(self.permissions)
         return data
 
 

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -52,19 +52,19 @@ def translate_permissions_from_admin_roles_to_db(permissions):
 
 class User(UserMixin):
     def __init__(self, fields, max_failed_login_count=3):
-        self._id = fields.get('id')
-        self._name = fields.get('name')
-        self._email_address = fields.get('email_address')
-        self._mobile_number = fields.get('mobile_number')
-        self._password_changed_at = fields.get('password_changed_at')
+        self.id = fields.get('id')
+        self.name = fields.get('name')
+        self.email_address = fields.get('email_address')
+        self.mobile_number = fields.get('mobile_number')
+        self.password_changed_at = fields.get('password_changed_at')
         self._set_permissions(fields.get('permissions', {}))
-        self._auth_type = fields.get('auth_type')
-        self._failed_login_count = fields.get('failed_login_count')
-        self._state = fields.get('state')
+        self.auth_type = fields.get('auth_type')
+        self.failed_login_count = fields.get('failed_login_count')
+        self.state = fields.get('state')
         self.max_failed_login_count = max_failed_login_count
         self.platform_admin = fields.get('platform_admin')
         self.current_session_id = fields.get('current_session_id')
-        self._organisations = fields.get('organisations', [])
+        self.organisations = fields.get('organisations', [])
 
     def _set_permissions(self, permissions_by_service):
         """
@@ -104,54 +104,6 @@ class User(UserMixin):
         )
 
     @property
-    def id(self):
-        return self._id
-
-    @id.setter
-    def id(self, id):
-        self._id = id
-
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, name):
-        self._name = name
-
-    @property
-    def email_address(self):
-        return self._email_address
-
-    @email_address.setter
-    def email_address(self, email_address):
-        self._email_address = email_address
-
-    @property
-    def mobile_number(self):
-        return self._mobile_number
-
-    @mobile_number.setter
-    def mobile_number(self, mobile_number):
-        self._mobile_number = mobile_number
-
-    @property
-    def password_changed_at(self):
-        return self._password_changed_at
-
-    @password_changed_at.setter
-    def password_changed_at(self, password_changed_at):
-        self._password_changed_at = password_changed_at
-
-    @property
-    def state(self):
-        return self._state
-
-    @state.setter
-    def state(self, state):
-        self._state = state
-
-    @property
     def permissions(self):
         return self._permissions
 
@@ -178,22 +130,6 @@ class User(UserMixin):
     def has_permission_for_service(self, service_id, permission):
         return permission in self._permissions.get(service_id, [])
 
-    @property
-    def auth_type(self):
-        return self._auth_type
-
-    @auth_type.setter
-    def auth_type(self, auth_type):
-        self._auth_type = auth_type
-
-    @property
-    def failed_login_count(self):
-        return self._failed_login_count
-
-    @failed_login_count.setter
-    def failed_login_count(self, num):
-        self._failed_login_count += num
-
     def is_locked(self):
         return self.failed_login_count >= self.max_failed_login_count
 
@@ -216,10 +152,6 @@ class User(UserMixin):
 
     def set_password(self, pwd):
         self._password = pwd
-
-    @property
-    def organisations(self):
-        return self._organisations
 
 
 class InvitedUser(object):

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -32,6 +32,10 @@ def _get_service_id_from_view_args():
     return request.view_args.get('service_id', None)
 
 
+def _get_org_id_from_view_args():
+    return request.view_args.get('org_id', None)
+
+
 def translate_permissions_from_db_to_admin_roles(permissions):
     """
     Given a list of database permissions, return a set of roles
@@ -123,9 +127,14 @@ class User(UserMixin):
 
         # Service id is always set on the request for service specific views.
         service_id = _get_service_id_from_view_args()
-        if service_id in self._permissions:
-            return any(x in self._permissions[service_id] for x in permissions)
-        return False
+        org_id = _get_org_id_from_view_args()
+
+        if org_id:
+            return org_id in self.organisations
+        elif service_id:
+            return any(x in self._permissions.get(service_id, []) for x in permissions)
+        else:
+            return False
 
     def has_permission_for_service(self, service_id, permission):
         return permission in self._permissions.get(service_id, [])

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -133,7 +133,7 @@ class UserApiClient(NotifyAdminAPIClient):
     def get_count_of_users_with_permission(self, service_id, permission):
         return len([
             user for user in self.get_users_for_service(service_id)
-            if user.has_permissions(permission, any_=True)
+            if user.has_permissions(permission)
         ])
 
     def get_users_for_organisation(self, org_id):

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -148,8 +148,7 @@ class UserApiClient(NotifyAdminAPIClient):
         # permissions passed in are the combined admin roles, not db permissions
         endpoint = '/service/{}/users/{}'.format(service_id, user_id)
         data = [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
-        resp = self.post(endpoint, data=data)
-        return User(resp['data'], max_failed_login_count=self.max_failed_login_count)
+        self.post(endpoint, data=data)
 
     def add_user_to_organisation(self, org_id, user_id):
         resp = self.post('/organisations/{}/users/{}'.format(org_id, user_id), data={})

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -1,7 +1,10 @@
 from notifications_python_client.errors import HTTPError
 
 from app.notify_client import NotifyAdminAPIClient
-from app.notify_client.models import User
+from app.notify_client.models import (
+    User,
+    translate_permissions_from_admin_roles_to_db,
+)
 
 ALLOWED_ATTRIBUTES = {
     'name',
@@ -142,8 +145,9 @@ class UserApiClient(NotifyAdminAPIClient):
         return [User(data) for data in resp['data']]
 
     def add_user_to_service(self, service_id, user_id, permissions):
+        # permissions passed in are the combined admin roles, not db permissions
         endpoint = '/service/{}/users/{}'.format(service_id, user_id)
-        data = [{'permission': x} for x in permissions]
+        data = [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
         resp = self.post(endpoint, data=data)
         return User(resp['data'], max_failed_login_count=self.max_failed_login_count)
 
@@ -152,7 +156,8 @@ class UserApiClient(NotifyAdminAPIClient):
         return User(resp['data'], max_failed_login_count=self.max_failed_login_count)
 
     def set_user_permissions(self, user_id, service_id, permissions):
-        data = [{'permission': x} for x in permissions]
+        # permissions passed in are the combined admin roles, not db permissions
+        data = [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
         endpoint = '/user/{}/service/{}/permission'.format(user_id, service_id)
         self.post(endpoint, data=data)
 

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -136,7 +136,7 @@ class UserApiClient(NotifyAdminAPIClient):
     def get_count_of_users_with_permission(self, service_id, permission):
         return len([
             user for user in self.get_users_for_service(service_id)
-            if user.has_permissions(permission)
+            if user.has_permission_for_service(service_id, permission)
         ])
 
     def get_users_for_organisation(self, org_id):

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -44,7 +44,7 @@
           {% if current_user.is_authenticated %}
             <li><a href="{{ url_for('main.documentation') }}">Documentation</a></li>
             <li><a href="{{ url_for('main.user_profile') }}">{{ current_user.name }}</a></li>
-            {% if current_user.has_permissions(admin_override=True) %}
+            {% if current_user.platform_admin %}
               <li><a href="{{ url_for('main.platform_admin') }}">Platform admin</a></li>
             {% endif %}
             <li><a href="{{ url_for('main.sign_out')}}">Sign out</a></li>

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -107,7 +107,7 @@
 
 {% macro edit_field(text, link, permissions=[]) -%}
   {% call field(align='right') %}
-    {% if current_user.has_permissions(*permissions, **{'any_':True, 'admin_override': True}) or not permissions %}
+    {% if current_user.has_permissions(*permissions, **{'any_': True}) or not permissions %}
       <a href="{{ link }}">{{ text }}</a>
     {% endif %}
   {% endcall %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -107,7 +107,7 @@
 
 {% macro edit_field(text, link, permissions=[]) -%}
   {% call field(align='right') %}
-    {% if current_user.has_permissions(*permissions) or not permissions %}
+    {% if not permissions or current_user.has_permissions(*permissions) %}
       <a href="{{ link }}">{{ text }}</a>
     {% endif %}
   {% endcall %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -107,7 +107,7 @@
 
 {% macro edit_field(text, link, permissions=[]) -%}
   {% call field(align='right') %}
-    {% if current_user.has_permissions(*permissions, **{'any_': True}) or not permissions %}
+    {% if current_user.has_permissions(*permissions) or not permissions %}
       <a href="{{ link }}">{{ text }}</a>
     {% endif %}
   {% endcall %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -51,7 +51,7 @@
   {% if current_user.has_permissions('manage_service') %}
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
   {% endif %}
-  {% if current_user.has_permissions('manage_api_keys', 'manage_service', any_=True) %}
+  {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
     <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
   {% endif %}
   {% if current_user.has_permissions('manage_api_keys') %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -48,10 +48,10 @@
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
   {% endif %}
   <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
-  {% if current_user.has_permissions('manage_users', 'manage_settings', admin_override=True) %}
+  {% if current_user.has_permissions('manage_service', admin_override=True) %}
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
   {% endif %}
-  {% if current_user.has_permissions('manage_api_keys', 'manage_settings', admin_override=True, any_=True) %}
+  {% if current_user.has_permissions('manage_api_keys', 'manage_service', admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
   {% endif %}
   {% if current_user.has_permissions('manage_api_keys', admin_override=True) %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -44,17 +44,17 @@
 <nav class="navigation">
   <ul>
     <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
-  {% if current_user.has_permissions('view_activity', admin_override=True) %}
+  {% if current_user.has_permissions('view_activity') %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
   {% endif %}
   <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
-  {% if current_user.has_permissions('manage_service', admin_override=True) %}
+  {% if current_user.has_permissions('manage_service') %}
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
   {% endif %}
-  {% if current_user.has_permissions('manage_api_keys', 'manage_service', admin_override=True, any_=True) %}
+  {% if current_user.has_permissions('manage_api_keys', 'manage_service', any_=True) %}
     <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
   {% endif %}
-  {% if current_user.has_permissions('manage_api_keys', admin_override=True) %}
+  {% if current_user.has_permissions('manage_api_keys') %}
     <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
   {% endif %}
   </ul>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -44,14 +44,12 @@
 <nav class="navigation">
   <ul>
     <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
-  {% if current_user.has_permissions('view_activity', 'manage_templates', 'manage_api_keys', admin_override=True, any_=True) %}
+  {% if current_user.has_permissions('view_activity', admin_override=True) %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
   {% endif %}
+  <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% if current_user.has_permissions('manage_users', 'manage_settings', admin_override=True) %}
-    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
-  {% elif current_user.has_permissions('view_activity') %}
-    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
   {% if current_user.has_permissions('manage_api_keys', 'manage_settings', admin_override=True, any_=True) %}
     <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -1,8 +1,6 @@
 <nav class="navigation">
   <ul>
   	<li><a href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Dashboard</a></li>
-    {% if current_user.has_permissions(admin_override=True) %}
-      <li><a href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
-    {% endif %}
+    <li><a href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
   </ul>
 </nav>

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -22,7 +22,7 @@
       'messages',
     ) }}
 
-    {% if current_user.has_permissions('send_texts', admin_override=True) %}
+    {% if current_user.has_permissions('send_messages', admin_override=True) %}
       <p class="sms-message-reply-link">
         <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
       </p>

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -22,7 +22,7 @@
       'messages',
     ) }}
 
-    {% if current_user.has_permissions('send_messages', admin_override=True) %}
+    {% if current_user.has_permissions('send_messages') %}
       <p class="sms-message-reply-link">
         <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
       </p>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -19,7 +19,7 @@
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}
       {% endif %}
-    {% elif not current_user.has_permissions('send_texts', 'send_emails', 'send_letters', 'manage_api_keys', any_=True) %}
+    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', any_=True) %}
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -15,11 +15,11 @@
   <div class="dashboard">
 
     <h1 class="visuallyhidden">Dashboard</h1>
-    {% if current_user.has_permissions('manage_templates', admin_override=True) %}
+    {% if current_user.has_permissions('manage_templates') %}
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}
       {% endif %}
-    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', any_=True, admin_override=True) %}
+    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', any_=True) %}
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -19,7 +19,7 @@
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}
       {% endif %}
-    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', any_=True) %}
+    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', any_=True, admin_override=True) %}
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -19,7 +19,7 @@
       {% if not templates %}
         {% include 'views/dashboard/write-first-messages.html' %}
       {% endif %}
-    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', any_=True) %}
+    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys') %}
       {% include 'views/dashboard/no-permissions-banner.html' %}
     {% endif %}
 

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -19,7 +19,7 @@
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
-          {% if current_user.has_permissions(admin_override=True) %}
+          {% if current_user.platform_admin %}
              {{ radios(form.process_type) }}
           {% endif %}
           {{ page_footer(

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -20,7 +20,7 @@
         </div>
         <div class="column-two-thirds">
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=5) }}
-          {% if current_user.has_permissions(admin_override=True) %}
+          {% if current_user.platform_admin %}
             {{ radios(form.process_type) }}
           {% endif %}
           {{ page_footer(

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -64,19 +64,19 @@
         <ul class="tick-cross-list">
           <div class="tick-cross-list-permissions">
             {{ tick_cross(
-              user.has_permissions('send_messages'),
+              user.has_permission_for_service(current_service.id, 'send_messages'),
               'Send messages'
             ) }}
             {{ tick_cross(
-              user.has_permissions('manage_templates'),
+              user.has_permission_for_service(current_service.id, 'manage_templates'),
               'Add and edit templates'
             ) }}
             {{ tick_cross(
-              user.has_permissions('manage_service'),
+              user.has_permission_for_service(current_service.id, 'manage_service'),
               'Manage service'
             ) }}
             {{ tick_cross(
-              user.has_permissions('manage_api_keys'),
+              user.has_permission_for_service(current_service.id, 'manage_api_keys'),
               'Access API keys'
             ) }}
             {% if 'email_auth' in current_service['permissions'] %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -24,7 +24,7 @@
         Team members
       </h1>
     </div>
-    {% if current_user.has_permissions('manage_users', admin_override=True) %}
+    {% if current_user.has_permissions('manage_service', admin_override=True) %}
       <div class="column-one-third">
         <a href="{{ url_for('.invite_user', service_id=current_service.id) }}" class="button align-with-heading">Invite team member</a>
       </div>
@@ -64,7 +64,7 @@
         <ul class="tick-cross-list">
           <div class="tick-cross-list-permissions">
             {{ tick_cross(
-              user.has_permissions('send_texts', 'send_emails', 'send_letters'),
+              user.has_permissions('send_messages'),
               'Send messages'
             ) }}
             {{ tick_cross(
@@ -72,7 +72,7 @@
               'Add and edit templates'
             ) }}
             {{ tick_cross(
-              user.has_permissions('manage_users', 'manage_settings'),
+              user.has_permissions('manage_service'),
               'Manage service'
             ) }}
             {{ tick_cross(
@@ -89,7 +89,7 @@
               </div>
             {% endif %}
           </div>
-          {% if current_user.has_permissions('manage_users', admin_override=True) %}
+          {% if current_user.has_permissions('manage_service', admin_override=True) %}
             <li class="tick-cross-list-edit-link">
               {% if user.status == 'pending' %}
                 <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -24,7 +24,7 @@
         Team members
       </h1>
     </div>
-    {% if current_user.has_permissions('manage_service', admin_override=True) %}
+    {% if current_user.has_permissions('manage_service') %}
       <div class="column-one-third">
         <a href="{{ url_for('.invite_user', service_id=current_service.id) }}" class="button align-with-heading">Invite team member</a>
       </div>
@@ -89,7 +89,7 @@
               </div>
             {% endif %}
           </div>
-          {% if current_user.has_permissions('manage_service', admin_override=True) %}
+          {% if current_user.has_permissions('manage_service') %}
             <li class="tick-cross-list-edit-link">
               {% if user.status == 'pending' %}
                 <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -45,7 +45,7 @@
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}
 
-    {% if current_user.has_permissions('send_messages', admin_override=True) and template.template_type == 'sms' and can_receive_inbound %}
+    {% if current_user.has_permissions('send_messages') and template.template_type == 'sms' and can_receive_inbound %}
       <p>
         <a href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
       </p>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -45,7 +45,7 @@
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}
 
-    {% if current_user.has_permissions('send_texts', admin_override=True) and template.template_type == 'sms' and can_receive_inbound %}
+    {% if current_user.has_permissions('send_messages', admin_override=True) and template.template_type == 'sms' and can_receive_inbound %}
       <p>
         <a href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
       </p>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -227,7 +227,7 @@
       </ul>
 
       <p>
-        {% if current_user.has_permissions('manage_service') %}
+        {% if current_user.has_permissions('manage_service', admin_override=True) %}
           To remove these restrictions
           <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
         {% else %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -250,7 +250,7 @@
 
     {% endif %}
 
-    {% if current_user.has_permissions(admin_override=True) %}
+    {% if current_user.platform_admin %}
 
       <h2 class="heading-medium">Platform admin settings</h2>
       {% call mapping_table(

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -26,7 +26,7 @@
           {{ edit_field(
               'Change',
               url_for('.service_name_change', service_id=current_service.id),
-              permissions=['manage_settings']
+              permissions=['manage_service']
             )
           }}
         {% endcall %}
@@ -42,7 +42,7 @@
               'Change',
               url_for('.service_set_auth_type',
               service_id=current_service.id),
-              permissions=['manage_settings']
+              permissions=['manage_service']
             )
           }}
         {% endcall %}
@@ -63,7 +63,7 @@
               'Change',
               url_for('.service_set_email',
               service_id=current_service.id),
-              permissions=['manage_settings']
+              permissions=['manage_service']
               )
           }}
         {% endcall %}
@@ -85,7 +85,7 @@
                 'Manage' if reply_to_email_address_count else 'Change',
                 url_for('.service_email_reply_to',
                 service_id=current_service.id),
-                permissions=['manage_settings','manage_api_keys']
+                permissions=['manage_service','manage_api_keys']
               )
             }}
           {% endcall %}
@@ -108,7 +108,7 @@
               'Change',
               url_for('.service_set_sms',
               service_id=current_service.id),
-              permissions=['manage_settings']
+              permissions=['manage_service']
             )
           }}
         {% endcall %}
@@ -129,7 +129,7 @@
                 'Manage' if sms_sender_count else 'Change',
                 url_for('.service_sms_senders',
                 service_id=current_service.id),
-                permissions=['manage_settings','manage_api_keys']
+                permissions=['manage_service','manage_api_keys']
             )
             }}
           {% endcall %}
@@ -141,7 +141,7 @@
                 'Change',
                 url_for('.service_set_sms_prefix',
                 service_id=current_service.id),
-                permissions=['manage_settings']
+                permissions=['manage_service']
             )
             }}
           {% endcall %}
@@ -153,7 +153,7 @@
                 'Change',
                 url_for('.service_set_international_sms',
                 service_id=current_service.id),
-                permissions=['manage_settings']
+                permissions=['manage_service']
             )
             }}
           {% endcall %}
@@ -165,7 +165,7 @@
                 'Change',
                 url_for('.service_set_inbound_sms',
                 service_id=current_service.id),
-                permissions=['manage_settings']
+                permissions=['manage_service']
             )
             }}
           {% endcall %}
@@ -188,7 +188,7 @@
               'Change',
               url_for('.service_set_letters',
               service_id=current_service.id),
-              permissions=['manage_settings']
+              permissions=['manage_service']
           )
           }}
         {% endcall %}
@@ -208,7 +208,7 @@
                 'Manage' if letter_contact_details_count else 'Change',
                 url_for('.service_letter_contact_details',
                 service_id=current_service.id),
-                permissions=['manage_settings','manage_api_keys']
+                permissions=['manage_service','manage_api_keys']
             )
             }}
           {% endcall %}
@@ -227,7 +227,7 @@
       </ul>
 
       <p>
-        {% if current_user.has_permissions('manage_settings') %}
+        {% if current_user.has_permissions('manage_service') %}
           To remove these restrictions
           <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
         {% else %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -227,7 +227,7 @@
       </ul>
 
       <p>
-        {% if current_user.has_permissions('manage_service', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service') %}
           To remove these restrictions
           <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
         {% else %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -15,7 +15,7 @@
         Email reply to addresses
       </h1>
     </div>
-  {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+  {% if current_user.has_permissions('manage_service', admin_override=True) %}
 	  <div class="column-one-third">
 	    <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
 	  </div>
@@ -36,7 +36,7 @@
             {% endif %}
           </span>
         </h3>
-        {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service', admin_override=True) %}
           <a class="user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
         {% endif %}
         {% if reply_to_email_addresses|length  > 1 %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -15,7 +15,7 @@
         Email reply to addresses
       </h1>
     </div>
-  {% if current_user.has_permissions('manage_service', admin_override=True) %}
+  {% if current_user.has_permissions('manage_service') %}
 	  <div class="column-one-third">
 	    <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
 	  </div>
@@ -36,7 +36,7 @@
             {% endif %}
           </span>
         </h3>
-        {% if current_user.has_permissions('manage_service', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service') %}
           <a class="user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
         {% endif %}
         {% if reply_to_email_addresses|length  > 1 %}

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -15,7 +15,7 @@
         Sender addresses
       </h1>
     </div>
-    {% if current_user.has_permissions('manage_service', admin_override=True) %}
+    {% if current_user.has_permissions('manage_service') %}
       <div class="column-one-third">
         <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id) }}" class="button align-with-heading">Add a new address</a>
       </div>
@@ -37,7 +37,7 @@
             (default)
           {% endif %}
         </p>
-        {% if current_user.has_permissions('manage_service', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service') %}
         <a class="user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
         {% endif %}
         {% if letter_contact_details|length  > 1 %}

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -15,7 +15,7 @@
         Sender addresses
       </h1>
     </div>
-    {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+    {% if current_user.has_permissions('manage_service', admin_override=True) %}
       <div class="column-one-third">
         <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id) }}" class="button align-with-heading">Add a new address</a>
       </div>
@@ -37,7 +37,7 @@
             (default)
           {% endif %}
         </p>
-        {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service', admin_override=True) %}
         <a class="user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
         {% endif %}
         {% if letter_contact_details|length  > 1 %}

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -19,7 +19,7 @@
           If you want to turn this feature off,
           <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
         </p>
-        {% if current_user.has_permissions('manage_api_keys', admin_override=True) %}
+        {% if current_user.has_permissions('manage_api_keys') %}
           <p>
             You can set up callbacks for received text messages on the
             <a href="{{ url_for('.api_callbacks', service_id=current_service.id) }}">API integration page</a>.

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -14,7 +14,7 @@
         Text message senders
       </h1>
     </div>
-    {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+    {% if current_user.has_permissions('manage_service', admin_override=True) %}
   	<div class="column-one-third">
   	  <a href="{{ url_for('.service_add_sms_sender', service_id=current_service.id) }}" class="button align-with-heading">Add text message sender</a>
   	</div>
@@ -37,7 +37,7 @@
             </span>
           {% endif %}
         </h3>
-        {% if current_user.has_permissions('manage_settings', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service', admin_override=True) %}
           <a class="user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
         {% endif %}
         {% if sms_senders|length  > 1 %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -14,7 +14,7 @@
         Text message senders
       </h1>
     </div>
-    {% if current_user.has_permissions('manage_service', admin_override=True) %}
+    {% if current_user.has_permissions('manage_service') %}
   	<div class="column-one-third">
   	  <a href="{{ url_for('.service_add_sms_sender', service_id=current_service.id) }}" class="button align-with-heading">Add text message sender</a>
   	</div>
@@ -37,7 +37,7 @@
             </span>
           {% endif %}
         </h3>
-        {% if current_user.has_permissions('manage_service', admin_override=True) %}
+        {% if current_user.has_permissions('manage_service') %}
           <a class="user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
         {% endif %}
         {% if sms_senders|length  > 1 %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -6,7 +6,7 @@
   {% else %}
     <div class="bottom-gutter-2-3">
       <div class="grid-row">
-        {% if current_user.has_permissions('send_messages') %}
+        {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
         <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
           <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
             Upload recipients

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -19,7 +19,7 @@
         </div>
         {% endif %}
         {% if
-          current_user.has_permissions('manage_templates', admin_override=True) and
+          current_user.has_permissions('manage_templates') and
           template.template_type != 'letter'
         %}
         <div class="column-one-third">
@@ -33,7 +33,7 @@
   {% endif %}
 </div>
 <div class="column-whole template-container">
-  {% if current_user.has_permissions('manage_templates', admin_override=True) and template.template_type == 'letter' %}
+  {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
     <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
   {% endif %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -6,7 +6,7 @@
   {% else %}
     <div class="bottom-gutter-2-3">
       <div class="grid-row">
-        {% if current_user.has_permissions('send_texts', 'send_emails', 'send_letters') %}
+        {% if current_user.has_permissions('send_messages') %}
         <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
           <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
             Upload recipients

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -14,7 +14,7 @@
 
   {% if not templates %}
 
-    {% if current_user.has_permissions('manage_templates', any_=True) %}
+    {% if current_user.has_permissions('manage_templates') %}
        <p class="bottom-gutter">
          You need a template before you can send text messages.
        </p>

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -41,7 +41,7 @@
       <div class="column-two-thirds">
         <h1 class="heading-large">Templates</h1>
       </div>
-      {% if current_user.has_permissions('manage_templates', admin_override=True) %}
+      {% if current_user.has_permissions('manage_templates') %}
         <div class="column-one-third">
           <a href="{{ url_for('.add_template_by_type', service_id=current_service.id) }}" class="button align-with-heading">Add new template</a>
         </div>

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -14,7 +14,7 @@
 
     <h1 class="heading-large">Templates</h1>
 
-    {% if current_user.has_permissions('manage_templates', any_=True) %}
+    {% if current_user.has_permissions('manage_templates') %}
        <p class="bottom-gutter">
          You need a template before you can send
          {% if 'letter' in current_service.permissions %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -63,7 +63,7 @@
       &emsp;
       <br/>
     {% endif %}
-    {% if current_user.has_permissions('manage_templates', admin_override=True) %}
+    {% if current_user.has_permissions('manage_templates') %}
       {% if not template._template.archived %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
           <a href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>

--- a/app/utils.py
+++ b/app/utils.py
@@ -59,15 +59,14 @@ class BrowsableItem(object):
         pass
 
 
-def user_has_permissions(*permissions, admin_override=False, any_=False):
+def user_has_permissions(*permissions, **permission_kwargs):
     def wrap(func):
         @wraps(func)
         def wrap_func(*args, **kwargs):
             if current_user and current_user.is_authenticated:
                 if current_user.has_permissions(
                     *permissions,
-                    admin_override=admin_override,
-                    any_=any_
+                    **permission_kwargs
                 ):
                     return func(*args, **kwargs)
                 else:

--- a/app/utils.py
+++ b/app/utils.py
@@ -78,6 +78,17 @@ def user_has_permissions(*permissions, admin_override=False, any_=False):
     return wrap
 
 
+def user_is_platform_admin(f):
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        if not current_user.is_authenticated:
+            abort(401)
+        if not current_user.platform_admin:
+            abort(403)
+        return f(*args, **kwargs)
+    return wrapped
+
+
 def redirect_to_sign_in(f):
     @wraps(f)
     def wrapped(*args, **kwargs):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,6 +47,7 @@ def user_json(
     mobile_number='+447700900986',
     password_changed_at=None,
     permissions={generate_uuid(): [
+        'view_activity',
         'send_texts',
         'send_emails',
         'send_letters',

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -100,7 +100,7 @@ def test_exact_permissions(
         True)
 
 
-def test_platform_admin_user_can_access_page(
+def test_platform_admin_user_can_access_page_that_has_no_permissions(
     client,
     platform_admin_user,
     mocker,
@@ -110,8 +110,7 @@ def test_platform_admin_user_can_access_page(
         client,
         platform_admin_user,
         [],
-        will_succeed=True,
-        kwargs={'admin_override': True})
+        True)
 
 
 def test_platform_admin_user_can_not_access_page(

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -43,7 +43,7 @@ def test_user_has_permissions_on_endpoint_fail(
     _test_permissions(
         client,
         user,
-        ['send_texts'],
+        ['send_messages'],
         '',
         False)
 
@@ -57,7 +57,7 @@ def test_user_has_permissions_success(
     _test_permissions(
         client,
         user,
-        ['manage_users'],
+        ['manage_service'],
         '',
         True)
 
@@ -71,7 +71,7 @@ def test_user_has_permissions_or(
     _test_permissions(
         client,
         user,
-        ['send_texts', 'manage_users'],
+        ['send_messages', 'manage_service'],
         '',
         True,
         any_=True)
@@ -86,7 +86,7 @@ def test_user_has_permissions_multiple(
     _test_permissions(
         client,
         user,
-        ['manage_templates', 'manage_users'],
+        ['manage_templates', 'manage_service'],
         '',
         will_succeed=True)
 
@@ -100,7 +100,7 @@ def test_exact_permissions(
     _test_permissions(
         client,
         user,
-        ['manage_users', 'manage_templates', 'manage_settings'],
+        ['manage_service', 'manage_templates'],
         '',
         True)
 

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -156,6 +156,42 @@ def test_user_has_permissions_for_organisation(
     index()
 
 
+def test_platform_admin_can_see_orgs_they_dont_have(
+    client,
+    platform_admin_user,
+    mocker,
+):
+    platform_admin_user.organisations = []
+    mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
+    client.login(platform_admin_user)
+
+    request.view_args = {'org_id': 'org_2'}
+
+    @user_has_permissions()
+    def index():
+        pass
+
+    index()
+
+
+def test_cant_use_decorator_without_view_args(
+    client,
+    platform_admin_user,
+    mocker,
+):
+    mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
+    client.login(platform_admin_user)
+
+    request.view_args = {}
+
+    @user_has_permissions()
+    def index():
+        pass
+
+    with pytest.raises(NotImplementedError):
+        index()
+
+
 def test_user_doesnt_have_permissions_for_organisation(
     client,
     mocker,

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -70,8 +70,7 @@ def test_user_has_permissions_or(
         client,
         user,
         ['send_messages', 'manage_service'],
-        True,
-        kwargs={'any_': True})
+        True)
 
 
 def test_user_has_permissions_multiple(

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -3,6 +3,10 @@ from flask import request
 from werkzeug.exceptions import Forbidden, Unauthorized
 
 from app.main.views.index import index
+from app.notify_client.models import (
+    translate_permissions_from_admin_roles_to_db,
+    translate_permissions_from_db_to_admin_roles,
+)
 from app.utils import user_has_permissions
 
 
@@ -159,3 +163,15 @@ def _user_with_permissions():
                  }
     user = User(user_data)
     return user
+
+
+def test_translate_permissions_from_db_to_admin_roles():
+    db_perms = ['send_texts', 'send_emails', 'send_letters', 'manage_templates', 'some_unknown_permission']
+    roles = translate_permissions_from_db_to_admin_roles(db_perms)
+    assert roles == {'send_messages', 'manage_templates', 'some_unknown_permission'}
+
+
+def test_translate_permissions_from_admin_roles_to_db():
+    roles = ['send_messages', 'manage_templates', 'some_unknown_permission']
+    db_perms = translate_permissions_from_admin_roles_to_db(roles)
+    assert db_perms == {'send_texts', 'send_emails', 'send_letters', 'manage_templates', 'some_unknown_permission'}

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -14,16 +14,16 @@ def _test_permissions(
     client,
     usr,
     permissions,
-    service_id,
     will_succeed,
-    any_=False,
-    admin_override=False,
+    kwargs={}
 ):
-    request.view_args.update({'service_id': service_id})
+    request.view_args.update({'service_id': 'foo'})
     if usr:
         client.login(usr)
-    decorator = user_has_permissions(*permissions, any_=any_, admin_override=admin_override)
+
+    decorator = user_has_permissions(*permissions, **kwargs)
     decorated_index = decorator(index)
+
     if will_succeed:
         decorated_index()
     else:
@@ -44,7 +44,6 @@ def test_user_has_permissions_on_endpoint_fail(
         client,
         user,
         ['send_messages'],
-        '',
         False)
 
 
@@ -58,7 +57,6 @@ def test_user_has_permissions_success(
         client,
         user,
         ['manage_service'],
-        '',
         True)
 
 
@@ -72,9 +70,8 @@ def test_user_has_permissions_or(
         client,
         user,
         ['send_messages', 'manage_service'],
-        '',
         True,
-        any_=True)
+        kwargs={'any_': True})
 
 
 def test_user_has_permissions_multiple(
@@ -87,7 +84,6 @@ def test_user_has_permissions_multiple(
         client,
         user,
         ['manage_templates', 'manage_service'],
-        '',
         will_succeed=True)
 
 
@@ -101,7 +97,6 @@ def test_exact_permissions(
         client,
         user,
         ['manage_service', 'manage_templates'],
-        '',
         True)
 
 
@@ -115,9 +110,8 @@ def test_platform_admin_user_can_access_page(
         client,
         platform_admin_user,
         [],
-        '',
         will_succeed=True,
-        admin_override=True)
+        kwargs={'admin_override': True})
 
 
 def test_platform_admin_user_can_not_access_page(
@@ -130,9 +124,8 @@ def test_platform_admin_user_can_not_access_page(
         client,
         platform_admin_user,
         [],
-        '',
         will_succeed=False,
-        admin_override=False)
+        kwargs={'restrict_admin_usage': True})
 
 
 def test_no_user_returns_401_unauth(
@@ -144,7 +137,6 @@ def test_no_user_returns_401_unauth(
         client,
         None,
         [],
-        '',
         will_succeed=False)
 
 
@@ -158,7 +150,7 @@ def _user_with_permissions():
                  'mobile_number': '+4412341234',
                  'state': 'active',
                  'failed_login_count': 0,
-                 'permissions': {'': ['manage_users', 'manage_templates', 'manage_settings']},
+                 'permissions': {'foo': ['manage_users', 'manage_templates', 'manage_settings']},
                  'platform_admin': False
                  }
     user = User(user_data)

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -22,7 +22,7 @@ def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     mocker,
 ):
     expected_service = service_one['id']
-    expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
+    expected_permissions = {'send_messages', 'manage_service', 'manage_api_keys'}
 
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
 
@@ -49,7 +49,7 @@ def test_existing_user_with_no_permissions_accept_invite(
 ):
     expected_service = service_one['id']
     sample_invite['permissions'] = ''
-    expected_permissions = []
+    expected_permissions = set()
     mocker.patch('app.invite_api_client.accept_invite', return_value=sample_invite)
 
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
@@ -121,7 +121,7 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
     mocker,
 ):
     expected_service = service_one['id']
-    expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
+    expected_permissions = {'send_messages', 'manage_service', 'manage_api_keys'}
 
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
 
@@ -368,7 +368,7 @@ def test_new_invited_user_verifies_and_added_to_service(
 
     # when they post codes back to admin user should be added to
     # service and sent on to dash board
-    expected_permissions = ['send_messages', 'manage_service', 'manage_api_keys']
+    expected_permissions = {'send_messages', 'manage_service', 'manage_api_keys'}
 
     with client.session_transaction() as session:
         new_user_id = session['user_id']

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -778,7 +778,7 @@ def test_menu_send_messages(
             app_,
             api_user_active,
             service_one,
-            ['view_activity', 'send_texts', 'send_emails', 'send_letters'])
+            ['view_activity', 'send_messages'])
         page = resp.get_data(as_text=True)
         assert url_for(
             'main.choose_template',
@@ -810,7 +810,7 @@ def test_menu_manage_service(
             app_,
             api_user_active,
             service_one,
-            ['view_activity', 'manage_users', 'manage_templates', 'manage_settings'])
+            ['view_activity', 'manage_templates', 'manage_service'])
         page = resp.get_data(as_text=True)
         assert url_for(
             'main.choose_template',

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -3,7 +3,6 @@ import copy
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
-from tests.conftest import service_one as create_sample_service
 from tests.conftest import (
     SERVICE_ONE_ID,
     active_user_manage_template_permission,
@@ -12,6 +11,7 @@ from tests.conftest import (
     active_user_with_permissions,
     normalize_spaces,
 )
+from tests.conftest import service_one as create_sample_service
 
 import app
 from app.notify_client.models import InvitedUser

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from tests.conftest import service_one as create_sample_service
 from tests.conftest import (
     SERVICE_ONE_ID,
     active_user_manage_template_permission,
@@ -11,7 +12,6 @@ from tests.conftest import (
     active_user_with_permissions,
     normalize_spaces,
 )
-from tests.conftest import service_one as create_sample_service
 
 import app
 from app.notify_client.models import InvitedUser

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -248,12 +248,9 @@ def test_edit_user_permissions(
         str(active_user_with_permissions.id),
         service['id'],
         permissions={
-            'send_texts',
-            'send_emails',
-            'send_letters',
-            'manage_users',
+            'send_messages',
+            'manage_service',
             'manage_templates',
-            'manage_settings',
             'manage_api_keys',
             'view_activity'
         }
@@ -289,9 +286,7 @@ def test_edit_some_user_permissions(
         str(active_user_with_permissions.id),
         service_id,
         permissions={
-            'send_texts',
-            'send_emails',
-            'send_letters',
+            'send_messages',
             'view_activity'
         }
     )
@@ -330,12 +325,9 @@ def test_edit_user_permissions_including_authentication_with_email_auth_service(
         str(active_user_with_permissions.id),
         service_one['id'],
         permissions={
-            'send_texts',
-            'send_emails',
-            'send_letters',
-            'manage_users',
+            'send_messages',
             'manage_templates',
-            'manage_settings',
+            'manage_service',
             'manage_api_keys',
             'view_activity'
         }
@@ -399,7 +391,7 @@ def test_invite_user(
     flash_banner = page.find('div', class_='banner-default-with-tick').string.strip()
     assert flash_banner == 'Invite sent to test@example.gov.uk'
 
-    expected_permissions = 'manage_api_keys,manage_settings,manage_templates,manage_users,send_emails,send_letters,send_texts,view_activity'  # noqa
+    expected_permissions = {'manage_api_keys', 'manage_service', 'manage_templates', 'send_messages', 'view_activity'}
 
     app.invite_api_client.create_invite.assert_called_once_with(sample_invite['from_user'],
                                                                 sample_invite['service'],
@@ -451,7 +443,7 @@ def test_invite_user_with_email_auth_service(
     flash_banner = page.find('div', class_='banner-default-with-tick').string.strip()
     assert flash_banner == 'Invite sent to test@example.gov.uk'
 
-    expected_permissions = 'manage_api_keys,manage_settings,manage_templates,manage_users,send_emails,send_letters,send_texts,view_activity'  # noqa
+    expected_permissions = {'manage_api_keys', 'manage_service', 'manage_templates', 'send_messages', 'view_activity'}
 
     app.invite_api_client.create_invite.assert_called_once_with(sample_invite['from_user'],
                                                                 sample_invite['service'],
@@ -479,12 +471,19 @@ def test_cancel_invited_user_cancels_user_invitations(
 @pytest.mark.parametrize('invite_status, expected_text', [
     ('pending', (
         'invited_user@test.gov.uk (invited) '
-        'Can’t Send messages Can’t Add and edit templates Can’t Manage service Can Access API keys '
+        'Can Send messages '
+        'Can’t Add and edit templates '
+        'Can Manage service '
+        'Can Access API keys '
         'Cancel invitation'
     )),
     ('cancelled', (
         'invited_user@test.gov.uk (cancelled invite) '
-        'Can’t Send messages Can’t Add and edit templates Can’t Manage service Can’t Access API keys'
+        # all permissions are greyed out
+        'Can’t Send messages '
+        'Can’t Add and edit templates '
+        'Can’t Manage service '
+        'Can’t Access API keys'
     )),
 ])
 def test_manage_users_shows_invited_user(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1752,7 +1752,7 @@ def test_route_permissions(
             service_id=service_one['id'],
             template_id=fake_uuid
         ),
-        ['view_activity', 'send_texts', 'send_emails', 'send_letters'],
+        ['view_activity', 'send_messages'],
         api_user_active,
         service_one)
 
@@ -1787,7 +1787,7 @@ def test_route_permissions_send_check_notifications(
             service_id=service_one['id'],
             template_id=fake_uuid
         ),
-        ['send_texts', 'send_emails', 'send_letters'],
+        ['send_messages'],
         api_user_active,
         service_one
     )

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1752,7 +1752,7 @@ def test_route_permissions(
             service_id=service_one['id'],
             template_id=fake_uuid
         ),
-        ['send_texts', 'send_emails', 'send_letters'],
+        ['view_activity', 'send_texts', 'send_emails', 'send_letters'],
         api_user_active,
         service_one)
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1948,7 +1948,7 @@ def test_check_messages_shows_too_many_messages_errors(
 ):
     # csv with 100 phone numbers
     mocker.patch('app.main.views.send.s3download', return_value=',\n'.join(
-        ['phone number'] + ([mock_get_users_by_service(None)[0]._mobile_number] * 100)
+        ['phone number'] + ([mock_get_users_by_service(None)[0].mobile_number] * 100)
     ))
     mocker.patch('app.service_api_client.get_detailed_service_for_today', return_value={
         'data': {

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -571,7 +571,7 @@ def test_route_permissions(
         "GET",
         200,
         url_for(route, service_id=service_one['id']),
-        ['manage_settings'],
+        ['manage_service'],
         api_user_active,
         service_one)
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -11,6 +11,7 @@ from tests import (
     template_json,
     validate_route_permission,
 )
+from tests.conftest import service_one as create_sample_service
 from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_service_email_template,
@@ -18,9 +19,8 @@ from tests.conftest import (
     mock_get_service_template,
     no_letter_contact_blocks,
     normalize_spaces,
+    single_letter_contact_block,
 )
-from tests.conftest import service_one as create_sample_service
-from tests.conftest import single_letter_contact_block
 
 from app.main.views.templates import (
     get_human_readable_delta,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -11,7 +11,6 @@ from tests import (
     template_json,
     validate_route_permission,
 )
-from tests.conftest import service_one as create_sample_service
 from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_service_email_template,
@@ -19,8 +18,9 @@ from tests.conftest import (
     mock_get_service_template,
     no_letter_contact_blocks,
     normalize_spaces,
-    single_letter_contact_block,
 )
+from tests.conftest import service_one as create_sample_service
+from tests.conftest import single_letter_contact_block
 
 from app.main.views.templates import (
     get_human_readable_delta,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -139,7 +139,7 @@ def test_should_be_able_to_view_a_template_with_links(
     permissions,
     links_to_be_shown,
 ):
-    active_user_with_permissions._permissions[service_one['id']] = permissions
+    active_user_with_permissions._permissions[service_one['id']] = permissions + ['view_activity']
     client.login(active_user_with_permissions, mocker, service_one)
 
     response = client.get(url_for(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -120,11 +120,11 @@ def test_should_show_page_for_one_template(
         ['.edit_service_template']
     ),
     (
-        ['send_texts', 'send_emails', 'send_letters'],
+        ['send_messages'],
         ['.send_messages', '.set_sender']
     ),
     (
-        ['send_texts', 'send_emails', 'send_letters', 'manage_templates'],
+        ['send_messages', 'manage_templates'],
         ['.send_messages', '.set_sender', '.edit_service_template']
     ),
 ])

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -21,7 +21,7 @@ def test_client_creates_invite(
     )
 
     invite_api_client.create_invite(
-        '12345', '67890', 'test@example.com', 'send_messages', 'sms_auth'
+        '12345', '67890', 'test@example.com', {'send_messages'}, 'sms_auth'
     )
 
     mock_post.assert_called_once_with(
@@ -32,7 +32,7 @@ def test_client_creates_invite(
             'from_user': '12345',
             'service': '67890',
             'created_by': ANY,
-            'permissions': 'send_messages',
+            'permissions': 'send_emails,send_letters,send_texts',
             'invite_link_host': 'http://localhost:6012',
         }
     )

--- a/tests/app/notify_client/test_template_statistics_client.py
+++ b/tests/app/notify_client/test_template_statistics_client.py
@@ -1,7 +1,8 @@
 import uuid
 
-from app.notify_client.template_statistics_api_client import \
-    TemplateStatisticsApiClient
+from app.notify_client.template_statistics_api_client import (
+    TemplateStatisticsApiClient,
+)
 
 
 def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocker, api_user_active):

--- a/tests/app/notify_client/test_template_statistics_client.py
+++ b/tests/app/notify_client/test_template_statistics_client.py
@@ -1,8 +1,7 @@
 import uuid
 
-from app.notify_client.template_statistics_api_client import (
-    TemplateStatisticsApiClient,
-)
+from app.notify_client.template_statistics_api_client import \
+    TemplateStatisticsApiClient
 
 
 def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocker, api_user_active):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -131,3 +131,29 @@ def test_client_passes_admin_url_when_sending_email_auth(
             'email_auth_link_host': 'http://localhost:6012',
         }
     )
+
+
+def test_client_converts_admin_permissions_to_db_permissions_on_edit(app_, mocker):
+    mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
+
+    user_api_client.set_user_permissions('user_id', 'service_id', permissions={'send_messages', 'view_activity'})
+
+    assert sorted(mock_post.call_args[1]['data'], key=lambda x: x['permission']) == sorted([
+        {'permission': 'send_texts'},
+        {'permission': 'send_emails'},
+        {'permission': 'send_letters'},
+        {'permission': 'view_activity'},
+    ], key=lambda x: x['permission'])
+
+
+def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(app_, mocker):
+    mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post', return_value={'data': {}})
+
+    user_api_client.add_user_to_service('service_id', 'user_id', permissions={'send_messages', 'view_activity'})
+
+    assert sorted(mock_post.call_args[1]['data'], key=lambda x: x['permission']) == sorted([
+        {'permission': 'send_texts'},
+        {'permission': 'send_emails'},
+        {'permission': 'send_letters'},
+        {'permission': 'view_activity'},
+    ], key=lambda x: x['permission'])

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -40,8 +40,8 @@ def test_client_returns_count_of_users_with_manage_service(
     mock_get_users = mocker.patch(
         'app.notify_client.user_api_client.UserApiClient.get_users_for_service',
         return_value=[
-            _service_one_user_with_permissions('manage_settings', 'view_activity'),
-            _service_one_user_with_permissions('manage_settings'),
+            _service_one_user_with_permissions('manage_service', 'view_activity'),
+            _service_one_user_with_permissions('manage_service'),
             _service_one_user_with_permissions('view_activity'),
             _service_one_user_with_permissions('manage_templates'),
         ]
@@ -54,7 +54,7 @@ def test_client_returns_count_of_users_with_manage_service(
 
     assert user_api_client.get_count_of_users_with_permission(
         SERVICE_ONE_ID,
-        'manage_settings'
+        'manage_service'
     ) == 2
 
     assert user_api_client.get_count_of_users_with_permission(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2052,7 +2052,7 @@ def mock_accept_invite(mocker, sample_invite):
 @pytest.fixture(scope='function')
 def mock_add_user_to_service(mocker, service_one, api_user_active):
     def _add_user(service_id, user_id, permissions):
-        return api_user_active
+        return
 
     return mocker.patch('app.user_api_client.add_user_to_service', side_effect=_add_user)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1931,7 +1931,7 @@ def mock_no_inbound_number_for_service(mocker):
 
 @pytest.fixture(scope='function')
 def mock_has_permissions(mocker):
-    def _has_permission(*permissions, any_=False, admin_override=False):
+    def _has_permission(*permissions, any_=False, admin_override=False, restrict_admin_usage=False):
         return True
 
     return mocker.patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1931,7 +1931,7 @@ def mock_no_inbound_number_for_service(mocker):
 
 @pytest.fixture(scope='function')
 def mock_has_permissions(mocker):
-    def _has_permission(*permissions, any_=False, admin_override=False, restrict_admin_usage=False):
+    def _has_permission(*permissions, any_=False, restrict_admin_usage=False):
         return True
 
     return mocker.patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1432,7 +1432,7 @@ def mock_get_user_by_email(mocker, user=None):
         user = api_user_active(fake_uuid())
 
     def _get_user(email_address):
-        user._email_address = email_address
+        user.email_address = email_address
         return user
 
     return mocker.patch('app.user_api_client.get_user_by_email', side_effect=_get_user)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1931,7 +1931,7 @@ def mock_no_inbound_number_for_service(mocker):
 
 @pytest.fixture(scope='function')
 def mock_has_permissions(mocker):
-    def _has_permission(*permissions, any_=False, restrict_admin_usage=False):
+    def _has_permission(*permissions, restrict_admin_usage=False):
         return True
 
     return mocker.patch(


### PR DESCRIPTION
I strongly encourage you to look at this commit by commit. It's a big PR but I took a lot of effort to separate it out to make it digestable.

Heavily refactored the permissions decorator, including but not limited to:

* simplified permissions! send_texts ❎ send_emails ❎ send_letters ❎ send_messages ✅✅✅
* add organisations! Now `@user_has_permissions()` on a page with an `<org_id>` arg in the URL will check that the current user is part of that org id
* inverted admin override logic! Instead of almost every endpoint having an admin override, admins can now do anything unless the permission  fn/decorator has `restrict_admin_usage=True`. That is CSV upload, one-off flow, and creating API keys.
* Don't need to say `any_=True` because we literally have zero cases where we require you to have all of more than one permission. So if there's more than one permission now, it's implicitly looking for any one of those. 
* simplified platform admin permissions! now you should use `@user_is_platform_admin` instead, because that's nice and unambiguous