### PR TITLE
Fix misaligned elements on invite page

### DIFF
--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -14,15 +14,14 @@
     Invite a team member
   </h1>
 
-  <div class="grid-row">
-    {% call form_wrapper() %}
+  {% call form_wrapper() %}
 
-      {{ textbox(form.email_address, width='1-1', safe_error_message=True) }}
+    {{ textbox(form.email_address, width='1-1', safe_error_message=True) }}
 
-      {% include 'views/manage-users/permissions.html' %}
+    {% include 'views/manage-users/permissions.html' %}
 
-      {{ page_footer('Send invitation email') }}
+    {{ page_footer('Send invitation email') }}
 
-    {% endcall %}
-  </div>
+  {% endcall %}
+
 {% endblock %}


### PR DESCRIPTION
This page doesn’t need a grid any more (everything goes full width).

# Before 

![image](https://user-images.githubusercontent.com/355079/47780612-a0ef4880-dcf3-11e8-89d4-bda749114ff8.png)

# After 

![image](https://user-images.githubusercontent.com/355079/47780638-b1072800-dcf3-11e8-941b-2236ef34bf5d.png)
