### PR TITLE
Strip commas from estimated volumes

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -173,9 +173,9 @@ def submit_request_to_go_live(service_id):
                 '{user_email}, '
                 '-, '
                 '{date}, '
-                '{volume_sms}, '
-                '{volume_email}, '
-                '{volume_letter}'
+                '{volume_sms_normalised}, '
+                '{volume_email_normalised}, '
+                '{volume_letter_normalised}'
             ).format(
                 service_name=current_service.name,
                 service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
@@ -183,8 +183,11 @@ def submit_request_to_go_live(service_id):
                 agreement=AgreementInfo.from_current_user().as_human_readable,
                 checklist=current_service.go_live_checklist_completed_as_yes_no,
                 volume_email=form.volume_email.data,
+                volume_email_normalised=form.volume_email.data.replace(',', ''),
                 volume_sms=form.volume_sms.data,
+                volume_sms_normalised=form.volume_sms.data.replace(',', ''),
                 volume_letter=form.volume_letter.data,
+                volume_letter_normalised=form.volume_letter.data.replace(',', ''),
                 research_consent=form.research_consent.data.title(),
                 service_id=current_service.id,
                 organisation=AgreementInfo.from_current_user().owner,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -816,9 +816,9 @@ def test_should_redirect_after_request_to_go_live(
         'main.submit_request_to_go_live',
         service_id=SERVICE_ONE_ID,
         _data={
-            'volume_email': '111',
-            'volume_sms': '222',
-            'volume_letter': '333',
+            'volume_email': '111,111',
+            'volume_sms': '222,222',
+            'volume_letter': '333,333',
             'research_consent': 'yes',
         },
         _follow_redirects=True
@@ -845,13 +845,13 @@ def test_should_redirect_after_request_to_go_live(
         'Organisation type: Central\n'
         'Agreement signed: Can’t tell (domain is user.gov.uk)\n'
         'Checklist completed: No\n'
-        'Emails in next year: 111\n'
-        'Text messages in next year: 222\n'
-        'Letters in next year: 333\n'
+        'Emails in next year: 111,111\n'
+        'Text messages in next year: 222,222\n'
+        'Letters in next year: 333,333\n'
         'Consent to research: Yes\n'
         '\n'
         '---\n'
-        '{}, None, service one, Test User, test@user.gov.uk, -, 21/12/2012, 222, 111, 333'
+        '{}, None, service one, Test User, test@user.gov.uk, -, 21/12/2012, 222222, 111111, 333333'
     ).format(SERVICE_ONE_ID, SERVICE_ONE_ID)
 
     assert normalize_spaces(page.select_one('.banner-default').text) == (


### PR DESCRIPTION
We suggest people format their numbers with commas when telling us how many things they’re going to send.

This causes problems when we paste these values into a spreadsheet, because the commas get interpreted as column separators.