### PR TITLE
Add error if building the frontend w/out env

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -9,6 +9,10 @@ import gulp from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import stylish from 'jshint-stylish';
 
+if (process.env.NOTIFY_ENVIRONMENT === undefined) {
+  throw 'NOTIFY_ENVIRONMENT is undefined – you need to source environment.sh';
+}
+
 const plugins = loadPlugins(),
 
 // 2. CONFIGURATION


### PR DESCRIPTION
If you build the frontend locally without having `NOTIFY_ENVIRONMENT` set then some of the assets will `404`. If you’re not that familiar with how the frontend works this could be  tricky problem to figure out.

This error will make it easy to figure out what’s gone wrong.