### PR TITLE
Show better error message if precompiled letters can't be opened

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -373,7 +373,8 @@ def format_notification_status(status, template_type):
             'pending-virus-check': 'Pending virus check',
             'virus-scan-failed': 'Virus detected',
             'returned-letter': 'Delivered',
-            'cancelled': 'Cancelled,'
+            'cancelled': 'Cancelled,',
+            'validation-failed': 'Validation failed',
         }
     }[template_type].get(status, status)
 

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -157,12 +157,12 @@
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
         <a href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
       {% endif %}
-      {% if notification['notification_type'] != "letter" or notification.status == 'virus-scan-failed' %}
+      {% if notification['notification_type'] != "letter" or notification.status in ('virus-scan-failed', 'validation-failed') %}
         {{ notification.status|format_notification_status(
           notification.template.template_type
         ) }}
       {% endif %}
-      {% if notification.notification_type == "letter" and notification.status in ['permanent-failure', 'validation-failed', 'cancelled'] %}
+      {% if notification.notification_type == "letter" and notification.status in ['permanent-failure', 'cancelled'] %}
         Cancelled
       {% endif %}
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}

--- a/app/templates/views/notifications/invalid_precompiled_letter.html
+++ b/app/templates/views/notifications/invalid_precompiled_letter.html
@@ -1,0 +1,17 @@
+{% extends "withnav_template.html" %}
+
+{% block service_page_title %}
+  Letter
+{% endblock %}
+
+{% block maincolumn_content %}
+
+    <h1 class="heading-large">Letter</h1>
+
+    <p>
+      Provided as PDF on {{ created_at|format_datetime_short }}
+    </p>
+    <p class="notification-status-cancelled">
+      Couldn’t read this file
+    </p>
+{% endblock %}

--- a/app/templates/views/notifications/invalid_precompiled_letter.html
+++ b/app/templates/views/notifications/invalid_precompiled_letter.html
@@ -12,6 +12,6 @@
       Provided as PDF on {{ created_at|format_datetime_short }}
     </p>
     <p class="notification-status-cancelled">
-      Couldn’t read this file
+      Validation failed – this isn’t a PDF file that Notify can read
     </p>
 {% endblock %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -16,7 +16,7 @@
 
     <p>
       {% if is_precompiled_letter %}
-      Provided as PDF, sent
+      Provided as PDF
       {% else %}
         {% if help %}
           ‘{{ template.name }}’
@@ -43,8 +43,7 @@
         </p>
       {% elif notification_status == 'validation-failed' %}
         <p class="notification-status-cancelled">
-          Cancelled {{ updated_at|format_datetime_short }}
-          (letter has content outside the printable area)
+          Validation failed – content is outside the printable area
         </p>
       {% else %}
         <p>

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -602,10 +602,10 @@ def test_big_numbers_and_search_dont_show_for_letters(
         ('sms', 'delivered', 'Delivered 27 September at 5:31pm', True),
         ('letter', 'delivered', '27 September at 5:30pm', True),
         ('letter', 'permanent-failure', 'Cancelled 27 September at 5:31pm', False),
-        ('letter', 'validation-failed', 'Cancelled 27 September at 5:30pm', False),
+        ('letter', 'validation-failed', 'Validation failed 27 September at 5:30pm', False),
     ]
 )
-def test_sending_status_hint_does_not_include_status_for_letters(
+def test_sending_status_hint_displays_correctly_on_notifications_page(
     client_request,
     service_one,
     active_user_with_permissions,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -202,7 +202,7 @@ def test_notification_page_shows_page_for_letter_notification(
     ),
     (
         'validation-failed',
-        'Cancelled 1 January at 1:02am (letter has content outside the printable area)',
+        'Validation failed – content is outside the printable area',
     ),
 ))
 @freeze_time("2016-01-01 01:01")
@@ -426,7 +426,7 @@ def test_notifification_page_shows_error_message_if_precompiled_letter_cannot_be
     )
 
     error_message = page.find('p', class_='notification-status-cancelled').text
-    assert normalize_spaces(error_message) == "Couldn’t read this file"
+    assert normalize_spaces(error_message) == "Validation failed – this isn’t a PDF file that Notify can read"
 
 
 def test_should_404_for_unknown_extension(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -7,6 +7,7 @@ import pytest
 from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import APIError
+from PyPDF2.utils import PdfReadError
 
 from app.main.views.notifications import get_letter_printing_statement
 from tests.conftest import (
@@ -396,6 +397,36 @@ def test_should_show_preview_error_image_letter_notification_on_preview_error(
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'preview error image'
+
+
+def test_notifification_page_shows_error_message_if_precompiled_letter_cannot_be_opened(
+    client_request,
+    mocker,
+    fake_uuid,
+):
+    mock_get_notification(
+        mocker,
+        fake_uuid,
+        notification_status='validation-failed',
+        template_type='letter',
+        is_precompiled_letter=True,
+    )
+    mocker.patch(
+        'app.main.views.notifications.view_letter_notification_as_preview',
+        side_effect=PdfReadError()
+    )
+    mocker.patch(
+        'app.main.views.notifications.pdf_page_count',
+        side_effect=PdfReadError()
+    )
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    error_message = page.find('p', class_='notification-status-cancelled').text
+    assert normalize_spaces(error_message) == "Couldn’t read this file"
 
 
 def test_should_404_for_unknown_extension(


### PR DESCRIPTION
Changed how notifications with the status of `validation-failed` are displayed in the table showing all letters - this used to say 'Cancelled' and now says 'Validation failed'

Added a custom page to be shown if a precompiled letter can't be opened, e.g. because the PDF has no EOF marker or because the file is not a PDF. (Previously we would show the `500` status page.)

Changed the error message for precompiled letters which fail validation due to content outside the printable area.

### Letter table after the changes
<img width="819" alt="screen shot 2019-01-09 at 13 14 52" src="https://user-images.githubusercontent.com/12881990/50901725-eecdae80-1410-11e9-89b2-b205b2246657.png">

### Validation failed - file can't be opened
<img width="789" alt="screen shot 2019-01-09 at 13 19 07" src="https://user-images.githubusercontent.com/12881990/50901837-39e7c180-1411-11e9-8b2e-1ee8aa7f2a84.png">

### Validation failed - content outside the margins
<img width="833" alt="screen shot 2019-01-09 at 13 18 48" src="https://user-images.githubusercontent.com/12881990/50901826-348a7700-1411-11e9-8ba4-5f83d5dfbdd0.png">

