### PR TITLE
Precompiled page count for preview

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -46,9 +46,8 @@ def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
     notification['template'].update({'reply_to_text': notification['reply_to_text']})
 
-    file_contents = view_letter_notification_as_preview(service_id, notification_id, "pdf")
-
     if notification['template']['is_precompiled_letter']:
+        file_contents = view_letter_notification_as_preview(service_id, notification_id, "pdf")
         page_count = pdf_page_count(io.BytesIO(file_contents))
     else:
         page_count = get_page_count_for_letter(notification['template'])

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+import io
 import os
 from datetime import datetime
 
@@ -14,6 +15,7 @@ from flask import (
 )
 from flask_login import login_required
 from notifications_python_client.errors import APIError
+from notifications_utils.pdf import pdf_page_count
 
 from app import (
     current_service,
@@ -44,6 +46,13 @@ def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
     notification['template'].update({'reply_to_text': notification['reply_to_text']})
 
+    file_contents = view_letter_notification_as_preview(service_id, notification_id, "pdf")
+
+    if notification['template']['is_precompiled_letter']:
+        page_count = pdf_page_count(io.BytesIO(file_contents))
+    else:
+        page_count = get_page_count_for_letter(notification['template'])
+
     template = get_template(
         notification['template'],
         current_service,
@@ -53,7 +62,7 @@ def view_notification(service_id, notification_id):
             notification_id=notification_id,
             filetype='png',
         ),
-        page_count=get_page_count_for_letter(notification['template']),
+        page_count=page_count,
         show_recipient=True,
         redact_missing_personalisation=True,
     )

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -166,7 +166,7 @@ def test_should_show_image_of_letter_notification(
     mock_get_notification(mocker, fake_uuid, template_type='letter')
 
     mocker.patch(
-        'app.notify_client.notification_api_client.NotificationApiClient.get',
+        'app.main.views.notifications.notification_api_client.get_notification_letter_preview',
         return_value={
             'content': base64.b64encode(b'foo').decode('utf-8')
         }
@@ -192,7 +192,7 @@ def test_should_show_preview_error_image_letter_notification_on_preview_error(
     mock_get_notification(mocker, fake_uuid, template_type='letter')
 
     mocker.patch(
-        'app.notify_client.notification_api_client.NotificationApiClient.get',
+        'app.main.views.notifications.notification_api_client.get_notification_letter_preview',
         side_effect=APIError
     )
 
@@ -366,7 +366,7 @@ def test_should_show_image_of_precompiled_letter_notification(
     )
 
     mocker.patch(
-        'app.notify_client.notification_api_client.NotificationApiClient.get',
+        'app.main.views.notifications.notification_api_client.get_notification_letter_preview',
         return_value={
             'content': base64.b64encode(b'foo').decode('utf-8')
         }

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -320,8 +320,19 @@ def test_notification_page_has_expected_template_link_for_letter(
     has_template_link
 ):
 
+    mocker.patch(
+        'app.main.views.notifications.view_letter_notification_as_preview',
+        return_value=b'foo'
+    )
+
+    mocker.patch(
+        'app.main.views.notifications.pdf_page_count',
+        return_value=1
+    )
+
     mock_get_notification(
         mocker, fake_uuid, template_type='letter', is_precompiled_letter=is_precompiled_letter)
+
     mocker.patch(
         'app.main.views.notifications.get_page_count_for_letter',
         return_value=1
@@ -339,3 +350,35 @@ def test_notification_page_has_expected_template_link_for_letter(
         assert link
     else:
         assert link is None
+
+
+def test_should_show_image_of_precompiled_letter_notification(
+    logged_in_client,
+    fake_uuid,
+    mocker,
+):
+
+    mock_get_notification(mocker, fake_uuid, template_type='letter', is_precompiled_letter=True)
+
+    mock_pdf_page_count = mocker.patch(
+        'app.main.views.notifications.pdf_page_count',
+        return_value=1
+    )
+
+    mocker.patch(
+        'app.notify_client.notification_api_client.NotificationApiClient.get',
+        return_value={
+            'content': base64.b64encode(b'foo').decode('utf-8')
+        }
+    )
+
+    response = logged_in_client.get(url_for(
+        'main.view_letter_notification_as_preview',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        filetype="png"
+    ))
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == 'foo'
+    assert mock_pdf_page_count.called_once()


### PR DESCRIPTION
Updated so that a precompiled pdf page count can be passed to the rendering template. Currently it uses the template from the API to calculate this which for a precompiled template is always 1.

Gets the PDF and then uses the utils method to get the page count.

* Added logic for precompiled letters
* Added test to test the new path
* Updated existing tests now the path has changed