### PR TITLE
Limit number of navigable financial years to 3

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -130,6 +130,7 @@ def template_usage(service_id):
         ),
         years=get_tuples_of_financial_years(
             partial(url_for, '.template_usage', service_id=service_id),
+            start=current_financial_year - 2,
             end=current_financial_year,
         ),
         selected_year=year
@@ -179,6 +180,7 @@ def monthly(service_id):
         ),
         years=get_tuples_of_financial_years(
             partial_url=partial(url_for, '.monthly', service_id=service_id),
+            start=current_financial_year - 2,
             end=current_financial_year,
         ),
         selected_year=year,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -472,6 +472,29 @@ def test_monthly_shows_letters_in_breakdown(
     assert normalize_spaces(columns[2].text) == 'letters'
 
 
+@pytest.mark.parametrize('endpoint', [
+    'main.monthly',
+    'main.template_usage',
+])
+@freeze_time("2015-01-01 15:15:15.000000")
+def test_stats_pages_show_last_3_years(
+    client_request,
+    endpoint,
+    mock_get_monthly_notification_stats,
+    mock_get_monthly_template_usage,
+):
+    page = client_request.get(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert normalize_spaces(page.select_one('.pill').text) == (
+        '2012 to 2013 financial year '
+        '2013 to 2014 financial year '
+        '2014 to 2015 financial year'
+    )
+
+
 def test_monthly_has_equal_length_tables(
     client_request,
     service_one,


### PR DESCRIPTION
Because more than 3 looks ugly.

## Before

![image](https://user-images.githubusercontent.com/355079/38264421-d8bc3392-376a-11e8-83be-de3a7d1f2389.png)

## After 

![image](https://user-images.githubusercontent.com/355079/38264433-e002375a-376a-11e8-921a-df3ab0a41005.png)
