### PR TITLE
Make ‘Add new’ buttons sticky on more pages

### DIFF
--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -3,7 +3,7 @@ $item-top-padding: $gutter-half;
 .user-list {
 
   @include core-19;
-  margin-bottom: $gutter * 1.5;
+  margin-bottom: $gutter;
 
   &-item {
 

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -10,16 +10,9 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">
-        API keys
-      </h1>
-    </div>
-    <div class="column-one-third">
-      <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}" class="button align-with-heading">Create an API key</a>
-    </div>
-  </div>
+  <h1 class="heading-large">
+    API keys
+  </h1>
 
   <div class="body-copy-table">
     {% call(item, row_number) list_table(
@@ -59,9 +52,8 @@
     {% endcall %}
   </div>
 
-  {{ page_footer(
-    secondary_link=url_for('.api_integration', service_id=current_service.id),
-    secondary_link_text='Back to API integration'
-  ) }}
+  <div class="js-stick-at-bottom-when-scrolling">
+    <a href="{{ url_for('.create_api_key', service_id=current_service.id) }}" class="button-secondary">Create an API key</a>
+  </div>
 
 {% endblock %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -11,18 +11,9 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row bottom-gutter">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">
-        Team members
-      </h1>
-    </div>
-    {% if current_user.has_permissions('manage_service') %}
-      <div class="column-one-third">
-        <a href="{{ url_for('.invite_user', service_id=current_service.id) }}" class="button align-with-heading">Invite team member</a>
-      </div>
-    {% endif %}
-  </div>
+  <h1 class="heading-large">
+    Team members
+  </h1>
 
   {% if show_search_box %}
     <div data-module="autofocus">
@@ -80,5 +71,11 @@
       </div>
     {% endfor %}
   </div>
+
+  {% if current_user.has_permissions('manage_service') %}
+    <div class="js-stick-at-bottom-when-scrolling">
+      <a href="{{ url_for('.invite_user', service_id=current_service.id) }}" class="button-secondary">Invite a team member</a>
+    </div>
+  {% endif %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -9,18 +9,10 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row bottom-gutter">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">
-        Email reply-to addresses
-      </h1>
-    </div>
-  {% if current_user.has_permissions('manage_service') %}
-	  <div class="column-one-third">
-	    <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button align-with-heading">Add email address</a>
-	  </div>
-  {% endif %}
-  </div>
+  <h1 class="heading-large">
+    Email reply-to addresses
+  </h1>
+
   <div class="user-list">
     {% if not current_service.email_reply_to_addresses %}
       <div class="user-list-item">
@@ -46,6 +38,13 @@
     {% endfor %}
   </div>
   <div class="grid-row">
+    <div class="column-whole">
+      {% if current_user.has_permissions('manage_service') %}
+        <div class="js-stick-at-bottom-when-scrolling">
+          <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button">Add email reply-to address</a>
+        </div>
+      {% endif %}
+    </div>
     <div class="column-five-sixths">
       <p>
         You need to add at least one reply-to address so recipients can reply to your messages.
@@ -59,4 +58,5 @@
       </ul>
     </div>
   </div>
+
 {% endblock %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -8,18 +8,11 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <div class="grid-row bottom-gutter">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">
-        Text message senders
-      </h1>
-    </div>
-    {% if current_user.has_permissions('manage_service') %}
-  	<div class="column-one-third">
-  	  <a href="{{ url_for('.service_add_sms_sender', service_id=current_service.id) }}" class="button align-with-heading">Add text message sender</a>
-  	</div>
-    {% endif %}
-  </div>
+
+  <h1 class="heading-large">
+    Text message senders
+  </h1>
+
   <div class="user-list">
     {% if not current_service.sms_senders %}
       <div class="user-list-item">
@@ -46,6 +39,14 @@
       </div>
     {% endfor %}
   </div>
+
+  {% if current_user.has_permissions('manage_service') %}
+    <div class="grid-row bottom-gutter">
+      <div class="column-whole">
+        <a href="{{ url_for('.service_add_sms_sender', service_id=current_service.id) }}" class="button">Add text message sender</a>
+      </div>
+    </div>
+  {% endif %}
   <p>
     The text message sender tells your users who the message is from.
   </p>


### PR DESCRIPTION
For consistency with the template management page.

# Team members page

## Before 

![image](https://user-images.githubusercontent.com/355079/52130433-0bd15800-2632-11e9-9522-2d1e4efecc08.png)

## After 

![image](https://user-images.githubusercontent.com/355079/52130366-df1d4080-2631-11e9-9b76-9ac1c071f0d4.png)

# API keys page

## Before 

![image](https://user-images.githubusercontent.com/355079/52130421-ffe59600-2631-11e9-9318-000da6a41e95.png)

## After 

![image](https://user-images.githubusercontent.com/355079/52130399-ef352000-2631-11e9-888f-c4bf776a0284.png)
