### PR TITLE
Format letter statuses so they make more sense to our users

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -78,8 +78,12 @@ class NotificationApiClient(NotifyAdminAPIClient):
     @staticmethod
     def map_letters_to_accepted(notifications):
         for notification in notifications['notifications']:
-            if notification['notification_type'] == 'letter' and notification['status'] in ('created', 'sending'):
-                notification['status'] = 'accepted'
+            if notification['notification_type'] == 'letter':
+                if notification['status'] in ('created', 'sending'):
+                    notification['status'] = 'accepted'
+
+                if notification['status'] in ('delivered', 'returned-letter'):
+                    notification['status'] = 'received'
         return notifications
 
     def get_notification_letter_preview(self, service_id, notification_id, file_type, page=None):

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -67,11 +67,18 @@ def test_get_notification(mocker):
     )
 
 
-def test_get_api_notifications_changes_letter_statuses(mocker):
+@pytest.mark.parametrize("letter_status, expected_status", [
+    ('created', 'accepted'),
+    ('sending', 'accepted'),
+    ('delivered', 'received'),
+    ('returned-letter', 'received'),
+    ("technical-failure", "technical-failure")
+])
+def test_get_api_notifications_changes_letter_statuses(mocker, letter_status, expected_status):
     service_id = str(uuid.uuid4())
     sms_notification = single_notification_json(service_id, notification_type='sms', status='created')
     email_notification = single_notification_json(service_id, notification_type='email', status='created')
-    letter_notification = single_notification_json(service_id, notification_type='letter', status='created')
+    letter_notification = single_notification_json(service_id, notification_type='letter', status=letter_status)
     notis = notification_json(service_id=service_id, rows=0)
     notis['notifications'] = [sms_notification, email_notification, letter_notification]
 
@@ -84,7 +91,7 @@ def test_get_api_notifications_changes_letter_statuses(mocker):
     assert ret['notifications'][2]['notification_type'] == 'letter'
     assert ret['notifications'][0]['status'] == 'created'
     assert ret['notifications'][1]['status'] == 'created'
-    assert ret['notifications'][2]['status'] == 'accepted'
+    assert ret['notifications'][2]['status'] == expected_status
 
 
 def test_update_notification_to_cancelled(mocker):


### PR DESCRIPTION
status 'delivered' doesn't really mean that the letter was delivered to the addressee, only that it was moved on to DVLA, so we want the status that we show to our users to reflect that.

Pivotal ticket: https://www.pivotaltracker.com/story/show/162310324