### PR TITLE
Show if letters are sent using a test key

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -125,7 +125,10 @@ def view_notification(service_id, notification_id):
         can_receive_inbound=(current_service.has_permission('inbound_sms')),
         is_precompiled_letter=notification['template']['is_precompiled_letter'],
         letter_print_day=letter_print_day,
-        show_cancel_button=show_cancel_button
+        show_cancel_button=show_cancel_button,
+        sent_with_test_key=(
+            notification.get('key_type') == KEY_TYPE_TEST
+        ),
     )
 
 

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -57,12 +57,11 @@
           </p>
           {% if is_precompiled_letter %}
             <p>
-              This letter has passed our checks, but it won’t be printed
-              because you used a test key
+              This letter passed our checks, but we will not print it because you used a test key.
             </p>
           {% else %}
             <p>
-              This letter won’t be printed because you used a test key
+              We will not print this letter because you used a test key.
             </p>
           {% endif %}
         {% else %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -16,7 +16,7 @@
 
     <p>
       {% if is_precompiled_letter %}
-      Provided as PDF
+        Provided as PDF
       {% else %}
         {% if help %}
           ‘{{ template.name }}’
@@ -51,15 +51,31 @@
           fixed the problem
         </p>
       {% else %}
-        <p>
-          {{ letter_print_day }}
-        </p>
-        <p>
-          Postage: {{ postage }} class
-        </p>
-        <p>
-          Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
-        </p>
+        {% if sent_with_test_key %}
+          <p>
+            Postage: {{ postage }} class
+          </p>
+          {% if is_precompiled_letter %}
+            <p>
+              This letter has passed our checks, but it won’t be printed
+              because you used a test key
+            </p>
+          {% else %}
+            <p>
+              This letter won’t be printed because you used a test key
+            </p>
+          {% endif %}
+        {% else %}
+          <p>
+            {{ letter_print_day }}
+          </p>
+          <p>
+            Postage: {{ postage }} class
+          </p>
+          <p>
+            Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
+          </p>
+        {% endif %}
       {% endif %}
     {% endif %}
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -197,13 +197,13 @@ def test_notification_page_shows_page_for_letter_notification(
         True,
         'Provided as PDF on 1 January at 1:01am',
         'Postage: second class',
-        'This letter has passed our checks, but it won’t be printed because you used a test key',
+        'This letter passed our checks, but we will not print it because you used a test key.',
     ),
     (
         False,
         '‘sample template’ was sent on 1 January at 1:01am',
         'Postage: second class',
-        'This letter won’t be printed because you used a test key',
+        'We will not print this letter because you used a test key.',
     ),
 ))
 def test_notification_page_shows_page_for_letter_sent_with_test_key(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -191,6 +191,76 @@ def test_notification_page_shows_page_for_letter_notification(
     assert mock_page_count.call_args_list[0][1]['values'] == {'name': 'Jo'}
 
 
+@freeze_time("2016-01-01 01:01")
+@pytest.mark.parametrize('is_precompiled_letter, expected_p1, expected_p2, expected_p3', (
+    (
+        True,
+        'Provided as PDF on 1 January at 1:01am',
+        'Postage: second class',
+        'This letter has passed our checks, but it won’t be printed because you used a test key',
+    ),
+    (
+        False,
+        '‘sample template’ was sent on 1 January at 1:01am',
+        'Postage: second class',
+        'This letter won’t be printed because you used a test key',
+    ),
+))
+def test_notification_page_shows_page_for_letter_sent_with_test_key(
+    client_request,
+    mocker,
+    fake_uuid,
+    is_precompiled_letter,
+    expected_p1,
+    expected_p2,
+    expected_p3,
+):
+
+    mocker.patch(
+        'app.main.views.notifications.view_letter_notification_as_preview',
+        return_value=b'foo'
+    )
+
+    mocker.patch(
+        'app.main.views.notifications.pdf_page_count',
+        return_value=1
+    )
+
+    mocker.patch(
+        'app.main.views.notifications.get_page_count_for_letter',
+        return_value=1,
+    )
+
+    notification = mock_get_notification(
+        mocker,
+        fake_uuid,
+        notification_status='created',
+        template_type='letter',
+        is_precompiled_letter=is_precompiled_letter,
+        postage='second',
+        key_type='test',
+        sent_one_off=False,
+    )
+    notification.created_at = datetime.utcnow()
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    assert normalize_spaces(page.select('main p:nth-of-type(1)')[0].text) == (
+        expected_p1
+    )
+    assert normalize_spaces(page.select('main p:nth-of-type(2)')[0].text) == (
+        expected_p2
+    )
+    assert normalize_spaces(page.select('main p:nth-of-type(3)')[0].text) == (
+        expected_p3
+    )
+    assert page.select('p.notification-status') == []
+
+
 @pytest.mark.parametrize('notification_status, expected_message', (
     (
         'permanent-failure',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2693,7 +2693,8 @@ def mock_get_notification(
     template_name='sample template',
     is_precompiled_letter=False,
     key_type=None,
-    postage=None
+    postage=None,
+    sent_one_off=True,
 ):
     def _get_notification(
         service_id,
@@ -2708,11 +2709,12 @@ def mock_get_notification(
         )['notifications'][0]
 
         noti['id'] = notification_id
-        noti['created_by'] = {
-            'id': fake_uuid,
-            'name': 'Test User',
-            'email_address': 'test@user.gov.uk'
-        }
+        if sent_one_off:
+            noti['created_by'] = {
+                'id': fake_uuid,
+                'name': 'Test User',
+                'email_address': 'test@user.gov.uk'
+            }
         noti['personalisation'] = {'name': 'Jo'}
         noti['template'] = template_json(
             service_id,


### PR DESCRIPTION
It’s inaccurate to have an estimated delivery date for letters sent using a test key. We should reassure people that:
- the letter won’t be printed
- (in the case of precompiled letters) that the letter has passed validation

Wording is up for grabs but those are the messages I want to get across.

![image](https://user-images.githubusercontent.com/355079/51324873-af800d00-1a63-11e9-8d2f-a1fc4241d765.png)
