### PR TITLE
Always show checked items in live search

### DIFF
--- a/app/assets/javascripts/liveSearch.js
+++ b/app/assets/javascripts/liveSearch.js
@@ -11,6 +11,11 @@
 
       let content = $('.live-search-relevant', this).text() || $(this).text();
 
+      if ($(this).has(':checked').length) {
+        $(this).show();
+        return;
+      }
+
       if (query == '') {
         $(this).css('display', '');
         return;


### PR DESCRIPTION
If you’ve searched to select an item and then you want to perform an action on it it’s confusing when it goes away if you change your search.

It should always be clear which items you’re performing an action on. This means that checked items should always be visible, no matter what your search term is.

***

![image](https://user-images.githubusercontent.com/355079/49510614-aacf1300-f880-11e8-9cc6-c0fb0f76f47a.png)
