### PR TITLE
Make the example spreadsheet scroll horizontally

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -30,6 +30,8 @@
         window.GOVUK.stopScrollingAtFooter.updateFooterTop();
       }
 
+      this.maintainWidth();
+
     };
 
     this.insertShims = () => {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -147,6 +147,10 @@ details summary {
 
   margin-bottom: -$gutter;
 
+  .table {
+    margin-bottom: 0;
+  }
+
   th,
   .table-field-index {
     background: $grey-4;
@@ -161,7 +165,21 @@ details summary {
   }
 
   td {
+
     border-top: 0;
+    // 194 is the width of the table * 1/3.5, so the overflow cuts off
+    // at 3.5 columns wide.
+    // 11 accounts for the padding of the table cell
+    min-width: 194px - 11px;
+
+    &:first-child {
+      min-width: auto;
+    }
+
+  }
+
+  .fullscreen-fixed-table {
+    z-index: 1000;
   }
 
 }

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -29,7 +29,8 @@
     <acronym title="Open Document Spreadsheet">ODS</acronym>,
     or Microsoft Excel spreadsheet
   </p>
-  <div class="spreadsheet">
+
+  <div class="spreadsheet" data-module="fullscreen-table">
     {% call(item, row_number) list_table(
       example,
       caption="Example",


### PR DESCRIPTION
This replicates how we let large spreadsheets scroll horizontally.

Pro: this looks nicer and is more usable

Con: the code for this feels a bit fragile, especially the calling of `.maintainWidth` twice, ie as many times as a it takes to get stuff to render properly. But I wanna get this in for a demo tomorrow.

# Before

<img width="935" alt="screen shot 2018-11-01 at 15 38 05" src="https://user-images.githubusercontent.com/355079/47862107-44238900-ddec-11e8-80d9-c4fd94749190.png">

# After 

![overflow-x-spreadsheet](https://user-images.githubusercontent.com/355079/47862115-4980d380-ddec-11e8-88ae-54781dbf8535.gif)
