### PR TITLE
Fix display of permanent failure on notifications page

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -144,7 +144,7 @@
 
 {% macro notification_status_field(notification) %}
 
-  {% set displayed_on_single_line = notification.status in ['created', 'pending', 'pending-virus-check', 'sending', 'sent', 'delivered', 'returned-letter', 'accepted', 'received', 'permanent-failure'] %}
+  {% set displayed_on_single_line = notification.status in ['created', 'pending', 'pending-virus-check', 'sending', 'sent', 'delivered', 'returned-letter', 'accepted', 'received'] %}
 
   {% if not notification %}
     {% call field(align='right') %}{% endcall %}

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -601,14 +601,25 @@ def test_big_numbers_and_search_dont_show_for_letters(
 @freeze_time("2017-09-27 16:30:00.000000")
 @pytest.mark.parametrize(
     "message_type, status, expected_hint_status, single_line", [
+        ('email', 'created', 'Sending since 27 September at 5:30pm', True),
+        ('email', 'sending', 'Sending since 27 September at 5:30pm', True),
+        ('email', 'temporary-failure', 'Inbox not accepting messages right now 27 September at 5:31pm', False),
+        ('email', 'permanent-failure', 'Email address doesn’t exist 27 September at 5:31pm', False),
         ('email', 'delivered', 'Delivered 27 September at 5:31pm', True),
+        ('sms', 'created', 'Sending since 27 September at 5:30pm', True),
+        ('sms', 'sending', 'Sending since 27 September at 5:30pm', True),
+        ('sms', 'temporary-failure', 'Phone not accepting messages right now 27 September at 5:31pm', False),
+        ('sms', 'permanent-failure', 'Phone number doesn’t exist 27 September at 5:31pm', False),
         ('sms', 'delivered', 'Delivered 27 September at 5:31pm', True),
         ('letter', 'created', '27 September at 5:30pm', True),
+        ('letter', 'pending-virus-check', '27 September at 5:30pm', True),
         ('letter', 'sending', '27 September at 5:30pm', True),
         ('letter', 'delivered', '27 September at 5:30pm', True),
         ('letter', 'received', '27 September at 5:30pm', True),
         ('letter', 'accepted', '27 September at 5:30pm', True),
-        ('letter', 'permanent-failure', '27 September at 5:31pm', True),
+        ('letter', 'cancelled', '27 September at 5:30pm', False),  # The API won’t return cancelled letters
+        ('letter', 'permanent-failure', '27 September at 5:31pm', False),  # Deprecated for ‘cancelled’
+        ('letter', 'temporary-failure', '27 September at 5:30pm', False),  # Not currently a real letter status
         ('letter', 'virus-scan-failed', 'Virus detected 27 September at 5:30pm', False),
         ('letter', 'validation-failed', 'Validation failed 27 September at 5:30pm', False),
         ('letter', 'technical-failure', 'Technical failure 27 September at 5:30pm', False),


### PR DESCRIPTION
It had too much whitespace because it was accidentally being given the wrong class.

This commit undoes the change that caused it (which was while working on letters) and beefs up our tests for email and text messages (so if this happened again the tests would catch it).