### PR TITLE
Rename 'reply-to address'

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -630,7 +630,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
 
 
 class ServiceReplyToEmailForm(StripWhitespaceForm):
-    email_address = email_address(label='Email reply to address', gov_user=False)
+    email_address = email_address(label='Email reply-to address', gov_user=False)
     is_default = BooleanField("Make this email address the default")
 
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -80,7 +80,7 @@
         {% endcall %}
 
         {% call settings_row(if_has_permission='email') %}
-          {{ text_field('Email reply to addresses') }}
+          {{ text_field('Email reply-to addresses') }}
           {% call field(status='default' if default_reply_to_email_address == "Not set" else '') %}
 
             {{ default_reply_to_email_address }}

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -4,7 +4,7 @@
 {% from "components/table.html" import mapping_table, row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
 {% block service_page_title %}
-  Email reply to addresses
+  Email reply-to addresses
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -4,13 +4,13 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Add email reply to address
+  Add email reply-to address
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    Add email reply to address
+    Add email reply-to address
   </h1>
   <form method="post" novalidate>
     {{ textbox(

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -4,7 +4,7 @@
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
 {% block service_page_title %}
-  Email reply to addresses
+  Email reply-to addresses
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -12,7 +12,7 @@
   <div class="grid-row bottom-gutter">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        Email reply to addresses
+        Email reply-to addresses
       </h1>
     </div>
   {% if current_user.has_permissions('manage_service') %}
@@ -24,7 +24,7 @@
   <div class="user-list">
     {% if not reply_to_email_addresses %}
       <div class="user-list-item">
-        <span class="hint">You haven’t added any email reply to addresses yet</span>
+        <span class="hint">You haven’t added any email reply-to addresses yet</span>
       </div>
     {% endif %}
     {% for item in reply_to_email_addresses %}
@@ -60,7 +60,7 @@
         from your users.
         {% if current_service.restricted and not reply_to_email_addresses %}
           Your service can’t go live until you’ve added at least one
-          reply to address.
+          reply-to address.
         {% endif %}
       </p>
     </div>

--- a/app/templates/views/service-settings/set-reply-to-email.html
+++ b/app/templates/views/service-settings/set-reply-to-email.html
@@ -3,13 +3,13 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Email reply to address
+  Email reply-to address
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    Email reply to address
+    Email reply-to address
   </h1>
   <p>
     Your emails will be sent from


### PR DESCRIPTION
We currently use the label `reply to address` (no hyphen) in Settings.

Suggest we use `reply-to address` (with a hyphen) instead. 

Reasons:

- this is consistent with the way Gmail and other email providers usually label it
- 'reply to address' (no hyphen) looks confusing when it appears within a sentence

We may need to update our documentation as a result of this change.