### PR TITLE
Make the new Ruby docs live

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -17,7 +17,7 @@
       <li><a href="https://github.com/alphagov/notifications-node-client" target="_blank" rel="noopener">Node JS</a></li>
       <li><a href="https://github.com/alphagov/notifications-php-client" target="_blank" rel="noopener">PHP</a></li>
       <li><a href="https://docs.notifications.service.gov.uk/python.html" target="_blank" rel="noopener">Python</a></li>
-      <li><a href="https://github.com/alphagov/notifications-ruby-client" target="_blank" rel="noopener">Ruby</a></li>
+      <li><a href="https://docs.notifications.service.gov.uk/ruby.html" target="_blank" rel="noopener">Ruby</a></li>
     </ul>
     <p>You can also find out about <a href="{{ url_for('main.integration_testing')}}">integration testing</a> and the different types of API keys that you can use.</p>
   </div>


### PR DESCRIPTION
The Ruby docs are now finished, so we can change the documentation link to point to the new docs.