### PR TITLE
Fix missing ‘no templates’ message

### DIFF
--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -18,7 +18,7 @@
 
 {% block maincolumn_content %}
 
-  {% if (not templates) and (not template_folders) and (not template_folder_path) %}
+  {% if (not current_service.all_templates) and (not current_service.all_template_folders) %}
 
     <h1 class="heading-large">
       {{ page_title }}


### PR DESCRIPTION
This got broken because `template_folder_path` is never an empty list any more (it always contains at least one item, _Templates_, which is the root).

# Broken

![image](https://user-images.githubusercontent.com/355079/48718390-2f7c2900-ec13-11e8-9aa7-3d13646943c6.png)

# Fixed 

![image](https://user-images.githubusercontent.com/355079/48718401-360aa080-ec13-11e8-8b69-af50f99a4538.png)
