### PR TITLE
Remove Council for Science & Technology

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -1262,10 +1262,6 @@ crowboroughtowncouncil.gov.uk:
   owner: Crowborough Town Council
   crown: false
   agreement_signed: false
-cst.gov.uk:
-  owner: Council for Science and Technology
-  crown: false
-  agreement_signed: false
 cullomptontowncouncil.gov.uk:
   owner: Cullompton Town Council
   crown: false


### PR DESCRIPTION
They’re not a council in the sense of a local council.