### PR TITLE
Add Comhairle nan Eilean Siar to domains list

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -1282,6 +1282,10 @@ colwyn-tc.gov.uk:
   owner: Bay of Colwyn Town Council
   crown: false
   agreement_signed: false
+cne-siar.gov.uk:
+  owner: Comhairle nan Eilean Siar 
+  crown: false
+  agreement_signed: false
 congleton-tc.gov.uk:
   owner: Congleton Town Council
   crown: false


### PR DESCRIPTION
Comhairle nan Eilean Siar (Scottish Gaelic pronunciation: [ˈkʰõ.ərˠʎə nə ˈɲelan ˈʃiəɾ]) is the local government council for Na h-Eileanan Siar council area of Scotland, comprising the Outer Hebrides.