### PR TITLE
Delete caches when user accepts invite or creates service

### DIFF
--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 from app.notify_client.models import (
     InvitedUser,
     translate_permissions_from_admin_roles_to_db,
@@ -44,6 +44,8 @@ class InviteApiClient(NotifyAdminAPIClient):
         self.post(url='/service/{0}/invite/{1}'.format(service_id, invited_user_id),
                   data=data)
 
+    @cache.delete('service')
+    @cache.delete('user', key_from_args=[1])
     def accept_invite(self, service_id, invited_user_id):
         data = {'status': 'accepted'}
         self.post(url='/service/{0}/invite/{1}'.format(service_id, invited_user_id),

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -9,6 +9,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a" * 73, "b")
 
+    @cache.delete('user', key_from_args=[4])
     def create_service(
         self,
         service_name,

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 import pytest
 from tests.conftest import SERVICE_ONE_ID, fake_uuid
 
-from app import service_api_client, user_api_client
+from app import invite_api_client, service_api_client, user_api_client
 from app.notify_client.service_api_client import ServiceAPIClient
 
 
@@ -221,6 +221,7 @@ def test_returns_value_from_cache(
     (service_api_client, 'update_service_callback_api', [SERVICE_ONE_ID] + [''] * 4, {}),
     (service_api_client, 'create_service_callback_api', [SERVICE_ONE_ID] + [''] * 3, {}),
     (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, fake_uuid(), []], {}),
+    (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, fake_uuid()], {}),
 ])
 def test_deletes_service_cache(
     app_,

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -58,12 +58,12 @@ def test_client_creates_service_with_correct_data(
     mocker.patch('app.notify_client.current_user', id='123')
 
     client.create_service(
-        service_name='My first service',
-        organisation_type='central_government',
-        message_limit=1,
-        restricted=True,
-        user_id=fake_uuid,
-        email_from='test@example.com',
+        'My first service',
+        'central_government',
+        1,
+        True,
+        fake_uuid,
+        'test@example.com',
     )
     mock_post.assert_called_once_with(
         '/service',

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 import pytest
 from tests.conftest import SERVICE_ONE_ID, api_user_pending, fake_uuid
 
-from app import service_api_client, user_api_client
+from app import invite_api_client, service_api_client, user_api_client
 from app.notify_client.models import User
 
 user_id = fake_uuid()
@@ -248,6 +248,7 @@ def test_returns_value_from_cache(
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),
     (user_api_client, 'activate_user', [api_user_pending(fake_uuid())], {}),
     (service_api_client, 'remove_user_from_service', [SERVICE_ONE_ID, user_id], {}),
+    (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, user_id], {}),
 ])
 def test_deletes_user_cache(
     app_,

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -248,6 +248,7 @@ def test_returns_value_from_cache(
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),
     (user_api_client, 'activate_user', [api_user_pending(fake_uuid())], {}),
     (service_api_client, 'remove_user_from_service', [SERVICE_ONE_ID, user_id], {}),
+    (service_api_client, 'create_service', ['', '', 0, False, user_id, fake_uuid()], {}),
     (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, user_id], {}),
 ])
 def test_deletes_user_cache(


### PR DESCRIPTION
Accepting an invite changes:
- the `user_to_service` list of users returned by `GET /service/<id>`
- the `services` list return by `GET /user/<id>`

Creating a service changes:
- the `services` list return by `GET /user/<id>`

The latter change is causing the functional tests to fail.