### PR TITLE
Update email_domains.yml

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -42,3 +42,4 @@
 - networkrail.co.uk
 - uksbs.co.uk
 - socialworkengland.org.uk 
+- careinspectorate.com


### PR DESCRIPTION
Adding careinspectorate.com  - they're a scrutiny body specialising in health and social care, early learning and childcare, social work, children’s services, and community justice