### PR TITLE
Hide Postage setting when letters are not enabled for service

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -236,7 +236,7 @@
         {% endcall %}
 
         {% if current_user.platform_admin %}
-          {% call row() %}
+          {% call settings_row(if_has_permission='letter') %}
             {{ text_field('Postage') }}
               {% set postage = {'first': 'First class only', 'second': 'Second class only'} %}
               {{ text_field(postage[current_service.postage]) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -89,7 +89,6 @@ def mock_get_service_settings_page_common(
 
         'Label Value Action',
         'Send letters Off Change',
-        'Postage Second class only Change',
 
         'Label Value Action',
         'Organisation Org 1 Change',
@@ -214,6 +213,25 @@ def test_should_show_overview_for_service_with_more_things_set(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     for index, row in enumerate(expected_rows):
         assert row == " ".join(page.find_all('tr')[index + 1].text.split())
+
+
+def test_if_cant_send_letters_then_cant_see_postage(
+    logged_in_platform_admin_client,
+    service_one,
+    single_reply_to_email_address,
+    single_letter_contact_block,
+    mock_get_service_organisation,
+    single_sms_sender,
+    mock_get_service_settings_page_common,
+):
+    response = logged_in_platform_admin_client.get(url_for('main.service_settings', service_id=SERVICE_ONE_ID))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    letter_table = page.find_all('table')[3]
+    rows = letter_table.find_all('tr')
+
+    assert len(rows) == 2
+    assert 'Postage' not in letter_table
 
 
 def test_if_cant_send_letters_then_cant_see_letter_contact_block(


### PR DESCRIPTION
We don't show the sender addresses and letter branding on the settings page if a service doesn't have letters enabled, so we should also hide the postage for services that can't send letters.

(Postage can only be seen by Platform Admin users at the moment, but this will change later).

#### Before
<img width="798" alt="screen shot 2018-09-20 at 15 41 26" src="https://user-images.githubusercontent.com/12881990/45826513-87b6ad80-bcec-11e8-8523-349160a473bd.png">

#### After
<img width="779" alt="screen shot 2018-09-20 at 15 40 33" src="https://user-images.githubusercontent.com/12881990/45826530-8d13f800-bcec-11e8-8e59-89f465659115.png">
