### PR TITLE
Make sending messages quicker for everyone without it being a separate view

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -72,6 +72,7 @@
     display: block;
     text-align: left;
     padding: 10px $gutter-half;
+    text-align: center;
 
     &:link,
     &:visited {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -256,13 +256,13 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
     auth_type = HiddenField('auth_type', validators=[DataRequired()])
 
 
-class AbstractPermissionsForm(StripWhitespaceForm):
+class PermissionsForm(StripWhitespaceForm):
 
-    view_activity = HiddenField("View activity")
-    send_messages = BooleanField("Send messages from existing templates")
+    view_activity = BooleanField("See dashboard and reports")
+    send_messages = BooleanField("Send messages")
     manage_templates = BooleanField("Add and edit templates")
     manage_service = BooleanField("Manage this service and its team")
-    manage_api_keys = BooleanField("Create and revoke API keys")
+    manage_api_keys = BooleanField("Manage API keys")
 
     login_authentication = RadioField(
         'Sign in using',
@@ -277,38 +277,18 @@ class AbstractPermissionsForm(StripWhitespaceForm):
     def permissions(self):
         return {role for role in roles.keys() if self[role].data is True}
 
-
-class AdminPermissionsForm(AbstractPermissionsForm):
-
-    def process(self, *args, **kwargs):
-        super().process(*args, **kwargs)
-        # view_activity is a default role to be added to all users.
-        self.view_activity.data = True
-
-
-class CaseworkingPermissionsForm(AbstractPermissionsForm):
-
-    def process(self, *args, **kwargs):
-        super().process(*args, **kwargs)
-        if self.user_type.data == 'admin':
-            self.view_activity.data = True
-        elif self.user_type.data == 'caseworker':
-            self.view_activity.data = False
-            self.manage_templates.data = False
-            self.manage_service.data = False
-            self.manage_api_keys.data = False
-            self.send_messages.data = True
-
-    user_type = RadioField(
-        'User type',
-        choices=[
-            ('caseworker', 'Basic view'),
-            ('admin', 'Admin view'),
-        ],
-    )
+    @classmethod
+    def from_user(cls, user, service_id):
+        return cls(
+            **{
+                role: user.has_permission_for_service(service_id, role)
+                for role in roles.keys()
+            },
+            login_authentication=user.auth_type
+        )
 
 
-class AbstractInviteUserForm(StripWhitespaceForm):
+class InviteUserForm(PermissionsForm):
     email_address = email_address(gov_user=False)
 
     def __init__(self, invalid_email_address, *args, **kwargs):
@@ -318,14 +298,6 @@ class AbstractInviteUserForm(StripWhitespaceForm):
     def validate_email_address(self, field):
         if field.data.lower() == self.invalid_email_address:
             raise ValidationError("You can’t send an invitation to yourself")
-
-
-class AdminInviteUserForm(AbstractInviteUserForm, AdminPermissionsForm):
-    pass
-
-
-class CaseworkingInviteUserForm(AbstractInviteUserForm, CaseworkingPermissionsForm):
-    pass
 
 
 class InviteOrgUserForm(StripWhitespaceForm):

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -59,7 +59,7 @@ def old_service_dashboard(service_id):
 
 @main.route("/services/<service_id>")
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def service_dashboard(service_id):
 
     if session.get('invited_user'):

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -39,7 +39,7 @@ from app.utils import (
 
 @main.route("/services/<service_id>/jobs")
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def view_jobs(service_id):
     page = int(request.args.get('page', 1))
     jobs_response = job_api_client.get_page_of_jobs(service_id, page=page)
@@ -74,7 +74,7 @@ def view_jobs(service_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>")
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def view_job(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     if job['job_status'] == 'cancelled':
@@ -156,7 +156,7 @@ def cancel_job(service_id, job_id):
 
 
 @main.route("/services/<service_id>/jobs/<job_id>.json")
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def view_job_updates(service_id, job_id):
 
     job = job_api_client.get_job(service_id, job_id)['data']
@@ -174,7 +174,7 @@ def view_job_updates(service_id, job_id):
 @main.route('/services/<service_id>/notifications', methods=['GET', 'POST'])
 @main.route('/services/<service_id>/notifications/<message_type>', methods=['GET', 'POST'])
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def view_notifications(service_id, message_type=None):
     return render_template(
         'views/notifications.html',
@@ -198,7 +198,7 @@ def view_notifications(service_id, message_type=None):
 
 @main.route('/services/<service_id>/notifications.json', methods=['GET', 'POST'])
 @main.route('/services/<service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(
         service_id, message_type, status_override=request.args.get('status')
@@ -206,7 +206,7 @@ def get_notifications_as_json(service_id, message_type=None):
 
 
 @main.route('/services/<service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def get_notifications(service_id, message_type, status_override=None):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -24,7 +24,7 @@ from app.utils import user_has_permissions
 
 @main.route("/services/<service_id>/users")
 @login_required
-@user_has_permissions('view_activity')
+@user_has_permissions()
 def manage_users(service_id):
     users = sorted(
         user_api_client.get_users_for_service(service_id=service_id) + [

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -10,6 +10,7 @@ from app import (
 )
 from app.main import main
 from app.main.forms import InviteUserForm, PermissionsForm, SearchUsersForm
+from app.notify_client.models import permissions
 from app.utils import user_has_permissions
 
 
@@ -31,6 +32,7 @@ def manage_users(service_id):
         current_user=current_user,
         show_search_box=(len(users) > 7),
         form=SearchUsersForm(),
+        permissions=permissions,
     )
 
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -438,7 +438,7 @@ def send_test_step(service_id, template_id, step_index):
         step_index == 0 and
         template.template_type != 'letter' and
         not (template.template_type == 'sms' and current_user.mobile_number is None) and
-        current_user.has_permissions('view_activity')
+        current_user.has_permissions('manage_templates', 'manage_service')
     ):
         skip_link = (
             'Use my {}'.format(first_column_headings[template.template_type][0]),

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -451,7 +451,8 @@ def send_test_step(service_id, template_id, step_index):
         page_title=get_send_test_page_title(
             template.template_type,
             get_help_argument(),
-            entering_recipient=not session['recipient']
+            entering_recipient=not session['recipient'],
+            name=template.name,
         ),
         template=template,
         form=form,
@@ -751,13 +752,13 @@ def all_placeholders_in_session(placeholders):
     )
 
 
-def get_send_test_page_title(template_type, help_argument, entering_recipient):
+def get_send_test_page_title(template_type, help_argument, entering_recipient, name=None):
     if help_argument:
         return 'Example text message'
     if template_type == 'letter':
         return 'Print a test letter'
     if entering_recipient:
-        return 'Who should this message be sent to?'
+        return 'Send ‘{}’'.format(name)
     return 'Personalise this message'
 
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -459,6 +459,10 @@ def send_test_step(service_id, template_id, step_index):
         optional_placeholder=optional_placeholder,
         back_link=back_link,
         help=get_help_argument(),
+        link_to_upload=(
+            request.endpoint == 'main.send_one_off_step' and
+            step_index == 0
+        ),
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -48,14 +48,15 @@ page_headings = {
 @login_required
 @user_has_permissions()
 def view_template(service_id, template_id):
+    template = service_api_client.get_service_template(service_id, str(template_id))['data']
     if (
         current_user.has_permissions('send_messages') and
-        not current_user.has_permissions('manage_templates', 'manage_api_keys')
+        not current_user.has_permissions('manage_templates', 'manage_api_keys') and
+        template['template_type'] != 'letter'
     ):
         return redirect(url_for(
             '.send_one_off', service_id=service_id, template_id=template_id
         ))
-    template = service_api_client.get_service_template(service_id, str(template_id))['data']
     if template["template_type"] == "letter":
         letter_contact_details = service_api_client.get_letter_contacts(service_id)
         default_letter_contact_block_id = next(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -48,7 +48,10 @@ page_headings = {
 @login_required
 @user_has_permissions('view_activity', 'send_messages')
 def view_template(service_id, template_id):
-    if not current_user.has_permissions('view_activity'):
+    if (
+        current_user.has_permissions('send_messages') and
+        not current_user.has_permissions('manage_templates', 'manage_api_keys')
+    ):
         return redirect(url_for(
             '.send_one_off', service_id=service_id, template_id=template_id
         ))

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -46,7 +46,7 @@ page_headings = {
 
 @main.route("/services/<service_id>/templates/<uuid:template_id>")
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def view_template(service_id, template_id):
     if (
         current_user.has_permissions('send_messages') and
@@ -106,7 +106,7 @@ def start_tour(service_id, template_id):
 @main.route("/services/<service_id>/templates")
 @main.route("/services/<service_id>/templates/<template_type>")
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def choose_template(service_id, template_type='all'):
     templates = service_api_client.get_service_templates(service_id)['data']
 
@@ -161,7 +161,7 @@ def choose_template(service_id, template_type='all'):
 
 @main.route("/services/<service_id>/templates/<template_id>.<filetype>")
 @login_required
-@user_has_permissions('view_activity', 'send_messages')
+@user_has_permissions()
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -188,7 +188,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")
 @login_required
-@user_has_permissions('view_activity')
+@user_has_permissions()
 def view_template_version(service_id, template_id, version):
     return render_template(
         'views/templates/template_history.html',
@@ -198,7 +198,7 @@ def view_template_version(service_id, template_id, version):
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.<filetype>")
 @login_required
-@user_has_permissions('view_activity')
+@user_has_permissions()
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = service_api_client.get_service_template(service_id, template_id, version=version)['data']
     return TemplatePreview.from_database_object(db_template, filetype)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -111,10 +111,7 @@ def start_tour(service_id, template_id):
 def choose_template(service_id, template_type='all'):
     templates = service_api_client.get_service_templates(service_id)['data']
 
-    letters_available = (
-        current_service.has_permission('letter') and
-        current_user.has_permissions('view_activity')
-    )
+    letters_available = current_service.has_permission('letter')
 
     available_template_types = list(filter(None, (
         'email',

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -197,7 +197,7 @@ class InvitedUser(object):
         return set(self.permissions) > set(permissions)
 
     def has_permission_for_service(self, service_id, permission):
-        if self.status == 'cancelled' and permission != 'view_activity':
+        if self.status == 'cancelled':
             return False
         return self.service == service_id and permission in self.permissions
 

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -20,6 +20,14 @@ roles_by_permission = {
 
 all_permissions = set(roles_by_permission.values())
 
+permissions = (
+    ('view_activity', 'See dashboard and reports'),
+    ('send_messages', 'Send messages using templates'),
+    ('manage_templates', 'Add and edit templates'),
+    ('manage_service', 'Manage settings, team members and usage'),
+    ('manage_api_keys', 'Manage API integration'),
+)
+
 
 def _get_service_id_from_view_args():
     return request.view_args.get('service_id', None)

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -21,10 +21,10 @@ roles_by_permission = {
 all_permissions = set(roles_by_permission.values())
 
 permissions = (
-    ('view_activity', 'See dashboard and reports'),
-    ('send_messages', 'Send messages using templates'),
+    ('view_activity', 'See dashboard'),
+    ('send_messages', 'Send messages'),
     ('manage_templates', 'Add and edit templates'),
-    ('manage_service', 'Manage settings, team members and usage'),
+    ('manage_service', 'Manage settings, team and usage'),
     ('manage_api_keys', 'Manage API integration'),
 )
 

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -124,7 +124,10 @@ class User(UserMixin):
         org_id = _get_org_id_from_view_args()
 
         if self.previewing_basic_view:
-            return self._permissions.get(service_id) and 'send_messages' in permissions
+            return self._permissions.get(service_id) and (
+                'send_messages' in permissions or
+                permissions == ()
+            )
 
         if not service_id and not org_id:
             # we shouldn't have any pages that require permissions, but don't specify a service or organisation.
@@ -137,7 +140,9 @@ class User(UserMixin):
 
         if org_id:
             return org_id in self.organisations
-        elif service_id:
+        if not permissions:
+            return service_id in self._permissions
+        if service_id:
             return any(x in self._permissions.get(service_id, []) for x in permissions)
 
     def has_permission_for_service(self, service_id, permission):

--- a/app/templates/components/message-count-label.html
+++ b/app/templates/components/message-count-label.html
@@ -26,3 +26,32 @@
     {%- endif -%}
   {%- endif %} {{ suffix }}
 {%- endmacro %}
+
+{% macro recipient_count_label(count, template_type) -%}
+  {% if template_type == None %}
+    {%- if count == 1 -%}
+      recipient
+    {%- else -%}
+      recipients
+    {%- endif -%}
+  {% endif %}
+  {%- if template_type == 'sms' -%}
+    {%- if count == 1 -%}
+      phone number
+    {%- else -%}
+      phone numbers
+    {%- endif -%}
+  {%- elif template_type == 'email' -%}
+    {%- if count == 1 -%}
+      email address
+    {%- else -%}
+      email addresses
+    {%- endif -%}
+  {%- elif template_type == 'letter' -%}
+    {%- if count == 1 -%}
+      address
+    {%- else -%}
+      addresses
+    {%- endif -%}
+  {%- endif %}
+{%- endmacro %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -1,10 +1,18 @@
 {% if help %}
   {% include 'partials/tour.html' %}
-{% elif current_user.has_permissions('view_activity') %}
+{% else %}
 <nav class="navigation">
   <ul>
+  {% if current_user.has_permissions('view_activity') %}
     <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}" {{ main_navigation.is_selected('dashboard') }}>Dashboard</a></li>
+  {% endif %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ main_navigation.is_selected('templates') }}>Templates</a></li>
+  {% if not current_user.has_permissions('view_activity') %}
+    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>
+    {% if current_service.has_jobs() %}
+      <li><a href="{{ url_for('.view_jobs', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploaded-files') }}>Uploaded files</a></li>
+    {% endif %}
+  {% endif %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
   {% if current_user.has_permissions('manage_service') %}
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
@@ -16,16 +24,5 @@
     <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
   {% endif %}
   </ul>
-</nav>
-{% else %}
-<nav class="navigation">
-  <ul>
-    <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ casework_navigation.is_selected('send-one-off') }}>Templates</a></li>
-    <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>
-    {% if current_service.has_jobs() %}
-      <li><a href="{{ url_for('.view_jobs', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploaded-files') }}>Uploaded files</a></li>
-    {% endif %}
-  </ul>
-
 </nav>
 {% endif %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -63,35 +63,26 @@
         </h3>
         <ul class="tick-cross-list">
           <div class="tick-cross-list-permissions">
-            {% if user.has_permission_for_service(current_service.id, 'view_activity') %}
-              {% if 'caseworking' in current_service.permissions %}
-                {{ tick_cross(
-                  user.status != 'cancelled',
-                  'Admin view'
-                ) }}
-              {% endif %}
-              {{ tick_cross(
-                user.has_permission_for_service(current_service.id, 'send_messages'),
-                'Send messages'
-              ) }}
-              {{ tick_cross(
-                user.has_permission_for_service(current_service.id, 'manage_templates'),
-                'Add and edit templates'
-              ) }}
-              {{ tick_cross(
-                user.has_permission_for_service(current_service.id, 'manage_service'),
-                'Manage service'
-              ) }}
-              {{ tick_cross(
-                user.has_permission_for_service(current_service.id, 'manage_api_keys'),
-                'Access API keys'
-              ) }}
-            {% else %}
-              {{ tick_cross(
-                user.status != 'cancelled',
-                'Basic view'
-              ) }}
-            {% endif %}
+            {{ tick_cross(
+              user.has_permission_for_service(current_service.id, 'view_activity'),
+              'See dashboard and reports'
+            ) }}
+            {{ tick_cross(
+              user.has_permission_for_service(current_service.id, 'send_messages'),
+              'Send messages'
+            ) }}
+            {{ tick_cross(
+              user.has_permission_for_service(current_service.id, 'manage_templates'),
+              'Add and edit templates'
+            ) }}
+            {{ tick_cross(
+              user.has_permission_for_service(current_service.id, 'manage_service'),
+              'Manage service'
+            ) }}
+            {{ tick_cross(
+              user.has_permission_for_service(current_service.id, 'manage_api_keys'),
+              'Access API keys'
+            ) }}
             {% if current_service.has_permission('email_auth') %}
               <div class="tick-cross-list-hint">
                 {% if user.auth_type == 'sms_auth' %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -63,26 +63,12 @@
         </h3>
         <ul class="tick-cross-list">
           <div class="tick-cross-list-permissions">
-            {{ tick_cross(
-              user.has_permission_for_service(current_service.id, 'view_activity'),
-              'See dashboard and reports'
-            ) }}
-            {{ tick_cross(
-              user.has_permission_for_service(current_service.id, 'send_messages'),
-              'Send messages'
-            ) }}
-            {{ tick_cross(
-              user.has_permission_for_service(current_service.id, 'manage_templates'),
-              'Add and edit templates'
-            ) }}
-            {{ tick_cross(
-              user.has_permission_for_service(current_service.id, 'manage_service'),
-              'Manage service'
-            ) }}
-            {{ tick_cross(
-              user.has_permission_for_service(current_service.id, 'manage_api_keys'),
-              'Access API keys'
-            ) }}
+            {% for permission, label in permissions %}
+              {{ tick_cross(
+                user.has_permission_for_service(current_service.id, permission),
+                label
+              ) }}
+            {% endfor %}
             {% if current_service.has_permission('email_auth') %}
               <div class="tick-cross-list-hint">
                 {% if user.auth_type == 'sms_auth' %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -1,56 +1,16 @@
 {% from "components/checkbox.html" import checkbox %}
 {% from "components/radios.html" import radio, radios, radios_wrapper, conditional_radio_panel %}
 
-{% if 'caseworking' in current_service.permissions %}
-  <div class="conditional-radios" data-module='conditional-radios'>
-    {% call radios_wrapper(form.user_type, hide_legend=True) %}
-      {% for option in form.user_type %}
-
-        <div class="bottom-gutter-1-3">
-          {{ radio(option, option_hints={
-              'admin': 'Show dashboard and other options',
-              'caseworker': 'Send messages, hide dashboard and other options'
-          }) }}
-        </div>
-        {% if option.data == 'admin' %}
-          {% call conditional_radio_panel('admin') %}
-            <fieldset class="form-group">
-              <legend class="form-label">
-                Extra permissions
-              </legend>
-              {{ checkbox(form.send_messages) }}
-              {{ checkbox(form.manage_templates) }}
-              {{ checkbox(form.manage_service) }}
-              {{ checkbox(form.manage_api_keys) }}
-            </fieldset>
-          {% endcall %}
-        {% endif %}
-
-      {% endfor %}
-    {% endcall %}
-  </div>
-
-{% else %}
-  <fieldset class="form-group">
-    <legend class="form-label">
-      Permissions
-    </legend>
-    {{ checkbox(form.send_messages) }}
-    {{ checkbox(form.manage_templates) }}
-    {{ checkbox(form.manage_service) }}
-    {{ checkbox(form.manage_api_keys) }}
-  </fieldset>
-  <div class="bottom-gutter">
-    <p class="form-label">
-      All team members can see
-    </p>
-    <ul class="list list-bullet">
-      <li>templates</li>
-      <li>history of sent messages</li>
-      <li>who the other team members are</li>
-    </ul>
-  </div>
-{% endif %}
+<fieldset class="form-group">
+  <legend class="form-label visually-hidden">
+    Permissions
+  </legend>
+  {{ checkbox(form.view_activity) }}
+  {{ checkbox(form.send_messages) }}
+  {{ checkbox(form.manage_templates) }}
+  {{ checkbox(form.manage_service) }}
+  {{ checkbox(form.manage_api_keys) }}
+</fieldset>
 
 {% if service_has_email_auth %}
   {% if user_has_no_mobile_number %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -2,15 +2,17 @@
 {% from "components/radios.html" import radio, radios, radios_wrapper, conditional_radio_panel %}
 
 <fieldset class="form-group">
-  <legend class="form-label visually-hidden">
+  <legend class="form-label">
     Permissions
   </legend>
-  {{ checkbox(form.view_activity) }}
-  {{ checkbox(form.send_messages) }}
-  {{ checkbox(form.manage_templates) }}
-  {{ checkbox(form.manage_service) }}
-  {{ checkbox(form.manage_api_keys) }}
+  {% for field in form.permissions_fields %}
+    {{ checkbox(field) }}
+  {% endfor %}
 </fieldset>
+
+<p class="bottom-gutter">
+  All team members can see sent messages.
+</p>
 
 {% if service_has_email_auth %}
   {% if user_has_no_mobile_number %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -21,13 +21,11 @@
   </h1>
   {% if not message_type == "letter" %}
 
-    {% if current_user.has_permissions('view_activity') %}
-      {{ ajax_block(
-        partials,
-        url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
-        'counts'
-      ) }}
-    {% endif %}
+    {{ ajax_block(
+      partials,
+      url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
+      'counts'
+    ) }}
 
     <form
       method="post"

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -3,7 +3,7 @@
 {% from "components/message-count-label.html" import message_count_label %}
 
 {% block service_page_title %}
-  {{ "Error" if error else "Preview of {}".format(template.name) }}
+  {{ "Error" if error else "Preview of ‘{}’".format(template.name) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -35,7 +35,7 @@
     </div>
   {% else %}
     <h1 class="heading-large">
-      Preview of {{ template.name }}
+      Preview of ‘{{ template.name }}’
     </h1>
   {% endif %}
 

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -1,8 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/file-upload.html" import file_upload %}
+{% from "components/message-count-label.html" import recipient_count_label %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/table.html" import list_table, field, text_field, index_field, index_field_heading %}
 
 {% block service_page_title %}
   {{ page_title }}
@@ -29,6 +28,13 @@
         </div>
       {% endif %}
     </div>
+    {% if link_to_upload %}
+      <p>
+        <a href="{{ url_for('.send_messages', service_id=current_service.id, template_id=template.id) }}">
+          Upload a list of {{ recipient_count_label(999, template.template_type) }}
+        </a>
+      </p>
+    {% endif %}
     {{ page_footer('Continue', back_link=back_link) }}
   </form>
 

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -1,15 +1,18 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
+{% from "components/message-count-label.html" import recipient_count_label %}
 {% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
 
 {% block service_page_title %}
-  Upload recipients
+  Upload a list of {{ recipient_count_label(999, template.template_type) }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Upload recipients</h1>
+  <h1 class="heading-large">
+    Upload a list of {{ recipient_count_label(999, template.template_type) }}
+  </h1>
 
   <div class="page-footer bottom-gutter">
     {{file_upload(

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -14,27 +14,34 @@
   {% else %}
     <div class="bottom-gutter-2-3">
       <div class="grid-row">
-        {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
-        <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
-          <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-            Upload recipients
-          </a>
-        </div>
-        <div class="{{ 'column-half' if template.template_type == 'letter' else 'column-third' }}">
-          <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-            {{ 'Print a test letter' if template.template_type == 'letter' else 'Send to one recipient' }}
-          </a>
-        </div>
-        {% endif %}
-        {% if
-          current_user.has_permissions('manage_templates') and
-          template.template_type != 'letter'
-        %}
-        <div class="column-one-third">
-          <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-            Edit template
-          </a>
-        </div>
+        {% if template.template_type == 'letter' %}
+          {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+            <div class="column-half">
+              <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+                Upload recipients
+              </a>
+            </div>
+            <div class="column-half">
+              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+                Print a test letter
+              </a>
+            </div>
+          {% endif %}
+        {% else %}
+          {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+            <div class="column-half">
+              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+                Send
+              </a>
+            </div>
+          {% endif %}
+          {% if current_user.has_permissions('manage_templates') %}
+            <div class="column-half">
+              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+                Edit
+              </a>
+            </div>
+          {% endif %}
         {% endif %}
       </div>
     </div>

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -18,7 +18,7 @@
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
             <div class="column-half">
               <a href="{{ url_for(".send_messages", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
-                Upload recipients
+                Upload a list of addresses
               </a>
             </div>
             <div class="column-half">

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -295,7 +295,7 @@ def test_conversation_reply_redirects_with_phone_number_from_notification(
     )
 
     for element, expected_text in [
-        ('h1', 'Preview of Two week reminder'),
+        ('h1', 'Preview of ‘Two week reminder’'),
         ('.sms-message-recipient', 'To: 07123 456789'),
         ('.sms-message-wrapper', 'service one: Template <em>content</em> with & entity'),
     ]:

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -26,18 +26,18 @@ from tests.conftest import service_one as create_sample_service
         (
             'Test User (you) '
             'Can See dashboard and reports '
-            'Can Send messages '
+            'Can Send messages using templates '
             'Can Add and edit templates '
-            'Can Manage service '
-            'Can Access API keys'
+            'Can Manage settings, team members and usage '
+            'Can Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys '
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration '
             'Edit permissions'
         )
     ),
@@ -46,18 +46,18 @@ from tests.conftest import service_one as create_sample_service
         (
             'Test User With Empty Permissions (you) '
             'Can’t See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         ),
     ),
     (
@@ -65,18 +65,18 @@ from tests.conftest import service_one as create_sample_service
         (
             'Test User With Permissions (you) '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         )
     ),
     (
@@ -84,18 +84,18 @@ from tests.conftest import service_one as create_sample_service
         (
             'Test User With Permissions (you) '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         )
     ),
     (
@@ -103,18 +103,18 @@ from tests.conftest import service_one as create_sample_service
         (
             'Test User With Permissions (you) '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
             'Can See dashboard and reports '
-            'Can’t Send messages '
+            'Can’t Send messages using templates '
             'Can’t Add and edit templates '
-            'Can’t Manage service '
-            'Can’t Access API keys'
+            'Can’t Manage settings, team members and usage '
+            'Can’t Manage API integration'
         )
     ),
 ])
@@ -175,19 +175,19 @@ def test_should_show_caseworker_on_overview_page(
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User With Permissions (you) '
         'Can See dashboard and reports '
-        'Can’t Send messages '
+        'Can’t Send messages using templates '
         'Can’t Add and edit templates '
-        'Can’t Manage service '
-        'Can’t Access API keys'
+        'Can’t Manage settings, team members and usage '
+        'Can’t Manage API integration'
     )
     # [1:5] are invited users
     assert normalize_spaces(page.select('.user-list-item')[6].text) == (
         'Test User zzzzzzz@example.gov.uk '
         'Can’t See dashboard and reports '
-        'Can Send messages '
+        'Can Send messages using templates '
         'Can’t Add and edit templates '
-        'Can’t Manage service '
-        'Can’t Access API keys'
+        'Can’t Manage settings, team members and usage '
+        'Can’t Manage API integration'
     )
 
 
@@ -606,20 +606,20 @@ def test_cancel_invited_user_cancels_user_invitations(
     ('pending', (
         'invited_user@test.gov.uk (invited) '
         'Can See dashboard and reports '
-        'Can Send messages '
+        'Can Send messages using templates '
         'Can’t Add and edit templates '
-        'Can Manage service '
-        'Can Access API keys '
+        'Can Manage settings, team members and usage '
+        'Can Manage API integration '
         'Cancel invitation'
     )),
     ('cancelled', (
         'invited_user@test.gov.uk (cancelled invite) '
         # all permissions are greyed out
         'Can’t See dashboard and reports '
-        'Can’t Send messages '
+        'Can’t Send messages using templates '
         'Can’t Add and edit templates '
-        'Can’t Manage service '
-        'Can’t Access API keys'
+        'Can’t Manage settings, team members and usage '
+        'Can’t Manage API integration'
     )),
 ])
 def test_manage_users_shows_invited_user(

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -25,18 +25,18 @@ from tests.conftest import service_one as create_sample_service
         active_user_with_permissions,
         (
             'Test User (you) '
-            'Can See dashboard and reports '
-            'Can Send messages using templates '
+            'Can See dashboard '
+            'Can Send messages '
             'Can Add and edit templates '
-            'Can Manage settings, team members and usage '
+            'Can Manage settings, team and usage '
             'Can Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration '
             'Edit permissions'
         )
@@ -45,18 +45,18 @@ from tests.conftest import service_one as create_sample_service
         active_user_empty_permissions,
         (
             'Test User With Empty Permissions (you) '
-            'Can’t See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can’t See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         ),
     ),
@@ -64,18 +64,18 @@ from tests.conftest import service_one as create_sample_service
         active_user_view_permissions,
         (
             'Test User With Permissions (you) '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         )
     ),
@@ -83,18 +83,18 @@ from tests.conftest import service_one as create_sample_service
         active_user_manage_template_permission,
         (
             'Test User With Permissions (you) '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         )
     ),
@@ -102,18 +102,18 @@ from tests.conftest import service_one as create_sample_service
         active_user_manage_template_permission,
         (
             'Test User With Permissions (you) '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         ),
         (
             'ZZZZZZZZ zzzzzzz@example.gov.uk '
-            'Can See dashboard and reports '
-            'Can’t Send messages using templates '
+            'Can See dashboard '
+            'Can’t Send messages '
             'Can’t Add and edit templates '
-            'Can’t Manage settings, team members and usage '
+            'Can’t Manage settings, team and usage '
             'Can’t Manage API integration'
         )
     ),
@@ -174,19 +174,19 @@ def test_should_show_caseworker_on_overview_page(
     assert normalize_spaces(page.select_one('h1').text) == 'Team members'
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User With Permissions (you) '
-        'Can See dashboard and reports '
-        'Can’t Send messages using templates '
+        'Can See dashboard '
+        'Can’t Send messages '
         'Can’t Add and edit templates '
-        'Can’t Manage settings, team members and usage '
+        'Can’t Manage settings, team and usage '
         'Can’t Manage API integration'
     )
     # [1:5] are invited users
     assert normalize_spaces(page.select('.user-list-item')[6].text) == (
         'Test User zzzzzzz@example.gov.uk '
-        'Can’t See dashboard and reports '
-        'Can Send messages using templates '
+        'Can’t See dashboard '
+        'Can Send messages '
         'Can’t Add and edit templates '
-        'Can’t Manage settings, team members and usage '
+        'Can’t Manage settings, team and usage '
         'Can’t Manage API integration'
     )
 
@@ -605,20 +605,20 @@ def test_cancel_invited_user_cancels_user_invitations(
 @pytest.mark.parametrize('invite_status, expected_text', [
     ('pending', (
         'invited_user@test.gov.uk (invited) '
-        'Can See dashboard and reports '
-        'Can Send messages using templates '
+        'Can See dashboard '
+        'Can Send messages '
         'Can’t Add and edit templates '
-        'Can Manage settings, team members and usage '
+        'Can Manage settings, team and usage '
         'Can Manage API integration '
         'Cancel invitation'
     )),
     ('cancelled', (
         'invited_user@test.gov.uk (cancelled invite) '
         # all permissions are greyed out
-        'Can’t See dashboard and reports '
-        'Can’t Send messages using templates '
+        'Can’t See dashboard '
+        'Can’t Send messages '
         'Can’t Add and edit templates '
-        'Can’t Manage settings, team members and usage '
+        'Can’t Manage settings, team and usage '
         'Can’t Manage API integration'
     )),
 ])

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -919,7 +919,7 @@ def test_send_test_doesnt_show_file_contents(
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.select('h1')[0].text.strip() == 'Preview of Two week reminder'
+    assert page.select('h1')[0].text.strip() == 'Preview of ‘Two week reminder’'
     assert len(page.select('table')) == 0
     assert len(page.select('.banner-dangerous')) == 0
     assert page.select_one('button[type=submit]').text.strip() == 'Send 1 text message'
@@ -1039,7 +1039,7 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     (
         mock_get_service_template_with_placeholders,
         partial(url_for, 'main.send_one_off'),
-        'Who should this message be sent to?',
+        'Send ‘Two week reminder’',
         False,
     ),
     (
@@ -1063,7 +1063,7 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     (
         mock_get_service_email_template,
         partial(url_for, 'main.send_one_off'),
-        'Who should this message be sent to?',
+        'Send ‘Two week reminder’',
         False,
     ),
     (
@@ -1479,7 +1479,7 @@ def test_send_test_email_message_without_placeholders_redirects_to_check_page(
     )
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.select('h1')[0].text.strip() == 'Preview of Two week reminder'
+    assert page.select('h1')[0].text.strip() == 'Preview of ‘Two week reminder’'
 
 
 @pytest.mark.parametrize('user, expected_back_link_endpoint, extra_args', (
@@ -2755,7 +2755,7 @@ def test_check_notification_shows_preview(
         template_id=fake_uuid
     )
 
-    assert page.h1.text.strip() == 'Preview of Two week reminder'
+    assert page.h1.text.strip() == 'Preview of ‘Two week reminder’'
     assert (
         page.findAll('a', {'class': 'page-footer-back-link'})[0]['href']
     ) == url_for(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2216,13 +2216,13 @@ def test_route_permissions_send_check_notifications(
     )
 
 
-@pytest.mark.parametrize('route', [
-    'main.choose_template',
-    'main.send_messages',
-    'main.get_example_csv',
-    'main.send_test'
+@pytest.mark.parametrize('route, expected_status', [
+    ('main.choose_template', 200),
+    ('main.send_messages', 403),
+    ('main.get_example_csv', 403),
+    ('main.send_test', 403),
 ])
-def test_route_invalid_permissions(
+def test_route_permissions_sending(
     mocker,
     app_,
     client,
@@ -2235,12 +2235,13 @@ def test_route_invalid_permissions(
     mock_create_job,
     fake_uuid,
     route,
+    expected_status,
 ):
     validate_route_permission(
         mocker,
         app_,
         "GET",
-        403,
+        expected_status,
         url_for(
             route,
             service_id=service_one['id'],

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -205,12 +205,12 @@ def test_caseworker_redirected_to_one_off(
     ),
     (
         ['send_messages'],
-        ['.send_messages', '.set_sender'],
+        ['.set_sender'],
         None,
     ),
     (
         ['send_messages', 'manage_templates'],
-        ['.send_messages', '.set_sender', '.edit_service_template'],
+        ['.set_sender', '.edit_service_template'],
         None,
     ),
 ])

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -187,6 +187,32 @@ def test_caseworker_redirected_to_one_off(
     )
 
 
+def test_user_with_only_send_and_view_redirected_to_one_off(
+    client_request,
+    mock_get_service_templates,
+    active_user_with_permissions,
+    mocker,
+    fake_uuid,
+):
+    active_user_with_permissions._permissions[SERVICE_ONE_ID] = [
+        'send_messages',
+        'view_activity',
+    ]
+    client_request.login(active_user_with_permissions)
+    client_request.get(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _expected_status=302,
+        _expected_redirect=url_for(
+            'main.send_one_off',
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _external=True,
+        ),
+    )
+
+
 @pytest.mark.parametrize('permissions, links_to_be_shown, permissions_warning_to_be_shown', [
     (
         ['view_activity'],
@@ -201,11 +227,6 @@ def test_caseworker_redirected_to_one_off(
     (
         ['manage_templates'],
         ['.edit_service_template'],
-        None,
-    ),
-    (
-        ['send_messages'],
-        ['.set_sender'],
         None,
     ),
     (

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -353,7 +353,8 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
     response = logged_in_platform_admin_client.get(url_for(
         '.edit_service_template',
         service_id='1234',
-        template_id=template_id))
+        template_id=template_id,
+    ))
 
     assert response.status_code == 200
     assert "Two week reminder" in response.get_data(as_text=True)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -74,19 +74,21 @@ from tests.conftest import single_letter_contact_block
             active_caseworking_user,
             'Templates',
             {},
-            ['Text message', 'Email'],
+            ['Text message', 'Email', 'Letter'],
             [
                 'sms_template_one',
                 'sms_template_two',
                 'email_template_one',
                 'email_template_two',
+                'letter_template_one',
+                'letter_template_two',
             ],
         ),
         (
             active_caseworking_user,
             'Templates',
             {'template_type': 'email'},
-            ['All', 'Text message'],
+            ['All', 'Text message', 'Letter'],
             ['email_template_one', 'email_template_two'],
         ),
     ]

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -167,6 +167,7 @@ def test_should_show_page_for_one_template(
 def test_caseworker_redirected_to_one_off(
     client_request,
     mock_get_service_templates,
+    mock_get_service_template,
     mocker,
     fake_uuid,
 ):
@@ -190,6 +191,7 @@ def test_caseworker_redirected_to_one_off(
 def test_user_with_only_send_and_view_redirected_to_one_off(
     client_request,
     mock_get_service_templates,
+    mock_get_service_template,
     active_user_with_permissions,
     mocker,
     fake_uuid,
@@ -211,6 +213,34 @@ def test_user_with_only_send_and_view_redirected_to_one_off(
             _external=True,
         ),
     )
+
+
+@pytest.mark.parametrize('permissions', (
+    {'send_messages', 'view_activity'},
+    {'send_messages'},
+    {'view_activity'},
+    {},
+))
+def test_user_with_only_send_and_view_sees_letter_page(
+    client_request,
+    mock_get_service_templates,
+    mock_get_service_letter_template,
+    single_letter_contact_block,
+    mock_has_jobs,
+    active_user_with_permissions,
+    mocker,
+    fake_uuid,
+    permissions,
+):
+    mocker.patch('app.main.views.templates.get_page_count_for_letter', return_value=1)
+    active_user_with_permissions._permissions[SERVICE_ONE_ID] = permissions
+    client_request.login(active_user_with_permissions)
+    page = client_request.get(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+    assert page.select_one('h1').text.strip() == 'Two week reminder'
 
 
 @pytest.mark.parametrize('permissions, links_to_be_shown, permissions_warning_to_be_shown', [

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -160,7 +160,7 @@ def test_caseworkers_get_caseworking_navigation(
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('#content nav').text) == (
-        'Templates Sent messages'
+        'Templates Sent messages Team members'
     )
 
 
@@ -177,5 +177,5 @@ def test_caseworkers_see_jobs_nav_if_jobs_exist(
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('#content nav').text) == (
-        'Templates Sent messages Uploaded files'
+        'Templates Sent messages Uploaded files Team members'
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2642,7 +2642,7 @@ def client_request(
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 follow_redirects=_follow_redirects,
             )
-            assert resp.status_code == _expected_status
+            assert resp.status_code == _expected_status, resp.location
             if _expected_redirect:
                 assert resp.location == _expected_redirect
             page = BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1248,6 +1248,27 @@ def active_user_view_permissions(fake_uuid):
 
 
 @pytest.fixture
+def active_user_empty_permissions(fake_uuid):
+    from app.notify_client.user_api_client import User
+
+    user_data = {'id': fake_uuid,
+                 'name': 'Test User With Empty Permissions',
+                 'password': 'somepassword',
+                 'password_changed_at': str(datetime.utcnow()),
+                 'email_address': 'test@user.gov.uk',
+                 'mobile_number': '07700 900763',
+                 'state': 'active',
+                 'failed_login_count': 0,
+                 'permissions': {SERVICE_ONE_ID: []},
+                 'platform_admin': False,
+                 'auth_type': 'sms_auth',
+                 'organisations': []
+                 }
+    user = User(user_data)
+    return user
+
+
+@pytest.fixture
 def active_user_manage_template_permission(fake_uuid):
     from app.notify_client.user_api_client import User
 


### PR DESCRIPTION
_This PR is a continuation of https://github.com/alphagov/notifications-admin/pull/2175 – read that for context first._

It makes two main changes which move us beyond ‘basic view’ as being the thing that makes Notify better for users who only send messages.

***

# Skip template page for users who only send messages

If you only send messages then there’s no longer much point in the template page. It now, for you, only has one action – ‘Send’:

Choose page | Template page | Send page
---|---|---
![localhost_6012_services_42a9d4f2-1444-4e22-9133-52d9e406213f_templates_all ipad](https://user-images.githubusercontent.com/355079/43765801-b5e69436-9a28-11e8-83a1-92a16b71a8cb.png) | ![localhost_6012_services_42a9d4f2-1444-4e22-9133-52d9e406213f_templates_be433bfc-fe31-464b-9f2c-5be11abf2176 ipad 1](https://user-images.githubusercontent.com/355079/43765760-9bed5fce-9a28-11e8-8009-24c41f5bd621.png) | ![localhost_6012_services_42a9d4f2-1444-4e22-9133-52d9e406213f_send_be433bfc-fe31-464b-9f2c-5be11abf2176_one-off_step-0 ipad](https://user-images.githubusercontent.com/355079/43765808-ba08e26c-9a28-11e8-9851-244d79d7fe9b.png)

This PR changes the journey for these users so they go straight from clicking the name of the template to the page where you enter the phone number or email address:

Choose page | Template page | Send page
---|---|---
![localhost_6012_services_42a9d4f2-1444-4e22-9133-52d9e406213f_templates_all ipad](https://user-images.githubusercontent.com/355079/43765801-b5e69436-9a28-11e8-83a1-92a16b71a8cb.png) | ![image](https://user-images.githubusercontent.com/355079/43766923-ab5a937a-9a2b-11e8-9521-fe9263d3828b.png) | ![localhost_6012_services_42a9d4f2-1444-4e22-9133-52d9e406213f_send_be433bfc-fe31-464b-9f2c-5be11abf2176_one-off_step-0 ipad](https://user-images.githubusercontent.com/355079/43765808-ba08e26c-9a28-11e8-9851-244d79d7fe9b.png)

This is better because it reduces the number of steps a user has to click through to send a message.

This journey is what we were previously calling ‘basic view’. But this changes makes it automatically available to anyone who would benefit from it. It removes the complexity of:
- having to opt in to basic view at a service level
- having to choose on a per-user basis who has basic view
- understanding the nuance between basic view and only choosing the  ‘Send messages’ permission

Users who will still see the template page are:
- those who can edit templates – they need the ‘edit’ link
- users with the manage API keys permission – they need a place to get the template ID

# Add a ‘see dashboard’ permission

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/43767116-20537192-9a2c-11e8-994e-2810c2b85676.png) | ![image](https://user-images.githubusercontent.com/355079/43767103-186156f2-9a2c-11e8-901b-6bbc169c221a.png)
![image](https://user-images.githubusercontent.com/355079/43767163-439d10b8-9a2c-11e8-8a6f-0efada4b61d0.png) | _‘Basic view’ goes away_

Our research and prototyping around ‘basic view’ found that:
- a lot of users who send messages rarely or never look at the dashboard (yet it’s the first page they see when they sign in)
- team managers like the idea of taking away things that users don’t need in order to make the interface simpler

Therefore users who were given ‘basic view’ didn’t see the dashboard.

In the above change we’ve disentangled the simpler way of sending messages from being part of ‘basic view’. This means we can give managers the option of taking away the dashboard as an independent choice, not something that’s wrapped up in a separate ‘view’.

I think that this checkbox is a more straightforward proposition than ‘basic view’ ever was (despite all the work we did to explain it and develop the nested checkbox pattern). In research users would often
explain the feature back to us as being about hiding the dashboard – we should try to make Notify operate in terms of concepts that come naturally to people wherever possible.