### PR TITLE
Stop automatically resending email verification links

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -2,7 +2,6 @@ import json
 
 from flask import (
     current_app,
-    flash,
     redirect,
     render_template,
     request,
@@ -42,25 +41,14 @@ def two_factor_email(token):
             current_app.config['EMAIL_2FA_EXPIRY_SECONDS']
         ))
     except SignatureExpired:
-        # lets decode again, without the expiry, to get the user id out
-        orig_data = json.loads(check_token(
-            token,
-            current_app.config['SECRET_KEY'],
-            current_app.config['DANGEROUS_SALT'],
-            None
-        ))
-        session['user_details'] = {'id': orig_data['user_id']}
-        flash("The link in the email we sent you has expired. We’ve sent you a new one.")
-        return redirect(url_for('.resend_email_link'))
+        return render_template('views/email-link-invalid.html')
 
     user_id = token_data['user_id']
     # checks if code was already used
     logged_in, msg = user_api_client.check_verify_code(user_id, token_data['secret_code'], "email")
 
     if not logged_in:
-        flash("This link has already been used")
-        session['user_details'] = {'id': user_id}
-        return redirect(url_for('.resend_email_link'))
+        return render_template('views/email-link-invalid.html')
     return log_in_user(user_id)
 
 

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -129,13 +129,7 @@ class UserApiClient(NotifyAdminAPIClient):
             return True, ''
         except HTTPError as e:
             if e.status_code == 400 or e.status_code == 404:
-                if 'Code not found' in e.message:
-                    return False, 'Code not found'
-                elif 'Code has expired' in e.message:
-                    return False, 'Code has expired'
-                else:
-                    # TODO what is the default message?
-                    return False, 'Code not found'
+                return False, e.message
             raise e
 
     def get_users_for_service(self, service_id):

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -1,0 +1,19 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block per_page_title %}
+  Invalid email link
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">The link has expired</h1>
+
+    <p><a href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -235,11 +235,8 @@ def test_two_factor_email_link_has_expired(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-    assert normalize_spaces(
-        page.select_one('.banner-dangerous').text
-    ) == "The link in the email we sent you has expired. We’ve sent you a new one."
-    assert page.h1.text.strip() == 'Email resent'
-    mock_send_verify_code.assert_called_once_with(fake_uuid, 'email', None)
+    assert page.h1.text.strip() == 'The link has expired'
+    mock_send_verify_code.assert_not_called
 
 
 def test_two_factor_email_link_is_invalid(
@@ -272,10 +269,10 @@ def test_two_factor_email_link_is_already_used(
     )
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert normalize_spaces(
-        page.select_one('.banner-dangerous').text
-    ) == "This link has already been used"
     assert response.status_code == 200
+
+    assert page.h1.text.strip() == 'The link has expired'
+    mock_send_verify_code.assert_not_called
 
 
 def test_two_factor_email_link_when_user_is_locked_out(
@@ -292,10 +289,10 @@ def test_two_factor_email_link_when_user_is_locked_out(
     )
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert normalize_spaces(
-        page.select_one('.banner-dangerous').text
-    ) == "This link has already been used"
     assert response.status_code == 200
+
+    assert page.h1.text.strip() == 'The link has expired'
+    mock_send_verify_code.assert_not_called
 
 
 def test_two_factor_email_link_used_when_user_already_logged_in(


### PR DESCRIPTION
This commit stops a new email verification link from being sent to a
user if they click on an email link which has expired or which has
already been used. Instead, they will be see an error message with a
link to the sign in page. This stops the situation where someone could
log in indefinitely (without the needing to enter their password) by
trying to use a used / expired email verification link and receiving a
new, valid link automatically.

#### Page seen when trying to use a link that has expired / already been used
<img width="1067" alt="screen shot 2019-01-17 at 11 05 58" src="https://user-images.githubusercontent.com/12881990/51314594-08da4300-1a48-11e9-995a-90e6e3596f9d.png">
