### PR TITLE
Warn if a file has been sent already

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -609,6 +609,9 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         )),
         required_recipient_columns=OrderedSet(recipients.recipient_column_headers) - optional_address_columns,
         preview_row=preview_row,
+        sent_previously=job_api_client.has_sent_previously(
+            service_id, template.id, db_template['version'], request.args.get('original_file_name', '')
+        )
     )
 
 
@@ -625,7 +628,8 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
         not data['count_of_recipients'] or
         not data['recipients'].has_recipient_columns or
         data['recipients'].duplicate_recipient_column_headers or
-        data['recipients'].missing_column_headers
+        data['recipients'].missing_column_headers or
+        data['sent_previously']
     ):
         return render_template('views/check/column-errors.html', **data)
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -60,6 +60,17 @@ class JobApiClient(NotifyAdminAPIClient):
 
         return jobs
 
+    def has_sent_previously(self, service_id, template_id, template_version, original_file_name):
+        return (
+            template_id, template_version, original_file_name
+        ) in (
+            (
+                job['template'], job['template_version'], job['original_file_name'],
+            )
+            for job in self.get_jobs(service_id, limit_days=0)['data']
+            if job['job_status'] != 'cancelled'
+        )
+
     def get_page_of_jobs(self, service_id, page):
         return self.get_jobs(
             service_id,

--- a/app/templates/partials/check/sent-previously.html
+++ b/app/templates/partials/check/sent-previously.html
@@ -1,0 +1,6 @@
+<h1 class='banner-title' data-module="track-error" data-error-type="File previously sent" data-error-label="{{ upload_id }}">
+  You already sent these messages
+</h1>
+<p>
+  If you want to send the same messages again, rename the file and re-upload it
+</p>

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -98,6 +98,10 @@
           ) }}.
         </p>
 
+      {% elif sent_previously %}
+
+        {% include "partials/check/sent-previously.html" %}
+
       {% elif not recipients.allowed_to_send_to %}
 
         {% with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1854,7 +1854,7 @@ def mock_has_no_jobs(mocker):
 def mock_get_jobs(mocker, api_user_active):
     def _get_jobs(service_id, limit_days=None, statuses=None, page=1):
         if statuses is None:
-            statuses = ['', 'scheduled', 'pending', 'cancelled']
+            statuses = ['', 'scheduled', 'pending', 'cancelled', 'finished']
 
         jobs = [
             job_json(
@@ -1862,16 +1862,17 @@ def mock_get_jobs(mocker, api_user_active):
                 api_user_active,
                 original_file_name=filename,
                 scheduled_for=scheduled_for,
-                job_status=job_status
+                job_status=job_status,
+                template_version=template_version,
             )
-            for filename, scheduled_for, job_status in (
-                ('export 1/1/2016.xls', '', 'finished'),
-                ('all email addresses.xlsx', '', 'pending'),
-                ('applicants.ods', '', 'finished'),
-                ('thisisatest.csv', '', 'finished'),
-                ('send_me_later.csv', '2016-01-01 11:09:00.061258', 'scheduled'),
-                ('even_later.csv', '2016-01-01 23:09:00.061258', 'scheduled'),
-                ('full_of_regret.csv', '2016-01-01 23:09:00.061258', 'cancelled')
+            for filename, scheduled_for, job_status, template_version in (
+                ('export 1/1/2016.xls', '', 'finished', 1),
+                ('all email addresses.xlsx', '', 'pending', 1),
+                ('applicants.ods', '', 'finished', 1),
+                ('thisisatest.csv', '', 'finished', 2),
+                ('send_me_later.csv', '2016-01-01 11:09:00.061258', 'scheduled', 1),
+                ('even_later.csv', '2016-01-01 23:09:00.061258', 'scheduled', 1),
+                ('full_of_regret.csv', '2016-01-01 23:09:00.061258', 'cancelled', 1)
             )
         ]
         return {


### PR DESCRIPTION
We have some teams who have a series of files they have to send each day. It’s easy to get muddled up and accidentally send the same file again, if you lose track of which ones you’ve already sent

This commit blocks you from sending the same combination of template version and filename more than once on the same day[1].

![image](https://user-images.githubusercontent.com/355079/52214960-ebe8a100-288a-11e9-9cb0-050aacb9fb8e.png)

This won’t affect teams who re-use the same template to give (for example) updates on an incident for business continuity. These teams edit the template between each send, thereby updating the version
number of the template.

1. This is based on how the `limit_days` argument to the API works - you can dig into the code here: https://github.com/alphagov/notifications-api/blob/2bd4f74ad0e24f7066e1a6bd4d0e515b4b925e10/app/dao/jobs_dao.py#L50