### PR TITLE
Update email_domains.yml

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -46,3 +46,4 @@
 - careinspectorate.com
 - unitypartnership.com 
 - nao.org.uk
+- skillsforcare.org.uk


### PR DESCRIPTION
Adult Social Care Workforce Data Set service  is funded by the Department of Health and Social Care and is being delivered by Skills for Care as a delivery partner