### PR TITLE
Don’t attempt to store domain as empty string

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -728,6 +728,8 @@ class GovernmentDomainField(StringField):
     ]
 
     def post_validate(self, form, validation_stopped):
+        if self.data == '':
+            self.data = None
         if self.data and not self.errors:
             self.data = AgreementInfo(self.data).canonical_domain
 

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -84,18 +84,24 @@ def test_create_email_branding_does_not_show_any_branding_info(
     assert page.select_one('#domain').attrs.get('value') == ''
 
 
+@pytest.mark.parametrize('posted_domain, persisted_domain', [
+    ('voa.gov.uk', 'voa.gov.uk'),
+    ('', None),
+])
 def test_create_new_email_branding_without_logo(
     logged_in_platform_admin_client,
     mocker,
     fake_uuid,
-    mock_create_email_branding
+    mock_create_email_branding,
+    posted_domain,
+    persisted_domain,
 ):
     data = {
         'logo': None,
         'colour': '#ff0000',
         'text': 'new text',
         'name': 'new name',
-        'domain': 'voa.gov.uk',
+        'domain': posted_domain,
         'brand_type': 'org'
     }
 
@@ -114,7 +120,7 @@ def test_create_new_email_branding_without_logo(
         name=data['name'],
         text=data['text'],
         colour=data['colour'],
-        domain=data['domain'],
+        domain=persisted_domain,
         brand_type=data['brand_type']
     )
     assert mock_persist.call_args_list == []


### PR DESCRIPTION
When there is a uniqueness constraint on a DB column you can still have multiple `null` values.

You can’t have multiple empty string values.

We are trying to save the domain as empty string when creating or updating a new branding. This means that it’s currently not possible to create or update a branding with no domain, because the uniqueness constraint is violated.