### PR TITLE
Updated data protection law description

### DIFF
--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -31,7 +31,7 @@
     <p>Any user data you upload is only held for 7 days.</p>
     <p>The Cabinet Office acts as data processor for Notify. Your organisation is the data controller.</p>
     <h3 class="heading-small">Data Protection Act</h3>
-    <p>Notify complies with the Data Protection Act. To make sure it stays compliant, there are regular legal reviews of the service’s:</p>
+    <p>Notify complies with data protection law. To make sure it stays compliant, there are regular legal reviews of the service’s:</p>
     <ul class="list list-bullet">
       <li>privacy policy</li>
       <li>terms of use</li>


### PR DESCRIPTION
Updated 'Notify complies with the Data Protection Act' to take account of GDPR.

'Notify complies with data protection law' covers both DPA and GDPR.

This change is consistent with the Service Manual.