### PR TITLE
Reduce logging noise in traceback output

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+log_level = 999
 env =
     NOTIFY_ENVIRONMENT=test
     ADMIN_CLIENT_SECRET=dev-notify-secret-key


### PR DESCRIPTION
When running tests locally Pytest returns a lot of captured logging info.

This is redundant because Pytest also captures stdout. 

This commit sets the logging to the most minimal level when running tests against the app.

# Before 

![image](https://user-images.githubusercontent.com/355079/47491561-01d5d700-d843-11e8-94de-df7ed4cc1fbd.png)

# After 

![image](https://user-images.githubusercontent.com/355079/47491522-ed91da00-d842-11e8-9169-777c31d065d5.png)
