### PR TITLE
Remove keyword args from call to create service

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -29,12 +29,12 @@ def _create_service(service_name, organisation_type, email_from, form):
     free_sms_fragment_limit = current_app.config['DEFAULT_FREE_SMS_FRAGMENT_LIMITS'].get(organisation_type)
     try:
         service_id = service_api_client.create_service(
-            service_name=service_name,
-            organisation_type=organisation_type,
-            message_limit=current_app.config['DEFAULT_SERVICE_LIMIT'],
-            restricted=True,
-            user_id=session['user_id'],
-            email_from=email_from,
+            service_name,
+            organisation_type,
+            current_app.config['DEFAULT_SERVICE_LIMIT'],
+            True,
+            session['user_id'],
+            email_from,
         )
         session['service_id'] = service_id
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -43,12 +43,12 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
     )
     assert mock_get_services_with_no_services.called
     mock_create_service.assert_called_once_with(
-        service_name='testing the post',
-        organisation_type='local',
-        message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
-        restricted=True,
-        user_id=api_user_active.id,
-        email_from='testing.the.post'
+        'testing the post',
+        'local',
+        app_.config['DEFAULT_SERVICE_LIMIT'],
+        True,
+        api_user_active.id,
+        'testing.the.post'
     )
     mock_create_service_template.assert_called_once_with(
         'Example text message template',
@@ -95,12 +95,12 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     )
     assert mock_get_services.called
     mock_create_service.assert_called_once_with(
-        service_name='testing the post',
-        organisation_type=organisation_type,
-        message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
-        restricted=True,
-        user_id=api_user_active.id,
-        email_from='testing.the.post'
+        'testing the post',
+        organisation_type,
+        app_.config['DEFAULT_SERVICE_LIMIT'],
+        True,
+        api_user_active.id,
+        'testing.the.post'
     )
     mock_create_or_update_free_sms_fragment_limit.assert_called_once_with(101, free_allowance)
     assert len(mock_create_service_template.call_args_list) == 0


### PR DESCRIPTION
The cache decorator doesn’t work with functions that use keyword arguments (at the moment).

---

I’ve checked that no other cached methods are being called with kwargs.