### PR TITLE
Fix displaying of services on User Information page

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -30,7 +30,9 @@ def find_users_by_email():
 @user_is_platform_admin
 def user_information(user_id):
     user = user_api_client.get_user(user_id)
+    services = user_api_client.get_organisations_and_services_for_user(user)
     return render_template(
         'views/find-users/user-information.html',
-        user=user
+        user=user,
+        services=services['services_without_organisations'],
     )

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -18,7 +18,7 @@
         <ul>
         {% for service in services %}
           <li class="browse-list-item">
-            <p class="browse-list-hint">{{ service.name }}</p>
+            <a class="browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
           </li>
         {% endfor %}
         </ul>

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -16,9 +16,9 @@
       <h2 class="heading-medium">Services</h2>
       <nav class="browse-list">
         <ul>
-        {% for service in user.services %}
+        {% for service in services %}
           <li class="browse-list-item">
-            <p class="browse-list-sub-item">{{ service.name }}</p>
+            <p class="browse-list-hint">{{ service.name }}</p>
           </li>
         {% endfor %}
         </ul>

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -115,8 +115,8 @@ def test_user_information_page_shows_information_about_user(
     assert document.xpath("//p/text()[normalize-space()='+447700900986']")
 
     assert document.xpath("//h2/text()[normalize-space()='Services']")
-    assert document.xpath("//p/text()[normalize-space()='Fresh Orchard Juice']")
-    assert document.xpath("//p/text()[normalize-space()='Nature Therapy']")
+    assert document.xpath("//a/text()[normalize-space()='Fresh Orchard Juice']")
+    assert document.xpath("//a/text()[normalize-space()='Nature Therapy']")
 
     assert document.xpath("//h2/text()[normalize-space()='Last login']")
     assert not document.xpath("//p/text()[normalize-space()='0 failed login attempts']")

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -93,11 +93,17 @@ def test_user_information_page_shows_information_about_user(
 ):
     mocker.patch('app.user_api_client.get_user', side_effect=[
         platform_admin_user,
-        User(user_json(name="Apple Bloom", services=[
+        User(user_json(name="Apple Bloom", services=[1, 2]))
+    ], autospec=True)
+
+    mocker.patch(
+        'app.user_api_client.get_organisations_and_services_for_user',
+        return_value={'organisations': [], 'services_without_organisations': [
             {"id": 1, "name": "Fresh Orchard Juice"},
             {"id": 2, "name": "Nature Therapy"},
-        ]))
-    ], autospec=True)
+        ]},
+        autospec=True
+    )
     client.login(platform_admin_user)
     response = client.get(url_for('main.user_information', user_id=345))
     assert response.status_code == 200
@@ -125,6 +131,15 @@ def test_user_information_page_displays_if_there_are_failed_login_attempts(
         platform_admin_user,
         User(user_json(name="Apple Bloom", failed_login_count=2))
     ], autospec=True)
+
+    mocker.patch(
+        'app.user_api_client.get_organisations_and_services_for_user',
+        return_value={'organisations': [], 'services_without_organisations': [
+            {"id": 1, "name": "Fresh Orchard Juice"},
+            {"id": 2, "name": "Nature Therapy"},
+        ]},
+        autospec=True
+    )
     client.login(platform_admin_user)
     response = client.get(url_for('main.user_information', user_id=345))
     assert response.status_code == 200


### PR DESCRIPTION
Services for the user did not show up earlier, because `user_api_client.get_user` only fetches service id, not the name. Hence, I added a second API call to fetch service objects for that user.

After Chris' comment I also made service name into a link and updated the screenshot.

Below a screenshot of the page with services displayed:
<img width="866" alt="screen shot 2018-07-16 at 17 30 46" src="https://user-images.githubusercontent.com/20957548/42771453-2e47b2cc-891f-11e8-82e9-8938f86a7629.png">
