### PR TITLE
Fix missing `>` in delete confirmation

### DIFF
--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -13,7 +13,7 @@
     {% if delete_button %}
       <form method='post'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <button type="submit" class="button" name="delete">{{ delete_button }}</button
+        <button type="submit" class="button" name="delete">{{ delete_button }}</button>
       </form>
     {% endif %}
   </div>


### PR DESCRIPTION
It’s messing up the layout of the page (and is invalid HTML):

![image](https://user-images.githubusercontent.com/355079/38425826-d90f685c-39ac-11e8-82d9-028d4c667c2b.png)
