### PR TITLE
Hide ‘7 days’ paragraph from basic view

### DIFF
--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -11,7 +11,7 @@
       notifications,
       caption="Recent activity",
       caption_visible=False,
-      empty_message='No messages found',
+      empty_message='No messages found &thinsp;(messages are kept for 7 days)'|safe,
       field_headings=['Recipient', 'Status'],
       field_headings_visible=False
     ) %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -52,13 +52,13 @@
     </form>
   {% endif %}
 
-  <p class="bottom-gutter">
-    {% if current_user.has_permissions('view_activity') %}
+  {% if current_user.has_permissions('view_activity') %}
+    <p class="bottom-gutter">
       <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
       &emsp;
-    {% endif %}
-    Data available for 7 days
-  </p>
+      Data available for 7 days
+    </p>
+  {% endif %}
 
   {{ ajax_block(
     partials,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -289,7 +289,7 @@ def test_shows_message_when_no_notifications(
     )
 
     assert normalize_spaces(page.select('tbody tr')[0].text) == (
-        'No messages found'
+        'No messages found (messages are kept for 7 days)'
     )
 
 


### PR DESCRIPTION
It looks too prominent as a paragraph on the page. This commit moves the info about how long we keep data for into the ‘empty’ message we show when there are no results (ie the message people will see if they search for something that was sent more than 7 days ago).

# Before
![image](https://user-images.githubusercontent.com/355079/42522766-e8715ca4-8463-11e8-98c2-0c747c09189f.png)

# After
![image](https://user-images.githubusercontent.com/355079/42522781-f324fda4-8463-11e8-8991-08b1e6244215.png)

