### PR TITLE
Add Scottish Parliament to list of government email addresses

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -5,6 +5,7 @@
 - ddc-mod.org
 - slc.co.uk
 - gov.scot
+- parliament.scot
 - parliament.uk
 - nhs.uk
 - nhs.net


### PR DESCRIPTION
We have the Welsh and UK parliaments already.

Northern Ireland’s devolved legislature use `niassembly.gov.uk`, so they’re covered by virtue of their domain ending in .gov.uk