### PR TITLE
Revise how we talk about what basic view is

### DIFF
--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -8,8 +8,8 @@
 
         <div class="bottom-gutter-1-3">
           {{ radio(option, option_hints={
-              'admin': 'Show dashboard, templates and team members',
-              'caseworker': 'Hide dashboard and other options, send messages from existing templates'
+              'admin': 'Show dashboard and other options',
+              'caseworker': 'Send messages, hide dashboard and other options'
           }) }}
         </div>
         {% if option.data == 'admin' %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -9,7 +9,7 @@
         <div class="bottom-gutter-1-3">
           {{ radio(option, option_hints={
               'admin': 'Show dashboard, templates and team members',
-              'caseworker': 'Send messages from existing templates, hide other options'
+              'caseworker': 'Hide dashboard and other options, send messages from existing templates'
           }) }}
         </div>
         {% if option.data == 'admin' %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -8,8 +8,8 @@
 
         <div class="bottom-gutter-1-3">
           {{ radio(option, option_hints={
-              'admin': 'See dashboard and team members',
-              'caseworker': 'Send messages and see sent messages'
+              'admin': 'Show dashboard, templates and team members',
+              'caseworker': 'Send messages from existing templates, hide other options'
           }) }}
         </div>
         {% if option.data == 'admin' %}

--- a/app/templates/views/service-settings/set-basic-view.html
+++ b/app/templates/views/service-settings/set-basic-view.html
@@ -18,7 +18,7 @@
         Choose basic view for team members who only need to:
       </p>
       <ul class="list list-bullet">
-        <li>send one-off messages using existing templates</li>
+        <li>send messages using existing templates</li>
         <li>see a list of their sent messages</li>
       </ul>
       <p>

--- a/app/templates/views/service-settings/set-basic-view.html
+++ b/app/templates/views/service-settings/set-basic-view.html
@@ -12,18 +12,17 @@
     <form method="post" class="column-five-sixths">
       <h1 class="heading-large">Basic view</h1>
       <p>
-        Make Notify quicker and simpler to use for team members who only
-        need to send messages.
+        Control what other people see when they sign in to Notify.
       </p>
       <p>
-        Basic view hides everything except:
+        Choose basic view for team members who only need to:
       </p>
       <ul class="list list-bullet">
-        <li>templates</li>
-        <li>a list of sent messages</li>
+        <li>send one-off messages using existing templates</li>
+        <li>see a list of their sent messages</li>
       </ul>
       <p>
-        You can choose which team members have basic view.
+        Basic view hides the dashboard and other options, making Notify quicker and simpler to use.
       </p>
       <p>
         <a href="{{ url_for('main.preview_basic_view', service_id=current_service.id) }}">See a preview of basic view</a>.

--- a/app/templates/views/service-settings/set-basic-view.html
+++ b/app/templates/views/service-settings/set-basic-view.html
@@ -12,18 +12,18 @@
     <form method="post" class="column-five-sixths">
       <h1 class="heading-large">Basic view</h1>
       <p>
-        Control what other people see when they sign in to Notify.
+        Hide the dashboard and other options from team members who only need to send messages.
       </p>
       <p>
-        Choose basic view for team members who only need to:
+        Turn on basic view then edit team members' permissions.
+      </p>
+      <p>
+        Team members with basic view can only:
       </p>
       <ul class="list list-bullet">
         <li>send messages using existing templates</li>
         <li>see a list of their sent messages</li>
       </ul>
-      <p>
-        Basic view hides the dashboard and other options, making Notify quicker and simpler to use.
-      </p>
       <p>
         <a href="{{ url_for('main.preview_basic_view', service_id=current_service.id) }}">See a preview of basic view</a>.
       </p>

--- a/app/templates/views/service-settings/set-basic-view.html
+++ b/app/templates/views/service-settings/set-basic-view.html
@@ -22,7 +22,7 @@
       </p>
       <ul class="list list-bullet">
         <li>send messages using existing templates</li>
-        <li>see a list of their sent messages</li>
+        <li>see a list of sent messages</li>
       </ul>
       <p>
         <a href="{{ url_for('main.preview_basic_view', service_id=current_service.id) }}">See a preview of basic view</a>.

--- a/app/templates/views/service-settings/set-basic-view.html
+++ b/app/templates/views/service-settings/set-basic-view.html
@@ -12,14 +12,18 @@
     <form method="post" class="column-five-sixths">
       <h1 class="heading-large">Basic view</h1>
       <p>
-        Basic view lets you restrict a team member to only:
+        Make Notify quicker and simpler to use for team members who only
+        need to send messages.
+      </p>
+      <p>
+        Basic view hides everything except:
       </p>
       <ul class="list list-bullet">
-        <li>send messages</li>
-        <li>see sent messages</li>
+        <li>templates</li>
+        <li>a list of sent messages</li>
       </ul>
       <p>
-        You’ll get to choose which team members have basic view.
+        You can choose which team members have basic view.
       </p>
       <p>
         <a href="{{ url_for('main.preview_basic_view', service_id=current_service.id) }}">See a preview of basic view</a>.

--- a/app/templates/views/service-settings/set-basic-view.html
+++ b/app/templates/views/service-settings/set-basic-view.html
@@ -15,7 +15,7 @@
         Hide the dashboard and other options from team members who only need to send messages.
       </p>
       <p>
-        Turn on basic view then edit team members' permissions.
+        Turn on basic view then edit team members’ permissions.
       </p>
       <p>
         Team members with basic view can only:


### PR DESCRIPTION
_Changes and writeup from @karlchillmaid_

# The page where you switch on the feature

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/42769566-605bb20e-891a-11e8-8fea-bbf8f7337bf2.png) | ![image](https://user-images.githubusercontent.com/355079/42769539-4f380112-891a-11e8-80e1-2a1c3e2e129b.png)

This content aims to describe:
- the benefit of basic view – ‘make Notify quicker and simpler’
- who it benefits – ‘team members who only need to send messages’
- how it does it – ‘by hiding…’
- what it prevents users from being able to do or see –  ‘everything except…’
- what it allows users to do – ‘send messages’, [see] ‘templates, a list of sent messages’

I’m still keen to mention sent messages here, as it feels weird not to mention it at all when it’s 1 of only 2 options in Basic view. I don’t think it’s as important to mention it on the Edit team member screen.

I’ve specifically used ‘a list of sent messages’ rather than just ‘sent messages’, to make it seem less like a noun (new feature).

# The page where you choose whether someone has basic view

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/42769586-7c62d6d0-891a-11e8-88ee-41b245d821b2.png) | ![image](https://user-images.githubusercontent.com/355079/42769694-dc53cd60-891a-11e8-8389-d00005fba978.png)



Switches the focus from what you can see to what you can’t.

Aims to be consistent with both:
- the description of permissions in admin view
- the language used to describe basic view in settings