### PR TITLE
Make spacing tighter on templates page

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -2,7 +2,7 @@
 
   &-name {
     @include bold-24;
-    margin: 20px 0 5px 0;
+    margin: 0;
 
     a {
       display: block;
@@ -14,8 +14,12 @@
 
   &-type {
     color: $secondary-text-colour;
-    margin-bottom: $gutter / 3;
+    margin: 0 0 $gutter-two-thirds 0;
     pointer-events: none;
   }
 
+}
+
+#template-list {
+  margin-top: $gutter;
 }

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -51,7 +51,7 @@
     </div>
 
     {% if show_template_nav %}
-      <div class="bottom-gutter-2-3">
+      <div class="bottom-gutter">
         {{ pill(template_nav_items, current_value=template_type, show_count=False) }}
       </div>
     {% endif %}


### PR DESCRIPTION
Before | After 
---|---
<img width="1016" alt="screen shot 2018-10-29 at 14 46 46" src="https://user-images.githubusercontent.com/355079/47657730-80a37a80-db89-11e8-8f2d-fce62664a555.png">|<img width="1033" alt="screen shot 2018-10-29 at 14 50 38" src="https://user-images.githubusercontent.com/355079/47657963-0a534800-db8a-11e8-97af-ac195f9f1ae9.png">

The prototype for folders tightens up the templates page to fit more templates on the screen. Partly because it looks better, and partly because the sticky bottom toolbar means that there’s less available space. So reducing the spacing means that roughly the same number of templates fit on the screen.

For those who won’t see the checkboxes (people who don’t have the send permission) or use folders, this just means that they’ll have slightly less scrolling to do if they have a lot of templates.

Doing this before adding the folders so that:
- we roll out changes more gradually
- once we add the folders we can see if the spacing has stayed consistent
- changing where the margins are applied to resolve the excessive spacing when there is/isn’t tabbed navigation or a search box shown:

  Before | After 
  ---|---
  <img width="739" alt="screen shot 2018-10-29 at 14 44 34" src="https://user-images.githubusercontent.com/355079/47657539-2f938680-db89-11e8-973e-6b2d661a4a46.png"> | <img width="736" alt="screen shot 2018-10-29 at 14 43 43" src="https://user-images.githubusercontent.com/355079/47657488-12f74e80-db89-11e8-9b7a-c9a39c63d99e.png">

# Variations

## Tabs and search

<img width="752" alt="screen shot 2018-10-29 at 14 52 36" src="https://user-images.githubusercontent.com/355079/47658122-53a39780-db8a-11e8-843c-eec2c4ced64a.png">

## Tabs only 

<img width="747" alt="screen shot 2018-10-29 at 14 53 47" src="https://user-images.githubusercontent.com/355079/47658197-7930a100-db8a-11e8-97f3-3e949db396c7.png">

## Search only 

<img width="751" alt="screen shot 2018-10-29 at 14 54 37" src="https://user-images.githubusercontent.com/355079/47658269-9a918d00-db8a-11e8-929c-d15a28ba0981.png">
