### PR TITLE
Make pricing page consistent in talking about MoU

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -52,6 +52,7 @@ def pricing():
             for cc, country in INTERNATIONAL_BILLING_RATES.items()
         ], key=lambda x: x[0]),
         search_form=SearchTemplatesForm(),
+        agreement_info=AgreementInfo.from_current_user(),
     )
 
 

--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -30,11 +30,11 @@
       <li>25,000 free text messages for other public sector services</li>
     </ul>
     <p>It costs 1.58 pence (plus VAT) for each text message you send after your free allowance.</p>
-    
+
     <h3 class="heading-small">Multiple services</h3>
     <p>If your organisation offers multiple services, you can have a different Notify account for each of them.</p>
     <p>Each service will get its own free message allowance.</p>
-    
+
     <h3 class="heading-small">Long text messages</h3>
     <p>If a text message is beyond a certain length, it’ll be charged as more than one message:</p>
     <div class="bottom-gutter-3-2">
@@ -124,8 +124,18 @@
 
     <h2 class="heading-medium" id="paying">How to pay</h2>
     <p>You can find details of how to pay for Notify in our data sharing and financial agreement.</p>
-    <p><a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">Contact us</a> to get a copy of the agreement or find out if we already have one in place with your organisation.</p>
-    
+    <p>
+      <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback', body='Please send me a copy of the GOV.UK Notify data sharing and financial agreement.')}}">Contact us</a> to get a copy of the agreement
+      {% if agreement_info.agreement_signed %}
+        ({{ agreement_info.owner }} has already accepted it).
+      {% else %}
+        {% if agreement_info.owner and agreement_info.agreement_signed != None %}
+          ({{ agreement_info.owner }} hasn’t accepted it yet).
+        {% else %}
+          or find out if we already have one in place with your organisation.
+        {% endif %}
+      {% endif %}
+    </p>
   </div>
 </div>
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -102,12 +102,16 @@ def test_terms_is_generic_if_user_is_not_logged_in(
     )
 
 
-@pytest.mark.parametrize('email_address, expected_first_paragraph', [
+@pytest.mark.parametrize('email_address, expected_terms_paragraph, expected_pricing_paragraph', [
     (
         'test@cabinet-office.gov.uk',
         (
             'Your organisation (Cabinet Office) has already accepted '
             'the GOV.UK Notify data sharing and financial agreement.'
+        ),
+        (
+            'Contact us to get a copy of the agreement '
+            '(Cabinet Office has already accepted it).'
         ),
     ),
     (
@@ -117,12 +121,20 @@ def test_terms_is_generic_if_user_is_not_logged_in(
             'accept our data sharing and financial agreement. Contact '
             'us to get a copy.'
         ),
+        (
+            'Contact us to get a copy of the agreement '
+            '(Aylesbury Town Council hasn’t accepted it yet).'
+        ),
     ),
     (
         'larry@downing-street.gov.uk',
         (
             'Your organisation must also accept our data sharing and '
             'financial agreement. Contact us to get a copy.'
+        ),
+        (
+            'Contact us to get a copy of the agreement or find out if '
+            'we already have one in place with your organisation.'
         ),
     ),
 ])
@@ -131,10 +143,13 @@ def test_terms_tells_logged_in_users_what_we_know_about_their_agreement(
     fake_uuid,
     client_request,
     email_address,
-    expected_first_paragraph,
+    expected_terms_paragraph,
+    expected_pricing_paragraph,
 ):
     user = active_user_with_permissions(fake_uuid)
     user.email_address = email_address
     mocker.patch('app.user_api_client.get_user', return_value=user)
-    page = client_request.get('main.terms')
-    assert normalize_spaces(page.select('main p')[1].text) == expected_first_paragraph
+    terms_page = client_request.get('main.terms')
+    pricing_page = client_request.get('main.pricing')
+    assert normalize_spaces(terms_page.select('main p')[1].text) == expected_terms_paragraph
+    assert normalize_spaces(pricing_page.select('main p')[-1].text) == expected_pricing_paragraph


### PR DESCRIPTION
We shouldn’t tell people on one page (the terms page) that we know about their organisations agreement and then on the pricing page tell them to contact us to find out what we know about the agreement.

So this commit adds the same logic from the terms page to the pricing page, with wording that makes sense in the pricing context.