### PR TITLE
Make terms page smarter about the agreement

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -134,6 +134,9 @@ def feedback(ticket_type):
             abort(500, "Feedback submission failed")
         return redirect(url_for('.thanks', urgent=urgent, anonymous=anonymous))
 
+    if not form.feedback.data:
+        form.feedback.data = request.args.get('body', '')
+
     return render_template(
         'views/support/{}.html'.format(ticket_type),
         form=form,

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -9,6 +9,7 @@ from app import convert_to_boolean
 from app.main import main
 from app.main.forms import SearchTemplatesForm
 from app.main.views.sub_navigation_dictionaries import features_nav
+from app.utils import GovernmentDomain
 
 
 @main.route('/')
@@ -152,7 +153,8 @@ def security():
 def terms():
     return render_template(
         'views/terms-of-use.html',
-        navigation_links=features_nav()
+        navigation_links=features_nav(),
+        agreement_info=GovernmentDomain.from_current_user(),
     )
 
 

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -16,31 +16,28 @@ Terms of use
 
     <h1 class="heading-large">Terms of use</h1>
 
-    <p>By using GOV.UK Notify, you agree to follow our terms of use.</p>
-    <p>The service manager for your service has to accept the terms of use when you request to go live on Notify.</p>
-
-    <h2 class="heading-medium">Data sharing and financial agreement</h2>
+    <p>
+      These terms apply to your service’s use of GOV.UK&nbsp;Notify. You must be the service manager to accept them.
+    </p>
 
     {% if agreement_info.agreement_signed %}
       <p>Your organisation ({{ agreement_info.owner }}) has already accepted the GOV.UK&nbsp;Notify data sharing and financial agreement.</p>
     {% else %}
-      <p>For your service to go live on Notify, your organisation must accept our data sharing and financial agreement.</p>
-      <p><a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">Contact us</a> to get a copy of the agreement or find out if your organisation has already accepted it.</p>
+      <p>
+        Your organisation
+        {% if agreement_info.owner %}
+          ({{ agreement_info.owner }})
+          must also accept our data sharing and financial agreement.
+          <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback', body='Please send me a copy of the GOV.UK Notify data sharing and financial agreement for {} to sign.'.format(agreement_info.owner)) }}">Contact us</a> to get a copy.
+        {% else %}
+          must also accept our data sharing and financial agreement.
+          <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback', body='Please send me a copy of the GOV.UK Notify data sharing and financial agreement.') }}">Contact us</a> to get a copy.
+        {% endif %}
+      </p>
     {% endif %}
 
-    <h2 class="heading-medium">Notify’s side of the agreement</h2>
-    <p>We agree to:</p>
-    <ul class="list list-bullet">
-      <li>send all the messages you pass to us, as long as they meet our guidelines</li>
-      <li>
-        show how Notify is performing (through our <a href="https://www.gov.uk/performance/govuk-notify">performance</a> and <a href="https://status.notifications.service.gov.uk/">status</a> pages)
-      </li>
-      <li>keep your data <a href="{{ url_for('.security') }}">secure</a></li>
-      <li>give you one month’s notice by email if we change our terms of use or delivery providers</li>
-    </ul>
-
-    <h2 class="heading-medium">Your side of the agreement</h2>
-    <p>You agree to:</p>
+    <h2 class="heading-medium">When using Notify</h2>
+    <p>You must:</p>
     <ul class="list list-bullet">
       <li>complete your organisation’s information assurance process (you don’t need to include Notify or our delivery partners, we’ve already done that)</li>
       <li>tell us immediately if you have any security breaches</li>
@@ -52,7 +49,17 @@ Terms of use
       <li>not send messages containing any personally or commercially sensitive information</li>
       <li>check that the data you add to Notify is accurate and complies with Data Protection Act principles</li>
     </ul>
-    <p>If you don’t keep to your side of the agreement, we might have to stop sending your messages.</p>
+    <p>If you don’t keep to these terms, we might have to stop sending your messages.</p>
+
+    <p>Notify will:</p>
+    <ul class="list list-bullet">
+      <li>send all the messages you pass to us, as long as they meet our guidelines</li>
+      <li>
+        show how Notify is performing (through our <a href="https://www.gov.uk/performance/govuk-notify">performance</a> and <a href="https://status.notifications.service.gov.uk/">status</a> pages)
+      </li>
+      <li>keep your data <a href="{{ url_for('.security') }}">secure</a></li>
+      <li>give you one month’s notice by email if we change our terms of use or delivery providers</li>
+    </ul>
 
     <h2 class="heading-medium">Leaving Notify</h2>
     <p>You can leave Notify at any time. Just <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> and we’ll close your account.</p>

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -15,9 +15,18 @@ Terms of use
   <div class="column-two-thirds">
 
     <h1 class="heading-large">Terms of use</h1>
-    <p>To go live on GOV.UK Notify, you must accept our data sharing and financial agreement.</p>
-    <p><a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">Contact us</a> to get a copy of the agreement or find out if your organisation has already accepted it.</p>
-    <p>To accept these terms of use, you must be the service manager for your service.</p>
+
+    <p>By using GOV.UK Notify, you agree to follow our terms of use.</p>
+    <p>The service manager for your service has to accept the terms of use when you request to go live on Notify.</p>
+
+    <h2 class="heading-medium">Data sharing and financial agreement</h2>
+
+    {% if agreement_info.agreement_signed %}
+      <p>Your organisation ({{ agreement_info.owner }}) has already accepted the GOV.UK&nbsp;Notify data sharing and financial agreement.</p>
+    {% else %}
+      <p>For your service to go live on Notify, your organisation must accept our data sharing and financial agreement.</p>
+      <p><a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">Contact us</a> to get a copy of the agreement or find out if your organisation has already accepted it.</p>
+    {% endif %}
 
     <h2 class="heading-medium">Notify’s side of the agreement</h2>
     <p>We agree to:</p>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -1,6 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from tests.conftest import active_user_with_permissions, normalize_spaces
 
 
 def test_non_logged_in_user_can_see_homepage(
@@ -86,3 +87,48 @@ def test_old_static_pages_redirect(
         'main.{}'.format(expected_view),
         _external=True
     )
+
+
+def test_terms_is_generic_if_user_is_not_logged_in(
+    client
+):
+    response = client.get(url_for('main.terms'))
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert normalize_spaces(page.select('main p')[2].text) == (
+        'For your service to go live on Notify, your organisation must accept our data sharing and financial agreement.'
+    )
+    assert normalize_spaces(page.select('main p')[3].text) == (
+        'Contact us to get a copy of the agreement or find out if your organisation has already accepted it.'
+    )
+
+
+@pytest.mark.parametrize('email_address, expected_first_paragraph', [
+    (
+        'test@cabinet-office.gov.uk',
+        (
+            'Your organisation (Cabinet Office) has already accepted '
+            'the GOV.UK Notify data sharing and financial agreement.'
+        ),
+    ),
+    (
+        'larry@downing-street.gov.uk',
+        (
+            'For your service to go live on Notify, your organisation '
+            'must accept our data sharing and financial agreement.'
+        ),
+    ),
+])
+def test_terms_tells_logged_in_users_what_we_know_about_their_agreement(
+    mocker,
+    fake_uuid,
+    client_request,
+    email_address,
+    expected_first_paragraph,
+):
+    user = active_user_with_permissions(fake_uuid)
+    user.email_address = email_address
+    mocker.patch('app.user_api_client.get_user', return_value=user)
+    page = client_request.get('main.terms')
+    assert normalize_spaces(page.select('main p')[2].text) == expected_first_paragraph

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -96,11 +96,9 @@ def test_terms_is_generic_if_user_is_not_logged_in(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-    assert normalize_spaces(page.select('main p')[2].text) == (
-        'For your service to go live on Notify, your organisation must accept our data sharing and financial agreement.'
-    )
-    assert normalize_spaces(page.select('main p')[3].text) == (
-        'Contact us to get a copy of the agreement or find out if your organisation has already accepted it.'
+    assert normalize_spaces(page.select('main p')[1].text) == (
+        'Your organisation must also accept our data sharing and '
+        'financial agreement. Contact us to get a copy.'
     )
 
 
@@ -113,10 +111,18 @@ def test_terms_is_generic_if_user_is_not_logged_in(
         ),
     ),
     (
+        'test@aylesburytowncouncil.gov.uk',
+        (
+            'Your organisation (Aylesbury Town Council) must also '
+            'accept our data sharing and financial agreement. Contact '
+            'us to get a copy.'
+        ),
+    ),
+    (
         'larry@downing-street.gov.uk',
         (
-            'For your service to go live on Notify, your organisation '
-            'must accept our data sharing and financial agreement.'
+            'Your organisation must also accept our data sharing and '
+            'financial agreement. Contact us to get a copy.'
         ),
     ),
 ])
@@ -131,4 +137,4 @@ def test_terms_tells_logged_in_users_what_we_know_about_their_agreement(
     user.email_address = email_address
     mocker.patch('app.user_api_client.get_user', return_value=user)
     page = client_request.get('main.terms')
-    assert normalize_spaces(page.select('main p')[2].text) == expected_first_paragraph
+    assert normalize_spaces(page.select('main p')[1].text) == expected_first_paragraph


### PR DESCRIPTION
People are emailing us asking if their organisation has signed the agreement. In some cases they have, so this is a waste of their and our time.

This commit adds a bit of logic to the terms of use page to tell users when their organisation has already signed the agreement. This only applies in cases where we can know for sure from their email address that they have.

If we don’t know | Now we know
---|---
![image](https://user-images.githubusercontent.com/355079/37150537-03c33122-22ca-11e8-89c0-950f9c770ebc.png) | ![image](https://user-images.githubusercontent.com/355079/37150544-0bb952da-22ca-11e8-9db4-26fe8801308e.png)

The wording here needs reviewing by @thomchambers, and we should check that it’s correct legally-speaking.