### PR TITLE
People who can't send messages still see template postage class

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -21,12 +21,12 @@
                 Send
               </a>
             </div>
-            {% if current_service.has_permission("choose_postage") %}
-              <div class="column-whole" id="postage">
-                <h2 class="heading-small heading-inline">Postage</h2>:
-                {{ template_postage or current_service.postage }} class
-              </div>
-            {% endif %}
+          {% endif %}
+          {% if current_service.has_permission("choose_postage") %}
+            <div class="column-whole" id="postage">
+              <h2 class="heading-small heading-inline">Postage</h2>:
+              {{ template_postage or current_service.postage }} class
+            </div>
           {% endif %}
         {% else %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}


### PR DESCRIPTION
Postage information on template page has been moved so that people who cannot send messages can see that information, too.