### PR TITLE
Catch duplicate recipient columns in spreadsheets

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -581,6 +581,7 @@ def check_messages(service_id, template_type, upload_id, row_index=2):
         data['recipients'].too_many_rows or
         not data['count_of_recipients'] or
         not data['recipients'].has_recipient_columns or
+        data['recipients'].duplicate_recipient_column_headers or
         data['recipients'].missing_column_headers
     ):
         return render_template('views/check/column-errors.html', **data)

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -69,6 +69,21 @@
           ) }}.
         </p>
 
+      {% elif recipients.duplicate_recipient_column_headers %}
+
+        <h1 class='banner-title' data-module="track-error" data-error-type="Duplicate recipient columns" data-error-label="{{ upload_id }}">
+          Your file has more than one column called {{ (
+            recipients.duplicate_recipient_column_headers
+          ) | formatted_list(
+            conjunction='or',
+            prefix='',
+            prefix_plural=''
+          ) }}
+        </h1>
+        <p>
+          Delete or rename one of these columns and try again.
+        </p>
+
       {% elif recipients.missing_column_headers %}
 
         <h1 class='banner-title' data-module="track-error" data-error-type="Missing placeholder columns" data-error-label="{{ upload_id }}">
@@ -128,6 +143,8 @@
 
   {% if not request.args.from_test %}
 
+    {% set column_headers = recipients._raw_column_headers if recipients.duplicate_recipient_column_headers else recipients.column_headers %}
+
     <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
 
     <div class="fullscreen-content" data-module="fullscreen-table">
@@ -137,14 +154,14 @@
         caption_visible=False,
         field_headings=[
           '<span class="visually-hidden">Row in file</span><span aria-hidden="true">1</span>'|safe
-        ] + recipients.column_headers
+        ] + column_headers
       ) %}
         {% call index_field() %}
           <span>
             {{ item.index + 2 }}
           </span>
         {% endcall %}
-        {% for column in recipients.column_headers %}
+        {% for column in column_headers %}
           {% if item['columns'][column].error and not recipients.missing_column_headers %}
             {% call field() %}
               <span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ notifications-python-client==4.7.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@23.8.0#egg=notifications-utils==23.8.0
+git+https://github.com/alphagov/notifications-utils.git@23.8.1#egg=notifications-utils==23.8.1


### PR DESCRIPTION
If someone has duplicate recipient columns in their file we don’t know which one to use. This commit adds an error message which should help them fix the duplication.

This commit doesn’t go to the extra effort to actually show the duplication in the preview. Don’t think it’s worth the effort/complexity for how infrequently we’ve seen this error.

---

![image](https://user-images.githubusercontent.com/355079/36895537-17d55888-1e07-11e8-996e-9b3a29c4fe04.png)

---

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/376