### PR TITLE
Fix ‘Back’ link from first step of one off

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -29,6 +29,7 @@ from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
     email_or_sms_not_enabled,
     get_template,
+    should_skip_template_page,
     user_has_permissions,
 )
 
@@ -49,11 +50,7 @@ page_headings = {
 @user_has_permissions()
 def view_template(service_id, template_id):
     template = service_api_client.get_service_template(service_id, str(template_id))['data']
-    if (
-        current_user.has_permissions('send_messages') and
-        not current_user.has_permissions('manage_templates', 'manage_api_keys') and
-        template['template_type'] != 'letter'
-    ):
+    if should_skip_template_page(template['template_type']):
         return redirect(url_for(
             '.send_one_off', service_id=service_id, template_id=template_id
         ))

--- a/app/utils.py
+++ b/app/utils.py
@@ -655,3 +655,11 @@ def guess_name_from_email_address(email_address):
     ).then(
         normalize_spaces
     )
+
+
+def should_skip_template_page(template_type):
+    return (
+        current_user.has_permissions('send_messages') and
+        not current_user.has_permissions('manage_templates', 'manage_api_keys') and
+        template_type != 'letter'
+    )


### PR DESCRIPTION
If you skip past the templates page (because you don’t have the edit permission) but then click back you end up in a loop which redirects you to the page you’re already on.

This commit makes sure that you’re sent back a step further, so you don’t get stuck in that loop.