### PR TITLE
Improve navigation in basic view 

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -140,14 +140,8 @@ def choose_template(service_id, template_type='all'):
         )
     ]
 
-    if current_user.has_permissions('view_activity'):
-        page_title = 'Templates'
-    else:
-        page_title = 'Choose a template'
-
     return render_template(
         'views/templates/choose.html',
-        page_title=page_title,
         templates=templates_on_page,
         show_search_box=(len(templates_on_page) > 7),
         show_template_nav=has_multiple_template_types and (len(templates) > 2),

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -20,7 +20,7 @@
 {% else %}
 <nav class="navigation">
   <ul>
-    <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ casework_navigation.is_selected('send-one-off') }}>Send a message</a></li>
+    <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ casework_navigation.is_selected('send-one-off') }}>Templates</a></li>
   </ul>
   <ul>
     <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -4,16 +4,20 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 
+{% set page_title = (
+  message_count_label(99, message_type, suffix='') | capitalize
+  if current_user.has_permissions('view_activity')
+  else 'Sent messages'
+) %}
+
 {% block service_page_title %}
-  {{ message_count_label(99, message_type, suffix='') | capitalize }}
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    {% if not current_user.has_permissions('view_activity') %}<span class="visually-hidden">{% endif %}
-      {{ message_count_label(99, message_type, suffix='') | capitalize }}
-    {% if not current_user.has_permissions('view_activity') %}</span>{% endif %}
+    {{ page_title }}
   </h1>
   {% if not message_type == "letter" %}
 

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -4,6 +4,8 @@
 
 {% extends "withnav_template.html" %}
 
+{% set page_title = 'Templates' %}
+
 {% block service_page_title %}
   {{ page_title }}
 {% endblock %}

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -122,7 +122,7 @@ def test_invite_goes_in_session(
 
 @pytest.mark.parametrize('user, landing_page_title', [
     (active_user_with_permissions, 'Dashboard'),
-    (active_caseworking_user, 'Choose a template'),
+    (active_caseworking_user, 'Templates'),
 ])
 def test_accepting_invite_removes_invite_from_session(
     client_request,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2459,7 +2459,7 @@ def test_preview_basic_view(
     with client_request.session_transaction() as session:
         assert session['basic'] is True
 
-    assert page.h1.text.strip() == 'Choose a template'
+    assert page.h1.text.strip() == 'Templates'
     page.select('.navigation-service-basic-view-preview')
     assert normalize_spaces(page.select_one('.navigation-service').text) == (
         'service one '

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -70,7 +70,7 @@ from tests.conftest import single_letter_contact_block
         ),
         (
             active_caseworking_user,
-            'Choose a template',
+            'Templates',
             {},
             ['Text message', 'Email'],
             [
@@ -82,7 +82,7 @@ from tests.conftest import single_letter_contact_block
         ),
         (
             active_caseworking_user,
-            'Choose a template',
+            'Templates',
             {'template_type': 'email'},
             ['All', 'Text message'],
             ['email_template_one', 'email_template_two'],

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -159,5 +159,5 @@ def test_caseworkers_get_caseworking_navigation(
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('#content nav').text) == (
-        'Send a message Sent messages'
+        'Templates Sent messages'
     )


### PR DESCRIPTION
Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/42701618-fd4dd1ae-86be-11e8-886f-e193a2b22370.png) | ![image](https://user-images.githubusercontent.com/355079/42701639-0c856ec0-86bf-11e8-85a8-cd3e48823337.png)

# Rename ‘Send a message’ to ‘Templates’

From @karlchillmaid:

> Templates – this should be consistent with Admin view. Users may switch from Basic to Admin view (or vice versa), they will also interact with users who have a different view or permissions to them.
> Neither should have to learn new interfaces and language if possible.

> ‘Send a message’ was a nice, active label – but Notify options aren’t usually actions. If we’re going to change this we should be consistent across both Admin and Basic views.

> For the same reason, I have rejected ‘see’, ‘search’ and ‘view sent messages’. It will be interesting to see in user testing whether users read ‘sent messages’ as ‘send messages’.

# Add `<h1>` to sent messages page 

From @karlchillmaid:

> Suggest making the H1 visible here for consistency, but also to make it clear to users what they’re looking at.

> This screen is similar to – but not exactly the same as – the individual text, email and letter dashboard screens from Admin view, so the H1 could help to distinguish it from them for users who may have interacted with both.

