### PR TITLE
Allow service contact details to be a phone number, email or url

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -2,6 +2,9 @@ $(() => $("time.timeago").timeago());
 
 $(() => GOVUK.stickAtTopWhenScrolling.init());
 
+var showHideContent = new GOVUK.ShowHideContent();
+showHideContent.init();
+
 $(() => GOVUK.modules.start());
 
 $(() => $('.error-message').eq(0).parent('label').next('input').trigger('focus'));

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -32,8 +32,8 @@
   </div>
 {% endmacro %}
 
-{% macro radio(option, disable=[], option_hints={}) %}
-  <div class="multiple-choice">
+{% macro radio(option, disable=[], option_hints={}, data_target=None) %}
+  <div class="multiple-choice" {% if data_target %}data-target="{{ data_target }}"{% endif %}>
     <input
       id="{{ option.id }}" name="{{ option.name }}" type="radio" value="{{ option.data }}"
       {% if option.data in disable %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -47,7 +47,7 @@
         {% endcall %}
 
         {% call settings_row(if_has_permission='upload_document') %}
-          {{ text_field('Contact link') }}
+          {{ text_field('Contact details') }}
           {{ text_field(current_service.contact_link, truncate=true) }}
           {{ edit_field(
               'Change',

--- a/app/templates/views/service-settings/contact_link.html
+++ b/app/templates/views/service-settings/contact_link.html
@@ -1,24 +1,46 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/radios.html" import radio, radios_wrapper %}
 
 {% block service_page_title %}
-  {{ 'Change link on' if 'upload_document' in current_service.permissions else 'Add link for' }} ‘Download your document’ page
+  {{ 'Change' if 'upload_document' in current_service.permissions else 'Add' }} contact details for ‘Download your document’ page
 {% endblock %}
 
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-five-sixths">
       <h1 class="heading-large">
-        {{ 'Change link on' if 'upload_document' in current_service.permissions else 'Add link for' }} ‘Download your document’ page
+        {{ 'Change' if 'upload_document' in current_service.permissions else 'Add' }} contact details for ‘Download your document’ page
       </h1>
       <p>
-        When you send users a document to download, you need to include a link to your service
+        When you send users a document to download, you need to include the contact details for your service
         on the download page. This is so users can contact you if there’s a problem (for example,
         if the link to download the document has expired).
       </p>
-      <form method="post">
-        {{ textbox(form.url, width='1-1') }}
+      <form method="post" novalidate>
+
+        {% call radios_wrapper(form.contact_details_type, hide_legend=true) %}
+          {% for option in form.contact_details_type %}
+            {% if option.data == 'url' %}
+              {{ radio(option, data_target="url-type") }}
+              <div class="panel panel-border-narrow js-hidden" id="url-type">
+                {{ textbox(form.url, label=' ', width='1-1') }}
+              </div>
+            {% elif option.data == 'email_address' %}
+              {{ radio(option, data_target="email-address-type") }}
+              <div class="panel panel-border-narrow js-hidden" id="email-address-type">
+                {{ textbox(form.email_address, label=' ', width='1-1') }}
+              </div>
+            {% elif option.data == 'phone_number' %}
+              {{ radio(option, data_target="phone-number-type") }}
+              <div class="panel panel-border-narrow js-hidden" id="phone-number-type">
+                {{ textbox(form.phone_number, label=' ', width='1-1') }}
+              </div>
+            {% endif %}
+          {% endfor %}
+        {% endcall %}
+
         {{ page_footer(
           'Save',
           back_link=url_for('.service_settings', service_id=current_service.id),

--- a/app/templates/views/service-settings/contact_link.html
+++ b/app/templates/views/service-settings/contact_link.html
@@ -22,22 +22,12 @@
 
         {% call radios_wrapper(form.contact_details_type, hide_legend=true) %}
           {% for option in form.contact_details_type %}
-            {% if option.data == 'url' %}
-              {{ radio(option, data_target="url-type") }}
-              <div class="panel panel-border-narrow js-hidden" id="url-type">
-                {{ textbox(form.url, label=' ', width='1-1') }}
-              </div>
-            {% elif option.data == 'email_address' %}
-              {{ radio(option, data_target="email-address-type") }}
-              <div class="panel panel-border-narrow js-hidden" id="email-address-type">
-                {{ textbox(form.email_address, label=' ', width='1-1') }}
-              </div>
-            {% elif option.data == 'phone_number' %}
-              {{ radio(option, data_target="phone-number-type") }}
-              <div class="panel panel-border-narrow js-hidden" id="phone-number-type">
-                {{ textbox(form.phone_number, label=' ', width='1-1') }}
-              </div>
-            {% endif %}
+            {% set data_target = option.data.replace('_', '-') ~ "-type" %}
+
+            {{ radio(option, data_target=data_target) }}
+            <div class="panel panel-border-narrow js-hidden" id={{data_target}}>
+              {{ textbox(form|attr(option.data), label=' ', width='1-1') }}
+            </div>
           {% endfor %}
         {% endcall %}
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -58,6 +58,7 @@ gulp.task('copy:govuk_template:fonts', () => gulp.src(paths.template + 'assets/s
 gulp.task('javascripts', () => gulp
   .src([
     paths.toolkit + 'javascripts/govuk/modules.js',
+    paths.toolkit + 'javascripts/govuk/show-hide-content.js',
     paths.toolkit + 'javascripts/govuk/stop-scrolling-at-footer.js',
     paths.toolkit + 'javascripts/govuk/stick-at-top-when-scrolling.js',
     paths.src + 'javascripts/detailsPolyfill.js',

--- a/tests/app/main/test_service_contact_details_form.py
+++ b/tests/app/main/test_service_contact_details_form.py
@@ -1,0 +1,92 @@
+import pytest
+
+from app.main.forms import ServiceContactDetailsForm
+
+
+def test_form_fails_validation_with_no_radio_buttons_selected(app_):
+    with app_.test_request_context(method='POST', data={}):
+        form = ServiceContactDetailsForm()
+
+        assert not form.validate_on_submit()
+        assert len(form.errors) == 1
+        assert form.errors['contact_details_type'] == ['Not a valid choice']
+
+
+@pytest.mark.parametrize('selected_radio_button, selected_text_box, text_box_data', [
+    ('email_address', 'url', 'http://www.example.com'),
+    ('phone_number', 'url', 'http://www.example.com'),
+    ('url', 'email_address', 'user@example.com'),
+    ('phone_number', 'email_address', 'user@example.com'),
+    ('url', 'phone_number', '0207 123 4567'),
+    ('email_address', 'phone_number', '0207 123 4567'),
+])
+def test_form_fails_validation_when_radio_button_selected_and_text_box_filled_in_do_not_match(
+    app_,
+    selected_radio_button,
+    selected_text_box,
+    text_box_data
+):
+    data = {'contact_details_type': selected_radio_button, selected_text_box: text_box_data}
+
+    with app_.test_request_context(method='POST', data=data):
+        form = ServiceContactDetailsForm()
+
+        assert not form.validate_on_submit()
+        assert len(form.errors) == 1
+        assert form.errors[selected_radio_button] == ['This field is required.']
+
+
+@pytest.mark.parametrize('selected_field, url, email_address, phone_number', [
+    ('url', 'http://www.example.com', 'invalid-email.com', 'phone'),
+    ('email_address', 'www.invalid-url.com', 'me@example.com', 'phone'),
+    ('phone_number', 'www.invalid-url.com', 'invalid-email.com', '0207 123 4567'),
+])
+def test_form_only_validates_the_field_which_matches_the_selected_radio_button(
+    app_,
+    selected_field,
+    url,
+    email_address,
+    phone_number,
+):
+    data = {'contact_details_type': selected_field,
+            'url': url,
+            'email_address': email_address,
+            'phone_number': phone_number}
+
+    with app_.test_request_context(method='POST', data=data):
+        form = ServiceContactDetailsForm()
+
+        assert form.validate_on_submit()
+
+
+def test_form_url_validation_fails_with_invalid_url_field(app_):
+    data = {'contact_details_type': 'url', 'url': 'www.example.com'}
+
+    with app_.test_request_context(method='POST', data=data):
+        form = ServiceContactDetailsForm()
+
+        assert not form.validate_on_submit()
+        assert len(form.errors) == 1
+        assert len(form.errors['url']) == 1
+
+
+def test_form_email_validation_fails_with_invalid_email_address_field(app_):
+    data = {'contact_details_type': 'email_address', 'email_address': '1@co'}
+
+    with app_.test_request_context(method='POST', data=data):
+        form = ServiceContactDetailsForm()
+
+        assert not form.validate_on_submit()
+        assert len(form.errors) == 1
+        assert len(form.errors['email_address']) == 2
+
+
+def test_form_phone_number_validation_fails_with_invalid_phone_number_field(app_):
+    data = {'contact_details_type': 'phone_number', 'phone_number': '1235 A'}
+
+    with app_.test_request_context(method='POST', data=data):
+        form = ServiceContactDetailsForm()
+
+        assert not form.validate_on_submit()
+        assert len(form.errors) == 1
+        assert form.errors['phone_number'] == ['Must be a valid phone number']


### PR DESCRIPTION
Service contact details are needed if the upload document permission is enabled - this used to be a link but services can now choose to use a link, email address or phone number. The form to add or change service contact details now gives these options and validates the data according to the type of contact details provided.

When validating phone numbers we can't use the existing validation because we want to allow landlines too, so there is a basic check that the phone number is the right length and doesn't include certain characters.

[Pivotal story](https://www.pivotaltracker.com/story/show/159490824)

### Updated settings page
<img width="768" alt="screen shot 2018-08-10 at 14 14 10" src="https://user-images.githubusercontent.com/12881990/43960034-9667bb26-9ca8-11e8-8623-86c06ad37acc.png">

### Updated form
<img width="672" alt="screen shot 2018-08-10 at 14 14 30" src="https://user-images.githubusercontent.com/12881990/43960048-a48f98cc-9ca8-11e8-9358-d4f88eedf1ed.png">

