### PR TITLE
Remove GUNICORN_CMD_ARGS before we start our app

### DIFF
--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -2,6 +2,7 @@
 
 buildpack: python_buildpack
 command: >
+  unset GUNICORN_CMD_ARGS;
   scripts/run_app_paas.sh
   gunicorn
   -c /home/vcap/app/gunicorn_config.py


### PR DESCRIPTION
Cloudfoundry adds this env var which forces gunicorn to print
its access log to stdout because reasons.

This also takes precedence over *anything* we put in our config file,
including disabling the access logs.

Related commit:
https://github.com/cloudfoundry/python-buildpack/commit/7b350f292a6c42d7f00c87820bf3fa0fe79872db#diff-153f90501612878d9c6fcd50247547bcR526