### PR TITLE
Set min text message sender length to 4 characters

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -644,7 +644,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Can’t be empty"),
             Length(max=11, message="Enter 11 characters or fewer"),
-            Length(min=3, message="Enter 3 characters or more"),
+            Length(min=4, message="Enter 4 characters or more"),
             LettersNumbersAndFullStopsOnly(),
             DoesNotStartWithDoubleZero(),
         ]

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -214,11 +214,11 @@ def test_sms_sender_form_validation(
     form.validate()
     assert 'Use letters and numbers only' == form.errors['sms_sender'][0]
 
-    form.sms_sender.data = '0'
+    form.sms_sender.data = '333'
     form.validate()
-    assert 'Enter 3 characters or more' == form.errors['sms_sender'][0]
+    assert 'Enter 4 characters or more' == form.errors['sms_sender'][0]
 
-    form.sms_sender.data = '111'
+    form.sms_sender.data = '4444'
     form.validate()
     assert not form.errors
 


### PR DESCRIPTION
We’ve learned of a change implemented today by the UK mobile network operators, to stop allowing text message sender names of 3 or less characters.

Adding this validation will not affect existing senders, only those users trying to add to or update their senders.