### PR TITLE
Fix breadcrumbs on manage_template_folder page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -395,7 +395,8 @@ def manage_template_folder(service_id, template_folder_id):
         form=form,
         template_folder_path=current_service.get_template_folder_path(template_folder_id),
         current_service_id=current_service.id,
-        template_folder_id=template_folder_id
+        template_folder_id=template_folder_id,
+        template_type="all"
     )
 
 
@@ -447,7 +448,8 @@ def delete_template_folder(service_id, template_folder_id):
         form=form,
         template_folder_path=template_folder_path,
         current_service_id=current_service.id,
-        template_folder_id=template_folder_id
+        template_folder_id=template_folder_id,
+        template_type="all"
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -442,14 +442,15 @@ def delete_template_folder(service_id, template_folder_id):
             else:
                 abort(500, e)
 
-    flash("Are you sure you want to delete the '{}' folder?".format(template_folder_name), 'delete')
+    flash("Are you sure you want to delete the ‘{}’ folder?".format(template_folder_name), 'delete')
     return render_template(
         'views/templates/manage-template-folder.html',
         form=form,
         template_folder_path=template_folder_path,
         current_service_id=current_service.id,
         template_folder_id=template_folder_id,
-        template_type="all"
+        template_type="all",
+        delete_folder=True
     )
 
 

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -22,18 +22,21 @@ Templates
   {% endfor %}
 </h1>
 
+  {% if not delete_folder %}
+    {% call form_wrapper() %}
+      {{ textbox(form.name) }}
+      {{ page_footer(
+        'Save',
+        delete_link=url_for(
+          '.delete_template_folder',
+          service_id=current_service_id,
+          template_folder_id=template_folder_id
+        ),
+        delete_link_text="Delete this folder") }}
 
-  {% call form_wrapper() %}
-    {{ textbox(form.name) }}
-    {{ page_footer(
-      'Save',
-      delete_link=url_for(
-        '.delete_template_folder',
-        service_id=current_service_id,
-        template_folder_id=template_folder_id
-      ),
-      delete_link_text="Delete this folder") }}
-
-  {% endcall %}
+    {% endcall %}
+  {% else %}
+    <a href="{{url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)}}">Back to manage folder page</a>
+  {% endif %}
 
 {% endblock %}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -378,6 +378,60 @@ def test_rename_folder(client_request, service_one, mock_get_template_folders, m
     )
 
 
+def test_delete_template_folder_should_request_confirmation(
+    client_request, service_one, mock_get_template_folders, mocker
+):
+    service_one['permissions'] += ['edit_folders']
+    folder_id = str(uuid.uuid4())
+    mock_get_template_folders.side_effect = [[
+        {'id': folder_id, 'name': 'sacrifice', 'parent_id': None},
+    ], []]
+    mocker.patch(
+        'app.models.service.Service.get_templates',
+        return_value=[],
+    )
+    page = client_request.get(
+        'main.delete_template_folder', service_id=service_one['id'],
+        template_folder_id=folder_id
+    )
+    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
+        'Are you sure you want to delete the ‘sacrifice’ folder? '
+        'Yes, delete'
+    )
+
+    assert len(page.select('label')) == 0
+    assert len(page.select('button')) == 1
+    assert "Back to manage folder page" in page.text
+
+
+def test_delete_template_folder_should_detect_non_empty_folder_on_get(
+    client_request, service_one, mock_get_template_folders, mocker
+):
+    service_one['permissions'] += ['edit_folders']
+    folder_id = str(uuid.uuid4())
+    child_folder_id = str(uuid.uuid4())
+    mock_get_template_folders.side_effect = [[
+        {'id': folder_id, 'name': 'sacrifice', 'parent_id': None},
+    ], [{'id': child_folder_id, 'name': 'sacrifice', 'parent_id': None}]]
+    mocker.patch(
+        'app.models.service.Service.get_templates',
+        return_value=[],
+    )
+    page = client_request.get(
+        'main.delete_template_folder', service_id=service_one['id'],
+        template_folder_id=folder_id
+    )
+    import pdb; pdb.set_trace()
+    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
+        'Are you sure you want to delete the ‘sacrifice’ folder? '
+        'Yes, delete'
+    )
+
+    assert len(page.select('label')) == 0
+    assert len(page.select('button')) == 1
+    assert "Back to manage folder page" in page.text
+
+
 def test_delete_folder(client_request, service_one, mock_get_template_folders, mocker):
     mock_delete = mocker.patch('app.template_folder_api_client.delete_template_folder')
     folder_id = str(uuid.uuid4())

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -409,27 +409,27 @@ def test_delete_template_folder_should_detect_non_empty_folder_on_get(
 ):
     service_one['permissions'] += ['edit_folders']
     folder_id = str(uuid.uuid4())
-    child_folder_id = str(uuid.uuid4())
-    mock_get_template_folders.side_effect = [[
-        {'id': folder_id, 'name': 'sacrifice', 'parent_id': None},
-    ], [{'id': child_folder_id, 'name': 'sacrifice', 'parent_id': None}]]
+    template_id = str(uuid.uuid4())
+    mock_get_template_folders.side_effect = [
+        [{'id': folder_id, 'name': "can't touch me", 'parent_id': None}],
+        []
+    ]
     mocker.patch(
         'app.models.service.Service.get_templates',
-        return_value=[],
+        return_value=[{'id': template_id, 'name': 'template'}],
     )
-    page = client_request.get(
+    client_request.get(
         'main.delete_template_folder', service_id=service_one['id'],
-        template_folder_id=folder_id
+        template_folder_id=folder_id,
+        _expected_redirect=url_for(
+            "main.choose_template",
+            template_type="all",
+            service_id=service_one['id'],
+            template_folder_id=folder_id,
+            _external=True
+        ),
+        _expected_status=302
     )
-    import pdb; pdb.set_trace()
-    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
-        'Are you sure you want to delete the ‘sacrifice’ folder? '
-        'Yes, delete'
-    )
-
-    assert len(page.select('label')) == 0
-    assert len(page.select('button')) == 1
-    assert "Back to manage folder page" in page.text
 
 
 def test_delete_folder(client_request, service_one, mock_get_template_folders, mocker):


### PR DESCRIPTION
Also:
- remove name changing functionality when in folder-deletion mode
- write more tests for delete-folder endpoint

### Screenshot of updated delete-folder page:

<img width="991" alt="screen shot 2018-11-16 at 15 56 17" src="https://user-images.githubusercontent.com/20957548/48632193-34916c00-e9b8-11e8-8e75-37e1216f637d.png">
