### PR TITLE
Pre-populate rename folder form with current name

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -374,7 +374,10 @@ def manage_template_folder(service_id, template_folder_id):
     if not current_service.has_permission('edit_folders'):
         abort(403)
 
-    form = TemplateFolderForm()
+    form = TemplateFolderForm(
+        name=current_service.get_template_folder(template_folder_id)['name']
+    )
+
     if form.validate_on_submit():
         template_folder_api_client.update_template_folder(
             current_service.id, template_folder_id, name=form.name.data

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -1,3 +1,4 @@
+from flask import abort
 from notifications_utils.field import Field
 from werkzeug.utils import cached_property
 
@@ -306,6 +307,15 @@ class Service():
                 self.is_folder_visible(folder['id'], template_type)
             )
         ]
+
+    def get_template_folder(self, folder_id):
+        try:
+            return next(
+                folder for folder in self.all_template_folders
+                if folder['id'] == folder_id
+            )
+        except StopIteration:
+            abort(404)
 
     def is_folder_visible(self, template_folder_id, template_type='all'):
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -324,7 +324,17 @@ def test_get_manage_folder_page(client_request, service_one, mock_get_template_f
         service_id=service_one['id'],
         template_folder_id=folder_id
     )
-    assert page.select_one('input[name=name]') is not None
+    assert page.select_one('input[name=name]')['value'] == 'folder_two'
+
+
+def test_manage_folder_page_404s(client_request, service_one, mock_get_template_folders):
+    service_one['permissions'] += ['edit_folders']
+    client_request.get(
+        'main.manage_template_folder',
+        service_id=service_one['id'],
+        template_folder_id=str(uuid.uuid4()),
+        _expected_status=404,
+    )
 
 
 def test_get_manage_folder_page_no_permissions(client_request, service_one, mock_get_template_folders):


### PR DESCRIPTION
Often people will be editing the existing name, not changing it completely.

This matches what we do when someone wants to rename their template or service.

***

![image](https://user-images.githubusercontent.com/355079/48426244-48da2c80-e75e-11e8-8f25-cb4dfd87db62.png)
