### PR TITLE
Prevent sticky overflowing screen

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -310,6 +310,7 @@
   Sticky.prototype.recalculate = function (opts) {
     var self = this;
     var onSyncComplete = function () {
+      self.setEvents();
       if (_mode === 'dialog') {
         dialog.fitToHeight(self);
         dialog.adjustForResize(self);
@@ -425,24 +426,23 @@
     }
   };
   Sticky.prototype.init = function (opts) {
+    this.recalculate(opts);
+  };
+  Sticky.prototype.setEvents = function () {
     var self = this;
 
-    if (this._els.length) {
-      // flag when scrolling takes place and check (and re-position) sticky elements relative to
-      // window position
-      if (self._scrollTimeout === false) {
-        $(global).scroll(function (e) { self.onScroll(); });
-        self._scrollTimeout = global.setInterval(function (e) { self.checkScroll(); }, 50);
-      }
-
-      // Recalculate all dimensions when the window resizes
-      if (self._resizeTimeout === false) {
-        $(global).resize(function (e) { self.onResize(); });
-        self._resizeTimeout = global.setInterval(function (e) { self.checkResize(); }, 50);
-      }
+    // flag when scrolling takes place and check (and re-position) sticky elements relative to
+    // window position
+    if (self._scrollTimeout === false) {
+      $(global).scroll(function (e) { self.onScroll(); });
+      self._scrollTimeout = global.setInterval(function (e) { self.checkScroll(); }, 50);
     }
 
-    this.recalculate(opts);
+    // Recalculate all dimensions when the window resizes
+    if (self._resizeTimeout === false) {
+      $(global).resize(function (e) { self.onResize(); });
+      self._resizeTimeout = global.setInterval(function (e) { self.checkResize(); }, 50);
+    }
   };
   Sticky.prototype.viewportIsWideEnough = function (windowWidth) {
     return windowWidth > 768;

--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -188,24 +188,38 @@
   Sticky.prototype.allElementsLoaded = function (totalEls) {
     return this._els.length === totalEls;
   };
+  Sticky.prototype.add = function (el, setPositions, cb) {
+    var self = this;
+    var $el = $(el);
+    var elObj = new StickyElement($el, self);
+
+    self.setElementDimensions(elObj, function () {
+      self._els.push(elObj);
+      if (setPositions) {
+        self.setElementPositions();
+      }
+      if (cb !== undefined) {
+        cb();
+      }
+    });
+  }; 
   Sticky.prototype.init = function () {
     var self = this;
     var $els = $(self.CSS_SELECTOR);
     var numOfEls = $els.length;
+    var onAllLoaded = function () {
+      if (self._els.length === numOfEls) {
+        self._elsLoaded = true;
+
+        // set positions based on initial scroll position
+        self.setElementPositions();
+      }
+    };
 
     if (numOfEls > 0) {
       $els.each(function (i, el) {
-        var $el = $(el);
-        var elObj = new StickyElement($el, self);
-
-        self.setElementDimensions(elObj, function () {
-          self._els.push(elObj);
-          // set positions based on initial scroll positionu
-          if (self._els.length === numOfEls) {
-            self._elsLoaded = true;
-            self.setElementPositions();
-          }
-        });
+        // delay setting position until all stickys are loaded
+        self.add(el, false, onAllLoaded);
       });
 
       // flag when scrolling takes place and check (and re-position) sticky elements relative to

--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -462,6 +462,9 @@
     }
 
     if (numOfEls) {
+      // reset flag marking page load
+      this._initialPositionsSet = false;
+
       $els.each(function (i, el) {
         // delay setting position until all stickys are loaded
         self.add(el, false, onLoaded);

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -17,12 +17,12 @@
 
       // all the diff states that we want to show or hide
       this.states = [
-        {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false, isStickyGroup: false},
-        {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false, isStickyGroup: false},
-        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, isStickyGroup: true},
-        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, isStickyGroup: false},
-        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, isStickyGroup: false},
-        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, isStickyGroup: true}
+        {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false},
+        {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false},
+        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true},
+        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true},
+        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true},
+        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true}
       ];
 
       // cancel/clear buttons only relevant if JS enabled, so
@@ -45,12 +45,12 @@
     };
 
     this.activateStickyElements = function() {
-      var oldClass = '.js-will-stick-at-bottom-when-scrolling';
+      var oldClass = 'js-will-stick-at-bottom-when-scrolling';
       var newClass = 'js-stick-at-bottom-when-scrolling';
 
       this.states.forEach(state => {
         state.$el
-          .find(oldClass)
+          .find('.' + oldClass)
           .removeClass(oldClass)
           .addClass(newClass);
       });
@@ -146,29 +146,29 @@
 
       // make sticky JS recalculate its cache of the element's position
       // use dialog mode for states which contain more than one form control
-      if (['move-to-existing-folder', 'add-new-template'].includes(this.currentState)) {
-        GOVUK.stickAtBottomWhenScrolling.recalculate({ 'mode': 'dialog' });
-      } else {
-        GOVUK.stickAtBottomWhenScrolling.recalculate();
-      }
+      GOVUK.stickAtBottomWhenScrolling.recalculate({ 'mode': 'dialog' });
     };
 
     this.nothingSelectedButtons = $(`
-      <div id="nothing_selected" class="js-stick-at-bottom-when-scrolling">
-        <button class="button-secondary" value="add-new-template">New template</button>
-        <button class="button-secondary" value="add-new-folder">New folder</button>
-        <div class="template-list-selected-counter">
-          Nothing selected
+      <div id="nothing_selected">
+        <div class="js-stick-at-bottom-when-scrolling">
+          <button class="button-secondary" value="add-new-template">New template</button>
+          <button class="button-secondary" value="add-new-folder">New folder</button>
+          <div class="template-list-selected-counter">
+            Nothing selected
+          </div>
         </div>
       </div>
     `).get(0);
 
     this.itemsSelectedButtons = $(`
-      <div id="items_selected" class="js-stick-at-bottom-when-scrolling">
-        <button class="button-secondary" value="move-to-existing-folder">Move</button>
-        <button class="button-secondary" value="move-to-new-folder">Add to a new folder</button>
-        <div class="template-list-selected-counter">
-          <span class="template-list-selected-counter-count">1</span> selected
+      <div id="items_selected">
+        <div class="js-stick-at-bottom-when-scrolling">
+          <button class="button-secondary" value="move-to-existing-folder">Move</button>
+          <button class="button-secondary" value="move-to-new-folder">Add to a new folder</button>
+          <div class="template-list-selected-counter">
+            <span class="template-list-selected-counter-count">1</span> selected
+          </div>
         </div>
       </div>
     `).get(0);

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -13,9 +13,7 @@
       this.$stickyBottom = this.$form.find('#sticky_template_forms');
 
       this.$stickyBottom.append(this.nothingSelectedButtons);
-      GOVUK.stickAtBottomWhenScrolling.add(this.nothingSelectedButtons, true);
       this.$stickyBottom.append(this.itemsSelectedButtons);
-      GOVUK.stickAtBottomWhenScrolling.add(this.itemsSelectedButtons, true);
 
       // all the diff states that we want to show or hide
       this.states = [

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -13,21 +13,32 @@
       this.$stickyBottom = this.$form.find('#sticky_template_forms');
 
       this.$stickyBottom.append(this.nothingSelectedButtons);
+      GOVUK.stickAtBottomWhenScrolling.add(this.nothingSelectedButtons, true);
       this.$stickyBottom.append(this.itemsSelectedButtons);
+      GOVUK.stickAtBottomWhenScrolling.add(this.itemsSelectedButtons, true);
 
       // all the diff states that we want to show or hide
       this.states = [
-        {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false},
-        {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false},
-        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true},
-        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true},
-        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true},
-        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true}
+        {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false, isStickyGroup: false},
+        {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false, isStickyGroup: false},
+        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, isStickyGroup: true},
+        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, isStickyGroup: false},
+        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, isStickyGroup: false},
+        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, isStickyGroup: true}
       ];
 
       // cancel/clear buttons only relevant if JS enabled, so
       this.states.filter(state => state.cancellable).forEach((x) => this.addCancelButton(x));
       this.states.filter(state => state.key === 'items-selected-buttons').forEach(x => this.addClearButton(x));
+
+      // add all sticky elements from states
+      this.states.forEach(state => {
+        if (state.isStickyGroup) {
+          state.$el.find(".js-stick-at-bottom-when-scrolling").each((idx, el) => {
+            GOVUK.stickAtBottomWhenScrolling.add(el, false);
+          });
+        }
+      });
 
       // first off show the new template / new folder buttons
       this.currentState = this.$form.data('prev-state') || 'unknown';
@@ -135,25 +146,25 @@
       }
     };
 
-    this.nothingSelectedButtons = `
-      <div id="nothing_selected">
+    this.nothingSelectedButtons = $(`
+      <div id="nothing_selected" class="js-stick-at-bottom-when-scrolling">
         <button class="button-secondary" value="add-new-template">New template</button>
         <button class="button-secondary" value="add-new-folder">New folder</button>
         <div class="template-list-selected-counter">
           Nothing selected
         </div>
       </div>
-    `;
+    `).get(0);
 
-    this.itemsSelectedButtons = `
-      <div id="items_selected">
+    this.itemsSelectedButtons = $(`
+      <div id="items_selected" class="js-stick-at-bottom-when-scrolling">
         <button class="button-secondary" value="move-to-existing-folder">Move</button>
         <button class="button-secondary" value="move-to-new-folder">Add to a new folder</button>
         <div class="template-list-selected-counter">
           <span class="template-list-selected-counter-count">1</span> selected
         </div>
       </div>
-    `;
+    `).get(0);
   };
 
 })(window.GOVUK.Modules);

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -29,6 +29,9 @@
       this.states.filter(state => state.cancellable).forEach((x) => this.addCancelButton(x));
       this.states.filter(state => state.key === 'items-selected-buttons').forEach(x => this.addClearButton(x));
 
+      // activate stickiness of elements in each state
+      this.activateStickyElements();
+
       // first off show the new template / new folder buttons
       this.currentState = this.$form.data('prev-state') || 'unknown';
       if (this.currentState === 'unknown') {
@@ -39,6 +42,18 @@
 
       this.$form.on('click', 'button.button-secondary', (event) => this.actionButtonClicked(event));
       this.$form.on('change', 'input[type=checkbox]', () => this.templateFolderCheckboxChanged());
+    };
+
+    this.activateStickyElements = function() {
+      var oldClass = '.js-will-stick-at-bottom-when-scrolling';
+      var newClass = 'js-stick-at-bottom-when-scrolling';
+
+      this.states.forEach(state => {
+        state.$el
+          .find(oldClass)
+          .removeClass(oldClass)
+          .addClass(newClass);
+      });
     };
 
     this.addCancelButton = function(state) {

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -31,15 +31,6 @@
       this.states.filter(state => state.cancellable).forEach((x) => this.addCancelButton(x));
       this.states.filter(state => state.key === 'items-selected-buttons').forEach(x => this.addClearButton(x));
 
-      // add all sticky elements from states
-      this.states.forEach(state => {
-        if (state.isStickyGroup) {
-          state.$el.find(".js-stick-at-bottom-when-scrolling").each((idx, el) => {
-            GOVUK.stickAtBottomWhenScrolling.add(el, false);
-          });
-        }
-      });
-
       // first off show the new template / new folder buttons
       this.currentState = this.$form.data('prev-state') || 'unknown';
       if (this.currentState === 'unknown') {
@@ -141,7 +132,10 @@
       );
 
       // make sticky JS recalculate its cache of the element's position
-      if ('stickAtBottomWhenScrolling' in GOVUK) {
+      // use dialog mode for states which contain more than one form control
+      if (['move-to-existing-folder', 'add-new-template'].includes(this.currentState)) {
+        GOVUK.stickAtBottomWhenScrolling.recalculate({ 'mode': 'dialog' });
+      } else {
         GOVUK.stickAtBottomWhenScrolling.recalculate();
       }
     };

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -72,6 +72,7 @@
   background: $white;
   z-index: 100;
   padding-right: $gutter-half;
+  margin-top: 0;
 
   .back-to-top-link {
     opacity: 1;

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -86,6 +86,11 @@
 
   top: 0;
   margin-top: 0;
+
+}
+
+.js-stick-at-top-when-scrolling.content-fixed__top {
+
   border-bottom: 1px solid $border-colour;
   box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
 
@@ -102,6 +107,11 @@
 
   top: auto; // cancel `top: 0;` inherited from govuk-template
   bottom: 0;
+
+}
+
+.js-stick-at-bottom-when-scrolling.content-fixed__bottom {
+
   border-top: 1px solid $border-colour;
   box-shadow: 0 -2px 0 0 rgba($border-colour, 0.2);
 

--- a/app/templates/components/live-search.html
+++ b/app/templates/components/live-search.html
@@ -9,7 +9,7 @@
     {%- set search_label = label or form.search.label.text %}
     {% if show %}
       <div data-module="autofocus">
-        <div class="live-search" data-module="live-search" data-targets="{{ target_selector }}">
+        <div class="live-search js-header" data-module="live-search" data-targets="{{ target_selector }}">
           {{ textbox(
             form.search,
             width='1-1',

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -1,15 +1,19 @@
 {% from "components/radios.html" import radios, radios_nested %}
 {% from "components/page-footer.html" import page_footer %}
 
-<div id="sticky_template_forms" class="js-stick-at-bottom-when-scrolling">
+<div id="sticky_template_forms">
   <button type="submit" name="operation" value="unknown" hidden></button>
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
   {% if templates_and_folders_form.move_to.choices and template_list.templates_to_show %}
     <div id="move_to_folder_radios">
+      <div class="js-stick-at-bottom-when-scrolling">
       {{ radios_nested(templates_and_folders_form.move_to, move_to_children, option_hints=option_hints) }}
+      </div>
+      <div class="js-stick-at-bottom-when-scrolling">
       {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder') }}
+      </div>
     </div>
-    <div id="move_to_new_folder_form">
+    <div id="move_to_new_folder_form" class="js-stick-at-bottom-when-scrolling">
       <fieldset>
         <legend class="visuallyhidden">Move to a new folder</legend>
         {{ textbox(templates_and_folders_form.move_to_new_folder_name) }}
@@ -17,7 +21,7 @@
       </fieldset>
     </div>
   {% endif %}
-  <div id="add_new_folder_form">
+  <div id="add_new_folder_form" class="js-stick-at-bottom-when-scrolling">
     <fieldset>
       <legend class="visuallyhidden">Add a new folder</legend>
       {{ textbox(templates_and_folders_form.add_new_folder_name) }}
@@ -27,8 +31,12 @@
   <div id="add_new_template_form">
     <fieldset>
       <legend class="visuallyhidden">Add a new template</legend>
+      <div class="js-stick-at-bottom-when-scrolling">
       {{ radios(templates_and_folders_form.add_template_by_template_type) }}
+      </div>
+      <div class="js-stick-at-bottom-when-scrolling">
       {{ page_footer('Continue', button_name='operation', button_value='add-new-template') }}
+      </div>
     </fieldset>
   </div>
 </div>

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -6,14 +6,14 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
   {% if templates_and_folders_form.move_to.choices and template_list.templates_to_show %}
     <div id="move_to_folder_radios">
-      <div class="js-stick-at-bottom-when-scrolling">
+      <div class="js-will-stick-at-bottom-when-scrolling">
       {{ radios_nested(templates_and_folders_form.move_to, move_to_children, option_hints=option_hints) }}
       </div>
-      <div class="js-stick-at-bottom-when-scrolling">
+      <div class="js-will-stick-at-bottom-when-scrolling">
       {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder') }}
       </div>
     </div>
-    <div id="move_to_new_folder_form" class="js-stick-at-bottom-when-scrolling">
+    <div id="move_to_new_folder_form" class="js-will-stick-at-bottom-when-scrolling">
       <fieldset>
         <legend class="visuallyhidden">Move to a new folder</legend>
         {{ textbox(templates_and_folders_form.move_to_new_folder_name) }}
@@ -21,7 +21,7 @@
       </fieldset>
     </div>
   {% endif %}
-  <div id="add_new_folder_form" class="js-stick-at-bottom-when-scrolling">
+  <div id="add_new_folder_form" class="js-will-stick-at-bottom-when-scrolling">
     <fieldset>
       <legend class="visuallyhidden">Add a new folder</legend>
       {{ textbox(templates_and_folders_form.add_new_folder_name) }}
@@ -31,10 +31,10 @@
   <div id="add_new_template_form">
     <fieldset>
       <legend class="visuallyhidden">Add a new template</legend>
-      <div class="js-stick-at-bottom-when-scrolling">
+      <div class="js-will-stick-at-bottom-when-scrolling">
       {{ radios(templates_and_folders_form.add_template_by_template_type) }}
       </div>
-      <div class="js-stick-at-bottom-when-scrolling">
+      <div class="js-will-stick-at-bottom-when-scrolling">
       {{ page_footer('Continue', button_name='operation', button_value='add-new-template') }}
       </div>
     </fieldset>

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -13,16 +13,16 @@
       {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder') }}
       </div>
     </div>
-    <div id="move_to_new_folder_form" class="js-will-stick-at-bottom-when-scrolling">
-      <fieldset>
+    <div id="move_to_new_folder_form">
+      <fieldset class="js-will-stick-at-bottom-when-scrolling">
         <legend class="visuallyhidden">Move to a new folder</legend>
         {{ textbox(templates_and_folders_form.move_to_new_folder_name) }}
         {{ page_footer('Move to a new folder', button_name='operation', button_value='move-to-new-folder') }}
       </fieldset>
     </div>
   {% endif %}
-  <div id="add_new_folder_form" class="js-will-stick-at-bottom-when-scrolling">
-    <fieldset>
+  <div id="add_new_folder_form">
+    <fieldset class="js-will-stick-at-bottom-when-scrolling">
       <legend class="visuallyhidden">Add a new folder</legend>
       {{ textbox(templates_and_folders_form.add_new_folder_name) }}
       {{ page_footer('New folder', button_name='operation', button_value='add-new-folder') }}


### PR DESCRIPTION
This adds a new version of sticky UI for when we want to stick a stacked collection of UI elements to the screen.

Part of this is that it can deal with that collection being too tall for the screen.

https://www.pivotaltracker.com/story/show/162987940

## How it works

Here's [a pull request that explains the basics of how the sticky behaviours work](https://github.com/alphagov/notifications-admin/pull/2469).

This introduces a mode for the stickys in the page. If set to 'dialog', it assumes all the sticky elements will be stacked vertically together in the same part of the document. When they go off-screen they will stick to the top/bottom of the screen in one bunch.

If the stack is too tall for the screen, elements in it will be put back into the document from the top down until the stack fits*. If this happens, the screen will then scroll so those still stuck are displayed below those put back, so they all appear together.

*That's if set to stick to the bottom of the screen. If stuck to the stop, they will be put back from the bottom up.

If none of the stack fit, they will all be put back into the document and will not stick to the screen.

![sticky-element-overflow-behaviour](https://user-images.githubusercontent.com/87140/51622662-ed32d900-1f2e-11e9-9b3f-4dca0fc16d15.png)

## Testing this work

You'll need the 'Allow to edit folder' option to be turned on in the 'settings' section. Once that's done, try to move a template or folder into a different folder. To see the full range of behaviours, try this with one of either:
- too many folders to fit vertically on your screen
- a screen size which doesn't fit the folders you have.

