### PR TITLE
fix relative datetime function to handle dates correctly

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -251,19 +251,15 @@ def format_time_24h(date):
 
 def get_human_day(time):
 
-    #  Add 1 hour to get ‘midnight today’ instead of ‘midnight tomorrow’
-    time_as_day = (gmt_timezones(time) - timedelta(hours=1)).strftime('%A')
-    six_days_ago = gmt_timezones((datetime.utcnow() + timedelta(days=-6)).isoformat())
-
-    if gmt_timezones(time) < six_days_ago:
-        return format_date_short(time)
-    if time_as_day == (datetime.utcnow() + timedelta(days=1)).strftime('%A'):
+    #  Add 1 minute to transform 00:00 into ‘midnight today’ instead of ‘midnight tomorrow’
+    date = (gmt_timezones(time) - timedelta(minutes=1)).date()
+    if date == (datetime.utcnow() + timedelta(days=1)).date():
         return 'tomorrow'
-    if time_as_day == datetime.utcnow().strftime('%A'):
+    if date == datetime.utcnow().date():
         return 'today'
-    if time_as_day == (datetime.utcnow() + timedelta(days=-1)).strftime('%A'):
+    if date == (datetime.utcnow() - timedelta(days=1)).date():
         return 'yesterday'
-    return format_date_short(time)
+    return _format_datetime_short(date)
 
 
 def format_time(date):
@@ -285,7 +281,11 @@ def format_date_normal(date):
 
 
 def format_date_short(date):
-    return gmt_timezones(date).strftime('%d %B').lstrip('0')
+    return _format_datetime_short(gmt_timezones(date))
+
+
+def _format_datetime_short(datetime):
+    return datetime.strftime('%d %B').lstrip('0')
 
 
 def format_delta(date):

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 from freezegun import freeze_time
 from tests.conftest import fake_uuid
 
+from app import format_datetime_relative
 from app.utils import (
     AgreementInfo,
     Spreadsheet,
@@ -470,3 +471,43 @@ def test_validate_government_domain_data():
         assert agreement_info.agreement_signed in {
             True, False, None
         }
+
+
+@pytest.mark.parametrize('time, human_readable_datetime', [
+    ('2018-03-14 09:00', '14 March at 9:00am'),
+    ('2018-03-14 15:00', '14 March at 3:00pm'),
+
+    ('2018-03-15 09:00', '15 March at 9:00am'),
+    ('2018-03-15 15:00', '15 March at 3:00pm'),
+
+    ('2018-03-19 09:00', '19 March at 9:00am'),
+    ('2018-03-19 15:00', '19 March at 3:00pm'),
+    ('2018-03-19 23:59', '19 March at 11:59pm'),
+
+    ('2018-03-20 00:00', '19 March at midnight'),  # we specifically refer to 00:00 as belonging to the day before.
+    ('2018-03-20 00:01', 'yesterday at 12:01am'),
+    ('2018-03-20 09:00', 'yesterday at 9:00am'),
+    ('2018-03-20 15:00', 'yesterday at 3:00pm'),
+    ('2018-03-20 23:59', 'yesterday at 11:59pm'),
+
+    ('2018-03-21 00:00', 'yesterday at midnight'),  # we specifically refer to 00:00 as belonging to the day before.
+    ('2018-03-21 00:01', 'today at 12:01am'),
+    ('2018-03-21 09:00', 'today at 9:00am'),
+    ('2018-03-21 12:00', 'today at midday'),
+    ('2018-03-21 15:00', 'today at 3:00pm'),
+    ('2018-03-21 23:59', 'today at 11:59pm'),
+
+    ('2018-03-22 00:00', 'today at midnight'),  # we specifically refer to 00:00 as belonging to the day before.
+    ('2018-03-22 00:01', 'tomorrow at 12:01am'),
+    ('2018-03-22 09:00', 'tomorrow at 9:00am'),
+    ('2018-03-22 15:00', 'tomorrow at 3:00pm'),
+    ('2018-03-22 23:59', 'tomorrow at 11:59pm'),
+
+    ('2018-03-23 00:01', '23 March at 12:01am'),
+    ('2018-03-23 09:00', '23 March at 9:00am'),
+    ('2018-03-23 15:00', '23 March at 3:00pm'),
+
+])
+def test_format_datetime_relative(time, human_readable_datetime):
+    with freeze_time('2018-03-21 12:00'):
+        assert format_datetime_relative(time) == human_readable_datetime


### PR DESCRIPTION
This was seen on the inbound conversation page for a text message:

![image](https://user-images.githubusercontent.com/5020841/37721515-a3d34646-2d21-11e8-9a4c-df79363a1cb6.png)


and add a billion tests to prove it works

Previously, we were looking at the day of the week - so messages sent six days ago would show up as "tomorrow". We now look at the actual date, so that won't happen again.

We were also subtracting an hour to make 00:00 this evening show up as "midnight today", despite it technically being tomorrow. However, this means that 00:59 tomorrow morning would show up as "00:59 today", a full day out. So reduce that to just a minute, so it doesn't affect other times of day.