### PR TITLE
Allow service contact_link or contact_details naming

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -341,7 +341,8 @@ def service_switch_can_upload_document(service_id):
 
     # If turning the permission off, or turning it on and the service already has a contact_link,
     # don't show the form to add the link
-    if current_service.has_permission('upload_document') or current_service.get('contact_link'):
+    if current_service.has_permission('upload_document') or (
+       current_service.get('contact_link') or current_service.get('contact_details')):
         switch_service_permissions(service_id, 'upload_document')
         return redirect(url_for('.service_settings', service_id=service_id))
 
@@ -350,7 +351,8 @@ def service_switch_can_upload_document(service_id):
 
         service_api_client.update_service(
             current_service.id,
-            contact_link=form.data[contact_type]
+            contact_link=form.data[contact_type],
+            contact_details=form.data[contact_type],
         )
         switch_service_permissions(service_id, 'upload_document')
         return redirect(url_for('.service_settings', service_id=service_id))
@@ -402,7 +404,7 @@ def service_set_contact_link(service_id):
     form = ServiceContactDetailsForm()
 
     if request.method == 'GET':
-        contact_details = current_service.get('contact_link')
+        contact_details = current_service.get('contact_link') or current_service.get('contact_details')
         contact_type = check_contact_details_type(contact_details)
         field_to_update = getattr(form, contact_type)
 
@@ -414,7 +416,8 @@ def service_set_contact_link(service_id):
 
         service_api_client.update_service(
             current_service.id,
-            contact_link=form.data[contact_type]
+            contact_link=form.data[contact_type],
+            contact_details=form.data[contact_type],
         )
         return redirect(url_for('.service_settings', service_id=current_service.id))
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -86,6 +86,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             'free_sms_fragment_limit',
             'prefix_sms',
             'contact_link',
+            'contact_details',
         }
         if disallowed_attributes:
             raise TypeError('Not allowed to update service attributes: {}'.format(

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -48,7 +48,7 @@
 
         {% call settings_row(if_has_permission='upload_document') %}
           {{ text_field('Contact details') }}
-          {{ text_field(current_service.contact_link, truncate=true) }}
+          {{ text_field(current_service.contact_link or current_service.contact_details, truncate=true) }}
           {{ edit_field(
               'Change',
               url_for('.service_set_contact_link',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2356,7 +2356,7 @@ def test_service_set_contact_link_updates_contact_details_and_redirects_to_setti
     )
 
     assert page.h1.text == 'Settings'
-    mock_update_service.assert_called_once_with(SERVICE_ONE_ID, contact_link=new_value)
+    mock_update_service.assert_called_once_with(SERVICE_ONE_ID, contact_link=new_value, contact_details=new_value)
 
 
 def test_service_set_contact_link_updates_contact_details_for_the_selected_field_when_multiple_textboxes_contain_data(
@@ -2383,7 +2383,10 @@ def test_service_set_contact_link_updates_contact_details_for_the_selected_field
     )
 
     assert page.h1.text == 'Settings'
-    mock_update_service.assert_called_once_with(SERVICE_ONE_ID, contact_link='http://www.new-url.com')
+    mock_update_service.assert_called_once_with(
+        SERVICE_ONE_ID,
+        contact_link='http://www.new-url.com',
+        contact_details='http://www.new-url.com')
 
 
 def test_service_set_contact_link_displays_error_message_when_no_radio_button_selected(


### PR DESCRIPTION
The Service `contact_link` property in Notifications API will be renamed
`contact_details`. To ensure that there is no downtime or errors while the
name is being changed, this commit takes both the old and new name into
account by
- checking for both names where we were previously just checking for
`contact_link`
- sending values for both `contact_link` and `contact_details` to the API

Once the name has been changed in API, we can replace `contact_link` with
`contact_details` instead of keeping both names.