### PR TITLE
Let users add new template from the choose page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1200,12 +1200,12 @@ class TemplateAndFoldersSelectionForm(Form):
             if item['id'] != str(current_folder_id)
         ]
 
-        self.add_template_by_template_type.choices = filter(None, [
+        self.add_template_by_template_type.choices = list(filter(None, [
             ('email', 'Email template'),
             ('sms', 'Text message template'),
             ('letter', 'Letter template') if allow_adding_letter_template else None,
             ('copy-existing', 'Copy of an existing template') if allow_adding_copy_of_template else None,
-        ])
+        ]))
 
     def validate(self):
         self.op = request.form.get('operation')

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -258,10 +258,10 @@ def add_template_by_type(service_id, template_folder_id=None):
 
     form = ChooseTemplateType(
         include_letters=current_service.has_permission('letter'),
-        include_copy=any((
-            len(current_service.all_templates) > 0,
-            len(user_api_client.get_service_ids_for_user(current_user)) > 1,
-        )),
+        include_copy=(
+            current_service.all_templates or
+            len(user_api_client.get_service_ids_for_user(current_user)) > 1
+        ),
         include_folder=current_service.has_permission('edit_folders')
     )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -116,6 +116,11 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         template_list=template_list,
         template_type=template_type,
         current_folder_id=template_folder_id,
+        allow_adding_letter_template=current_service.has_permission('letter'),
+        allow_adding_copy_of_template=(
+            current_service.all_templates or
+            len(user_api_client.get_service_ids_for_user(current_user)) > 1
+        ),
     )
 
     if request.method == 'POST' and templates_and_folders_form.validate_on_submit():
@@ -144,7 +149,13 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
 def process_folder_management_form(form, current_folder_id):
     new_folder_id = None
 
-    if form.is_add_op:
+    if form.is_add_template_op:
+        return _add_template_by_type(
+            form.add_template_by_template_type.data,
+            current_folder_id,
+        )
+
+    if form.is_add_folder_op:
         new_folder_id = template_folder_api_client.create_template_folder(
             current_service.id,
             name=form.get_folder_name(),
@@ -248,53 +259,57 @@ def add_template_by_type(service_id, template_folder_id=None):
     form = ChooseTemplateType(
         include_letters=current_service.has_permission('letter'),
         include_copy=any((
-            service_api_client.count_service_templates(service_id) > 0,
+            len(current_service.all_templates) > 0,
             len(user_api_client.get_service_ids_for_user(current_user)) > 1,
         )),
         include_folder=current_service.has_permission('edit_folders')
     )
 
     if form.validate_on_submit():
-
-        if form.template_type.data == 'copy-existing':
-            return redirect(url_for(
-                '.choose_template_to_copy',
-                service_id=service_id,
-            ))
-
-        if form.template_type.data == 'letter':
-            blank_letter = service_api_client.create_service_template(
-                'Untitled',
-                'letter',
-                'Body',
-                service_id,
-                'Main heading',
-                'normal',
-                template_folder_id
-            )
-            return redirect(url_for(
-                '.view_template',
-                service_id=service_id,
-                template_id=blank_letter['data']['id'],
-            ))
-
-        if email_or_sms_not_enabled(form.template_type.data, current_service.permissions):
-            return redirect(url_for(
-                '.action_blocked',
-                service_id=service_id,
-                notification_type=form.template_type.data,
-                return_to='add_new_template',
-                template_id='0'
-            ))
-        else:
-            return redirect(url_for(
-                '.add_service_template',
-                service_id=service_id,
-                template_type=form.template_type.data,
-                template_folder_id=template_folder_id,
-            ))
+        return _add_template_by_type(form.template_type.data, template_folder_id)
 
     return render_template('views/templates/add.html', form=form)
+
+
+def _add_template_by_type(template_type, template_folder_id):
+
+    if template_type == 'copy-existing':
+        return redirect(url_for(
+            '.choose_template_to_copy',
+            service_id=current_service.id,
+        ))
+
+    if template_type == 'letter':
+        blank_letter = service_api_client.create_service_template(
+            'Untitled',
+            'letter',
+            'Body',
+            current_service.id,
+            'Main heading',
+            'normal',
+            template_folder_id
+        )
+        return redirect(url_for(
+            '.view_template',
+            service_id=current_service.id,
+            template_id=blank_letter['data']['id'],
+        ))
+
+    if email_or_sms_not_enabled(template_type, current_service.permissions):
+        return redirect(url_for(
+            '.action_blocked',
+            service_id=current_service.id,
+            notification_type=template_type,
+            return_to='add_new_template',
+            template_id='0'
+        ))
+    else:
+        return redirect(url_for(
+            '.add_service_template',
+            service_id=current_service.id,
+            template_type=template_type,
+            template_folder_id=template_folder_id,
+        ))
 
 
 @main.route("/services/<service_id>/templates/copy")

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -1,19 +1,20 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 
-{% if templates_and_folders_form.move_to.choices and template_list.templates_to_show %}
   <button type="submit" name="operation" value="unknown" hidden></button>
-  <div id="move_to_folder_radios">
-    {{ radios(templates_and_folders_form.move_to) }}
-    {{ page_footer('Move', button_name='operation', button_value='move_to_existing_folder') }}
-  </div>
-  <div id="move_to_new_folder_form">
-    <fieldset>
-      <legend class="visuallyhidden">Move to a new folder</legend>
-      {{ textbox(templates_and_folders_form.move_to_new_folder_name) }}
-      {{ page_footer('Move to a new folder', button_name='operation', button_value='move_to_new_folder') }}
-    </fieldset>
-  </div>
+  {% if templates_and_folders_form.move_to.choices and template_list.templates_to_show %}
+    <div id="move_to_folder_radios">
+      {{ radios(templates_and_folders_form.move_to) }}
+      {{ page_footer('Move', button_name='operation', button_value='move_to_existing_folder') }}
+    </div>
+    <div id="move_to_new_folder_form">
+      <fieldset>
+        <legend class="visuallyhidden">Move to a new folder</legend>
+        {{ textbox(templates_and_folders_form.move_to_new_folder_name) }}
+        {{ page_footer('Move to a new folder', button_name='operation', button_value='move_to_new_folder') }}
+      </fieldset>
+    </div>
+  {% endif %}
   <div id="add_new_folder_form">
     <fieldset>
       <legend class="visuallyhidden">Add a new folder</legend>
@@ -21,4 +22,10 @@
       {{ page_footer('New folder', button_name='operation', button_value='add_new_folder') }}
     </fieldset>
   </div>
-{% endif %}
+  <div id="add_new_template_form">
+    <fieldset>
+      <legend class="visuallyhidden">Add a new template</legend>
+      {{ radios(templates_and_folders_form.add_template_by_template_type) }}
+      {{ page_footer('Continue', button_name='operation', button_value='add_template') }}
+    </fieldset>
+  </div>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2188,12 +2188,12 @@ def test_set_postage_saves(
 
 @pytest.mark.parametrize('current_branding, expected_values, expected_labels', [
     (None, [
-        'None', '1', '2', '3', '4', '5',
+        '__NONE__', '1', '2', '3', '4', '5',
     ], [
         'GOV.UK', 'org 1', 'org 2', 'org 3', 'org 4', 'org 5'
     ]),
     ('5', [
-        '5', 'None', '1', '2', '3', '4',
+        '5', '__NONE__', '1', '2', '3', '4',
     ], [
         'org 5', 'GOV.UK', 'org 1', 'org 2', 'org 3', 'org 4',
     ]),
@@ -2314,7 +2314,8 @@ def test_should_preview_email_branding(
 
 @pytest.mark.parametrize('posted_value, submitted_value', (
     ('1', '1'),
-    ('None', None),
+    ('__NONE__', None),
+    pytest.param('None', None, marks=pytest.mark.xfail(raises=AssertionError)),
 ))
 def test_should_set_branding_and_organisations(
     logged_in_platform_admin_client,

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -901,7 +901,7 @@ def test_should_be_able_to_move_a_sub_item(
         template_folder_id=PARENT_FOLDER_ID,
         _data={
             'operation': 'move_to_existing_folder',
-            'move_to': 'None',
+            'move_to': '__NONE__',
             'templates_and_folders': [GRANDCHILD_FOLDER_ID],
         },
         _expected_status=302,
@@ -929,6 +929,13 @@ def test_should_be_able_to_move_a_sub_item(
         'move_to_new_folder_name': 'foo',
         'move_to': PARENT_FOLDER_ID
     },
+    # move to existing, but no templates to move
+    {
+        'operation': 'move_to_existing_folder',
+        'templates_and_folders': [],
+        'move_to_new_folder_name': '',
+        'move_to': PARENT_FOLDER_ID
+    },
     # move to new, but nothing selected to move
     {
         'operation': 'move_to_new_folder',
@@ -942,6 +949,14 @@ def test_should_be_able_to_move_a_sub_item(
         'templates_and_folders': [],
         'move_to_new_folder_name': '',
         'move_to': PARENT_FOLDER_ID,
+        'add_template_by_template_type': 'email',
+    },
+    # add a new template, but also move to root folder
+    {
+        'operation': 'add_template',
+        'templates_and_folders': [],
+        'move_to_new_folder_name': '',
+        'move_to': '__NONE__',
         'add_template_by_template_type': 'email',
     },
 ])

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -785,7 +785,7 @@ def test_should_show_radios_and_buttons_for_move_destination_if_correct_permissi
         'main.choose_template',
         service_id=SERVICE_ONE_ID,
     )
-    radios = page.select('input[type=radio]')
+    radios = page.select('#move_to_folder_radios input[type=radio]')
     radio_div = page.find('div', {'id': 'move_to_folder_radios'})
     assert radios == page.select('input[name=move_to]')
 
@@ -799,7 +799,8 @@ def test_should_show_radios_and_buttons_for_move_destination_if_correct_permissi
         'unknown',
         'move_to_existing_folder',
         'move_to_new_folder',
-        'add_new_folder'
+        'add_new_folder',
+        'add_template',
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,10 @@ from . import (
 )
 
 
+class ElementNotFound(Exception):
+    pass
+
+
 @pytest.fixture
 def app_(request):
     app = Flask('app')


### PR DESCRIPTION
Since we’re letting users add new folders directly from the choose page it makes sense that they should also be able to add templates from there.

This resolves the problem we saw in user research where people found it hard to know where to go to add a new folder when they were all behind one green button.

***

![image](https://user-images.githubusercontent.com/355079/49156727-f4b27900-f315-11e8-8355-2a40d555088d.png)
