### PR TITLE
Add information about how static assets are served

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ make freeze-requirements
 `requirements.txt` should be committed alongside `requirements-app.txt` changes.
 
 
-## Working with static assets 
+## Working with static assets
 
-When running locally static assets are served by Whitenoise at http://localhost:6012/static/…
+When running locally static assets are served by Flask at http://localhost:6012/static/…
 
 When running on preview, staging and production there’s a bit more to it:
 
-![notify-static](https://user-images.githubusercontent.com/355079/50014775-c6db5e80-ffbc-11e8-9096-de41d97d67bf.png)
+![notify-static-after](https://user-images.githubusercontent.com/355079/50343595-6ea5de80-051f-11e9-85cf-2c20eb3cdefa.png)


### PR DESCRIPTION
This should help developers new to Notify understand how it works.

![notify-static](https://user-images.githubusercontent.com/355079/50343636-9432e800-051f-11e9-8786-9e84d0c56930.png)
