### PR TITLE
Pin patch version of govuk-elements-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-core": "6.26.0",
     "babel-preset-es2015": "6.24.1",
     "diff-dom": "2.3.1",
-    "govuk-elements-sass": "3.1.x",
+    "govuk-elements-sass": "3.1.2",
     "govuk_frontend_toolkit": "7.2.0",
     "govuk_template_jinja": "0.24.0",
     "gulp": "3.9.1",


### PR DESCRIPTION
Version 3.1.3 of govuk-elements changed heading classes to display block (https://github.com/alphagov/govuk_elements/pull/552). This is a breaking change for us since we are using the heading classes in a number of places that aren't headings in order to make font bold. Upgrading to 3.1.3 adds line breaks in places where we don't want them and causes some functional tests to fail.

I started by trying to update the CSS so that everything still looks the same with 3.1.3, but this was getting increasingly complicated. And since we will be replacing govuk-elements with the new design system soon anyway, it is simpler to pin the version of govuk-elements for now.

#### Example of an unwanted line break in version 3.1.3
<img width="551" alt="screen shot 2018-08-07 at 16 44 50" src="https://user-images.githubusercontent.com/12881990/43832413-4da37240-9aff-11e8-9c8b-678cab1c2c4a.png">
