### PR TITLE
Be clearer about the templates needed to go live

### DIFF
--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -26,7 +26,7 @@
         ) }}
         {{ tick_cross_done_not_done(
           has_templates,
-          'Create some <a href="{}">templates</a>'.format(
+          'Create <a href="{}">templates</a> showing the kind of messages you plan to send'.format(
             url_for('main.choose_template', service_id=current_service.id)
           )|safe,
         ) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -460,9 +460,9 @@ def test_should_raise_duplicate_name_handled(
     (2, 'Done: Have more than one team member with the ‘Manage service’ permission'),
 ])
 @pytest.mark.parametrize('count_of_templates, expected_templates_checklist_item', [
-    (0, 'Not done: Create some templates'),
-    (1, 'Done: Create some templates'),
-    (2, 'Done: Create some templates'),
+    (0, 'Not done: Create templates showing the kind of messages you plan to send'),
+    (1, 'Done: Create templates showing the kind of messages you plan to send'),
+    (2, 'Done: Create templates showing the kind of messages you plan to send'),
 ])
 @pytest.mark.parametrize('count_of_email_templates, reply_to_email_addresses, expected_reply_to_checklist_item', [
     pytest.mark.xfail((0, [], ''), raises=IndexError),


### PR DESCRIPTION
Adding a ‘testing’ template is not enough. It needs to have some real looking content, so that we can:
- work out what a service is doing
- assess whether that’s a reasonable (ie meeting the terms of use) thing to be doing with Notify

At the moment we’re having to go back to services quite a lot when they request to go live and ask them for this stuff.

# Before

![image](https://user-images.githubusercontent.com/355079/38498306-e6805e64-3bfb-11e8-8adf-5b05f30cfc0c.png)

# After

![image](https://user-images.githubusercontent.com/355079/38498294-d73c9936-3bfb-11e8-94fd-dbce43c2c2df.png)

---

Wording by @thomchambers 