### PR TITLE
Put ‘copy’ at end of new template name

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -317,7 +317,7 @@ def copy_template(service_id, template_id):
         return add_service_template(service_id, template['template_type'])
 
     template['template_content'] = template['content']
-    template['name'] = 'Copy of ‘{}’'.format(template['name'])
+    template['name'] = _get_template_copy_name(template, current_service.all_templates)
     form = form_objects[template['template_type']](**template)
 
     return render_template(
@@ -327,6 +327,20 @@ def copy_template(service_id, template_id):
         heading_action='Add',
         services=user_api_client.get_service_ids_for_user(current_user),
     )
+
+
+def _get_template_copy_name(template, existing_templates):
+
+    template_names = [existing['name'] for existing in existing_templates]
+
+    for index in reversed(range(1, 10)):
+        if '{} (copy {})'.format(template['name'], index) in template_names:
+            return '{} (copy {})'.format(template['name'], index + 1)
+
+    if '{} (copy)'.format(template['name']) in template_names:
+        return '{} (copy 2)'.format(template['name'])
+
+    return '{} (copy)'.format(template['name'])
 
 
 @main.route("/services/<service_id>/templates/action-blocked/<notification_type>/<return_to>/<template_id>")


### PR DESCRIPTION
In multiple user research sessions we’ve noticed people edit the auto-generated template name to put something at the end of it.

This is fiddly because of the quotes we put around the name:

![image](https://user-images.githubusercontent.com/355079/48424345-5c839400-e75a-11e8-8bf2-33f75526e0ce.png)

It also means that if they keep our prefix then the template doesn’t sort alongside the one it’s replacing.

This pull request changes the name of copied templates to better match the behaviour our users are showing. It also adds a bit of auto numbering, just as a nice detail.

So our users will see:
![image](https://user-images.githubusercontent.com/355079/48424402-7d4be980-e75a-11e8-92a8-ce6d74abc494.png)

***

In the future this should be limited to only look at templates in the destination folder.