### PR TITLE
Remove httpretty dependency

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,7 +6,6 @@ pytest-mock==1.10.0
 pytest-cov==2.6.0
 pytest-xdist==1.24.0
 coveralls==1.5.1
-httpretty==0.9.5
 beautifulsoup4==4.6.3
 freezegun==0.3.11
 flake8==3.5.0


### PR DESCRIPTION
We don’t use it for anything.

Even the [commit that introduced it](https://github.com/alphagov/notifications-admin/commit/494e49ee45ce624a88f969d7598e8c72b70b0034) didn’t seem to actually use it.

Closes #2446