### PR TITLE
Bump utils for email branding bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
-DATE = $(shell date +%Y-%m-%d:%H:%M:%S)
+DATE = $(shell date +%Y-%m-%dT%H:%M:%S)
 
 PIP_ACCEL_CACHE ?= ${CURDIR}/cache/pip-accel
 APP_VERSION_FILE = app/version.py

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,4 +21,4 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.5#egg=notifications-utils==29.3.5
+git+https://github.com/alphagov/notifications-utils.git@29.3.6#egg=notifications-utils==29.3.6

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,4 +21,4 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.4#egg=notifications-utils==29.3.4
+git+https://github.com/alphagov/notifications-utils.git@29.3.5#egg=notifications-utils==29.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,13 +23,13 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.4#egg=notifications-utils==29.3.4
+git+https://github.com/alphagov/notifications-utils.git@29.3.5#egg=notifications-utils==29.3.5
 
 ## The following requirements were added by pip freeze:
-awscli==1.15.70
+awscli==1.15.74
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.69
+botocore==1.10.73
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
@@ -47,11 +47,11 @@ jdcal==1.4
 Jinja2==2.10
 jmespath==0.9.3
 lml==0.0.1
-lxml==4.2.3
+lxml==4.2.4
 MarkupSafe==1.0
 mistune==0.8.3
 monotonic==1.5
-openpyxl==2.5.4
+openpyxl==2.5.5
 orderedset==2.0.1
 phonenumbers==8.9.4
 pyasn1==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,14 +23,14 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.3.5#egg=notifications-utils==29.3.5
+git+https://github.com/alphagov/notifications-utils.git@29.3.6#egg=notifications-utils==29.3.6
 
 ## The following requirements were added by pip freeze:
-awscli==1.15.74
+awscli==1.15.77
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.73
-certifi==2018.4.16
+botocore==1.10.76
+certifi==2018.8.13
 chardet==3.0.4
 click==6.7
 colorama==0.3.9


### PR DESCRIPTION
Sits on top of [the other pull request for bumping utils](https://github.com/alphagov/notifications-admin/pull/2215).

Brings in:

alphagov/notifications-utils#513

Only effects the email branding preview at `/_email` so only used by platform admins.