### PR TITLE
Make Redis hold onto cached API responses longer

### DIFF
--- a/app/notify_client/cache.py
+++ b/app/notify_client/cache.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from functools import wraps
 from inspect import signature
 
-TTL = int(timedelta(hours=24).total_seconds())
+TTL = int(timedelta(days=7).total_seconds())
 
 
 def _get_argument(argument_name, client_method, args, kwargs):

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -175,7 +175,7 @@ def test_client_returns_count_of_service_templates(
                 call(
                     'service-{}'.format(SERVICE_ONE_ID),
                     '{"data_from": "api"}',
-                    ex=86400
+                    ex=604800,
                 )
             ],
             {'data_from': 'api'},
@@ -205,7 +205,7 @@ def test_client_returns_count_of_service_templates(
                 call(
                     'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
                     '{"data_from": "api"}',
-                    ex=86400
+                    ex=604800,
                 )
             ],
             {'data_from': 'api'},
@@ -235,7 +235,7 @@ def test_client_returns_count_of_service_templates(
                 call(
                     'template-{}-version-1'.format(FAKE_TEMPLATE_ID),
                     '{"data_from": "api"}',
-                    ex=86400
+                    ex=604800,
                 )
             ],
             {'data_from': 'api'},
@@ -265,7 +265,7 @@ def test_client_returns_count_of_service_templates(
                 call(
                     'service-{}-templates'.format(SERVICE_ONE_ID),
                     '{"data_from": "api"}',
-                    ex=86400
+                    ex=604800,
                 )
             ],
             {'data_from': 'api'},
@@ -295,7 +295,7 @@ def test_client_returns_count_of_service_templates(
                 call(
                     'template-{}-versions'.format(FAKE_TEMPLATE_ID),
                     '{"data_from": "api"}',
-                    ex=86400
+                    ex=604800,
                 )
             ],
             {'data_from': 'api'},

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -191,7 +191,7 @@ def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(a
                 call(
                     'user-{}'.format(user_id),
                     '{"data": "from api"}',
-                    ex=86400
+                    ex=604800
                 )
             ],
             'from api',


### PR DESCRIPTION
Redis is giving us a big performance boost (it’s roughly halved the median request time on the admin app):

![image](https://user-images.githubusercontent.com/355079/39139721-880adad8-471a-11e8-9fe3-19d4ba8f67ac.png)

---

Once we’re confident that it’s working properly<sup>1</sup> we can eke out a bit more performance from it by keeping the caches alive for longer. As far as I can tell we’re still using Redis in a very low-volume way<sup>2</sup>, so increasing the number of things we’re storing shouldn’t start taxing our Redis server at all. But reducing the number of times we have to hit the API to refresh the cache _should_ result in some performance increase.

---

1. ie we’re not seeing instances of stale caches not being invalidated

2. We have 2.5G of available space in Redis. Here is our current usage:
```
used_memory:7728960
used_memory_human:7.37M
used_memory_rss:7728960
used_memory_peak:16563776
used_memory_peak_human:15.79M
used_memory_lua:37888
```