### PR TITLE
Normalise spacing of template breadcrumb heading

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -147,7 +147,7 @@
 .folder-heading {
 
   .column-main>.grid-row:first-child &.heading-medium {
-    margin-top: 18px;
+    margin-top: $gutter-half;
   }
 
   a,
@@ -235,7 +235,7 @@
   &-manage-link {
     display: block;
     text-align: right;
-    padding: ($gutter - 7px) 0 0 0;
+    padding: $gutter-two-thirds 0 0 0;
   }
 
 }


### PR DESCRIPTION
Removes the magic numbers, makes it visually look like it’s in the same position as the 36px type size headings.