### PR TITLE
Fix truncation message for large file

### DIFF
--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -190,7 +190,7 @@
 
   {% if recipients.too_many_rows %}
     <p class="table-show-more-link">
-      Can’t show the contents of this file
+        Only showing the first {{ count_of_displayed_recipients }} rows
     </p>
   {% elif count_of_displayed_recipients < count_of_recipients %}
     <p class="table-show-more-link">


### PR DESCRIPTION
We do show the initial rows now, so this is wrong:

![image](https://user-images.githubusercontent.com/355079/39512980-ae5ef7ec-4dea-11e8-91a1-53871fa3559c.png)

---

![image](https://user-images.githubusercontent.com/355079/39512970-a36c96fa-4dea-11e8-86db-c84f6e28af47.png)
