### PR TITLE
Fix live search on email brand selection

### DIFF
--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -17,7 +17,7 @@
     </div>
     <div class="grid-row">
       <div class="column-full">
-        {{ live_search(target_selector='.brand_styles .multiple-choice', show=show_search_box, form=search_form, label='Search branding styles by name') }}
+        {{ live_search(target_selector='.multiple-choice', show=show_search_box, form=search_form, label='Search branding styles by name') }}
         {{ radios(form.branding_style) }}
       </div>
     </div>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1926,6 +1926,9 @@ def test_should_show_live_search_if_list_of_brand_styles_taller_than_page(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     assert page.select('.live-search')
+    search_target = page.select_one('.live-search')['data-targets']
+    assert search_target == '.multiple-choice'
+    assert len(page.select(search_target)) == 9
 
 
 def test_should_send_branding_and_organisations_to_preview(


### PR DESCRIPTION
At some point the element with a `class` of `brand-styles` was removed from the page, meaning the search stopped working.