### PR TITLE
Show all letter pages on the notification page

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -48,11 +48,13 @@ def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
     notification['template'].update({'reply_to_text': notification['reply_to_text']})
 
+    personalisation = get_all_personalisation_from_notification(notification)
+
     if notification['template']['is_precompiled_letter']:
         file_contents = view_letter_notification_as_preview(service_id, notification_id, "pdf")
         page_count = pdf_page_count(io.BytesIO(file_contents))
     else:
-        page_count = get_page_count_for_letter(notification['template'])
+        page_count = get_page_count_for_letter(notification['template'], values=personalisation)
 
     template = get_template(
         notification['template'],
@@ -67,7 +69,7 @@ def view_notification(service_id, notification_id):
         show_recipient=True,
         redact_missing_personalisation=True,
     )
-    template.values = get_all_personalisation_from_notification(notification)
+    template.values = personalisation
     if notification['job']:
         job = job_api_client.get_job(service_id, notification['job']['id'])['data']
     else:

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -142,7 +142,7 @@ def test_notification_page_shows_page_for_letter_notification(
     count_of_pages = 3
 
     mock_get_notification(mocker, fake_uuid, template_type='letter', postage='second')
-    mocker.patch(
+    mock_page_count = mocker.patch(
         'app.main.views.notifications.get_page_count_for_letter',
         return_value=count_of_pages
     )
@@ -172,6 +172,10 @@ def test_notification_page_shows_page_for_letter_notification(
         assert page.select('img')[index]['src'].endswith(
             '.png?page={}'.format(index)
         )
+
+    assert len(mock_page_count.call_args_list) == 1
+    assert mock_page_count.call_args_list[0][0][0]['name'] == 'sample template'
+    assert mock_page_count.call_args_list[0][1]['values'] == {'name': 'Jo'}
 
 
 @pytest.mark.parametrize('notification_status, expected_message', (


### PR DESCRIPTION
Sometimes a long placeholder can push stuff onto a new page, so we need to take the personalisation into account when counting pages.