### PR TITLE
Show contact link on service settings page

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -265,3 +265,9 @@ a.table-show-more-link {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.truncate-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -78,7 +78,7 @@
   </td>
 {%- endmacro %}
 
-{% macro text_field(text, status='') -%}
+{% macro text_field(text, status='', truncate=false) -%}
   {% call field(status=status) %}
     {% if text is iterable and text is not string %}
       <ul class="list list-bullet">
@@ -89,15 +89,20 @@
         {% endfor %}
       </ul>
     {% else %}
-      {{ text }}
+      {% if truncate %}
+        <div class="truncate-text" title="{{ text }}">{{text}}</div>
+      {% else %}
+        {{ text }}
+      {% endif %}
     {% endif %}
   {% endcall %}
 {%- endmacro %}
 
-{% macro optional_text_field(text, default='Not set') -%}
+{% macro optional_text_field(text, default='Not set', truncate=false) -%}
   {{ text_field(
     text or default,
-    status='' if text else 'default'
+    status='' if text else 'default',
+    truncate=truncate
   ) }}
 {%- endmacro %}
 

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -19,13 +19,13 @@
 	  ) %}
 	    {% call row() %}
 	      {{ text_field('Callbacks for delivery receipts') }}
-	      {{ optional_text_field(delivery_status_callback) }}
+	      {{ optional_text_field(delivery_status_callback, truncate=true) }}
 	      {{ edit_field('Change', url_for('.delivery_status_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 
 	    {% call row() %}
 	      {{ text_field('Callbacks for received text messages') }}
-          {{ optional_text_field(received_text_messages_callback) }}
+          {{ optional_text_field(received_text_messages_callback, truncate=true) }}
 	   	  {{ edit_field('Change', url_for('.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 	  {% endcall %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -49,7 +49,7 @@
         {% if 'upload_document' in current_service.permissions %}
         {% call row() %}
           {{ text_field('Contact link') }}
-          {{ text_field(current_service.contact_link) }}
+          {{ text_field(current_service.contact_link, truncate=true) }}
           {{ edit_field(
               'Change',
               url_for('.service_set_contact_link',

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -46,6 +46,20 @@
           }}
         {% endcall %}
 
+        {% if 'upload_document' in current_service.permissions %}
+        {% call row() %}
+          {{ text_field('Contact link') }}
+          {{ text_field(current_service.contact_link) }}
+          {{ edit_field(
+              'Change',
+              url_for('.service_set_contact_link',
+              service_id=current_service.id),
+              permissions=['manage_service']
+            )
+          }}
+        {% endcall %}
+        {% endif %}
+
       {% endcall %}
 
       {% call mapping_table(

--- a/app/templates/views/service-settings/contact_link.html
+++ b/app/templates/views/service-settings/contact_link.html
@@ -3,13 +3,15 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Change link on ‘Download your document’ page
+  {{ 'Change link on' if 'upload_document' in current_service.permissions else 'Add link for' }} ‘Download your document’ page
 {% endblock %}
 
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Change link on ‘Download your document’ page</h1>
+      <h1 class="heading-large">
+        {{ 'Change link on' if 'upload_document' in current_service.permissions else 'Add link for' }} ‘Download your document’ page
+      </h1>
       <p>
         When you send users a document to download, you need to include a link to your service
         on the download page. This is so users can contact you if there’s a problem (for example,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1977,6 +1977,77 @@ def test_switch_service_enable_international_sms(
     assert mocked_fn.call_args[0][0] == service_one['id']
 
 
+@pytest.mark.parametrize('start_permissions, contact_link, end_permissions', [
+    (['upload_document'], 'http://example.com/', []),
+    (['upload_document'], None, []),
+    ([], 'http://example.com/', ['upload_document']),
+])
+def test_service_switch_can_upload_document_changes_the_permission_if_not_adding_the_permission_without_a_contact_link(
+    logged_in_platform_admin_client,
+    service_one,
+    mock_update_service,
+    mock_get_service_settings_page_common,
+    mock_get_service_organisation,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    single_sms_sender,
+    start_permissions,
+    contact_link,
+    end_permissions,
+):
+    service_one['permissions'] = start_permissions
+    service_one['contact_link'] = contact_link
+
+    response = logged_in_platform_admin_client.get(
+        url_for('main.service_switch_can_upload_document', service_id=SERVICE_ONE_ID),
+        follow_redirects=True
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert service_one['permissions'] == end_permissions
+    assert page.h1.text.strip() == 'Settings'
+
+
+def test_service_switch_can_upload_document_turning_permission_on_with_no_contact_link_shows_link_form(
+    logged_in_platform_admin_client,
+    service_one,
+    mock_get_service_settings_page_common,
+    mock_get_service_organisation,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    single_sms_sender,
+):
+    response = logged_in_platform_admin_client.get(
+        url_for('main.service_switch_can_upload_document', service_id=SERVICE_ONE_ID),
+        follow_redirects=True
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert 'upload_document' not in service_one['permissions']
+    assert page.h1.text.strip() == "Add link for ‘Download your document’ page"
+
+
+def test_service_switch_can_upload_document_lets_contact_link_be_added_and_switches_permission(
+    logged_in_platform_admin_client,
+    service_one,
+    mock_update_service,
+    mock_get_service_settings_page_common,
+    mock_get_service_organisation,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    single_sms_sender,
+):
+    response = logged_in_platform_admin_client.post(
+        url_for('main.service_switch_can_upload_document', service_id=SERVICE_ONE_ID),
+        data={'url': 'http://example.com/'},
+        follow_redirects=True
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert 'upload_document' in service_one['permissions']
+    assert page.h1.text.strip() == 'Settings'
+
+
 def test_archive_service_after_confirm(
     logged_in_platform_admin_client,
     service_one,
@@ -2200,7 +2271,7 @@ def test_service_set_contact_link_does_not_update_invalid_link(
         _follow_redirects=True
     )
 
-    assert page.h1.text == "Change link on ‘Download your document’ page"
+    assert page.h1.text.strip() == "Add link for ‘Download your document’ page"
     update_mock.assert_not_called()
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2204,6 +2204,39 @@ def test_service_set_contact_link_does_not_update_invalid_link(
     update_mock.assert_not_called()
 
 
+def test_contact_link_is_displayed_with_upload_document_permission(
+    logged_in_client,
+    service_one,
+    mock_get_service_settings_page_common,
+    mock_get_service_organisation,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    single_sms_sender,
+):
+    service_one['permissions'] = ['upload_document']
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert 'Contact link' in page.text
+
+
+def test_contact_link_is_not_displayed_without_the_upload_document_permission(
+    logged_in_client,
+    service_one,
+    mock_get_service_settings_page_common,
+    mock_get_service_organisation,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    single_sms_sender,
+):
+    response = logged_in_client.get(url_for('main.service_settings', service_id=service_one['id']))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert response.status_code == 200
+    assert 'Contact link' not in page.text
+
+
 @pytest.mark.parametrize('endpoint, permissions, expected_p', [
     (
         'main.service_set_inbound_sms',


### PR DESCRIPTION
The contact link for a service is now displayed on the service settings page if the service has the `upload_document` permission. When adding the `upload_document` permission, the user will be taken to the form to add a contact link if the service doesn't already have one. If the service does already have a contact link, the platform admin button will toggle the permission on or off.

#### Settings page with the changes - 
<img width="818" alt="screen shot 2018-06-07 at 11 29 38" src="https://user-images.githubusercontent.com/12881990/41104455-49ece5ea-6a63-11e8-9043-f6d93a09de15.png">
