### PR TITLE
Do not format letter statuses on admin app level.

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -67,20 +67,12 @@ class NotificationApiClient(NotifyAdminAPIClient):
         return self.get(url='/service/{}/notifications/{}'.format(service_id, notification_id))
 
     def get_api_notifications_for_service(self, service_id):
-        ret = self.get_notifications_for_service(
+        return self.get_notifications_for_service(
             service_id,
             include_jobs=False,
             include_from_test_key=True,
             include_one_off=False
         )
-        return self.map_letters_to_accepted(ret)
-
-    @staticmethod
-    def map_letters_to_accepted(notifications):
-        for notification in notifications['notifications']:
-            if notification['notification_type'] == 'letter' and notification['status'] in ('created', 'sending'):
-                notification['status'] = 'accepted'
-        return notifications
 
     def get_notification_letter_preview(self, service_id, notification_id, file_type, page=None):
 

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -1,9 +1,6 @@
-import uuid
-
 import pytest
 
 from app.notify_client.notification_api_client import NotificationApiClient
-from tests import notification_json, single_notification_json
 
 
 @pytest.mark.parametrize("arguments,expected_call", [
@@ -65,26 +62,6 @@ def test_get_notification(mocker):
     mock_get.assert_called_once_with(
         url='/service/foo/notifications/bar'
     )
-
-
-def test_get_api_notifications_changes_letter_statuses(mocker):
-    service_id = str(uuid.uuid4())
-    sms_notification = single_notification_json(service_id, notification_type='sms', status='created')
-    email_notification = single_notification_json(service_id, notification_type='email', status='created')
-    letter_notification = single_notification_json(service_id, notification_type='letter', status='created')
-    notis = notification_json(service_id=service_id, rows=0)
-    notis['notifications'] = [sms_notification, email_notification, letter_notification]
-
-    mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get', return_value=notis)
-
-    ret = NotificationApiClient().get_api_notifications_for_service(service_id)
-
-    assert ret['notifications'][0]['notification_type'] == 'sms'
-    assert ret['notifications'][1]['notification_type'] == 'email'
-    assert ret['notifications'][2]['notification_type'] == 'letter'
-    assert ret['notifications'][0]['status'] == 'created'
-    assert ret['notifications'][1]['status'] == 'created'
-    assert ret['notifications'][2]['status'] == 'accepted'
 
 
 def test_update_notification_to_cancelled(mocker):


### PR DESCRIPTION
This work is now done on api level and the data admin app pulls is ready for use.

Here is the API PR: https://github.com/alphagov/notifications-api/pull/2277

Pivotal ticket: https://www.pivotaltracker.com/story/show/162950719