### PR TITLE
Stick email status to bottom of screen

### DIFF
--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -50,6 +50,10 @@
     margin-bottom: 0;
   }
 
+  .notification-status {
+    margin: 0;
+  }
+
 }
 
 .content-fixed,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -65,6 +65,7 @@ def view_notification(service_id, notification_id):
             notification_id=notification_id,
             filetype='png',
         ),
+        expand_emails=True,
         page_count=page_count,
         show_recipient=True,
         redact_missing_personalisation=True,

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -60,7 +60,13 @@
     {{ template|string }}
 
     {% if template.template_type != 'letter' %}
+
+      {% if template.template_type == 'email' %}<div class="js-stick-at-bottom-when-scrolling">{% endif %}
+
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
+
+      {% if template.template_type == 'email' %}</div>{% endif %}
+
     {% endif %}
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}


### PR DESCRIPTION
We’ve moved away from using the expand/collapse pattern on the page where you click ‘send’. Instead we’re putting the send button in the sticky footer.

So it’s a bit jarring to still have the expand/collapse on the page you see after you’ve sent an email. This commit replaces it with the sticky footer as well.

This is only relevant for emails because:

1. Text messages are generally short enough to fit on the screen
2. We don’t show the status of letters because they don’t really change

# Before 

Check | Sent
---|---
![image](https://user-images.githubusercontent.com/355079/48897062-ffb26880-ee40-11e8-8485-ab9b5330c971.png) | ![image](https://user-images.githubusercontent.com/355079/48897116-27a1cc00-ee41-11e8-9125-4806c63a4758.png)


# After

Check | Sent
---|---
![image](https://user-images.githubusercontent.com/355079/48897062-ffb26880-ee40-11e8-8485-ab9b5330c971.png) | ![image](https://user-images.githubusercontent.com/355079/48897096-19ec4680-ee41-11e8-9d93-be6c37efaaa9.png)
