### PR TITLE
Update notifications-utils to 30.5.6

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,8 @@ awscli-cwlogs>=1.4,<1.5
 awscli==1.15.82
 botocore<1.11.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.5.5#egg=notifications-utils==30.5.5
+
+# Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
+itsdangerous==0.24  # pyup: <1.0.0
+
+git+https://github.com/alphagov/notifications-utils.git@30.5.6#egg=notifications-utils==30.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,11 @@ awscli-cwlogs>=1.4,<1.5
 awscli==1.15.82
 botocore<1.11.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.5.5#egg=notifications-utils==30.5.5
+
+# Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
+itsdangerous==0.24  # pyup: <1.0.0
+
+git+https://github.com/alphagov/notifications-utils.git@30.5.6#egg=notifications-utils==30.5.6
 
 ## The following requirements were added by pip freeze:
 bleach==2.1.3
@@ -39,11 +43,10 @@ docopt==0.6.2
 docutils==0.14
 et-xmlfile==1.0.1
 Flask-Redis==0.3.0
-future==0.16.0
+future==0.17.0
 greenlet==0.4.15
 html5lib==1.0.1
 idna==2.7
-itsdangerous==0.24
 jdcal==1.4
 Jinja2==2.10
 jmespath==0.9.3
@@ -52,14 +55,14 @@ lxml==4.2.5
 MarkupSafe==1.0
 mistune==0.8.3
 monotonic==1.5
-openpyxl==2.5.8
+openpyxl==2.5.9
 orderedset==2.0.1
 phonenumbers==8.9.4
 pyasn1==0.4.4
 pyexcel-ezodf==0.3.4
 PyJWT==1.6.4
 PyPDF2==1.26.0
-python-dateutil==2.7.3
+python-dateutil==2.7.5
 python-json-logger==0.1.8
 PyYAML==3.13
 redis==2.10.6


### PR DESCRIPTION
This brings in the change to email validation which removes obscure white space from email addresses.

[Pivotal story](https://www.pivotaltracker.com/story/show/161290942)