### PR TITLE
Replace native Array.includes with jQuery version

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -147,7 +147,7 @@
       );
 
       // use dialog mode for states which contain more than one form control
-      if (['move-to-existing-folder', 'add-new-template'].includes(this.currentState)) {
+      if ($.inArray(this.currentState, ['move-to-existing-folder', 'add-new-template'])) {
         mode = 'dialog';
       }
       GOVUK.stickAtBottomWhenScrolling.setMode(mode);


### PR DESCRIPTION
This was failing with a 'Object doesn't have method' error on IE11. Assume Babel wasn't
polyfilling Array.includes so reverting to jQuery version for now.