### PR TITLE
Bump utils to show error message for long letters

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,4 +21,4 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.1.0#egg=notifications-utils==30.1.0
+git+https://github.com/alphagov/notifications-utils.git@30.1.2#egg=notifications-utils==30.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,13 +23,13 @@ notifications-python-client==5.0.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.1.0#egg=notifications-utils==30.1.0
+git+https://github.com/alphagov/notifications-utils.git@30.1.2#egg=notifications-utils==30.1.2
 
 ## The following requirements were added by pip freeze:
-awscli==1.15.81
+awscli==1.15.83
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.10.80
+botocore==1.10.82
 certifi==2018.8.13
 chardet==3.0.4
 click==6.7


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/518

Changes: https://github.com/alphagov/notifications-utils/compare/30.1.0...30.1.2