### PR TITLE
Updated the pricing page to reflect public sector pricing

### DIFF
--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -26,8 +26,8 @@
     <h2 class="heading-medium">Text messages</h2>
     <p>You have a free allowance of text messages each financial year. You’ll get:</p>
     <ul class="list list-bullet">
-      <li>250,000 free text messages for a central government service</li>
-      <li>25,000 free text messages for a local government service</li>
+      <li>250,000 free text messages for central government services</li>
+      <li>25,000 free text messages for other public sector service</li>
     </ul>
     <p>It costs 1.58 pence (plus VAT) for each text message you send after your free allowance.</p>
     <h3 class="heading-small">Long text messages</h3>
@@ -92,7 +92,7 @@
     <div class="bottom-gutter-3-2">
       {% call mapping_table(
         caption='Letter pricing',
-        field_headings=['', 'Central government', 'Local government'],
+        field_headings=['', 'Crown bodies', 'Other public sector organisations'],
         field_headings_visible=True,
         caption_visible=False
       ) %}


### PR DESCRIPTION
Needed to extend from central vs local to central vs the rest of the public sector for free text messages allowances (not that NHS and other forces are allowed to use Notify)

Also needed letter pricing to be about crown vs non-crown rather than central and local as that isn't correct.... some central are non-crown and non-crown is wider than local.