### PR TITLE
Add Her Majesty’s Passport Office to domain list

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -126,6 +126,8 @@ trade.gsi.gov.uk: trade.gov.uk
 trade.gov.uk:
   owner: Department for International Trade
   agreement_signed: true
+hmpo.gov.uk: homeoffice.gov.uk
+hmpo.gsi.gov.uk: homeoffice.gov.uk
 homeoffice.gsi.gov.uk: homeoffice.gov.uk
 homeoffice.gov.uk:
   owner: Home Office


### PR DESCRIPTION
They are covered by the agreement we have with Home Office.

> HM Passport Office is part of the Home Office.
– https://www.gov.uk/government/organisations/hm-passport-office