### PR TITLE
Pin wtforms==2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ ago==0.0.92
 Flask==1.0.2
 Flask-WTF==0.14.2
 Flask-Login==0.4.1
+wtforms==2.1  # pyup: ignore
 
 blinker==1.4
 pyexcel==0.5.8


### PR DESCRIPTION
Tests fail with `wtforms==2.2.1`.  We're not sure of the reason but on production this version is used and locally it's not, because we only require flask-wtforms, which doesn't pin its requirements at all. We should probably pin all requirements from jenkins onwards to prevent this kind of thing happening again.