### PR TITLE
Allow coloured branding without logo in preview

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -108,7 +108,8 @@ def email_template():
         colour = email_branding['colour']
         brand_name = email_branding['text']
         brand_colour = colour
-        brand_logo = 'https://{}/{}'.format(get_cdn_domain(), email_branding['logo'])
+        brand_logo = ('https://{}/{}'.format(get_cdn_domain(), email_branding['logo'])
+                      if email_branding['logo'] else None)
         govuk_banner = branding_type in ['govuk', 'both']
         brand_banner = branding_type == 'org_banner'
 


### PR DESCRIPTION
Fix effecting the `/_email` preview page (appears in an iframe, showing a preview of an email brand).

Coloured brandings can just be a coloured background with text. The controller for the page assumed any branding would have an image but in this case gets a `None` value. It therefore ends up constructing a path for it like `BASE_PATH/None`.

## Before

<img width="732" alt="broken_coloured_branding_without_logo_image" src="https://user-images.githubusercontent.com/87140/46747892-47729b80-ccaa-11e8-8dc1-a96cc2cd5849.png">

## After

<img width="739" alt="fixed_coloured_branding_without_logo_image" src="https://user-images.githubusercontent.com/87140/46747900-4c374f80-ccaa-11e8-8048-bdec931e3dba.png">
