### PR TITLE
Update utils to 30.7.1 to silence 'Header missing' warnings

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,4 +24,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.0#egg=notifications-utils==30.7.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@30.7.0#egg=notifications-utils==30.7.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1
 
 ## The following requirements were added by pip freeze:
 awscli==1.16.62


### PR DESCRIPTION
Brings in changes from https://github.com/alphagov/notifications-utils/pull/553