### PR TITLE
Set far-future cache headers on S3 assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ upload-paas-artifact:
 
 .PHONY: upload-static ## Upload the static files to be served from S3
 upload-static:
-	aws s3 cp --region eu-west-1 --recursive ./app/static s3://${DNS_NAME}-static
+	aws s3 cp --region eu-west-1 --recursive --cache-control max-age=315360000,immutable ./app/static s3://${DNS_NAME}-static
 
 .PHONY: test
 test: venv ## Run tests


### PR DESCRIPTION
So that browsers will cache them for as long as possible. We invalidate this cache by adding the hash of each file to the query string.

There’s no way of doing this on a whole bucket; it has to be set on each item. Adding this flag does so at the time of uploading the items.