### PR TITLE
Add Scottish Environmental Protection Agency

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -34,3 +34,4 @@
 - tfgm.com
 - nationalgalleries.org
 - sch.uk
+- sepa.org.uk


### PR DESCRIPTION
They are a (Scottish) government organisation.

https://www.sepa.org.uk/