### PR TITLE
Reword templates line on go live task list

### DIFF
--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -24,8 +24,8 @@
         ) }}
         {{ task_list_item(
           has_templates,
-          '<a href="{}">Add content to
-templates to show the kind of messages you’ll send</a>'.format(
+          '<a href="{}">Add templates with examples of the content you plan to send
+</a>'.format(
             url_for('main.choose_template', service_id=current_service.id)
           )|safe,
         ) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -509,9 +509,9 @@ def test_should_raise_duplicate_name_handled(
     (2, 'Add a team member who can manage settings, team and usage Completed'),
 ])
 @pytest.mark.parametrize('count_of_templates, expected_templates_checklist_item', [
-    (0, 'Add content to templates to show the kind of messages you’ll send Not completed'),
-    (1, 'Add content to templates to show the kind of messages you’ll send Completed'),
-    (2, 'Add content to templates to show the kind of messages you’ll send Completed'),
+    (0, 'Add templates with examples of the content you plan to send Not completed'),
+    (1, 'Add templates with examples of the content you plan to send Completed'),
+    (2, 'Add templates with examples of the content you plan to send Completed'),
 ])
 @pytest.mark.parametrize('count_of_email_templates, reply_to_email_addresses, expected_reply_to_checklist_item', [
     pytest.mark.xfail((0, [], ''), raises=IndexError),


### PR DESCRIPTION
This version might read a little clearer and look a little neater.

# Before

![image](https://user-images.githubusercontent.com/355079/44855247-8ef51900-ac62-11e8-984b-45b5b13f5f7f.png)

# After

![image](https://user-images.githubusercontent.com/355079/44855118-43db0600-ac62-11e8-89e7-9483cbbef151.png)