### PR TITLE
Validate non canonical domains

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -33,6 +33,7 @@ from wtforms.validators import URL, DataRequired, Length, Optional, Regexp
 
 from app.main.validators import (
     Blacklist,
+    CanonicalGovernmentDomain,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     KnownGovernmentDomain,
@@ -721,7 +722,10 @@ class ServicePreviewBranding(StripWhitespaceForm):
 
 
 class GovernmentDomainField(StringField):
-    validators = [KnownGovernmentDomain()]
+    validators = [
+        KnownGovernmentDomain(),
+        CanonicalGovernmentDomain(),
+    ]
 
     def post_validate(self, form, validation_stopped):
         if self.data and not self.errors:

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -111,3 +111,25 @@ class KnownGovernmentDomain:
     def __call__(self, form, field):
         if field.data and AgreementInfo(field.data).owner is None:
             raise ValidationError(self.message)
+
+
+class CanonicalGovernmentDomain:
+
+    message = 'Not {} domain (use {} if appropriate)'
+
+    def __call__(self, form, field):
+
+        if not field.data:
+            return
+
+        domain = AgreementInfo(field.data)
+
+        if not domain.is_canonical:
+            raise ValidationError(
+                self.message.format('a canonical', domain.canonical_domain)
+            )
+
+        if field.data != domain.canonical_domain:
+            raise ValidationError(
+                self.message.format('an organisation-level', domain.canonical_domain)
+            )


### PR DESCRIPTION
At the moment we transform what the user gives us, so if someone enters `digital.cabinet-office.gov.uk` it will automagically be saved as `cabinet-office.gov.uk`. This happens without the user knowing, and might have unintended consequences.

So let’s tell them what the problem is, and let them decide what to do about it (which might be accepting the canonical domain, or adding a new organisation to domains.yml first).

---

![image](https://user-images.githubusercontent.com/355079/45155050-873cf380-b1d1-11e8-90ab-2eb97bdc8560.png)

![image](https://user-images.githubusercontent.com/355079/45155058-915ef200-b1d1-11e8-86c2-c18109fd8fb6.png)
