### PR TITLE
Use static domains for static assets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -194,7 +194,7 @@ def init_app(application):
     @application.context_processor
     def inject_global_template_variables():
         return {
-            'asset_path': '/static/',
+            'asset_path': application.config['ASSET_PATH'],
             'header_colour': application.config['HEADER_COLOUR'],
             'asset_url': asset_fingerprinter.get_url
         }

--- a/app/config.py
+++ b/app/config.py
@@ -74,6 +74,8 @@ class Config(object):
     REDIS_URL = os.environ.get('REDIS_URL')
     REDIS_ENABLED = os.environ.get('REDIS_ENABLED') == '1'
 
+    ASSET_PATH = '/static/'
+
 
 class Development(Config):
     NOTIFY_LOG_PATH = 'application.log'
@@ -117,6 +119,7 @@ class Preview(Config):
     MOU_BUCKET_NAME = 'notify.works-mou'
     NOTIFY_ENVIRONMENT = 'preview'
     CHECK_PROXY_HEADER = False
+    ASSET_PATH = 'https://static.notify.works/'
 
 
 class Staging(Config):
@@ -129,6 +132,7 @@ class Staging(Config):
     MOU_BUCKET_NAME = 'staging-notify.works-mou'
     NOTIFY_ENVIRONMENT = 'staging'
     CHECK_PROXY_HEADER = False
+    ASSET_PATH = 'https://static.staging-notify.works/'
 
 
 class Live(Config):
@@ -141,6 +145,7 @@ class Live(Config):
     MOU_BUCKET_NAME = 'notifications.service.gov.uk-mou'
     NOTIFY_ENVIRONMENT = 'live'
     CHECK_PROXY_HEADER = False
+    ASSET_PATH = 'https://static.notifications.service.gov.uk/'
 
 
 class CloudFoundryConfig(Config):


### PR DESCRIPTION
Since moving to putting the admin app on Cloudfront anything on the
`www.notifications.service.gov.uk` domain is:
- not GZipped

The PaaS proxy used to GZip and set headers for anything served from a path starting with `/static/`:
https://github.com/alphagov/notifications-aws/blob/76dd511a8aaa2e4f8ffec17662bbe08841c52455/ansible/roles/paas-proxy/templates/admin.conf.j2#L53-L64

Anything served from `static.notifications.service.gov.uk` is:
- GZipped
- and as a bonus, cached by Cloudfront where possible (meaning the requests won’t ever hit our app)

This commit moves to serving static asset from `/static/` to `static.notifications.service.gov.uk`, to get the above listed benefits.

# Before 
![image](https://user-images.githubusercontent.com/355079/49163455-09e2d400-f325-11e8-9bcd-65c947e66699.png)

# After 
![image](https://user-images.githubusercontent.com/355079/49163483-19fab380-f325-11e8-8899-eae28fcff466.png)

***

We could do even better by setting long cache expiry headers on the static subdomain (currently they’re only set to cache for 60 seconds). But that’s out of scope for this commit.


