### PR TITLE
Don’t duplicate columns in example spreadsheet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ notifications-python-client==4.8.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.0.0#egg=notifications-utils==29.0.0
+git+https://github.com/alphagov/notifications-utils.git@29.1.0#egg=notifications-utils==29.1.0

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -262,6 +262,25 @@ def test_should_not_allow_files_to_be_uploaded_without_the_correct_permission(
     )
 
 
+def test_example_spreadsheet(
+    client_request,
+    mock_get_service_template_with_placeholders_same_as_recipient,
+    fake_uuid,
+):
+
+    page = client_request.get(
+        '.send_messages',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid
+    )
+
+    assert normalize_spaces(
+        page.select_one('tbody tr').text
+    ) == (
+        '1 phone number name date'
+    )
+
+
 @pytest.mark.parametrize(
     "filename, acceptable_file",
     list(zip(test_spreadsheet_files, repeat(True))) +
@@ -1541,7 +1560,7 @@ def test_download_example_csv(
     api_user_active,
     mock_login,
     mock_get_service,
-    mock_get_service_template,
+    mock_get_service_template_with_placeholders_same_as_recipient,
     mock_has_permissions,
     fake_uuid
 ):
@@ -1551,7 +1570,10 @@ def test_download_example_csv(
         follow_redirects=True
     )
     assert response.status_code == 200
-    assert response.get_data(as_text=True) == 'phone number\r\n07700 900321\r\n'
+    assert response.get_data(as_text=True) == (
+        'phone number,name,date\r\n'
+        '07700 900321,example,example\r\n'
+    )
     assert 'text/csv' in response.headers['Content-Type']
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -831,6 +831,20 @@ def mock_get_service_template_with_placeholders(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_service_template_with_placeholders_same_as_recipient(mocker):
+    def _get(service_id, template_id):
+        template = template_json(
+            service_id, template_id, "Two week reminder", "sms", "((name)) ((date)) ((PHONENUMBER))"
+        )
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template',
+        side_effect=_get
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_service_email_template(mocker, content=None, subject=None, redact_personalisation=False):
     def _get(service_id, template_id, version=None):
         template = template_json(


### PR DESCRIPTION
If a template has a placeholder like `((email address))` then the sample spreadsheet and CSV file have the email column twice.

Trying to upload this spreadsheet will result in a ‘duplicate column’ error.

This commit fixes it so that the column will only appear once.