### PR TITLE
Remove `branding` attribute from service model

### DIFF
--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -270,7 +270,6 @@ class Service(dict):
 
     ALLOWED_PROPERTIES = {
         'active',
-        'branding',
         'dvla_organisation',
         'email_branding',
         'email_from',
@@ -293,7 +292,7 @@ class Service(dict):
     def __getattr__(self, attr):
         if attr in self.ALLOWED_PROPERTIES:
             return self[attr]
-        raise AttributeError
+        raise AttributeError('`{}` is not a service attribute'.format(attr))
 
     @property
     def trial_mode(self):


### PR DESCRIPTION
To correspond with us dropping this column from the database.

Remove the attribute from the model gives us more confidence that it’s not being used (because it will raise exceptions in any tests that refer to it).

---

Tests will fail until these are merged and this branch is rebased:
- [x] https://github.com/alphagov/notifications-admin/pull/2262
- [x] https://github.com/alphagov/notifications-admin/pull/2266