### PR TITLE
Refactor hex colour preview Javascript

### DIFF
--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -15,7 +15,7 @@
       );
 
       this.$input
-        .on('change keyup', this.update)
+        .on('input', this.update)
         .trigger('change');
 
     };

--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -9,7 +9,10 @@
     this.start = component => {
 
       this.$input = $('input', component);
-      this.$preview = $('.textbox-colour-preview', component);
+
+      $(component).append(
+        this.$preview = $('<span class="textbox-colour-preview"></span>')
+      );
 
       this.$input
         .on('change keyup', this.update)

--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -1,0 +1,26 @@
+(function(Modules) {
+  "use strict";
+
+  let isSixDigitHex = value => value.match(/^#[0-9A-F]{6}$/i);
+  let colourOrWhite = value => isSixDigitHex(value) ? value : '#FFFFFF';
+
+  Modules.ColourPreview = function() {
+
+    this.start = component => {
+
+      this.$input = $('input', component);
+      this.$preview = $('.textbox-colour-preview', component);
+
+      this.$input
+        .on('change keyup', this.update)
+        .trigger('change');
+
+    };
+
+    this.update = () => this.$preview.css(
+      'background', colourOrWhite(this.$input.val())
+    );
+
+  };
+
+})(window.GOVUK.Modules);

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -62,11 +62,13 @@
 
 .textbox-colour-preview {
   @include media(desktop) {
-    width: 34px;
-    height: 34px;
+    width: 38px;
+    height: 38px;
     margin-left: 5px;
-    border: 2px solid #0B0C0C;
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px rgba($black, 0.2);
     display: inline-block;
     vertical-align: top;
+    transition: background 0.3s ease-out;
   }
 }

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -734,21 +734,18 @@ class ServiceUpdateEmailBranding(StripWhitespaceForm):
     domain = StringField('Domain')
     colour = StringField(
         'Colour',
-        render_kw={'onchange': 'update_colour(this)'},
         validators=[
             Regexp(regex="^$|^#(?:[0-9a-fA-F]{3}){1,2}$", message='Must be a valid color hex code')
         ]
     )
     banner_colour = StringField(
         'Banner colour',
-        render_kw={'onchange': 'update_colour(this)'},
         validators=[
             Regexp(regex="^$|^#(?:[0-9a-fA-F]{3}){1,2}$", message='Must be a valid color hex code')
         ]
     )
     single_id_colour = StringField(
         'Single identity colour',
-        render_kw={'onchange': 'update_colour(this)'},
         validators=[
             Regexp(regex="^$|^#(?:[0-9a-fA-F]{3}){1,2}$", message='Must be a valid color hex code')
         ]

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -60,10 +60,9 @@
 
 {% macro colour_textbox(
   field,
-  width='2-3',
-  colour='#FFFFFF'
+  width='2-3'
 ) %}
-  <div class="form-group{% if field.errors %} form-group-error{% endif %}">
+  <div class="form-group{% if field.errors %} form-group-error{% endif %}" data-module="colour-preview">
     <label class="form-label" for="{{ field.name }}">
       {{ field.label.text }}
       {% if field.errors %}
@@ -80,6 +79,6 @@
       rows='1',
       **kwargs
     ) }}
-    <span class="textbox-colour-preview" style="background:{{ colour }}"></span>
+    <span class="textbox-colour-preview"></span>
   </div>
 {% endmacro %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -4,6 +4,7 @@
   hint=False,
   highlight_tags=False,
   autofocus=False,
+  colour_preview=False,
   help_link=None,
   help_link_text=None,
   width='2-3',
@@ -11,7 +12,10 @@
   safe_error_message=False,
   rows=8
 ) %}
-  <div class="form-group{% if field.errors %} form-group-error{% endif %}" {% if autofocus %}data-module="autofocus"{% endif %}>
+  <div
+    class="form-group{% if field.errors %} form-group-error{% endif %}"
+    data-module="{% if autofocus %}autofocus{% elif colour_preview %}colour-preview{% endif %}"
+  >
     <label class="form-label" for="{{ field.name }}">
       {% if label %}
         {{ label }}
@@ -55,30 +59,5 @@
         <a href='{{ help_link }}'>{{ help_link_text }}</a>
       </p>
     {% endif %}
-  </div>
-{% endmacro %}
-
-{% macro colour_textbox(
-  field,
-  width='2-3'
-) %}
-  <div class="form-group{% if field.errors %} form-group-error{% endif %}" data-module="colour-preview">
-    <label class="form-label" for="{{ field.name }}">
-      {{ field.label.text }}
-      {% if field.errors %}
-        <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
-          {{ field.errors[0] }}
-        </span>
-      {% endif %}
-    </label>
-    {% set field_class = 'form-control-{} {}'.format(width, 'textbox-right-aligned' if suffix else '') %}
-    {% set field_class = 'form-control ' + field_class + (' form-control-error' if field.errors else '') %}
-    {{ field(
-      class=field_class,
-      data_module='',
-      rows='1',
-      **kwargs
-    ) }}
-    <span class="textbox-colour-preview"></span>
   </div>
 {% endmacro %}

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -34,15 +34,5 @@
         </div>
       </form>
     </div>
-  </div>
-  <script type="text/javascript">
-    function update_colour(element){
-      colour_preview = document.getElementsByClassName("textbox-colour-preview")[0];
-      if (element.value.match(/^#[0-9A-F]{6}$/i)) {
-        colour_preview.style.background = element.value;
-      } else {
-        colour_preview.style.background = '#FFFFFF';
-      }
-    }
-  </script>
+
 {% endblock %}

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -1,7 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/textbox.html" import textbox, colour_textbox %}
+{% from "components/textbox.html" import textbox %}
 
 {% block service_page_title %}
   {{ '{} email branding'.format('Update' if email_branding else 'Create')}}
@@ -22,9 +22,9 @@
         <div class="form-group">
           <div style='margin-top:15px;'>{{textbox(form.name)}}</div>
           <div style='margin-top:15px;'>{{textbox(form.text)}}</div>
-          {{colour_textbox(form.colour, width='1-4', colour=email_branding.colour if email_branding)}}
-          {{colour_textbox(form.banner_colour, width='1-4', colour=email_branding.banner_colour if email_branding)}}
-          {{colour_textbox(form.single_id_colour, width='1-4', colour=email_branding.single_id_colour if email_branding)}}
+          {{ textbox(form.colour, width='1-4', colour_preview=True) }}
+          {{ textbox(form.banner_colour, width='1-4', colour_preview=True) }}
+          {{ textbox(form.single_id_colour, width='1-4', colour_preview=True) }}
            <div style='margin-top:15px;'>{{textbox(form.domain)}}</div>
           {{ page_footer(
             'Save',

--- a/app/templates/views/organisations/organisation/settings/edit-name/index.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/index.html
@@ -1,6 +1,6 @@
 {% extends "org_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/textbox.html" import textbox, colour_textbox %}
+{% from "components/textbox.html" import textbox %}
 
 {% block org_page_title %}
   Change organisation name

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -75,6 +75,7 @@ gulp.task('javascripts', () => gulp
     paths.src + 'javascripts/preventDuplicateFormSubmissions.js',
     paths.src + 'javascripts/fullscreenTable.js',
     paths.src + 'javascripts/emailPreviewPane.js',
+    paths.src + 'javascripts/colourPreview.js',
     paths.src + 'javascripts/main.js'
   ])
   .pipe(plugins.prettyerror())


### PR DESCRIPTION
This commit improves the code that previews a hex colour when setting up or changing an email branding.

Specifically it:
- refactors the Javascript to conform to our patterns (module pattern, preprocessed as part of the Gulp pipeline)
- makes the code work when there are multiple colour previews on one page

It also does some visual prettifying, because I couldn’t help myself…

Before | After 
---|---
![col-prev--prev](https://user-images.githubusercontent.com/355079/44344606-04096700-a489-11e8-9dc8-815bd1a31440.gif) | ![col-prev](https://user-images.githubusercontent.com/355079/44344535-de7c5d80-a488-11e8-8716-642589819309.gif)

