### PR TITLE
Make the corner of the spreadsheet grey again

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -179,7 +179,13 @@ details summary {
   }
 
   .fullscreen-fixed-table {
+
     z-index: 1000;
+
+    .table-field-heading-first {
+      background: $grey-4;
+    }
+
   }
 
 }


### PR DESCRIPTION
It was being overriden to white by the scrollable table code.