### PR TITLE
Add what we know of agreements to go live request

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -53,6 +53,8 @@ innovateuk.gov.uk:
 ncsc.gov.uk:
   owner: National Cyber Security Center
   agreement_signed: true
+nhs.net:
+  owner: NHS
 nhsdigital.nhs.uk: digital.nhs.uk
 digital.nhs.uk:
   owner: NHS Digital

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -44,6 +44,7 @@ from app.main.forms import (
     SMSPrefixForm,
 )
 from app.utils import (
+    GovernmentDomain,
     email_safe,
     get_cdn_domain,
     user_has_permissions,
@@ -171,6 +172,7 @@ def request_to_go_live(service_id):
 @user_has_permissions('manage_service')
 def submit_request_to_go_live(service_id):
     form = RequestToGoLiveForm()
+    agreement_info = GovernmentDomain.from_current_user()
 
     if form.validate_on_submit():
         try:
@@ -180,6 +182,7 @@ def submit_request_to_go_live(service_id):
                     'On behalf of {} ({})\n'
                     '\n---'
                     '\nOrganisation type: {}'
+                    '\nAgreement signed: {} ({})'
                     '\nMOU in place: {}'
                     '\nChannel: {}\nStart date: {}\nStart volume: {}'
                     '\nPeak volume: {}'
@@ -188,6 +191,7 @@ def submit_request_to_go_live(service_id):
                     current_service['name'],
                     url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                     current_service['organisation_type'],
+                    agreement_info.agreement_signed, agreement_info.owner,
                     form.mou.data,
                     formatted_list(filter(None, (
                         'email' if form.channel_email.data else None,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -172,7 +172,6 @@ def request_to_go_live(service_id):
 @user_has_permissions('manage_service')
 def submit_request_to_go_live(service_id):
     form = RequestToGoLiveForm()
-    agreement_info = GovernmentDomain.from_current_user()
 
     if form.validate_on_submit():
         try:
@@ -182,7 +181,7 @@ def submit_request_to_go_live(service_id):
                     'On behalf of {} ({})\n'
                     '\n---'
                     '\nOrganisation type: {}'
-                    '\nAgreement signed: {} ({})'
+                    '\nAgreement signed: {}'
                     '\nMOU in place: {}'
                     '\nChannel: {}\nStart date: {}\nStart volume: {}'
                     '\nPeak volume: {}'
@@ -191,7 +190,7 @@ def submit_request_to_go_live(service_id):
                     current_service['name'],
                     url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                     current_service['organisation_type'],
-                    agreement_info.agreement_signed, agreement_info.owner,
+                    GovernmentDomain.from_current_user().as_human_readable,
                     form.mou.data,
                     formatted_list(filter(None, (
                         'email' if form.channel_email.data else None,

--- a/app/utils.py
+++ b/app/utils.py
@@ -462,6 +462,14 @@ class GovernmentDomain:
             self.agreement_signed
         ) = self._get_details_of_domain()
 
+    @classmethod
+    def from_user(cls, user):
+        return cls(user.email_address if user.is_authenticated else '')
+
+    @classmethod
+    def from_current_user(cls):
+        return cls.from_user(current_user)
+
     @staticmethod
     def get_matching_function(email_address_or_domain):
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -470,6 +470,26 @@ class GovernmentDomain:
     def from_current_user(cls):
         return cls.from_user(current_user)
 
+    @property
+    def as_human_readable(self):
+        if self.agreement_signed:
+            return 'Yes, on behalf of {}'.format(self.owner)
+        elif self.owner:
+            return '{} (organisation is {}, {})'.format(
+                {
+                    False: 'No',
+                    None: 'Can’t tell',
+                }.get(self.agreement_signed),
+                self.owner,
+                {
+                    True: 'a crown body',
+                    False: 'a non-crown body',
+                    None: 'crown status unknown',
+                }.get(self.crown_status),
+            )
+        else:
+            return 'Can’t tell'
+
     @staticmethod
     def get_matching_function(email_address_or_domain):
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -530,6 +530,7 @@ def test_should_redirect_after_request_to_go_live(
     returned_message = mock_post.call_args[1]['message']
     assert 'On behalf of service one' in returned_message
     assert 'Organisation type: central' in returned_message
+    assert 'Agreement signed: None (None)' in returned_message
     assert 'Channel: email and text messages' in returned_message
     assert 'Start date: 01/01/2017' in returned_message
     assert 'Start volume: 100,000' in returned_message

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -530,7 +530,7 @@ def test_should_redirect_after_request_to_go_live(
     returned_message = mock_post.call_args[1]['message']
     assert 'On behalf of service one' in returned_message
     assert 'Organisation type: central' in returned_message
-    assert 'Agreement signed: None (None)' in returned_message
+    assert 'Agreement signed: Can’t tell' in returned_message
     assert 'Channel: email and text messages' in returned_message
     assert 'Start date: 01/01/2017' in returned_message
     assert 'Start volume: 100,000' in returned_message

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -387,6 +387,9 @@ def test_get_valid_government_domain_known_details(domain_or_email_address):
     assert government_domain.crown_status is None
     assert government_domain.owner == "Ministry of Housing, Communities & Local Government"
     assert government_domain.agreement_signed is True
+    assert government_domain.as_human_readable == (
+        'Yes, on behalf of Ministry of Housing, Communities & Local Government'
+    )
 
 
 @pytest.mark.parametrize("domain_or_email_address", (
@@ -397,6 +400,16 @@ def test_get_valid_government_domain_unknown_details(domain_or_email_address):
     assert government_domain.crown_status is None
     assert government_domain.owner is None
     assert government_domain.agreement_signed is None
+    assert government_domain.as_human_readable == 'Can’t tell'
+
+
+def test_get_valid_government_domain_only_org_known():
+    government_domain = GovernmentDomain('nhs.net')
+    # Some parts of the NHS are Crown, some aren’t
+    assert government_domain.crown_status is None
+    assert government_domain.owner == 'NHS'
+    assert government_domain.agreement_signed is None
+    assert government_domain.as_human_readable == 'Can’t tell (organisation is NHS, crown status unknown)'
 
 
 def test_get_valid_government_domain_some_known_details():
@@ -404,6 +417,19 @@ def test_get_valid_government_domain_some_known_details():
     assert government_domain.crown_status is None
     assert government_domain.owner == "Marine Management Organisation"
     assert government_domain.agreement_signed is True
+    assert government_domain.as_human_readable == (
+        'Yes, on behalf of Marine Management Organisation'
+    )
+
+
+def test_get_valid_local_government_domain_some_known_details():
+    government_domain = GovernmentDomain("aberdeenshire.gov.uk")
+    assert government_domain.crown_status is False
+    assert government_domain.owner == "Aberdeenshire Council"
+    assert government_domain.agreement_signed is False
+    assert government_domain.as_human_readable == (
+        'No (organisation is Aberdeenshire Council, a non-crown body)'
+    )
 
 
 def test_get_valid_government_domain_gets_most_specific_first():
@@ -412,11 +438,17 @@ def test_get_valid_government_domain_gets_most_specific_first():
     assert generic.crown_status is None
     assert generic.owner is None
     assert generic.agreement_signed is None
+    assert generic.as_human_readable == (
+        'Can’t tell'
+    )
 
     specific = GovernmentDomain("dacorum.gov.uk")
     assert specific.crown_status is False
     assert specific.owner == 'Dacorum Borough Council'
     assert specific.agreement_signed is True
+    assert specific.as_human_readable == (
+        'Yes, on behalf of Dacorum Borough Council'
+    )
 
 
 def test_validate_government_domain_data():


### PR DESCRIPTION
When we process a go live request it’s a pain to have to go fishing in the Google Drive to see if there’s a signed agreement in there. This should make it easier when we know there’s already an agreement.