### PR TITLE
Remove GOV.UK as option when creating a branding

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -727,7 +727,6 @@ class ServiceUpdateEmailBranding(StripWhitespaceForm):
     brand_type = RadioField(
         "Brand type",
         choices=[
-            ('govuk', 'GOV.UK only'),
             ('both', 'GOV.UK and branding'),
             ('org', 'Branding only'),
             ('org_banner', 'Branding banner'),

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -91,7 +91,7 @@ def update_email_branding(branding_id, logo=None):
 @login_required
 @user_is_platform_admin
 def create_email_branding(logo=None):
-    form = ServiceUpdateEmailBranding(brand_type='govuk')
+    form = ServiceUpdateEmailBranding(brand_type='org')
 
     if form.validate_on_submit():
         if form.file.data:

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -92,7 +92,7 @@ def test_create_new_email_branding_without_logo(
         'text': 'new text',
         'name': 'new name',
         'domain': 'sample.com',
-        'brand_type': 'govuk'
+        'brand_type': 'org'
     }
 
     mock_persist = mocker.patch('app.main.views.email_branding.persist_logo')
@@ -131,7 +131,7 @@ def test_create_new_email_branding_when_branding_saved(
         'text': 'new text',
         'name': 'new name',
         'domain': 'sample.com',
-        'brand_type': 'govuk'
+        'brand_type': 'org_banner'
     }
 
     temp_filename = LOGO_LOCATION_STRUCTURE.format(
@@ -230,7 +230,7 @@ def test_update_existing_branding(
         'text': 'new text',
         'name': 'new name',
         'domain': 'sample.com',
-        'brand_type': 'govuk'
+        'brand_type': 'both'
     }
 
     temp_filename = LOGO_LOCATION_STRUCTURE.format(
@@ -342,7 +342,7 @@ def test_colour_regex_validation(
         'text': 'new text',
         'name': 'new name',
         'domain': 'sample.com',
-        'brand_type': 'govuk'
+        'brand_type': 'org'
     }
 
     mocker.patch('app.main.views.email_branding.delete_temp_files_created_by')


### PR DESCRIPTION
It doesn’t make sense to create a brand which doesn’t get shown.

This will make it safe to remove this option from the database.