### PR TITLE
Remove link from preview precompiled view and dashboard

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -80,6 +80,7 @@ def view_notification(service_id, notification_id):
         estimated_letter_delivery_date=get_letter_timings(notification['created_at']).earliest_delivery,
         notification_id=notification['id'],
         can_receive_inbound=('inbound_sms' in current_service['permissions']),
+        is_precompiled_letter=notification['template']['is_precompiled_letter']
     )
 
 

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -17,10 +17,17 @@
   ) %}
 
     {% call row_heading() %}
+      {% if item.is_precompiled_letter %}
+      Provided as PDF
+      <span class="file-list-hint">
+        Letter
+      </span>
+      {% else %}
       <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
       <span class="file-list-hint">
         {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
       </span>
+      {% endif %}
     {% endcall %}
     {% if template_statistics|length > 1 %}
       {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -15,12 +15,16 @@
     </h1>
 
     <p>
-      {% if help %}
-        {{ template.name }}
+      {% if is_precompiled_letter %}
+      Sent
       {% else %}
-        <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+        {% if help %}
+          {{ template.name }}
+        {% else %}
+          <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+        {% endif %}
+        sent
       {% endif %}
-      sent
       {% if job and job.original_file_name != 'Report' %}
         from
         <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -205,6 +205,7 @@ def template_json(service_id,
                   service_letter_contact=None,
                   reply_to=None,
                   reply_to_text=None,
+                  is_precompiled_letter=False,
                   ):
     template = {
         'id': id_,
@@ -219,6 +220,7 @@ def template_json(service_id,
         'service_letter_contact': service_letter_contact,
         'reply_to': reply_to,
         'reply_to_text': reply_to_text,
+        'is_precompiled_letter': is_precompiled_letter,
     }
     if content is None:
         template['content'] = "template content"

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -40,6 +40,19 @@ stub_template_stats = [
         'template_name': 'two',
         'template_id': 'id-2',
         'count': 200
+    },
+    {
+        'template_type': 'letter',
+        'template_name': 'three',
+        'template_id': 'id-3',
+        'count': 300
+    },
+    {
+        'template_type': 'letter',
+        'template_name': 'four',
+        'template_id': 'id-4',
+        'count': 400,
+        'is_precompiled_letter': True
     }
 ]
 
@@ -358,15 +371,23 @@ def test_should_show_recent_templates_on_dashboard(
 
     table_rows = page.find_all('tbody')[1].find_all('tr')
 
-    assert len(table_rows) == 2
+    assert len(table_rows) == 4
 
-    assert 'two' in table_rows[0].find_all('th')[0].text
-    assert 'Email template' in table_rows[0].find_all('th')[0].text
-    assert '200' in table_rows[0].find_all('td')[0].text
+    assert 'Provided as PDF' in table_rows[0].find_all('th')[0].text
+    assert 'Letter' in table_rows[0].find_all('th')[0].text
+    assert '400' in table_rows[0].find_all('td')[0].text
 
-    assert 'one' in table_rows[1].find_all('th')[0].text
-    assert 'Text message template' in table_rows[1].find_all('th')[0].text
-    assert '100' in table_rows[1].find_all('td')[0].text
+    assert 'three' in table_rows[1].find_all('th')[0].text
+    assert 'Letter template' in table_rows[1].find_all('th')[0].text
+    assert '300' in table_rows[1].find_all('td')[0].text
+
+    assert 'two' in table_rows[2].find_all('th')[0].text
+    assert 'Email template' in table_rows[2].find_all('th')[0].text
+    assert '200' in table_rows[2].find_all('td')[0].text
+
+    assert 'one' in table_rows[3].find_all('th')[0].text
+    assert 'Text message template' in table_rows[3].find_all('th')[0].text
+    assert '100' in table_rows[3].find_all('td')[0].text
 
 
 @freeze_time("2016-07-01 12:00")  # 4 months into 2016 financial year
@@ -910,15 +931,23 @@ def test_aggregate_template_stats():
     from app.main.views.dashboard import aggregate_usage
     expected = aggregate_usage(copy.deepcopy(stub_template_stats))
 
-    assert len(expected) == 2
-    assert expected[0]['template_name'] == 'two'
-    assert expected[0]['count'] == 200
-    assert expected[0]['template_id'] == 'id-2'
-    assert expected[0]['template_type'] == 'email'
-    assert expected[1]['template_name'] == 'one'
-    assert expected[1]['count'] == 100
-    assert expected[1]['template_id'] == 'id-1'
-    assert expected[1]['template_type'] == 'sms'
+    assert len(expected) == 4
+    assert expected[0]['template_name'] == 'four'
+    assert expected[0]['count'] == 400
+    assert expected[0]['template_id'] == 'id-4'
+    assert expected[0]['template_type'] == 'letter'
+    assert expected[1]['template_name'] == 'three'
+    assert expected[1]['count'] == 300
+    assert expected[1]['template_id'] == 'id-3'
+    assert expected[1]['template_type'] == 'letter'
+    assert expected[2]['template_name'] == 'two'
+    assert expected[2]['count'] == 200
+    assert expected[2]['template_id'] == 'id-2'
+    assert expected[2]['template_type'] == 'email'
+    assert expected[3]['template_name'] == 'one'
+    assert expected[3]['count'] == 100
+    assert expected[3]['template_id'] == 'id-1'
+    assert expected[3]['template_type'] == 'sms'
 
 
 def test_service_dashboard_updates_gets_dashboard_totals(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -277,3 +277,37 @@ def test_notification_page_has_link_to_download_letter(
         download_link = None
 
     assert download_link == expected_link(notification_id=fake_uuid)
+
+
+@pytest.mark.parametrize('is_precompiled_letter, has_template_link', [
+    (True, False),
+    (False, True),
+])
+def test_notification_page_has_expected_template_link_for_letter(
+    client_request,
+    mocker,
+    fake_uuid,
+    service_one,
+    is_precompiled_letter,
+    has_template_link
+):
+
+    mock_get_notification(
+        mocker, fake_uuid, template_type='letter', is_precompiled_letter=is_precompiled_letter)
+    mocker.patch(
+        'app.main.views.notifications.get_page_count_for_letter',
+        return_value=1
+    )
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    link = page.select_one('main > p:nth-of-type(1) > a')
+
+    if has_template_link:
+        assert link
+    else:
+        assert link is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2404,6 +2404,8 @@ def mock_get_notification(
     notification_status='delivered',
     redact_personalisation=False,
     template_type=None,
+    template_name='sample template',
+    is_precompiled_letter=False
 ):
     def _get_notification(
         service_id,
@@ -2430,6 +2432,8 @@ def mock_get_notification(
             subject='blah',
             redact_personalisation=redact_personalisation,
             type_=template_type,
+            is_precompiled_letter=is_precompiled_letter,
+            name=template_name
         )
         return noti
 


### PR DESCRIPTION
## What 

Removed links to the template view from the preview of notifications so that it will just show -

`Sent on <date>` rather than `<template name> sent on <date>` 

Removed template link from the dashboard so that it shows -

`Provided as PDF` rather than `<template name>`
`Letter` rather than `Letter template` as the hint

## Dependency 

API PR must be deployed before deploying this - https://github.com/alphagov/notifications-api/pull/1732

## Reference

https://www.pivotaltracker.com/story/show/155323846