### PR TITLE
Update email_domains.yml

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -43,3 +43,4 @@
 - uksbs.co.uk
 - socialworkengland.org.uk 
 - careinspectorate.com
+- unitypartnership.com 


### PR DESCRIPTION
Unity Partnership is wholly owned by Oldham Council