### PR TITLE
Stop passing dvla_org_id to template preview

### DIFF
--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -12,7 +12,6 @@ class TemplatePreview:
             'template': template,
             'values': values,
             'filename': current_service.letter_logo_filename,
-            'dvla_org_id': current_service.dvla_organisation,
         }
         resp = requests.post(
             '{}/preview.{}{}'.format(

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -49,9 +49,7 @@ def test_from_database_object_makes_request(
 ):
     resp = Mock(content='a', status_code='b', headers={'c': 'd'})
     request_mock = mocker.patch('app.template_previews.requests.post', return_value=resp)
-    mocker.patch('app.template_previews.current_service',
-                 dvla_organisation='123',
-                 letter_logo_filename='hm-government')
+    mocker.patch('app.template_previews.current_service', letter_logo_filename='hm-government')
     template = mock_get_service_letter_template('123', '456')['data']
 
     ret = partial_call(template=template)
@@ -65,7 +63,6 @@ def test_from_database_object_makes_request(
         'template': template,
         'values': None,
         'filename': 'hm-government',
-        'dvla_org_id': '123',
     }
     headers = {'Authorization': 'Token my-secret-key'}
 


### PR DESCRIPTION
We were passing both `dvla_org_id` and `filename` to template-preview
temporarily while we switch to only using filename. Now that
template-preview is set up to use `filename`, we can stop sending the
`dvla_org_id` too.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)

_Needs https://github.com/alphagov/notifications-template-preview/pull/229 to be merged first_