### PR TITLE
Require name when adding email branding

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -729,7 +729,7 @@ class GovernmentDomainField(StringField):
 
 
 class ServiceUpdateEmailBranding(StripWhitespaceForm):
-    name = StringField('Name of brand')
+    name = StringField('Name of brand', validators=[DataRequired()])
     text = StringField('Text')
     domain = GovernmentDomainField('Domain')
     colour = StringField(

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -284,7 +284,10 @@ def test_deletes_previous_temp_logo_after_uploading_logo(
 
     logged_in_platform_admin_client.post(
         url_for('main.create_email_branding', logo=temp_old_filename, branding_id=fake_uuid),
-        data={'file': (BytesIO(''.encode('utf-8')), 'test.png')},
+        data={
+            'file': (BytesIO(''.encode('utf-8')), 'test.png'),
+            'name': 'Test',
+        },
         content_type='multipart/form-data'
     )
 
@@ -361,7 +364,10 @@ def test_temp_logo_is_shown_after_uploading_logo(
 
     response = logged_in_platform_admin_client.post(
         url_for('main.create_email_branding'),
-        data={'file': (BytesIO(''.encode('utf-8')), 'test.png')},
+        data={
+            'file': (BytesIO(''.encode('utf-8')), 'test.png'),
+            'name': 'Test',
+        },
         content_type='multipart/form-data',
         follow_redirects=True
     )
@@ -391,7 +397,10 @@ def test_logo_persisted_when_organisation_saved(
 
     resp = logged_in_platform_admin_client.post(
         url_for('.create_email_branding', logo=temp_filename),
-        content_type='multipart/form-data'
+        content_type='multipart/form-data',
+        data={
+            'name': 'Test',
+        }
     )
     assert resp.status_code == 302
 


### PR DESCRIPTION
Otherwise name can be blank and it never appears in the list, so you can’t find it again.