### PR TITLE
Don’t change colour of sent date for letters

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -356,17 +356,32 @@ def format_notification_status_as_time(status, created, updated):
     }.get(status, updated)
 
 
-def format_notification_status_as_field_status(status):
+def format_notification_status_as_field_status(status, notification_type):
     return {
-        'failed': 'error',
-        'technical-failure': 'error',
-        'temporary-failure': 'error',
-        'permanent-failure': 'error',
-        'delivered': None,
-        'sent': None,
-        'sending': 'default',
-        'created': 'default'
-    }.get(status, 'error')
+        'letter': {
+            'failed': 'error',
+            'technical-failure': 'error',
+            'temporary-failure': 'error',
+            'permanent-failure': 'error',
+            'delivered': None,
+            'sent': None,
+            'sending': None,
+            'created': None,
+            'accepted': None,
+        }
+    }.get(
+        notification_type,
+        {
+            'failed': 'error',
+            'technical-failure': 'error',
+            'temporary-failure': 'error',
+            'permanent-failure': 'error',
+            'delivered': None,
+            'sent': None,
+            'sending': 'default',
+            'created': 'default'
+        }
+    ).get(status, 'error')
 
 
 def format_notification_status_as_url(status):

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -130,7 +130,10 @@
   {% if not notification %}
     {% call field(align='right') %}{% endcall %}
   {% else %}
-    {% call field(status=notification.status|format_notification_status_as_field_status, align='right') %}
+    {% call field(
+      status=notification.status|format_notification_status_as_field_status(notification.notification_type),
+      align='right'
+    ) %}
       {% if notification.status in ['created', 'sending', 'delivered'] %}<span class="align-with-message-body">{% endif %}
       {% if notification.status|format_notification_status_as_url %}
         <a href="{{ notification.status|format_notification_status_as_url }}">

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -1,5 +1,5 @@
 <div class="ajax-block-container">
-  <p class="notification-status {{ notification.status|format_notification_status_as_field_status }}">
+  <p class="notification-status {{ notification.status|format_notification_status_as_field_status(notification.notification_type) }}">
     {% if notification.status|format_notification_status_as_url %}
       <a href="{{ notification.status|format_notification_status_as_url }}">
     {% endif %}


### PR DESCRIPTION
For text messages/emails it makes sense for ‘sending’ to be gray and ‘delivered’ to be black. But since we don’t show sending/delivered for letters it doesn’t make sense for the text to change colour.

Will stop this from happening:

![image](https://user-images.githubusercontent.com/355079/37035791-8ecec1c2-2145-11e8-9645-3de0cb9de629.png)
