### PR TITLE
Prevent cells containing commas breaking downloads

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -175,7 +175,7 @@ def generate_notifications_csv(**kwargs):
                     notification['created_at'],
                     notification['updated_at']
                 ]
-            yield ','.join(map(str, values)) + '\n'
+            yield Spreadsheet.from_rows([map(str, values)]).as_csv_data
 
         if notifications_resp['links'].get('next'):
             kwargs['page'] += 1

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -145,6 +145,14 @@ def test_can_create_spreadsheet_from_dict_with_filename():
         ['Row number', 'phone_number', 'a', 'b', 'c', 'Template', 'Type', 'Job', 'Status', 'Time'],
         ['1', '07700900123', '🐜', '🐝', '🦀', 'foo', 'sms', 'bar.csv', 'Delivered', 'Thursday 19 April at 12:00'],
     ),
+    (
+        """
+            "phone_number", "a", "b", "c"
+            "07700900123","🐜,🐜","🐝,🐝","🦀"
+        """,
+        ['Row number', 'phone_number', 'a', 'b', 'c', 'Template', 'Type', 'Job', 'Status', 'Time'],
+        ['1', '07700900123', '🐜,🐜', '🐝,🐝', '🦀', 'foo', 'sms', 'bar.csv', 'Delivered', 'Thursday 19 April at 12:00'],
+    ),
 ])
 def test_generate_notifications_csv_returns_correct_csv_file(
     app_,


### PR DESCRIPTION
If a cell in the original file contains a comma, it comes back as two cells in the downloaded file.

The CSV writer has logic to deal with this. It seems to work a lot better that just concatenating the columns with commas ourselves.

Will stop this from happening:

![image](https://user-images.githubusercontent.com/355079/37040019-c5372f82-2150-11e8-8d42-88a0cb45c437.png)

It’s calling this code underneath:
https://github.com/alphagov/notifications-admin/blob/35f523c95734701719b5cf4d7e17cabb01f906b2/app/utils.py#L248-L255