### PR TITLE
Fix bug with inbound message page

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -102,7 +102,9 @@ def get_user_number(service_id, notification_id):
 def get_sms_thread(service_id, user_number):
 
     for notification in sorted((
-        notification_api_client.get_notifications_for_service(service_id, to=user_number)['notifications'] +
+        notification_api_client.get_notifications_for_service(service_id,
+                                                              to=user_number,
+                                                              template_type='sms')['notifications'] +
         service_api_client.get_inbound_sms(service_id, user_number=user_number)
     ), key=lambda notification: notification['created_at']):
 

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -79,7 +79,7 @@ def test_view_conversation(
     mock_get_inbound_sms
 ):
 
-    mock_get_notifications(
+    mock = mock_get_notifications(
         mocker,
         api_user_active,
         template_content='Hello ((name))',
@@ -157,6 +157,8 @@ def test_view_conversation(
             normalize_spaces(messages[index].text),
             normalize_spaces(statuses[index].text),
         ) == expected
+
+    mock.assert_called_once_with(SERVICE_ONE_ID, to='07123 456789', template_type='sms')
 
 
 def test_view_conversation_updates(


### PR DESCRIPTION
The get notifications endpoint needs the template_type for search. The inbox page for inbound sms messages was not passing that through, which caused a 400 response.
This resolves that by passing the template_type to the api.