### PR TITLE
Org links don't show if user doesn't have permissions

### DIFF
--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -11,6 +11,7 @@
 
   &-item,
   &-sub-item {
+    @include bold-24;
     list-style: none;
     margin-bottom: $gutter-half;
   }

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -56,6 +56,9 @@ def add_organisation():
 @user_has_permissions()
 def organisation_dashboard(org_id):
     organisation_services = organisations_client.get_organisation_services(org_id)
+    for service in organisation_services:
+        has_permission = current_user.has_permission_for_service(service['id'], 'view_activity')
+        service.update({'has_permission_to_view': has_permission})
 
     return render_template(
         'views/organisations/organisation/index.html',

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -16,7 +16,11 @@
   <ul>
   {% for service in organisation_services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="browse-list-link">{{ service['name'] }}</a>
+      {% if service.has_permission_to_view %}
+        <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="browse-list-link">{{ service['name'] }}</a>
+      {% else %}
+        {{ service['name'] }}
+      {% endif %}
     </li>
   {% endfor %}
   </ul>

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -99,14 +99,17 @@ def test_organisation_services_show(
 
     assert len(page.select('.browse-list-item')) == 3
 
-    for i in range(0, 3):
+    for i in range(0, 2):
         service_name = mock_get_organisation_services(mock_get_organisation['id'])[i]['name']
         service_id = mock_get_organisation_services(mock_get_organisation['id'])[i]['id']
 
         assert normalize_spaces(page.select('.browse-list-item')[i].text) == service_name
-        assert normalize_spaces(
-            page.select('.browse-list-item a')[i]['href']
-        ) == '/services/{}'.format(service_id)
+        if i > 1:
+            assert normalize_spaces(
+                page.select('.browse-list-item a')[i]['href']
+            ) == '/services/{}'.format(service_id)
+        else:
+            assert page.select('.browse-list-item')[i].find('a') is None
 
 
 def test_view_team_members(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2756,12 +2756,12 @@ def mock_update_service_organisation(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_get_organisation_services(mocker):
+def mock_get_organisation_services(mocker, api_user_active):
     def _get_organisation_services(organisation_id):
         return [
             service_json('12345', 'service one'),
             service_json('67890', 'service two'),
-            service_json('09876', 'service three')
+            service_json(SERVICE_ONE_ID, 'service one', [api_user_active.id])
         ]
 
     return mocker.patch(


### PR DESCRIPTION
Currently, users see all the services in an organisation with link. If they click on one they don't have permissions to see, they get a 403. This PR removes the link so this flow is no longer possible.

![image](https://user-images.githubusercontent.com/31617728/37667754-a94019e6-2c5a-11e8-9ed1-8c06bed47305.png)

