### PR TITLE
allow non-gov reply to email addresses

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -579,7 +579,7 @@ class ProviderForm(StripWhitespaceForm):
 
 
 class ServiceReplyToEmailForm(StripWhitespaceForm):
-    email_address = email_address(label='Email reply to address')
+    email_address = email_address(label='Email reply to address', gov_user=False)
     is_default = BooleanField("Make this email address the default")
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -891,7 +891,6 @@ def test_no_senders_message_shows(
 @pytest.mark.parametrize('reply_to_input, expected_error', [
     ('', 'Can’t be empty'),
     ('testtest', 'Enter a valid email address'),
-    ('test@hello.com', 'Enter a government email address. If you think you should have access contact us')
 ])
 def test_incorrect_reply_to_email_address_input(
     reply_to_input,
@@ -977,7 +976,7 @@ def test_add_reply_to_email_address(
     mock_add_reply_to_email_address
 ):
     fixture(mocker)
-    data['email_address'] = "test@example.gov.uk"
+    data['email_address'] = "test@example.com"
     client_request.post(
         'main.service_add_email_reply_to',
         service_id=SERVICE_ONE_ID,
@@ -986,7 +985,7 @@ def test_add_reply_to_email_address(
 
     mock_add_reply_to_email_address.assert_called_once_with(
         SERVICE_ONE_ID,
-        email_address="test@example.gov.uk",
+        email_address="test@example.com",
         is_default=api_default_args
     )
 


### PR DESCRIPTION
we reckon users will like to see gov reply-to email addresses because it will improve their confidence in the email.

however, some services, for a few complex reasons, don't want a gov reply to address. rather than add their specific domains to the whitelist for signups etc, just make reply tos allowed from any domain.

We vet reply-tos before services go live anyway.