### PR TITLE
Cancelled notifications do not show as failures on dashboard stats

### DIFF
--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -34,8 +34,7 @@
   link=None,
   show_failures=True,
   smaller=False,
-  smallest=False,
-  failed_as_cancelled=False
+  smallest=False
 ) %}
   <div class="big-number-with-status">
     {{ big_number(number, label, link=link, smaller=smaller, smallest=smallest) }}
@@ -45,26 +44,14 @@
           {% if failure_link %}
             <a href="{{ failure_link }}">
               {{ "{:,}".format(failures) }}
-              {% if failed_as_cancelled %}
-                cancelled
-              {% else %}
-                failed – {{ failure_percentage }}%
-              {% endif %}
+              failed – {{ failure_percentage }}%
             </a>
           {% else %}
             {{ "{:,}".format(failures) }}
-            {% if failed_as_cancelled %}
-              cancelled
-            {% else %}
-              failed – {{ failure_percentage }}%
-            {% endif %}
+            failed – {{ failure_percentage }}%
           {% endif %}
         {% else %}
-          {% if failed_as_cancelled %}
-            0 cancelled
-          {% else %}
-            No failures
-          {% endif %}
+          No failures
         {% endif %}
       </div>
     {% endif %}

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -37,8 +37,7 @@
           statistics['letter']['show_warning'],
           failure_link=url_for(".view_notifications", service_id=service_id, message_type='letter', status='failed'),
           link=url_for(".view_notifications", service_id=service_id, message_type='letter', status=''),
-          smaller=smaller_font_size,
-          failed_as_cancelled=True
+          smaller=smaller_font_size
         ) }}
       </div>
     {% endif %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -5,8 +5,13 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/form.html" import form_wrapper %}
 
+{% set title_status = (
+  'Failed '
+  if status == 'failed' and message_type == 'letter'
+  else ''
+) %}
 {% set page_title = (
-  message_count_label(99, message_type, suffix='') | capitalize
+  (title_status + message_count_label(99, message_type, suffix='')) | capitalize
   if current_user.has_permissions('view_activity')
   else 'Sent messages'
 ) %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -40,7 +40,7 @@ from werkzeug.datastructures import MultiDict
 SENDING_STATUSES = ['created', 'pending', 'sending', 'pending-virus-check']
 DELIVERED_STATUSES = ['delivered', 'sent', 'returned-letter']
 FAILURE_STATUSES = ['failed', 'temporary-failure', 'permanent-failure',
-                    'technical-failure', 'virus-scan-failed']
+                    'technical-failure', 'virus-scan-failed', 'validation-failed']
 REQUESTED_STATUSES = SENDING_STATUSES + DELIVERED_STATUSES + FAILURE_STATUSES
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -40,7 +40,7 @@ from werkzeug.datastructures import MultiDict
 SENDING_STATUSES = ['created', 'pending', 'sending', 'pending-virus-check']
 DELIVERED_STATUSES = ['delivered', 'sent', 'returned-letter']
 FAILURE_STATUSES = ['failed', 'temporary-failure', 'permanent-failure',
-                    'technical-failure', 'virus-scan-failed', 'cancelled']
+                    'technical-failure', 'virus-scan-failed']
 REQUESTED_STATUSES = SENDING_STATUSES + DELIVERED_STATUSES + FAILURE_STATUSES
 
 

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -53,7 +53,7 @@ from tests.conftest import (
                 'created', 'pending', 'sending', 'pending-virus-check',
                 'delivered', 'sent', 'returned-letter',
                 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
-                'virus-scan-failed', 'cancelled',
+                'virus-scan-failed',
             ]
         ),
         (
@@ -66,7 +66,7 @@ from tests.conftest import (
         ),
         (
             'failed',
-            ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed', 'cancelled']
+            ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed']
         )
     ]
 )

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -53,7 +53,7 @@ from tests.conftest import (
                 'created', 'pending', 'sending', 'pending-virus-check',
                 'delivered', 'sent', 'returned-letter',
                 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
-                'virus-scan-failed',
+                'virus-scan-failed', 'validation-failed'
             ]
         ),
         (
@@ -66,7 +66,10 @@ from tests.conftest import (
         ),
         (
             'failed',
-            ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed']
+            [
+                'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
+                'virus-scan-failed', 'validation-failed'
+            ]
         )
     ]
 )

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -157,7 +157,7 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
                 'created', 'pending', 'sending', 'pending-virus-check',
                 'delivered', 'sent', 'returned-letter',
                 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
-                'virus-scan-failed', 'cancelled',
+                'virus-scan-failed',
             ]
         ),
         (
@@ -170,7 +170,7 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
         ),
         (
             'failed',
-            ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed', 'cancelled']
+            ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed']
         )
     ]
 )
@@ -340,7 +340,6 @@ def test_should_show_letter_job(
             'permanent-failure',
             'technical-failure',
             'virus-scan-failed',
-            'cancelled',
         ],
     )
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -157,7 +157,7 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
                 'created', 'pending', 'sending', 'pending-virus-check',
                 'delivered', 'sent', 'returned-letter',
                 'failed', 'temporary-failure', 'permanent-failure', 'technical-failure',
-                'virus-scan-failed',
+                'virus-scan-failed', 'validation-failed'
             ]
         ),
         (
@@ -170,7 +170,10 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
         ),
         (
             'failed',
-            ['failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed']
+            [
+                'failed', 'temporary-failure', 'permanent-failure', 'technical-failure', 'virus-scan-failed',
+                'validation-failed'
+            ]
         )
     ]
 )
@@ -340,6 +343,7 @@ def test_should_show_letter_job(
             'permanent-failure',
             'technical-failure',
             'virus-scan-failed',
+            'validation-failed'
         ],
     )
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -202,7 +202,11 @@ def test_notification_page_shows_page_for_letter_notification(
     ),
     (
         'validation-failed',
+<<<<<<< HEAD
         'Validation failed – content is outside the printable area',
+=======
+        'Can’t print this letter – content is outside the printable area.',
+>>>>>>> Cancelled notifications do not show as failures on dashboard stats
     ),
 ))
 @freeze_time("2016-01-01 01:01")

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -191,24 +191,11 @@ def test_notification_page_shows_page_for_letter_notification(
     assert mock_page_count.call_args_list[0][1]['values'] == {'name': 'Jo'}
 
 
-@pytest.mark.parametrize('notification_status, expected_message', (
-    (
-        'permanent-failure',
-        'Cancelled 1 January at 1:02am',
-    ),
-    (
-        'cancelled',
-        'Cancelled 1 January at 1:02am',
-    ),
-    (
-        'validation-failed',
-<<<<<<< HEAD
-        'Validation failed – content is outside the printable area',
-=======
-        'Can’t print this letter – content is outside the printable area.',
->>>>>>> Cancelled notifications do not show as failures on dashboard stats
-    ),
-))
+@pytest.mark.parametrize('notification_status, expected_message', [
+    ('permanent-failure', 'Cancelled 1 January at 1:02am'),
+    ('cancelled', 'Cancelled 1 January at 1:02am'),
+    ('validation-failed', 'Validation failed – content is outside the printable area'),
+])
 @freeze_time("2016-01-01 01:01")
 def test_notification_page_shows_cancelled_letter(
     client_request,


### PR DESCRIPTION
### Work done:
- instead of cancelled letters, green/red box on on dashboard shows failures
- cancelled letters are not counted as failures
- a page with list of failed letters does not show cancelled letters, and title changed from "Letters" to "Failed letters"
- 'validation-failed' added to FAILURE_STATUSES in admin app, now consistent with api

### To do:
- Release together with this API PR: https://github.com/alphagov/notifications-api/pull/2290 (API released now 👍 )
- Update api documentation with description of "cancelled" status

### Pivotal ticket:
https://www.pivotaltracker.com/n/projects/1443052

### Screenshots
![screen shot 2019-01-09 at 13 08 04](https://user-images.githubusercontent.com/20957548/50901396-f6408800-140f-11e9-9a47-3fa93596d6e3.png)
   
   
   
![screen shot 2019-01-09 at 13 08 21](https://user-images.githubusercontent.com/20957548/50901395-f5a7f180-140f-11e9-89d2-a6ebf7db9fcd.png)