### PR TITLE
Remove branding type from set email branding page

### DIFF
--- a/app/assets/javascripts/emailPreviewPane.js
+++ b/app/assets/javascripts/emailPreviewPane.js
@@ -5,18 +5,16 @@
   const root = this,
       $ = this.jQuery;
 
-  let branding_type = $('.multiple-choice input[name="branding_type"]:checked');
   let branding_style = $('.multiple-choice input[name="branding_style"]:checked');
 
-  if (!branding_type.length || !branding_style.length) { return; }
+  if (!branding_style.length) { return; }
 
-  branding_type = branding_type.val();
   branding_style = branding_style.val();
 
   const $paneWrapper = $('<div class="column-full"></div>');
   const $form = $('form');
-  const $previewPane = $('<iframe src="/_email?' +
-                          buildQueryString(['branding_type', branding_type], ['branding_style', branding_style]) +
+  const $previewPane = $('<iframe src="/_email?' + 
+                          buildQueryString(['branding_style', branding_style]) +
                           '" class="email-branding-preview"></iframe>');
 
   function buildQueryString () {
@@ -25,13 +23,10 @@
 
   function setPreviewPane (e) {
     const $target = $(e.target);
-    if ($target.attr('name') == 'branding_type') {
-      branding_type = $target.val();
-    }
     if ($target.attr('name') == 'branding_style') {
       branding_style = $target.val();
     }
-    $previewPane.attr('src', '/_email?' + buildQueryString(['branding_type', branding_type], ['branding_style', branding_style]));
+    $previewPane.attr('src', '/_email?' + buildQueryString(['branding_style', branding_style]));
   }
 
   $paneWrapper.append($previewPane);
@@ -39,5 +34,5 @@
   $form.attr('action', location.pathname.replace(/set-email-branding$/, 'preview-email-branding'));
   $form.find('button[type="submit"]').text('Save');
 
-  $('fieldset').on('change', 'input[name="branding_type"], input[name="branding_style"]', setPreviewPane);
+  $('fieldset').on('change', 'input[name="branding_style"]', setPreviewPane);
 })();

--- a/app/assets/javascripts/emailPreviewPane.js
+++ b/app/assets/javascripts/emailPreviewPane.js
@@ -13,7 +13,7 @@
 
   const $paneWrapper = $('<div class="column-full"></div>');
   const $form = $('form');
-  const $previewPane = $('<iframe src="/_email?' + 
+  const $previewPane = $('<iframe src="/_email?' +
                           buildQueryString(['branding_style', branding_style]) +
                           '" class="email-branding-preview"></iframe>');
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -682,23 +682,6 @@ class ServiceSwitchLettersForm(StripWhitespaceForm):
 
 class ServiceSetBranding(StripWhitespaceForm):
 
-    def __init__(self, email_branding=[], *args, **kwargs):
-        self.branding_style.choices = email_branding
-        super(ServiceSetBranding, self).__init__(*args, **kwargs)
-
-    branding_type = RadioField(
-        'Branding type',
-        choices=[
-            ('govuk', 'GOV.UK only'),
-            ('both', 'GOV.UK and branding'),
-            ('org', 'Branding only'),
-            ('org_banner', 'Branding banner')
-        ],
-        validators=[
-            DataRequired()
-        ]
-    )
-
     branding_style = RadioField(
         'Branding style',
         validators=[
@@ -709,7 +692,6 @@ class ServiceSetBranding(StripWhitespaceForm):
 
 class ServicePreviewBranding(StripWhitespaceForm):
 
-    branding_type = HiddenField('branding_type')
     branding_style = HiddenField('branding_style')
 
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -81,9 +81,9 @@ def design_content():
 @main.route('/_email')
 def email_template():
     branding_type = 'govuk'
-    branding_style = request.args.get('branding_style', None)
+    branding_style = request.args.get('branding_style', 'None')
 
-    if branding_style:
+    if branding_style != 'None':
         email_branding = email_branding_client.get_email_branding(branding_style)['email_branding']
         branding_type = email_branding['brand_type']
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -80,17 +80,20 @@ def design_content():
 
 @main.route('/_email')
 def email_template():
-    branding_type = request.args.get('branding_type', 'govuk')
-    branding_style = request.args.get('branding_style', 'None')
+    branding_type = 'govuk'
+    branding_style = request.args.get('branding_style', None)
 
-    if branding_type == 'govuk' or branding_style == 'None':
+    if branding_style:
+        email_branding = email_branding_client.get_email_branding(branding_style)['email_branding']
+        branding_type = email_branding['brand_type']
+
+    if branding_type == 'govuk':
         brand_name = None
         brand_colour = None
         brand_logo = None
         govuk_banner = True
         brand_banner = False
     else:
-        email_branding = email_branding_client.get_email_branding(branding_style)['email_branding']
         colour = email_branding['colour']
         brand_name = email_branding['text']
         brand_colour = colour

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -971,11 +971,15 @@ def link_service_to_organisation(service_id):
 @user_has_permissions('manage_service')
 def branding_request(service_id):
 
-    email_branding = email_branding_client.get_email_branding(
-        current_service.email_branding)['email_branding']
+    branding_type = 'govuk'
+
+    if current_service.email_branding:
+        email_branding = email_branding_client.get_email_branding(
+            current_service.email_branding)['email_branding']
+        branding_type = email_branding['brand_type']
 
     form = BrandingOptionsEmail(
-        options=email_branding['brand_type']
+        options=branding_type
     )
 
     if form.validate_on_submit():

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -874,7 +874,7 @@ def service_set_email_branding(service_id):
     # dynamically create org choices, including the null option
     email_brandings = sorted(get_branding_as_value_and_label(email_branding),
                              key=lambda tup: tup[1].lower())
-    form.branding_style.choices = [('None', 'None')] + email_brandings
+    form.branding_style.choices = [('None', 'GOV.UK')] + email_brandings
 
     if form.validate_on_submit():
         branding_style = None if form.branding_style.data == 'None' else form.branding_style.data

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -868,9 +868,8 @@ def set_free_sms_allowance(service_id):
 @user_is_platform_admin
 def service_set_email_branding(service_id):
     email_branding = email_branding_client.get_all_email_branding()
-    branding_type = current_service.get('branding')
 
-    form = ServiceSetBranding(branding_type=branding_type)
+    form = ServiceSetBranding()
 
     # dynamically create org choices, including the null option
     email_brandings = sorted(get_branding_as_value_and_label(email_branding),
@@ -880,7 +879,7 @@ def service_set_email_branding(service_id):
     if form.validate_on_submit():
         branding_style = None if form.branding_style.data == 'None' else form.branding_style.data
         return redirect(url_for('.service_preview_email_branding', service_id=service_id,
-                        branding_type=form.branding_type.data, branding_style=branding_style))
+                        branding_style=branding_style))
 
     form.branding_style.data = current_service['email_branding'] or 'None'
 
@@ -897,16 +896,14 @@ def service_set_email_branding(service_id):
 @login_required
 @user_is_platform_admin
 def service_preview_email_branding(service_id):
-    branding_type = request.args.get('branding_type', None)
     branding_style = request.args.get('branding_style', None)
 
-    form = ServicePreviewBranding(branding_type=branding_type, branding_style=branding_style)
+    form = ServicePreviewBranding(branding_style=branding_style)
 
     if form.validate_on_submit():
         branding_style = None if form.branding_style.data == 'None' else form.branding_style.data
         service_api_client.update_service(
             service_id,
-            branding=form.branding_type.data,
             email_branding=branding_style
         )
         return redirect(url_for('.service_settings', service_id=service_id))

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -971,8 +971,11 @@ def link_service_to_organisation(service_id):
 @user_has_permissions('manage_service')
 def branding_request(service_id):
 
+    email_branding = email_branding_client.get_email_branding(
+        current_service.email_branding)['email_branding']
+
     form = BrandingOptionsEmail(
-        options=current_service.branding
+        options=email_branding['brand_type']
     )
 
     if form.validate_on_submit():

--- a/app/templates/views/service-settings/preview-email-branding.html
+++ b/app/templates/views/service-settings/preview-email-branding.html
@@ -9,7 +9,7 @@
   <h1 class="heading-large">Preview email branding</h1>
   <div class="grid-row">
     <div class="column-full">
-      <iframe src="{{ url_for('main.email_template', branding_type=form.branding_type.data, branding_style=form.branding_style.data) }}" class="email-branding-preview"></iframe>
+      <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="email-branding-preview"></iframe>
       <form method="post" action="{{ action }}">
         <div class="form-group">
           {{ form.hidden_tag() }}

--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -12,14 +12,11 @@
   <h1 class="heading-large">Set email branding</h1>
   <form method="post">
     <div class="grid-row">
-      <div class="column-one-whole">
+      <div class="column-full preview-pane">
       </div>
     </div>
     <div class="grid-row">
-      <div class="column-one-half">
-        {{ radios(form.branding_type) }}
-      </div>
-      <div class="column-one-half brand_styles">
+      <div class="column-full">
         {{ live_search(target_selector='.brand_styles .multiple-choice', show=show_search_box, form=search_form, label='Search branding styles by name') }}
         {{ radios(form.branding_style) }}
       </div>

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -32,9 +32,9 @@ def test_displays_govuk_branding_by_default(client):
     assert page.find("a", attrs={"href": "https://www.gov.uk"})
 
 
-def test_displays_govuk_branding(client):
+def test_displays_govuk_branding(client, mock_get_email_branding_with_govuk_brand_type):
 
-    response = client.get(url_for('main.email_template', branding_type="govuk", branding_style="1"))
+    response = client.get(url_for('main.email_template', branding_style="1"))
 
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
@@ -43,14 +43,14 @@ def test_displays_govuk_branding(client):
     assert page.find("a", attrs={"href": "https://www.gov.uk"})
 
 
-def test_displays_both_branding(client, mock_get_email_branding):
+def test_displays_both_branding(client, mock_get_email_branding_with_both_brand_type):
 
-    response = client.get(url_for('main.email_template', branding_type="both", branding_style="1"))
+    response = client.get(url_for('main.email_template', branding_style="1"))
 
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
     assert response.status_code == 200
-    mock_get_email_branding.assert_called_once_with('1')
+    mock_get_email_branding_with_both_brand_type.assert_called_once_with('1')
 
     assert page.find("a", attrs={"href": "https://www.gov.uk"})
     assert page.find("img", attrs={"src": re.compile("example.png$")})
@@ -60,7 +60,8 @@ def test_displays_both_branding(client, mock_get_email_branding):
 
 def test_displays_org_branding(client, mock_get_email_branding):
 
-    response = client.get(url_for('main.email_template', branding_type="org", branding_style="1"))
+    # mock_get_email_branding has 'brand_type' of 'org'
+    response = client.get(url_for('main.email_template', branding_style="1"))
 
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
@@ -74,15 +75,15 @@ def test_displays_org_branding(client, mock_get_email_branding):
         .get_text().strip() == 'Organisation text'  # brand text is set
 
 
-def test_displays_org_branding_with_banner(client, mock_get_email_branding):
+def test_displays_org_branding_with_banner(
+        client, mock_get_email_branding_with_org_banner_brand_type):
 
-    response = client.get(url_for('main.email_template', branding_type="org_banner",
-                                  branding_style="1"))
+    response = client.get(url_for('main.email_template', branding_style="1"))
 
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 
     assert response.status_code == 200
-    mock_get_email_branding.assert_called_once_with('1')
+    mock_get_email_branding_with_org_banner_brand_type.assert_called_once_with('1')
 
     assert not page.find("a", attrs={"href": "https://www.gov.uk"})
     assert page.find("img", attrs={"src": re.compile("example.png")})
@@ -94,8 +95,8 @@ def test_displays_org_branding_with_banner(client, mock_get_email_branding):
 def test_displays_org_branding_with_banner_without_brand_text(
         client, mock_get_email_branding_without_brand_text):
 
-    response = client.get(url_for('main.email_template', branding_type="org_banner",
-                                  branding_style="1"))
+    # mock_get_email_branding_without_brand_text has 'brand_type' of 'org_banner'
+    response = client.get(url_for('main.email_template', branding_style="1"))
 
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2731,10 +2731,13 @@ def test_update_service_organisation_does_not_update_if_same_value(
 
 def test_show_email_branding_request_page(
     client_request,
+    mock_get_email_branding
 ):
     page = client_request.get(
         '.branding_request', service_id=SERVICE_ONE_ID
     )
+
+    mock_get_email_branding.called_once_with(None)
 
     radios = page.select('input[type=radio]')
 
@@ -2767,6 +2770,11 @@ def test_submit_email_branding_request(
     single_sms_sender,
 ):
 
+    email_branding_client = mocker.patch(
+        'app.email_branding_client.get_email_branding',
+        return_value={'email_branding': {'brand_type': choice}}
+    )
+
     zendesk = mocker.patch(
         'app.main.views.service_settings.zendesk_client.create_ticket',
         autospec=True,
@@ -2779,6 +2787,8 @@ def test_submit_email_branding_request(
         },
         _follow_redirects=True,
     )
+
+    email_branding_client.assert_called_once_with(None)
 
     zendesk.assert_called_once_with(
         message='\n'.join([

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1744,7 +1744,7 @@ def test_should_show_branding_styles(
     assert branding_style_choices[5]['value'] == '5'
 
     # radios should be in alphabetical order, based on their labels
-    assert radio_labels == ['None', 'org 1', 'org 2', 'org 3', 'org 4', 'org 5']
+    assert radio_labels == ['GOV.UK', 'org 1', 'org 2', 'org 3', 'org 4', 'org 5']
 
     assert 'checked' in branding_style_choices[0].attrs
     assert 'checked' not in branding_style_choices[1].attrs

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1718,31 +1718,6 @@ def test_set_letter_branding_saves(
     mock_update_service.assert_called_once_with(service_one['id'], dvla_organisation='500')
 
 
-def test_should_show_branding_types(
-    logged_in_platform_admin_client,
-    service_one,
-    mock_get_all_email_branding,
-):
-    response = logged_in_platform_admin_client.get(url_for(
-        'main.service_set_email_branding', service_id=service_one['id']
-    ))
-    assert response.status_code == 200
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-
-    assert page.find('input', attrs={"id": "branding_type-0"})['value'] == 'govuk'
-    assert page.find('input', attrs={"id": "branding_type-1"})['value'] == 'both'
-    assert page.find('input', attrs={"id": "branding_type-2"})['value'] == 'org'
-    assert page.find('input', attrs={"id": "branding_type-3"})['value'] == 'org_banner'
-
-    assert 'checked' in page.find('input', attrs={"id": "branding_type-0"}).attrs
-    assert 'checked' not in page.find('input', attrs={"id": "branding_type-1"}).attrs
-    assert 'checked' not in page.find('input', attrs={"id": "branding_type-2"}).attrs
-    assert 'checked' not in page.find('input', attrs={"id": "branding_type-3"}).attrs
-
-    app.email_branding_client.get_all_email_branding.assert_called_once_with()
-    app.service_api_client.get_service.assert_called_once_with(service_one['id'])
-
-
 def test_should_show_branding_styles(
     logged_in_platform_admin_client,
     service_one,
@@ -1827,8 +1802,8 @@ def test_should_send_branding_and_organisations_to_preview(
     )
     assert response.status_code == 302
     assert response.location == url_for('main.service_preview_email_branding',
-                                        service_id=service_one['id'], branding_type='org',
-                                        branding_style='1', _external=True)
+                                        service_id=service_one['id'], branding_style='1',
+                                        _external=True)
 
     mock_get_all_email_branding.assert_called_once_with()
 
@@ -1847,10 +1822,8 @@ def test_should_preview_email_branding(
     iframeURLComponents = urlparse(iframe['src'])
     iframeQString = parse_qs(iframeURLComponents.query)
 
-    assert page.find('input', attrs={"id": "branding_type"})['value'] == 'org'
     assert page.find('input', attrs={"id": "branding_style"})['value'] == '1'
     assert iframeURLComponents.path == '/_email'
-    assert iframeQString['branding_type'] == ['org']
     assert iframeQString['branding_style'] == ['1']
 
     app.service_api_client.get_service.assert_called_once_with(service_one['id'])
@@ -1866,7 +1839,6 @@ def test_should_set_branding_and_organisations(
             'main.service_preview_email_branding', service_id=service_one['id']
         ),
         data={
-            'branding_type': 'org',
             'branding_style': '1'
         }
     )
@@ -1876,7 +1848,6 @@ def test_should_set_branding_and_organisations(
 
     mock_update_service.assert_called_once_with(
         service_one['id'],
-        branding='org',
         email_branding='1'
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2519,20 +2519,57 @@ def mock_no_email_branding(mocker):
     )
 
 
+def create_email_branding(id, non_standard_values={}):
+    branding = {
+        'logo': 'example.png',
+        'name': 'Organisation name',
+        'text': 'Organisation text',
+        'id': id,
+        'colour': '#f00',
+        'domain': 'sample.com',
+        'brand_type': 'org',
+    }
+
+    if bool(non_standard_values):
+        branding.update(non_standard_values)
+
+    return {'email_branding': branding}
+
+
 @pytest.fixture(scope='function')
 def mock_get_email_branding(mocker, fake_uuid):
     def _get_email_branding(id):
-        return {
-            'email_branding': {
-                'logo': 'example.png',
-                'name': 'Organisation name',
-                'text': 'Organisation text',
-                'id': fake_uuid,
-                'colour': '#f00',
-                'domain': 'sample.com',
-                'brand_type': 'org',
-            }
-        }
+        return create_email_branding(fake_uuid)
+
+    return mocker.patch(
+        'app.email_branding_client.get_email_branding', side_effect=_get_email_branding
+    )
+
+
+@pytest.fixture(scope='function')
+def mock_get_email_branding_with_govuk_brand_type(mocker, fake_uuid):
+    def _get_email_branding(id):
+        return create_email_branding(fake_uuid, {'brand_type': 'govuk'})
+
+    return mocker.patch(
+        'app.email_branding_client.get_email_branding', side_effect=_get_email_branding
+    )
+
+
+@pytest.fixture(scope='function')
+def mock_get_email_branding_with_both_brand_type(mocker, fake_uuid):
+    def _get_email_branding(id):
+        return create_email_branding(fake_uuid, {'brand_type': 'both'})
+
+    return mocker.patch(
+        'app.email_branding_client.get_email_branding', side_effect=_get_email_branding
+    )
+
+
+@pytest.fixture(scope='function')
+def mock_get_email_branding_with_org_banner_brand_type(mocker, fake_uuid):
+    def _get_email_branding(id):
+        return create_email_branding(fake_uuid, {'brand_type': 'org_banner'})
 
     return mocker.patch(
         'app.email_branding_client.get_email_branding', side_effect=_get_email_branding
@@ -2542,16 +2579,7 @@ def mock_get_email_branding(mocker, fake_uuid):
 @pytest.fixture(scope='function')
 def mock_get_email_branding_without_brand_text(mocker, fake_uuid):
     def _get_email_branding_without_brand_text(id):
-        return {
-            'email_branding': {
-                'logo': 'example.png',
-                'name': 'Organisation name',
-                'text': '',
-                'id': fake_uuid,
-                'colour': '#f00',
-                'brand_type': 'org_banner'
-            }
-        }
+        return create_email_branding(fake_uuid, {'text': '', 'brand_type': 'org_banner'})
 
     return mocker.patch(
         'app.email_branding_client.get_email_branding',


### PR DESCRIPTION
Updating the 'Set email branding' page, from service settings, so it uses the new email_branding model added in https://github.com/alphagov/notifications-admin/pull/2249.

For a task in this story: https://www.pivotaltracker.com/story/show/159986276

### Set email branding page

|Before|After|
|---|---|
|![old_set_email_branding](https://user-images.githubusercontent.com/87140/44797023-2183b280-aba6-11e8-8186-14b6ed683d97.png)|![newer_set_email_branding](https://user-images.githubusercontent.com/87140/44861246-0aa99280-ac70-11e8-9491-41b12bcf5f1d.png)|

Includes changes to the email preview page (iframe'd into the 'Set email branding' page) and the brand request page. They both needed changes so they accessed the brand type from the new email_branding model.