### PR TITLE
Move images into place before processing SASS

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -164,9 +164,9 @@ gulp.task('default',
     'copy:govuk_template:css',
     'copy:govuk_template:js',
     'copy:govuk_template:error_page',
+    'images',
     'javascripts',
-    'sass',
-    'images'
+    'sass'
   ]
 );
 


### PR DESCRIPTION
As part of the SASS processing we base64 and embed every image found in the SASS files. In order to do this the images need to be in place beforehand.

This was causing a bug where the first deploy of an image would cause it to 404.