### PR TITLE
Add organisation info to branding requests

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -980,11 +980,13 @@ def branding_request(service_id):
         zendesk_client.create_ticket(
             subject='Email branding request - {}'.format(current_service['name']),
             message=(
+                'Organisation: {}\n'
                 'Service: {}\n'
                 '{}\n'
                 '\n---'
                 '\nBranding requested: {}'
             ).format(
+                AgreementInfo.from_current_user().as_human_readable,
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 branding_options_dict[form.options.data],

--- a/app/utils.py
+++ b/app/utils.py
@@ -437,6 +437,8 @@ class AgreementInfo:
             self.domain_names,
         ), None)
 
+        self._domain = email_address_or_domain.split('@')[-1]
+
         (
             self.owner,
             self.crown_status,
@@ -469,7 +471,7 @@ class AgreementInfo:
                 }.get(self.crown_status),
             )
         else:
-            return 'Can’t tell'
+            return 'Can’t tell (domain is {})'.format(self._domain)
 
     @property
     def as_jinja_template(self):

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2774,6 +2774,7 @@ def test_submit_email_branding_request(
 
     zendesk.assert_called_once_with(
         message='\n'.join([
+            'Organisation: Can’t tell (domain is user.gov.uk)',
             'Service: service one',
             'http://localhost/services/596364a0-858e-42c8-9062-a8fe822260eb',
             '',

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -403,7 +403,7 @@ def test_get_valid_agreement_info_unknown_details(domain_or_email_address):
     assert government_domain.crown_status is None
     assert government_domain.owner is None
     assert government_domain.agreement_signed is None
-    assert government_domain.as_human_readable == 'Can’t tell'
+    assert government_domain.as_human_readable == 'Can’t tell (domain is police.gov.uk)'
 
 
 def test_get_valid_agreement_info_only_org_known():
@@ -442,7 +442,7 @@ def test_get_valid_government_domain_gets_most_specific_first():
     assert generic.owner is None
     assert generic.agreement_signed is None
     assert generic.as_human_readable == (
-        'Can’t tell'
+        'Can’t tell (domain is gov.uk)'
     )
 
     specific = AgreementInfo("dacorum.gov.uk")


### PR DESCRIPTION
This will let us know which organisation the person asking for the branding is from. This should reduce how often we have to go back to them and ask.