### PR TITLE
Add alternative Food Standards Agency domain

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -37,6 +37,7 @@ environment-agency.gsi.gov.uk: environment-agency.gov.uk
 environment-agency.gov.uk:
   owner: Environment Agency
   agreement_signed: true
+food.gov.uk: foodstandards.gov.uk
 foodstandards.gsi.gov.uk: foodstandards.gov.uk
 foodstandards.gov.uk:
   owner: Food Standards Agency


### PR DESCRIPTION
Closes #1979

Jenkins can’t build that branch because there are brackets in the branch name…