### PR TITLE
 Use single api call for service notification stats and template usage stats

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -268,8 +268,9 @@ def get_inbox_partials(service_id):
 
 def aggregate_template_usage(template_statistics, sort_key='count'):
     templates = []
+    template_statistics = [s for s in template_statistics if s.get("status") != "cancelled"]
     for k, v in groupby(sorted(template_statistics, key=lambda x: x['template_id']), key=lambda x: x['template_id']):
-        template_stats = [s for s in v if s.get('status') != 'cancelled']
+        template_stats = list(v)
 
         templates.append({
             "template_id": k,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,6 +1,7 @@
 import calendar
 from datetime import datetime
 from functools import partial
+from itertools import groupby
 
 from flask import (
     Response,
@@ -265,16 +266,24 @@ def get_inbox_partials(service_id):
     )}
 
 
-def aggregate_usage(template_statistics, sort_key='count'):
-    return sorted(
-        template_statistics,
-        key=lambda template_statistic: template_statistic[sort_key],
-        reverse=True
-    )
+def aggregate_template_usage(template_statistics, sort_key='count'):
+    templates = []
+    for k, v in groupby(sorted(template_statistics, key=lambda x: x['template_id']), key=lambda x: x['template_id']):
+        template_stats = [s for s in v if s.get('status') != 'cancelled']
+
+        templates.append({
+            "template_id": k,
+            "template_name": template_stats[0]['template_name'],
+            "template_type": template_stats[0]['template_type'],
+            "is_precompiled_letter": template_stats[0]['is_precompiled_letter'],
+            "count": sum(s['count'] for s in template_stats)
+        })
+
+    return sorted(templates, key=lambda x: x[sort_key], reverse=True)
 
 
 def get_dashboard_partials(service_id):
-    template_statistics = aggregate_usage(
+    template_statistics = aggregate_template_usage(
         template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     )
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -28,6 +28,7 @@ from app import (
 from app.main import main
 from app.statistics_utils import add_rate_to_job, get_formatted_percentage
 from app.utils import (
+    DELIVERED_STATUSES,
     FAILURE_STATUSES,
     REQUESTED_STATUSES,
     Spreadsheet,
@@ -266,9 +267,13 @@ def get_inbox_partials(service_id):
     )}
 
 
+def filter_out_cancelled_stats(template_statistics):
+    return [s for s in template_statistics if s["status"] != "cancelled"]
+
+
 def aggregate_template_usage(template_statistics, sort_key='count'):
+    template_statistics = filter_out_cancelled_stats(template_statistics)
     templates = []
-    template_statistics = [s for s in template_statistics if s["status"] != "cancelled"]
     for k, v in groupby(sorted(template_statistics, key=lambda x: x['template_id']), key=lambda x: x['template_id']):
         template_stats = list(v)
 
@@ -283,10 +288,26 @@ def aggregate_template_usage(template_statistics, sort_key='count'):
     return sorted(templates, key=lambda x: x[sort_key], reverse=True)
 
 
+def aggregate_notifications_stats(template_statistics):
+    template_statistics = filter_out_cancelled_stats(template_statistics)
+    notifications = {
+        template_type: {
+            status: 0 for status in ('requested', 'delivered', 'failed')
+        } for template_type in current_service.TEMPLATE_TYPES
+    }
+    for stat in template_statistics:
+        notifications[stat["template_type"]]["requested"] += stat["count"]
+        if stat["status"] in DELIVERED_STATUSES:
+            notifications[stat["template_type"]]["delivered"] += stat["count"]
+        elif stat["status"] in FAILURE_STATUSES:
+            notifications[stat["template_type"]]["failed"] += stat["count"]
+
+    return notifications
+
+
 def get_dashboard_partials(service_id):
-    template_statistics = aggregate_template_usage(
-        template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
-    )
+    all_statistics = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
+    template_statistics = aggregate_template_usage(all_statistics)
 
     scheduled_jobs, immediate_jobs = [], []
     if job_api_client.has_jobs(service_id):
@@ -296,7 +317,7 @@ def get_dashboard_partials(service_id):
             for job in job_api_client.get_immediate_jobs(service_id)
         ]
 
-    stats = service_api_client.get_service_statistics(service_id, today_only=False)
+    stats = aggregate_notifications_stats(all_statistics)
     column_width, max_notifiction_count = get_column_properties(
         number_of_columns=(
             3 if current_service.has_permission('letter') else 2

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -268,7 +268,7 @@ def get_inbox_partials(service_id):
 
 def aggregate_template_usage(template_statistics, sort_key='count'):
     templates = []
-    template_statistics = [s for s in template_statistics if s.get("status") != "cancelled"]
+    template_statistics = [s for s in template_statistics if s["status"] != "cancelled"]
     for k, v in groupby(sorted(template_statistics, key=lambda x: x['template_id']), key=lambda x: x['template_id']):
         template_stats = list(v)
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -293,7 +293,7 @@ def aggregate_notifications_stats(template_statistics):
     notifications = {
         template_type: {
             status: 0 for status in ('requested', 'delivered', 'failed')
-        } for template_type in current_service.TEMPLATE_TYPES
+        } for template_type in ["sms", "email", "letter"]
     }
     for stat in template_statistics:
         notifications[stat["template_type"]]["requested"] += stat["count"]

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -10,7 +10,9 @@ from flask import url_for
 from freezegun import freeze_time
 
 from app.main.views.dashboard import (
+    aggregate_notifications_stats,
     aggregate_status_types,
+    aggregate_template_usage,
     format_monthly_stats_to_list,
     format_template_stats_to_list,
     get_dashboard_totals,
@@ -44,7 +46,15 @@ stub_template_stats = [
         'template_name': 'two',
         'template_id': 'id-2',
         'status': 'created',
-        'count': 200,
+        'count': 100,
+        'is_precompiled_letter': False
+    },
+    {
+        'template_type': 'email',
+        'template_name': 'two',
+        'template_id': 'id-2',
+        'status': 'technical-failure',
+        'count': 100,
         'is_precompiled_letter': False
     },
     {
@@ -1064,9 +1074,7 @@ def test_route_for_service_permissions(
 
 
 def test_aggregate_template_stats():
-    from app.main.views.dashboard import aggregate_template_usage
     expected = aggregate_template_usage(copy.deepcopy(stub_template_stats))
-
     assert len(expected) == 4
     assert expected[0]['template_name'] == 'four'
     assert expected[0]['count'] == 400
@@ -1084,6 +1092,15 @@ def test_aggregate_template_stats():
     assert expected[3]['count'] == 100
     assert expected[3]['template_id'] == 'id-1'
     assert expected[3]['template_type'] == 'sms'
+
+
+def test_aggregate_notifications_stats():
+    expected = aggregate_notifications_stats(copy.deepcopy(stub_template_stats))
+    assert expected == {
+        "sms": {"requested": 100, "delivered": 50, "failed": 0},
+        "letter": {"requested": 700, "delivered": 700, "failed": 0},
+        "email": {"requested": 200, "delivered": 0, "failed": 100}
+    }
 
 
 def test_service_dashboard_updates_gets_dashboard_totals(

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -35,19 +35,22 @@ stub_template_stats = [
         'template_type': 'sms',
         'template_name': 'one',
         'template_id': 'id-1',
-        'count': 100
+        'count': 100,
+        'is_precompiled_letter': False
     },
     {
         'template_type': 'email',
         'template_name': 'two',
         'template_id': 'id-2',
-        'count': 200
+        'count': 200,
+        'is_precompiled_letter': False
     },
     {
         'template_type': 'letter',
         'template_name': 'three',
         'template_id': 'id-3',
-        'count': 300
+        'count': 300,
+        'is_precompiled_letter': False
     },
     {
         'template_type': 'letter',
@@ -1033,8 +1036,8 @@ def test_route_for_service_permissions(
 
 
 def test_aggregate_template_stats():
-    from app.main.views.dashboard import aggregate_usage
-    expected = aggregate_usage(copy.deepcopy(stub_template_stats))
+    from app.main.views.dashboard import aggregate_template_usage
+    expected = aggregate_template_usage(copy.deepcopy(stub_template_stats))
 
     assert len(expected) == 4
     assert expected[0]['template_name'] == 'four'

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -35,13 +35,15 @@ stub_template_stats = [
         'template_type': 'sms',
         'template_name': 'one',
         'template_id': 'id-1',
-        'count': 100,
+        'status': 'created',
+        'count': 50,
         'is_precompiled_letter': False
     },
     {
         'template_type': 'email',
         'template_name': 'two',
         'template_id': 'id-2',
+        'status': 'created',
         'count': 200,
         'is_precompiled_letter': False
     },
@@ -49,16 +51,42 @@ stub_template_stats = [
         'template_type': 'letter',
         'template_name': 'three',
         'template_id': 'id-3',
+        'status': 'delivered',
         'count': 300,
+        'is_precompiled_letter': False
+    },
+    {
+        'template_type': 'sms',
+        'template_name': 'one',
+        'template_id': 'id-1',
+        'status': 'delivered',
+        'count': 50,
         'is_precompiled_letter': False
     },
     {
         'template_type': 'letter',
         'template_name': 'four',
         'template_id': 'id-4',
+        'status': 'delivered',
         'count': 400,
         'is_precompiled_letter': True
-    }
+    },
+    {
+        'template_type': 'letter',
+        'template_name': 'four',
+        'template_id': 'id-4',
+        'status': 'cancelled',
+        'count': 5,
+        'is_precompiled_letter': True
+    },
+    {
+        'template_type': 'letter',
+        'template_name': 'thirty-three',
+        'template_id': 'id-33',
+        'status': 'cancelled',
+        'count': 5,
+        'is_precompiled_letter': False
+    },
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2268,7 +2268,8 @@ def mock_get_template_statistics(mocker, service_one, fake_uuid):
         "template_name": template['name'],
         "template_type": template['template_type'],
         "template_id": template['id'],
-        "is_precompiled_letter": False
+        "is_precompiled_letter": False,
+        "status": "delivered"
     }
 
     def _get_stats(service_id, limit_days=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2268,7 +2268,7 @@ def mock_get_template_statistics(mocker, service_one, fake_uuid):
         "template_name": template['name'],
         "template_type": template['template_type'],
         "template_id": template['id'],
-        "day": "2016-04-04"
+        "is_precompiled_letter": False
     }
 
     def _get_stats(service_id, limit_days=None):


### PR DESCRIPTION
Second admin PR in the series, based on this one: https://github.com/alphagov/notifications-admin/pull/2663
Needs to be deployed AFTER the API changes: alphagov/notifications-api#2303

Pivotal ticket: https://www.pivotaltracker.com/story/show/163153273