### PR TITLE
Fix display of folders when copying template

### DIFF
--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -22,22 +22,22 @@
       <nav id="template-list">
         {% for item in services_templates_and_folders %}
           <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
-            <h2 class="message-name {% if item.is_folder or (item.ancestors and not item.is_folder) %}template-list-folder{% endif %}">
+            <h2 class="message-name">
               {% for ancestor in item.ancestors %}
                 {% if ancestor.is_service %}
-                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}">
+                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="template-list-folder">
                 {% else %}
-                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}">
+                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}" class="template-list-folder">
                 {% endif %}
                   {{ ancestor.name }}
                 </a> <span class="message-name-separator">/</span>
               {% endfor %}
               {% if item.is_service %}
-                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}">
+                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}" class="template-list-folder">
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% elif item.is_folder %}
-                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}">
+                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}" class="template-list-folder">
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% else %}


### PR DESCRIPTION
It was broken because we didn’t copy the markup changes made to the list of template.

# Before

![image](https://user-images.githubusercontent.com/355079/52120901-bc7d2e80-2615-11e9-8a69-406a5c10d7c1.png)

# After 

![image](https://user-images.githubusercontent.com/355079/52120889-b0916c80-2615-11e9-93f8-d5696f21c8c4.png)
