### PR TITLE
Allow callbacks to be removed

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -829,9 +829,7 @@ class ServiceInboundNumberForm(StripWhitespaceForm):
 class CallbackForm(StripWhitespaceForm):
 
     def validate(self):
-        return super().validate() or (
-            self.url.data == '' and self.bearer_token.data == ''
-        )
+        return super().validate() or self.url.data == ''
 
 
 class ServiceReceiveMessagesCallbackForm(CallbackForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -826,7 +826,15 @@ class ServiceInboundNumberForm(StripWhitespaceForm):
     )
 
 
-class ServiceReceiveMessagesCallbackForm(StripWhitespaceForm):
+class CallbackForm(StripWhitespaceForm):
+
+    def validate(self):
+        return super().validate() or (
+            self.url.data == '' and self.bearer_token.data == ''
+        )
+
+
+class ServiceReceiveMessagesCallbackForm(CallbackForm):
     url = StringField(
         "URL",
         validators=[DataRequired(message='Can’t be empty'),
@@ -839,7 +847,7 @@ class ServiceReceiveMessagesCallbackForm(StripWhitespaceForm):
     )
 
 
-class ServiceDeliveryStatusCallbackForm(StripWhitespaceForm):
+class ServiceDeliveryStatusCallbackForm(CallbackForm):
     url = StringField(
         "URL",
         validators=[DataRequired(message='Can’t be empty'),

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -208,9 +208,11 @@ def delivery_status_callback(service_id):
     )
 
     if form.validate_on_submit():
-        if delivery_status_callback:
-            if (delivery_status_callback.get('url') != form.url.data
-                    or form.bearer_token.data != dummy_bearer_token):
+        if delivery_status_callback and form.url.data:
+            if (
+                delivery_status_callback.get('url') != form.url.data or
+                form.bearer_token.data != dummy_bearer_token
+            ):
                 service_api_client.update_service_callback_api(
                     service_id,
                     url=form.url.data,
@@ -218,7 +220,12 @@ def delivery_status_callback(service_id):
                     user_id=current_user.id,
                     callback_api_id=delivery_status_callback.get('id')
                 )
-        else:
+        elif delivery_status_callback and not form.url.data:
+            service_api_client.delete_service_callback_api(
+                service_id,
+                delivery_status_callback['id'],
+            )
+        elif form.url.data:
             service_api_client.create_service_callback_api(
                 service_id,
                 url=form.url.data,
@@ -255,9 +262,11 @@ def received_text_messages_callback(service_id):
     )
 
     if form.validate_on_submit():
-        if received_text_messages_callback:
-            if (received_text_messages_callback.get('url') != form.url.data
-                    or form.bearer_token.data != dummy_bearer_token):
+        if received_text_messages_callback and form.url.data:
+            if (
+                received_text_messages_callback.get('url') != form.url.data or
+                form.bearer_token.data != dummy_bearer_token
+            ):
                 service_api_client.update_service_inbound_api(
                     service_id,
                     url=form.url.data,
@@ -265,7 +274,12 @@ def received_text_messages_callback(service_id):
                     user_id=current_user.id,
                     inbound_api_id=received_text_messages_callback.get('id')
                 )
-        else:
+        elif received_text_messages_callback and not form.url.data:
+            service_api_client.delete_service_inbound_api(
+                service_id,
+                received_text_messages_callback['id'],
+            )
+        elif form.url.data:
             service_api_client.create_service_inbound_api(
                 service_id,
                 url=form.url.data,

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -232,6 +232,12 @@ def delivery_status_callback(service_id):
                 bearer_token=form.bearer_token.data,
                 user_id=current_user.id
             )
+        else:
+            # If no callback is set up and the user chooses to continue
+            # having no callback (ie both fields empty) then there’s
+            # nothing for us to do here
+            pass
+
         return redirect(url_for(back_link, service_id=service_id))
 
     return render_template(

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -332,6 +332,12 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             )
         )['data']
 
+    @cache.delete('service-{service_id}')
+    def delete_service_inbound_api(self, service_id, callback_api_id):
+        return self.delete("/service/{}/inbound-api/{}".format(
+            service_id, callback_api_id
+        ))
+
     def get_reply_to_email_addresses(self, service_id):
         return self.get(
             "/service/{}/email-reply-to".format(
@@ -462,6 +468,12 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         if bearer_token:
             data['bearer_token'] = bearer_token
         return self.post("/service/{}/delivery-receipt-api/{}".format(service_id, callback_api_id), data)
+
+    @cache.delete('service-{service_id}')
+    def delete_service_callback_api(self, service_id, callback_api_id):
+        return self.delete("/service/{}/delivery-receipt-api/{}".format(
+            service_id, callback_api_id
+        ))
 
     @cache.delete('service-{service_id}')
     def create_service_callback_api(self, service_id, url, bearer_token, user_id):

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -521,6 +521,7 @@ def test_callback_forms_validation(
         mock_get_empty_service_inbound_api,
     ), [], False),
 ])
+@pytest.mark.parametrize('bearer_token', ['', 'some-bearer-token'])
 @pytest.mark.parametrize('endpoint, expected_delete_url', [
     (
         'main.delivery_status_callback',
@@ -539,6 +540,7 @@ def test_callback_forms_can_be_cleared(
     delete_should_be_called,
     endpoint,
     expected_delete_url,
+    bearer_token,
     mocker,
 ):
 
@@ -555,7 +557,7 @@ def test_callback_forms_can_be_cleared(
         service_id=service_one['id'],
         _data={
             'url': '',
-            'bearer_token': '',
+            'bearer_token': bearer_token,
         },
         _expected_redirect=url_for(
             'main.api_callbacks',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2721,11 +2721,35 @@ def mock_get_valid_service_callback_api(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_empty_service_inbound_api(mocker):
+    return mocker.patch(
+        'app.service_api_client.get_service_inbound_api',
+        side_effect=lambda service_id, callback_api_id: None,
+    )
+
+
+@pytest.fixture(scope='function')
+def mock_get_empty_service_callback_api(mocker):
+    return mocker.patch(
+        'app.service_api_client.get_service_callback_api',
+        side_effect=lambda service_id, callback_api_id: None,
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_create_service_inbound_api(mocker):
     def _create_service_inbound_api(service_id, url, bearer_token, user_id):
         return
 
     return mocker.patch('app.service_api_client.create_service_inbound_api', side_effect=_create_service_inbound_api)
+
+
+@pytest.fixture(scope='function')
+def mock_delete_service_inbound_api(mocker):
+    return mocker.patch(
+        'app.service_api_client.delete_service_callback_api',
+        side_effect=lambda service_id: None
+    )
 
 
 @pytest.fixture(scope='function')
@@ -2742,6 +2766,14 @@ def mock_create_service_callback_api(mocker):
         return
 
     return mocker.patch('app.service_api_client.create_service_callback_api', side_effect=_create_service_callback_api)
+
+
+@pytest.fixture(scope='function')
+def mock_delete_service_callback_api(mocker):
+    return mocker.patch(
+        'app.service_api_client.delete_service_callback_api',
+        side_effect=lambda service_id: None
+    )
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
We’ve had a user who’s said:

> Seems configured callbacks cannot be removed once they’re set as the fields have a presence check. Is that intentional?

This means it’s not working as they expect. Rather than have to go and change stuff in the database for them, let’s make it work as they’d expect.

Only lets you clear the form if you remove both the token and the URL.