### PR TITLE
redirect to show_accounts_or_dashboard on login

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -13,7 +13,7 @@ from flask_login import current_user, login_user
 from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import check_token
 
-from app import service_api_client, user_api_client
+from app import user_api_client
 from app.main import main
 from app.main.forms import TwoFactorForm
 from app.utils import redirect_to_sign_in
@@ -112,9 +112,4 @@ def redirect_when_logged_in(user_id):
     if current_user.platform_admin:
         return redirect(url_for('main.platform_admin'))
 
-    services = service_api_client.get_active_services({'user_id': str(user_id)}).get('data', [])
-
-    if len(services) == 1:
-        return redirect(url_for('main.service_dashboard', service_id=services[0]['id']))
-    else:
-        return redirect(url_for('main.choose_account'))
+    return redirect(url_for('main.show_accounts_or_dashboard'))

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -100,7 +100,7 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
     response = client.post(url_for('.new_password', token=token), data={'new_password': 'a-new_password'})
 
     assert response.status_code == 302
-    assert response.location == url_for('.choose_account', _external=True)
+    assert response.location == url_for('.show_accounts_or_dashboard', _external=True)
     assert mock_get_user_by_email_request_password_reset.called
     assert mock_reset_failed_login_count.called
 


### PR DESCRIPTION
show_accounts_or_dashboard has logic about where you should redirect to. If we let it do this, then that's nicer than duplicating its logic. We found that it wasn't accounting for orgs in redirects properly.