### PR TITLE
Add tooltip to ‘Templates’ in breadcrumb

### DIFF
--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -23,7 +23,7 @@
           {% if folder.id %}
             <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
           {% else %}
-            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" class="{% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
+            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="{% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
           {% endif %}
           {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
         {% endif %}


### PR DESCRIPTION
Because sometimes we show it truncated to ‘T…’