### PR TITLE
Improve number formatting on platform-admin page

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -11,7 +11,10 @@ from app import (
 )
 from app.main import main
 from app.main.forms import DateFilterForm
-from app.statistics_utils import get_formatted_percentage
+from app.statistics_utils import (
+    get_formatted_percentage,
+    get_formatted_percentage_two_dp,
+)
 from app.utils import (
     generate_next_dict,
     generate_previous_dict,
@@ -54,7 +57,7 @@ def is_over_threshold(number, total, threshold):
 
 def get_status_box_data(stats, key, label, threshold=FAILURE_THRESHOLD):
     return {
-        'number': stats['failures'][key],
+        'number': "{:,}".format(stats['failures'][key]),
         'label': label,
         'failing': is_over_threshold(
             stats['failures'][key],
@@ -88,7 +91,7 @@ def make_columns(global_stats, complaints_number):
                     'label': 'complaints',
                     'failing': is_over_threshold(complaints_number,
                                                  global_stats['email']['total'], COMPLAINT_THRESHOLD),
-                    'percentage': get_formatted_percentage(complaints_number, global_stats['email']['total']),
+                    'percentage': get_formatted_percentage_two_dp(complaints_number, global_stats['email']['total']),
                     'url': url_for('main.platform_admin_list_complaints')
                 }
             ],

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -52,6 +52,13 @@ def get_formatted_percentage(x, tot):
     return "{0:.1f}".format((float(x) / tot * 100)) if tot else '0'
 
 
+def get_formatted_percentage_two_dp(x, tot):
+    """
+    Return a percentage to two decimal places
+    """
+    return "{0:.2f}".format((float(x) / tot * 100)) if tot else '0'
+
+
 def statistics_by_state(statistics):
     return {
         'sms': {


### PR DESCRIPTION
Minor changes to the number formatting for the `/platform-admin` page to
- Show the complaint percentage to 2 decimal places. (The number of
complaints is often below 0.0% so 1 decimal place isn't useful)
- Format the numbers in the status boxes to use a comma as a thousands
separator.