### PR TITLE
Fix spacing on upload link when not inside sticky

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -70,6 +70,7 @@ $path: '/static/images/';
 @import 'views/product-page';
 @import 'views/template';
 @import 'views/notification';
+@import 'views/send';
 
 // TODO: break this up
 @import 'app';

--- a/app/assets/stylesheets/views/send.scss
+++ b/app/assets/stylesheets/views/send.scss
@@ -1,0 +1,7 @@
+.send-one-off-form {
+
+  .form-group {
+    margin-bottom: 20px;
+  }
+
+}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -15,7 +15,7 @@
   </h1>
 
   {% call form_wrapper(
-    class="js-stick-at-top-when-scrolling" if template.template_type != 'sms' else '',
+    class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
     module="autofocus"
   ) %}
     <div class="grid-row">


### PR DESCRIPTION
We adjust the spacing under the textbox when doing the send one off flow. This was based on the assumption that there would always be a sticky header in the send one off flow.

This assumption is no longer true, so this commit implements the same spacing in an independent way.