### PR TITLE
Untick ‘basic view’ if invite is cancelled

### DIFF
--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -88,7 +88,7 @@
               ) }}
             {% else %}
               {{ tick_cross(
-                True,
+                user.status != 'cancelled',
                 'Basic view'
               ) }}
             {% endif %}


### PR DESCRIPTION
If an invite is cancelled then the user no longer has permission to do anything, so we shouldn’t show the green tick. We already do this for other permissions; this makes the ‘basic view’ row consistent.