### PR TITLE
Fix spacing and overflow on breaking change page

### DIFF
--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -46,7 +46,7 @@
     column{{ 's' if column_headings|length > 1 else '' }} of data:
   </p>
 
-  <div class="spreadsheet">
+  <div class="spreadsheet fullscreen-content" data-module="fullscreen-table"">
     {% call(item, row_number) list_table(
       example_rows,
       caption="Example",

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -64,6 +64,6 @@
     {% endcall %}
   </div>
 
-  <p>Developers, you’ll need to update your API calls</p>
+  <p class="top-gutter">Developers, you’ll need to update your API calls</p>
 
 {% endblock %}


### PR DESCRIPTION
Quick fix so it looks a bit less… broken.

# Before 

![image](https://user-images.githubusercontent.com/355079/51240246-3dc89600-1973-11e9-98da-0b80a879ec81.png)

# After 

![image](https://user-images.githubusercontent.com/355079/51240707-3655bc80-1974-11e9-9e85-cae5c98b37a7.png)
