### PR TITLE
Fix asset path in asset fingeprinter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -103,6 +103,7 @@ def create_app(application):
     notify_environment = os.environ['NOTIFY_ENVIRONMENT']
 
     application.config.from_object(configs[notify_environment])
+    asset_fingerprinter._asset_root = application.config['ASSET_PATH']
 
     init_app(application)
     antivirus_client.init_app(application)

--- a/app/config.py
+++ b/app/config.py
@@ -113,6 +113,7 @@ class Test(Development):
     ANTIVIRUS_API_KEY = 'test-antivirus-secret'
 
     ASSET_DOMAIN = 'static.example.com'
+    ASSET_PATH = 'https://static.example.com/'
 
 
 class Preview(Config):

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -241,3 +241,18 @@ def test_terms_tells_logged_in_users_what_we_know_about_their_agreement(
     else:
         assert not terms_page.select_one('main p').select('a')
     assert normalize_spaces(pricing_page.select('main p')[-1].text) == expected_pricing_paragraph
+
+
+def test_css_is_served_from_correct_path(client_request):
+
+    page = client_request.get('main.pricing')  # easy static page
+
+    for index, link in enumerate(
+        page.select('link[rel=stylesheet]')
+    ):
+        assert link['href'].startswith([
+            'https://static.example.com/stylesheets/govuk-template.css?',
+            'https://static.example.com/stylesheets/govuk-template-print.css?',
+            'https://static.example.com/stylesheets/fonts.css?',
+            'https://static.example.com/stylesheets/main.css?',
+        ][index])


### PR DESCRIPTION
The asset fingerprinter was hard coded to always point to `/static`.

It needs to change depending on which environment the app is running in.