### PR TITLE
Use sticky footer when setting email branding

### DIFF
--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -22,14 +22,12 @@
         {{ radios(form.branding_style) }}
       </div>
     </div>
-    <div class="grid-row">
-      <div class="column-three-quarters">
-        {{ page_footer(
-          'Preview',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
-      </div>
+    <div class="js-stick-at-bottom-when-scrolling">
+      {{ page_footer(
+        'Preview',
+        back_link=url_for('.service_settings', service_id=current_service.id),
+        back_link_text='Back to settings'
+      ) }}
     </div>
   {% endcall %}
 


### PR DESCRIPTION
You don’t want to scroll all the way through the big list to get to the button.

![image](https://user-images.githubusercontent.com/355079/51900374-0d3e1e80-23ad-11e9-8377-3dbaa0307149.png)
