### PR TITLE
Add adjustment for padding missed from previous

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -197,10 +197,12 @@
       // if next to opposite edge to the one the dialog is stuck to, no offset
       if (elIdx === (els.length - 1)) { return 0; }
 
-      // get all els between this one and the opposite edge
-      els = els.slice(elIdx + 1);
+      // make els all those from this one to the window edge
+      els = els.slice(elIdx);
+      // get all els between this one and the window edge
+      elsBetween = els.slice(1);
 
-      return this._getTotalHeight(els);
+      return this._getTotalHeight(elsBetween) - this._getPaddingBetweenEls(els);
     },
     // checks total height of all this._sticky elements against a height
     // unsticks each that won't fit and marks them as unstickable


### PR DESCRIPTION
This adds something missed from https://github.com/alphagov/notifications-admin/pull/2702 (sorry).

The part of that which [tightened the spacing between sticky elements when stacked](https://github.com/alphagov/notifications-admin/commit/707c426b9aa5b7730ac49dff21763b27507d08bd) didn't cover all the states a stack can have.

In short, when a stack is stopped, because it hits the end of its scroll area, it used to look like this:

![stopped_at_top_before](https://user-images.githubusercontent.com/87140/52069938-ae78d080-2577-11e9-8956-fd31e3198ee9.png)

This makes it look like this:

![stopped_at_top_after](https://user-images.githubusercontent.com/87140/52069950-b769a200-2577-11e9-87dd-93c4633d3f28.png)

...which means both states now have the same spacing.