### PR TITLE
Update documentation to refer 5 sheets of letters

### DIFF
--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -104,7 +104,9 @@
         {% for sheets, central, local in [
           ('1 sheet', '30', '33'),
           ('2 sheets', '33', '39'),
-          ('3 sheets', '36', '45')
+          ('3 sheets', '36', '45'),
+          ('4 sheets', '39', '51'),
+          ('5 sheets', '42', '57'),
         ] %}
           {% call row() %}
             {% call row_heading() %} {{ sheets }} (double sided) {% endcall %}

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -82,7 +82,7 @@
     </ul>
 
     <h2 class="heading-medium">Letters</h2>
-    <p>Letters can be up to 6 pages long (3 sides of paper, double-sided).</p>
+    <p>Letters can be up to 10 pages long (5 sides of paper, double-sided).</p>
     <p>Notify sends letters in C5 size envelopes, with a window.</p>
 
   </div>


### PR DESCRIPTION
Letters can now be 4 or 5 sheets -
* Updated the pricing page with the new prices
* Updated the using Notify page with the new letter length

[Pivotal story](https://www.pivotaltracker.com/story/show/158660727)

### Updated pricing table
<img width="781" alt="screen shot 2018-07-05 at 15 47 26" src="https://user-images.githubusercontent.com/12881990/42330543-4c7e59c4-806b-11e8-8f39-ea439fb17b77.png">