### PR TITLE
Ensure non-gov invited users get added to services

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -2,27 +2,10 @@ from flask import current_app, redirect, render_template, session, url_for
 from flask_login import login_required
 from notifications_python_client.errors import HTTPError
 
-from app import (
-    billing_api_client,
-    email_branding_client,
-    invite_api_client,
-    service_api_client,
-    user_api_client,
-)
+from app import billing_api_client, email_branding_client, service_api_client
 from app.main import main
 from app.main.forms import CreateServiceForm
-from app.models.user import InvitedUser
 from app.utils import AgreementInfo, email_safe, user_is_gov_user
-
-
-def _add_invited_user_to_service(invited_user):
-    invitation = InvitedUser(**invited_user)
-    # if invited user add to service and redirect to dashboard
-    user = user_api_client.get_user(session['user_id'])
-    service_id = invited_user['service']
-    user_api_client.add_user_to_service(service_id, user.id, invitation.permissions)
-    invite_api_client.accept_invite(service_id, invitation.id)
-    return service_id
 
 
 def _create_service(service_name, organisation_type, email_from, form):
@@ -70,11 +53,6 @@ def _create_example_template(service_id):
 @login_required
 @user_is_gov_user
 def add_service():
-    invited_user = session.get('invited_user')
-    if invited_user:
-        service_id = _add_invited_user_to_service(invited_user)
-        return redirect(url_for('main.service_dashboard', service_id=service_id))
-
     form = CreateServiceForm()
     heading = 'About your service'
 

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -68,7 +68,6 @@ def register_from_org_invite():
             abort(400)
         _do_registration(form, send_email=False, send_sms=True, organisation_id=invited_org_user['organisation'])
         org_invite_api_client.accept_invite(invited_org_user['organisation'], invited_org_user['id'])
-        user_api_client.add_user_to_organisation(invited_org_user['organisation'], session['user_details']['id'])
 
         return redirect(url_for('main.verify'))
     return render_template('views/register-from-org-invite.html', invited_org_user=invited_org_user, form=form)


### PR DESCRIPTION
We were adding invited users to services in the `main.add_service` view
function as the last step in the process of inviting users. Since this
view function is decorated with `@user_is_gov_user`, invited users with
non-governmental email addresses would never reach this point and would
be able to register an account but would not get linked to a service.

To fix this, we now add the invited user to the service at the point at
which the user gets activated and also ensure that non-gov users don't
get redirected to a page which they don't have permission to view.

[Pivotal story](https://www.pivotaltracker.com/story/show/163230875)