### PR TITLE
Add nhm.ac.uk to list of allowed domains

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -28,3 +28,4 @@
 - britishmuseum.org
 - derrystrabane.com
 - highwaysengland.co.uk
+- nhm.ac.uk


### PR DESCRIPTION
NHM is an executive non-departmental public body, sponsored by the Department for Digital, Culture, Media & Sport.

– https://www.gov.uk/government/organisations/natural-history-museum