### PR TITLE
Fix count of users on request to go live

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -167,7 +167,7 @@ def request_to_go_live(service_id):
         'views/service-settings/request-to-go-live.html',
         has_team_members=(
             user_api_client.get_count_of_users_with_permission(
-                service_id, 'manage_settings'
+                service_id, 'manage_service'
             ) > 1
         ),
         has_templates=(

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -3,6 +3,7 @@ from notifications_python_client.errors import HTTPError
 from app.notify_client import NotifyAdminAPIClient
 from app.notify_client.models import (
     User,
+    roles,
     translate_permissions_from_admin_roles_to_db,
 )
 
@@ -134,6 +135,8 @@ class UserApiClient(NotifyAdminAPIClient):
         return [User(data) for data in resp['data']]
 
     def get_count_of_users_with_permission(self, service_id, permission):
+        if permission not in roles.keys():
+            raise TypeError('{} is not a valid permission'.format(permission))
         return len([
             user for user in self.get_users_for_service(service_id)
             if user.has_permission_for_service(service_id, permission)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -516,7 +516,7 @@ def test_should_show_request_to_go_live_checklist(
         service_id=SERVICE_ONE_ID,
     )
 
-    mock_count_users.assert_called_once_with(SERVICE_ONE_ID, 'manage_settings')
+    mock_count_users.assert_called_once_with(SERVICE_ONE_ID, 'manage_service')
     assert mock_count_templates.call_args_list == [
         call(SERVICE_ONE_ID),
         call(SERVICE_ONE_ID, template_type='email'),


### PR DESCRIPTION
We were counting users who had the `manage_settings` permission. This is the old name for it, therefore there would never be any users with this permission, so the tick would never go green.

The new name for the permission is `manage_service`. This commit fixes the error, and adds an extra safeguard against something like this happening again.