### PR TITLE
'Data available for {}' message on job page accounts for flexible data retention

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -399,6 +399,9 @@ def get_job_partials(job, template):
             counts=_get_job_counts(job),
             status=filter_args['status']
         )
+    service_data_retention_days = service_api_client.get_service_data_retention_by_notification_type(
+        current_service.id, template['template_type']
+    ).get('days_of_retention', current_app.config['ACTIVITY_STATS_LIMIT_DAYS'])
 
     return {
         'counts': counts,
@@ -415,7 +418,7 @@ def get_job_partials(job, template):
                 job_id=job['id'],
                 status=request.args.get('status')
             ),
-            time_left=get_time_left(job['created_at']),
+            time_left=get_time_left(job['created_at'], service_data_retention_days=service_data_retention_days),
             job=job,
             template=template,
             template_version=job['template_version'],

--- a/app/utils.py
+++ b/app/utils.py
@@ -338,12 +338,14 @@ def get_current_financial_year():
     return current_year if current_month > 3 else current_year - 1
 
 
-def get_time_left(created_at):
+def get_time_left(created_at, service_data_retention_days=7):
     return ago.human(
         (
-            datetime.now(timezone.utc).replace(hour=23, minute=59, second=59)
+            datetime.now(timezone.utc)
         ) - (
-            dateutil.parser.parse(created_at) + timedelta(days=8)
+            dateutil.parser.parse(created_at).replace(hour=0, minute=0, second=0) + timedelta(
+                days=service_data_retention_days + 1
+            )
         ),
         future_tense='Data available for {}',
         past_tense='Data no longer available',  # No-one should ever see this

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -453,7 +453,7 @@ def test_should_show_notifications_for_a_service_with_next_previous(
     "job_created_at, expected_message", [
         ("2016-01-10 11:09:00.000000+00:00", "Data available for 7 days"),
         ("2016-01-04 11:09:00.000000+00:00", "Data available for 1 day"),
-        ("2016-01-03 11:09:00.000000+00:00", "Data available for 11 hours"),
+        ("2016-01-03 11:09:00.000000+00:00", "Data available for 12 hours"),
         ("2016-01-02 23:59:59.000000+00:00", "Data no longer available")
     ]
 )

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -221,6 +221,29 @@ def test_should_show_page_for_one_job(
     )
 
 
+@freeze_time("2016-01-01 11:09:00.061258")
+def test_should_show_page_for_one_job_with_flexible_data_retention(
+    client_request,
+    active_user_with_permissions,
+    mock_get_service_template,
+    mock_get_job,
+    mocker,
+    mock_get_notifications,
+    mock_get_service_data_retention_by_notification_type,
+    fake_uuid,
+):
+
+    mock_get_service_data_retention_by_notification_type.side_effect = [{"days_of_retention": 10}]
+    page = client_request.get(
+        'main.view_job',
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        status='delivered'
+    )
+
+    assert page.find('span', {'id': 'time-left'}).text == 'Data available for 10 days'
+
+
 def test_get_jobs_should_tell_user_if_more_than_one_page(
     logged_in_client,
     fake_uuid,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -181,6 +181,7 @@ def test_should_show_page_for_one_job(
     mock_get_job,
     mocker,
     mock_get_notifications,
+    mock_get_service_data_retention_by_notification_type,
     fake_uuid,
     status_argument,
     expected_api_call,
@@ -227,6 +228,7 @@ def test_get_jobs_should_tell_user_if_more_than_one_page(
     mock_get_job,
     mock_get_service_template,
     mock_get_notifications_with_previous_next,
+    mock_get_service_data_retention_by_notification_type,
 ):
     response = logged_in_client.get(url_for(
         'main.view_job',
@@ -248,6 +250,7 @@ def test_should_show_job_in_progress(
     mock_get_job_in_progress,
     mocker,
     mock_get_notifications,
+    mock_get_service_data_retention_by_notification_type,
     fake_uuid,
 ):
 
@@ -267,6 +270,7 @@ def test_should_show_letter_job(
     client_request,
     mock_get_service_letter_template,
     mock_get_job,
+    mock_get_service_data_retention_by_notification_type,
     fake_uuid,
     active_user_with_permissions,
     mocker,
@@ -322,6 +326,7 @@ def test_should_show_letter_job_with_banner_after_sending(
     mock_get_service_letter_template,
     mock_get_job,
     mock_get_notifications,
+    mock_get_service_data_retention_by_notification_type,
     fake_uuid,
 ):
 
@@ -344,6 +349,7 @@ def test_should_show_scheduled_job(
     active_user_with_permissions,
     mock_get_service_template,
     mock_get_scheduled_job,
+    mock_get_service_data_retention_by_notification_type,
     mocker,
     mock_get_notifications,
     fake_uuid,
@@ -411,6 +417,7 @@ def test_should_show_updates_for_one_job_as_json(
     mock_get_notifications,
     mock_get_service_template,
     mock_get_job,
+    mock_get_service_data_retention_by_notification_type,
     mocker,
     fake_uuid,
 ):
@@ -433,7 +440,7 @@ def test_should_show_updates_for_one_job_as_json(
     "job_created_at, expected_message", [
         ("2016-01-10 11:09:00.000000+00:00", "Data available for 7 days"),
         ("2016-01-04 11:09:00.000000+00:00", "Data available for 1 day"),
-        ("2016-01-03 11:09:00.000000+00:00", "Data available for 11 hours"),
+        ("2016-01-03 11:09:00.000000+00:00", "Data available for 12 hours"),
         ("2016-01-02 23:59:59.000000+00:00", "Data no longer available")
     ]
 )
@@ -447,6 +454,7 @@ def test_should_show_letter_job_with_first_class_if_notifications_are_first_clas
     client_request,
     mock_get_service_letter_template,
     mock_get_job,
+    mock_get_service_data_retention_by_notification_type,
     fake_uuid,
     active_user_with_permissions,
     mocker,
@@ -474,6 +482,7 @@ def test_should_show_letter_job_with_first_class_if_no_notifications(
     mock_get_job,
     fake_uuid,
     mock_get_notifications_with_no_notifications,
+    mock_get_service_data_retention_by_notification_type,
     mocker
 ):
     mocker.patch('app.main.views.jobs.current_service', postage='first')

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2001,6 +2001,7 @@ def test_create_job_should_call_api(
     mock_get_job,
     mock_get_notifications,
     mock_get_service_template,
+    mock_get_service_data_retention_by_notification_type,
     mocker,
     fake_uuid,
     when


### PR DESCRIPTION
- 'Data available for {}' message on job page accounts for flexible data retention
- Tests updated to reflect that
- New test written to test how message is displayed when data retention policy is changed;

Connected to and reliant on this pull request: https://github.com/alphagov/notifications-api/pull/2233

Pivotal ticket: https://www.pivotaltracker.com/story/show/162008638