### PR TITLE
Add client reference to API Integration / message log

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -66,10 +66,12 @@
         <div>
           <dl id="notification-{{ notification.id }}" class="api-notifications-item-data bottom-gutter-1-2">
             {% for key in [
-              'id', 'notification_type', 'created_at', 'updated_at', 'sent_at', 'status'
+              'id', 'client_reference', 'notification_type', 'created_at', 'updated_at', 'sent_at', 'status'
             ] %}
-              <dt>{{ key }}:</dt>
-              <dd class="api-notifications-item-data-item">{{ notification[key] }}</dd>
+              {% if notification[key] %}
+                <dt>{{ key }}:</dt>
+                <dd class="api-notifications-item-data-item">{{ notification[key] }}</dd>
+              {% endif %}
             {% endfor %}
             {% if notification['notification_type'] == 'letter' %}
               <a href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=notification.id) }}">View letter</a>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -16,7 +16,7 @@
 
     <p>
       {% if is_precompiled_letter %}
-      Provided as PDF. Sent
+      Provided as PDF, sent
       {% else %}
         {% if help %}
           {{ template.name }}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -358,7 +358,8 @@ def notification_json(
     rows=5,
     personalisation=None,
     template_type=None,
-    reply_to_text=None
+    reply_to_text=None,
+    client_reference=None,
 ):
     if template is None:
         template = template_json(service_id, str(generate_uuid()), type_=template_type)
@@ -407,6 +408,7 @@ def notification_json(
             'personalisation': personalisation or {},
             'notification_type': template_type,
             'reply_to_text': reply_to_text,
+            'client_reference': client_reference,
         } for i in range(rows)],
         'total': rows,
         'page_size': 50,

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -89,6 +89,34 @@ def test_letter_notifications_should_have_link_to_view_letter(
     assert (page.select_one('details a') is not None) == has_links
 
 
+@pytest.mark.parametrize('client_reference, shows_ref', [
+    ('foo', True),
+    (None, False),
+])
+def test_letter_notifications_should_show_client_reference(
+    client_request,
+    api_user_active,
+    fake_uuid,
+    mock_has_permissions,
+    mocker,
+    client_reference,
+    shows_ref
+):
+    mock_get_notifications(mocker, api_user_active, client_reference=client_reference)
+
+    page = client_request.get(
+        'main.api_integration',
+        service_id=fake_uuid,
+    )
+    dt_arr = [p.text for p in page.select('dt')]
+
+    if shows_ref:
+        assert 'client_reference:' in dt_arr
+        assert page.select_one('dd:nth-of-type(2)').text == 'foo'
+    else:
+        assert 'client_reference:' not in dt_arr
+
+
 def test_should_show_api_page_for_live_service(
     logged_in_client,
     mock_login,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1764,6 +1764,7 @@ def mock_get_notifications(
     personalisation=None,
     redact_personalisation=False,
     is_precompiled_letter=False,
+    client_reference=None,
 ):
     def _get_notifications(
         service_id,
@@ -1803,7 +1804,8 @@ def mock_get_notifications(
             rows=rows,
             job=job,
             personalisation=personalisation,
-            template_type=diff_template_type
+            template_type=diff_template_type,
+            client_reference=client_reference,
         )
 
     return mocker.patch(


### PR DESCRIPTION
## What

`client_reference` added to api message log

- makes it clearer for users and easier to copy
- also updated text in preview message