### PR TITLE
Fix missing ‘complete’ tag in go live request

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1120,13 +1120,12 @@ def get_request_to_go_live_tags(service, user):
 def _get_request_to_go_live_tags(service, agreement_signed):
 
     BASE = 'notify_request_to_go_live'
-    COMPLETE = BASE + '_complete'
-    INCOMPLETE = BASE + '_incomplete'
 
     yield BASE
 
     if service.go_live_checklist_completed and agreement_signed:
-        return COMPLETE
+        yield BASE + '_complete'
+        return
 
     for test, tag in (
         (True, ''),
@@ -1138,4 +1137,4 @@ def _get_request_to_go_live_tags(service, agreement_signed):
         (service.needs_to_change_sms_sender, '_sms_sender'),
     ):
         if test:
-            yield INCOMPLETE + tag
+            yield BASE + '_incomplete' + tag

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -818,6 +818,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             [
                 'notify_request_to_go_live',
+                'notify_request_to_go_live_complete',
             ],
         ),
         (  # Needs to set reply to address
@@ -849,6 +850,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             [
                 'notify_request_to_go_live',
+                'notify_request_to_go_live_complete',
             ],
         ),
         (  # Needs to change SMS sender


### PR DESCRIPTION
This tag was not showing up in the call to the Zendesk API because the return value of a generator is not included as a member of that generator (on things `yield`ed from it are).