### PR TITLE
Bump utils to 30.3.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,4 +21,4 @@ notifications-python-client==5.2.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.3.0#egg=notifications-utils==30.3.0
+git+https://github.com/alphagov/notifications-utils.git@30.3.1#egg=notifications-utils==30.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ notifications-python-client==5.2.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@30.3.0#egg=notifications-utils==30.3.0
+git+https://github.com/alphagov/notifications-utils.git@30.3.1#egg=notifications-utils==30.3.1
 
 ## The following requirements were added by pip freeze:
 awscli==1.16.20


### PR DESCRIPTION
Brings in stripping of the [line separator character](https://www.fileformat.info/info/unicode/char/2028/index.htm) from email previews.

https://github.com/alphagov/notifications-utils/pull/531

Doesn't alter the content of email templates in the database, just strips line separators out from the template view page.