### PR TITLE
Label the search box dependent on message type

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -871,7 +871,19 @@ class SearchUsersForm(StripWhitespaceForm):
 
 class SearchNotificationsForm(StripWhitespaceForm):
 
-    to = SearchField('Search by phone number or email address')
+    to = SearchField()
+
+    labels = {
+        'email': 'Search by email address',
+        'sms': 'Search by phone number',
+    }
+
+    def __init__(self, message_type, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.to.label.text = self.labels.get(
+            message_type,
+            'Search by phone number or email address',
+        )
 
 
 class PlaceholderForm(StripWhitespaceForm):

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -183,7 +183,10 @@ def view_notifications(service_id, message_type=None):
         status=request.args.get('status') or 'sending,delivered,failed',
         page=request.args.get('page', 1),
         to=request.form.get('to', ''),
-        search_form=SearchNotificationsForm(to=request.form.get('to', '')),
+        search_form=SearchNotificationsForm(
+            message_type=message_type,
+            to=request.form.get('to', ''),
+        ),
         download_link=url_for(
             '.download_notifications_csv',
             service_id=current_service.id,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -297,13 +297,21 @@ def test_shows_message_when_no_notifications(
 @pytest.mark.parametrize((
     'initial_query_arguments,'
     'form_post_data,'
+    'expected_search_box_label,'
     'expected_search_box_contents'
 ), [
+    (
+        {},
+        {},
+        'Search by phone number or email address',
+        '',
+    ),
     (
         {
             'message_type': 'sms',
         },
         {},
+        'Search by phone number',
         '',
     ),
     (
@@ -313,6 +321,7 @@ def test_shows_message_when_no_notifications(
         {
             'to': '+33(0)5-12-34-56-78',
         },
+        'Search by phone number',
         '+33(0)5-12-34-56-78',
     ),
     (
@@ -324,6 +333,7 @@ def test_shows_message_when_no_notifications(
         {
             'to': 'test@example.com',
         },
+        'Search by email address',
         'test@example.com',
     ),
 ])
@@ -333,6 +343,7 @@ def test_search_recipient_form(
     mock_get_service_statistics,
     initial_query_arguments,
     form_post_data,
+    expected_search_box_label,
     expected_search_box_contents,
 ):
     response = logged_in_client.post(
@@ -351,10 +362,12 @@ def test_search_recipient_form(
     url = urlparse(action_url)
     assert url.path == '/services/{}/notifications/{}'.format(
         SERVICE_ONE_ID,
-        initial_query_arguments['message_type']
-    )
+        initial_query_arguments.get('message_type', '')
+    ).rstrip('/')
     query_dict = parse_qs(url.query)
     assert query_dict == {}
+
+    assert page.select_one('label[for=to]').text.strip() == expected_search_box_label
 
     recipient_inputs = page.select("input[name=to]")
     assert(len(recipient_inputs) == 2)


### PR DESCRIPTION
It doesn’t make sense to say ‘Search by email address or phone number’ when you’re only looking at emails.