### PR TITLE
Expose `application` as a variable

### DIFF
--- a/application.py
+++ b/application.py
@@ -9,7 +9,8 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'app', 'static')
 STATIC_URL = 'static/'
 
-app = Flask('app')
+flask_app = Flask('app')
 
-create_app(app)
-app.wsgi_app = WhiteNoise(app.wsgi_app, STATIC_ROOT, STATIC_URL, max_age=WhiteNoise.FOREVER)
+create_app(flask_app)
+
+application = WhiteNoise(flask_app.wsgi_app, STATIC_ROOT, STATIC_URL, max_age=WhiteNoise.FOREVER)


### PR DESCRIPTION
This is what Gunicorn is looking for when it’s running the app.

Renaming this variable to `app` has caused the app to break once deployed on PaaS.

This commit also renames `app` to `flask_app` to make it clear which app is wrapping which other app.