### PR TITLE
Make resend email page consistent

### DIFF
--- a/app/templates/views/resend-email-verification.html
+++ b/app/templates/views/resend-email-verification.html
@@ -8,11 +8,8 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-large">Check your email</h1>
-    <p>A new confirmation email has been sent to {{email}}</p>
-  </div>
-</div>
+<h1 class="heading-large">Check your email</h1>
+<p>A new confirmation email has been sent to {{ email }}</p>
+<p>Click the link in the email to continue your registration.</p>
 
 {% endblock %}


### PR DESCRIPTION
Its grid and copy weren’t consistent with the original page you see when you’ve first been sent the confirmation email.

# Resend page

![image](https://user-images.githubusercontent.com/355079/46799639-34fd6e00-cd4d-11e8-89ab-56d7980d32a4.png)

# Original page

![image](https://user-images.githubusercontent.com/355079/46799647-3c247c00-cd4d-11e8-861b-5cde0529f99f.png)

# Resend page fixed 

![image](https://user-images.githubusercontent.com/355079/46804541-c8896b80-cd5a-11e8-8e4d-f05528a39b75.png)
