### PR TITLE
Remove learning and skills council from domains

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -282,10 +282,6 @@ antrim.gov.uk:
   owner: Antrim Borough Council
   crown: false
   agreement_signed: false
-apprenticeships.gov.uk:
-  owner: Learning and Skills Council
-  crown: false
-  agreement_signed: false
 archifaugwent.gov.uk:
   owner: Blaenau Gwent County Borough Council
   crown: false


### PR DESCRIPTION
Because:
- they’re not a council
- they don’t exist any more (part of SFA, which has become ESFA)