### PR TITLE
Update the free allowance when the organisation type is changed

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1,5 +1,6 @@
 from flask import (
     abort,
+    current_app,
     flash,
     redirect,
     render_template,
@@ -695,10 +696,15 @@ def set_organisation_type(service_id):
     form = OrganisationTypeForm(organisation_type=current_service.get('organisation_type'))
 
     if form.validate_on_submit():
+        free_sms_fragment_limit = current_app.config['DEFAULT_FREE_SMS_FRAGMENT_LIMITS'].get(
+            form.organisation_type.data)
+
         service_api_client.update_service(
             service_id,
             organisation_type=form.organisation_type.data,
         )
+        billing_api_client.create_or_update_free_sms_fragment_limit(service_id, free_sms_fragment_limit)
+
         return redirect(url_for('.service_settings', service_id=service_id))
 
     return render_template(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1554,7 +1554,7 @@ def test_should_show_page_to_set_organisation_type(
     ('central', 250000),
     ('local', 25000),
     ('nhs', 25000),
-    (pytest.mark.xfail('private sector'), 1000)
+    pytest.mark.xfail(('private sector', 1000))
 ])
 def test_should_set_organisation_type(
     logged_in_platform_admin_client,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1560,6 +1560,7 @@ def test_should_set_organisation_type(
     logged_in_platform_admin_client,
     mock_update_service,
     organisation_type,
+    mock_create_or_update_free_sms_fragment_limit
 ):
     response = logged_in_platform_admin_client.post(
         url_for(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1550,16 +1550,17 @@ def test_should_show_page_to_set_organisation_type(
         assert normalize_spaces(labels[index].text) == expected
 
 
-@pytest.mark.parametrize('organisation_type', [
-    'central',
-    'local',
-    'nhs',
-    pytest.mark.xfail('private sector'),
+@pytest.mark.parametrize('organisation_type, free_allowance', [
+    ('central', 250000),
+    ('local', 25000),
+    ('nhs', 25000),
+    (pytest.mark.xfail('private sector'), 1000)
 ])
 def test_should_set_organisation_type(
     logged_in_platform_admin_client,
     mock_update_service,
     organisation_type,
+    free_allowance,
     mock_create_or_update_free_sms_fragment_limit
 ):
     response = logged_in_platform_admin_client.post(
@@ -1579,6 +1580,7 @@ def test_should_set_organisation_type(
         SERVICE_ONE_ID,
         organisation_type=organisation_type,
     )
+    mock_create_or_update_free_sms_fragment_limit.assert_called_once_with(SERVICE_ONE_ID, free_allowance)
 
 
 def test_should_show_page_to_set_sms_allowance(


### PR DESCRIPTION
The free allowance affect the number of free text messages a services get per year, as seen on the usage page.
This allowance is being set properly when an organisation is created by not updated.
This PR updates the free allowance when the organisation type is updated.
The free allowance can also be changed if service has an exceptional free allowance.