### PR TITLE
Don’t show postage to users who can’t choose it

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -21,13 +21,12 @@
                 Send
               </a>
             </div>
-            <div class="column-whole">
-            {% if current_service.has_permission("choose_postage") and template_postage %}
-              <h2 class="heading-small heading-inline">Postage</h2>: {{ template_postage }} class
-            {% elif (current_service.has_permission("choose_postage") and not template_postage) or not current_service.has_permission("choose_postage") %}
-              <h2 class="heading-small heading-inline">Postage</h2>: {{ current_service.postage }} class
+            {% if current_service.has_permission("choose_postage") %}
+              <div class="column-whole" id="postage">
+                <h2 class="heading-small heading-inline">Postage</h2>:
+                {{ template_postage or current_service.postage }} class
+              </div>
             {% endif %}
-            </div>
           {% endif %}
         {% else %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -403,9 +403,13 @@ def test_user_with_only_send_and_view_sees_letter_page(
 
 
 @pytest.mark.parametrize("permissions,template_postage,expected_result", [
-    (["choose_postage", "letter"], "first", "first"),
-    (["choose_postage", "letter"], None, "second"),
-    (["letter"], "first", "second"),
+    (["choose_postage", "letter"], "first", "Postage: first class"),
+    (["choose_postage", "letter"], "second", "Postage: second class"),
+    (["choose_postage", "letter"], None, "Postage: second class"),
+    pytest.param(
+        ["letter"], None, "Postage: second class",
+        marks=pytest.mark.xfail(raises=AttributeError)
+    ),
 ])
 def test_view_letter_template_displays_postage_dynamically_based_on_service_permissions_and_template_postage(
     client_request,
@@ -431,7 +435,7 @@ def test_view_letter_template_displays_postage_dynamically_based_on_service_perm
         template_id=fake_uuid,
     )
 
-    assert "Postage: {} class".format(expected_result) in page.text
+    assert normalize_spaces(page.select_one('#postage').text) == expected_result
 
 
 def test_view_non_letter_template_does_not_display_postage(


### PR DESCRIPTION
If you can’t choose postage on a per-template basis, you shouldn’t be see the thing that indicates that postage can be changed.
