### PR TITLE
More agreement go live tweaks

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -226,7 +226,7 @@ def submit_request_to_go_live(service_id):
         except DeskproError:
             abort(500, "Request to go live submission failed")
 
-        flash('We’ve received your request to go live', 'default')
+        flash('Thanks for your request to go live. We’ll get back to you within one working day.', 'default')
         return redirect(url_for('.service_settings', service_id=service_id))
 
     return render_template('views/service-settings/submit-request-to-go-live.html', form=form)

--- a/app/templates/views/agreement.html
+++ b/app/templates/views/agreement.html
@@ -25,7 +25,7 @@
         <a href="{{ url_for('main.download_agreement') }}">Download the agreement</a>.
       </li>
       <li>
-        Get it signed by someone who has the authority to do so on behalf of {{ owner }}. Typically this is a director of digital or head of finance.
+        Get it signed by someone who has the authority to do so on behalf of {{ owner }}.
       </li>
       <li>
         Return the signed copy to <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -595,7 +595,7 @@ def test_should_redirect_after_request_to_go_live(
     assert 'Features: one off, file upload and API' in returned_message
 
     assert normalize_spaces(page.select_one('.banner-default').text) == (
-        'We’ve received your request to go live'
+        'Thanks for your request to go live. We’ll get back to you within one working day.'
     )
     assert normalize_spaces(page.select_one('h1').text) == (
         'Settings'


### PR DESCRIPTION
# Remove line about who can sign the agreement

It isn’t adding anything.

# Reword request to go live message 

We want to stop people writing support tickets that say something like “I’ve just submitted a request to go live, how long does the process take?”

![pasted image at 2018_04_12 01_11 pm](https://user-images.githubusercontent.com/355079/38676636-91f54468-3e53-11e8-893f-3b1393e8c54b.png)
