### PR TITLE
Map ‘pending’ status to ‘sending’

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -372,6 +372,7 @@ def format_notification_status(status, template_type):
             'delivered': 'Delivered',
             'sending': 'Sending',
             'created': 'Sending',
+            'pending': 'Sending',
             'sent': 'Sent internationally'
         },
         'letter': {
@@ -391,10 +392,9 @@ def format_notification_status(status, template_type):
 
 
 def format_notification_status_as_time(status, created, updated):
-    return {
-        'sending': ' since {}'.format(created),
-        'created': ' since {}'.format(created)
-    }.get(status, updated)
+    return dict.fromkeys(
+        {'created', 'pending', 'sending'}, ' since {}'.format(created)
+    ).get(status, updated)
 
 
 def format_notification_status_as_field_status(status, notification_type):
@@ -423,7 +423,8 @@ def format_notification_status_as_field_status(status, notification_type):
             'delivered': None,
             'sent': None,
             'sending': 'default',
-            'created': 'default'
+            'created': 'default',
+            'pending': 'default',
         }
     ).get(status, 'error')
 


### PR DESCRIPTION
For some reason we are getting pending back as a status from one of our text message providers.

Because this is unrecognised by the admin app it shows up in the list of messages as the raw status, styled like an error.

This commit maps it to sending instead, because the user doesn’t need to know or care about the difference.