### PR TITLE
 Add support for new template statistics API response

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -268,8 +268,9 @@ def get_inbox_partials(service_id):
 
 def aggregate_template_usage(template_statistics, sort_key='count'):
     templates = []
+    template_statistics = [s for s in template_statistics if s.get("status") != "cancelled"]
     for k, v in groupby(sorted(template_statistics, key=lambda x: x['template_id']), key=lambda x: x['template_id']):
-        template_stats = [s for s in v if s.get('status') != 'cancelled']
+        template_stats = list(v)
 
         templates.append({
             "template_id": k,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,6 +1,7 @@
 import calendar
 from datetime import datetime
 from functools import partial
+from itertools import groupby
 
 from flask import (
     Response,
@@ -265,16 +266,24 @@ def get_inbox_partials(service_id):
     )}
 
 
-def aggregate_usage(template_statistics, sort_key='count'):
-    return sorted(
-        template_statistics,
-        key=lambda template_statistic: template_statistic[sort_key],
-        reverse=True
-    )
+def aggregate_template_usage(template_statistics, sort_key='count'):
+    templates = []
+    for k, v in groupby(sorted(template_statistics, key=lambda x: x['template_id']), key=lambda x: x['template_id']):
+        template_stats = [s for s in v if s.get('status') != 'cancelled']
+
+        templates.append({
+            "template_id": k,
+            "template_name": template_stats[0]['template_name'],
+            "template_type": template_stats[0]['template_type'],
+            "is_precompiled_letter": template_stats[0]['is_precompiled_letter'],
+            "count": sum(s['count'] for s in template_stats)
+        })
+
+    return sorted(templates, key=lambda x: x[sort_key], reverse=True)
 
 
 def get_dashboard_partials(service_id):
-    template_statistics = aggregate_usage(
+    template_statistics = aggregate_template_usage(
         template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     )
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -35,19 +35,22 @@ stub_template_stats = [
         'template_type': 'sms',
         'template_name': 'one',
         'template_id': 'id-1',
-        'count': 100
+        'count': 100,
+        'is_precompiled_letter': False
     },
     {
         'template_type': 'email',
         'template_name': 'two',
         'template_id': 'id-2',
-        'count': 200
+        'count': 200,
+        'is_precompiled_letter': False
     },
     {
         'template_type': 'letter',
         'template_name': 'three',
         'template_id': 'id-3',
-        'count': 300
+        'count': 300,
+        'is_precompiled_letter': False
     },
     {
         'template_type': 'letter',
@@ -1033,8 +1036,8 @@ def test_route_for_service_permissions(
 
 
 def test_aggregate_template_stats():
-    from app.main.views.dashboard import aggregate_usage
-    expected = aggregate_usage(copy.deepcopy(stub_template_stats))
+    from app.main.views.dashboard import aggregate_template_usage
+    expected = aggregate_template_usage(copy.deepcopy(stub_template_stats))
 
     assert len(expected) == 4
     assert expected[0]['template_name'] == 'four'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2268,7 +2268,7 @@ def mock_get_template_statistics(mocker, service_one, fake_uuid):
         "template_name": template['name'],
         "template_type": template['template_type'],
         "template_id": template['id'],
-        "day": "2016-04-04"
+        "is_precompiled_letter": False
     }
 
     def _get_stats(service_id, limit_days=None):


### PR DESCRIPTION
The new API response for template statistics returns separate
count for each status. We get rid of template stats for cancelled
notifications and group the rest of the statuses together.

Needs to be deployed before the API changes: https://github.com/alphagov/notifications-api/pull/2303

Pivotal ticket: https://www.pivotaltracker.com/story/show/163153273