### PR TITLE
Guess people’s names when they’re invited

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -257,3 +257,7 @@ details .arrow {
   outline: 2px solid $black;
   max-width: 100%;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -41,6 +41,7 @@ from app.main.validators import (
     ValidGovEmail,
 )
 from app.notify_client.models import roles
+from app.utils import guess_name_from_email_address
 
 
 def get_time_value_and_label(future_time):
@@ -215,20 +216,18 @@ class RegisterUserForm(StripWhitespaceForm):
     auth_type = HiddenField('auth_type', default='sms_auth')
 
 
-class RegisterUserFromInviteForm(StripWhitespaceForm):
+class RegisterUserFromInviteForm(RegisterUserForm):
     def __init__(self, invited_user):
         super().__init__(
             service=invited_user['service'],
             email_address=invited_user['email_address'],
             auth_type=invited_user['auth_type'],
+            name=guess_name_from_email_address(
+                invited_user['email_address']
+            ),
         )
 
-    name = StringField(
-        'Full name',
-        validators=[DataRequired(message='Can’t be empty')]
-    )
     mobile_number = InternationalPhoneNumber('Mobile number', validators=[])
-    password = password()
     service = HiddenField('service')
     email_address = HiddenField('email_address')
     auth_type = HiddenField('auth_type', validators=[DataRequired()])

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -11,7 +11,10 @@ Create an account
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
-    <p>Your account will be created with this email: {{invited_user.email_address}}</p>
+    <p>
+      Your account will be created with this email address:
+      <span class="nowrap">{{invited_user.email_address}}</span>
+    </p>
     <form method="post" autocomplete="off">
       {{ textbox(form.name, width='3-4') }}
       {% if invited_user.auth_type == 'sms_auth' %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -25,6 +25,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from notifications_utils.formatters import make_quotes_smart
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.template import (
     EmailPreviewTemplate,
@@ -613,3 +614,13 @@ class GovernmentEmailDomain(AgreementInfo):
 def unicode_truncate(s, length):
     encoded = s.encode('utf-8')[:length]
     return encoded.decode('utf-8', 'ignore')
+
+
+def guess_name_from_email_address(email_address):
+
+    possible_name = re.split(r'[\@\+]', email_address)[0]
+
+    if '.' not in possible_name:
+        return ''
+
+    return make_quotes_smart(possible_name.replace('.', ' ').title())

--- a/app/utils.py
+++ b/app/utils.py
@@ -27,6 +27,7 @@ from flask import (
 from flask_login import current_user
 from notifications_utils.formatters import make_quotes_smart
 from notifications_utils.recipients import RecipientCSV
+from notifications_utils.take import Take
 from notifications_utils.template import (
     EmailPreviewTemplate,
     LetterImageTemplate,
@@ -616,11 +617,41 @@ def unicode_truncate(s, length):
     return encoded.decode('utf-8', 'ignore')
 
 
+def starts_with_initial(name):
+    return bool(re.match(r'^.\.', name))
+
+
+def remove_middle_initial(name):
+    return re.sub(r'\s+.\s+', ' ', name)
+
+
+def remove_digits(name):
+    return ''.join(c for c in name if not c.isdigit())
+
+
+def normalize_spaces(name):
+    return ' '.join(name.split())
+
+
 def guess_name_from_email_address(email_address):
 
     possible_name = re.split(r'[\@\+]', email_address)[0]
 
-    if '.' not in possible_name:
+    if '.' not in possible_name or starts_with_initial(possible_name):
         return ''
 
-    return make_quotes_smart(possible_name.replace('.', ' ').title())
+    return Take(
+        possible_name
+    ).then(
+        str.replace, '.', ' '
+    ).then(
+        remove_digits
+    ).then(
+        remove_middle_initial
+    ).then(
+        str.title
+    ).then(
+        make_quotes_smart
+    ).then(
+        normalize_spaces
+    )

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -264,8 +264,10 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string.strip() == 'Create an account'
 
-    email_in_page = page.find('main').find('p')
-    assert email_in_page.text.strip() == 'Your account will be created with this email: invited_user@test.gov.uk'  # noqa
+    assert normalize_spaces(page.select_one('main p').text) == (
+        'Your account will be created with this email address: '
+        'invited_user@test.gov.uk'
+    )
 
     form = page.find('form')
     name = form.find('input', id='name')

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -171,13 +171,23 @@ def test_register_with_existing_email_sends_emails(
 
 
 @pytest.mark.parametrize('email_address, expected_value', [
-    ("example123@example.com", ""),
     ("first.last@example.com", "First Last"),
     ("first.middle.last@example.com", "First Middle Last"),
+    ("first.m.last@example.com", "First Last"),
     ("first.last-last@example.com", "First Last-Last"),
     ("first.o'last@example.com", "First O’Last"),
     ("first.last+testing@example.com", "First Last"),
     ("first.last+testing+testing@example.com", "First Last"),
+    ("first.last6@example.com", "First Last"),
+    ("first.last.212@example.com", "First Last"),
+    ("first.2.last@example.com", "First Last"),
+    ("first.2b.last@example.com", "First Last"),
+    ("first.1.2.3.last@example.com", "First Last"),
+    ("first.last.1.2.3@example.com", "First Last"),
+    # Instances where we can’t make a good-enough guess:
+    ("example123@example.com", ""),
+    ("f.last@example.com", ""),
+    ("f.m.last@example.com", ""),
 ])
 def test_shows_registration_page_from_invite(
     client_request,


### PR DESCRIPTION
Most people’s names, especially in government are in the format firstname.lastname@dept.gov.uk. This means that you can pretty reliably guess that their name is ‘Firstname Lastname’.

When users are invited to Notify we know their email address already.

So this commit pre-populates the registration form based on this guess.

This is a nice little detail, but it should also stop the browser pre-filling the name field with someone’s email address (which I think happens because the browser assumes a registration form will have an
email field).

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/42152686-d4027d66-7dd8-11e8-9439-f39160568691.png) | ![image](https://user-images.githubusercontent.com/355079/42152665-bec1ad5a-7dd8-11e8-9f01-1ed00904148f.png) 

