### PR TITLE
Say ‘Change’ not ‘Edit’ postage

### DIFF
--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -4,13 +4,13 @@
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
-  Edit postage
+  Change postage
 {% endblock %}
 
 {% block maincolumn_content %}
 
     <h1 class="heading-large">
-      Edit postage
+      Change postage
     </h1>
     {% call form_wrapper() %}
       <div class="grid-row">

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -493,7 +493,7 @@ def test_edit_letter_template_postage_page_displays_correctly(
         template_id=fake_uuid,
     )
 
-    assert page.select_one('h1').text.strip() == 'Edit postage'
+    assert page.select_one('h1').text.strip() == 'Change postage'
     assert page.select('input[checked]')[0].attrs["value"] == 'second'
 
 


### PR DESCRIPTION
To match the call to action on the template page.

Karl said:

> I feel good about it. You're not really editing it so much as choosing between 2 options. It feels more human.
>
> I think it only started out as edit to match all the other sections of the letter – it certainly wasn't given any real consideration.