### PR TITLE
Relabel ‘modify service’ to ‘manage service’

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -262,7 +262,7 @@ class AbstractPermissionsForm(StripWhitespaceForm):
     view_activity = HiddenField("View activity")
     send_messages = BooleanField("Send messages from existing templates")
     manage_templates = BooleanField("Add and edit templates")
-    manage_service = BooleanField("Modify this service and its team")
+    manage_service = BooleanField("Manage this service and its team")
     manage_api_keys = BooleanField("Create and revoke API keys")
 
     login_authentication = RadioField(


### PR DESCRIPTION
Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/42444243-78a7a718-8367-11e8-87cd-3f2057f7f7d2.png) | ![image](https://user-images.githubusercontent.com/355079/42444274-8c1f8fa4-8367-11e8-8172-a73efa1e1e52.png)

We are not consistent about this. We use ‘manage service’ on:

- the page listing all the users ![image](https://user-images.githubusercontent.com/355079/42444312-a1907da8-8367-11e8-9284-67f507a788ff.png)

- the request to go live checklist ![image](https://user-images.githubusercontent.com/355079/42444360-c760ae72-8367-11e8-856f-062bb2051921.png)


We use modify service on:
- the page where you edit a team member’s permissions
- the page where you invite a new team member

This commit changes the latter to be consistent with the former.