### PR TITLE
Fix issues with JS for sticky elements 

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -4,6 +4,7 @@
   var $ = global.jQuery;
   var GOVUK = global.GOVUK || {};
 
+  // Constructor for objects holding data for each element to have sticky behaviour
   var StickyElement = function ($el, sticky) {
     this._sticky = sticky;
     this.$fixedEl = $el;
@@ -30,6 +31,8 @@
     this._appliedClass = null;
     this._hasBeenCalled = true;
   };
+  // When a sticky element is moved into the 'stuck' state, a shim is inserted into the
+  // page to preserve the space the element occupies in the flow.
   StickyElement.prototype.addShim = function (position) {
     this._$shim = $('<div class="shim" style="width: ' + this.horizontalSpace + 'px; height: ' + this.verticalSpace + 'px">&nbsp</div>');
     this.$fixedEl[position](this._$shim);
@@ -38,6 +41,7 @@
     this._$shim.remove();
     this._$shim = null;
   };
+  // Changes to the dimensions of a sticky element with a shim need to be passed on to the shim
   StickyElement.prototype.updateShim = function () {
     if (this._$shim) {
       this._$shim.css({
@@ -56,7 +60,8 @@
     return this._stopped;
   };
 
-  // Stick elements to top of screen when you scroll past, documentation is in the README.md
+  // Constructor for objects collecting together all generic behaviour for controlling the state of
+  // sticky elements
   var Sticky = function (selector) {
     this._hasScrolled = false;
     this._scrollTimeout = false;
@@ -79,6 +84,7 @@
       scrollTop: $(global).scrollTop()
     };
   };
+  // Change state of sticky elements based on their position relative to the window
   Sticky.prototype.setElementPositions = function () {
     var self = this;
 
@@ -103,6 +109,7 @@
 
     if (self._initialPositionsSet === false) { self._initialPositionsSet = true; }
   };
+  // Store all the dimensions for a sticky element to limit DOM queries
   Sticky.prototype.setElementDimensions = function (el, callback) {
     var self = this;
     var $el = el.$fixedEl;
@@ -122,6 +129,7 @@
     this.setElWidth(el);
     this.setElHeight(el, onHeightSet);
   };
+  // Recalculate stored dimensions for all sticky elements
   Sticky.prototype.recalculate = function () {
     var self = this;
 
@@ -175,11 +183,14 @@
         });
       });
 
+      // flag when scrolling takes place and check (and re-position) sticky elements relative to
+      // window position
       if (self._scrollTimeout === false) {
         $(global).scroll(function (e) { self.onScroll(); });
         self._scrollTimeout = global.setInterval(function (e) { self.checkScroll(); }, 50);
       }
 
+      // Recalculate all dimensions when the window resizes
       if (self._resizeTimeout === false) {
         $(global).resize(function (e) { self.onResize(); });
         self._resizeTimeout = global.setInterval(function (e) { self.checkResize(); }, 50);
@@ -240,10 +251,13 @@
     }
   };
 
+  // Extension of sticky object to add behaviours specific to sticking to top of window
   var stickAtTop = new Sticky('.js-stick-at-top-when-scrolling');
+  // Store top of sticky elements while unstuck
   stickAtTop.getScrolledFrom = function ($el) {
     return $el.offset().top;
   };
+  // Store furthest point top of sticky element is allowed
   stickAtTop.getScrollingTo = function (el) {
     var footer = $('.js-footer:eq(0)');
     if (footer.length === 0) {
@@ -284,10 +298,13 @@
     }
   };
 
+  // Extension of sticky object to add behaviours specific to sticking to bottom of window
   var stickAtBottom = new Sticky('.js-stick-at-bottom-when-scrolling');
+  // Store bottom of sticky elements while unstuck
   stickAtBottom.getScrolledFrom = function ($el) {
     return $el.offset().top + $el.outerHeight();
   };
+  // Store furthest point bottom of sticky element is allowed
   stickAtBottom.getScrollingTo = function (el) {
     var header = $('.js-header:eq(0)');
     if (header.length === 0) {

--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -119,7 +119,6 @@
       }
     };
 
-    this.setFixedTop(el);
     this.setElWidth(el);
     this.setElHeight(el, onHeightSet);
   };
@@ -130,14 +129,6 @@
       self.setElementDimensions(el);
     });
     self.setElementPositions();
-  };
-  Sticky.prototype.setFixedTop = function (el) {
-    var $siblingEl = $('<div></div>');
-    $siblingEl.insertBefore(el.$fixedEl);
-    var fixedTop = $siblingEl.offset().top - $siblingEl.position().top;
-    $siblingEl.remove();
-
-    el.fixedTop = fixedTop;
   };
   Sticky.prototype.setElWidth = function (el) {
     el.horizontalSpace = el.$fixedEl.outerWidth(true);

--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -39,6 +39,14 @@
     this._$shim.remove();
     this._$shim = null;
   };
+  StickyElement.prototype.updateShim = function () {
+    if (this._$shim) {
+      this._$shim.css({
+        'height': this.verticalSpace,
+        'width': this.horizontalSpace
+      });
+    }
+  };
   StickyElement.prototype.stop = function () {
     this._stopped = true;
   };
@@ -100,6 +108,7 @@
     var self = this;
     var onHeightSet = function () {
       el.scrolledTo = self.getScrollingTo(el);
+      el.updateShim(el);
       if (callback !== undefined) {
         callback();
       }
@@ -108,6 +117,14 @@
     this.setFixedTop(el);
     this.setElWidth(el);
     this.setElHeight(el, onHeightSet);
+  };
+  Sticky.prototype.recalculate = function () {
+    var self = this;
+
+    $.each(self._els, function (i, el) {
+      self.setElementDimensions(el);
+    });
+    self.setElementPositions();
   };
   Sticky.prototype.setFixedTop = function (el) {
     var $siblingEl = $('<div></div>');
@@ -122,22 +139,19 @@
   };
   Sticky.prototype.setElHeight = function (el, callback) {
     var self = this;
-    var fixedOffset = parseInt(el.$fixedEl.css('top'), 10);
     var $el = el.$fixedEl;
     var $img = $el.find('img');
-
-    fixedOffset = isNaN(fixedOffset) ? 0 : fixedOffset;
 
     if ((!self._elsLoaded) && ($img.length > 0)) {
       var image = new global.Image();
       image.onload = function () {
-        el.verticalSpace = $el.outerHeight(true) + fixedOffset;
+        el.verticalSpace = $el.outerHeight(true);
         el.height = $el.outerHeight();
         callback();
       };
       image.src = $img.attr('src');
     } else {
-      el.verticalSpace = $el.outerHeight() + fixedOffset;
+      el.verticalSpace = $el.outerHeight(true);
       el.height = $el.outerHeight();
       callback();
     }

--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -12,7 +12,6 @@
     this._appliedClass = null;
     this._$shim = null;
     this._stopped = false;
-    this.scrolledFrom = this._sticky.getScrolledFrom($el);
   };
   StickyElement.prototype.stickyClass = function () {
     return (this._sticky._initialPositionsSet) ? this._fixedClass : this._initialFixedClass;
@@ -106,9 +105,15 @@
   };
   Sticky.prototype.setElementDimensions = function (el, callback) {
     var self = this;
+    var $el = el.$fixedEl;
     var onHeightSet = function () {
       el.scrolledTo = self.getScrollingTo(el);
-      el.updateShim(el);
+      // if element is shim'ed, pass changes in dimension on to the shim
+      if (el._$shim) {
+        el.updateShim();
+        $el = el._$shim;
+      }
+      el.scrolledFrom = self.getScrolledFrom($el);
       if (callback !== undefined) {
         callback();
       }

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -36,8 +36,6 @@
 
       this.$form.on('click', 'button.button-secondary', (event) => this.actionButtonClicked(event));
       this.$form.on('change', 'input[type=checkbox]', () => this.templateFolderCheckboxChanged());
-
-      this.render();
     };
 
     this.addCancelButton = function(state) {
@@ -96,6 +94,11 @@
       this.states.forEach(
         state => (state.key === this.currentState ? this.$stickyBottom.append(state.$el) : state.$el.detach())
       );
+
+      // make sticky JS recalculate its cache of the element's position
+      if ('stickAtBottomWhenScrolling' in GOVUK) {
+        GOVUK.stickAtBottomWhenScrolling.recalculate();
+      }
     };
 
     this.nothingSelectedButtons = `


### PR DESCRIPTION
Fixes the following:

## Changes to sticky element content doesn't update stored references

`templateFolderForm.js` updates the content of a sticky element which changes its dimensions. Sticky JS stores data about the element's dimensions and position to reduce DOM queries. This add a public `recalculate` method to force an update.

## Changes to elements when stuck were not being passed to their shim

When elements are stuck to the window they are positioned absolutely so occupy no space in the document flow. We swap their out for a shim in the document to preserve this space.

Updates to any 'stuck' elements are now passed to the shim.

## Broken code for resize events

The code that runs when the window resizes no longer worked and could be replaced with that introduced for the `recalculate`method.