### PR TITLE
Don’t wrap users onto multiple lines

### DIFF
--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -11,6 +11,19 @@ $item-top-padding: $gutter-half;
     border-top: 1px solid $border-colour;
     position: relative;
 
+    h3 {
+
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: $secondary-text-colour;  // So the ellipsis is grey
+
+      .heading-small {
+        color: $black;
+      }
+
+    }
+
     &:last-child {
       border-bottom: 1px solid $border-colour;
     }

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -33,7 +33,7 @@
   <div class="user-list">
     {% for user in users %}
       <div class="user-list-item">
-        <h3>
+        <h3 title="{{ user.email_address }}">
           {%- if user.name -%}
             <span class="heading-small">{{ user.name }}</span>&ensp;
           {%- endif -%}


### PR DESCRIPTION
It looks cleaner to truncate instead. You can always see the full email address by clicking into ‘edit’.

# Before

![image](https://user-images.githubusercontent.com/355079/48898084-c29ba580-ee43-11e8-848b-e061ba50a0de.png)

# After 

![image](https://user-images.githubusercontent.com/355079/48898075-b57eb680-ee43-11e8-9029-38b427b1c6a6.png)
