### PR TITLE
Add guidance about horizontal lines

### DIFF
--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,27 +1,41 @@
 <h2 class="heading-medium">Formatting</h2>
-<p>
+<p class="bottom-gutter-1-3">
   To put a title in your template, use a hash:
 </p>
-<div class="panel panel-border-wide">
+<div class="panel panel-border-wide bottom-gutter">
   <p>
     # This is a title
   </p>
 </div>
-<p>
+<p class="bottom-gutter-1-3">
   To make bullet points, use asterisks:
 </p>
-<div class="panel panel-border-wide">
+<div class="panel panel-border-wide bottom-gutter">
   <p>
     * point 1<br/>
     * point 2<br/>
     * point 3<br/>
   </p>
 </div>
-<p>
+<p class="bottom-gutter-1-3">
   To add a callout, use a caret:
+</p>
+<div class="panel panel-border-wide bottom-gutter">
+  <p>
+    ^ You must tell us if your circumstances change
+  </p>
+</div>
+<p class="bottom-gutter-1-3">
+  To add a horizontal line, use three dashes:
 </p>
 <div class="panel panel-border-wide">
   <p>
-    ^ You must tell us if your circumstances change
+    First paragraph
+  </p>
+  <p style="letter-spacing: 1px;">
+    ---
+  </p>
+  <p>
+    Second paragraph
   </p>
 </div>

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -1,5 +1,5 @@
 <h2 class="heading-medium">Links and URLs</h2>
-<p>
+<p class="bottom-gutter-1-3">
   Always use full URLs, starting with https://
 </p>
 <div class="panel panel-border-wide">

--- a/app/templates/partials/templates/guidance-optional-content.html
+++ b/app/templates/partials/templates/guidance-optional-content.html
@@ -4,7 +4,7 @@
 <p>
   Use double brackets and ‘??’ to define optional content.
 </p>
-<p>
+<p class="bottom-gutter-1-3">
   For example if you only want to show something to people who are under
   18:
 </p>

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">
   Personalisation
 </h2>
-<p>
+<p class="bottom-gutter-1-3">
   Use double brackets to personalise your message:
 </p>
 <div class="panel panel-border-wide">


### PR DESCRIPTION
We’ve supported this for a while but don’t tell anyone how to do it.

This commit also alters the spacing of things so the description groups better with the example.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/42043055-66935590-7aed-11e8-8daf-ac649dda641e.png) | ![image](https://user-images.githubusercontent.com/355079/42043037-5b309708-7aed-11e8-9107-25f7f4263b43.png)
