### PR TITLE
Cache email branding in Redis

### DIFF
--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import NotifyAdminAPIClient
+from app.notify_client import NotifyAdminAPIClient, cache
 
 
 class EmailBrandingClient(NotifyAdminAPIClient):
@@ -6,9 +6,11 @@ class EmailBrandingClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a" * 73, "b")
 
+    @cache.set('email_branding-{branding_id}')
     def get_email_branding(self, branding_id):
         return self.get(url='/email-branding/{}'.format(branding_id))
 
+    @cache.set('email_branding')
     def get_all_email_branding(self, sort_key=None):
         brandings = self.get(url='/email-branding')['email_branding']
         if sort_key and sort_key in brandings[0]:
@@ -18,6 +20,7 @@ class EmailBrandingClient(NotifyAdminAPIClient):
     def get_letter_email_branding(self):
         return self.get(url='/dvla_organisations')
 
+    @cache.delete('email_branding')
     def create_email_branding(self, logo, name, text, colour, domain, brand_type):
         data = {
             "logo": logo,
@@ -29,6 +32,8 @@ class EmailBrandingClient(NotifyAdminAPIClient):
         }
         return self.post(url="/email-branding", data=data)
 
+    @cache.delete('email_branding')
+    @cache.delete('email_branding-{branding_id}')
     def update_email_branding(self, branding_id, logo, name, text, colour, domain, brand_type):
         data = {
             "logo": logo,

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -1,19 +1,53 @@
+from unittest.mock import call
+
 from app.notify_client.email_branding_client import EmailBrandingClient
 
 
 def test_get_email_branding(mocker, fake_uuid):
-    mock_get = mocker.patch('app.notify_client.email_branding_client.EmailBrandingClient.get')
+    mock_get = mocker.patch(
+        'app.notify_client.email_branding_client.EmailBrandingClient.get',
+        return_value={'foo': 'bar'}
+    )
+    mock_redis_get = mocker.patch(
+        'app.notify_client.RedisClient.get',
+        return_value=None,
+    )
+    mock_redis_set = mocker.patch(
+        'app.notify_client.RedisClient.set',
+    )
     EmailBrandingClient().get_email_branding(fake_uuid)
     mock_get.assert_called_once_with(
         url='/email-branding/{}'.format(fake_uuid)
     )
+    mock_redis_get.assert_called_once_with('email_branding-{}'.format(fake_uuid))
+    mock_redis_set.assert_called_once_with(
+        'email_branding-{}'.format(fake_uuid),
+        '{"foo": "bar"}',
+        ex=604800,
+    )
 
 
 def test_get_all_email_branding(mocker):
-    mock_get = mocker.patch('app.notify_client.email_branding_client.EmailBrandingClient.get')
+    mock_get = mocker.patch(
+        'app.notify_client.email_branding_client.EmailBrandingClient.get',
+        return_value={'email_branding': [1, 2, 3]}
+    )
+    mock_redis_get = mocker.patch(
+        'app.notify_client.RedisClient.get',
+        return_value=None,
+    )
+    mock_redis_set = mocker.patch(
+        'app.notify_client.RedisClient.set',
+    )
     EmailBrandingClient().get_all_email_branding()
     mock_get.assert_called_once_with(
         url='/email-branding'
+    )
+    mock_redis_get.assert_called_once_with('email_branding')
+    mock_redis_set.assert_called_once_with(
+        'email_branding',
+        '[1, 2, 3]',
+        ex=604800,
     )
 
 
@@ -30,6 +64,7 @@ def test_create_email_branding(mocker):
                 'domain': 'sample.com', 'brand_type': 'org'}
 
     mock_post = mocker.patch('app.notify_client.email_branding_client.EmailBrandingClient.post')
+    mock_redis_delete = mocker.patch('app.notify_client.RedisClient.delete')
     EmailBrandingClient().create_email_branding(
         logo=org_data['logo'], name=org_data['name'], text=org_data['text'], colour=org_data['colour'],
         domain=org_data['domain'], brand_type='org'
@@ -40,12 +75,15 @@ def test_create_email_branding(mocker):
         data=org_data
     )
 
+    mock_redis_delete.assert_called_once_with('email_branding')
+
 
 def test_update_email_branding(mocker, fake_uuid):
     org_data = {'logo': 'test.png', 'name': 'test name', 'text': 'test name', 'colour': 'red',
                 'domain': 'sample.com', 'brand_type': 'org'}
 
     mock_post = mocker.patch('app.notify_client.email_branding_client.EmailBrandingClient.post')
+    mock_redis_delete = mocker.patch('app.notify_client.RedisClient.delete')
     EmailBrandingClient().update_email_branding(
         branding_id=fake_uuid, logo=org_data['logo'], name=org_data['name'], text=org_data['text'],
         colour=org_data['colour'], domain=org_data['domain'], brand_type='org')
@@ -54,3 +92,7 @@ def test_update_email_branding(mocker, fake_uuid):
         url='/email-branding/{}'.format(fake_uuid),
         data=org_data
     )
+    assert mock_redis_delete.call_args_list == [
+        call('email_branding'),
+        call('email_branding-{}'.format(fake_uuid)),
+    ]


### PR DESCRIPTION
If we’re going to be referring to email branding as part of the service creation journey then we should make sure it doesn’t slow things down too much by adding an extra API call. Caching things in Redis is a way of avoiding unneeded API calls.