### PR TITLE
Fix colour preview not loading on page load

### DIFF
--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -16,7 +16,7 @@
 
       this.$input
         .on('input', this.update)
-        .trigger('change');
+        .trigger('input');
 
     };
 


### PR DESCRIPTION
The event was changed from `change` to `input`. The trigger was not updated accordingly.