### PR TITLE
Stop flicker when hovering postage on precompiled

### DIFF
--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -85,7 +85,7 @@ $iso-paper-ratio: 141.42135624%;
     .letter-sent &:hover {
 
       background-color: transparent;
-      border: none;
+      border-color: transparent;
       box-shadow: none;
       background-image: file-url('envelope-fold.svg');
 


### PR DESCRIPTION
We were removing the border to ‘unfold’ the corner of the page. This was causing the size of the element to shrink.

This meant that it you hovered the bottom 1px of the element it would cycle in and out of the hover state as fast as the browser could render it.

This commit fixes that by making the border transparent, rather than removing it.

![flicker](https://user-images.githubusercontent.com/355079/52492483-320e6f00-2bc1-11e9-8fc8-d7dd8944d3c2.gif)
