### PR TITLE
Redirect to job if no session on send message

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -628,7 +628,15 @@ def start_job(service_id, upload_id):
     try:
         upload_data = session['file_uploads'][upload_id]
     except KeyError:
-        return redirect(url_for('main.choose_template', service_id=service_id), code=301)
+        return redirect(
+            url_for(
+                'main.view_job',
+                job_id=upload_id,
+                service_id=service_id,
+                help=request.form.get('help'),
+                just_sent='yes',
+            )
+        )
 
     if request.files or not upload_data.get('valid'):
         # The csv was invalid, validate the csv again

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2794,13 +2794,6 @@ def test_sms_sender_is_previewed(
             'template_type': 'email',
             'upload_id': fake_uuid()
         }
-    ),
-    (
-        'main.start_job',
-        'POST',
-        {
-            'upload_id': fake_uuid()
-        }
     )
 ])
 @pytest.mark.parametrize('session_data', [
@@ -2838,3 +2831,26 @@ def test_redirects_to_choose_template_if_no_session_exists_for_upload_id(
             _expected_status=301,
             _expected_redirect=url_for('main.choose_template', service_id=SERVICE_ONE_ID, _external=True)
         )
+
+
+def test_send_message_redirects_to_job_if_no_session(
+    client_request,
+
+):
+    with client_request.session_transaction() as session:
+        session['file_uploads'] = {}
+
+    client_request.post(
+        'main.start_job',
+        service_id=SERVICE_ONE_ID,
+        upload_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a4',
+        _expected_status=302,
+        _expected_redirect=url_for(
+            'main.view_job',
+            job_id='6ce466d0-fd6a-11e5-82f5-e0accb9d11a4',
+            service_id=SERVICE_ONE_ID,
+            help=None,
+            just_sent='yes',
+            _external=True
+        )
+    )


### PR DESCRIPTION
There have been issues with people being redirected to the choose templates page after they have pressed the send button. The only way this is possible is because the session id for their upload no longer exists, and we think this may be because the job has already been created and the session popped. To solve this issue, we will now redirect them straight to the job page, so as to not cause any confusion.