### PR TITLE
Put template_id back in the session

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -547,6 +547,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
 
     if any(recipients) and not recipients.has_errors:
         session['file_uploads'][upload_id]['notification_count'] = len(recipients)
+        session['file_uploads'][upload_id]['template_id'] = str(template_id)
         session['file_uploads'][upload_id]['valid'] = True
     else:
         session['file_uploads'].pop(upload_id)

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1443,9 +1443,9 @@ def test_upload_csvfile_with_valid_phone_shows_all_numbers(
         follow_redirects=True
     )
     with logged_in_client.session_transaction() as sess:
-        assert 'template_id' not in sess['file_uploads'][fake_uuid]
         assert 'original_file_name' not in sess['file_uploads'][fake_uuid]
         assert sess['file_uploads'][fake_uuid]['notification_count'] == 53
+        assert sess['file_uploads'][fake_uuid]['template_id'] == fake_uuid
         assert sess['file_uploads'][fake_uuid]['valid'] is True
 
     content = response.get_data(as_text=True)


### PR DESCRIPTION
The start job endpoint needs the template ID in order to make the API call.

It doesn’t make sense to add it to the start job URL, because users could potentially start a job with the wrong template by hacking the URL (which would blow up at some point, if the template didn’t match the columns in the file).