### PR TITLE
Add Social Work England to list of email domains

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -41,3 +41,4 @@
 - bi.team
 - networkrail.co.uk
 - uksbs.co.uk
+- socialworkengland.org.uk 


### PR DESCRIPTION
Social Work England will be the new, specialist regulator for social workers in England.

https://www.gov.uk/government/publications/social-work-england-secondary-legislation

https://www.socialworkengland.org.uk