### PR TITLE
disable gunicorn access logs

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,5 +1,12 @@
+import os
 import sys
 import traceback
+
+workers = 5
+worker_class = "eventlet"
+errorlog = "/home/vcap/logs/gunicorn_error.log"
+bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+disable_redirect_access_to_syslog = True
 
 
 def worker_abort(worker):

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -5,10 +5,6 @@ command: >
   scripts/run_app_paas.sh
   gunicorn
   -c /home/vcap/app/gunicorn_config.py
-  --error-logfile /home/vcap/logs/gunicorn_error.log
-  -w 5
-  -b 0.0.0.0:$PORT
-  -k eventlet
   application
 
 instances: 1


### PR DESCRIPTION
they're turning up in syslog, which means they're getting into kibana now

also move config settings from manifest to gunicorn_config.py