### PR TITLE
Rename ‘caseworker’ to ‘basic view’ on team members

### DIFF
--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -67,7 +67,7 @@
               {% if 'caseworking' in current_service.permissions %}
                 {{ tick_cross(
                   user.status != 'cancelled',
-                  'Admin'
+                  'Admin view'
                 ) }}
               {% endif %}
               {{ tick_cross(
@@ -89,7 +89,7 @@
             {% else %}
               {{ tick_cross(
                 True,
-                'Caseworker'
+                'Basic view'
               ) }}
             {% endif %}
             {% if 'email_auth' in current_service['permissions'] %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -121,7 +121,7 @@ def test_should_show_caseworker_on_overview_page(
     assert normalize_spaces(page.select_one('h1').text) == 'Team members'
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User With Permissions (you) '
-        'Can Admin '
+        'Can Admin view '
         'Can’t Send messages '
         'Can’t Add and edit templates '
         'Can’t Manage service '
@@ -130,7 +130,7 @@ def test_should_show_caseworker_on_overview_page(
     # [1:5] are invited users
     assert normalize_spaces(page.select('.user-list-item')[6].text) == (
         'Test User zzzzzzz@example.gov.uk '
-        'Can Caseworker'
+        'Can Basic view'
     )
 
 


### PR DESCRIPTION
Missed this in https://github.com/alphagov/notifications-admin/pull/2146