### PR TITLE
Add page to show available letter branding

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -34,4 +34,5 @@ from app.main.views import (  # noqa
     notifications,
     inbound_number,
     agreement,
+    letter_branding,
 )

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -1,0 +1,26 @@
+from flask import render_template, send_file
+from flask_login import login_required
+
+from app.main import main
+from app.template_previews import get_letter_logo_file, get_letter_logos
+from app.utils import user_is_platform_admin
+
+
+@main.route("/letter-branding", methods=['GET'])
+@login_required
+@user_is_platform_admin
+def letter_branding():
+    return render_template(
+        'views/letter-branding/letter-branding.html',
+        logos=sorted(get_letter_logos().items()),
+    )
+
+
+@main.route("/letter-branding/<filename>", methods=['GET'])
+@login_required
+@user_is_platform_admin
+def letter_branding_logo(filename):
+    return send_file(
+        get_letter_logo_file(filename),
+        attachment_filename=filename
+    )

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 import requests
 from flask import current_app, json
 
@@ -43,3 +45,24 @@ def get_page_count_for_letter(template, values=None):
     page_count = json.loads(page_count.decode('utf-8'))['count']
 
     return page_count
+
+
+def get_letter_logos():
+    response = requests.get(
+        '{}/logos.json'.format(
+            current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+        ),
+        headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+    )
+    return json.loads(response.content)
+
+
+def get_letter_logo_file(filename):
+    response = requests.get(
+        '{}/static/images/letter-template/{}'.format(
+            current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+            filename
+        ),
+        headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+    )
+    return BytesIO(response.content)

--- a/app/templates/views/letter-branding/letter-branding.html
+++ b/app/templates/views/letter-branding/letter-branding.html
@@ -1,0 +1,27 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/radios.html" import radios, branding_radios %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block service_page_title %}
+  Select email branding
+{% endblock %}
+
+{% block platform_admin_content %}
+
+  <h1 class="heading-large">
+    <div>Letter branding</div>
+  </h1>
+  {% for id, filename in logos %}
+    <h2 class="heading-small">
+      {{id}}
+    </h2>
+    <p>
+      <img
+        src="{{ url_for('.letter_branding_logo', filename=filename) }}"
+        height="100"
+        class="bottom-gutter"
+      >
+    </p>
+  {% endfor %}
+
+{% endblock %}

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -18,6 +18,7 @@
           ('Organisations', url_for('main.organisations')),
           ('Providers', url_for('main.view_providers')),
           ('Email branding', url_for('main.email_branding')),
+          ('Letter branding', url_for('main.letter_branding')),
           ('Letter jobs', url_for('main.letter_jobs')),
           ('Inbound SMS numbers', url_for('main.inbound_sms_admin')),
           ('Email Complaints', url_for('main.platform_admin_list_complaints'))


### PR DESCRIPTION
This is a bit of a proof of concept. Later on we can extend it to add a ‘choose branding’ UI. Then we can update a service’s letter branding without having to do a DB migration.

![localhost_6012_letter-branding ipad](https://user-images.githubusercontent.com/355079/38039501-4b73f1e2-32a5-11e8-9cd3-e8d9c630d162.png)

---

Depends on:

- [x] https://github.com/alphagov/notifications-template-preview/pull/108