### PR TITLE
Use friendlier relative dates for ‘last edited’

### DIFF
--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -57,7 +57,13 @@
 
   <div class="bottom-gutter-1-2">
     {% if template._template.updated_at %}
-      <h2 class="heading-small bottom-gutter-2-3 heading-inline">Last edited {{ template._template.updated_at|format_delta }}</h2>
+      <h2 class="heading-small bottom-gutter-2-3 heading-inline">
+        Last edited
+        <time class="timeago" datetime="{{ template._template.updated_at }}">
+          {{ template._template.updated_at|format_delta }}
+        </time>
+      </h2>
+
       &emsp;
       <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
       &emsp;


### PR DESCRIPTION
Because ‘2 months ago’ is more human-sounding than ‘70 days ago’.

Using this pattern (borrowed from the API integration page) will also use Javascript to keep the time updated, so ‘just now’ will turn into ‘1 minute ago’ without having to reload the page.

# Tired

![image](https://user-images.githubusercontent.com/355079/45167429-10175780-b1f1-11e8-92af-d1229ac68d9e.png)

# Wired 

![image](https://user-images.githubusercontent.com/355079/45167457-19082900-b1f1-11e8-909e-d7f7fd544601.png)
