### PR TITLE
Adding derrystrabane.com (local council)

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -36,3 +36,5 @@
 - sch.uk
 - sepa.org.uk
 - lincoln.fire-uk.org
+- derrystrabane.com
+


### PR DESCRIPTION
For *reasons* they've gone with dot com addresses.