### PR TITLE
Stop calling `fake_uuid` fixture directly

### DIFF
--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -1,15 +1,15 @@
 import uuid
 from collections import OrderedDict
 from unittest.mock import call
+from uuid import uuid4
 
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests import validate_route_permission
+from tests import sample_uuid, validate_route_permission
 from tests.conftest import (
     SERVICE_ONE_ID,
-    fake_uuid,
     mock_get_empty_service_callback_api,
     mock_get_empty_service_inbound_api,
     mock_get_live_service,
@@ -515,7 +515,7 @@ def test_callback_forms_validation(
     ((
         mock_get_valid_service_callback_api,
         mock_get_valid_service_inbound_api,
-    ), [fake_uuid()], True),
+    ), [uuid4()], True),
     ((
         mock_get_empty_service_callback_api,
         mock_get_empty_service_inbound_api,
@@ -793,7 +793,7 @@ def test_update_delivery_status_and_receive_text_message_callbacks_without_chang
         'Callbacks for delivery receipts Not set Change'
     ),
     (
-        fake_uuid(), {'url': 'https://delivery.receipts'},
+        sample_uuid(), {'url': 'https://delivery.receipts'},
         'Callbacks for delivery receipts https://delivery.receipts Change'
     ),
 ])
@@ -803,7 +803,7 @@ def test_update_delivery_status_and_receive_text_message_callbacks_without_chang
         'Callbacks for received text messages Not set Change'
     ),
     (
-        fake_uuid(), {'url': 'https://inbound.sms'},
+        sample_uuid(), {'url': 'https://inbound.sms'},
         'Callbacks for received text messages https://inbound.sms Change'
     ),
 ])

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -6,6 +6,7 @@ from glob import glob
 from io import BytesIO
 from itertools import repeat
 from os import path
+from uuid import uuid4
 from zipfile import BadZipFile
 
 import pytest
@@ -3006,15 +3007,15 @@ def test_send_notification_shows_email_error_in_trial_mode(
 
 @pytest.mark.parametrize('endpoint, extra_args', [
     ('main.check_messages', {
-        'template_id': fake_uuid(), 'upload_id': fake_uuid(), 'original_file_name': 'example.csv'
+        'template_id': uuid4(), 'upload_id': uuid4(), 'original_file_name': 'example.csv'
     }),
     ('main.send_one_off_step', {
-        'template_id': fake_uuid(), 'step_index': 0
+        'template_id': uuid4(), 'step_index': 0
     }),
 ])
 @pytest.mark.parametrize('reply_to_address', [
     None,
-    fake_uuid(),
+    uuid4(),
 ])
 def test_reply_to_is_previewed_if_chosen(
     client_request,
@@ -3059,12 +3060,12 @@ def test_reply_to_is_previewed_if_chosen(
 
 
 @pytest.mark.parametrize('endpoint, extra_args', [
-    ('main.check_messages', {'template_id': fake_uuid(), 'upload_id': fake_uuid()}),
-    ('main.send_one_off_step', {'template_id': fake_uuid(), 'step_index': 0}),
+    ('main.check_messages', {'template_id': uuid4(), 'upload_id': uuid4()}),
+    ('main.send_one_off_step', {'template_id': uuid4(), 'step_index': 0}),
 ])
 @pytest.mark.parametrize('sms_sender', [
     None,
-    fake_uuid(),
+    uuid4(),
 ])
 def test_sms_sender_is_previewed(
     client_request,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2,6 +2,7 @@ import uuid
 from functools import partial
 from unittest.mock import ANY, PropertyMock, call
 from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
 import pytest
 from bs4 import BeautifulSoup
@@ -11,13 +12,12 @@ from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
 
 import app
 from app.utils import email_safe
-from tests import service_json, validate_route_permission
+from tests import sample_uuid, service_json, validate_route_permission
 from tests.conftest import (
     SERVICE_ONE_ID,
     active_user_no_api_key_permission,
     active_user_no_settings_permission,
     active_user_with_permissions,
-    fake_uuid,
     get_default_letter_contact_block,
     get_default_reply_to_email_address,
     get_default_sms_sender,
@@ -741,7 +741,7 @@ def test_should_check_for_mou_on_request_to_go_live(
         return_value=[],
     )
 
-    user = active_user_with_permissions(fake_uuid())
+    user = active_user_with_permissions(uuid4())
     user.email_address = email_address
     client_request.login(user)
 
@@ -1008,11 +1008,11 @@ def test_ready_to_go_live(
         ).return_value = locals()[prop]
 
     assert app.notify_client.models.Service({
-        'id': fake_uuid()
+        'id': SERVICE_ONE_ID
     }).go_live_checklist_completed_as_yes_no == expected_readyness
 
     assert list(app.main.views.service_settings._get_request_to_go_live_tags(
-        app.notify_client.models.Service({'id': fake_uuid()}),
+        app.notify_client.models.Service({'id': SERVICE_ONE_ID}),
         agreement_signed,
     )) == expected_tags
 
@@ -1541,14 +1541,11 @@ def test_edit_reply_to_email_address(
     )
 
 
-fixed_fake_uuid = fake_uuid()
-
-
 @pytest.mark.parametrize('fixture, expected_link_text, partial_href', [
     (
         get_non_default_reply_to_email_address,
         'Delete',
-        partial(url_for, 'main.service_confirm_delete_email_reply_to', reply_to_email_id=fixed_fake_uuid),
+        partial(url_for, 'main.service_confirm_delete_email_reply_to', reply_to_email_id=sample_uuid()),
     ),
     (
         get_default_reply_to_email_address,
@@ -1570,7 +1567,7 @@ def test_shows_delete_link_for_email_reply_to_address(
     page = client_request.get(
         'main.service_edit_email_reply_to',
         service_id=SERVICE_ONE_ID,
-        reply_to_email_id=fixed_fake_uuid,
+        reply_to_email_id=sample_uuid(),
     )
 
     last_link = page.select('.page-footer a')[-1]
@@ -1760,7 +1757,7 @@ def test_default_box_shows_on_non_default_sender_details_while_editing(
     (
         get_non_default_sms_sender,
         'Delete',
-        partial(url_for, 'main.service_confirm_delete_sms_sender', sms_sender_id=fixed_fake_uuid),
+        partial(url_for, 'main.service_confirm_delete_sms_sender', sms_sender_id=sample_uuid()),
     ),
     (
         get_default_sms_sender,
@@ -1782,7 +1779,7 @@ def test_shows_delete_link_for_sms_sender(
     page = client_request.get(
         'main.service_edit_sms_sender',
         service_id=SERVICE_ONE_ID,
-        sms_sender_id=fixed_fake_uuid,
+        sms_sender_id=sample_uuid(),
     )
 
     last_link = page.select('.page-footer a')[-1]

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -1,29 +1,28 @@
 from unittest.mock import call
+from uuid import uuid4
 
 import pytest
 
 from app import invite_api_client, service_api_client, user_api_client
 from app.notify_client.service_api_client import ServiceAPIClient
-from tests.conftest import SERVICE_ONE_ID, fake_uuid
+from tests.conftest import SERVICE_ONE_ID
 
-FAKE_TEMPLATE_ID = fake_uuid()
+FAKE_TEMPLATE_ID = uuid4()
 
 
 def test_client_posts_archived_true_when_deleting_template(mocker):
-    service_id = fake_uuid()
-    template_id = fake_uuid()
     mocker.patch('app.notify_client.current_user', id='1')
 
     expected_data = {
         'archived': True,
         'created_by': '1'
     }
-    expected_url = '/service/{}/template/{}'.format(service_id, template_id)
+    expected_url = '/service/{}/template/{}'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)
 
     client = ServiceAPIClient()
     mock_post = mocker.patch('app.notify_client.service_api_client.ServiceAPIClient.post')
 
-    client.delete_service_template(service_id, template_id)
+    client.delete_service_template(SERVICE_ONE_ID, FAKE_TEMPLATE_ID)
     mock_post.assert_called_once_with(expected_url, data=expected_data)
 
 
@@ -361,8 +360,8 @@ def test_returns_value_from_cache(
     (service_api_client, 'delete_sms_sender', [SERVICE_ONE_ID, ''], {}),
     (service_api_client, 'update_service_callback_api', [SERVICE_ONE_ID] + [''] * 4, {}),
     (service_api_client, 'create_service_callback_api', [SERVICE_ONE_ID] + [''] * 3, {}),
-    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, fake_uuid(), []], {}),
-    (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, fake_uuid()], {}),
+    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, uuid4(), []], {}),
+    (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, uuid4()], {}),
 ])
 def test_deletes_service_cache(
     app_,

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -4,9 +4,10 @@ import pytest
 
 from app import invite_api_client, service_api_client, user_api_client
 from app.notify_client.models import User
-from tests.conftest import SERVICE_ONE_ID, api_user_pending, fake_uuid
+from tests import sample_uuid
+from tests.conftest import SERVICE_ONE_ID, api_user_pending
 
-user_id = fake_uuid()
+user_id = sample_uuid()
 
 
 def test_client_gets_all_users_for_service(
@@ -236,7 +237,7 @@ def test_returns_value_from_cache(
 
 
 @pytest.mark.parametrize('client, method, extra_args, extra_kwargs', [
-    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, fake_uuid(), []], {}),
+    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, sample_uuid(), []], {}),
     (user_api_client, 'update_user_attribute', [user_id], {}),
     (user_api_client, 'reset_failed_login_count', [user_id], {}),
     (user_api_client, 'update_user_attribute', [user_id], {}),
@@ -244,11 +245,11 @@ def test_returns_value_from_cache(
     (user_api_client, 'verify_password', [user_id, 'hunter2'], {}),
     (user_api_client, 'check_verify_code', [user_id, '', ''], {}),
     (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, user_id, []], {}),
-    (user_api_client, 'add_user_to_organisation', [fake_uuid(), user_id], {}),
+    (user_api_client, 'add_user_to_organisation', [sample_uuid(), user_id], {}),
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),
-    (user_api_client, 'activate_user', [api_user_pending(fake_uuid())], {}),
+    (user_api_client, 'activate_user', [api_user_pending(sample_uuid())], {}),
     (service_api_client, 'remove_user_from_service', [SERVICE_ONE_ID, user_id], {}),
-    (service_api_client, 'create_service', ['', '', 0, False, user_id, fake_uuid()], {}),
+    (service_api_client, 'create_service', ['', '', 0, False, user_id, sample_uuid()], {}),
     (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, user_id], {}),
 ])
 def test_deletes_user_cache(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1430,7 +1430,7 @@ def mock_register_user(mocker, api_user_pending):
 @pytest.fixture(scope='function')
 def mock_get_non_govuser(mocker, user=None):
     if user is None:
-        user = api_user_active(fake_uuid(), email_address='someuser@notonwhitelist.com')
+        user = api_user_active(sample_uuid(), email_address='someuser@notonwhitelist.com')
 
     def _get_user(id_):
         user.id = id_
@@ -1443,7 +1443,7 @@ def mock_get_non_govuser(mocker, user=None):
 @pytest.fixture(scope='function')
 def mock_get_user(mocker, user=None):
     if user is None:
-        user = api_user_active(fake_uuid())
+        user = api_user_active(sample_uuid())
 
     def _get_user(id_):
         user.id = id_
@@ -1456,7 +1456,7 @@ def mock_get_user(mocker, user=None):
 @pytest.fixture(scope='function')
 def mock_get_organisation_user(mocker, user=None):
     if user is None:
-        user = api_user_active(fake_uuid())
+        user = api_user_active(sample_uuid())
 
     def _get_user(id_):
         user.id = id_
@@ -1486,7 +1486,7 @@ def mock_get_user_pending(mocker, api_user_pending):
 @pytest.fixture(scope='function')
 def mock_get_user_by_email(mocker, user=None):
     if user is None:
-        user = api_user_active(fake_uuid())
+        user = api_user_active(sample_uuid())
 
     def _get_user(email_address):
         user.email_address = email_address
@@ -2096,7 +2096,7 @@ def mock_get_users_by_service(mocker):
 @pytest.fixture(scope='function')
 def mock_s3_upload(mocker):
     def _upload(service_id, filedata, region):
-        return fake_uuid()
+        return sample_uuid()
 
     return mocker.patch('app.main.views.send.s3upload', side_effect=_upload)
 


### PR DESCRIPTION
Pytest is deprecating the direct calling of fixtures. One fixture that we call directly quite a lot is `fake_uuid`. Since it just returns the value of `sample_uuid()` we can either call that instead (where we need a fixed value) or generate a new UUID each time (where a fixed value is not needed).