### PR TITLE
Bump utils to 30.5.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,4 @@ awscli-cwlogs>=1.4,<1.5
 awscli==1.15.82
 botocore<1.11.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.4.0#egg=notifications-utils==30.4.0
+git+https://github.com/alphagov/notifications-utils.git@30.5.1#egg=notifications-utils==30.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ awscli-cwlogs>=1.4,<1.5
 awscli==1.15.82
 botocore<1.11.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.4.0#egg=notifications-utils==30.4.0
+git+https://github.com/alphagov/notifications-utils.git@30.5.1#egg=notifications-utils==30.5.1
 
 ## The following requirements were added by pip freeze:
 bleach==2.1.3


### PR DESCRIPTION
Brings in some fixes for HTML validation problems with the email template:

https://github.com/alphagov/notifications-utils/pull/538