### PR TITLE
Add the download activity link for notifications

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -7,12 +7,12 @@ from datetime import datetime
 from flask import (
     Response,
     abort,
+    current_app,
     jsonify,
     render_template,
     request,
     stream_with_context,
     url_for,
-    current_app
 )
 from flask_login import login_required
 from notifications_python_client.errors import APIError

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -12,6 +12,7 @@ from flask import (
     request,
     stream_with_context,
     url_for,
+    current_app
 )
 from flask_login import login_required
 from notifications_python_client.errors import APIError
@@ -178,7 +179,8 @@ def download_notifications_csv(service_id):
                 page=request.args.get('page', 1),
                 page_size=5000,
                 format_for_csv=True,
-                template_type=filter_args.get('message_type')
+                template_type=filter_args.get('message_type'),
+                limit_days=current_app.config['ACTIVITY_STATS_LIMIT_DAYS'],
             )
         ),
         mimetype='text/csv',

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -47,6 +47,11 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
   {% endif %}
+  <p class="bottom-gutter">
+     <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+     &emsp;
+     Data available for 7 days
+  </p>
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),

--- a/app/utils.py
+++ b/app/utils.py
@@ -149,13 +149,12 @@ def generate_notifications_csv(**kwargs):
                 ]
             else:
                 values = [
-                    notification['to'],
-                    notification['template']['name'],
-                    notification['template']['template_type'],
-                    notification.get('job_name', None),
+                    notification['recipient'],
+                    notification['template_name'],
+                    notification['template_type'],
+                    notification['job_name'],
                     notification['status'],
-                    notification['created_at'],
-                    notification['updated_at']
+                    notification['created_at']
                 ]
             yield Spreadsheet.from_rows([map(str, values)]).as_csv_data
 


### PR DESCRIPTION
This works locally for a long running request and a large number of messages. However I suspect that nginx may be timing out the request. I'd like to try this on staging.