### PR TITLE
Don’t version control Pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 coverage.xml
 test_results.xml
 *,cover


### PR DESCRIPTION
Pytest moved its cache from `./.cache` (which is in our `.gitignore`) to `./.pytest_cache` (which isn’t).

It’s annoying having to be careful not to commit it all the time, so this commit makes it ignored.

See https://github.com/pytest-dev/pytest/issues/3286 for more context.