### PR TITLE
Show domains, not owners against brands

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -22,7 +22,7 @@ def email_branding():
 
     return render_template(
         'views/email-branding/select-branding.html',
-        email_brandings=_add_domain_info(brandings),
+        email_brandings=brandings,
         search_form=SearchTemplatesForm(),
         show_search_box=len(brandings) > 9,
         agreement_info=AgreementInfo,
@@ -129,11 +129,3 @@ def create_email_branding(logo=None):
         cdn_url=get_logo_cdn_domain(),
         logo=logo
     )
-
-
-def _add_domain_info(email_brands):
-    for brand in email_brands:
-        yield dict(
-            domain_owner=AgreementInfo(brand.get('domain') or '').owner,
-            **brand
-        )

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -26,11 +26,13 @@
             {{ brand.name or 'Unnamed' }}
           </a>
         </div>
-        {% if brand.domain_owner %}
-          <p class="message-type">
-            Default for {{ brand.domain_owner }}
-          </p>
-        {% endif %}
+        <p class="message-type">
+          {% if brand.domain %}
+            Default for {{ brand.domain }}
+          {% else %}
+            –
+          {% endif %}
+        </p>
       </div>
     {% endfor %}
   </nav>

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -27,6 +27,7 @@ def test_email_branding_page_shows_full_branding_list(
     links = page.select('.message-name a')
     brand_names = [normalize_spaces(link.text) for link in links]
     hrefs = [link['href'] for link in links]
+    brand_hints = [normalize_spaces(hint.text) for hint in page.select('.message-type')]
 
     assert normalize_spaces(
         page.select_one('h1').text
@@ -34,8 +35,14 @@ def test_email_branding_page_shows_full_branding_list(
 
     assert page.select_one('.column-three-quarters a')['href'] == url_for('main.create_email_branding')
 
-    assert brand_names == [
-        'org 1', 'org 2', 'org 3', 'org 4', 'org 5'
+    assert list(zip(
+        brand_names, brand_hints
+    )) == [
+        ('org 1', '–'),
+        ('org 2', '–'),
+        ('org 3', '–'),
+        ('org 4', 'Default for nhs.uk'),
+        ('org 5', 'Default for voa.gov.uk'),
     ]
     assert hrefs == [
         url_for('.update_email_branding', branding_id=1),


### PR DESCRIPTION
The owner is often repetetive, eg

> **Hackney Council**
> Default for Hackney Council

Instead it’s more useful to reflect what the person setting up the brand has entered – the domain:

> **Hackney Council**
> Default for hackney.gov.uk

This also adds an empty hint for non-default brands so that the page is evenly spaced and nothing overlaps.