### PR TITLE
Pass letter logo filename to template preview

### DIFF
--- a/app/notify_client/models.py
+++ b/app/notify_client/models.py
@@ -278,6 +278,7 @@ class Service(dict):
         'id',
         'inbound_api',
         'letter_contact_block',
+        'letter_logo_filename',
         'message_limit',
         'name',
         'organisation_type',

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -11,6 +11,7 @@ class TemplatePreview:
             'letter_contact_block': template.get('reply_to_text', ''),
             'template': template,
             'values': values,
+            'filename': current_service.letter_logo_filename,
             'dvla_org_id': current_service.dvla_organisation,
         }
         resp = requests.post(

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -49,7 +49,9 @@ def test_from_database_object_makes_request(
 ):
     resp = Mock(content='a', status_code='b', headers={'c': 'd'})
     request_mock = mocker.patch('app.template_previews.requests.post', return_value=resp)
-    mocker.patch('app.template_previews.current_service', dvla_organisation='123')
+    mocker.patch('app.template_previews.current_service',
+                 dvla_organisation='123',
+                 letter_logo_filename='hm-government')
     template = mock_get_service_letter_template('123', '456')['data']
 
     ret = partial_call(template=template)
@@ -62,6 +64,7 @@ def test_from_database_object_makes_request(
         'letter_contact_block': None,
         'template': template,
         'values': None,
+        'filename': 'hm-government',
         'dvla_org_id': '123',
     }
     headers = {'Authorization': 'Token my-secret-key'}


### PR DESCRIPTION
We now pass through `filename` to the Template Preview `/preview.<filetype>`
endpoint in addition to the `dvla_org_id`. Template Preview will be
changed to only use `filename`, and once this has been done we can change
the code to only pass through `dvla_org_id` instead of passing through
both pieces of information.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)