### PR TITLE
Use new tech docs format for Java client

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -12,7 +12,7 @@
 	<h1 class="heading-large"> Documentation </h1>
 	<p>Integrate with the GOV.UK Notify API using one of our clients (links open in a new tab):</p>
 	<ul class="list list-bullet">
-      <li><a href="https://github.com/alphagov/notifications-java-client" target="_blank" rel="noopener">Java</a></li>
+      <li><a href="https://docs.notifications.service.gov.uk/java.html" target="_blank" rel="noopener">Java</a></li>
       <li><a href="https://github.com/alphagov/notifications-net-client" target="_blank" rel="noopener">.NET</a></li>
       <li><a href="https://github.com/alphagov/notifications-node-client" target="_blank" rel="noopener">Node JS</a></li>
       <li><a href="https://github.com/alphagov/notifications-php-client" target="_blank" rel="noopener">PHP</a></li>


### PR DESCRIPTION
Because it’s (nearly) ready to go now.