### PR TITLE
Put checkered background behind email branding

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -230,3 +230,14 @@ details .arrow {
 .heading-inline {
   display: inline-block;
 }
+
+.branding-radio {
+
+  img {
+    background: linear-gradient(45deg, rgba(0, 0, 0, 0.3) 25%, transparent 25%, transparent 75%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 0), linear-gradient(45deg, rgba(0, 0, 0, 0.3) 25%, transparent 25%, transparent 75%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 0), $white;
+    background-repeat: repeat, repeat;
+    background-position: 0px 0, 5px 5px;
+    background-size: 10px 10px, 10px 10px;
+  }
+
+}

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -98,7 +98,7 @@
         {% endif %}
       </legend>
       {% for value, option, checked in field.iter_choices() %}
-        <div class="multiple-choice">
+        <div class="multiple-choice branding-radio">
           <input
             type="radio"
             name="{{ field.name }}"


### PR DESCRIPTION
This will stop images which are white with a transparent background being invisible in the admin app (and accidentally getting overwritten).

# Before

![image](https://user-images.githubusercontent.com/355079/37597465-714f63e0-2b77-11e8-887b-f1f1ed2dd75a.png)

# After 

![image](https://user-images.githubusercontent.com/355079/37597445-648084c8-2b77-11e8-8c1d-364ff776f18a.png)
