### PR TITLE
Set template subject to Provided as PDF for precompiled letters

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -399,6 +399,8 @@ def add_preview_of_content_to_notifications(notifications):
                 **notification
             )
         else:
+            if notification['template']['is_precompiled_letter']:
+                notification['template']['subject'] = 'Provided as PDF'
             yield dict(
                 preview_of_content=(
                     WithSubjectTemplate(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -404,3 +404,29 @@ def test_sending_status_hint_does_not_include_status_for_letters(
         assert normalize_spaces(page.select(".align-with-message-body")[0].text) == "27 September at 5:30pm"
     else:
         assert normalize_spaces(page.select(".align-with-message-body")[0].text) == "Delivered 27 September at 5:31pm"
+
+
+@pytest.mark.parametrize("is_precompiled_letter,expected_hint", [
+    (True, "Provided as PDF"),
+    (False, "template subject")
+])
+def test_should_expected_hint_for_letters(
+    logged_in_client,
+    service_one,
+    active_user_with_permissions,
+    mock_get_detailed_service,
+    mocker,
+    fake_uuid,
+    is_precompiled_letter,
+    expected_hint
+):
+    mock_get_notifications(
+        mocker, active_user_with_permissions, is_precompiled_letter=is_precompiled_letter)
+
+    response = logged_in_client.get(url_for(
+        'main.view_notifications',
+        service_id=SERVICE_ONE_ID,
+        message_type='letter'
+    ))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.find('p', {'class': 'file-list-hint'}).text.strip() == expected_hint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1763,6 +1763,7 @@ def mock_get_notifications(
     diff_template_type=None,
     personalisation=None,
     redact_personalisation=False,
+    is_precompiled_letter=False,
 ):
     def _get_notifications(
         service_id,
@@ -1787,6 +1788,7 @@ def mock_get_notifications(
                 type_=diff_template_type or template_type[0],
                 content=template_content,
                 redact_personalisation=redact_personalisation,
+                is_precompiled_letter=is_precompiled_letter,
             )
         else:
             template = template_json(


### PR DESCRIPTION
## What

Changed the text from the template subject for precompiled letters of `Pre-compiled PDF` to `Provided as PDF`

Easier to change the text in Admin rather than do a database update on API and should be easy to change if the text should change in the future.

## Reference 

https://www.pivotaltracker.com/story/show/155323846