### PR TITLE
Explain text message sender

### DIFF
--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -23,7 +23,7 @@
   <div class="user-list">
     {% if not sms_senders %}
       <div class="user-list-item">
-        <span class="hint">You haven’t added any sms senders yet</span>
+        <span class="hint">You haven’t added any text message senders yet</span>
       </div>
     {% endif %}
     {% for item in sms_senders %}
@@ -46,4 +46,7 @@
       </div>
     {% endfor %}
   </div>
+  <p>
+    The text message sender tells your users who the message is from.
+  </p>
 {% endblock %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1021,7 +1021,7 @@ def test_default_option_shows_for_default_sender(
     (
         'main.service_sms_senders',
         no_sms_senders,
-        'You haven’t added any sms senders yet'
+        'You haven’t added any text message senders yet'
     ),
 ])
 def test_no_senders_message_shows(


### PR DESCRIPTION
We sometimes have to do this over support tickets as part of the go-live process; now we’re directing people to add a sender (as part of the task list) we can explain what it is in context.

---

![image](https://user-images.githubusercontent.com/355079/44906231-3da16400-ad0c-11e8-8903-09a0b6640b51.png)

---

Content from https://docs.google.com/document/d/1dG-_ufgvqlkn4-mar8WU56MyTWXWOZ3QtbvMTFAKUyg/edit?ts=5b87beab