### PR TITLE
Scope live search on team page to name and email

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -18,19 +18,11 @@ from app.utils import user_has_permissions
 @login_required
 @user_has_permissions()
 def manage_users(service_id):
-    users = sorted(
-        (
-            user_api_client.get_users_for_service(service_id=service_id) +
-            invite_api_client.get_invites_for_service(service_id=service_id)
-        ),
-        key=lambda user: user.email_address,
-    )
-
     return render_template(
         'views/manage-users.html',
-        users=users,
+        users=current_service.team_members,
         current_user=current_user,
-        show_search_box=(len(users) > 7),
+        show_search_box=(len(current_service.team_members) > 7),
         form=SearchUsersForm(),
         permissions=permissions,
     )

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -19,10 +19,10 @@ from app.utils import user_has_permissions
 @user_has_permissions()
 def manage_users(service_id):
     users = sorted(
-        user_api_client.get_users_for_service(service_id=service_id) + [
-            invite for invite in invite_api_client.get_invites_for_service(service_id=service_id)
-            if invite.status != 'accepted'
-        ],
+        (
+            user_api_client.get_users_for_service(service_id=service_id) +
+            invite_api_client.get_invites_for_service(service_id=service_id)
+        ),
         key=lambda user: user.email_address,
     )
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -101,13 +101,13 @@ class Service():
 
     @cached_property
     def team_members(self):
-        return list(sorted(
+        return sorted(
             (
                 invite_api_client.get_invites_for_service(service_id=self.id) +
                 user_api_client.get_users_for_service(service_id=self.id)
             ),
             key=lambda user: user.email_address,
-        ))
+        )
 
     @cached_property
     def has_team_members(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -6,6 +6,7 @@ from app.notify_client.api_key_api_client import api_key_api_client
 from app.notify_client.billing_api_client import billing_api_client
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.inbound_number_client import inbound_number_client
+from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
 from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.service_api_client import service_api_client
@@ -97,6 +98,16 @@ class Service():
     @cached_property
     def has_jobs(self):
         return job_api_client.has_jobs(self.id)
+
+    @cached_property
+    def team_members(self):
+        return list(sorted(
+            (
+                invite_api_client.get_invites_for_service(service_id=self.id) +
+                user_api_client.get_users_for_service(service_id=self.id)
+            ),
+            key=lambda user: user.email_address,
+        ))
 
     @cached_property
     def has_team_members(self):

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -28,11 +28,16 @@ class InviteApiClient(NotifyAdminAPIClient):
         return InvitedUser(**resp['data'])
 
     def get_invites_for_service(self, service_id):
-        endpoint = '/service/{}/invite'.format(service_id)
-        resp = self.get(endpoint)
-        invites = resp['data']
-        invited_users = self._get_invited_users(invites)
-        return invited_users
+        return [
+            InvitedUser(**invite)
+            for invite in self._get_invites_for_service(service_id)
+            if invite['status'] != 'accepted'
+        ]
+
+    def _get_invites_for_service(self, service_id):
+        return self.get(
+            '/service/{}/invite'.format(service_id)
+        )['data']
 
     def check_token(self, token):
         resp = self.get(url='/invite/service/{}'.format(token))
@@ -50,13 +55,6 @@ class InviteApiClient(NotifyAdminAPIClient):
         data = {'status': 'accepted'}
         self.post(url='/service/{0}/invite/{1}'.format(service_id, invited_user_id),
                   data=data)
-
-    def _get_invited_users(self, invites):
-        invited_users = []
-        for invite in invites:
-            invited_user = InvitedUser(**invite)
-            invited_users.append(invited_user)
-        return invited_users
 
 
 invite_api_client = InviteApiClient()

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -35,17 +35,17 @@
       <div class="user-list-item">
         <h3 title="{{ user.email_address }}">
           {%- if user.name -%}
-            <span class="heading-small">{{ user.name }}</span>&ensp;
+            <span class="heading-small live-search-relevant">{{ user.name }}</span>&ensp;
           {%- endif -%}
           <span class="hint">
             {%- if user.status == 'pending' -%}
-              {{ user.email_address }} (invited)
+              <span class="live-search-relevant">{{ user.email_address }}</span> (invited)
             {%- elif user.status == 'cancelled' -%}
-              {{ user.email_address }} (cancelled invite)
+              <span class="live-search-relevant">{{ user.email_address }}</span> (cancelled invite)
             {%- elif user.id == current_user.id -%}
-              (you)
+              <span class="live-search-relevant">(you)</span>
             {% else %}
-              {{ user.email_address }}
+              <span class="live-search-relevant">{{ user.email_address }}</span>
             {% endif %}
           </span>
         </h3>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2174,10 +2174,10 @@ def mock_get_invites_for_service(mocker, service_one, sample_invite):
         for i in range(0, 5):
             invite = copy.copy(sample_invite)
             invite['email_address'] = 'user_{}@testnotify.gov.uk'.format(i)
-            data.append(InvitedUser(**invite))
+            data.append(invite)
         return data
 
-    return mocker.patch('app.invite_api_client.get_invites_for_service', side_effect=_get_invites)
+    return mocker.patch('app.invite_api_client._get_invites_for_service', side_effect=_get_invites)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
It’s not useful for the search to also be picking up ‘Send messages’ or ‘Signs in with an email link’. This uses the code added to search across templates when a service has folders.

This PR also does some refactoring of things out of the view layer and into the model or API client where appropriate. See individual commits for details.