### PR TITLE
Change breadcrumb to reflect new Service Toolkit nomenclature

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -15,7 +15,7 @@
       <nav class="breadcrumbs breadcrumbs--inverse" aria-label="Breadcrumbs">
        <ol itemscope itemtype="http://schema.org/BreadcrumbList">
          <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-           <a href="https://www.gov.uk/service-toolkit#components" itemprop="item"><span itemprop="name">Components</span></a>
+           <a href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
          </li>
          <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
            <a href="#main" itemprop="item"><span itemprop="name">GOV.UK Notify</span></a>


### PR DESCRIPTION
The Service Toolkit<sup>1</sup> used to categorise Government as a Platform Programme<sup>2</sup> things under ‘Components’ so the breadcrumb reflected this.

This commit also fixes the anchor link, which has also changed<sup>3</sup> to the new terminology.

1. https://www.gov.uk/service-toolkit
2. Rest in peace
3. https://www.w3.org/Provider/Style/URI

***

![image](https://user-images.githubusercontent.com/355079/51901135-dff27000-23ae-11e9-8410-896ec26fb27c.png)
