### PR TITLE
Stop email preview showing brand name

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -91,7 +91,7 @@ def email_template():
         brand_banner = False
     else:
         email_branding = email_branding_client.get_email_branding(branding_style)['email_branding']
-        brand_name = email_branding['name']
+        brand_name = email_branding['text']
         brand_colour = email_branding['colour']
         brand_logo = 'https://{}/{}'.format(get_cdn_domain(), email_branding['logo'])
         govuk_banner = branding_type in ['govuk', 'both']

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -54,6 +54,8 @@ def test_displays_both_branding(client, mock_get_email_branding):
 
     assert page.find("a", attrs={"href": "https://www.gov.uk"})
     assert page.find("img", attrs={"src": re.compile("example.png$")})
+    assert page.select("body > table table > tr:nth-of-type(2) > td:nth-of-type(5)")[0]\
+        .get_text().strip() == 'Organisation text'  # brand text is set
 
 
 def test_displays_org_branding(client, mock_get_email_branding):
@@ -67,7 +69,9 @@ def test_displays_org_branding(client, mock_get_email_branding):
 
     assert not page.find("a", attrs={"href": "https://www.gov.uk"})
     assert page.find("img", attrs={"src": re.compile("example.png")})
-    assert not page.select("body > table > tr > td[bgcolor='#f00']")
+    assert not page.select("body > table > tr > td[bgcolor='#f00']")  # banner colour is not set
+    assert page.select("body > table table > tr:nth-of-type(2) > td:nth-of-type(5)")[0]\
+        .get_text().strip() == 'Organisation text'  # brand text is set
 
 
 def test_displays_org_branding_with_banner(client, mock_get_email_branding):
@@ -82,4 +86,23 @@ def test_displays_org_branding_with_banner(client, mock_get_email_branding):
 
     assert not page.find("a", attrs={"href": "https://www.gov.uk"})
     assert page.find("img", attrs={"src": re.compile("example.png")})
-    assert page.select("body > table > tr > td[bgcolor='#f00']")
+    assert page.select("body > table > tr > td[bgcolor='#f00']")  # banner colour is set
+    assert page.select("body > table table > tr > td > span")[0]\
+        .get_text().strip() == 'Organisation text'  # brand text is set
+
+
+def test_displays_org_branding_with_banner_without_brand_text(
+        client, mock_get_email_branding_without_brand_text):
+
+    response = client.get(url_for('main.email_template', branding_type="org_banner",
+                                  branding_style="1"))
+
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+    assert response.status_code == 200
+    mock_get_email_branding_without_brand_text.assert_called_once_with('1')
+
+    assert not page.find("a", attrs={"href": "https://www.gov.uk"})
+    assert page.find("img", attrs={"src": re.compile("example.png")})
+    assert page.select("body > table > tr > td[bgcolor='#f00']")  # banner colour is set
+    assert not page.select("body > table table > tr > td > span") == 0  # brand text is not set

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2486,6 +2486,25 @@ def mock_get_email_branding(mocker, fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def mock_get_email_branding_without_brand_text(mocker, fake_uuid):
+    def _get_email_branding_without_brand_text(id):
+        return {
+            'email_branding': {
+                'logo': 'example.png',
+                'name': 'Organisation name',
+                'text': '',
+                'id': fake_uuid,
+                'colour': '#f00'
+            }
+        }
+
+    return mocker.patch(
+        'app.email_branding_client.get_email_branding',
+        side_effect=_get_email_branding_without_brand_text
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_create_email_branding(mocker):
     def _create_email_branding(logo, name, text, colour):
         return


### PR DESCRIPTION
This is a leftover from when email brands didn't have a 'text' field.

It also adds some tests to check the brand name is displaying correctly.