### PR TITLE
Look up email branding from user’s domain

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -65,7 +65,8 @@ innovateuk.gov.uk:
   owner: Innovate UK
   agreement_signed: true
 ncsc.gov.uk: gchq.gov.uk
-nhs.net:
+nhs.net: nhs.uk
+nhs.uk:
   owner: NHS
 nhsdigital.nhs.uk: digital.nhs.uk
 digital.nhs.uk:

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -43,7 +43,7 @@ from app.main.validators import (
     ValidGovEmail,
 )
 from app.notify_client.models import permissions, roles
-from app.utils import guess_name_from_email_address
+from app.utils import AgreementInfo, guess_name_from_email_address
 
 
 def get_time_value_and_label(future_time):
@@ -720,10 +720,18 @@ class ServicePreviewBranding(StripWhitespaceForm):
     branding_style = HiddenField('branding_style')
 
 
+class GovernmentDomainField(StringField):
+    validators = [KnownGovernmentDomain()]
+
+    def post_validate(self, form, validation_stopped):
+        if self.data and not self.errors:
+            self.data = AgreementInfo(self.data).canonical_domain
+
+
 class ServiceUpdateEmailBranding(StripWhitespaceForm):
     name = StringField('Name of brand')
     text = StringField('Text')
-    domain = StringField('Domain', validators=[KnownGovernmentDomain()])
+    domain = GovernmentDomainField('Domain')
     colour = StringField(
         'Colour',
         validators=[

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -35,6 +35,7 @@ from app.main.validators import (
     Blacklist,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
+    KnownGovernmentDomain,
     LettersNumbersAndFullStopsOnly,
     NoCommasInPlaceHolders,
     OnlyGSMCharacters,
@@ -722,7 +723,7 @@ class ServicePreviewBranding(StripWhitespaceForm):
 class ServiceUpdateEmailBranding(StripWhitespaceForm):
     name = StringField('Name of brand')
     text = StringField('Text')
-    domain = StringField('Domain')
+    domain = StringField('Domain', validators=[KnownGovernmentDomain()])
     colour = StringField(
         'Colour',
         validators=[

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -11,7 +11,7 @@ from wtforms.validators import Email
 
 from app import formatted_list
 from app.main._blacklisted_passwords import blacklisted_passwords
-from app.utils import Spreadsheet, is_gov_user
+from app.utils import AgreementInfo, Spreadsheet, is_gov_user
 
 
 class Blacklist:
@@ -101,4 +101,13 @@ class DoesNotStartWithDoubleZero:
 
     def __call__(self, form, field):
         if field.data and field.data.startswith("00"):
+            raise ValidationError(self.message)
+
+
+class KnownGovernmentDomain:
+
+    message = 'Not a known government domain (you might need to update domains.yml)'
+
+    def __call__(self, form, field):
+        if field.data and AgreementInfo(field.data).owner is None:
             raise ValidationError(self.message)

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -29,6 +29,7 @@ def _add_invited_user_to_service(invited_user):
 def _create_service(service_name, organisation_type, email_from, form):
     free_sms_fragment_limit = current_app.config['DEFAULT_FREE_SMS_FRAGMENT_LIMITS'].get(organisation_type)
     email_branding = email_branding_client.get_email_branding_id_for_domain(
+        'nhs.uk' if organisation_type == 'nhs' else
         AgreementInfo.from_current_user().canonical_domain
     )
     try:

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import abort
 
 from app import (
     billing_api_client,
+    email_branding_client,
     invite_api_client,
     service_api_client,
     user_api_client,
@@ -12,7 +13,7 @@ from app import (
 from app.main import main
 from app.main.forms import CreateServiceForm
 from app.notify_client.models import InvitedUser
-from app.utils import email_safe, is_gov_user
+from app.utils import AgreementInfo, email_safe, is_gov_user
 
 
 def _add_invited_user_to_service(invited_user):
@@ -27,6 +28,9 @@ def _add_invited_user_to_service(invited_user):
 
 def _create_service(service_name, organisation_type, email_from, form):
     free_sms_fragment_limit = current_app.config['DEFAULT_FREE_SMS_FRAGMENT_LIMITS'].get(organisation_type)
+    email_branding = email_branding_client.get_email_branding_id_for_domain(
+        AgreementInfo.from_current_user().canonical_domain
+    )
     try:
         service_id = service_api_client.create_service(
             service_name=service_name,
@@ -37,6 +41,9 @@ def _create_service(service_name, organisation_type, email_from, form):
             email_from=email_from,
         )
         session['service_id'] = service_id
+
+        if email_branding:
+            service_api_client.update_service(service_id, email_branding=email_branding)
 
         billing_api_client.create_or_update_free_sms_fragment_limit(service_id, free_sms_fragment_limit)
 

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -11,8 +11,7 @@ from app.main.s3_client import (
     persist_logo,
     upload_logo,
 )
-from app.main.views.service_settings import get_branding_as_value_and_label
-from app.utils import get_cdn_domain, user_is_platform_admin
+from app.utils import AgreementInfo, get_cdn_domain, user_is_platform_admin
 
 
 @main.route("/email-branding", methods=['GET', 'POST'])
@@ -23,9 +22,10 @@ def email_branding():
 
     return render_template(
         'views/email-branding/select-branding.html',
-        email_brandings=get_branding_as_value_and_label(brandings),
+        email_brandings=_add_domain_info(brandings),
         search_form=SearchTemplatesForm(),
         show_search_box=len(brandings) > 9,
+        agreement_info=AgreementInfo,
     )
 
 
@@ -129,3 +129,11 @@ def create_email_branding(logo=None):
         cdn_url=get_cdn_domain(),
         logo=logo
     )
+
+
+def _add_domain_info(email_brands):
+    for brand in email_brands:
+        yield dict(
+            domain_owner=AgreementInfo(brand.get('domain') or '').owner,
+            **brand
+        )

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -17,6 +17,12 @@ class EmailBrandingClient(NotifyAdminAPIClient):
             brandings.sort(key=lambda branding: branding[sort_key].lower())
         return brandings
 
+    def get_email_branding_id_for_domain(self, domain):
+        for branding in self.get_all_email_branding():
+            if domain and branding.get('domain') == domain:
+                return branding['id']
+        return None
+
     def get_letter_email_branding(self):
         return self.get(url='/dvla_organisations')
 

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -17,13 +17,20 @@
       <a href="{{ url_for('.create_email_branding') }}" class="button align-with-heading">Add new brand</a>
     </div>
   </div>
-  {{ live_search(target_selector='.message-name', show=show_search_box, form=search_form) }}
+  {{ live_search(target_selector='.email-brand', show=show_search_box, form=search_form) }}
   <nav>
-    {% for id, name in email_brandings %}
-      <div class="message-name">
-        <a href="{{ url_for('.update_email_branding', branding_id=id) }}">
-          {{name}}
-        </a>
+    {% for brand in email_brandings %}
+      <div class="email-brand">
+        <div class="message-name">
+          <a href="{{ url_for('.update_email_branding', branding_id=brand.id) }}">
+            {{ brand.name }}
+          </a>
+        </div>
+        {% if brand.domain_owner %}
+          <p class="message-type">
+            Default for {{ brand.domain_owner }}
+          </p>
+        {% endif %}
       </div>
     {% endfor %}
   </nav>

--- a/app/utils.py
+++ b/app/utils.py
@@ -445,7 +445,8 @@ class AgreementInfo:
         (
             self.owner,
             self.crown_status,
-            self.agreement_signed
+            self.agreement_signed,
+            self.canonical_domain,
         ) = self._get_info()
 
     @classmethod
@@ -584,13 +585,16 @@ class AgreementInfo:
         details = self.domains.get(self._match) or {}
 
         if isinstance(details, str):
+            self.is_canonical = False
             return AgreementInfo(details)._get_info()
 
         elif isinstance(details, dict):
+            self.is_canonical = bool(details)
             return(
                 details.get("owner"),
                 details.get("crown"),
                 details.get("agreement_signed"),
+                self._match,
             )
 
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -395,6 +395,21 @@ def test_get_valid_agreement_info_known_details(domain_or_email_address):
     )
 
 
+@pytest.mark.parametrize("domain_or_email_address, is_canonical", (
+    ("test@dclgdatamart.co.uk", False),
+    ("test@communities.gsi.gov.uk", False),
+    ("test@communities.gov.uk", True),
+))
+def test_get_canonical_domain(domain_or_email_address, is_canonical):
+    assert AgreementInfo(domain_or_email_address).canonical_domain == 'communities.gov.uk'
+    assert AgreementInfo(domain_or_email_address).is_canonical == is_canonical
+
+
+def test_get_canonical_domain_passes_through_unknown_domain():
+    assert AgreementInfo('example.com').canonical_domain is None
+    assert AgreementInfo('example.com').is_canonical is False
+
+
 @pytest.mark.parametrize("domain_or_email_address", (
     "test@police.gov.uk", "police.gov.uk",
 ))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2449,7 +2449,7 @@ def create_email_brandings(number_of_brandings, non_standard_values={}, shuffle=
         } for idx in range(1, number_of_brandings + 1)]
 
     for idx, row in enumerate(non_standard_values):
-        brandings[row['idx']].update(non_standard_values)
+        brandings[row['idx']].update(non_standard_values[idx])
 
     if shuffle:
         brandings.insert(3, brandings.pop(4))
@@ -2464,7 +2464,7 @@ def mock_get_all_email_branding(mocker):
             {'idx': 1, 'colour': 'red'},
             {'idx': 2, 'colour': 'orange'},
             {'idx': 3, 'text': None},
-            {'idx': 4, 'colour': 'blue'},
+            {'idx': 4, 'colour': 'blue', 'domain': 'voa.gov.uk'},
         ]
         shuffle = sort_key is None
         return create_email_brandings(5, non_standard_values=non_standard_values, shuffle=shuffle)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2463,7 +2463,7 @@ def mock_get_all_email_branding(mocker):
         non_standard_values = [
             {'idx': 1, 'colour': 'red'},
             {'idx': 2, 'colour': 'orange'},
-            {'idx': 3, 'text': None},
+            {'idx': 3, 'text': None, 'domain': 'nhs.uk'},
             {'idx': 4, 'colour': 'blue', 'domain': 'voa.gov.uk'},
         ]
         shuffle = sort_key is None


### PR DESCRIPTION
Uses this:

![image](https://user-images.githubusercontent.com/355079/44988973-4b611e80-af84-11e8-8457-f883443b3927.png)

To show this:
![image](https://user-images.githubusercontent.com/355079/44988996-59af3a80-af84-11e8-8d37-3dc787a29a99.png)

Then when a user creates a service, this happens automatically:

![image](https://user-images.githubusercontent.com/355079/44989040-806d7100-af84-11e8-9795-37b5e2152de9.png)

So when they send an email:

![hmr](https://user-images.githubusercontent.com/355079/44989125-c62a3980-af84-11e8-8c5a-83d7e6261f31.gif)

---

This also works (differently in the background but the same way for the user) for users who choose ‘NHS’ as the answer to the ‘Who runs this service’ question. In other words those services will automatically get NHS branding.

---

Stories:
- General https://www.pivotaltracker.com/story/show/159623304
- NHS-specific https://www.pivotaltracker.com/story/show/159623188