### PR TITLE
Make ‘New folder’ textbox full width

### DIFF
--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -16,7 +16,7 @@
     <div id="move_to_new_folder_form">
       <fieldset class="js-will-stick-at-bottom-when-scrolling">
         <legend class="visuallyhidden">Move to a new folder</legend>
-        {{ textbox(templates_and_folders_form.move_to_new_folder_name) }}
+        {{ textbox(templates_and_folders_form.move_to_new_folder_name, width='1-1') }}
         {{ page_footer('Move to a new folder', button_name='operation', button_value='move-to-new-folder') }}
       </fieldset>
     </div>
@@ -24,7 +24,7 @@
   <div id="add_new_folder_form">
     <fieldset class="js-will-stick-at-bottom-when-scrolling">
       <legend class="visuallyhidden">Add a new folder</legend>
-      {{ textbox(templates_and_folders_form.add_new_folder_name) }}
+      {{ textbox(templates_and_folders_form.add_new_folder_name, width='1-1') }}
       {{ page_footer('New folder', button_name='operation', button_value='add-new-folder') }}
     </fieldset>
   </div>


### PR DESCRIPTION
Looks neater when it aligns with everything else.

# Before 

![image](https://user-images.githubusercontent.com/355079/52122201-0e27b800-261a-11e9-9540-774cc801b2c9.png)

# After 

![image](https://user-images.githubusercontent.com/355079/52122218-1b44a700-261a-11e9-809f-d117929ec80b.png)
