### PR TITLE
Make Whitenoise serve static assets

### DIFF
--- a/application.py
+++ b/application.py
@@ -12,4 +12,4 @@ STATIC_URL = 'static/'
 app = Flask('app')
 
 create_app(app)
-application = WhiteNoise(app, STATIC_ROOT, STATIC_URL)
+app.wsgi_app = WhiteNoise(app.wsgi_app, STATIC_ROOT, STATIC_URL)

--- a/application.py
+++ b/application.py
@@ -12,4 +12,4 @@ STATIC_URL = 'static/'
 app = Flask('app')
 
 create_app(app)
-app.wsgi_app = WhiteNoise(app.wsgi_app, STATIC_ROOT, STATIC_URL)
+app.wsgi_app = WhiteNoise(app.wsgi_app, STATIC_ROOT, STATIC_URL, max_age=WhiteNoise.FOREVER)


### PR DESCRIPTION
Currently it’s not configured properly, so isn’t having any effect. This change makes it wrap the Flask app, so it intercepts any requests for static content.

Follows the pattern documented in http://whitenoise.evans.io/en/stable/flask.html#enable-whitenoise