### PR TITLE
Make sure we always mock endpoints in tests

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -1,3 +1,5 @@
+from flask import request
+
 from app import events_api_client
 
 
@@ -6,17 +8,15 @@ def on_user_logged_in(sender, user):
 
 
 def _send_event(sender, **kwargs):
-    from flask import request
-    try:
-        event_data = _construct_event_data(request)
-        if kwargs.get('user'):
-            event_data['user_id'] = kwargs.get('user').id
-        if not kwargs.get('event_type'):
-            return
-        events_api_client.create_event(kwargs['event_type'], event_data)
-    except Exception as e:
-        sender.logger.error('Error creating event')
-        sender.logger.error(e)
+    if not kwargs.get('event_type'):
+        return
+
+    event_data = _construct_event_data(request)
+
+    if kwargs.get('user'):
+        event_data['user_id'] = kwargs.get('user').id
+
+    events_api_client.create_event(kwargs['event_type'], event_data)
 
 
 def _construct_event_data(request):

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -94,7 +94,9 @@ def get_conversation_partials(service_id, user_number):
 def get_user_number(service_id, notification_id):
     try:
         user_number = service_api_client.get_inbound_sms_by_id(service_id, notification_id)['user_number']
-    except HTTPError:
+    except HTTPError as e:
+        if e.status_code != 404:
+            raise
         user_number = notification_api_client.get_notification(service_id, notification_id)['to']
     return format_phone_number_human_readable(user_number)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import pytest
 import uuid
 
@@ -18,12 +19,13 @@ class TestClient(FlaskClient):
             session['user_id'] = user.id
         if mocker:
             mocker.patch('app.user_api_client.get_user', return_value=user)
-            mocker.patch('app.events_api_client.create_event')
         if mocker and service:
             with self.session_transaction() as session:
                 session['service_id'] = service['id']
             mocker.patch('app.service_api_client.get_service', return_value={'data': service})
-        login_user(user)
+
+        with patch('app.events_api_client.create_event'):
+            login_user(user)
 
     def logout(self, user):
         self.get(url_for("main.logout"))

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -373,6 +373,7 @@ def test_new_invited_user_verifies_and_added_to_service(
     mock_get_users_by_service,
     mock_get_detailed_service,
     mock_get_usage,
+    mock_create_event,
     mocker,
 ):
     # visit accept token page

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -141,14 +141,17 @@ def test_letter_notifications_should_show_client_reference(
 
 
 def test_should_show_api_page_for_live_service(
-    logged_in_client,
+    client_request,
     mock_login,
     api_user_active,
+    mock_get_notifications,
     mock_get_live_service,
     mock_has_permissions
 ):
-    response = logged_in_client.get(url_for('main.api_integration', service_id=str(uuid.uuid4())))
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    page = client_request.get(
+        'main.api_integration',
+        service_id=uuid.uuid4()
+    )
     assert 'Your service is in trial mode' not in page.find('main').text
 
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -555,13 +555,14 @@ def test_user_cant_invite_themselves(
 
 
 def test_no_permission_manage_users_page(
-    logged_in_client,
+    client_request,
     service_one,
+    mock_get_users_by_service,
+    mock_get_invites_for_service,
     api_user_active,
     mocker,
 ):
-    response = logged_in_client.get(url_for('main.manage_users', service_id=service_one['id']))
-    resp_text = response.get_data(as_text=True)
+    resp_text = client_request.get('main.manage_users', service_id=service_one['id'])
     assert url_for('.invite_user', service_id=service_one['id']) not in resp_text
     assert "Edit permission" not in resp_text
     assert "Team members" not in resp_text

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -239,6 +239,7 @@ def test_register_from_email_auth_invite(
     mock_send_verify_email,
     mock_send_verify_code,
     mock_accept_invite,
+    mock_create_event,
 ):
     sample_invite['auth_type'] = 'email_auth'
     with client.session_transaction() as session:
@@ -287,6 +288,7 @@ def test_can_register_email_auth_without_phone_number(
     mock_send_verify_email,
     mock_send_verify_code,
     mock_accept_invite,
+    mock_create_event,
 ):
     sample_invite['auth_type'] = 'email_auth'
     with client.session_transaction() as session:

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -192,14 +192,16 @@ def test_should_show_overview_for_service_with_more_things_set(
 
 
 def test_if_cant_send_letters_then_cant_see_letter_contact_block(
-        logged_in_client,
+        client_request,
         service_one,
+        single_reply_to_email_address,
+        no_letter_contact_blocks,
+        mock_get_service_organisation,
+        single_sms_sender,
         mock_get_service_settings_page_common,
 ):
-    response = logged_in_client.get(url_for(
-        'main.service_settings', service_id=service_one['id']
-    ))
-    assert 'Letter contact block' not in response.get_data(as_text=True)
+    response = client_request.get('main.service_settings', service_id=service_one['id'])
+    assert 'Letter contact block' not in response
 
 
 def test_letter_contact_block_shows_none_if_not_set(

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -26,6 +26,7 @@ def test_should_login_user_and_should_redirect_to_next_url(
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
+    mock_create_event,
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -48,6 +49,7 @@ def test_should_login_user_and_not_redirect_to_external_url(
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services_with_one_service,
+    mock_create_event,
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -65,6 +67,7 @@ def test_should_login_user_and_redirect_to_show_accounts(
     mock_get_user,
     mock_get_user_by_email,
     mock_check_verify_code,
+    mock_create_event,
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -100,6 +103,7 @@ def test_should_login_user_when_multiple_valid_codes_exist(
     mock_get_user_by_email,
     mock_check_verify_code,
     mock_get_services_with_one_service,
+    mock_create_event,
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -117,6 +121,7 @@ def test_two_factor_should_set_password_when_new_password_exists_in_session(
     mock_check_verify_code,
     mock_get_services_with_one_service,
     mock_update_user_password,
+    mock_create_event,
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -166,6 +171,7 @@ def test_two_factor_should_activate_pending_user(
     mocker,
     api_user_pending,
     mock_check_verify_code,
+    mock_create_event,
     mock_activate_user,
 ):
     mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)
@@ -186,7 +192,8 @@ def test_valid_two_factor_email_link_logs_in_user(
     valid_token,
     mock_get_user,
     mock_get_services_with_one_service,
-    mocker
+    mocker,
+    mock_create_event,
 ):
     mocker.patch('app.user_api_client.check_verify_code', return_value=(True, ''))
 

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -32,7 +32,8 @@ def test_should_redirect_to_add_service_when_sms_code_is_correct(
     mocker,
     mock_update_user_attribute,
     mock_check_verify_code,
-    fake_uuid
+    mock_create_event,
+    fake_uuid,
 ):
     api_user_active.current_session_id = str(uuid.UUID(int=1))
     mocker.patch('app.user_api_client.get_user', return_value=api_user_active)
@@ -60,6 +61,7 @@ def test_should_activate_user_after_verify(
     api_user_pending,
     mock_send_verify_code,
     mock_check_verify_code,
+    mock_create_event,
     mock_activate_user,
 ):
     mocker.patch('app.user_api_client.get_user', return_value=api_user_pending)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1886,6 +1886,20 @@ def mock_get_inbound_sms(mocker):
     )
 
 
+@pytest.fixture
+def mock_get_inbound_sms_by_id_with_no_messages(mocker):
+    def _get_inbound_sms_by_id(
+        service_id,
+        notification_id
+    ):
+        raise HTTPError(response=Mock(status_code=404))
+
+    return mocker.patch(
+        'app.service_api_client.get_inbound_sms_by_id',
+        side_effect=_get_inbound_sms_by_id,
+    )
+
+
 @pytest.fixture(scope='function')
 def mock_get_most_recent_inbound_sms(mocker):
     def _get_most_recent_inbound_sms(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2923,3 +2923,14 @@ def mock_get_organisations_and_services_for_user(mocker, organisation_one, api_u
         'app.user_api_client.get_organisations_and_services_for_user',
         side_effect=_get_orgs_and_services
     )
+
+
+@pytest.fixture
+def mock_create_event(mocker):
+    """
+    This should be used whenever your code is calling `flask_login.login_user`
+    """
+    def _add_event(event_type, event_data):
+        return
+
+    return mocker.patch('app.events_api_client.create_event', side_effect=_add_event)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1678,6 +1678,14 @@ def mock_get_job(mocker, api_user_active):
     return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)
 
 
+@pytest.fixture
+def mock_get_job_doesnt_exist(mocker):
+    def _get_job(service_id, job_id):
+        raise HTTPError(response=Mock(status_code=404, json={}), message={})
+
+    return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)
+
+
 @pytest.fixture(scope='function')
 def mock_get_scheduled_job(mocker, api_user_active):
     def _get_job(service_id, job_id):


### PR DESCRIPTION
* `client_request` always asserts on the response code. This makes it so much safer than `client` or `logged_in_client`, which don't.
* events api is called during login - so make the login method always patch it. And make it not catch and discard exceptions.
* avoid using suppress or a blanket except for `HTTPError`. We want to catch 404s, but not 503s.

please look at the commits separately i spent ages rebasing them