### PR TITLE
fix usage page sms rate calculation

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -377,10 +377,13 @@ def get_dashboard_totals(statistics):
 
 
 def calculate_usage(usage, free_sms_fragment_limit):
+    sms_breakdowns = [breakdown for breakdown in usage if breakdown['notification_type'] == 'sms']
+
+    # this relies on the assumption: only one SMS rate per financial year.
+    sms_rate = 0 if len(sms_breakdowns) == 0 else sms_breakdowns[0].get("rate", 0)
+    sms_sent = get_sum_billing_units(sms_breakdowns)
     sms_free_allowance = free_sms_fragment_limit
 
-    sms_rate = 0 if len(usage) == 0 else usage[0].get("rate", 0)
-    sms_sent = get_sum_billing_units(breakdown for breakdown in usage if breakdown['notification_type'] == 'sms')
     emails = [breakdown["billing_units"] for breakdown in usage if breakdown['notification_type'] == 'email']
     emails_sent = 0 if len(emails) == 0 else emails[0]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2181,6 +2181,8 @@ def mock_get_template_statistics_for_template(mocker, service_one):
 def mock_get_usage(mocker, service_one, fake_uuid):
     def _get_usage(service_id, year=None):
         return [
+            {"international": False, "rate": 0.00, "notification_type": "email",
+             "rate_multiplier": None, "billing_units": 1000},
             {"international": False, "rate": 0.0165, "rate_multiplier": 1,
              "notification_type": "sms", "billing_units": 251500},
             {"international": True, "rate": 0.0165, "rate_multiplier": 1,
@@ -2189,8 +2191,6 @@ def mock_get_usage(mocker, service_one, fake_uuid):
              "notification_type": "sms", "billing_units": 150},
             {"international": True, "rate": 0.0165, "rate_multiplier": 3,
              "notification_type": "sms", "billing_units": 30},
-            {"international": False, "rate": 0.0165, "notification_type": "email",
-             "rate_multiplier": None, "billing_units": 1000}
         ]
 
     return mocker.patch(


### PR DESCRIPTION
usage page used to make the assumption that the first row of the usage stats would always be SMS. This now isn't always the case, so make sure when working out the rate, it only looks at sms rows. Specifically, it takes the rate from the first stats row. This makes a big assumption that all the rows will have the same rate per financial year.