### PR TITLE
Label and filter folders depending on their contents 

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -126,7 +126,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         current_template_folder_id=template_folder_id,
         can_manage_folders=can_manage_folders(),
         template_folder_path=current_service.get_template_folder_path(template_folder_id),
-        template_folders=current_service.get_template_folders(template_folder_id),
+        template_folders=current_service.get_template_folders(template_folder_id, template_type),
         templates=current_service.get_templates(template_type, template_folder_id),
         show_search_box=(len(current_service.get_templates(template_type)) > 7),
         show_template_nav=(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -126,7 +126,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         current_template_folder_id=template_folder_id,
         can_manage_folders=can_manage_folders(),
         template_folder_path=current_service.get_template_folder_path(template_folder_id),
-        template_folders=current_service.get_template_folders(template_folder_id, template_type),
+        template_folders=current_service.get_template_folders(template_type, template_folder_id),
         templates=current_service.get_templates(template_type, template_folder_id),
         show_search_box=(len(current_service.get_templates(template_type)) > 7),
         show_template_nav=(

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -298,11 +298,30 @@ class Service():
     def all_template_folder_ids(self):
         return {folder['id'] for folder in self.all_template_folders}
 
-    def get_template_folders(self, parent_folder_id=None):
+    def get_template_folders(self, parent_folder_id=None, template_type='all'):
         return [
             folder for folder in self.all_template_folders
-            if folder['parent_id'] == parent_folder_id
+            if (
+                folder['parent_id'] == parent_folder_id and
+                self.show_folder(folder['id'], template_type)
+            )
         ]
+
+    def show_folder(self, template_folder_id, template_type='all'):
+
+        if template_type == 'all':
+            return True
+
+        if self.get_templates(template_type, template_folder_id):
+            return True
+
+        if any(
+            self.show_folder(child_folder['id'], template_type)
+            for child_folder in self.get_template_folders(template_folder_id, template_type)
+        ):
+            return True
+
+        return False
 
     def get_template_folder_path(self, template_folder_id):
         if template_folder_id is None:
@@ -322,7 +341,7 @@ class Service():
     def get_template_folders_and_templates(self, template_type, template_folder_id):
         return (
             self.get_templates(template_type, template_folder_id) +
-            self.get_template_folders(template_folder_id)
+            self.get_template_folders(template_folder_id, template_type)
         )
 
     def move_to_folder(self, ids_to_move, move_to):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -303,11 +303,11 @@ class Service():
             folder for folder in self.all_template_folders
             if (
                 folder['parent_id'] == parent_folder_id and
-                self.show_folder(folder['id'], template_type)
+                self.is_folder_visible(folder['id'], template_type)
             )
         ]
 
-    def show_folder(self, template_folder_id, template_type='all'):
+    def is_folder_visible(self, template_folder_id, template_type='all'):
 
         if template_type == 'all':
             return True
@@ -316,7 +316,7 @@ class Service():
             return True
 
         if any(
-            self.show_folder(child_folder['id'], template_type)
+            self.is_folder_visible(child_folder['id'], template_type)
             for child_folder in self.get_template_folders(template_type, template_folder_id)
         ):
             return True

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -298,7 +298,7 @@ class Service():
     def all_template_folder_ids(self):
         return {folder['id'] for folder in self.all_template_folders}
 
-    def get_template_folders(self, parent_folder_id=None, template_type='all'):
+    def get_template_folders(self, template_type='all', parent_folder_id=None):
         return [
             folder for folder in self.all_template_folders
             if (
@@ -317,7 +317,7 @@ class Service():
 
         if any(
             self.show_folder(child_folder['id'], template_type)
-            for child_folder in self.get_template_folders(template_folder_id, template_type)
+            for child_folder in self.get_template_folders(template_type, template_folder_id)
         ):
             return True
 
@@ -341,7 +341,7 @@ class Service():
     def get_template_folders_and_templates(self, template_type, template_folder_id):
         return (
             self.get_templates(template_type, template_folder_id) +
-            self.get_template_folders(template_folder_id, template_type)
+            self.get_template_folders(template_type, template_folder_id)
         )
 
     def move_to_folder(self, ids_to_move, move_to):

--- a/app/templates/components/message-count-label.html
+++ b/app/templates/components/message-count-label.html
@@ -55,3 +55,26 @@
     {%- endif -%}
   {%- endif %}
 {%- endmacro %}
+
+
+{% macro folder_contents_count(number_of_folders, number_of_templates) %}
+
+  {% if number_of_folders == number_of_templates == 0 %}
+    Empty
+  {% endif %}
+
+  {% if number_of_templates == 1 %}
+      {{ number_of_templates }} template
+  {%- elif number_of_templates > 1 -%}
+      {{ number_of_templates }} templates
+  {%- endif -%}
+
+  {%- if number_of_folders and number_of_templates %}, {% endif -%}
+
+  {%- if number_of_folders == 1 -%}
+      {{ number_of_folders }} folder
+  {%- elif number_of_folders > 1 -%}
+      {{ number_of_folders }} folders
+  {% endif %}
+
+{%- endmacro %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -18,7 +18,7 @@
       </h2>
       <p class="message-type">
         {{ folder_contents_count(
-          current_service.get_template_folders(template_folder.id, template_type)|length,
+          current_service.get_template_folders(template_type, template_folder.id)|length,
           current_service.get_templates(template_type, template_folder.id)|length,
         ) }}
       </p>

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -1,4 +1,5 @@
 {% from "components/checkbox.html" import unlabelled_checkbox %}
+{% from "components/message-count-label.html" import folder_contents_count %}
 
 <nav id=template-list>
   {% for template_folder in template_folders %}
@@ -15,7 +16,12 @@
           {{ template_folder.name }}
         </a>
       </h2>
-      <p class="message-type">Folder containing {{ template_count }} template{% if template_count != 1 %}s{% endif %}</p>
+      <p class="message-type">
+        {{ folder_contents_count(
+          current_service.get_template_folders(template_folder.id, template_type)|length,
+          current_service.get_templates(template_type, template_folder.id)|length,
+        ) }}
+      </p>
     </div>
   {% endfor %}
   {% for template in templates %}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -17,6 +17,14 @@ def _folder(name, folder_id=None, parent=None):
     }
 
 
+def _template(template_type, name):
+    return {
+        'id': str(uuid.uuid4()),
+        'name': name,
+        'template_type': template_type,
+    }
+
+
 @pytest.mark.parametrize('parent_folder_id', [None, PARENT_FOLDER_ID])
 def test_add_page_shows_option_for_folder(
     client_request,
@@ -149,6 +157,14 @@ def test_should_show_templates_folder_page(
         _folder('folder_one', PARENT_FOLDER_ID),
         _folder('folder_one_two', parent=PARENT_FOLDER_ID),
         _folder('folder_one_one', CHILD_FOLDER_ID, parent=PARENT_FOLDER_ID),
+    ]
+    mock_get_service_templates.return_value = [
+        _template('sms', 'sms_template_one'),
+        _template('sms', 'sms_template_two'),
+        _template('email', 'email_template_one'),
+        _template('email', 'email_template_two'),
+        _template('letter', 'letter_template_one'),
+        _template('letter', 'letter_template_two'),
     ]
 
     service_one['permissions'] += ['letter', 'edit_folders']

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -9,6 +9,14 @@ PARENT_FOLDER_ID = '7e979e79-d970-43a5-ac69-b625a8d147b0'
 CHILD_FOLDER_ID = '92ee1ee0-e4ee-4dcc-b1a7-a5da9ebcfa2b'
 
 
+def _folder(name, folder_id=None, parent=None):
+    return {
+        'name': name,
+        'id': folder_id or str(uuid.uuid4()),
+        'parent_id': parent,
+    }
+
+
 @pytest.mark.parametrize('parent_folder_id', [None, PARENT_FOLDER_ID])
 def test_add_page_shows_option_for_folder(
     client_request,
@@ -133,10 +141,10 @@ def test_should_show_templates_folder_page(
 ):
 
     mock_get_template_folders.return_value = [
-        {'id': str(uuid.uuid4()), 'name': 'folder_two', 'parent_id': None},
-        {'id': PARENT_FOLDER_ID, 'name': 'folder_one', 'parent_id': None},
-        {'id': str(uuid.uuid4()), 'name': 'folder_one_two', 'parent_id': PARENT_FOLDER_ID},
-        {'id': CHILD_FOLDER_ID, 'name': 'folder_one_one', 'parent_id': PARENT_FOLDER_ID},
+        _folder('folder_two'),
+        _folder('folder_one', PARENT_FOLDER_ID),
+        _folder('folder_one_two', parent=PARENT_FOLDER_ID),
+        _folder('folder_one_one', CHILD_FOLDER_ID, parent=PARENT_FOLDER_ID),
     ]
 
     service_one['permissions'] += ['letter', 'edit_folders']

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -111,8 +111,6 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {'template_type': 'sms'},
             ['All', 'Email', 'Letter'],
             [
-                'folder_one Folder containing templates',
-                'folder_two Folder containing templates',
                 'sms_template_one Text message template',
                 'sms_template_two Text message template',
             ],
@@ -122,8 +120,6 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {'template_type': 'sms', 'template_folder_id': PARENT_FOLDER_ID},
             ['All', 'Email', 'Letter'],
             [
-                'folder_one_one Folder containing templates',
-                'folder_one_two Folder containing templates',
             ],
         ),
         (

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -106,8 +106,8 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {},
             ['Text message', 'Email', 'Letter'],
             [
-                'folder_one Folder containing templates',
-                'folder_two Folder containing templates',
+                'folder_one 2 folders',
+                'folder_two Empty',
                 'sms_template_one Text message template',
                 'sms_template_two Text message template',
                 'email_template_one Email template',
@@ -121,9 +121,18 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {'template_type': 'sms'},
             ['All', 'Email', 'Letter'],
             [
-                'folder_one Folder containing templates',
+                'folder_one 1 folder',
                 'sms_template_one Text message template',
                 'sms_template_two Text message template',
+            ],
+        ),
+        (
+            'Templates / folder_one',
+            {'template_folder_id': PARENT_FOLDER_ID},
+            ['Text message', 'Email', 'Letter'],
+            [
+                'folder_one_one 1 template, 1 folder',
+                'folder_one_two Empty',
             ],
         ),
         (
@@ -131,15 +140,22 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {'template_type': 'sms', 'template_folder_id': PARENT_FOLDER_ID},
             ['All', 'Email', 'Letter'],
             [
-                'folder_one_one Folder containing templates',
+                'folder_one_one 1 folder',
             ],
+        ),
+        (
+            'Templates / folder_one',
+            {'template_type': 'email', 'template_folder_id': PARENT_FOLDER_ID},
+            ['All', 'Text message', 'Letter'],
+            [],
         ),
         (
             'Templates / folder_one / folder_one_one',
             {'template_folder_id': CHILD_FOLDER_ID},
             ['Text message', 'Email', 'Letter'],
             [
-                'folder_one_one_one Folder containing templates',
+                'folder_one_one_one 1 template',
+                'letter_template_nested Letter template',
             ],
         ),
         (
@@ -164,7 +180,6 @@ def test_should_show_templates_folder_page(
     expected_nav_links,
     expected_items,
 ):
-
     mock_get_template_folders.return_value = [
         _folder('folder_two'),
         _folder('folder_one', PARENT_FOLDER_ID),
@@ -181,7 +196,8 @@ def test_should_show_templates_folder_page(
             _template('email', 'email_template_two'),
             _template('letter', 'letter_template_one'),
             _template('letter', 'letter_template_two'),
-            _template('sms', 'sms_template_nested', parent=GRANDCHILD_FOLDER_ID)
+            _template('letter', 'letter_template_nested', parent=CHILD_FOLDER_ID),
+            _template('sms', 'sms_template_nested', parent=GRANDCHILD_FOLDER_ID),
         ]}
     )
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -89,21 +89,21 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
 
 
 @pytest.mark.parametrize(
-    'expected_page_title, extra_args, expected_nav_links, expected_links',
+    'expected_page_title, extra_args, expected_nav_links, expected_items',
     [
         (
             'Templates',
             {},
             ['Text message', 'Email', 'Letter'],
             [
-                'folder_one',
-                'folder_two',
-                'sms_template_one',
-                'sms_template_two',
-                'email_template_one',
-                'email_template_two',
-                'letter_template_one',
-                'letter_template_two',
+                'folder_one Folder containing templates',
+                'folder_two Folder containing templates',
+                'sms_template_one Text message template',
+                'sms_template_two Text message template',
+                'email_template_one Email template',
+                'email_template_two Email template',
+                'letter_template_one Letter template',
+                'letter_template_two Letter template',
             ]
         ),
         (
@@ -111,10 +111,10 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {'template_type': 'sms'},
             ['All', 'Email', 'Letter'],
             [
-                'folder_one',
-                'folder_two',
-                'sms_template_one',
-                'sms_template_two',
+                'folder_one Folder containing templates',
+                'folder_two Folder containing templates',
+                'sms_template_one Text message template',
+                'sms_template_two Text message template',
             ],
         ),
         (
@@ -122,8 +122,8 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             {'template_type': 'sms', 'template_folder_id': PARENT_FOLDER_ID},
             ['All', 'Email', 'Letter'],
             [
-                'folder_one_one',
-                'folder_one_two',
+                'folder_one_one Folder containing templates',
+                'folder_one_two Folder containing templates',
             ],
         ),
         (
@@ -145,7 +145,7 @@ def test_should_show_templates_folder_page(
     expected_page_title,
     extra_args,
     expected_nav_links,
-    expected_links,
+    expected_items,
 ):
 
     mock_get_template_folders.return_value = [
@@ -172,12 +172,12 @@ def test_should_show_templates_folder_page(
     for index, expected_link in enumerate(expected_nav_links):
         assert links_in_page[index].text.strip() == expected_link
 
-    page_links = page.select('.message-name a')
+    page_items = page.select('.template-list-item')
 
-    assert len(page_links) == len(expected_links)
+    assert len(page_items) == len(expected_items)
 
-    for index, expected_link in enumerate(expected_links):
-        assert page_links[index].text.strip() == expected_link
+    for index, expected_item in enumerate(expected_items):
+        assert normalize_spaces(page_items[index].text) == expected_item
 
     mock_get_service_templates.assert_called_once_with(SERVICE_ONE_ID)
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -110,13 +110,21 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             'Templates',
             {'template_type': 'sms'},
             ['All', 'Email', 'Letter'],
-            ['folder_one', 'folder_two', 'sms_template_one', 'sms_template_two'],
+            [
+                'folder_one',
+                'folder_two',
+                'sms_template_one',
+                'sms_template_two',
+            ],
         ),
         (
             'Templates / folder_one',
             {'template_type': 'sms', 'template_folder_id': PARENT_FOLDER_ID},
             ['All', 'Email', 'Letter'],
-            ['folder_one_one', 'folder_one_two'],
+            [
+                'folder_one_one',
+                'folder_one_two',
+            ],
         ),
         (
             'Templates / folder_one / folder_one_one',


### PR DESCRIPTION
<img width="561" alt="screen shot 2018-11-12 at 15 06 07" src="https://user-images.githubusercontent.com/355079/48355702-8a020c00-e68c-11e8-9797-c0a735eaaa4a.png"><sup>1</sup>


It feels like a solid reckon that knowing what’s in a folder before you click on it will help you navigate around.

However, what do you show in a folder if you’re filtering by template type? We think that:
- if you’re not filtering you should see all folders, even empty ones
- if you’re filtering you should only see folders that will get you to relevant templates

This matches what happens when you filter templates, we don’t ‘grey out’ the non-email templates, we hide them completely.

The logic then extends to how we describe the contents of a folder, ie we won’t count its subfolders if they don’t contain templates of the type we’re looking for. This means that however you see the folder
described (eg ‘3 templates, 1 folder’) will match what you see when you click into it.

1. https://docs.google.com/document/d/1Z8Cch19vHndibx_zMcaMQRga3HutCWrS02q-22KUXEE/edit?ts=5be1c99b#heading=h.txfueg136qtb