### PR TITLE
Upgrade GOV.UK template to newest version

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -51,6 +51,10 @@ gulp.task('copy:govuk_template:images', () => gulp.src(paths.template + 'assets/
   .pipe(gulp.dest(paths.dist + 'images/'))
 );
 
+gulp.task('copy:govuk_template:fonts', () => gulp.src(paths.template + 'assets/stylesheets/fonts/**/*')
+  .pipe(gulp.dest(paths.dist + 'fonts/'))
+);
+
 gulp.task('javascripts', () => gulp
   .src([
     paths.toolkit + 'javascripts/govuk/modules.js',
@@ -153,6 +157,7 @@ gulp.task('default',
   [
     'copy:govuk_template:template',
     'copy:govuk_template:images',
+    'copy:govuk_template:fonts',
     'copy:govuk_template:css',
     'copy:govuk_template:js',
     'copy:govuk_template:error_page',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "diff-dom": "2.3.1",
     "govuk-elements-sass": "3.1.x",
     "govuk_frontend_toolkit": "7.2.0",
-    "govuk_template_jinja": "0.23.0",
+    "govuk_template_jinja": "0.24.0",
     "gulp": "3.9.1",
     "gulp-add-src": "1.0.0",
     "gulp-babel": "7.0.0",


### PR DESCRIPTION
Changes: https://github.com/alphagov/govuk_template/compare/v0.23.0...v0.24.0

Includes a new way of serving the font files which will:
- save us ~300kb on non-cachd requests
- speed up the parsing of the CSS file