### PR TITLE
Bump PaaS python version to 3.5.5

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.4
+python-3.5.5


### PR DESCRIPTION
Python 3.5.4 support is being removed in Python buildpack 1.6.21