### PR TITLE
Updated reply-to address content

### DIFF
--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -14,7 +14,7 @@
     Add email reply-to address
   </h1>
   <p>
-    Let recipients send replies to a shared inbox that's managed by your team.
+    Let recipients send replies to a shared inbox that’s managed by your team.
   </p>
   <p>
     Do not use your own email address for replies.

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -13,8 +13,12 @@
   <h1 class="heading-large">
     Add email reply-to address
   </h1>
-<p>Let recipients send replies to a shared inbox that's managed by your team.</p>
-<p>Do not use your own email address for replies.</p>
+  <p>
+    Let recipients send replies to a shared inbox that's managed by your team.
+  </p>
+  <p>
+    Do not use your own email address for replies.
+  </p>
   {% call form_wrapper() %}
     {{ textbox(
       form.email_address,

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -13,6 +13,8 @@
   <h1 class="heading-large">
     Add email reply-to address
   </h1>
+<p>Let recipients send replies to a shared inbox that's managed by your team.</p>
+<p>Do not use your own email address for replies.</p>
   {% call form_wrapper() %}
     {{ textbox(
       form.email_address,

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -54,14 +54,9 @@
         Emails with a reply-to address:
       </p>
       <ul class="list list-bullet">
-	      <li>are less likely to be labelled as spam</li>
-	      <li>appear more trustworthy</li>
-	    </ul>
-        <!--{% if current_service.trial_mode and not current_service.has_email_reply_to_address %}
-          Your service can’t go live until you’ve added at least one
-          reply-to address.
-        {% endif %}-->
-      </p>
+        <li>are less likely to be labelled as spam</li>
+        <li>appear more trustworthy</li>
+      </ul>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -48,20 +48,19 @@
   <div class="grid-row">
     <div class="column-five-sixths">
       <p>
-        Your emails will be sent from
-        {{ current_service.email_from }}@notifications.service.gov.uk
+        You need to add at least one reply-to address so recipients can reply to your messages.
       </p>
       <p>
-        This is so they have the best chance of being delivered.
-        This email address can’t receive replies.
+        Emails with a reply-to address:
       </p>
-      <p>
-        Set up separate email addresses to receive replies
-        from your users.
-        {% if current_service.trial_mode and not current_service.has_email_reply_to_address %}
+      <ul class="list list-bullet">
+	      <li>are less likely to be labelled as spam</li>
+	      <li>appear more trustworthy</li>
+	    </ul>
+        <!--{% if current_service.trial_mode and not current_service.has_email_reply_to_address %}
           Your service can’t go live until you’ve added at least one
           reply-to address.
-        {% endif %}
+        {% endif %}-->
       </p>
     </div>
   </div>


### PR DESCRIPTION
Updated reply-to address content to better explain why users need to add a reply-to address.

Added a description to the 'Add reply-to address' page.

@quis I commented out the 'can't go live' message because it repeats the new content. We can change it if you think we still need it, or remove it if we don't.