### PR TITLE
Content changes for notification pages

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -32,6 +32,7 @@ from app.utils import (
     get_page_from_request,
     get_time_left,
     parse_filter_args,
+    printing_today_or_tomorrow,
     set_status_filters,
     user_has_permissions,
 )
@@ -108,7 +109,8 @@ def view_job(service_id, job_id):
         just_sent=bool(
             request.args.get('just_sent') == 'yes' and
             template['template_type'] == 'letter'
-        )
+        ),
+        printing_day=printing_today_or_tomorrow()
     )
 
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -93,6 +93,11 @@ def view_job(service_id, job_id):
         version=job['template_version']
     )['data']
 
+    just_sent_message = 'Your {} been sent. Printing starts {} at 5.30pm.'.format(
+        'letter has' if job['notification_count'] == 1 else 'letters have',
+        printing_today_or_tomorrow()
+    )
+
     return render_template(
         'views/jobs/job.html',
         finished=(total_notifications == processed_notifications),
@@ -110,7 +115,7 @@ def view_job(service_id, job_id):
             request.args.get('just_sent') == 'yes' and
             template['template_type'] == 'letter'
         ),
-        printing_day=printing_today_or_tomorrow()
+        just_sent_message=just_sent_message,
     )
 
 

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -14,7 +14,9 @@
     </h1>
 
     {% if just_sent %}
-      {{ banner('We’ve started printing your letters', type='default', with_tick=True) }}
+      {{ banner('Your letter has been sent. Printing starts {} at 5.30pm.'.format(printing_day),
+        type='default',
+        with_tick=True) }}
     {% else %}
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -14,9 +14,7 @@
     </h1>
 
     {% if just_sent %}
-      {{ banner('Your letter has been sent. Printing starts {} at 5.30pm.'.format(printing_day),
-        type='default',
-        with_tick=True) }}
+      {{ banner(just_sent_message, type='default', with_tick=True) }}
     {% else %}
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -19,14 +19,16 @@
       Provided as PDF, sent
       {% else %}
         {% if help %}
-          {{ template.name }}
+          ‘{{ template.name }}’
         {% else %}
-          <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">{{ template.name }}</a>
+          <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">‘{{ template.name }}’</a>
         {% endif %}
-        sent
+        was sent
       {% endif %}
       {% if job and job.original_file_name != 'Report' %}
-        from
+        {% set destination =
+          {'letter': 'an address', 'email': 'an email address', 'sms': 'a phone number'} %}
+        to {{ destination[template.template_type] }} from
         <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>
       {% elif created_by %}
         by {{ created_by.name }}
@@ -45,6 +47,9 @@
           (letter has content outside the printable area)
         </p>
       {% else %}
+        <p>
+          {{ letter_print_day }}
+        </p>
         <p>
           Postage: {{ postage }} class
         </p>

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,7 +2,7 @@ import csv
 import os
 import re
 import unicodedata
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, time, timedelta, timezone
 from functools import wraps
 from io import StringIO
 from itertools import chain
@@ -33,6 +33,7 @@ from notifications_utils.template import (
     LetterPreviewTemplate,
     SMSPreviewTemplate,
 )
+from notifications_utils.timezones import convert_utc_to_bst
 from orderedset._orderedset import OrderedSet
 from werkzeug.datastructures import MultiDict
 
@@ -643,3 +644,13 @@ def get_default_sms_sender(sms_senders):
         Field(x['sms_sender'], html='escape')
         for x in sms_senders if x['is_default']
     ), "None"))
+
+
+def printing_today_or_tomorrow():
+    now_utc = datetime.utcnow()
+    now_bst = convert_utc_to_bst(now_utc)
+
+    if now_bst.time() < time(17, 30):
+        return 'today'
+    else:
+        return 'tomorrow'

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -366,6 +366,29 @@ def test_should_show_letter_job_with_banner_after_sending_before_1730(
     )
 
 
+@freeze_time("2016-01-01 11:09:00")
+def test_should_show_letter_job_with_banner_when_there_are_multiple_CSV_rows(
+    client_request,
+    mock_get_service_letter_template,
+    mock_get_job_in_progress,
+    mock_get_notifications,
+    mock_get_service_data_retention_by_notification_type,
+    fake_uuid,
+):
+
+    page = client_request.get(
+        'main.view_job',
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        just_sent='yes',
+    )
+
+    assert page.select('p.bottom-gutter') == []
+    assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
+        'Your letters have been sent. Printing starts today at 5.30pm.'
+    )
+
+
 @freeze_time("2016-01-01 18:09:00")
 def test_should_show_letter_job_with_banner_after_sending_after_1730(
     client_request,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -343,8 +343,8 @@ def test_should_show_letter_job(
     )
 
 
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_should_show_letter_job_with_banner_after_sending(
+@freeze_time("2016-01-01 11:09:00")
+def test_should_show_letter_job_with_banner_after_sending_before_1730(
     client_request,
     mock_get_service_letter_template,
     mock_get_job,
@@ -362,7 +362,30 @@ def test_should_show_letter_job_with_banner_after_sending(
 
     assert page.select('p.bottom-gutter') == []
     assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
-        'We’ve started printing your letters'
+        'Your letter has been sent. Printing starts today at 5.30pm.'
+    )
+
+
+@freeze_time("2016-01-01 18:09:00")
+def test_should_show_letter_job_with_banner_after_sending_after_1730(
+    client_request,
+    mock_get_service_letter_template,
+    mock_get_job,
+    mock_get_notifications,
+    mock_get_service_data_retention_by_notification_type,
+    fake_uuid,
+):
+
+    page = client_request.get(
+        'main.view_job',
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        just_sent='yes',
+    )
+
+    assert page.select('p.bottom-gutter') == []
+    assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
+        'Your letter has been sent. Printing starts tomorrow at 5.30pm.'
     )
 
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -17,6 +17,7 @@ from app.utils import (
     generate_notifications_csv,
     generate_previous_dict,
     get_logo_cdn_domain,
+    printing_today_or_tomorrow,
 )
 from tests.conftest import fake_uuid
 
@@ -452,3 +453,27 @@ def test_validate_email_domain_data():
 def test_format_datetime_relative(time, human_readable_datetime):
     with freeze_time('2018-03-21 12:00'):
         assert format_datetime_relative(time) == human_readable_datetime
+
+
+@pytest.mark.parametrize('utc_datetime', [
+    '2018-08-01 23:00',
+    '2018-08-01 16:29',
+    '2018-11-01 00:00',
+    '2018-11-01 10:00',
+    '2018-11-01 17:29',
+])
+def test_printing_today_or_tomorrow_returns_today(utc_datetime):
+    with freeze_time(utc_datetime):
+        assert printing_today_or_tomorrow() == 'today'
+
+
+@pytest.mark.parametrize('datetime', [
+    '2018-08-01 22:59',
+    '2018-08-01 16:30',
+    '2018-11-01 17:30',
+    '2018-11-01 21:00',
+    '2018-11-01 23:59',
+])
+def test_printing_today_or_tomorrow_returns_tomorrow(datetime):
+    with freeze_time(datetime):
+        assert printing_today_or_tomorrow() == 'tomorrow'


### PR DESCRIPTION
Added the content for the notifications pages as agreed with @karlchillmaid , particularly the letter pages, which will make things clearer now that we will soon be allowing letters to be cancelled.

The main changes are:
* The confirmation banner for letters sent from a CSV file now states when printing will start.
* We state the CSV file that notifications were sent from on the notifications page
* The notification page for letters shows when printing starts (today, tomorrow, or that date that the letter was printed)

### Confirmation when uploading a letter CSV file
<img width="853" alt="screen shot 2018-11-27 at 17 31 10" src="https://user-images.githubusercontent.com/12881990/49219742-1e2ddc00-f3cc-11e8-8c66-e60b45e09b3a.png">

### Confirmation when uploading a letter CSV file with multiple rows
<img width="842" alt="screen shot 2018-11-29 at 11 09 30" src="https://user-images.githubusercontent.com/12881990/49219715-0c4c3900-f3cc-11e8-8449-5f0faaf0ca68.png">

### Letter due to be printed today
<img width="840" alt="screen shot 2018-11-27 at 17 02 28" src="https://user-images.githubusercontent.com/12881990/49099083-764bcd80-f268-11e8-8cde-7890203b44d1.png">

### Email sent via CSV upload
<img width="779" alt="screen shot 2018-11-27 at 17 03 16" src="https://user-images.githubusercontent.com/12881990/49099100-8499e980-f268-11e8-9b04-2ea8d6c58bc5.png">

### Letter printed in the past
<img width="794" alt="screen shot 2018-11-27 at 17 04 55" src="https://user-images.githubusercontent.com/12881990/49099145-a5623f00-f268-11e8-9c18-091f79080b8f.png">

### Text sent as one-off message
![screen shot 2018-11-27 at 17 20 53](https://user-images.githubusercontent.com/12881990/49099256-e8241700-f268-11e8-9034-20cad22f5ee0.png)

