### PR TITLE
Add an ‘add logo’ button on the letter template

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -45,3 +45,9 @@
   top: 51px; // aligns bottom edge to bottom of postmark
   right: 145px; // Aligns right edge to midpoint of postmark and fold
 }
+
+.edit-template-link-letter-branding {
+  @extend %edit-template-link;
+  top: 51px; // aligns with ‘change postage’ link
+  left: 66px; // Aligns to left of logo area
+}

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -829,6 +829,7 @@ def service_set_letter_branding(service_id):
 def request_letter_branding(service_id):
     return render_template(
         'views/service-settings/request-letter-branding.html',
+        from_template=request.args.get('from_template'),
     )
 
 

--- a/app/templates/views/service-settings/request-letter-branding.html
+++ b/app/templates/views/service-settings/request-letter-branding.html
@@ -22,10 +22,17 @@
         <a href="{{ url_for('main.feedback', ticket_type='ask-question-give-feedback', body='letter-branding') }}">Contact support</a>
         if you want to use a different logo.
       </p>
-      {{ page_footer(
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
+      {% if from_template %}
+        {{ page_footer(
+          back_link=url_for('.view_template', service_id=current_service.id, template_id=from_template),
+          back_link_text='Back to template'
+        ) }}
+      {% else %}
+        {{ page_footer(
+          back_link=url_for('.service_settings', service_id=current_service.id),
+          back_link_text='Back to settings'
+        ) }}
+      {% endif %}
     </div>
   </div>
 

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -44,7 +44,9 @@
 </div>
 <div class="column-whole template-container">
   {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
-    <a href="{{ url_for(".request_letter_branding", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-branding">Add logo</a>
+    {% if not current_service.letter_branding_id %}
+      <a href="{{ url_for(".request_letter_branding", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-branding">Add logo</a>
+    {% endif %}
     <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-postage">Change</a>
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
     <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-contact">Edit</a>

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -44,6 +44,7 @@
 </div>
 <div class="column-whole template-container">
   {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
+    <a href="{{ url_for(".request_letter_branding", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-branding">Add logo</a>
     <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-postage">Change</a>
     <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
     <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-contact">Edit</a>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -43,9 +43,7 @@
   {% endif %}
 
   <div class="grid-row">
-    {% with show_title=False, expanded=True %}
-      {% include 'views/templates/_template.html' %}
-    {% endwith %}
+    {% include 'views/templates/_template.html' %}
   </div>
 
   <div class="bottom-gutter-1-2">


### PR DESCRIPTION
Some people don’t know they can have their own logos on letters – it’s not very discoverable on the settings page. Some feedback we get:

> The HM Government Logo is at the top of the letter and we can't see a way of putting the [organisation] logo on

> We are intending to use the letter template feature for the first time and wondered whether the branding is configurable or whether the HM Government header is the standard default.

> Can we replace HM Government logo with our own in the letter? IF yes, then how?

> I don't seem to be able to set the branding on the letters to be [organisation]. it's always HM government. Is there something that needs enabling for this account?

No-one actually wants the HM Government logo (no-one is sending real letters using it). So we should leave the space blank and put a button there prompting people to add their own logo.

***

![image](https://user-images.githubusercontent.com/355079/52475631-ed201380-2b93-11e9-9c69-18b5f4bbe37b.png)

***

Depends on:
- [x] replacing the HM Government logo with a blank image.