### PR TITLE
Fix sticky shim having zero height

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -235,7 +235,7 @@
     return windowTop > el.scrolledTo;
   };
   stickAtTop.addShimForEl = function ($el, width, height) {
-    $el.before('<div class="shim" style="width: ' + width + 'px height: ' + height + 'px">&nbsp</div>');
+    $el.before('<div class="shim" style="width: ' + width + 'px; height: ' + height + 'px">&nbsp;</div>');
   };
   stickAtTop.stop = function (el) {
     if (!el.stopped()) {


### PR DESCRIPTION
We ‘shim’ the sticky element so that its space in the page is reserved while it is sticky.

This means the shim have have the same height as the sticky element. It’s height was not getting set because of a missing semicolon in the shim element’s `style` attribute.