### PR TITLE
Fix jumpy right position of selected items counter

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -110,9 +110,14 @@
 
   &-selected-counter {
     position: absolute;
-    right: $gutter-half;
+    right: 0;
     top: $gutter - 1px;
     color: $secondary-text-colour;
+
+    .content-fixed & {
+      right: $gutter-half;
+    }
+
   }
 
 }


### PR DESCRIPTION
The negative right margin counteracts the sticky footer being wider than its containing column. This is only the case when it’s actually sticky.

# Before 

![rpos-bug](https://user-images.githubusercontent.com/355079/51898372-adde0f80-23a8-11e9-90f6-315a108a09a0.gif)

# After 

![rpos-fix](https://user-images.githubusercontent.com/355079/51898384-b5051d80-23a8-11e9-9133-51e9a44691a1.gif)
