### PR TITLE
Fix empty folder message

### DIFF
--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -24,10 +24,10 @@ class TemplateList():
             yield TemplateListFolder(
                 item,
                 folders=self.service.get_template_folders(
-                    self.template_type, item['id']
+                    template_type, item['id']
                 ),
                 templates=self.service.get_templates(
-                    self.template_type, item['id']
+                    template_type, item['id']
                 ),
                 ancestors=ancestors,
                 service_id=self.service.id,
@@ -38,7 +38,7 @@ class TemplateList():
                 yield sub_item
 
         for item in self.service.get_templates(
-            self.template_type, template_folder_id
+            template_type, template_folder_id
         ):
             yield TemplateListTemplate(
                 item,

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -303,6 +303,24 @@ def test_post_add_template_folder_page(client_request, service_one, mocker, pare
             None,
         ),
         (
+            'folder_one_one_one – folder_one_one – folder_one – Templates – service one – GOV.UK Notify',
+            'Templates / folder_one / folder_one_one / folder_one_one_one',
+            [
+                {'template_type': 'email'},
+                {'template_type': 'email', 'template_folder_id': PARENT_FOLDER_ID},
+                {'template_type': 'email', 'template_folder_id': CHILD_FOLDER_ID},
+            ],
+            {
+                'template_type': 'email',
+                'template_folder_id': GRANDCHILD_FOLDER_ID,
+            },
+            ['All', 'Text message', 'Letter'],
+            [],
+            [],
+            [],
+            'There are no email templates in this folder',
+        ),
+        (
             'folder_two – Templates – service one – GOV.UK Notify',
             'Templates / folder_two',
             [{'template_type': 'all'}],


### PR DESCRIPTION
Sometimes, when filtering the view by template type, the message was saying the folder was empty, when really it should have been saying that there were no templates of the ‘type’ you’re looking for, eg:
> There are no email templates in this folder

This was because it was looking at the filtered list of templates, not all templates to determine whether a folder was really empty.