### PR TITLE
use letter branding object instead of letter_logo_filename

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -29,7 +29,6 @@ class Service():
         'inbound_api',
         'letter_branding',
         'letter_contact_block',
-        'letter_logo_filename',
         'message_limit',
         'name',
         'organisation_type',

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -11,7 +11,7 @@ class TemplatePreview:
             'letter_contact_block': template.get('reply_to_text', ''),
             'template': template,
             'values': values,
-            'filename': current_service.letter_logo_filename,
+            'filename': current_service.letter_branding and current_service.letter_branding['filename']
         }
         resp = requests.post(
             '{}/preview.{}{}'.format(

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -40,16 +40,22 @@ def test_from_utils_template_calls_through(
         'http://localhost:9999/preview.bar?page=99',
     ),
 ])
+@pytest.mark.parametrize('letter_branding, expected_filename', [
+    ({'filename': 'hm-government'}, 'hm-government'),
+    (None, None)
+])
 def test_from_database_object_makes_request(
     mocker,
     client,
     partial_call,
     expected_url,
+    letter_branding,
+    expected_filename,
     mock_get_service_letter_template
 ):
     resp = Mock(content='a', status_code='b', headers={'c': 'd'})
     request_mock = mocker.patch('app.template_previews.requests.post', return_value=resp)
-    mocker.patch('app.template_previews.current_service', letter_logo_filename='hm-government')
+    mocker.patch('app.template_previews.current_service', letter_branding=letter_branding)
     template = mock_get_service_letter_template('123', '456')['data']
 
     ret = partial_call(template=template)
@@ -62,7 +68,7 @@ def test_from_database_object_makes_request(
         'letter_contact_block': None,
         'template': template,
         'values': None,
-        'filename': 'hm-government',
+        'filename': expected_filename,
     }
     headers = {'Authorization': 'Token my-secret-key'}
 


### PR DESCRIPTION
This is part of migrating away from dvla organisations. This only affects in-app previews, not actual letters printed by the api.

![](https://user-images.githubusercontent.com/5020841/52582712-bbbe7680-2e25-11e9-9c79-54a40dab1754.png)

requires:

- [x] https://github.com/alphagov/notifications-template-preview/pull/278