### PR TITLE
Update roadmap – remove Q2

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -20,15 +20,6 @@
     <p>Notify is in public beta. This means it’s fully operational and supported, but we’re regularly adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
     <p>You can <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> for more detail about these features, or to suggest something else you’d like Notify to offer.</p>
 
-    <h2 class="heading-medium">July to September 2018</h2>
-
-    <ul class="list list-bullet">
-      <li>More formatting options for letters</li>
-      <li>Update your own email and letter branding</li>
-      <li>Restrict templates to different teams within your service</li>
-      <li>Email documents to your users (using the API)</li>
-    </ul>
-
     <h2 class="heading-medium">October to December 2018</h2>
 
     <ul class="list list-bullet">


### PR DESCRIPTION
Update roadmap to remove Q2 (July-September 2018)