### PR TITLE
Grey-out ‘Not set’ for email reply-to address

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -81,7 +81,7 @@
 
         {% call settings_row(if_has_permission='email') %}
           {{ text_field('Email reply-to addresses') }}
-          {% call field(status='default' if default_reply_to_email_address == None else '') %}
+          {% call field(status='default' if current_service.count_email_reply_to_addresses == 0 else '') %}
             {{ current_service.default_email_reply_to_address or 'Not set' }}
             {% if current_service.count_email_reply_to_addresses > 1 %}
               <div class="hint">


### PR DESCRIPTION
The `default_reply_to_email_address` variable was not set anywhere so the conditional was having no effect.

# Before 

![image](https://user-images.githubusercontent.com/355079/51924401-e00d6280-23e4-11e9-8d6b-e90d955a8e8a.png)

# After 

![image](https://user-images.githubusercontent.com/355079/51924380-d84dbe00-23e4-11e9-89d3-24cbb3c7891e.png)
