### PR TITLE
Add line about the data sharing and financial agreement to the checklist

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,8 +67,7 @@ from app.notify_client.billing_api_client import BillingAPIClient
 from app.notify_client.complaint_api_client import ComplaintApiClient
 from app.notify_client.platform_stats_api_client import PlatformStatsAPIClient
 from app.commands import setup_commands
-from app.utils import get_cdn_domain
-from app.utils import gmt_timezones
+from app.utils import get_cdn_domain, gmt_timezones, id_safe
 
 login_manager = LoginManager()
 csrf = CSRFProtect()
@@ -664,5 +663,6 @@ def add_template_filters(application):
         formatted_list,
         nl2br,
         format_phone_number_human_readable,
+        id_safe,
     ]:
         application.add_template_filter(fn)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -179,8 +179,13 @@ def service_name_change_confirm(service_id):
 @login_required
 @user_has_permissions('manage_service')
 def request_to_go_live(service_id):
+
+    agreement_signed = AgreementInfo.from_current_user().agreement_signed
+
     return render_template(
-        'views/service-settings/request-to-go-live.html'
+        'views/service-settings/request-to-go-live.html',
+        show_agreement=agreement_signed is not None,
+        agreement_signed=agreement_signed,
     )
 
 

--- a/app/templates/components/task-list.html
+++ b/app/templates/components/task-list.html
@@ -1,10 +1,10 @@
-{% macro task_list_item(completed, label) %}
+{% macro task_list_item(completed, label, link) %}
   <li class="task-list-item">
-    {{ label }}
+    <span aria-describedby="{{ label|id_safe }}"><a href="{{ link }}">{{ label }}</a></span>
     {% if completed %}
-      <span class="task-list-indicator-completed">Completed</span>
+      <strong class="task-list-indicator-completed" id="{{ label|id_safe }}">Completed</strong>
     {% else %}
-      <span class="task-list-indicator-not-completed">Not completed</span>
+      <strong class="task-list-indicator-not-completed" id="{{ label|id_safe }}">Not completed</strong>
     {% endif %}
   </li>
 {% endmacro %}

--- a/app/templates/views/agreement-choose.html
+++ b/app/templates/views/agreement-choose.html
@@ -2,7 +2,7 @@
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
-  Download the GOV.UK Notify data sharing and financial agreement
+  GOV.UK Notify data sharing and financial agreement
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -14,7 +14,7 @@
   <div class="column-two-thirds">
 
     <h1 class="heading-large">
-      Download the GOV.UK Notify data sharing and financial agreement
+      GOV.UK Notify data sharing and financial agreement
     </h1>
 
     <p>

--- a/app/templates/views/agreement-signed.html
+++ b/app/templates/views/agreement-signed.html
@@ -2,7 +2,7 @@
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
-  Download the GOV.UK Notify data sharing and financial agreement
+  GOV.UK Notify data sharing and financial agreement
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -14,7 +14,7 @@
   <div class="column-two-thirds">
 
     <h1 class="heading-large">
-      Download the GOV.UK Notify data sharing and financial agreement
+      GOV.UK Notify data sharing and financial agreement
     </h1>
 
     <p>

--- a/app/templates/views/agreement.html
+++ b/app/templates/views/agreement.html
@@ -2,7 +2,7 @@
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
-  Download the GOV.UK Notify data sharing and financial agreement
+  GOV.UK Notify data sharing and financial agreement
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -14,7 +14,7 @@
   <div class="column-two-thirds">
 
     <h1 class="heading-large">
-      Download the GOV.UK Notify data sharing and financial agreement
+      GOV.UK Notify data sharing and financial agreement
     </h1>
 
     <p>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -42,7 +42,7 @@
         {% if show_agreement %}
           {{ task_list_item(
             agreement_signed,
-            'Get our data sharing and financial agreement signed',
+            'Sign our data sharing and financial agreement',
             url_for('main.agreement'),
           ) }}
         {% endif %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -39,6 +39,13 @@
             url_for('main.service_sms_senders', service_id=current_service.id),
           ) }}
         {% endif %}
+        {% if show_agreement %}
+          {{ task_list_item(
+            agreement_signed,
+            'Get our data sharing and financial agreement signed',
+            url_for('main.agreement'),
+          ) }}
+        {% endif %}
       {% endcall %}
       <p>
         You also need to accept our <a href="{{ url_for('.terms') }}">terms of use</a>.

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -17,32 +17,26 @@
       {% call task_list_wrapper() %}
         {{ task_list_item(
           current_service.has_team_members,
-          '<a href="{}">Add a team member who can manage settings, team and usage</a>
-'.format(
-            url_for('main.manage_users', service_id=current_service.id)
-          )|safe,
+          'Add a team member who can manage settings, team and usage',
+          url_for('main.manage_users', service_id=current_service.id),
         ) }}
         {{ task_list_item(
           current_service.has_templates,
-          '<a href="{}">Add templates with examples of the content you plan to send
-</a>'.format(
-            url_for('main.choose_template', service_id=current_service.id)
-          )|safe,
+          'Add templates with examples of the content you plan to send',
+          url_for('main.choose_template', service_id=current_service.id),
         ) }}
         {% if current_service.has_email_templates %}
           {{ task_list_item(
             current_service.has_email_reply_to_address,
-            '<a href="{}">Add an email reply-to address</a>'.format(
-              url_for('main.service_email_reply_to', service_id=current_service.id)
-            )|safe,
+            'Add an email reply-to address',
+            url_for('main.service_email_reply_to', service_id=current_service.id),
           ) }}
         {% endif %}
         {% if current_service.has_sms_templates and current_service.shouldnt_use_govuk_as_sms_sender %}
           {{ task_list_item(
             not current_service.sms_sender_is_govuk,
-            '<a href="{}">Change your text message sender name</a>'.format(
-              url_for('main.service_sms_senders', service_id=current_service.id)
-            )|safe
+            'Change your text message sender name',
+            url_for('main.service_sms_senders', service_id=current_service.id),
           ) }}
         {% endif %}
       {% endcall %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -206,6 +206,10 @@ def email_safe(string, whitespace='.'):
     return string.strip('.')
 
 
+def id_safe(string):
+    return email_safe(string, whitespace='-')
+
+
 class Spreadsheet():
 
     allowed_file_extensions = ['csv', 'xlsx', 'xls', 'ods', 'xlsm', 'tsv']

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -710,11 +710,11 @@ def test_should_check_for_sms_sender_on_go_live(
     ),
     (
         'test@education.gov.uk',
-        'Get our data sharing and financial agreement signed Completed',
+        'Sign our data sharing and financial agreement Completed',
     ),
     (
         'test@aylesbury.gov.uk',
-        'Get our data sharing and financial agreement signed Not completed',
+        'Sign our data sharing and financial agreement Not completed',
     ),
 ))
 def test_should_check_for_mou_on_request_to_go_live(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -702,6 +702,58 @@ def test_should_check_for_sms_sender_on_go_live(
     mock_get_sms_senders.assert_called_once_with(SERVICE_ONE_ID)
 
 
+@pytest.mark.parametrize('email_address, expected_item', (
+    pytest.param(
+        'test@unknown.gov.uk',
+        '',
+        marks=pytest.mark.xfail(raises=IndexError)
+    ),
+    (
+        'test@education.gov.uk',
+        'Get our data sharing and financial agreement signed Completed',
+    ),
+    (
+        'test@aylesbury.gov.uk',
+        'Get our data sharing and financial agreement signed Not completed',
+    ),
+))
+def test_should_check_for_mou_on_request_to_go_live(
+    client_request,
+    service_one,
+    mocker,
+    email_address,
+    expected_item,
+):
+    mocker.patch(
+        'app.main.views.service_settings.user_api_client.get_count_of_users_with_permission',
+        return_value=0,
+    )
+    mocker.patch(
+        'app.main.views.service_settings.service_api_client.count_service_templates',
+        return_value=0,
+    )
+    mocker.patch(
+        'app.main.views.service_settings.service_api_client.get_sms_senders',
+        return_value=[],
+    )
+    mocker.patch(
+        'app.main.views.service_settings.service_api_client.get_reply_to_email_addresses',
+        return_value=[],
+    )
+
+    user = active_user_with_permissions(fake_uuid())
+    user.email_address = email_address
+    client_request.login(user)
+
+    page = client_request.get(
+        'main.request_to_go_live', service_id=SERVICE_ONE_ID
+    )
+    assert page.h1.text == 'Before you request to go live'
+
+    checklist_items = page.select('.task-list .task-list-item')
+    assert normalize_spaces(checklist_items[2].text) == expected_item
+
+
 def test_should_show_request_to_go_live(
     client_request,
 ):


### PR DESCRIPTION
Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/46006427-6caeb980-c0af-11e8-81ee-0b2e0ed31dd6.png) | ![image](https://user-images.githubusercontent.com/355079/46006410-60c2f780-c0af-11e8-9e71-2c8e312f6e02.png)


2/3 of our incomplete requests to go live are incomplete because the Data Sharing and Financial Agreement isn’t signed.

We reckon we can be pushier about this by saying it’s ‘incomplete’ where we know the agreement is signed.

Where the agreement is signed we should confirm this, rather than make the line disappear. This is so it makes more sense to someone who sees it as ‘incomplete’, signs it, then comes back to the page.

If we don’t know whether or not the agreement is signed we should wait until someone has got in touch with us by requesting to go live to figure it out. So that’s why we’re not showing that line at all.

***

Needs @karlchillmaid’s input on the content before merging.