### PR TITLE
Tag request to go live tickets automatically 

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1022,6 +1022,7 @@ def branding_request(service_id):
             ticket_type=zendesk_client.TYPE_QUESTION,
             user_email=current_user.email_address,
             user_name=current_user.name,
+            tags=['notify_action_add_branding'],
         )
 
         flash((

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1128,26 +1128,14 @@ def _get_request_to_go_live_tags(service, agreement_signed):
     if service.go_live_checklist_completed and agreement_signed:
         return COMPLETE
 
-    yield INCOMPLETE
-
-    if not service.go_live_checklist_completed:
-        yield INCOMPLETE + '_checklist'
-
-    if not agreement_signed:
-        yield INCOMPLETE + '_mou'
-
-    if service.has_email_templates and not service.has_email_reply_to_address:
-        yield INCOMPLETE + '_email_reply_to'
-
-    if not service.has_team_members:
-        yield INCOMPLETE + '_team_member'
-
-    if not service.has_templates:
-        yield INCOMPLETE + '_template_content'
-
-    if (
-        service.has_sms_templates and
-        service.shouldnt_use_govuk_as_sms_sender and
-        service.sms_sender_is_govuk
+    for test, tag in (
+        (True, ''),
+        (not service.go_live_checklist_completed, '_checklist'),
+        (not agreement_signed, '_mou'),
+        (service.needs_to_add_email_reply_to_address, '_email_reply_to'),
+        (not service.has_team_members, '_team_member'),
+        (not service.has_templates, '_template_content'),
+        (service.needs_to_change_sms_sender, '_sms_sender'),
     ):
-        yield INCOMPLETE + '_sms_sender'
+        if test:
+            yield INCOMPLETE + tag

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -222,7 +222,7 @@ def submit_request_to_go_live(service_id):
                 service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
                 organisation_type=str(current_service.organisation_type).title(),
                 agreement=AgreementInfo.from_current_user().as_human_readable,
-                checklist='Yes' if current_service.go_live_checklist_completed else 'No',
+                checklist=current_service.go_live_checklist_completed_as_yes_no,
                 volume_email=form.volume_email.data,
                 volume_sms=form.volume_sms.data,
                 volume_letter=form.volume_letter.data,
@@ -235,7 +235,8 @@ def submit_request_to_go_live(service_id):
             ),
             ticket_type=zendesk_client.TYPE_QUESTION,
             user_email=current_user.email_address,
-            user_name=current_user.name
+            user_name=current_user.name,
+            tags=get_request_to_go_live_tags(current_service, current_user),
         )
 
         flash('Thanks for your request to go live. We’ll get back to you within one working day.', 'default')
@@ -1106,3 +1107,46 @@ def check_contact_details_type(contact_details):
         return 'email_address'
     else:
         return 'phone_number'
+
+
+def get_request_to_go_live_tags(service, user):
+    return list(_get_request_to_go_live_tags(
+        service,
+        AgreementInfo.from_user(user).agreement_signed,
+    ))
+
+
+def _get_request_to_go_live_tags(service, agreement_signed):
+
+    BASE = 'notify_request_to_go_live'
+    COMPLETE = BASE + '_complete'
+    INCOMPLETE = BASE + '_incomplete'
+
+    yield BASE
+
+    if service.go_live_checklist_completed and agreement_signed:
+        return COMPLETE
+
+    yield INCOMPLETE
+
+    if not service.go_live_checklist_completed:
+        yield INCOMPLETE + '_checklist'
+
+    if not agreement_signed:
+        yield INCOMPLETE + '_mou'
+
+    if service.has_email_templates and not service.has_email_reply_to_address:
+        yield INCOMPLETE + '_email_reply_to'
+
+    if not service.has_team_members:
+        yield INCOMPLETE + '_team_member'
+
+    if not service.has_templates:
+        yield INCOMPLETE + '_template_content'
+
+    if (
+        service.has_sms_templates and
+        service.shouldnt_use_govuk_as_sms_sender and
+        service.sms_sender_is_govuk
+    ):
+        yield INCOMPLETE + '_sms_sender'

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -180,30 +180,7 @@ def service_name_change_confirm(service_id):
 @user_has_permissions('manage_service')
 def request_to_go_live(service_id):
     return render_template(
-        'views/service-settings/request-to-go-live.html',
-        has_team_members=(
-            user_api_client.get_count_of_users_with_permission(
-                service_id, 'manage_service'
-            ) > 1
-        ),
-        has_templates=(
-            service_api_client.count_service_templates(service_id) > 0
-        ),
-        has_email_templates=(
-            service_api_client.count_service_templates(service_id, template_type='email') > 0
-        ),
-        has_sms_templates=(
-            service_api_client.count_service_templates(service_id, template_type='sms') > 0
-        ),
-        has_email_reply_to_address=bool(
-            service_api_client.get_reply_to_email_addresses(service_id)
-        ),
-        shouldnt_use_govuk_as_sms_sender=(
-            current_service.organisation_type in {'local', 'nhs'}
-        ),
-        sms_sender_is_govuk=get_default_sms_sender(
-            service_api_client.get_sms_senders(service_id)
-        ) in {'GOVUK', 'None'},
+        'views/service-settings/request-to-go-live.html'
     )
 
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -199,6 +199,7 @@ def submit_request_to_go_live(service_id):
                 '\n---'
                 '\nOrganisation type: {organisation_type}'
                 '\nAgreement signed: {agreement}'
+                '\nChecklist completed: {checklist}'
                 '\nEmails in next year: {volume_email}'
                 '\nText messages in next year: {volume_sms}'
                 '\nLetters in next year: {volume_letter}'
@@ -221,6 +222,7 @@ def submit_request_to_go_live(service_id):
                 service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
                 organisation_type=str(current_service.organisation_type).title(),
                 agreement=AgreementInfo.from_current_user().as_human_readable,
+                checklist='Yes' if current_service.go_live_checklist_completed else 'No',
                 volume_email=form.volume_email.data,
                 volume_sms=form.volume_sms.data,
                 volume_letter=form.volume_letter.data,

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -346,6 +346,10 @@ class Service(dict):
         ))
 
     @property
+    def needs_to_add_email_reply_to_address(self):
+        return self.has_email_templates and not self.has_email_reply_to_address
+
+    @property
     def shouldnt_use_govuk_as_sms_sender(self):
         return self.organisation_type in {'local', 'nhs'}
 
@@ -357,19 +361,20 @@ class Service(dict):
         ) in {'GOVUK', 'None'}
 
     @property
+    def needs_to_change_sms_sender(self):
+        return all((
+            self.has_sms_templates,
+            self.shouldnt_use_govuk_as_sms_sender,
+            self.sms_sender_is_govuk,
+        ))
+
+    @property
     def go_live_checklist_completed(self):
         return all((
             self.has_team_members,
             self.has_templates,
-            any((
-                not self.has_email_templates,
-                self.has_email_reply_to_address,
-            )),
-            any((
-                not self.has_sms_templates,
-                not self.shouldnt_use_govuk_as_sms_sender,
-                not self.sms_sender_is_govuk,
-            ))
+            not self.needs_to_add_email_reply_to_address,
+            not self.needs_to_change_sms_sender,
         ))
 
     @property

--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -355,3 +355,23 @@ class Service(dict):
         return get_default_sms_sender(
             service_api_client.get_sms_senders(self.id)
         ) in {'GOVUK', 'None'}
+
+    @property
+    def go_live_checklist_completed(self):
+        return all((
+            self.has_team_members,
+            self.has_templates,
+            any((
+                not self.has_email_templates,
+                self.has_email_reply_to_address,
+            )),
+            any((
+                not self.has_sms_templates,
+                not self.shouldnt_use_govuk_as_sms_sender,
+                not self.sms_sender_is_govuk,
+            ))
+        ))
+
+    @property
+    def go_live_checklist_completed_as_yes_no(self):
+        return 'Yes' if self.go_live_checklist_completed else 'No'

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -9,7 +9,7 @@
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ main_navigation.is_selected('templates') }}>Templates</a></li>
   {% if not current_user.has_permissions('view_activity') %}
     <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>
-    {% if current_service.has_jobs() %}
+    {% if current_service.has_jobs %}
       <li><a href="{{ url_for('.view_jobs', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploaded-files') }}>Uploaded files</a></li>
     {% endif %}
   {% endif %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -16,30 +16,30 @@
       <h1 class="heading-large">Before you request to go live</h1>
       {% call task_list_wrapper() %}
         {{ task_list_item(
-          has_team_members,
+          current_service.has_team_members,
           '<a href="{}">Add a team member who can manage settings, team and usage</a>
 '.format(
             url_for('main.manage_users', service_id=current_service.id)
           )|safe,
         ) }}
         {{ task_list_item(
-          has_templates,
+          current_service.has_templates,
           '<a href="{}">Add templates with examples of the content you plan to send
 </a>'.format(
             url_for('main.choose_template', service_id=current_service.id)
           )|safe,
         ) }}
-        {% if has_email_templates %}
+        {% if current_service.has_email_templates %}
           {{ task_list_item(
-            has_email_reply_to_address,
+            current_service.has_email_reply_to_address,
             '<a href="{}">Add an email reply-to address</a>'.format(
               url_for('main.service_email_reply_to', service_id=current_service.id)
             )|safe,
           ) }}
         {% endif %}
-        {% if has_sms_templates and shouldnt_use_govuk_as_sms_sender %}
+        {% if current_service.has_sms_templates and current_service.shouldnt_use_govuk_as_sms_sender %}
           {{ task_list_item(
-            not sms_sender_is_govuk,
+            not current_service.sms_sender_is_govuk,
             '<a href="{}">Change your text message sender name</a>'.format(
               url_for('main.service_sms_senders', service_id=current_service.id)
             )|safe

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,4 +21,4 @@ notifications-python-client==5.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.1.2#egg=notifications-utils==30.1.2
+git+https://github.com/alphagov/notifications-utils.git@30.3.0#egg=notifications-utils==30.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ notifications-python-client==5.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.1.2#egg=notifications-utils==30.1.2
+git+https://github.com/alphagov/notifications-utils.git@30.3.0#egg=notifications-utils==30.3.0
 
 ## The following requirements were added by pip freeze:
 awscli==1.16.19

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3203,6 +3203,7 @@ def test_submit_email_branding_request(
         ticket_type='question',
         user_email='test@user.gov.uk',
         user_name='Test User',
+        tags=['notify_action_add_branding'],
     )
     assert normalize_spaces(page.select_one('.banner-default').text) == (
         'Thanks for your branding request. We’ll get back to you '


### PR DESCRIPTION
At the moment we manually tag tickets as they come in so we can analyse how many of each type we’re getting.

Further, we manually tag all the request to go live tickets once a month to analyse how many are complete/incomplete.

All this tagging is useful, but quite time consuming. Notify already knows this information and – using the Zendesk API – we can tag them automatically.

I’ve checked with Holly and this is the taxonomy we want to use.

---

Depends on:
- [x] alphagov/notifications-utils#529