### PR TITLE
Fix email branding preview for no branding

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -14,7 +14,7 @@ from notifications_utils.template import HTMLEmailTemplate
 
 from app import email_branding_client
 from app.main import main
-from app.main.forms import SearchTemplatesForm
+from app.main.forms import FieldWithNoneOption, SearchTemplatesForm
 from app.main.views.sub_navigation_dictionaries import features_nav
 from app.utils import AgreementInfo, get_logo_cdn_domain
 
@@ -92,9 +92,12 @@ def design_content():
 @main.route('/_email')
 def email_template():
     branding_type = 'govuk'
-    branding_style = request.args.get('branding_style', 'None')
+    branding_style = request.args.get('branding_style', None)
 
-    if branding_style != 'None':
+    if branding_style == FieldWithNoneOption.NONE_OPTION_VALUE:
+        branding_style = None
+
+    if branding_style is not None:
         email_branding = email_branding_client.get_email_branding(branding_style)['email_branding']
         branding_type = email_branding['brand_type']
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -4,7 +4,11 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests.conftest import active_user_with_permissions, normalize_spaces
+from tests.conftest import (
+    active_user_with_permissions,
+    normalize_spaces,
+    sample_uuid,
+)
 
 
 def test_non_logged_in_user_can_see_homepage(
@@ -256,3 +260,31 @@ def test_css_is_served_from_correct_path(client_request):
             'https://static.example.com/stylesheets/fonts.css?',
             'https://static.example.com/stylesheets/main.css?',
         ][index])
+
+
+@pytest.mark.parametrize('extra_args, email_branding_retrieved', (
+    (
+        {},
+        False,
+    ),
+    (
+        {'branding_style': '__NONE__'},
+        False,
+    ),
+    (
+        {'branding_style': sample_uuid()},
+        True,
+    ),
+))
+def test_email_branding_preview(
+    client_request,
+    mock_get_email_branding,
+    extra_args,
+    email_branding_retrieved,
+):
+    client_request.get(
+        'main.email_template',
+        _test_page_title=False,
+        **extra_args
+    )
+    assert mock_get_email_branding.called is email_branding_retrieved


### PR DESCRIPTION
The value that means no branding (in the form) has changed from `'None'` to `'__NONE__'`.

This commit:
- accounts for that value
- makes sure that no branding (ie plain GOV.UK) is still displayed when no query argument is given

# Before 

![image](https://user-images.githubusercontent.com/355079/49507822-2c22a780-f879-11e8-85da-b1d518d63eb0.png)

# After 

![image](https://user-images.githubusercontent.com/355079/49507803-1e6d2200-f879-11e8-9a95-f80e06319d59.png)
