### PR TITLE
fix pdf download link trying to request a page count

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -266,7 +266,7 @@ def platform_admin_letter_validation_preview():
             if response.status_code == 200:
                 pages, message, result = response.json()["pages"], response.json()["message"], response.json()["result"]
         except RequestException as error:
-            if error.response.status_code == 400:
+            if error.response and error.response.status_code == 400:
                 message = "Something was wrong with the file you tried to upload. Please upload a valid PDF file."
                 return render_template(
                     'views/platform-admin/letter-validation-preview.html',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -656,13 +656,17 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
 @login_required
 @user_has_permissions('send_messages')
 def check_messages_preview(service_id, template_id, upload_id, filetype, row_index=2):
-    if filetype not in ('pdf', 'png'):
+    if filetype == 'pdf':
+        page = None
+    elif filetype == 'png':
+        page = request.args.get('page', 1)
+    else:
         abort(404)
 
     template = _check_messages(
         service_id, template_id, upload_id, row_index, letters_as_pdf=True
     )['template']
-    return TemplatePreview.from_utils_template(template, filetype, page=request.args.get('page', 1))
+    return TemplatePreview.from_utils_template(template, filetype, page=page)
 
 
 @main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])


### PR DESCRIPTION
It doesn't make sense to get a pdf for only one page - the template preview app just returns a 400 if you try. So we shouldn't try.