### PR TITLE
Ensure Gulp tasks run sequentially

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,6 +8,7 @@
 import gulp from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import stylish from 'jshint-stylish';
+import runSequence from 'run-sequence';
 
 const plugins = loadPlugins(),
 
@@ -156,19 +157,23 @@ gulp.task('lint',
 );
 
 // Default: compile everything
-gulp.task('default',
-  [
-    'copy:govuk_template:template',
-    'copy:govuk_template:images',
-    'copy:govuk_template:fonts',
-    'copy:govuk_template:css',
-    'copy:govuk_template:js',
-    'copy:govuk_template:error_page',
-    'images',
-    'javascripts',
-    'sass'
-  ]
-);
+gulp.task('default', function() {
+  runSequence(
+    [
+      'copy:govuk_template:template',
+      'copy:govuk_template:images',
+      'copy:govuk_template:fonts',
+      'copy:govuk_template:css',
+      'copy:govuk_template:js',
+      'images',
+    ],
+    [
+      'copy:govuk_template:error_page',
+      'javascripts',
+      'sass'
+    ]
+  );
+});
 
 // Optional: recompile on changes
 gulp.task('watch',

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "gulp-sass-lint": "1.2.0",
     "jshint": "2.9.5",
     "jshint-stylish": "2.2.1",
-    "run-sequence": "^2.2.1"
+    "run-sequence": "2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-prettyerror": "1.2.1",
     "gulp-sass-lint": "1.2.0",
     "jshint": "2.9.5",
-    "jshint-stylish": "2.2.1"
+    "jshint-stylish": "2.2.1",
+    "run-sequence": "^2.2.1"
   }
 }


### PR DESCRIPTION
So that images are always copied into place before trying to build the SASS.