### PR TITLE
Remove old API key and service ID combo

### DIFF
--- a/app/templates/views/api/keys/show.html
+++ b/app/templates/views/api/keys/show.html
@@ -32,17 +32,4 @@
 
     </div>
 
-    <h2 class='heading-medium'>For older API clients</h2>
-
-    <p>
-      If the client you’re using needs a service ID and an API key,
-      use these values:
-    </p>
-
-    <div class="bottom-gutter">
-      {{ api_key(service_id, 'Service ID', thing='service ID') }}
-    </div>
-
-    {{ api_key(secret, 'API key') }}
-
 {% endblock %}


### PR DESCRIPTION
This PR attempts to resurrect https://github.com/alphagov/notifications-admin/pull/1145

---

Once all our users have upgraded to the latest clients they won’t need this. The latest clients only use the combined key and service ID.

Can we safely remove it?