### PR TITLE
Fix z-index on templates page

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -57,7 +57,7 @@
     border: 2px solid $black;
     outline: 1px solid rgba($white, 0.1);
     position: relative;
-    z-index: 1000;
+    z-index: 10;
     color: $text-colour;
 
     &:focus {


### PR DESCRIPTION
The template type selection was accidentally overlapping the sticky footer.

![image](https://user-images.githubusercontent.com/355079/50638224-dd8a2b00-0f54-11e9-9644-d993d512e64e.png)
