### PR TITLE
Hide email branding change link if the user doesn’t have the manage service permission

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -119,6 +119,7 @@
           {{ edit_field(
             'Change',
             url_for('.branding_request', service_id=current_service.id),
+            permissions=['manage_service'],
           )}}
         {% endcall %}
 


### PR DESCRIPTION
If you have the API keys permission you can see the settings page. But you  can’t change or request stuff, like email branding. So we shouldn’t show the link that suggests you can.