### PR TITLE
Email branding form validation fixes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,6 +61,7 @@ from app.notify_client.user_api_client import user_api_client
 from app.notify_client.events_api_client import events_api_client
 from app.notify_client.provider_client import provider_client
 from app.notify_client.email_branding_client import email_branding_client
+from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.org_invite_api_client import org_invite_api_client
 from app.notify_client.letter_jobs_client import letter_jobs_client
@@ -125,6 +126,7 @@ def create_app(application):
     events_api_client.init_app(application)
     provider_client.init_app(application)
     email_branding_client.init_app(application)
+    letter_branding_client.init_app(application)
     organisations_client.init_app(application)
     letter_jobs_client.init_app(application)
     inbound_number_client.init_app(application)

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -848,6 +848,11 @@ class ServiceUpdateEmailBranding(StripWhitespaceForm):
         ]
     )
 
+    def validate_name(form, name):
+        op = request.form.get('operation')
+        if op == 'email-branding-details' and not form.name.data:
+            raise ValidationError('This field is required')
+
 
 class PDFUploadForm(StripWhitespaceForm):
     file = FileField_wtf(

--- a/app/main/s3_client.py
+++ b/app/main/s3_client.py
@@ -31,7 +31,9 @@ def delete_s3_object(filename):
     get_s3_object(bucket_name, filename).delete()
 
 
-def rename_s3_object(old_name, new_name):
+def persist_logo(old_name, new_name):
+    if old_name == new_name:
+        return
     bucket_name = current_app.config['LOGO_UPLOAD_BUCKET_NAME']
     get_s3_object(bucket_name, new_name).copy_from(
         CopySource='{}/{}'.format(bucket_name, old_name))
@@ -110,16 +112,11 @@ def upload_logo(filename, filedata, region, user_id):
     return upload_file_name
 
 
-def persist_logo(filename, user_id):
+def permanent_logo_name(filename, user_id):
     if filename.startswith(TEMP_TAG.format(user_id=user_id)):
-        persisted_filename = get_temp_truncated_filename(
-            filename=filename, user_id=user_id)
+        return get_temp_truncated_filename(filename=filename, user_id=user_id)
     else:
         return filename
-
-    rename_s3_object(filename, persisted_filename)
-
-    return persisted_filename
 
 
 def delete_temp_files_created_by(user_id):

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -8,6 +8,7 @@ from app.main.s3_client import (
     TEMP_TAG,
     delete_temp_file,
     delete_temp_files_created_by,
+    permanent_logo_name,
     persist_logo,
     upload_logo,
 )
@@ -60,20 +61,22 @@ def update_email_branding(branding_id, logo=None):
 
             return redirect(url_for('.update_email_branding', branding_id=branding_id, logo=upload_filename))
 
-        if logo:
-            logo = persist_logo(logo, session["user_id"])
-
-        delete_temp_files_created_by(session["user_id"])
+        updated_logo_name = permanent_logo_name(logo, session["user_id"]) if logo else None
 
         email_branding_client.update_email_branding(
             branding_id=branding_id,
-            logo=logo,
+            logo=updated_logo_name,
             name=form.name.data,
             text=form.text.data,
             colour=form.colour.data,
             domain=form.domain.data,
             brand_type=form.brand_type.data,
         )
+
+        if logo:
+            persist_logo(logo, updated_logo_name)
+
+        delete_temp_files_created_by(session["user_id"])
 
         return redirect(url_for('.email_branding', branding_id=branding_id))
 
@@ -107,19 +110,21 @@ def create_email_branding(logo=None):
 
             return redirect(url_for('.create_email_branding', logo=upload_filename))
 
-        if logo:
-            logo = persist_logo(logo, session["user_id"])
-
-        delete_temp_files_created_by(session["user_id"])
+        updated_logo_name = permanent_logo_name(logo, session["user_id"]) if logo else None
 
         email_branding_client.create_email_branding(
-            logo=logo,
+            logo=updated_logo_name,
             name=form.name.data,
             text=form.text.data,
             colour=form.colour.data,
             domain=form.domain.data,
             brand_type=form.brand_type.data,
         )
+
+        if logo:
+            persist_logo(logo, updated_logo_name)
+
+        delete_temp_files_created_by(session["user_id"])
 
         return redirect(url_for('.email_branding'))
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -19,6 +19,7 @@ from app import (
     current_service,
     email_branding_client,
     inbound_number_client,
+    letter_branding_client,
     organisations_client,
     service_api_client,
     user_api_client,
@@ -854,7 +855,7 @@ def service_preview_email_branding(service_id):
 def set_letter_branding(service_id):
 
     form = LetterBranding(
-        choices=email_branding_client.get_letter_email_branding().items(),
+        choices=letter_branding_client.get_letter_branding().items(),
         dvla_org_id=current_service.dvla_organisation,
     )
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -8,6 +8,7 @@ from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
+from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.service_api_client import service_api_client
 from app.notify_client.template_folder_api_client import (
@@ -304,7 +305,7 @@ class Service():
 
     @cached_property
     def letter_branding(self):
-        return email_branding_client.get_letter_email_branding().get(
+        return letter_branding_client.get_letter_branding().get(
             self.dvla_organisation, '001'
         )
 

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -23,9 +23,6 @@ class EmailBrandingClient(NotifyAdminAPIClient):
                 return branding['id']
         return None
 
-    def get_letter_email_branding(self):
-        return self.get(url='/dvla_organisations')
-
     @cache.delete('email_branding')
     def create_email_branding(self, logo, name, text, colour, domain, brand_type):
         data = {

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -1,0 +1,13 @@
+from app.notify_client import NotifyAdminAPIClient
+
+
+class LetterBrandingClient(NotifyAdminAPIClient):
+
+    def __init__(self):
+        super().__init__("a" * 73, "b")
+
+    def get_letter_branding(self):
+        return self.get(url='/dvla_organisations')
+
+
+letter_branding_client = LetterBrandingClient()

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -29,6 +29,8 @@
            {{ radios(form.brand_type) }}
           {{ page_footer(
             'Save',
+            button_name='operation',
+            button_value='email-branding-details',
             back_link=url_for('.email_branding'),
             back_link_text='Back to email branding selection',
           ) }}

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -10,7 +10,7 @@ def get_service_settings_page(
     platform_admin_user,
     service_one,
     mock_get_inbound_number_for_service,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
     mock_get_service_organisation,
     mock_get_free_sms_fragment_limit,
     no_reply_to_email_addresses,
@@ -113,7 +113,7 @@ def test_normal_user_doesnt_see_any_toggle_buttons(
     no_letter_contact_blocks,
     mock_get_service_organisation,
     single_sms_sender,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
     mock_get_inbound_number_for_service,
     mock_get_free_sms_fragment_limit,
     mock_get_service_data_retention

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -4,6 +4,7 @@ from unittest.mock import call
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from notifications_python_client.errors import HTTPError
 
 from app.main.s3_client import LOGO_LOCATION_STRUCTURE, TEMP_TAG
 from tests.conftest import (
@@ -241,7 +242,7 @@ def test_create_new_email_branding_when_branding_saved(
         filename=data['logo']
     )
 
-    mocker.patch('app.main.views.email_branding.persist_logo', return_value=data['logo'])
+    mocker.patch('app.main.views.email_branding.persist_logo')
     mocker.patch('app.main.views.email_branding.delete_temp_files_created_by')
 
     logged_in_platform_admin_client.post(
@@ -257,9 +258,11 @@ def test_create_new_email_branding_when_branding_saved(
         }
     )
 
+    updated_logo_name = '{}-{}'.format(fake_uuid, data['logo'])
+
     assert mock_create_email_branding.called
     assert mock_create_email_branding.call_args == call(
-        logo=data['logo'],
+        logo=updated_logo_name,
         name=data['name'],
         text=data['text'],
         colour=data['colour'],
@@ -340,7 +343,7 @@ def test_update_existing_branding(
         filename=data['logo']
     )
 
-    mocker.patch('app.main.views.email_branding.persist_logo', return_value=data['logo'])
+    mocker.patch('app.main.views.email_branding.persist_logo')
     mocker.patch('app.main.views.email_branding.delete_temp_files_created_by')
 
     logged_in_platform_admin_client.post(
@@ -352,10 +355,12 @@ def test_update_existing_branding(
               }
     )
 
+    updated_logo_name = '{}-{}'.format(fake_uuid, data['logo'])
+
     assert mock_update_email_branding.called
     assert mock_update_email_branding.call_args == call(
         branding_id=fake_uuid,
-        logo=data['logo'],
+        logo=updated_logo_name,
         name=data['name'],
         text=data['text'],
         colour=data['colour'],
@@ -408,7 +413,7 @@ def test_logo_persisted_when_organisation_saved(
         temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename='test.png')
 
     mocked_upload_logo = mocker.patch('app.main.views.email_branding.upload_logo')
-    mocked_persist_logo = mocker.patch('app.main.views.email_branding.persist_logo', return_value='test.png')
+    mocked_persist_logo = mocker.patch('app.main.views.email_branding.persist_logo')
     mocked_delete_temp_files_by = mocker.patch('app.main.views.email_branding.delete_temp_files_created_by')
 
     resp = logged_in_platform_admin_client.post(
@@ -422,6 +427,31 @@ def test_logo_persisted_when_organisation_saved(
     assert mocked_delete_temp_files_by.called
     assert mocked_delete_temp_files_by.call_args == call(user_id)
     assert mock_create_email_branding.called
+
+
+def test_logo_does_not_get_persisted_if_updating_email_branding_client_throws_an_error(
+    logged_in_platform_admin_client,
+    mock_create_email_branding,
+    mocker,
+    fake_uuid
+):
+    with logged_in_platform_admin_client.session_transaction() as session:
+        user_id = session["user_id"]
+
+    temp_filename = LOGO_LOCATION_STRUCTURE.format(
+        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename='test.png')
+
+    mocked_persist_logo = mocker.patch('app.main.views.email_branding.persist_logo')
+    mocked_delete_temp_files_by = mocker.patch('app.main.views.email_branding.delete_temp_files_created_by')
+    mocker.patch('app.main.views.email_branding.email_branding_client.create_email_branding', side_effect=HTTPError())
+
+    logged_in_platform_admin_client.post(
+        url_for('.create_email_branding', logo=temp_filename),
+        content_type='multipart/form-data'
+    )
+
+    assert not mocked_persist_logo.called
+    assert not mocked_delete_temp_files_by.called
 
 
 @pytest.mark.parametrize('colour_hex, expected_status_code', [

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -38,7 +38,7 @@ from tests.conftest import (
 
 @pytest.fixture
 def mock_get_service_settings_page_common(
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
     mock_get_inbound_number_for_service,
     mock_get_free_sms_fragment_limit,
     mock_get_service_data_retention,
@@ -1216,7 +1216,7 @@ def test_route_for_platform_admin_update_service(
         client,
         platform_admin_user,
         service_one,
-        mock_get_letter_email_branding,
+        mock_get_letter_branding,
         route,
 ):
     mocker.patch('app.service_api_client.archive_service')
@@ -2142,7 +2142,7 @@ def test_set_letter_contact_block_has_max_10_lines(
 
 def test_request_letter_branding(
     client_request,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
 ):
     request_page = client_request.get(
         'main.request_letter_branding',
@@ -2186,7 +2186,7 @@ def test_set_letter_branding_platform_admin_only(
 def test_set_letter_branding_prepopulates(
     logged_in_platform_admin_client,
     service_one,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
     current_dvla_org_id,
     expected_selected,
     expected_items,
@@ -2213,7 +2213,7 @@ def test_set_letter_branding_saves(
     logged_in_platform_admin_client,
     service_one,
     mock_update_service,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
 ):
     response = logged_in_platform_admin_client.post(
         url_for('main.set_letter_branding', service_id=service_one['id']),
@@ -3098,7 +3098,7 @@ def test_service_settings_when_inbound_number_is_not_set(
     mock_get_service_organisation,
     single_sms_sender,
     mocker,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
     mock_get_free_sms_fragment_limit,
     mock_get_service_data_retention,
 ):
@@ -3116,7 +3116,7 @@ def test_set_inbound_sms_when_inbound_number_is_not_set(
     single_reply_to_email_address,
     single_letter_contact_block,
     mocker,
-    mock_get_letter_email_branding,
+    mock_get_letter_branding,
 ):
     mocker.patch('app.inbound_number_client.get_inbound_sms_number_for_service',
                  return_value={'data': {}})

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -51,14 +51,6 @@ def test_get_all_email_branding(mocker):
     )
 
 
-def test_get_letter_email_branding(mocker):
-    mock_get = mocker.patch('app.notify_client.email_branding_client.EmailBrandingClient.get')
-    EmailBrandingClient().get_letter_email_branding()
-    mock_get.assert_called_once_with(
-        url='/dvla_organisations'
-    )
-
-
 def test_create_email_branding(mocker):
     org_data = {'logo': 'test.png', 'name': 'test name', 'text': 'test name', 'colour': 'red',
                 'domain': 'sample.com', 'brand_type': 'org'}

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -1,0 +1,9 @@
+from app.notify_client.letter_branding_client import LetterBrandingClient
+
+
+def test_get_letter_branding(mocker):
+    mock_get = mocker.patch('app.notify_client.letter_branding_client.LetterBrandingClient.get')
+    LetterBrandingClient().get_letter_branding()
+    mock_get.assert_called_once_with(
+        url='/dvla_organisations'
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2547,8 +2547,8 @@ def mock_get_email_branding_that_can_fit_onscreen(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_get_letter_email_branding(mocker):
-    def _get_letter_email_branding():
+def mock_get_letter_branding(mocker):
+    def _get_letter_branding():
         return {
             '001': 'HM Government',
             '500': 'Land Registry',
@@ -2556,7 +2556,7 @@ def mock_get_letter_email_branding(mocker):
         }
 
     return mocker.patch(
-        'app.email_branding_client.get_letter_email_branding', side_effect=_get_letter_email_branding
+        'app.letter_branding_client.get_letter_branding', side_effect=_get_letter_branding
     )
 
 
@@ -2566,7 +2566,7 @@ def mock_no_email_branding(mocker):
         return []
 
     return mocker.patch(
-        'app.email_branding_client.get_letter_email_branding', side_effect=_get_email_branding
+        'app.email_branding_client.get_all_email_branding', side_effect=_get_email_branding
     )
 
 


### PR DESCRIPTION
* Created a letter branding client, so that the method to get all letter brandings can be removed from the email branding client
* Changed the point at which we persist the logos to the database and delete the temporary logo files. This has been changed so that if saving the email branding to the database raises an error, we haven't already saved the logo and deleted the temporary logo file.
* Validated the `name` field on the `ServiceUpdateEmailBranding` form - this field is required