### PR TITLE
remove any old file upload data on sign in

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 from string import ascii_uppercase
 from zipfile import BadZipFile
 
@@ -92,6 +93,14 @@ def get_example_letter_address(key):
 @login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_messages(service_id, template_id):
+    # if there's lots of data in the session, lets log it for debugging purposes
+    # TODO: Remove this once we're confident we have session size under control
+    if len(session.get('file_uploads', {}).keys()) > 2:
+        current_app.logger.info('session contains large file_uploads - json_len {}, keys: {}'.format(
+            len(json.dumps(session['file_uploads'])),
+            session['file_uploads'].keys())
+        )
+
     session['sender_id'] = None
     db_template = service_api_client.get_service_template(service_id, template_id)['data']
 

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -100,7 +100,9 @@ def log_in_user(user_id):
         activated_user = user_api_client.activate_user(user)
         login_user(activated_user)
     finally:
+        # get rid of anything in the session that we don't expect to have been set during register/sign in flow
         session.pop("user_details", None)
+        session.pop("file_uploads", None)
 
     return redirect_when_logged_in(user_id)
 


### PR DESCRIPTION
if a user signs in again, clear their file upload data from any aborted journeys from before, so that their cookies don't fill up

also add some temporary logging when the session starts getting full.