### PR TITLE
Increase SMS maximum length from 459 to 612

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,8 +51,6 @@ class Config(object):
     SESSION_COOKIE_SECURE = True
     SESSION_REFRESH_EACH_REQUEST = True
     SHOW_STYLEGUIDE = True
-    # TODO: move to utils
-    SMS_CHAR_COUNT_LIMIT = 459
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -15,6 +15,7 @@ from flask import (
 )
 from flask_login import current_user, login_required
 from notifications_python_client.errors import HTTPError
+from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.columns import Columns
 from notifications_utils.recipients import (
     RecipientCSV,
@@ -852,7 +853,7 @@ def get_template_error_dict(exception):
 
     return {
         'error': error,
-        'SMS_CHAR_COUNT_LIMIT': current_app.config['SMS_CHAR_COUNT_LIMIT'],
+        'SMS_CHAR_COUNT_LIMIT': SMS_CHAR_COUNT_LIMIT,
         'current_service': current_service,
 
         # used to trigger CSV specific err msg content, so not needed for single notification errors.

--- a/app/templates/views/pricing.html
+++ b/app/templates/views/pricing.html
@@ -47,7 +47,8 @@
         {% for message_length, charge in [
           ('Up to 160 characters', '1 text message'),
           ('Up to 306 characters', '2 text messages'),
-          ('Up to 459 characters', '3 text messages')
+          ('Up to 459 characters', '3 text messages'),
+          ('Up to 612 characters', '4 text messages'),
         ] %}
           {% call row() %}
             {{ text_field(message_length) }}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,4 +21,4 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.0.1#egg=notifications-utils==30.0.1
+git+https://github.com/alphagov/notifications-utils.git@30.1.0#egg=notifications-utils==30.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,13 +23,13 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.0.1#egg=notifications-utils==30.0.1
+git+https://github.com/alphagov/notifications-utils.git@30.1.0#egg=notifications-utils==30.1.0
 
 ## The following requirements were added by pip freeze:
-awscli==1.15.78
+awscli==1.15.79
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.77
+botocore==1.10.78
 certifi==2018.8.13
 chardet==3.0.4
 click==6.7

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2916,7 +2916,7 @@ TRIAL_MODE_MSG = (
     'Can’t send to this recipient when service is in trial mode – '
     'see https://www.notifications.service.gov.uk/trial-mode'
 )
-TOO_LONG_MSG = 'Content for template has a character count greater than the limit of 495'
+TOO_LONG_MSG = 'Content for template has a character count greater than the limit of 612'
 SERVICE_DAILY_LIMIT_MSG = 'Exceeded send limits (1000) for today'
 
 
@@ -2929,7 +2929,7 @@ SERVICE_DAILY_LIMIT_MSG = 'Exceeded send limits (1000) for today'
     (
         TOO_LONG_MSG,
         'Message too long',
-        'Text messages can’t be longer than 459 characters. Your message is 554 characters.'
+        'Text messages can’t be longer than 612 characters. Your message is 654 characters.'
     ),
     (
         SERVICE_DAILY_LIMIT_MSG,
@@ -2957,7 +2957,7 @@ def test_send_notification_shows_error_if_400(
     )
     with client_request.session_transaction() as session:
         session['recipient'] = '07700900001'
-        session['placeholders'] = {'name': 'a' * 500}
+        session['placeholders'] = {'name': 'a' * 600}
 
     page = client_request.post(
         'main.send_notification',


### PR DESCRIPTION
Bumped notifications-utils to bring in the new value for `SMS_CHAR_COUNT_LIMIT`. (Our provider limit is 612 characters for SMS, so we want to increase our limit to match.)

Admin, API and utils were all defining a value for `SMS_CHAR_COUNT_LIMIT`. This value has been updated in notifications-utils to allow text messages to be 4 fragments long so notifications-admin now gets the value of `SMS_CHAR_COUNT_LIMIT` from notifications-utils instead of defining it in config.

Also updated the pricing page with the change.

[Pivotal story](https://www.pivotaltracker.com/story/show/159695634)