### PR TITLE
Store boolean values in Redis as valid JSON

### DIFF
--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -90,7 +90,7 @@ class JobApiClient(NotifyAdminAPIClient):
 
         self.redis_client.set(
             'has_jobs-{}'.format(service_id),
-            True,
+            b'true',
             ex=cache.TTL,
         )
 

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -29,7 +29,7 @@ def test_client_creates_job_data_correctly(mocker, fake_uuid):
     mock_post.assert_called_once_with(url=expected_url, data=expected_data)
     mock_redis_set.assert_called_once_with(
         'has_jobs-{}'.format(service_id),
-        True,
+        b'true',
         ex=604800,
     )
 


### PR DESCRIPTION
Calling `.set()` with `True` stores the byte string `'True'` which cannot subsequently be decoded from JSON (because boolean values in JSON are lowercase, ie `true`).