### PR TITLE
Remove sticky textbox for one-off text messages

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -14,7 +14,10 @@
     {{ page_title }}
   </h1>
 
-  {% call form_wrapper(class="js-stick-at-top-when-scrolling", module="autofocus") %}
+  {% call form_wrapper(
+    class="js-stick-at-top-when-scrolling" if template.template_type != 'sms' else '',
+    module="autofocus"
+  ) %}
     <div class="grid-row">
       <div class="column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
         {{ textbox(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1172,6 +1172,33 @@ def test_send_one_off_has_skip_link(
         assert not skip_links
 
 
+@pytest.mark.parametrize('template_mock, expected_sticky', [
+    (mock_get_service_template, False),
+    (mock_get_service_email_template, True),
+    (mock_get_service_letter_template, True),
+])
+def test_send_one_off_has_sticky_header_for_email_and_letter(
+    mocker,
+    client_request,
+    fake_uuid,
+    mock_has_no_jobs,
+    template_mock,
+    expected_sticky,
+):
+    template_mock(mocker)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
+
+    page = client_request.get(
+        'main.send_one_off_step',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        step_index=0,
+        _follow_redirects=True,
+    )
+
+    assert bool(page.select('.js-stick-at-top-when-scrolling')) == expected_sticky
+
+
 @pytest.mark.parametrize('user', (
     active_user_with_permissions,
     active_caseworking_user,


### PR DESCRIPTION
The idea behind the sticky textbox on this page is so you can scroll through a long email or letter to find where in the message the placeholder appears, while still being able to see the textbox you
should be typing in.

With text messages, they’re hardly ever long enough for anything to be off the screen – ie no scrolling is required.

However if the user does scroll, they can end up covering the message content with the sticky top panel. Which then looks like the message has disappeared, so they click ‘back’ in the browser, then click into the message again to make the page reload.

This commit removes the stickyness when sending from a text message template.