### PR TITLE
Back button on one-off message preview takes user to their flow

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -803,6 +803,8 @@ def get_send_test_page_title(template_type, help_argument, entering_recipient, n
 
 
 def is_current_user_the_recipient():
+    if 'recipient' not in session:
+        return False
     if hasattr(current_user, 'phone_number'):
         return session['recipient'] in {current_user.email_address, current_user.phone_number}
     return session['recipient'] == current_user.email_address

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1117,13 +1117,13 @@ def test_send_one_off_or_test_has_correct_page_titles(
         active_user_with_permissions,
         mock_get_service_template,
         'Use my phone number',
-        partial(url_for, 'main.send_test')
+        partial(url_for, 'main.send_test_step')
     ),
     (
         active_user_with_permissions,
         mock_get_service_email_template,
         'Use my email address',
-        partial(url_for, 'main.send_test')
+        partial(url_for, 'main.send_test_step')
     ),
     (
         active_user_with_permissions,
@@ -1166,6 +1166,7 @@ def test_send_one_off_has_skip_link(
         assert skip_links[0]['href'] == expected_link_url(
             service_id=service_one['id'],
             template_id=fake_uuid,
+            step_index=1
         )
     else:
         assert not skip_links
@@ -1679,7 +1680,7 @@ def test_send_test_indicates_optional_address_columns(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     assert normalize_spaces(page.select('label')[0].text) == (
-        'address line 4 '
+        'address line 3 '
         'Optional'
     )
     assert page.select('.page-footer-back-link')[0]['href'] == url_for(


### PR DESCRIPTION
Earlier back button always took user to one-off flow, even when they came
from test flow. This made personalisation disappear when user was coming from test flow.

Also adjust steps calculation for test flow.

Pivotal ticket: https://www.pivotaltracker.com/story/show/161984520

Reservations (please discuss):
- I could not go through letter flow on my local as I couldn’t make antivirus run
- When you go through test flow (use user’s own email address/phone no.), and then go back all the way to choosing recipient, it will be blank. I think it would be better if it was filled with recipient(that is, current_user) data, that this data existed not only as `session['recipient']`, but also as a `placeholders` value. And then also the conditional on `line 393` in `send.py` would not be needed (I think that `current_placeholder` index influences address line numbers in letter template, so might be better to have the same number of placeholders for test flow and one-off flow). The thing is, I couldn’t make it work that way 😳.
