### PR TITLE
Make email branding logo backgrounds higher contrast

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -234,10 +234,10 @@ details .arrow {
 .branding-radio {
 
   img {
-    background: linear-gradient(45deg, rgba(0, 0, 0, 0.3) 25%, transparent 25%, transparent 75%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 0), linear-gradient(45deg, rgba(0, 0, 0, 0.3) 25%, transparent 25%, transparent 75%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 0), $white;
+    background: linear-gradient(45deg, $black 25%, transparent 25%, transparent 75%, $black 75%, $black 0), linear-gradient(45deg, $black 25%, transparent 25%, transparent 75%, $black 75%, $black 0), $white;
     background-repeat: repeat, repeat;
     background-position: 0px 0, 5px 5px;
-    background-size: 10px 10px, 10px 10px;
+    background-size: 2px 2px, 2px 2px;
   }
 
 }


### PR DESCRIPTION
So you can see both white and black foreground on transparent backgrounds.

## Before

<img width="524" alt="screen shot 2018-03-20 at 13 29 51" src="https://user-images.githubusercontent.com/355079/37657496-0ed8a79a-2c43-11e8-81db-e7a27a329696.png">

## After

<img width="513" alt="screen shot 2018-03-20 at 13 29 36" src="https://user-images.githubusercontent.com/355079/37657497-0ef3877c-2c43-11e8-89f4-4039a07321b6.png">