### PR TITLE
Bump utils to link URLs in text message previews

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ notifications-python-client==4.8.2
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.1.0#egg=notifications-utils==29.1.0
+git+https://github.com/alphagov/notifications-utils.git@29.3.0#egg=notifications-utils==29.3.0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/355079/41538103-4e18da0a-7302-11e8-9bb5-ef9b999ed168.png)

---

Brings in: https://github.com/alphagov/notifications-utils/pull/492

Changes: https://github.com/alphagov/notifications-utils/compare/29.1.0...autolink-sms