### PR TITLE
Cache `GET /user` response in Redis

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -127,6 +127,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post('/service/{}/resume'.format(service_id), data=None)
 
     @cache.delete('service')
+    @cache.delete('user', key_from_args=[1])
     def remove_user_from_service(self, service_id, user_id):
         """
         Remove a user from a service

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -237,7 +237,5 @@ def test_deletes_service_cache(
 
     getattr(client, method)(*extra_args, **extra_kwargs)
 
-    assert mock_redis_delete.call_args_list == [
-        call('service-{}'.format(SERVICE_ONE_ID))
-    ]
+    assert call('service-{}'.format(SERVICE_ONE_ID)) in mock_redis_delete.call_args_list
     assert len(mock_request.call_args_list) == 1


### PR DESCRIPTION
In the same way, and for the same reasons that we’re caching the service object.

Here’s a sample of the data returned by the API – so we should make sure that any changes to this data invalidate the cache.

If we ever change a user’s phone number (for example) directly in the database, then ~~we will need to invalidate this cache manually.~~ it will be OK because the cache will be cleared when they log in.

```python
{  
   'data':{  
      'organisations':[  
         '4c707b81-4c6d-4d33-9376-17f0de6e0405'
      ],
      'logged_in_at':'2018-04-10T11:41:03.781990Z',
      'id':'2c45486e-177e-40b8-997d-5f4f81a461ca',
      'email_address':'test@example.gov.uk',
      'platform_admin':False,
      'password_changed_at':'2018-01-01 10:10:10.100000',
      'permissions':{  
         '42a9d4f2-1444-4e22-9133-52d9e406213f':[  
            'manage_api_keys',
            'send_letters',
            'manage_users',
            'manage_templates',
            'view_activity',
            'send_texts',
            'send_emails',
            'manage_settings'
         ],
         'a928eef8-0f25-41ca-b480-0447f29b2c20':[  
            'manage_users',
            'manage_templates',
            'manage_settings',
            'send_texts',
            'send_emails',
            'send_letters',
            'manage_api_keys',
            'view_activity'
         ],
      },
      'state':'active',
      'mobile_number':'07700900123',
      'failed_login_count':0,
      'name':'Example',
      'services':[  
         '6078a8c0-52f5-4c4f-b724-d7d1ff2d3884',
         '6afe3c1c-7fda-4d8d-aa8d-769c4bdf7803',
      ],
      'current_session_id':'fea2ade1-db0a-4c90-93e7-c64a877ce83e',
      'auth_type':'sms_auth'
   }
}
```