### PR TITLE
Put pattern behind logo images

### DIFF
--- a/app/assets/stylesheets/components/email-preview-pane.scss
+++ b/app/assets/stylesheets/components/email-preview-pane.scss
@@ -5,3 +5,14 @@
   min-height: 200px;
   margin-bottom: $gutter
 }
+
+#logo-img {
+  background-color: $grey-4;
+  background-image: linear-gradient(45deg, $grey-3 25%, transparent 25%), linear-gradient(-45deg, $grey-3 25%, transparent 25%), linear-gradient(45deg, transparent 75%, $grey-3 75%), linear-gradient(-45deg, transparent 75%, $grey-3 75%);
+  background-size: 20px 20px;
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+  
+  img {
+    display: block;
+  }
+}


### PR DESCRIPTION
So that white on transparent images are visible.

# Before

![image](https://user-images.githubusercontent.com/355079/47855737-4500ee80-dddd-11e8-9d7a-c1dfd2e986ae.png)

# After 

![image](https://user-images.githubusercontent.com/355079/47855695-374b6900-dddd-11e8-8641-615b3d14b533.png)
