### PR TITLE
Hide download all link in basic view

### DIFF
--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -51,11 +51,15 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
   {% endif %}
+
   <p class="bottom-gutter">
-     <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
-     &emsp;
-     Data available for 7 days
+    {% if current_user.has_permissions('view_activity') %}
+      <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+      &emsp;
+    {% endif %}
+    Data available for 7 days
   </p>
+
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),


### PR DESCRIPTION
Can’t think of a good reason why someone who is only sending messages would need a download of all the messages their entire team has sent.

Most of the ‘caseworking’ teams have been getting on fine without this link; it’s only recently we brought it back.