### PR TITLE
add pagination to inbox page

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -105,7 +105,7 @@ def get_sms_thread(service_id, user_number):
         notification_api_client.get_notifications_for_service(service_id,
                                                               to=user_number,
                                                               template_type='sms')['notifications'] +
-        service_api_client.get_inbound_sms(service_id, user_number=user_number)
+        service_api_client.get_inbound_sms(service_id, user_number=user_number)['data']
     ), key=lambda notification: notification['created_at']):
 
         is_inbound = ('notify_number' in notification)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -261,13 +261,16 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def update_whitelist(self, service_id, data):
         return self.put(url='/service/{}/whitelist'.format(service_id), data=data)
 
-    def get_inbound_sms(self, service_id, user_number=''):
+    def get_inbound_sms(self, service_id, user_number='', page=None):
         return self.get(
-            '/service/{}/inbound-sms?user_number={}'.format(
+            '/service/{}/inbound-sms'.format(
                 service_id,
-                user_number,
-            )
-        )['data']
+            ),
+            params={
+                'user_number': user_number,
+                'page': page
+            }
+        )
 
     def get_inbound_sms_by_id(self, service_id, notification_id):
         return self.get(

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -1,4 +1,5 @@
 {% from "components/table.html" import list_table, field, hidden_field_heading, right_aligned_field_heading, row_heading %}
+{% from "components/previous-next-navigation.html" import previous_next_navigation %}
 {% from "components/message-count-label.html" import message_count_label %}
 
 <div class="ajax-block-container">
@@ -39,4 +40,7 @@
       from {{ count_of_users }} user{{ '' if 1 == count_of_users else 's' }}
     </p>
   {% endif %}
+
+  {{ previous_next_navigation(prev_page, next_page) }}
 </div>
+

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -196,13 +196,16 @@ def test_view_conversation_with_empty_inbound(
 ):
     mock_get_inbound_sms = mocker.patch(
         'app.main.views.conversation.service_api_client.get_inbound_sms',
-        return_value=[{
-            'user_number': '07900000001',
-            'notify_number': '07900000002',
-            'content': '',
-            'created_at': datetime.utcnow().isoformat(),
-            'id': fake_uuid
-        }]
+        return_value={
+            'has_next': False,
+            'data': [{
+                'user_number': '07900000001',
+                'notify_number': '07900000002',
+                'content': '',
+                'created_at': datetime.utcnow().isoformat(),
+                'id': fake_uuid
+            }]
+        }
     )
 
     page = client_request.get(

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -200,6 +200,27 @@ def test_inbox_showing_inbound_messages(
     )
 
 
+def test_get_inbound_sms_shows_page_links(
+    logged_in_client,
+    service_one,
+    mock_get_service_templates_when_no_templates_exist,
+    mock_get_jobs,
+    mock_get_detailed_service,
+    mock_get_template_statistics,
+    mock_get_usage,
+    mock_get_inbound_sms,
+    mock_get_inbound_number_for_service,
+):
+    service_one['permissions'] = ['inbound_sms']
+
+    response = logged_in_client.get(url_for('main.inbox', service_id=SERVICE_ONE_ID, page=2))
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert 'Next page' in page.find('li', {'class': 'next-page'}).text
+    assert 'Previous page' in page.find('li', {'class': 'previous-page'}).text
+
+
 def test_empty_inbox(
     logged_in_client,
     service_one,
@@ -222,6 +243,8 @@ def test_empty_inbox(
         'When users text your service’s phone number (0781239871) you’ll see the messages here'
     )
     assert not page.select('a[download]')
+    assert not page.select('li.next-page')
+    assert not page.select('li.previous-page')
 
 
 @pytest.mark.parametrize('endpoint', [
@@ -333,13 +356,16 @@ def test_download_inbox_strips_formulae(
 
     mocker.patch(
         'app.service_api_client.get_inbound_sms',
-        return_value=[{
-            'user_number': 'elevenchars',
-            'notify_number': 'foo',
-            'content': message_content,
-            'created_at': datetime.utcnow().isoformat(),
-            'id': fake_uuid,
-        }],
+        return_value={
+            'has_next': False,
+            'data': [{
+                'user_number': 'elevenchars',
+                'notify_number': 'foo',
+                'content': message_content,
+                'created_at': datetime.utcnow().isoformat(),
+                'id': fake_uuid,
+            }]
+        },
     )
     response = logged_in_client.get(
         url_for('main.inbox_download', service_id=SERVICE_ONE_ID)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1860,14 +1860,18 @@ def mock_get_inbound_sms(mocker):
     def _get_inbound_sms(
         service_id,
         user_number=None,
+        page=1
     ):
-        return [{
-            'user_number': '0790090000' + str(i),
-            'notify_number': '07900000002',
-            'content': 'message-{}'.format(index + 1),
-            'created_at': (datetime.utcnow() - timedelta(minutes=60 * (i + 1), seconds=index)).isoformat(),
-            'id': sample_uuid(),
-        } for index, i in enumerate([0, 0, 0, 2, 4, 6, 8, 8])]
+        return {
+            'has_next': True,
+            'data': [{
+                'user_number': '0790090000' + str(i),
+                'notify_number': '07900000002',
+                'content': 'message-{}'.format(index + 1),
+                'created_at': (datetime.utcnow() - timedelta(minutes=60 * (i + 1), seconds=index)).isoformat(),
+                'id': sample_uuid(),
+            } for index, i in enumerate([0, 0, 0, 2, 4, 6, 8, 8])]
+        }
 
     return mocker.patch(
         'app.service_api_client.get_inbound_sms',
@@ -1879,8 +1883,13 @@ def mock_get_inbound_sms(mocker):
 def mock_get_inbound_sms_with_no_messages(mocker):
     def _get_inbound_sms(
         service_id,
+        user_number=None,
+        page=1
     ):
-        return []
+        return {
+            'has_next': False,
+            'data': []
+        }
 
     return mocker.patch(
         'app.service_api_client.get_inbound_sms',


### PR DESCRIPTION
### Summary 
There was no pagination currently on the inbox pages, this lead to massive long lists of messages that were difficult to navigate. Pagination on every 50 has now been added to make this process easier. 

### Screenshot 
![image](https://user-images.githubusercontent.com/31617728/37899492-8ea730c8-30e3-11e8-89b5-9b6314f5fe21.png)
