### PR TITLE
Fix missing page title on email branding page

### DIFF
--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/live-search.html" import live_search %}
 
-{% block service_page_title %}
+{% block per_page_title %}
   Email branding
 {% endblock %}
 


### PR DESCRIPTION
It’s not a service-specific page so trying to set the service-specific page title does nothing.