### PR TITLE
Try to get more users to do the things we require before going live

### DIFF
--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -1,0 +1,41 @@
+$indicator-colour: $black;
+
+%task-list-indicator {
+  @include bold-16;
+  display: inline-block;
+  padding: 3px 8px 1px 8px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  margin-top: -15px;
+  border: 2px solid $indicator-colour;
+}
+
+.task-list {
+
+  border-bottom: 1px solid $border-colour;
+  margin: $gutter 0;
+
+  &-item {
+    border-top: 1px solid $border-colour;
+    padding: 15px 0;
+    padding-right: 20%;
+    position: relative;
+  }
+
+  &-indicator-completed {
+    @extend %task-list-indicator;
+    background-color: $indicator-colour;
+    color: $grey-4;
+    // Just a pinch of letter spacing to make reversed-out text a bit
+    // easier to read
+    letter-spacing: 0.02em;
+  }
+
+  &-indicator-not-completed {
+    @extend %task-list-indicator;
+    background-color: transparent;
+    color: $indicator-colour;
+  }
+
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -62,6 +62,7 @@ $path: '/static/images/';
 @import 'components/vendor/breadcrumbs';
 @import 'components/vendor/responsive-embed';
 @import 'components/email-preview-pane';
+@import 'components/task-list';
 
 @import 'views/dashboard';
 @import 'views/users';

--- a/app/templates/components/task-list.html
+++ b/app/templates/components/task-list.html
@@ -1,0 +1,16 @@
+{% macro task_list_item(completed, label) %}
+  <li class="task-list-item">
+    {{ label }}
+    {% if completed %}
+      <span class="task-list-indicator-completed">Completed</span>
+    {% else %}
+      <span class="task-list-indicator-not-completed">Not completed</span>
+    {% endif %}
+  </li>
+{% endmacro %}
+
+{% macro task_list_wrapper() %}
+  <ul class="task-list">
+    {{ caller() }}
+  </ul>
+{% endmacro %}

--- a/app/templates/components/tick-cross.html
+++ b/app/templates/components/tick-cross.html
@@ -14,7 +14,6 @@
   </li>
 {% endmacro %}
 
-
 {% macro tick_cross_done_not_done(yes, label) %}
   {{ tick_cross(yes, label, truthy_hint='Done: ', falsey_hint='Not done: ') }}
 {% endmacro %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -7,33 +7,32 @@
 {% from "components/task-list.html" import task_list_wrapper, task_list_item %}
 
 {% block service_page_title %}
-  Request to go live
+  Before you request to go live
 {% endblock %}
 
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-whole">
-      <h1 class="heading-large">Request to go live</h1>
-      <p>
-        Before your service can go live on Notify, you need:
-      </p>
+      <h1 class="heading-large">Before you request to go live</h1>
       {% call task_list_wrapper() %}
         {{ task_list_item(
           has_team_members,
-          'More than one <a href="{}">team member</a> with the ‘Manage settings’ permission'.format(
+          'Add a <a href="{}">team member</a> who can manage settings, team and usage
+'.format(
             url_for('main.manage_users', service_id=current_service.id)
           )|safe,
         ) }}
         {{ task_list_item(
           has_templates,
-          '<a href="{}">Templates</a> showing the kind of messages you plan to send'.format(
+          'Add content to
+<a href="{}">templates</a> to show the kind of messages you’ll send'.format(
             url_for('main.choose_template', service_id=current_service.id)
           )|safe,
         ) }}
         {% if has_email_templates %}
           {{ task_list_item(
             has_email_reply_to_address,
-            'An <a href="{}">email reply-to address</a>'.format(
+            'Add an <a href="{}">email reply-to address</a>'.format(
               url_for('main.service_email_reply_to', service_id=current_service.id)
             )|safe,
           ) }}
@@ -41,15 +40,14 @@
         {% if has_sms_templates and shouldnt_use_govuk_as_sms_sender %}
           {{ task_list_item(
             not sms_sender_is_govuk,
-            'Change your text message sender from GOVUK'
+            'Change your <a href="{}">text message sender name</a>'.format(
+              url_for('main.service_sms_senders', service_id=current_service.id)
+            )|safe
           ) }}
         {% endif %}
       {% endcall %}
       <p>
         You also need to accept our <a href="{{ url_for('.terms') }}">terms of use</a>.
-      </p>
-      <p class="bottom-gutter">
-        We’ll make your service live within one working day.
       </p>
       <p>
         <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Continue</a>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -4,7 +4,7 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/tick-cross.html" import tick_cross_done_not_done %}
+{% from "components/task-list.html" import task_list_wrapper, task_list_item %}
 
 {% block service_page_title %}
   Request to go live
@@ -15,30 +15,30 @@
     <div class="column-whole">
       <h1 class="heading-large">Request to go live</h1>
       <p>
-        Before your service can go live on Notify, you’ll need to:
+        Before your service can go live on Notify, you need:
       </p>
-      <ul class='bottom-gutter'>
-        {{ tick_cross_done_not_done(
+      {% call task_list_wrapper() %}
+        {{ task_list_item(
           has_team_members,
-          'Have more than one <a href="{}">team member</a> with the ‘Manage service’ permission'.format(
+          'More than one <a href="{}">team member</a> with the ‘Manage settings’ permission'.format(
             url_for('main.manage_users', service_id=current_service.id)
           )|safe,
         ) }}
-        {{ tick_cross_done_not_done(
+        {{ task_list_item(
           has_templates,
-          'Create <a href="{}">templates</a> showing the kind of messages you plan to send'.format(
+          '<a href="{}">Templates</a> showing the kind of messages you plan to send'.format(
             url_for('main.choose_template', service_id=current_service.id)
           )|safe,
         ) }}
         {% if has_email_templates %}
-          {{ tick_cross_done_not_done(
+          {{ task_list_item(
             has_email_reply_to_address,
-            'Add an <a href="{}">email reply-to address</a>'.format(
+            'An <a href="{}">email reply-to address</a>'.format(
               url_for('main.service_email_reply_to', service_id=current_service.id)
             )|safe,
           ) }}
         {% endif %}
-      </ul>
+      {% endcall %}
       <p>
         You also need to accept our <a href="{{ url_for('.terms') }}">terms of use</a>.
       </p>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -38,6 +38,12 @@
             )|safe,
           ) }}
         {% endif %}
+        {% if has_sms_templates and shouldnt_use_govuk_as_sms_sender %}
+          {{ task_list_item(
+            not sms_sender_is_govuk,
+            'Change your text message sender from GOVUK'
+          ) }}
+        {% endif %}
       {% endcall %}
       <p>
         You also need to accept our <a href="{{ url_for('.terms') }}">terms of use</a>.

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -17,22 +17,22 @@
       {% call task_list_wrapper() %}
         {{ task_list_item(
           has_team_members,
-          'Add a <a href="{}">team member</a> who can manage settings, team and usage
+          '<a href="{}">Add a team member who can manage settings, team and usage</a>
 '.format(
             url_for('main.manage_users', service_id=current_service.id)
           )|safe,
         ) }}
         {{ task_list_item(
           has_templates,
-          'Add content to
-<a href="{}">templates</a> to show the kind of messages you’ll send'.format(
+          '<a href="{}">Add content to
+templates to show the kind of messages you’ll send</a>'.format(
             url_for('main.choose_template', service_id=current_service.id)
           )|safe,
         ) }}
         {% if has_email_templates %}
           {{ task_list_item(
             has_email_reply_to_address,
-            'Add an <a href="{}">email reply-to address</a>'.format(
+            '<a href="{}">Add an email reply-to address</a>'.format(
               url_for('main.service_email_reply_to', service_id=current_service.id)
             )|safe,
           ) }}
@@ -40,7 +40,7 @@
         {% if has_sms_templates and shouldnt_use_govuk_as_sms_sender %}
           {{ task_list_item(
             not sms_sender_is_govuk,
-            'Change your <a href="{}">text message sender name</a>'.format(
+            '<a href="{}">Change your text message sender name</a>'.format(
               url_for('main.service_sms_senders', service_id=current_service.id)
             )|safe
           ) }}

--- a/app/templates/views/service-settings/submit-request-to-go-live.html
+++ b/app/templates/views/service-settings/submit-request-to-go-live.html
@@ -6,12 +6,16 @@
 {% from "components/banner.html" import banner_wrapper %}
 
 {% block service_page_title %}
-  How do you plan to use Notify?
+  Request to go live
 {% endblock %}
 
 {% block maincolumn_content %}
 
-      <h1 class="heading-large">How do you plan to use Notify?</h1>
+      <h1 class="heading-large">Request to go live</h1>
+
+      <p class="bottom-gutter">
+        Tell us how you plan to use Notify. When we receive your request we’ll make your service live within one working day.
+      </p>
 
       <form method="post" class="top-gutter">
         {{ checkbox_group('What kind of messages will you be sending?', [

--- a/app/utils.py
+++ b/app/utils.py
@@ -25,6 +25,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from notifications_utils.field import Field
 from notifications_utils.formatters import make_quotes_smart
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.take import Take
@@ -663,3 +664,10 @@ def should_skip_template_page(template_type):
         not current_user.has_permissions('manage_templates', 'manage_api_keys') and
         template_type != 'letter'
     )
+
+
+def get_default_sms_sender(sms_senders):
+    return str(next((
+        Field(x['sms_sender'], html='escape')
+        for x in sms_senders if x['is_default']
+    ), "None"))

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -503,22 +503,19 @@ def test_should_raise_duplicate_name_handled(
 
 
 @pytest.mark.parametrize('count_of_users_with_manage_service, expected_user_checklist_item', [
-    (1, 'More than one team member with the ‘Manage settings’ permission Not completed'),
-    (2, 'More than one team member with the ‘Manage settings’ permission Completed'),
+    (1, 'Add a team member who can manage settings, team and usage Not completed'),
+    (2, 'Add a team member who can manage settings, team and usage Completed'),
 ])
 @pytest.mark.parametrize('count_of_templates, expected_templates_checklist_item', [
-    (0, 'Templates showing the kind of messages you plan to send Not completed'),
-    (1, 'Templates showing the kind of messages you plan to send Completed'),
-    (2, 'Templates showing the kind of messages you plan to send Completed'),
+    (0, 'Add content to templates to show the kind of messages you’ll send Not completed'),
+    (1, 'Add content to templates to show the kind of messages you’ll send Completed'),
+    (2, 'Add content to templates to show the kind of messages you’ll send Completed'),
 ])
 @pytest.mark.parametrize('count_of_email_templates, reply_to_email_addresses, expected_reply_to_checklist_item', [
     pytest.mark.xfail((0, [], ''), raises=IndexError),
     pytest.mark.xfail((0, [{}], ''), raises=IndexError),
-    (1, [], 'An email reply-to address Not completed'),
-    (1, [{}], 'An email reply-to address Completed'),
-])
-@pytest.mark.parametrize('expected_sms_sender_item', [
-    ('Templates showing the kind of messages you plan to send Not completed'),
+    (1, [], 'Add an email reply-to address Not completed'),
+    (1, [{}], 'Add an email reply-to address Completed'),
 ])
 def test_should_show_request_to_go_live_checklist(
     client_request,
@@ -531,7 +528,6 @@ def test_should_show_request_to_go_live_checklist(
     count_of_email_templates,
     reply_to_email_addresses,
     expected_reply_to_checklist_item,
-    expected_sms_sender_item,
 ):
 
     def _count_templates(service_id, template_type=None):
@@ -556,7 +552,7 @@ def test_should_show_request_to_go_live_checklist(
     page = client_request.get(
         'main.request_to_go_live', service_id=SERVICE_ONE_ID
     )
-    assert page.h1.text == 'Request to go live'
+    assert page.h1.text == 'Before you request to go live'
 
     checklist_items = page.select('.task-list .task-list-item')
 
@@ -609,13 +605,13 @@ def test_should_show_request_to_go_live_checklist(
         'local',
         1,
         [],
-        'Change your text message sender from GOVUK Not completed',
+        'Change your text message sender name Not completed',
     ),
     (
         'local',
         1,
         [{'is_default': True, 'sms_sender': 'GOVUK'}],
-        'Change your text message sender from GOVUK Not completed',
+        'Change your text message sender name Not completed',
     ),
     (
         'local',
@@ -624,13 +620,13 @@ def test_should_show_request_to_go_live_checklist(
             {'is_default': False, 'sms_sender': 'GOVUK'},
             {'is_default': True, 'sms_sender': 'KUVOG'},
         ],
-        'Change your text message sender from GOVUK Completed',
+        'Change your text message sender name Completed',
     ),
     (
         'nhs',
         1,
         [{'is_default': True, 'sms_sender': 'KUVOG'}],
-        'Change your text message sender from GOVUK Completed',
+        'Change your text message sender name Completed',
     ),
 ])
 def test_should_check_for_sms_sender_on_go_live(
@@ -671,7 +667,7 @@ def test_should_check_for_sms_sender_on_go_live(
     page = client_request.get(
         'main.request_to_go_live', service_id=SERVICE_ONE_ID
     )
-    assert page.h1.text == 'Request to go live'
+    assert page.h1.text == 'Before you request to go live'
 
     checklist_items = page.select('.task-list .task-list-item')
     assert normalize_spaces(checklist_items[2].text) == expected_sms_sender_checklist_item
@@ -691,7 +687,7 @@ def test_should_show_request_to_go_live(
     page = client_request.get(
         'main.submit_request_to_go_live', service_id=SERVICE_ONE_ID
     )
-    assert page.h1.text == 'How do you plan to use Notify?'
+    assert page.h1.text == 'Request to go live'
     for channel, label in (
         ('email', 'Emails'),
         ('sms', 'Text messages'),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -503,19 +503,19 @@ def test_should_raise_duplicate_name_handled(
 
 
 @pytest.mark.parametrize('count_of_users_with_manage_service, expected_user_checklist_item', [
-    (1, 'Not done: Have more than one team member with the ‘Manage service’ permission'),
-    (2, 'Done: Have more than one team member with the ‘Manage service’ permission'),
+    (1, 'More than one team member with the ‘Manage settings’ permission Not completed'),
+    (2, 'More than one team member with the ‘Manage settings’ permission Completed'),
 ])
 @pytest.mark.parametrize('count_of_templates, expected_templates_checklist_item', [
-    (0, 'Not done: Create templates showing the kind of messages you plan to send'),
-    (1, 'Done: Create templates showing the kind of messages you plan to send'),
-    (2, 'Done: Create templates showing the kind of messages you plan to send'),
+    (0, 'Templates showing the kind of messages you plan to send Not completed'),
+    (1, 'Templates showing the kind of messages you plan to send Completed'),
+    (2, 'Templates showing the kind of messages you plan to send Completed'),
 ])
 @pytest.mark.parametrize('count_of_email_templates, reply_to_email_addresses, expected_reply_to_checklist_item', [
     pytest.mark.xfail((0, [], ''), raises=IndexError),
     pytest.mark.xfail((0, [{}], ''), raises=IndexError),
-    (1, [], 'Not done: Add an email reply-to address'),
-    (1, [{}], 'Done: Add an email reply-to address'),
+    (1, [], 'An email reply-to address Not completed'),
+    (1, [{}], 'An email reply-to address Completed'),
 ])
 def test_should_show_request_to_go_live_checklist(
     client_request,
@@ -552,7 +552,7 @@ def test_should_show_request_to_go_live_checklist(
     )
     assert page.h1.text == 'Request to go live'
 
-    checklist_items = page.select('main ul[class=bottom-gutter] li')
+    checklist_items = page.select('.task-list .task-list-item')
 
     assert normalize_spaces(checklist_items[0].text) == expected_user_checklist_item
     assert normalize_spaces(checklist_items[1].text) == expected_templates_checklist_item


### PR DESCRIPTION
Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/44538499-581a8280-a6f9-11e8-9a23-b5f97fac9147.png) | ![image](https://user-images.githubusercontent.com/355079/44538462-476a0c80-a6f9-11e8-91b2-4d7df3363fd2.png) 


# Use the task list pattern on the request to go live page

We’ve found a significant property of users (about 25%) who request to go live aren’t completing all the items on the checklist.

In 1 of 6 (17%) of the usability testing sessions we did on this process we saw someone skip straight past the checklist page because of big green button syndrome. While 1 in 6 people would normally be a small number<sup>1</sup> in the context of a usability testing session, it’s enough to cause a big workload for our team (assuming it is the sole cause of people not completing the items on the checklist).

The initial reason for using the tick cross pattern for the checklist was:
- it was coherent with the rest of Notify
- the task list pattern didn’t have a way of showing that something still needed doing – it put more visual emphasis on the things the user had already done

There’s been some interesting discussion on the GOV.UK Design System backlog about users failing to complete items in the task list. A few people have tried different patterns for communicating that items in the task list still need ‘completing’.

So this commit:
- adds a task list pattern
- uses the task list pattern for the request to go live checklist

The task list is adapted from the one in the design system in that:
- the ‘completed’ label has a black, not blue background (because Notify often uses blocks of blue to indicate something that’s clickable)
- it adds an explicit ‘not complete’ label which is visually not filled in (sort of how ticked/unticket radio buttons work)

# Check text message sender before going live

We often check that a service has an appropriate text message sender as a condition of them going live. We don’t mention this anywhere.

The services for whom GOVUK is definitely not an appropriate sender are those in local government. As we have more of these teams starting to use Notify, we should streamline the process by making this check automated.

This commit adds that check, for teams who:
- have text message templates
- have self-declared as NHS or local government

***

1. With the caveat that looking only at task completion and quantifying qualitative research can both be problematic and the intention here is to show that the numbers are close enough to say that they could be symptoms of the same problem. [Leisa Reichelt’s Mind the Product talk](https://vimeo.com/284015765) is good on this stuff.