### PR TITLE
Add IPS to list of domains

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -140,6 +140,8 @@ trade.gsi.gov.uk: trade.gov.uk
 trade.gov.uk:
   owner: Department for International Trade
   agreement_signed: true
+ips.gsi.gov.uk: ips.gov.uk
+ips.gov.uk: hmpo.gov.uk
 hmpo.gov.uk: homeoffice.gov.uk
 hmpo.gsi.gov.uk: homeoffice.gov.uk
 homeoffice.gsi.gov.uk: homeoffice.gov.uk


### PR DESCRIPTION
Identity and Passport Service is the old name for HM Passport Office, but they still use the domain for their emails.

> Identity and Passport Service became Her Majesty's Passport Office in May 2013.

– https://www.gov.uk/government/organisations/identity-and-passport-service/about