### PR TITLE
Allow users to preview all letters in trial mode

### DIFF
--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -168,7 +168,7 @@
               (not errors or recipients.more_rows_than_can_send) and
               displayed_index != preview_row
             ) %}
-              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=displayed_index) }}">{{ displayed_index }}</a>
+              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=displayed_index, original_file_name=original_file_name) }}">{{ displayed_index }}</a>
             {% else %}
               {{ displayed_index }}
             {% endif %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -162,7 +162,16 @@
       ) %}
         {% call index_field() %}
           <span>
-            {{ item.index + 2 }}
+            {% set displayed_index = item.index + 2 %}
+            {% if (
+              trying_to_send_letters_in_trial_mode and
+              (not errors or recipients.more_rows_than_can_send) and
+              displayed_index != preview_row
+            ) %}
+              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=displayed_index) }}">{{ displayed_index }}</a>
+            {% else %}
+              {{ displayed_index }}
+            {% endif %}
           </span>
         {% endcall %}
         {% for column in column_headers %}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -63,7 +63,7 @@
             {% if (item.index + 2) == preview_row %}
               {{ item.index + 2 }}
             {% else %}
-              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=(item.index + 2)) }}">{{ item.index + 2 }}</a>
+              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=(item.index + 2), original_file_name=original_file_name) }}">{{ item.index + 2 }}</a>
             {% endif %}
           </span>
         {% endcall %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -615,7 +615,12 @@ def test_upload_valid_csv_shows_preview_and_table(
 
     if expected_link_in_first_row:
         assert page.select_one('.table-field-index a')['href'] == url_for(
-            'main.check_messages', service_id=SERVICE_ONE_ID, template_id=fake_uuid, upload_id=fake_uuid, row_index=2
+            'main.check_messages',
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            upload_id=fake_uuid,
+            row_index=2,
+            original_file_name='example.csv',
         )
     else:
         assert not page.select_one('.table-field-index').select_one('a')

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2168,7 +2168,8 @@ def test_check_messages_shows_trial_mode_error(
 ])
 @pytest.mark.parametrize('number_of_rows, expected_error_message', [
     (1, 'You can’t send this letter'),
-    (111, 'You can’t send these letters'),
+    (11, 'You can’t send these letters'),  # Less than trial mode limit
+    (111, 'You can’t send these letters'),  # More than trial mode limit
 ])
 def test_check_messages_shows_trial_mode_error_for_letters(
     client_request,
@@ -2219,6 +2220,9 @@ def test_check_messages_shows_trial_mode_error_for_letters(
     else:
         assert not error
 
+    if number_of_rows > 1:
+        assert page.select_one('.table-field-index a').text == '3'
+
 
 def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
     mocker,
@@ -2233,6 +2237,7 @@ def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
 
     mocker.patch('app.main.views.send.s3download', return_value='\n'.join(
         ['address_line_1,address_line_2,postcode,'] +
+        ['              ,              ,11SW1 1AA'] +
         ['              ,              ,11SW1 1AA']
     ))
 
@@ -2255,9 +2260,10 @@ def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
         'There is a problem with example.xlsx '
-        'You need to enter missing data in 1 row '
+        'You need to enter missing data in 2 rows '
         'Skip to file contents'
     )
+    assert not page.select('.table-field-index a')
 
 
 def test_check_messages_column_error_doesnt_show_optional_columns(


### PR DESCRIPTION
If you’re in trial mode you can’t send letters for real. But you can still upload a spreadsheet with multiple rows, and there’s no reason why you shouldn’t be able to explore how Notify populates the letter for each row of the spreadsheet (since this is something we let you do when you can send the messages for real).

---

![image](https://user-images.githubusercontent.com/355079/40300880-6c0a461a-5ce2-11e8-9180-95252723d2d8.png)
