### PR TITLE
Don’t let non-government users request to go live 

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -75,7 +75,7 @@ def add_service():
         service_id = _add_invited_user_to_service(invited_user)
         return redirect(url_for('main.service_dashboard', service_id=service_id))
 
-    if not is_gov_user(current_user.email_address):
+    if not current_user.is_gov_user:
         abort(403)
 
     form = CreateServiceForm()

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,7 +1,6 @@
 from flask import current_app, redirect, render_template, session, url_for
-from flask_login import current_user, login_required
+from flask_login import login_required
 from notifications_python_client.errors import HTTPError
-from werkzeug.exceptions import abort
 
 from app import (
     billing_api_client,
@@ -13,7 +12,7 @@ from app import (
 from app.main import main
 from app.main.forms import CreateServiceForm
 from app.models.user import InvitedUser
-from app.utils import AgreementInfo, email_safe, is_gov_user
+from app.utils import AgreementInfo, email_safe, user_is_gov_user
 
 
 def _add_invited_user_to_service(invited_user):
@@ -69,14 +68,12 @@ def _create_example_template(service_id):
 
 @main.route("/add-service", methods=['GET', 'POST'])
 @login_required
+@user_is_gov_user
 def add_service():
     invited_user = session.get('invited_user')
     if invited_user:
         service_id = _add_invited_user_to_service(invited_user)
         return redirect(url_for('main.service_dashboard', service_id=service_id))
-
-    if not current_user.is_gov_user:
-        abort(403)
 
     form = CreateServiceForm()
     heading = 'About your service'

--- a/app/main/views/choose_account.py
+++ b/app/main/views/choose_account.py
@@ -26,7 +26,7 @@ def choose_account():
         'views/choose-account.html',
         organisations=orgs_and_services['organisations'],
         services_without_organisations=orgs_and_services['services_without_organisations'],
-        can_add_service=is_gov_user(current_user.email_address)
+        can_add_service=current_user.is_gov_user,
     )
 
 

--- a/app/main/views/choose_account.py
+++ b/app/main/views/choose_account.py
@@ -4,7 +4,6 @@ from werkzeug.routing import RequestRedirect
 
 from app import user_api_client
 from app.main import main
-from app.utils import is_gov_user
 
 
 @main.route("/services")

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -56,6 +56,7 @@ from app.utils import (
     email_safe,
     get_logo_cdn_domain,
     user_has_permissions,
+    user_is_gov_user,
     user_is_platform_admin,
 )
 
@@ -146,10 +147,8 @@ def request_to_go_live(service_id):
 @main.route("/services/<service_id>/service-settings/submit-request-to-go-live", methods=['GET', 'POST'])
 @login_required
 @user_has_permissions('manage_service')
+@user_is_gov_user
 def submit_request_to_go_live(service_id):
-
-    if not current_user.is_gov_user:
-        abort(403)
 
     form = RequestToGoLiveForm()
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -147,6 +147,10 @@ def request_to_go_live(service_id):
 @login_required
 @user_has_permissions('manage_service')
 def submit_request_to_go_live(service_id):
+
+    if not current_user.is_gov_user:
+        abort(403)
+
     form = RequestToGoLiveForm()
 
     if form.validate_on_submit():

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -1,13 +1,6 @@
 import json
 
-from flask import (
-    abort,
-    current_app,
-    redirect,
-    render_template,
-    session,
-    url_for,
-)
+from flask import current_app, redirect, render_template, session, url_for
 from flask_login import current_user, login_required
 from notifications_utils.url_safe_token import check_token
 
@@ -21,7 +14,7 @@ from app.main.forms import (
     ConfirmPasswordForm,
     TwoFactorForm,
 )
-from app.utils import is_gov_user
+from app.utils import user_is_gov_user
 
 NEW_EMAIL = 'new-email'
 NEW_MOBILE = 'new-mob'
@@ -56,10 +49,8 @@ def user_profile_name():
 
 @main.route("/user-profile/email", methods=['GET', 'POST'])
 @login_required
+@user_is_gov_user
 def user_profile_email():
-
-    if not current_user.is_gov_user:
-        abort(403)
 
     def _is_email_already_in_use(email):
         return user_api_client.is_email_already_in_use(email)

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -33,7 +33,7 @@ NEW_MOBILE_PASSWORD_CONFIRMED = 'new-mob-password-confirmed'
 def user_profile():
     return render_template(
         'views/user-profile.html',
-        can_see_edit=is_gov_user(current_user.email_address)
+        can_see_edit=current_user.is_gov_user,
     )
 
 
@@ -58,7 +58,7 @@ def user_profile_name():
 @login_required
 def user_profile_email():
 
-    if not is_gov_user(current_user.email_address):
+    if not current_user.is_gov_user:
         abort(403)
 
     def _is_email_already_in_use(email):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -3,6 +3,9 @@ from itertools import chain
 from flask import request, session
 from flask_login import AnonymousUserMixin, UserMixin
 
+from app.utils import is_gov_user
+
+
 roles = {
     'send_messages': ['send_texts', 'send_emails', 'send_letters'],
     'manage_templates': ['manage_templates'],
@@ -101,6 +104,10 @@ class User(UserMixin):
     @property
     def is_active(self):
         return self.state == 'active'
+
+    @property
+    def is_gov_user(self):
+        return is_gov_user(self.email_address)
 
     @property
     def is_authenticated(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -5,7 +5,6 @@ from flask_login import AnonymousUserMixin, UserMixin
 
 from app.utils import is_gov_user
 
-
 roles = {
     'send_messages': ['send_texts', 'send_emails', 'send_letters'],
     'manage_templates': ['manage_templates'],

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -47,12 +47,18 @@
           ) }}
         {% endif %}
       {% endcall %}
-      <p>
-        You also need to accept our <a href="{{ url_for('.terms') }}">terms of use</a>.
-      </p>
-      <p>
-        <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Continue</a>
-      </p>
+      {% if current_user.is_gov_user %}
+        <p>
+          You also need to accept our <a href="{{ url_for('.terms') }}">terms of use</a>.
+        </p>
+        <p>
+          <a href="{{ url_for('main.submit_request_to_go_live', service_id=current_service.id) }}" class="button">Continue</a>
+        </p>
+      {% else %}
+        <p>
+          Only team members with a government email address can request to go live.
+        </p>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -62,6 +62,15 @@ def user_has_permissions(*permissions, **permission_kwargs):
     return wrap
 
 
+def user_is_gov_user(f):
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        if not current_user.is_gov_user:
+            abort(403)
+        return f(*args, **kwargs)
+    return wrapped
+
+
 def user_is_platform_admin(f):
     @wraps(f)
     def wrapped(*args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1135,19 +1135,29 @@ def api_user_active_email_auth(fake_uuid, email_address='test@user.gov.uk'):
 @pytest.fixture(scope='function')
 def api_nongov_user_active(fake_uuid):
     from app.notify_client.user_api_client import User
-    user_data = {'id': fake_uuid,
-                 'name': 'Test User',
-                 'password': 'somepassword',
-                 'email_address': 'someuser@notonwhitelist.com',
-                 'mobile_number': '07700 900762',
-                 'state': 'active',
-                 'failed_login_count': 0,
-                 'permissions': {},
-                 'platform_admin': False,
-                 'auth_type': 'sms_auth',
-                 'password_changed_at': str(datetime.utcnow()),
-                 'organisations': []
-                 }
+    user_data = {
+        'id': fake_uuid,
+        'name': 'Test User',
+        'password': 'somepassword',
+        'email_address': 'someuser@notonwhitelist.com',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'send_texts',
+            'send_emails',
+            'send_letters',
+            'manage_users',
+            'manage_templates',
+            'manage_settings',
+            'manage_api_keys',
+            'view_activity',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'password_changed_at': str(datetime.utcnow()),
+        'organisations': []
+    }
     user = User(user_data)
     return user
 


### PR DESCRIPTION
Only users who work for government can accept the terms of use. This will save us from having to email these requesters back telling them they need to find someone else to submit the request.

Some refactoring in separate commits.

Government user | Not a government user 
---|---
![image](https://user-images.githubusercontent.com/355079/49873347-88ef0680-fe13-11e8-9e83-909e69130a97.png) | ![image](https://user-images.githubusercontent.com/355079/49873315-796fbd80-fe13-11e8-85e7-0d537fb9fa97.png)
