### PR TITLE
Add decorator deleting cache for template folder client update method

### DIFF
--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -43,6 +43,7 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
             template_ids,
         ))
 
+    @cache.delete('service-{service_id}-template-folders')
     def update_template_folder(self, service_id, template_folder_id, name):
         self.post(
             '/service/{}/template-folder/{}'.format(service_id, template_folder_id),

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -103,3 +103,21 @@ def test_move_templates_and_folders_to_root(mocker, api_user_active):
             'templates': ['a', 'b', 'c'],
         },
     )
+
+
+def test_update_template_folder_calls_correct_api_endpoint(mocker, api_user_active):
+    mock_redis_delete = mocker.patch('app.notify_client.RedisClient.delete')
+
+    some_service_id = uuid.uuid4()
+    template_folder_id = uuid.uuid4()
+    expected_url = '/service/{}/template-folder/{}'.format(some_service_id, template_folder_id)
+    data = {'name': 'foo'}
+
+    client = TemplateFolderAPIClient()
+
+    mock_post = mocker.patch('app.notify_client.template_folder_api_client.TemplateFolderAPIClient.post')
+
+    client.update_template_folder(some_service_id, template_folder_id, name='foo')
+
+    mock_post.assert_called_once_with(expected_url, data)
+    mock_redis_delete.assert_called_once_with('service-{}-template-folders'.format(some_service_id))


### PR DESCRIPTION
While testing our new update folder name feature on preview we found that the visible folder name is not being updated. We realised that we forgot to put in delete cache decorator. This PR fixes that omission and also adds a test for update method in template folder client.