### PR TITLE
Remove WhiteNoise

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,16 +1,6 @@
-import os
-
 from flask import Flask
-from whitenoise import WhiteNoise
-
 from app import create_app
 
-PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-STATIC_ROOT = os.path.join(PROJECT_ROOT, 'app', 'static')
-STATIC_URL = 'static/'
+application = Flask('app')
 
-flask_app = Flask('app')
-
-create_app(flask_app)
-
-application = WhiteNoise(flask_app.wsgi_app, STATIC_ROOT, STATIC_URL, max_age=WhiteNoise.FOREVER)
+create_app(application)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -14,7 +14,6 @@ pyexcel-xlsx==0.5.6
 pyexcel-ods3==0.5.3
 pytz==2018.7
 gunicorn==19.7.1  # >19.8 stops eventlet workers after a timeout
-whitenoise==4.1.2  #manages static assets
 eventlet==0.24.1
 notifications-python-client==5.2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ pyexcel-xlsx==0.5.6
 pyexcel-ods3==0.5.3
 pytz==2018.7
 gunicorn==19.7.1  # >19.8 stops eventlet workers after a timeout
-whitenoise==4.1.2  #manages static assets
 eventlet==0.24.1
 notifications-python-client==5.2.0
 
@@ -29,10 +28,10 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/alphagov/notifications-utils.git@30.7.1#egg=notifications-utils==30.7.1
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.75
+awscli==1.16.80
 bleach==2.1.3
 boto3==1.6.16
-botocore==1.12.65
+botocore==1.12.70
 certifi==2018.11.29
 chardet==3.0.4
 Click==7.0
@@ -76,5 +75,5 @@ urllib3==1.24.1
 webencodings==0.5.1
 Werkzeug==0.14.1
 WTForms==2.2.1
-xlrd==1.1.0
+xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
We’re now serving assets from S3 when running on PaaS. So we’ll set the appropriate caching headers there or in Cloudfront. This means that the app no longer needs to serve cache headers, which is what we were using WhiteNoise for.

This commits removes WhiteNoise in favour of letting Flask handle the serving of static assets.