### PR TITLE
Fix border around letter images

### DIFF
--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -28,11 +28,20 @@ $iso-paper-ratio: 141.42135624%;
     width: 0px;
   }
 
+  &:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-shadow: inset 0 0 0 1px $border-colour;
+  }
+
   img {
     display: block;
     width: 100%;
     background: $white;
-    box-shadow: inset 0 0 0 1px $border-colour;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Things in CSS stack top to bottom like this:
- image
- `box-shadow`
- `background`

We are drawing the border around the letter using `box-shadow`. This was working fine because the images of our letters had a transparent background, so you could see the border through them.

At some point our letters have changed to have a white background. So you can no longer see the border.

This commit:
- adds a new pseudo element which stacks above the image of the letter
- moves the border from the image itself to said pseudo element

# Before 

![image](https://user-images.githubusercontent.com/355079/37042525-8342a57e-2156-11e8-8f91-170adcac3c40.png)

# After 

![image](https://user-images.githubusercontent.com/355079/37042408-4a5cbfc4-2156-11e8-86d5-c6be98d6ef9b.png)
