### PR TITLE
Fix beheaded test name

### DIFF
--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1431,7 +1431,7 @@ def test_send_test_redirects_to_start_if_index_out_of_bounds_and_some_placeholde
     ('main.send_test', 'main.send_test_step'),
     ('main.send_one_off', 'main.send_one_off_step'),
 ])
-def _redirects_with_help_argument(
+def test_send_test_sms_message_redirects_with_help_argument(
     logged_in_client,
     mocker,
     service_one,


### PR DESCRIPTION
Tests wont run unless the function name starts with the word `test`.

Was accidentally deleted here:
https://github.com/alphagov/notifications-admin/commit/de92950d8eb0b4f92d9e4a8d4e570d89517a0972#diff-3f993e348666469cc699ac3bf0e0cc5bR543