### PR TITLE
Make deletion confirmation banner messages consistent across our app

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -130,9 +130,12 @@ def create_api_key(service_id):
 def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
     if request.method == 'GET':
+        flash([
+            "Are you sure you want to revoke this API key?",
+            "‘{}’ will no longer let you connect to GOV.UK Notify.".format(key_name)
+        ], 'revoke')
         return render_template(
             'views/api/keys.html',
-            revoke_key=key_name,
         )
     elif request.method == 'POST':
         api_key_api_client.revoke_api_key(service_id=service_id, key_id=key_id)

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -131,9 +131,9 @@ def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
     if request.method == 'GET':
         flash([
-            "Are you sure you want to revoke this API key?",
-            "‘{}’ will no longer let you connect to GOV.UK Notify.".format(key_name)
-        ], 'revoke')
+            "Are you sure you want to revoke ‘{}’?".format(key_name),
+            "You will not be able to use this API key to connect to GOV.UK Notify."
+        ], 'revoke this API key')
         return render_template(
             'views/api/keys.html',
         )

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -419,11 +419,12 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
             is_default=True if reply_to_email_address['is_default'] else form.is_default.data
         )
         return redirect(url_for('.service_email_reply_to', service_id=service_id))
+    if (request.endpoint == "main.service_confirm_delete_email_reply_to"):
+        flash("Are you sure you want to delete this email reply-to address?", 'delete')
     return render_template(
         'views/service-settings/email-reply-to/edit.html',
         form=form,
         reply_to_email_address_id=reply_to_email_id,
-        confirm_delete=(request.endpoint == "main.service_confirm_delete_email_reply_to"),
     )
 
 
@@ -687,13 +688,14 @@ def service_edit_sms_sender(service_id, sms_sender_id):
         return redirect(url_for('.service_sms_senders', service_id=service_id))
 
     form.is_default.data = sms_sender['is_default']
+    if (request.endpoint == "main.service_confirm_delete_sms_sender"):
+        flash("Are you sure you want to delete this text message sender?", 'delete')
     return render_template(
         'views/service-settings/sms-sender/edit.html',
         form=form,
         sms_sender=sms_sender,
         inbound_number=is_inbound_number,
-        sms_sender_id=sms_sender_id,
-        confirm_delete=(request.endpoint == "main.service_confirm_delete_sms_sender")
+        sms_sender_id=sms_sender_id
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -441,7 +441,7 @@ def delete_template_folder(service_id, template_folder_id):
             else:
                 abort(500, e)
 
-    flash("Are you sure you want to delete the '{}' folder?".format(template_folder_name), 'delete')
+    flash("Are you sure you want to delete the ‘{}’ folder?".format(template_folder_name), 'delete')
     return render_template(
         'views/templates/manage-template-folder.html',
         form=form,
@@ -628,12 +628,9 @@ def delete_service_template(service_id, template_id):
         else:
             raise e
 
+    flash(["Are you sure you want to delete ‘{}’?".format(template['name']), message], 'delete')
     return render_template(
         'views/templates/template.html',
-        template_delete_confirmation_message=(
-            'Are you sure you want to delete {}?'.format(template['name']),
-            message,
-        ),
         template=get_template(
             template,
             current_service,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -615,7 +615,7 @@ def delete_service_template(service_id, template_id):
         last_used_notification = template_statistics_client.get_template_statistics_for_template(
             service_id, template['id']
         )
-        message = 'It was last used {} ago'.format(
+        message = 'This template was last used {} ago.'.format(
             'more than seven days' if not last_used_notification else get_human_readable_delta(
                 parse(last_used_notification['created_at']).replace(tzinfo=None),
                 datetime.utcnow()

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -1,4 +1,4 @@
-{% macro banner(body, type=None, with_tick=False, delete_button=None, subhead=None) %}
+{% macro banner(body, type=None, with_tick=False, delete_button=None, subhead=None, context=None) %}
   <div
     class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'
     {% if type == 'dangerous' %}
@@ -10,6 +10,11 @@
       <h1 class="banner-title">{{ subhead }}</h1>
     {%- endif -%}
     {{ body }}
+    {% if context %}
+    <p>
+      {{ context }}
+    </p>
+    {% endif %}
     {% if delete_button %}
       <form method='post'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -4,10 +4,11 @@
     {% for category, message in messages %}
       <div class="bottom-gutter">
         {{ banner(
-          message,
+          message if message is string else message[0],
           'default' if ((category == 'default') or (category == 'default_with_tick')) else 'dangerous',
-          delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove'] else None,
-          with_tick=True if category == 'default_with_tick' else False
+          delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove', 'revoke'] else None,
+          with_tick=True if category == 'default_with_tick' else False,
+          context=message[1] if message is not string
         )}}
       </div>
     {% endfor %}

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -6,7 +6,7 @@
         {{ banner(
           message if message is string else message[0],
           'default' if ((category == 'default') or (category == 'default_with_tick')) else 'dangerous',
-          delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove', 'revoke'] else None,
+          delete_button="Yes, {}".format(category) if category in ['delete', 'suspend', 'resume', 'remove', 'revoke this API key'] else None,
           with_tick=True if category == 'default_with_tick' else False,
           context=message[1] if message is not string
         )}}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -10,30 +10,16 @@
 
 {% block maincolumn_content %}
 
-  {% if revoke_key %}
-    <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous', subhead='Are you sure you want to revoke this API key?') %}
-        <p>
-          ‘{{ revoke_key }}’ will no longer let you connect to GOV.UK Notify.
-        </p>
-        <form method='post'>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          <button type="submit" class="button" name="delete">Confirm</button>
-        </form>
-      {% endcall %}
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        API keys
+      </h1>
     </div>
-  {% else %}
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <h1 class="heading-large">
-          API keys
-        </h1>
-      </div>
-      <div class="column-one-third">
-        <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}" class="button align-with-heading">Create an API key</a>
-      </div>
+    <div class="column-one-third">
+      <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}" class="button align-with-heading">Create an API key</a>
     </div>
-  {% endif %}
+  </div>
 
   <div class="body-copy-table">
     {% call(item, row_number) list_table(

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -11,20 +11,9 @@
 
 {% block maincolumn_content %}
 
-  {% if confirm_delete %}
-    <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous', subhead="Are you sure you want to delete this email reply-to address?") %}
-        <form method='post'>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          <input type="submit" class="button" name="delete" value="Confirm" />
-        </form>
-      {% endcall %}
-    </div>
-  {% else %}
-    <h1 class="heading-large">
-      Edit email reply to address
-    </h1>
-  {% endif %}
+  <h1 class="heading-large">
+    Edit email reply to address
+  </h1>
   {% call form_wrapper() %}
     {{ textbox(
       form.email_address,

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -11,20 +11,9 @@
 
 {% block maincolumn_content %}
 
-  {% if confirm_delete %}
-    <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous', subhead="Are you sure you want to delete this text message sender?") %}
-        <form method='post'>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          <input type="submit" class="button" name="delete" value="Confirm" />
-        </form>
-      {% endcall %}
-    </div>
-  {% else %}
-    <h1 class="heading-large">
-      Edit text message sender
-    </h1>
-  {% endif %}
+  <h1 class="heading-large">
+    Edit text message sender
+  </h1>
   {% call form_wrapper() %}
     {% if inbound_number %}
       <p>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -27,20 +27,6 @@
         </form>
       {% endcall %}
     </div>
-  {% elif template_delete_confirmation_message %}
-    <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous', subhead=template_delete_confirmation_message[0]) %}
-        {% if template_delete_confirmation_message[1] %}
-          <p>
-            {{ template_delete_confirmation_message[1] }}
-          </p>
-        {% endif %}
-        <form method='post'>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          <button type="submit" class="button" name="delete">Confirm</button>
-        </form>
-      {% endcall %}
-    </div>
   {% else %}
     <h1 class="heading-large">{{ template.name }}</h1>
   {% endif %}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -37,5 +37,5 @@ npm test
 display_result $? 3 "Front end code style check"
 
 ## Code coverage
-py.test -n4 --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
+py.test -n4 --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict -p no:warnings
 display_result $? 4 "Code coverage"

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -308,9 +308,9 @@ def test_should_show_confirm_revoke_api_key(
         _test_page_title=False,
     )
     assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
-        'Are you sure you want to revoke this API key? '
-        '‘some key name’ will no longer let you connect to GOV.UK Notify. '
-        'Yes, revoke'
+        'Are you sure you want to revoke ‘some key name’? '
+        'You will not be able to use this API key to connect to GOV.UK Notify. '
+        'Yes, revoke this API key'
     )
     assert mock_get_api_keys.call_args_list == [
         call(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -310,7 +310,7 @@ def test_should_show_confirm_revoke_api_key(
     assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
         'Are you sure you want to revoke this API key? '
         '‘some key name’ will no longer let you connect to GOV.UK Notify. '
-        'Confirm'
+        'Yes, revoke'
     )
     assert mock_get_api_keys.call_args_list == [
         call(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1612,7 +1612,8 @@ def test_confirm_delete_reply_to_email_address(
     )
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
-        'Are you sure you want to delete this email reply-to address?'
+        'Are you sure you want to delete this email reply-to address? '
+        'Yes, delete'
     )
     assert 'action' not in page.select_one('.banner-dangerous form')
     assert page.select_one('.banner-dangerous form')['method'] == 'post'
@@ -1824,7 +1825,8 @@ def test_confirm_delete_sms_sender(
     )
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
-        'Are you sure you want to delete this text message sender?'
+        'Are you sure you want to delete this text message sender? '
+        'Yes, delete'
     )
     assert 'action' not in page.select_one('.banner-dangerous form')
     assert page.select_one('.banner-dangerous form')['method'] == 'post'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1281,7 +1281,7 @@ def test_should_show_delete_template_page_with_time_block(
             template_id=fake_uuid,
             _test_page_title=False,
         )
-    assert page.h1.text == 'Are you sure you want to delete Two week reminder?'
+    assert "Are you sure you want to delete ‘Two week reminder’?" in page.select('.banner-dangerous')[0].text
     assert normalize_spaces(page.select('.banner-dangerous p')[0].text) == (
         'It was last used 10 minutes ago'
     )
@@ -1310,7 +1310,7 @@ def test_should_show_delete_template_page_with_time_block_for_empty_notification
             template_id=fake_uuid,
             _test_page_title=False,
         )
-    assert page.h1.text == 'Are you sure you want to delete Two week reminder?'
+    assert "Are you sure you want to delete ‘Two week reminder’?" in page.select('.banner-dangerous')[0].text
     assert normalize_spaces(page.select('.banner-dangerous p')[0].text) == (
         'It was last used more than seven days ago'
     )
@@ -1336,7 +1336,7 @@ def test_should_show_delete_template_page_with_never_used_block(
         template_id=fake_uuid,
         _test_page_title=False,
     )
-    assert page.h1.text == 'Are you sure you want to delete Two week reminder?'
+    assert "Are you sure you want to delete ‘Two week reminder’?" in page.select('.banner-dangerous')[0].text
     assert not page.select('.banner-dangerous p')
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1283,7 +1283,7 @@ def test_should_show_delete_template_page_with_time_block(
         )
     assert "Are you sure you want to delete ‘Two week reminder’?" in page.select('.banner-dangerous')[0].text
     assert normalize_spaces(page.select('.banner-dangerous p')[0].text) == (
-        'It was last used 10 minutes ago'
+        'This template was last used 10 minutes ago.'
     )
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'
@@ -1312,7 +1312,7 @@ def test_should_show_delete_template_page_with_time_block_for_empty_notification
         )
     assert "Are you sure you want to delete ‘Two week reminder’?" in page.select('.banner-dangerous')[0].text
     assert normalize_spaces(page.select('.banner-dangerous p')[0].text) == (
-        'It was last used more than seven days ago'
+        'This template was last used more than seven days ago.'
     )
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'


### PR DESCRIPTION
Also introduce a way to provide context to a banner / flash message that will be displayed in plain font style.

### Screenshots:

#### Deleting template:
<img width="994" alt="screen shot 2018-11-16 at 11 03 39" src="https://user-images.githubusercontent.com/20957548/48617802-59bdb480-e98f-11e8-9dc5-46e517ea2e23.png">

#### Revoking API key:
<img width="994" alt="screen shot 2018-11-16 at 15 12 23" src="https://user-images.githubusercontent.com/20957548/48629649-1c1e5300-e9b2-11e8-8893-fc38a0419bb5.png">

#### Deleting reply-to email:
<img width="988" alt="screen shot 2018-11-16 at 17 07 57" src="https://user-images.githubusercontent.com/20957548/48636290-68718f00-e9c2-11e8-8603-a36a048bdb74.png">

#### Deleting sms sender:
<img width="991" alt="screen shot 2018-11-16 at 17 08 31" src="https://user-images.githubusercontent.com/20957548/48636306-6dced980-e9c2-11e8-965a-3fc45c7773a5.png">





