### PR TITLE
Fix broken anchor links from message status fields

### DIFF
--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -50,16 +50,16 @@
     <p>Notify won’t tell you if a user has opened or read a message.</p>
     <h3 class="heading-small">Sent internationally</h3>
     <p>You’ll see this when Notify sends a text message to an international number, but mobile networks in that country don’t provide delivery receipts.</p>
-    <h3 class="heading-small">Phone number or email address does not exist</h3>
+    <h3 class="heading-small" id="does-not-exist">Phone number or email address does not exist</h3>
     <p>You’ll see this when Notify couldn’t deliver a message because the email address or phone number was wrong.</p>
     <p>You should remove these email addresses or phone numbers from your database.</p>
     <p>You’ll still be charged for text messages to numbers that don’t exist.</p>
-    <h3 class="heading-small">Inbox/phone not accepting messages right now</h3>
+    <h3 class="heading-small" id="not-accepting-messages">Inbox/phone not accepting messages right now</h3>
     <p>You’ll see this if Notify can’t deliver an email or text message after trying for 72 hours.</p>
     <p>This might happen for a number of reasons. For example, the user’s inbox might be full, or their phone might be turned off.</p>
     <p>You can try sending the message again if you want.</p>
     <p>You’ll still be charged for text messages to phones that aren’t accepting messages.</p>
-    <h3 class="heading-small">Technical failure</h3>
+    <h3 class="heading-small" id="technical-failure">Technical failure</h3>
     <p>A technical failure means there’s a problem between Notify and our delivery providers. </p>
     <p>You’ll have to try sending your messages again. </p>
     <p>You won’t be charged for text messages that are affected by a technical failure.</p>


### PR DESCRIPTION
These IDs existed at some point but have been lost. They are needed because  we link to them from a failed message to give a bit more explanation.

Need to match here: https://github.com/alphagov/notifications-admin/blob/54e2c94d0923029745214ffda679f77dbfffead1/app/__init__.py#L394-L396

---

![image](https://user-images.githubusercontent.com/355079/39131741-17577e20-4708-11e8-8a1d-361229a966f6.png)
