### PR TITLE
Make API key page handle multiple lines of text better 

### DIFF
--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -34,6 +34,8 @@
             thing = $component.data('thing');
 
       $component
+        .addClass('api-key')
+        .css('min-height', $component.height())
         .html(states.keyVisible(key, thing))
         .attr('aria-live', 'polite')
         .on(

--- a/app/assets/stylesheets/components/api-key.scss
+++ b/app/assets/stylesheets/components/api-key.scss
@@ -1,5 +1,9 @@
 .api-key {
 
+  position: relative;
+  padding-bottom: 38px;  // height of button
+  display: flex;
+
   &-name {
     @include bold-19;
     margin-bottom: 5px;
@@ -8,12 +12,21 @@
   &-key {
     font-family: monospace;
     display: block;
-    margin-bottom: 10px;
+    padding: 0 0 10px 0;
+    margin: auto 0;
   }
 
   &-button-show,
   &-button-copy {
+
     @include button($grey-3);
+    position: absolute;
+    bottom: 2px;
+
+    &:active {
+      top: auto;
+    }
+
   }
 
 }

--- a/app/templates/views/api/keys/show.html
+++ b/app/templates/views/api/keys/show.html
@@ -14,8 +14,10 @@
     </h1>
 
     <p>
-      Copy your key to somewhere safe. You won’t be able to see it again
-      once you leave this page.
+      Copy your key to somewhere safe.
+    </p>
+    <p>
+      You won’t be able to see it again once you leave this page.
     </p>
 
     <div class="bottom-gutter-2">


### PR DESCRIPTION
# Before 

![key-before](https://user-images.githubusercontent.com/355079/47720347-94141b80-dc45-11e8-82c7-c7e518d30622.gif)

# After 

![key-after](https://user-images.githubusercontent.com/355079/47720353-970f0c00-dc45-11e8-9fb2-b2e9e4d0191b.gif)
