### PR TITLE
Redirect signed-in users to their service

### DIFF
--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -16,7 +16,7 @@ from app.main.views.verify import activate_user
 @main.route('/register', methods=['GET', 'POST'])
 def register():
     if current_user and current_user.is_authenticated:
-        return redirect(url_for('main.choose_account'))
+        return redirect(url_for('main.show_accounts_or_dashboard'))
 
     form = RegisterUserForm()
     if form.validate_on_submit():

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -18,7 +18,7 @@ from app.main.forms import LoginForm
 @main.route('/sign-in', methods=(['GET', 'POST']))
 def sign_in():
     if current_user and current_user.is_authenticated:
-        return redirect(url_for('main.choose_account'))
+        return redirect(url_for('main.show_accounts_or_dashboard'))
 
     form = LoginForm()
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -37,7 +37,7 @@ def test_logged_in_user_redirects_to_choose_account(
     assert response.status_code == 302
 
     response = logged_in_client.get(url_for('main.sign_in', follow_redirects=True))
-    assert response.location == url_for('main.choose_account', _external=True)
+    assert response.location == url_for('main.show_accounts_or_dashboard', _external=True)
 
 
 def test_robots(client):

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -18,18 +18,14 @@ def test_render_register_returns_template_with_form(client):
     assert 'Create an account' in response.get_data(as_text=True)
 
 
-def test_logged_in_user_redirects_to_choose_account(
-    logged_in_client,
-    api_user_active,
-    mock_get_user_by_email,
-    mock_send_verify_code,
-    mock_login,
+def test_logged_in_user_redirects_to_account(
+    client_request,
 ):
-    response = logged_in_client.get(url_for('main.register'))
-    assert response.status_code == 302
-
-    response = logged_in_client.get(url_for('main.sign_in', follow_redirects=True))
-    assert response.location == url_for('main.choose_account', _external=True)
+    client_request.get(
+        'main.register',
+        _expected_status=302,
+        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+    )
 
 
 @pytest.mark.parametrize('phone_number_to_register_with', [

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -73,11 +73,14 @@ def test_redirect_to_sign_in_if_logged_in_from_other_browser(
     assert response.location == url_for('main.sign_in', next='/accounts', _external=True)
 
 
-def test_logged_in_user_redirects_to_choose_account(
-    logged_in_client
+def test_logged_in_user_redirects_to_account(
+    client_request
 ):
-    response = logged_in_client.get(url_for('main.sign_in'))
-    assert response.location == url_for('main.choose_account', _external=True)
+    client_request.get(
+        'main.sign_in',
+        _expected_status=302,
+        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+    )
 
 
 @pytest.mark.parametrize('email_address, password', [


### PR DESCRIPTION
Some users are bookmarking the sign in page for quick access to their Notify service.

If they’re already signed in when they used this bookmark they get redirected. However the redirect isn’t very smart, because it just takes them to their list of services. This isn’t great if they only have one service.

This commit redirects them to the `show_accounts_or_dashboard` endpoint instead, which does the work to figure out which page is most useful to show someone when they sign in.