### PR TITLE
Store original filename as S3 metadata

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -558,7 +558,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
             valid=True,
             original_file_name=unicode_truncate(
                 request.args.get('original_file_name', ''),
-                1872
+                1600,
             ),
         )
     else:

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -46,6 +46,7 @@ from app.utils import (
     get_errors_for_csv,
     get_help_argument,
     get_template,
+    unicode_truncate,
     user_has_permissions,
 )
 
@@ -555,7 +556,10 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
             notification_count=len(recipients),
             template_id=str(template_id),
             valid=True,
-            original_file_name=request.args.get('original_file_name'),
+            original_file_name=unicode_truncate(
+                request.args.get('original_file_name', ''),
+                1872
+            ),
         )
     else:
         session['file_uploads'].pop(upload_id)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -589,9 +589,8 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
 @login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_messages(service_id, template_id, upload_id, row_index=2):
-    db_template = service_api_client.get_service_template(service_id, template_id)['data']
 
-    data = _check_messages(service_id, db_template['id'], upload_id, row_index)
+    data = _check_messages(service_id, template_id, upload_id, row_index)
 
     if (
         data['recipients'].too_many_rows or

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -555,6 +555,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
             notification_count=len(recipients),
             template_id=str(template_id),
             valid=True,
+            original_file_name=request.args.get('original_file_name'),
         )
     else:
         session['file_uploads'].pop(upload_id)

--- a/app/utils.py
+++ b/app/utils.py
@@ -568,3 +568,8 @@ class GovernmentEmailDomain(AgreementInfo):
             ))
         except StopIteration:
             raise NotGovernmentEmailDomain()
+
+
+def unicode_truncate(s, length):
+    encoded = s.encode('utf-8')[:length]
+    return encoded.decode('utf-8', 'ignore')

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -700,7 +700,7 @@ def test_file_name_truncated_to_fit_in_s3_metadata(
     assert sys.getsizeof(''.join((
         '{}{}'.format(key, value) for key, value in
         mock_s3_set_metadata.call_args_list[0][1].items()
-    )).encode('utf-8')) == 1998
+    )).encode('utf-8')) == 1724
 
 
 def test_show_all_columns_if_there_are_duplicate_recipient_columns(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -590,6 +590,7 @@ def test_upload_valid_csv_shows_preview_and_table(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         upload_id=fake_uuid,
+        original_file_name='example.csv',
         **extra_args
     )
 
@@ -599,6 +600,7 @@ def test_upload_valid_csv_shows_preview_and_table(
         notification_count=3,
         template_id=fake_uuid,
         valid=True,
+        original_file_name='example.csv',
     )
 
     assert page.h1.text.strip() == 'Preview of Two week reminder'
@@ -1506,6 +1508,7 @@ def test_upload_csvfile_with_valid_phone_shows_all_numbers(
         notification_count=53,
         template_id=fake_uuid,
         valid=True,
+        original_file_name='valid.csv',
     )
 
     content = response.get_data(as_text=True)

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import uuid
 from functools import partial
 from glob import glob
@@ -660,6 +661,46 @@ def test_upload_valid_csv_shows_preview_and_table(
         for index, cell in enumerate(row):
             row = page.select('table tbody tr')[row_index]
             assert normalize_spaces(str(row.select('td')[index + 1])) == cell
+
+
+def test_file_name_truncated_to_fit_in_s3_metadata(
+    client_request,
+    mocker,
+    mock_get_live_service,
+    mock_get_service_template_with_placeholders,
+    mock_get_users_by_service,
+    mock_get_detailed_service_for_today,
+    mock_s3_set_metadata,
+    fake_uuid,
+):
+
+    with client_request.session_transaction() as session:
+        session['file_uploads'] = {
+            fake_uuid: {'template_id': fake_uuid}
+        }
+
+    mocker.patch('app.main.views.send.s3download', return_value="""
+        phone number,name,thing,thing,thing
+        07700900001, A,   foo,  foo,  foo
+    """)
+
+    file_name = 'ü😁' * 2000
+
+    client_request.get(
+        'main.check_messages',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        upload_id=fake_uuid,
+        original_file_name=file_name,
+    )
+    assert sys.getsizeof(
+        file_name.encode('utf-8')
+    ) > 2000
+
+    assert sys.getsizeof(''.join((
+        '{}{}'.format(key, value) for key, value in
+        mock_s3_set_metadata.call_args_list[0][1].items()
+    )).encode('utf-8')) == 1998
 
 
 def test_show_all_columns_if_there_are_duplicate_recipient_columns(


### PR DESCRIPTION
By doing this we no longer have to store it in the request args. This is the last piece of metadata that’s currently posted to the API, so removing it means that all file metadata is passed by storing it in S3.