### PR TITLE
Hide ‘back to …’ link if it’s not your service

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -151,8 +151,11 @@ class User(UserMixin):
     def has_permission_for_service(self, service_id, permission):
         return permission in self._permissions.get(service_id, [])
 
+    def belongs_to_service(self, service_id):
+        return str(service_id) in self.services
+
     def belongs_to_service_or_403(self, service_id):
-        if str(service_id) not in self.services:
+        if not self.belongs_to_service(service_id):
             abort(403)
 
     def is_locked(self):

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -2,7 +2,7 @@
 
 {% block fullwidth_content %}
   <div id="content">
-    {% if current_service and current_user.is_authenticated %}
+    {% if current_service and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}
     <div class="navigation-service">
       <a href="{{ url_for('main.show_accounts_or_dashboard') }}">Back to {{ current_service.name }}</a>
     </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,11 @@ def service_one(api_user_active):
 
 
 @pytest.fixture(scope='function')
+def service_two(api_user_active):
+    return service_json(SERVICE_TWO_ID, 'service two', [api_user_active.id])
+
+
+@pytest.fixture(scope='function')
 def multiple_reply_to_email_addresses(mocker):
     def _get(service_id):
         return [


### PR DESCRIPTION
This can happen if you click a link for a service you don’t have access to. We shouldn’t show the back to service link in this case because:
- you shouldn’t be able to find out the service’s name from just knowing the link
- if you click the link you only get a `403` anyway