### PR TITLE
Style template management controls

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -43,7 +43,9 @@
     this.addCancelButton = function(state) {
       let $cancel =  $('<a></a>')
           .html('Cancel')
-          .click((event) => {
+          .attr('class', 'page-footer-js-cancel')
+          .attr('tabindex', '0')
+          .on('click keydown', (event) => {
             event.preventDefault();
             // clear existing data
             state.$el.find('input:radio').prop('checked', false);

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -163,5 +163,10 @@
 
   }
 
+  &-manage-link {
+    display: block;
+    text-align: right;
+    padding: ($gutter - 2px) 0 0 0;
+  }
 
 }

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -86,3 +86,21 @@
   }
 
 }
+
+.page-footer-js-cancel {
+
+  text-decoration: underline;
+  color: $govuk-blue;
+  cursor: pointer;
+
+  &:hover {
+    color: $link-hover-colour;
+  }
+
+  &:focus,
+  &:active, {
+    background: $yellow;
+    color: $govuk-blue;
+    outline: 3px solid $yellow;
+  }
+}

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -59,6 +59,10 @@
     margin: 0;
   }
 
+  .button-secondary {
+    margin-right: $gutter-half;
+  }
+
 }
 
 .content-fixed,

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -49,7 +49,7 @@
   {% else %}
 
     <div class="grid-row {% if current_service.all_template_folders %}bottom-gutter-1-2{% else %}bottom-gutter-2-3{% endif %}">
-      <div class="column-two-thirds">
+      <div class="{% if can_manage_folders %} column-five-sixths {% else %} column-two-thirds {% endif %}">
         {{ folder_path(
           folders=template_folder_path,
           service_id=current_service.id,
@@ -59,14 +59,16 @@
         ) }}
       </div>
       {% if current_user.has_permissions('manage_templates') %}
-        <div class="column-one-third">
         {% if not can_manage_folders %}
-          <a href="{{ url_for('.add_template_by_type', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="button align-with-heading">Add new template</a>
+          <div class="column-one-third">
+            <a href="{{ url_for('.add_template_by_type', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="button align-with-heading">Add new template</a>
+          </div>
         {% endif %}
         {% if can_manage_folders and current_template_folder_id %}
-          <a href="{{ url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="align-with-heading">Manage</a>
+          <div class="column-one-sixth">
+            <a href="{{ url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="folder-heading-manage-link">Manage</a>
+          </div>
         {% endif %}
-        </div>
       {% endif %}
     </div>
 


### PR DESCRIPTION
# Space out the buttons in the sticky footer

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/49528793-96087480-f8ac-11e8-85a2-d4f920027abc.png) | ![image](https://user-images.githubusercontent.com/355079/49528925-dd8f0080-f8ac-11e8-89ed-2e2773eeb4c0.png)

# Style the manage folder link

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/49528828-a6205400-f8ac-11e8-99ee-df13f4b8a943.png) | ![image](https://user-images.githubusercontent.com/355079/49528907-d1a33e80-f8ac-11e8-8d11-44cf99350f6b.png)

# Style cancel link and make it keyboard navigable

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/49528847-b3d5d980-f8ac-11e8-8dbc-1bbb3ab36810.png) | ![image](https://user-images.githubusercontent.com/355079/49528882-c7814000-f8ac-11e8-9687-5cb3d0fce91b.png)

