### PR TITLE
Adding sch.uk to the email domain list...

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -33,3 +33,4 @@
 - esfrs.org
 - tfgm.com
 - nationalgalleries.org
+- sch.uk


### PR DESCRIPTION
The DfE (Department for Education) has allocated every school in the country a domain name of the form of: www.schoolname.county.sch.uk.