### PR TITLE
Template form focus

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -576,9 +576,8 @@
 
       el.removeStickyClasses(this);
       $el.css('width', '');
-      if (_mode === 'dialog') {
-        dialog.releaseEl(el, this);
-      }
+      // clear styles from any elements stuck while in a dialog mode
+      dialog.releaseEl(el, this);
       el.removeShim();
       el.release(this);
     }
@@ -658,9 +657,15 @@
     }
   };
   stickAtTop.unstop = function (el) {
+    var offset = 0;
+
+    if (_mode === 'dialog') {
+      offset = dialog.getOffsetFromEdge(el, this);
+    }
+
     el.$fixedEl.css({
       'position': '',
-      'top': ''
+      'top': offset + 'px'
     });
     el.unstop();
   };

--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -263,7 +263,7 @@
         $(window).scrollTop(this.getInPageEdgePosition(sticky) - windowHeight);
       }
 
-      self.hasResized = false;
+      this.hasResized = false;
     },
     releaseEl: function (el, sticky) {
       el.$fixedEl.css(sticky.edge, '');

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -35,7 +35,7 @@
       // first off show the new template / new folder buttons
       this.currentState = this.$form.data('prev-state') || 'unknown';
       if (this.currentState === 'unknown') {
-        this.selectActionButtons();
+        this.selectActionButtons(false);
       } else {
         this.render();
       }
@@ -75,6 +75,7 @@
     };
 
     this.addCancelButton = function(state) {
+      let selector = `[value=${state.key}]`;
       let $cancel = this.makeButton('Cancel', () => {
 
         // clear existing data
@@ -82,8 +83,8 @@
         state.$el.find('input:text').val('');
 
         // go back to action buttons
-        this.selectActionButtons();
-      });
+        this.selectActionButtons(selector);
+      }, selector);
 
       state.$el.find('[type=submit]').after($cancel);
     };
@@ -91,7 +92,6 @@
     this.addClearButton = function(state) {
 
       let $clear = this.makeButton('Clear', () => {
-
         // uncheck all templates and folders
         this.$form.find('input:checkbox').prop('checked', false);
 
@@ -102,9 +102,10 @@
       state.$el.find('.template-list-selected-counter').append($clear);
     };
 
-    this.makeButton = (text, fn) => $('<a></a>')
+    this.makeButton = (text, fn, cancelSelector) => $('<a></a>')
       .html(text)
       .addClass('js-cancel')
+      .data('target', cancelSelector) // isn't set if cancelSelector is undefined
       .attr('tabindex', '0')
       .on('click keydown', event => {
         // space, enter or no keyCode (must be mouse input)
@@ -114,12 +115,16 @@
         }
       });
 
-    this.selectActionButtons = function () {
+    this.selectActionButtons = function (targetSelector) {
       // If we want to show one of the grey choose actions state, we can pretend we're in the choose actions state,
       // and then pretend a checkbox was clicked to work out whether to show zero or non-zero options.
       // This calls a render at the end
       this.currentState = 'nothing-selected-buttons';
       this.templateFolderCheckboxChanged();
+      if (targetSelector) {
+        let setFocus = this.getFocusRoutine(targetSelector, false);
+        setFocus();
+      }
     };
 
     this.actionButtonClicked = function(event) {

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -170,8 +170,6 @@
         state => (state.key === this.currentState ? this.$stickyBottom.append(state.$el) : state.$el.detach())
       );
 
-      if (currentStateObj && ('setFocus' in currentStateObj)) { currentStateObj.setFocus(); }
-
       // use dialog mode for states which contain more than one form control
       if (['move-to-existing-folder', 'add-new-template'].indexOf(this.currentState) !== -1) {
         mode = 'dialog';
@@ -179,6 +177,8 @@
       GOVUK.stickAtBottomWhenScrolling.setMode(mode);
       // make sticky JS recalculate its cache of the element's position
       GOVUK.stickAtBottomWhenScrolling.recalculate();
+
+      if (currentStateObj && ('setFocus' in currentStateObj)) { currentStateObj.setFocus(); }
     };
 
     this.nothingSelectedButtons = $(`

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -19,10 +19,10 @@
       this.states = [
         {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false},
         {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false},
-        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios fieldset', true)},
+        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios legend', true)},
         {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_new_folder_name', false)},
         {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_folder_name', false)},
-        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form fieldset', true)}
+        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form legend', true)}
       ];
 
       // cancel/clear buttons only relevant if JS enabled, so
@@ -47,9 +47,15 @@
     this.getFocusRoutine = function (selector, setTabindex) {
       return function () {
         let $el = $(selector);
+        let removeTabindex = (e) => {
+          $(e.target)
+            .removeAttr('tabindex')
+            .off('blur', removeTabindex);
+        };
 
         if (setTabindex) {
           $el.attr('tabindex', '-1');
+          $el.on('blur', removeTabindex);
         }
 
         $el.focus();

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -19,10 +19,10 @@
       this.states = [
         {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false},
         {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false},
-        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true},
-        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true},
-        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true},
-        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true}
+        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios fieldset', true)},
+        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_new_folder_name', false)},
+        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_folder_name', false)},
+        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form fieldset', true)}
       ];
 
       // cancel/clear buttons only relevant if JS enabled, so
@@ -42,6 +42,18 @@
 
       this.$form.on('click', 'button.button-secondary', (event) => this.actionButtonClicked(event));
       this.$form.on('change', 'input[type=checkbox]', () => this.templateFolderCheckboxChanged());
+    };
+
+    this.getFocusRoutine = function (selector, setTabindex) {
+      return function () {
+        let $el = $(selector);
+
+        if (setTabindex) {
+          $el.attr('tabindex', '-1');
+        }
+
+        $el.focus();
+      };
     };
 
     this.activateStickyElements = function() {
@@ -139,12 +151,15 @@
     };
 
     this.render = function() {
-      var mode = 'default';
+      let mode = 'default';
+      let currentStateObj = this.states.filter(state => { return (state.key === this.currentState); })[0];
 
       // detach everything, unless they are the currentState
       this.states.forEach(
         state => (state.key === this.currentState ? this.$stickyBottom.append(state.$el) : state.$el.detach())
       );
+
+      if (currentStateObj && ('setFocus' in currentStateObj)) { currentStateObj.setFocus(); }
 
       // use dialog mode for states which contain more than one form control
       if (['move-to-existing-folder', 'add-new-template'].indexOf(this.currentState) !== -1) {

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -4,18 +4,17 @@
 .js-stick-at-top-when-scrolling,
 .js-stick-at-bottom-when-scrolling {
 
-  @extend %contain-floats;
+  overflow: hidden;
   margin-left: -$gutter-half;
   padding: 10px 0 0 $gutter-half;
   position: relative;
 
-  fieldset:focus {
-    outline: solid 3px $focus-colour;
-    outline-offset: $gutter-half;
-  }
-
   .form-group {
     margin-bottom: 20px;
+
+    legend {
+      outline: none;
+    }
   }
 
   .back-to-top-link {
@@ -52,7 +51,7 @@
   margin-top: -$vertical-padding;
 
   & + .js-stick-at-bottom-when-scrolling {
-    margin-top: ($vertical-padding * 2) * -1;
+    margin-top: ($sticky-padding * 2) * -1;
   }
 
   .page-footer {

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -4,10 +4,15 @@
 .js-stick-at-top-when-scrolling,
 .js-stick-at-bottom-when-scrolling {
 
-  overflow: hidden;
+  @extend %contain-floats;
   margin-left: -$gutter-half;
   padding: 10px 0 0 $gutter-half;
   position: relative;
+
+  fieldset:focus {
+    outline: solid 3px $focus-colour;
+    outline-offset: $gutter-half;
+  }
 
   .form-group {
     margin-bottom: 20px;

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -1,6 +1,8 @@
 // CSS adapted from
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/d9489a987086471fe30b4b925a81c12cd198c91d/docs/javascript.md#stick-at-top-when-scrolling
 
+$sticky-padding: $gutter * 2 / 3;
+
 .js-stick-at-top-when-scrolling,
 .js-stick-at-bottom-when-scrolling {
 
@@ -44,11 +46,9 @@
 
 .js-stick-at-bottom-when-scrolling {
 
-  $vertical-padding: $gutter * 2 / 3;
-
   transition: bottom 0.1s ease-out, box-shadow 1s ease-in-out;
-  padding: $vertical-padding 0 $vertical-padding $gutter-half;
-  margin-top: -$vertical-padding;
+  padding: $sticky-padding 0 $sticky-padding $gutter-half;
+  margin-top: -$sticky-padding;
 
   & + .js-stick-at-bottom-when-scrolling {
     margin-top: ($sticky-padding * 2) * -1;

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -29,14 +29,11 @@
     </fieldset>
   </div>
   <div id="add_new_template_form">
-    <fieldset>
-      <legend class="visuallyhidden">Add a new template</legend>
-      <div class="js-will-stick-at-bottom-when-scrolling">
-      {{ radios(templates_and_folders_form.add_template_by_template_type) }}
-      </div>
-      <div class="js-will-stick-at-bottom-when-scrolling">
-      {{ page_footer('Continue', button_name='operation', button_value='add-new-template') }}
-      </div>
-    </fieldset>
+    <div class="js-will-stick-at-bottom-when-scrolling">
+    {{ radios(templates_and_folders_form.add_template_by_template_type) }}
+    </div>
+    <div class="js-will-stick-at-bottom-when-scrolling">
+    {{ page_footer('Continue', button_name='operation', button_value='add-new-template') }}
+    </div>
   </div>
 </div>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -320,7 +320,7 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
     if not page.select('#add_new_template_form'):
         raise ElementNotFound()
 
-    assert normalize_spaces(page.select_one('#add_new_template_form fieldset fieldset legend').text) == (
+    assert normalize_spaces(page.select_one('#add_new_template_form fieldset legend').text) == (
         'Add new'
     )
     assert [


### PR DESCRIPTION
Improvements to how focus moves around when we're changing the HTML on the templates page.

https://www.pivotaltracker.com/story/show/163524995

## Context

Browsers keep a sequence of elements that can be focused. When you tab through a page you're moving through that sequence.

The JS on the templates page changes the HTML which sometimes removes elements from the sequence, effecting tabbing.

For example, if a user clicks 'new folder', the current focus (the 'new folder' button) has been removed from the DOM but we don't move focus to another element.

These changes ensure focus is moved in the way we intend, that helps users complete the task they're on.

## Changes

- when 'new template' is clicked, we move focus to the radios for selecting the type of template
- when templates/folders are selected and 'move' is clicked, we move focus to the radios for selecting the folder to move them to
- when 'new folder' or 'add to new folder' is clicked, we move focus to the textbox for the folder name

## How to test this

Try all the tasks that are effected by the change in HTML, using the keyboard only:
- creating a new template
- creating a new folder
- moving a template/folder to an existing folder
- moving a template/folder to a new folder

...and for the above, try clicking the 'cancel' link when you see it.

You should be able to do all of them without making any extra tabbing movements to correct not being in the right place.