### PR TITLE
Don’t populate support form with arbitrary text

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -13,9 +13,24 @@ from app import (
 )
 from app.main import main
 from app.main.forms import Feedback, Problem, SupportType, Triage
+from app.utils import AgreementInfo
 
 QUESTION_TICKET_TYPE = 'ask-question-give-feedback'
 PROBLEM_TICKET_TYPE = "report-problem"
+
+
+def get_prefilled_message():
+    agreement_info = AgreementInfo.from_current_user()
+    return {
+        'agreement': (
+            agreement_info.as_request_for_agreement()
+        ),
+        'agreement-with-owner': (
+            agreement_info.as_request_for_agreement(with_owner=True)
+        ),
+    }.get(
+        request.args.get('body'), ''
+    )
 
 
 @main.route('/feedback', methods=['GET'])
@@ -135,7 +150,7 @@ def feedback(ticket_type):
         return redirect(url_for('.thanks', urgent=urgent, anonymous=anonymous))
 
     if not form.feedback.data:
-        form.feedback.data = request.args.get('body', '')
+        form.feedback.data = get_prefilled_message()
 
     return render_template(
         'views/support/{}.html'.format(ticket_type),

--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -125,7 +125,7 @@
     <h2 class="heading-medium" id="paying">How to pay</h2>
     <p>You can find details of how to pay for Notify in our data sharing and financial agreement.</p>
     <p>
-      <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback', body='Please send me a copy of the GOV.UK Notify data sharing and financial agreement.')}}">Contact us</a> to get a copy of the agreement
+      <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback', body='agreement')}}">Contact us</a> to get a copy of the agreement
       {% if agreement_info.agreement_signed %}
         ({{ agreement_info.owner }} has already accepted it).
       {% else %}

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -28,10 +28,10 @@ Terms of use
         {% if agreement_info.owner %}
           ({{ agreement_info.owner }})
           must also accept our data sharing and financial agreement.
-          <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback', body='Please send me a copy of the GOV.UK Notify data sharing and financial agreement for {} to sign.'.format(agreement_info.owner)) }}">Contact us</a> to get a copy.
+          <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback', body='agreement-with-owner') }}">Contact us</a> to get a copy.
         {% else %}
           must also accept our data sharing and financial agreement.
-          <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback', body='Please send me a copy of the GOV.UK Notify data sharing and financial agreement.') }}">Contact us</a> to get a copy.
+          <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback', body='agreement') }}">Contact us</a> to get a copy.
         {% endif %}
       </p>
     {% endif %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -464,6 +464,17 @@ class AgreementInfo:
         else:
             return 'Can’t tell'
 
+    def as_request_for_agreement(self, with_owner=False):
+        if with_owner and self.owner:
+            return (
+                'Please send me a copy of the GOV.UK Notify data sharing '
+                'and financial agreement for {} to sign.'.format(self.owner)
+            )
+        return (
+            'Please send me a copy of the GOV.UK Notify data sharing '
+            'and financial agreement.'
+        )
+
     @staticmethod
     def get_matching_function(email_address_or_domain):
 


### PR DESCRIPTION
I don’t think it’s a massive risk (we’re certainly mitigating against any XSS), but having a page on a GOV.UK domain where you can pre-fill text on the page from a query string probably isn’t great.

So this commit restricts pre-filling the support form to a set of named questions.