### PR TITLE
Fix org info in branding requests with known orgs

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -986,7 +986,7 @@ def branding_request(service_id):
                 '\n---'
                 '\nBranding requested: {}'
             ).format(
-                AgreementInfo.from_current_user().as_human_readable,
+                AgreementInfo.from_current_user().as_info_for_branding_request,
                 current_service['name'],
                 url_for('main.service_dashboard', service_id=current_service['id'], _external=True),
                 branding_options_dict[form.options.data],

--- a/app/utils.py
+++ b/app/utils.py
@@ -474,6 +474,10 @@ class AgreementInfo:
             return 'Can’t tell (domain is {})'.format(self._domain)
 
     @property
+    def as_info_for_branding_request(self):
+        return self.owner or 'Can’t tell (domain is {})'.format(self._domain)
+
+    @property
     def as_jinja_template(self):
         if self.crown_status is None:
             return 'agreement-choose'

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -454,6 +454,16 @@ def test_get_valid_government_domain_gets_most_specific_first():
     )
 
 
+def test_get_domain_info_for_branding_request():
+
+    assert AgreementInfo("gov.uk").as_info_for_branding_request == (
+        'Can’t tell (domain is gov.uk)'
+    )
+    assert AgreementInfo("dacorum.gov.uk").as_info_for_branding_request == (
+        'Dacorum Borough Council'
+    )
+
+
 def test_validate_government_domain_data():
 
     for domain in AgreementInfo.domains.keys():


### PR DESCRIPTION
This wasn’t looking quite right in the case where an organisation is in our list of domains.