### PR TITLE
Make send test letter preview use template ID

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -717,7 +717,7 @@ def make_and_upload_csv_file(service_id, template):
         '.check_messages',
         upload_id=upload_id,
         service_id=service_id,
-        template_type=template.template_type,
+        template_id=template.id,
         from_test=True,
         help=2 if get_help_argument() else 0
     ))


### PR DESCRIPTION
The check page expects template ID to be passed through in the URL not the session now. The send test letter page wasn’t changed.

This commit changes it, and adds a test to make sure this path is covered.