### PR TITLE
Bump notifications-utils to 30.7.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,6 +35,7 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.formatters import formatted_list
 from notifications_utils.sanitise_text import SanitiseASCII
+from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 from werkzeug.exceptions import abort, HTTPException as WerkzeugHTTPException
 from werkzeug.local import LocalProxy
 
@@ -69,7 +70,7 @@ from app.notify_client.complaint_api_client import complaint_api_client
 from app.notify_client.platform_stats_api_client import platform_stats_api_client
 from app.notify_client.template_folder_api_client import template_folder_api_client
 from app.commands import setup_commands
-from app.utils import get_cdn_domain, gmt_timezones, id_safe
+from app.utils import get_cdn_domain, id_safe
 
 login_manager = LoginManager()
 csrf = CSRFProtect()
@@ -256,17 +257,17 @@ def format_datetime_numeric(date):
 
 
 def format_date_numeric(date):
-    return gmt_timezones(date).strftime('%Y-%m-%d')
+    return utc_string_to_aware_gmt_datetime(date).strftime('%Y-%m-%d')
 
 
 def format_time_24h(date):
-    return gmt_timezones(date).strftime('%H:%M')
+    return utc_string_to_aware_gmt_datetime(date).strftime('%H:%M')
 
 
 def get_human_day(time):
 
     #  Add 1 minute to transform 00:00 into ‘midnight today’ instead of ‘midnight tomorrow’
-    date = (gmt_timezones(time) - timedelta(minutes=1)).date()
+    date = (utc_string_to_aware_gmt_datetime(time) - timedelta(minutes=1)).date()
     if date == (datetime.utcnow() + timedelta(days=1)).date():
         return 'tomorrow'
     if date == datetime.utcnow().date():
@@ -281,21 +282,21 @@ def format_time(date):
         '12:00AM': 'Midnight',
         '12:00PM': 'Midday'
     }.get(
-        gmt_timezones(date).strftime('%-I:%M%p'),
-        gmt_timezones(date).strftime('%-I:%M%p')
+        utc_string_to_aware_gmt_datetime(date).strftime('%-I:%M%p'),
+        utc_string_to_aware_gmt_datetime(date).strftime('%-I:%M%p')
     ).lower()
 
 
 def format_date(date):
-    return gmt_timezones(date).strftime('%A %d %B %Y')
+    return utc_string_to_aware_gmt_datetime(date).strftime('%A %d %B %Y')
 
 
 def format_date_normal(date):
-    return gmt_timezones(date).strftime('%d %B %Y').lstrip('0')
+    return utc_string_to_aware_gmt_datetime(date).strftime('%d %B %Y').lstrip('0')
 
 
 def format_date_short(date):
-    return _format_datetime_short(gmt_timezones(date))
+    return _format_datetime_short(utc_string_to_aware_gmt_datetime(date))
 
 
 def _format_datetime_short(datetime):
@@ -306,7 +307,7 @@ def format_delta(date):
     delta = (
         datetime.now(timezone.utc)
     ) - (
-        gmt_timezones(date)
+        utc_string_to_aware_gmt_datetime(date)
     )
     if delta < timedelta(seconds=30):
         return "just now"

--- a/app/utils.py
+++ b/app/utils.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 import ago
 import dateutil
 import pyexcel
-import pytz
 import yaml
 from flask import (
     Markup,
@@ -353,12 +352,6 @@ def get_time_left(created_at):
 
 def email_or_sms_not_enabled(template_type, permissions):
     return (template_type in ['email', 'sms']) and (template_type not in permissions)
-
-
-def gmt_timezones(date):
-    date = dateutil.parser.parse(date)
-    forced_utc = date.replace(tzinfo=pytz.utc)
-    return forced_utc.astimezone(pytz.timezone('Europe/London'))
 
 
 def get_cdn_domain():

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,4 +24,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.6.0#egg=notifications-utils==30.6.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.0#egg=notifications-utils==30.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,13 +26,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.6.0#egg=notifications-utils==30.6.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.0#egg=notifications-utils==30.7.0
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.53
+awscli==1.16.61
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.12.43
+botocore==1.12.51
 certifi==2018.10.15
 chardet==3.0.4
 Click==7.0
@@ -49,12 +49,12 @@ idna==2.7
 jdcal==1.4
 Jinja2==2.10
 jmespath==0.9.3
-lml==0.0.6
+lml==0.0.7
 lxml==4.2.5
 MarkupSafe==1.1.0
 mistune==0.8.3
 monotonic==1.5
-openpyxl==2.5.9
+openpyxl==2.5.11
 orderedset==2.0.1
 phonenumbers==8.9.4
 pyasn1==0.4.4


### PR DESCRIPTION
Bumped the notifications-utils version. The `gmt_timezones` function in
this repo and the `utc_string_to_aware_gmt_datetime` in
notifications-utils are the same, so have updated the code to always use
the version in utils.