### PR TITLE
Show if a letter has been cancelled

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -431,7 +431,9 @@ def format_notification_status_as_field_status(status, notification_type):
     ).get(status, 'error')
 
 
-def format_notification_status_as_url(status):
+def format_notification_status_as_url(status, notification_type):
+    if notification_type == 'letter':
+        return None
     url = partial(url_for, "main.using_notify")
     return {
         'technical-failure': url(_anchor='technical-failure'),

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -15,4 +15,9 @@
 
   }
 
+  &-cancelled {
+    @include bold-19;
+    color: $error-colour;
+  }
+
 }

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -76,6 +76,7 @@ def view_notification(service_id, notification_id):
     return render_template(
         'views/notifications/notification.html',
         finished=(notification['status'] in (DELIVERED_STATUSES + FAILURE_STATUSES)),
+        notification_status=notification['status'],
         uploaded_file_name='Report',
         template=template,
         job=job,
@@ -89,6 +90,7 @@ def view_notification(service_id, notification_id):
         partials=get_single_notification_partials(notification),
         created_by=notification.get('created_by'),
         created_at=notification['created_at'],
+        updated_at=notification['updated_at'],
         help=get_help_argument(),
         estimated_letter_delivery_date=get_letter_timings(
             notification['created_at'],

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -34,7 +34,8 @@
   link=None,
   show_failures=True,
   smaller=False,
-  smallest=False
+  smallest=False,
+  failed_as_cancelled=False
 ) %}
   <div class="big-number-with-status">
     {{ big_number(number, label, link=link, smaller=smaller, smallest=smallest) }}
@@ -43,13 +44,27 @@
         {% if failures %}
           {% if failure_link %}
             <a href="{{ failure_link }}">
-              {{ "{:,}".format(failures) }} failed – {{ failure_percentage }}%
+              {{ "{:,}".format(failures) }}
+              {% if failed_as_cancelled %}
+                cancelled
+              {% else %}
+                failed – {{ failure_percentage }}%
+              {% endif %}
             </a>
           {% else %}
-            {{ "{:,}".format(failures) }} failed – {{ failure_percentage }}%
+            {{ "{:,}".format(failures) }}
+            {% if failed_as_cancelled %}
+              cancelled
+            {% else %}
+              failed – {{ failure_percentage }}%
+            {% endif %}
           {% endif %}
         {% else %}
-          No failures
+          {% if failed_as_cancelled %}
+            0 cancelled
+          {% else %}
+            No failures
+          {% endif %}
         {% endif %}
       </div>
     {% endif %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -154,7 +154,7 @@
       align='right'
     ) %}
       {% if displayed_on_single_line %}<span class="align-with-message-body">{% endif %}
-      {% if notification.status|format_notification_status_as_url %}
+      {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
         <a href="{{ notification.status|format_notification_status_as_url }}">
       {% endif %}
       {% if notification['notification_type'] != "letter" or notification.status == 'virus-scan-failed' %}
@@ -162,12 +162,19 @@
           notification.template.template_type
         ) }}
       {% endif %}
-      {% if notification.status|format_notification_status_as_url %}
+      {% if notification.notification_type == "letter" and notification.status == 'permanent-failure' %}
+        Cancelled
+      {% endif %}
+      {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
         </a>
       {% endif %}
       <span class="status-hint">
         {% if notification['notification_type'] == "letter" %}
-          {{ notification.created_at|format_datetime_short }}
+          {% if notification.status == 'permanent-failure' %}
+            {{ (notification.updated_at)|format_datetime_short }}
+          {% else %}
+            {{ (notification.created_at)|format_datetime_short }}
+          {% endif %}
         {% else %}
           {{ notification.status|format_notification_status_as_time(
             notification.created_at|format_datetime_short,

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -162,7 +162,7 @@
           notification.template.template_type
         ) }}
       {% endif %}
-      {% if notification.notification_type == "letter" and notification.status == 'permanent-failure' %}
+      {% if notification.notification_type == "letter" and notification.status in ['permanent-failure', 'validation-failed'] %}
         Cancelled
       {% endif %}
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -1,12 +1,12 @@
 <div class="ajax-block-container">
   <p class="notification-status {{ notification.status|format_notification_status_as_field_status(notification.notification_type) }}">
-    {% if notification.status|format_notification_status_as_url %}
-      <a href="{{ notification.status|format_notification_status_as_url }}">
+    {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
+      <a href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
     {% endif %}
     {{ notification.status|format_notification_status(
       notification.template.template_type
     ) }}
-    {% if notification.status|format_notification_status_as_url %}
+    {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
       </a>
     {% endif %}
     {% if sent_with_test_key %}

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -37,7 +37,8 @@
           statistics['letter']['show_warning'],
           failure_link=url_for(".view_notifications", service_id=service_id, message_type='letter', status='failed'),
           link=url_for(".view_notifications", service_id=service_id, message_type='letter', status=''),
-          smaller=smaller_font_size
+          smaller=smaller_font_size,
+          failed_as_cancelled=True
         ) }}
       </div>
     {% endif %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -35,15 +35,21 @@
     </p>
 
     {% if template.template_type == 'letter' %}
-      <p>
-        Postage: {{ postage }} class
-      </p>
-      <p>
-        Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
-      </p>
-      <p class="bottom-gutter">
-        <a href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download>Download as a PDF</a>
-      </p>
+      {% if notification_status == 'permanent-failure' %}
+        <p class="notification-status-cancelled">
+          Cancelled {{ updated_at|format_datetime_short }}
+        </p>
+      {% else %}
+        <p>
+          Postage: {{ postage }} class
+        </p>
+        <p>
+          Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
+        </p>
+        <p class="bottom-gutter">
+          <a href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download>Download as a PDF</a>
+        </p>
+      {% endif %}
     {% endif %}
 
     {{ template|string }}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -39,6 +39,11 @@
         <p class="notification-status-cancelled">
           Cancelled {{ updated_at|format_datetime_short }}
         </p>
+      {% elif notification_status == 'validation-failed' %}
+        <p class="notification-status-cancelled">
+          Cancelled {{ updated_at|format_datetime_short }}
+          (letter has content outside the printable area)
+        </p>
       {% else %}
         <p>
           Postage: {{ postage }} class

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -542,10 +542,11 @@ def test_big_numbers_and_search_dont_show_for_letters(
 
 @freeze_time("2017-09-27 16:30:00.000000")
 @pytest.mark.parametrize(
-    "message_type, hint_status_visible", [
-        ('email', True),
-        ('sms', True),
-        ('letter', False)
+    "message_type, status, expected_hint_status, single_line", [
+        ('email', 'delivered', 'Delivered 27 September at 5:31pm', True),
+        ('sms', 'delivered', 'Delivered 27 September at 5:31pm', True),
+        ('letter', 'delivered', '27 September at 5:30pm', True),
+        ('letter', 'permanent-failure', 'Cancelled 27 September at 5:31pm', False),
     ]
 )
 def test_sending_status_hint_does_not_include_status_for_letters(
@@ -555,10 +556,12 @@ def test_sending_status_hint_does_not_include_status_for_letters(
     mock_get_service_statistics,
     mock_get_service_data_retention_by_notification_type,
     message_type,
-    hint_status_visible,
+    status,
+    expected_hint_status,
+    single_line,
     mocker
 ):
-    mock_get_notifications(mocker, True, diff_template_type=message_type)
+    mock_get_notifications(mocker, True, diff_template_type=message_type, noti_status=status)
 
     page = client_request.get(
         'main.view_notifications',
@@ -566,10 +569,8 @@ def test_sending_status_hint_does_not_include_status_for_letters(
         message_type=message_type
     )
 
-    if message_type == 'letter':
-        assert normalize_spaces(page.select(".align-with-message-body")[0].text) == "27 September at 5:30pm"
-    else:
-        assert normalize_spaces(page.select(".align-with-message-body")[0].text) == "Delivered 27 September at 5:31pm"
+    assert normalize_spaces(page.select(".table-field-right-aligned")[0].text) == expected_hint_status
+    assert bool(page.select('.align-with-message-body')) is single_line
 
 
 @pytest.mark.parametrize("is_precompiled_letter,expected_hint", [

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -547,6 +547,7 @@ def test_big_numbers_and_search_dont_show_for_letters(
         ('sms', 'delivered', 'Delivered 27 September at 5:31pm', True),
         ('letter', 'delivered', '27 September at 5:30pm', True),
         ('letter', 'permanent-failure', 'Cancelled 27 September at 5:31pm', False),
+        ('letter', 'validation-failed', 'Cancelled 27 September at 5:30pm', False),
     ]
 )
 def test_sending_status_hint_does_not_include_status_for_letters(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -174,18 +174,30 @@ def test_notification_page_shows_page_for_letter_notification(
         )
 
 
+@pytest.mark.parametrize('notification_status, expected_message', (
+    (
+        'permanent-failure',
+        'Cancelled 1 January at 1:02am',
+    ),
+    (
+        'validation-failed',
+        'Cancelled 1 January at 1:02am (letter has content outside the printable area)',
+    ),
+))
 @freeze_time("2016-01-01 01:01")
 def test_notification_page_shows_cancelled_letter(
     client_request,
     mocker,
     fake_uuid,
+    notification_status,
+    expected_message,
 ):
 
     mock_get_notification(
         mocker,
         fake_uuid,
         template_type='letter',
-        notification_status='permanent-failure',
+        notification_status=notification_status,
     )
     mocker.patch(
         'app.main.views.notifications.get_page_count_for_letter',
@@ -202,7 +214,7 @@ def test_notification_page_shows_cancelled_letter(
         'sample template sent by Test User on 1 January at 1:01am'
     )
     assert normalize_spaces(page.select('main p')[1].text) == (
-        'Cancelled 1 January at 1:02am'
+        expected_message
     )
     assert not page.select('p.notification-status')
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -175,6 +175,41 @@ def test_notification_page_shows_page_for_letter_notification(
 
 
 @freeze_time("2016-01-01 01:01")
+def test_notification_page_shows_cancelled_letter(
+    client_request,
+    mocker,
+    fake_uuid,
+):
+
+    mock_get_notification(
+        mocker,
+        fake_uuid,
+        template_type='letter',
+        notification_status='permanent-failure',
+    )
+    mocker.patch(
+        'app.main.views.notifications.get_page_count_for_letter',
+        return_value=1
+    )
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    assert normalize_spaces(page.select('main p')[0].text) == (
+        'sample template sent by Test User on 1 January at 1:01am'
+    )
+    assert normalize_spaces(page.select('main p')[1].text) == (
+        'Cancelled 1 January at 1:02am'
+    )
+    assert not page.select('p.notification-status')
+
+    assert page.select_one('main img')['src'].endswith('.png?page=1')
+
+
+@freeze_time("2016-01-01 01:01")
 def test_notification_page_shows_page_for_first_class_letter_notification(
     client_request,
     mocker,


### PR DESCRIPTION
At the moment we are manually cancelling letters for people when they ask us to. Once’s we’ve done this there is no indication that it’s happened except for the date going red on the list of letters.

This commit adds some error messaging and styling to show when a letter is cancelled.

Letting people cancel their own letters will be a future enhancement.

***

![image](https://user-images.githubusercontent.com/355079/46796861-899ceb00-cd45-11e8-88ba-873556ba0389.png)

***

<img width="757" alt="screen shot 2018-10-11 at 10 02 00" src="https://user-images.githubusercontent.com/355079/46796874-8f92cc00-cd45-11e8-904d-21c2e1ebecd5.png">

***

<img width="783" alt="screen shot 2018-10-11 at 10 22 43" src="https://user-images.githubusercontent.com/355079/46796872-8f92cc00-cd45-11e8-8d4a-5adc2eb9b159.png">

