### PR TITLE
Update pyexcel to 0.5.9.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,7 +7,7 @@ Flask-WTF==0.14.2
 Flask-Login==0.4.1
 
 blinker==1.4
-pyexcel==0.5.9
+pyexcel==0.5.9.1
 pyexcel-io==0.5.9.1
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-WTF==0.14.2
 Flask-Login==0.4.1
 
 blinker==1.4
-pyexcel==0.5.9
+pyexcel==0.5.9.1
 pyexcel-io==0.5.9.1
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.6


### PR DESCRIPTION
0.5.9 seems to have disappeared and is causing tests to fail on Jenkins.

https://github.com/pyexcel/pyexcel/compare/v0.5.9...v0.5.9.1