### PR TITLE
Don’t store info about bad uploads in session

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -623,6 +623,7 @@ def start_job(service_id, upload_id):
     try:
         upload_data = session['file_uploads'][upload_id]
     except KeyError:
+        current_app.logger.exception('upload_id not in session')
         return redirect(url_for('main.choose_template', service_id=service_id), code=301)
 
     if request.files or not upload_data.get('valid'):

--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -1,5 +1,11 @@
-{% macro file_upload(field, button_text="Choose file", alternate_link=None, alternate_link_text=None) %}
-  <form method="post" enctype="multipart/form-data" class="{% if field.errors %}form-group-error{% endif %}" data-module="file-upload">
+{% macro file_upload(
+  field,
+  action=None,
+  button_text="Choose file",
+  alternate_link=None,
+  alternate_link_text=None
+) %}
+  <form method="post" enctype="multipart/form-data" {% if action %}action="{{ action }}"{% endif %} class="{% if field.errors %}form-group-error{% endif %}" data-module="file-upload">
     <label class="file-upload-label" for="{{ field.name }}">
       <span class="visually-hidden">{{ field.label.text }}</span>
       {% if hint %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -135,7 +135,11 @@
       {% if request.args.from_test %}
         <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
       {% else %}
-        {{file_upload(form.file, button_text='Re-upload your file')}}
+        {{ file_upload(
+          form.file,
+          action=url_for('.send_messages', service_id=current_service.id, template_id=template.id),
+          button_text='Re-upload your file'
+        ) }}
       {% endif %}
     </div>
     <a href="#content" class="back-to-top-link">Back to top</a>

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -47,7 +47,11 @@
 
   <div class="js-stick-at-top-when-scrolling">
     <div class="form-group">
-      {{ file_upload(form.file, button_text='Re-upload your file') }}
+      {{ file_upload(
+        form.file,
+        action=url_for('.send_messages', service_id=current_service.id, template_id=template.id),
+        button_text='Re-upload your file'
+      ) }}
     </div>
     <a href="#content" class="back-to-top-link">Back to top</a>
   </div>


### PR DESCRIPTION
Because we now<sup>1</sup> store info about each file upload separately in the session the session isn’t overridden every time you upload a file. This is good because you can do multiple file uploads idempotently.

Generally we are cleaning up after ourselves because we pop anything to do with that upload from the session. However there is an edge case: if you never send the file then the info about the file stays in the session in perpetuity<sup>2</sup>. This is generally happening when people are
uploading files that are impossible to send, ie ones that have errors.

This is a problem because there is a limit to how much data we can store in the session<sup>3</sup>. I reckon that our sessions are eventually reaching this limit, and when they do the browser is silently refusing to store any more data in the session. This then stops the user from sending the job.

So this PR makes three changes:

1. Remove info about a file upload from the session as soon as we know that it contains errors.
2. `POST` reuploads to the same endpoint as initial uploads because otherwise we need to keep info about bad uploads in the session, which would prevent us from doing 1.
3. Add logging for when a user tries to send a job without the right info in the session so we can be alerted to it before our users alert us to it.

***

1. #1968
2. …or at least until the session is cleared by the user logging out
3. Generally 4kb