### PR TITLE
Replace ‘no permissions’ banner with a line on the template page 

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -44,6 +44,11 @@
   margin-top: $gutter-half;
 }
 
+.top-gutter-1-3 {
+  @extend %top-gutter;
+  margin-top: $gutter / 3;
+}
+
 %bottom-gutter,
 .bottom-gutter {
   @extend %contain-floats;

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -153,30 +153,3 @@
   }
 
 }
-
-.banner-warning {
-
-  @extend %banner;
-  @include bold-19;
-  background: $yellow;
-  color: $text-colour;
-  border: 5px solid $text-colour;
-  margin: $gutter-half 0 $gutter 0;
-  text-align: left;
-  padding: 20px;
-
-  .heading-medium {
-    @include bold-24;
-    margin: 0 0 $gutter-half 0;
-  }
-
-  .list {
-    margin-bottom: 10px;
-  }
-
-  a:link,
-  a:visited {
-    color: $text-colour;
-  }
-
-}

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -15,12 +15,8 @@
   <div class="dashboard">
 
     <h1 class="visuallyhidden">Dashboard</h1>
-    {% if current_user.has_permissions('manage_templates') %}
-      {% if not templates %}
-        {% include 'views/dashboard/write-first-messages.html' %}
-      {% endif %}
-    {% elif not current_user.has_permissions('send_messages', 'manage_api_keys') %}
-      {% include 'views/dashboard/no-permissions-banner.html' %}
+    {% if current_user.has_permissions('manage_templates') and not templates %}
+      {% include 'views/dashboard/write-first-messages.html' %}
     {% endif %}
 
     {{ ajax_block(partials, updates_url, 'upcoming') }}

--- a/app/templates/views/dashboard/no-permissions-banner.html
+++ b/app/templates/views/dashboard/no-permissions-banner.html
@@ -1,6 +1,0 @@
-{% from "components/banner.html" import banner_wrapper %}
-
-{% call banner_wrapper(type="warning") %}
-  You only have permission to view this service. To send messages, edit
-  templates or manage team members, contact the person who invited you.
-{% endcall %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -1,7 +1,15 @@
+{% from 'components/message-count-label.html' import message_count_label %}
+
 <div class="column-whole">
   {% if template._template.archived %}
     <p class="hint">
       This template was deleted {{ template._template.updated_at|format_datetime_relative }}.
+    </p>
+  {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', 'manage_templates', 'manage_service') %}
+    <p class="top-gutter-1-3 {% if template.template_type != 'sms' %}bottom-gutter{% endif %}">
+      If you need to send this
+      {{ message_count_label(1, template.template_type, suffix='') }}
+      or edit this template, contact your manager.
     </p>
   {% else %}
     <div class="bottom-gutter-2-3">

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -110,22 +110,31 @@ def test_should_show_page_for_one_template(
     mock_get_service_template.assert_called_with(service_one['id'], template_id)
 
 
-@pytest.mark.parametrize('permissions, links_to_be_shown', [
+@pytest.mark.parametrize('permissions, links_to_be_shown, permissions_warning_to_be_shown', [
     (
         ['view_activity'],
-        []
+        [],
+        'If you need to send this text message or edit this template, contact your manager.'
+    ),
+    (
+        ['manage_api_keys'],
+        [],
+        None,
     ),
     (
         ['manage_templates'],
-        ['.edit_service_template']
+        ['.edit_service_template'],
+        None,
     ),
     (
         ['send_messages'],
-        ['.send_messages', '.set_sender']
+        ['.send_messages', '.set_sender'],
+        None,
     ),
     (
         ['send_messages', 'manage_templates'],
-        ['.send_messages', '.set_sender', '.edit_service_template']
+        ['.send_messages', '.set_sender', '.edit_service_template'],
+        None,
     ),
 ])
 def test_should_be_able_to_view_a_template_with_links(
@@ -138,6 +147,7 @@ def test_should_be_able_to_view_a_template_with_links(
     fake_uuid,
     permissions,
     links_to_be_shown,
+    permissions_warning_to_be_shown,
 ):
     active_user_with_permissions._permissions[service_one['id']] = permissions + ['view_activity']
     client.login(active_user_with_permissions, mocker, service_one)
@@ -160,6 +170,10 @@ def test_should_be_able_to_view_a_template_with_links(
             service_id=service_one['id'],
             template_id=fake_uuid,
         )
+
+    assert normalize_spaces(page.select_one('main p').text) == (
+        permissions_warning_to_be_shown or 'To: phone number'
+    )
 
 
 def test_should_show_template_id_on_template_page(


### PR DESCRIPTION
# Remove warning banner from dashboard

We have teams who are using the dashboard every day, and being confronted with this alarming yellow banner. There’s no action they need to do since they’re only looking at the messages sent.

So this commit removes this banner from the dashboard:

![image](https://user-images.githubusercontent.com/355079/37295064-25058f18-260f-11e8-8745-f00917f34d27.png)

# Add line to template page if you can’t do anything 

If someone has no permissions but needs permissions the thing they’re probably going to need is to send a message or edit a template. The place they will probably come to is the place where the buttons would be – users with these permissions are finding the thing they need to do on this page.

So this commit adds a line to this page which (hopefully) makes it clear they’re in the right place, but need to go and speak to someone:

![image](https://user-images.githubusercontent.com/355079/37294935-e4a1101e-260e-11e8-9672-22e01a2df8ae.png)

![image](https://user-images.githubusercontent.com/355079/37294957-eaf971b8-260e-11e8-82c0-a603a58eb0a5.png)

![image](https://user-images.githubusercontent.com/355079/37294975-f1e98ca6-260e-11e8-8ccc-4fc0bc95e843.png)

---

Thanks to @soniaturcotte for feeding back from her research about this.