### PR TITLE
Rename ‘caseworker’ to ‘basic view’

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -303,8 +303,8 @@ class CaseworkingPermissionsForm(AbstractPermissionsForm):
     user_type = RadioField(
         'User type',
         choices=[
-            ('caseworker', 'Caseworker'),
-            ('admin', 'Admin'),
+            ('caseworker', 'Basic view'),
+            ('admin', 'Admin view'),
         ],
     )
 

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -3,7 +3,7 @@
 
 {% if 'caseworking' in current_service.permissions %}
   <div class="conditional-radios" data-module='conditional-radios'>
-    {% call radios_wrapper(form.user_type) %}
+    {% call radios_wrapper(form.user_type, hide_legend=True) %}
       {% for option in form.user_type %}
 
         <div class="bottom-gutter-1-3">

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -366,7 +366,7 @@
         </li>
         <li class="bottom-gutter">
           <a href="{{ url_for('.service_switch_caseworking', service_id=current_service.id) }}" class="button">
-            {{ 'Stop granting of caseworking permission' if 'caseworking' in current_service.permissions else 'Allow granting of caseworking permission' }}
+            {{ 'Stop basic view' if 'caseworking' in current_service.permissions else 'Allow basic view' }}
           </a>
         </li>
         <li class="bottom-gutter">

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -45,9 +45,9 @@ def get_service_settings_page(
         '.service_switch_can_upload_document', {}, 'Allow to upload documents'),
 
     ({'permissions': []},
-        '.service_switch_caseworking', {}, 'Allow granting of caseworking permission'),
+        '.service_switch_caseworking', {}, 'Allow basic view'),
     ({'permissions': ['caseworking']},
-        '.service_switch_caseworking', {}, 'Stop granting of caseworking permission'),
+        '.service_switch_caseworking', {}, 'Stop basic view'),
 
     ({'permissions': ['sms']}, '.service_set_inbound_number', {'set_inbound_sms': True}, 'Allow inbound sms'),
 


### PR DESCRIPTION
Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/42443109-7cdd5330-8364-11e8-9d48-c2f2b9ffa7b3.png) | ![image](https://user-images.githubusercontent.com/355079/42443744-3b6a4c30-8366-11e8-9517-3b5b75795d2d.png)


‘Caseworker’ was a bad name because it:
- suggested that Notify might be expanding into case management
- may or may not map to someone’s actual role, in a confusing way (this is why ‘manager’ is also a bad name)

‘Basic view’ is the best name we could come up with because:
- it describes the purpose of feature, not the user
- a ‘view’ changes what you can _see_ as much as it changes what you can do

Admin remains a good word – in research users self-describe their use of Notify in using it. This commit makes the name ‘admin view’ to match ‘basic view’.

***

Here’s a picture of all the different names and concepts we experimented with:

![img_8258](https://user-images.githubusercontent.com/355079/42443157-a4d9f956-8364-11e8-86fd-551b0ac84822.jpg)

*** 

We are hiding the `<legend>` for this `<fieldset>` now because we think the choices are self-explanatory.