### PR TITLE
Fix sticky with find as you type

### DIFF
--- a/app/assets/javascripts/liveSearch.js
+++ b/app/assets/javascripts/liveSearch.js
@@ -27,6 +27,12 @@
 
     });
 
+    // make sticky JS recalculate its cache of the element's position
+    // because live search can change the height document
+    if ('stickAtBottomWhenScrolling' in GOVUK) {
+      GOVUK.stickAtBottomWhenScrolling.recalculate();
+    }
+
   };
 
 


### PR DESCRIPTION
It was losing its position because filtering the list of templates with find as you type was causing the height of the page to change.

# Before 

![live-search-sticky-b4](https://user-images.githubusercontent.com/355079/50347679-4e315080-052e-11e9-8102-b1c836f131e4.gif)

# After 

![live-search-sticky](https://user-images.githubusercontent.com/355079/50347686-59847c00-052e-11e9-8f57-cb5f78e9d50f.gif)
