### PR TITLE
Clean up request to go live page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -554,18 +554,6 @@ class Triage(StripWhitespaceForm):
 
 
 class RequestToGoLiveForm(StripWhitespaceForm):
-    mou = RadioField(
-        (
-            'Has your organisation accepted the GOV.UK&nbsp;Notify data sharing and financial '
-            'agreement?'
-        ),
-        choices=[
-            ('yes', 'Yes'),
-            ('no', 'No'),
-            ('don’t know', 'I don’t know')
-        ],
-        validators=[DataRequired()]
-    )
     channel_email = BooleanField('Emails')
     channel_sms = BooleanField('Text messages')
     channel_letter = BooleanField('Letters')

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -198,7 +198,6 @@ def submit_request_to_go_live(service_id):
                     '\n---'
                     '\nOrganisation type: {}'
                     '\nAgreement signed: {}'
-                    '\nMOU in place: {}'
                     '\nChannel: {}\nStart date: {}\nStart volume: {}'
                     '\nPeak volume: {}'
                     '\nFeatures: {}'
@@ -207,7 +206,6 @@ def submit_request_to_go_live(service_id):
                     url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                     current_service['organisation_type'],
                     GovernmentDomain.from_current_user().as_human_readable,
-                    form.mou.data,
                     formatted_list(filter(None, (
                         'email' if form.channel_email.data else None,
                         'text messages' if form.channel_sms.data else None,

--- a/app/templates/views/service-settings/submit-request-to-go-live.html
+++ b/app/templates/views/service-settings/submit-request-to-go-live.html
@@ -13,7 +13,7 @@
 
       <h1 class="heading-large">Request to go live</h1>
 
-      <form method="post">
+      <form method="post" class="top-gutter">
         {{ checkbox_group('What kind of messages will you be sending?', [
           form.channel_email,
           form.channel_sms,
@@ -29,7 +29,7 @@
           form.method_upload,
           form.method_api
         ]) }}
-        <p>
+        <p class="bottom-gutter">
           By requesting to go live you’re agreeing to our <a href="{{ url_for('.terms') }}">terms of use</a>.
         </p>
 

--- a/app/templates/views/service-settings/submit-request-to-go-live.html
+++ b/app/templates/views/service-settings/submit-request-to-go-live.html
@@ -6,12 +6,12 @@
 {% from "components/banner.html" import banner_wrapper %}
 
 {% block service_page_title %}
-  Request to go live
+  How do you plan to use Notify?
 {% endblock %}
 
 {% block maincolumn_content %}
 
-      <h1 class="heading-large">Request to go live</h1>
+      <h1 class="heading-large">How do you plan to use Notify?</h1>
 
       <form method="post" class="top-gutter">
         {{ checkbox_group('What kind of messages will you be sending?', [

--- a/app/templates/views/service-settings/submit-request-to-go-live.html
+++ b/app/templates/views/service-settings/submit-request-to-go-live.html
@@ -14,13 +14,6 @@
       <h1 class="heading-large">Request to go live</h1>
 
       <form method="post">
-        <div class="form-group">
-          <p>We need permission to process your data before we can make your service live.</p>
-          {{ radios(form.mou, option_hints={
-            'no': 'We’ll send you a copy',
-            'don’t know': 'We’ll check for you',
-          }) }}
-        </div>
         {{ checkbox_group('What kind of messages will you be sending?', [
           form.channel_email,
           form.channel_sms,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -532,7 +532,7 @@ def test_should_show_request_to_go_live(
     page = client_request.get(
         'main.submit_request_to_go_live', service_id=SERVICE_ONE_ID
     )
-    assert page.h1.text == 'Request to go live'
+    assert page.h1.text == 'How do you plan to use Notify?'
     for channel, label in (
         ('email', 'Emails'),
         ('sms', 'Text messages'),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -566,7 +566,6 @@ def test_should_redirect_after_request_to_go_live(
         'main.submit_request_to_go_live',
         service_id=SERVICE_ONE_ID,
         _data={
-            'mou': 'yes',
             'channel_email': 'y',
             'channel_sms': 'y',
             'start_date': '01/01/2017',


### PR DESCRIPTION
Since we’ve changed the flow that leads into this page, there are a couple of things that we can clean up or need to change:

# 1. Remove the MoU question from request to go live

This question was designed to make people feel like it was OK to submit their request without getting the MoU signed. We reckoned that this was the fastest way of getting their service live (because the MoU is the bit that’s most likely to slow them down).

We now have a better way of telling people:
- if they’ve signed the MoU already
- or to contact us if they haven’t (which is what the majority of teams seem to do now)

We were never actually using the answer to this question – we were still checking for every service whether they had it signed.

So this commit removes this now-redundant question.

# 2. Retitle request to go live submission page

`<h1>`s should be unique across the site. This page’s `<h1>` matches that of the previous page (the one with the checklist).

This commit re-titles it to:
- be unique
- more accurately describe the content of the page

---

Before | After 
---|---
![localhost-6012-services-905e65d1-a816-4f48-b595-d37eabfe19d9-service-settings-submit-request-to-go-live ipad 1](https://user-images.githubusercontent.com/355079/37339738-92242e20-26b3-11e8-8d36-c24fb43ca334.png) | ![localhost-6012-services-905e65d1-a816-4f48-b595-d37eabfe19d9-service-settings-submit-request-to-go-live ipad](https://user-images.githubusercontent.com/355079/37339745-96430634-26b3-11e8-81ab-daf66ae26168.png)
