### PR TITLE
Clean up domains file

### DIFF
--- a/app/domains.yml
+++ b/app/domains.yml
@@ -223,7 +223,7 @@ acas.org.uk:
   owner: Advisory, Conciliation and Arbitration Service
   crown: true
   agreement_signed: false
-charitycommission.gsi.gov.uk:
+charitycommission.gsi.gov.uk: charitycommission.gov.uk
 charitycommission.gov.uk:
   owner: Charity Commission
   crown: true
@@ -257,7 +257,7 @@ hse.gov.uk:
   owner: Health and Safety Executive
   crown: true
   agreement_signed: false
-hmtreasury.gsi.gov.uk:
+hmtreasury.gsi.gov.uk: hmtreasury.gov.uk
 hmtreasury.gov.uk:
   owner: HM Treasury
   crown: true
@@ -5122,7 +5122,7 @@ wyrebc.gov.uk:
   owner: Wyre Borough Council
   crown: false
   agreement_signed: false
-wyreforestdc.gov.uk:
+wyreforestdc.gov.uk: wyreforest.gov.uk
 wyreforest.gov.uk:
   owner: Wyre Forest District Council
   crown: false

--- a/app/domains.yml
+++ b/app/domains.yml
@@ -309,7 +309,7 @@ aberdeenshire.gov.uk:
   owner: Aberdeenshire Council
   crown: false
   agreement_signed: true
-AbergavennyTownCouncil.gov.uk:
+abergavennytowncouncil.gov.uk:
   owner: Abergavenny Town Council
   crown: false
   agreement_signed: false
@@ -544,7 +544,7 @@ barmouthtowncouncil.gov.uk:
   owner: Barmouth Town Council
   crown: false
   agreement_signed: false
-BarnardCastleTownCouncil.gov.uk:
+barnardcastletowncouncil.gov.uk:
   owner: Barnard Castle Town Council
   crown: false
   agreement_signed: false
@@ -859,7 +859,7 @@ bridport-tc.gov.uk:
   owner: Bridport Town Council
   crown: false
   agreement_signed: false
-Brierfield.gov.uk:
+brierfield.gov.uk:
   owner: Brierfield Town Council
   crown: false
   agreement_signed: false
@@ -1553,7 +1553,7 @@ dover.gov.uk:
   owner: Dover District Council
   crown: false
   agreement_signed: false
-DoverTownCouncil.gov.uk:
+dovertowncouncil.gov.uk:
   owner: Dover Town Council
   crown: false
   agreement_signed: false
@@ -1857,7 +1857,7 @@ fife.gov.uk:
   owner: Fife Council
   crown: false
   agreement_signed: false
-FiltonTownCouncil.gov.uk:
+filtontowncouncil.gov.uk:
   owner: Filton Town Council
   crown: false
   agreement_signed: false
@@ -1969,7 +1969,7 @@ goole-tc.gov.uk:
   owner: Goole Town Council
   crown: false
   agreement_signed: false
-GorseinonTownCouncil.gov.uk:
+gorseinontowncouncil.gov.uk:
   owner: Gorseinon Town Council
   crown: false
   agreement_signed: false
@@ -2018,7 +2018,7 @@ guildford.gov.uk:
   owner: Guildford Borough Council
   crown: false
   agreement_signed: false
-GwentArchives.gov.uk:
+gwentarchives.gov.uk:
   owner: Blaenau Gwent County Borough Council
   crown: false
   agreement_signed: false
@@ -2205,7 +2205,7 @@ hertsmere.gov.uk:
   owner: Hertsmere Borough Council
   crown: false
   agreement_signed: false
-Hertspartnership-ala.gov.uk:
+hertspartnership-ala.gov.uk:
   owner: East Herts District Council
   crown: false
   agreement_signed: false
@@ -2469,7 +2469,7 @@ kirtoninlindseytowncouncil.gov.uk:
   owner: Kirton in Lindsey Town Council
   crown: false
   agreement_signed: false
-KnaresboroughTownCouncil.gov.uk:
+knaresboroughtowncouncil.gov.uk:
   owner: Knaresborough Town Council
   crown: false
   agreement_signed: false
@@ -2703,7 +2703,7 @@ llantwitmajortowncouncil.gov.uk:
   owner: Llantwit Major Town Council
   crown: false
   agreement_signed: false
-LlwchwrTownCouncil.gov.uk:
+llwchwrtowncouncil.gov.uk:
   owner: Llwchwr Town Council
   crown: false
   agreement_signed: false
@@ -2965,7 +2965,7 @@ morley.gov.uk:
   owner: Morley Town Council
   crown: false
   agreement_signed: false
-Morpeth-tc.gov.uk:
+morpeth-tc.gov.uk:
   owner: Morpeth Town Council
   crown: false
   agreement_signed: false
@@ -3051,7 +3051,7 @@ newbury.gov.uk:
   owner: Newbury Town Council
   crown: false
   agreement_signed: false
-NewcastleEmlynTownCouncil.gov.uk:
+newcastleemlyntowncouncil.gov.uk:
   owner: Newcastle Emlyn Town Council
   crown: false
   agreement_signed: false
@@ -3151,7 +3151,7 @@ norfolkprepared.gov.uk:
   owner: Norfolk County Council
   crown: false
   agreement_signed: false
-NorthallertonTownCouncil.gov.uk:
+northallertontowncouncil.gov.uk:
   owner: Northallerton Town Council
   crown: false
   agreement_signed: false
@@ -3408,7 +3408,7 @@ pembrokeshire.gov.uk:
   owner: Pembrokeshire County Council
   crown: false
   agreement_signed: true
-PenarthTownCouncil.gov.uk:
+penarthtowncouncil.gov.uk:
   owner: Penarth Town Council
   crown: false
   agreement_signed: false
@@ -3436,7 +3436,7 @@ pershore-tc.gov.uk:
   owner: Pershore Town Council
   crown: false
   agreement_signed: false
-PershoreTownCouncil.gov.uk:
+pershoretowncouncil.gov.uk:
   owner: Pershore Town Council
   crown: false
   agreement_signed: false
@@ -3485,7 +3485,7 @@ polperrocommunitycouncil.gov.uk:
   owner: Polperro Community Council
   crown: false
   agreement_signed: false
-PontarddulaisTownCouncil.gov.uk:
+pontarddulaistowncouncil.gov.uk:
   owner: Pontarddulais Town Council
   crown: false
   agreement_signed: false
@@ -3522,7 +3522,7 @@ powys.gov.uk:
   owner: Powys County Council
   crown: false
   agreement_signed: false
-PoyntonTownCouncil.gov.uk:
+poyntontowncouncil.gov.uk:
   owner: Poynton Town Council
   crown: false
   agreement_signed: false
@@ -3558,7 +3558,7 @@ queensparkcommunitycouncil.gov.uk:
   owner: Queens Park Community Council
   crown: false
   agreement_signed: false
-Radstock-tc.gov.uk:
+radstock-tc.gov.uk:
   owner: Radstock Town Council
   crown: false
   agreement_signed: false

--- a/app/domains.yml
+++ b/app/domains.yml
@@ -297,10 +297,7 @@ nao.org.uk:
   agreement_signed: false
 
 # Local Government
-aberdeencityandshire-sdpa.gov.uk:
-  owner: Aberdeen City Council
-  crown: false
-  agreement_signed: false
+aberdeencityandshire-sdpa.gov.uk: aberdeencity.gov.uk
 aberdeencity.gov.uk:
   owner: Aberdeen City Council
   crown: false
@@ -329,26 +326,17 @@ abingdon.gov.uk:
   owner: Abingdon Town Council
   crown: false
   agreement_signed: false
-abinger-pc.gov.uk:
-  owner: Mole Valley District Council
-  crown: false
-  agreement_signed: false
+abinger-pc.gov.uk: molevalley.gov.uk
 actoncommunitycouncil.gov.uk:
   owner: Acton Community Council
   crown: false
   agreement_signed: false
-adurdc.gov.uk:
-  owner: Adur District Council
-  crown: false
-  agreement_signed: false
+adurdc.gov.uk: adur.gov.uk
 adur.gov.uk:
   owner: Adur District Council
   crown: false
   agreement_signed: false
-adur-worthing.gov.uk:
-  owner: Adur District Council
-  crown: false
-  agreement_signed: false
+adur-worthing.gov.uk: adur.gov.uk
 alcester-tc.gov.uk:
   owner: Alcester Town Council
   crown: false
@@ -389,30 +377,18 @@ anglesey.gov.uk:
   owner: Isle of Anglesey County Council
   crown: false
   agreement_signed: false
-angliarevenues.gov.uk:
-  owner: St Edmundsbury Borough Council
-  crown: false
-  agreement_signed: false
+angliarevenues.gov.uk: westsuffolk.gov.uk
 angus.gov.uk:
   owner: Angus Council
   crown: false
   agreement_signed: false
-antrimandnewtownabbey.gov.uk:
-  owner: Antrim Borough Council
-  crown: false
-  agreement_signed: false
+antrimandnewtownabbey.gov.uk: antrim.gov.uk
 antrim.gov.uk:
   owner: Antrim Borough Council
   crown: false
   agreement_signed: false
-archifaugwent.gov.uk:
-  owner: Blaenau Gwent County Borough Council
-  crown: false
-  agreement_signed: false
-archifaumorgannwg.gov.uk:
-  owner: Cardiff Council
-  crown: false
-  agreement_signed: false
+archifaugwent.gov.uk: blaenau-gwent.gov.uk
+archifaumorgannwg.gov.uk: cardiff.gov.uk
 ardsandnorthdown.gov.uk:
   owner: North Down Borough Council
   crown: false
@@ -458,10 +434,7 @@ ashurstwood-vc.gov.uk:
   owner: Ashurst Wood Village Council
   crown: false
   agreement_signed: false
-askderbyshire.gov.uk:
-  owner: North East Derbyshire District Council
-  crown: false
-  agreement_signed: false
+askderbyshire.gov.uk: ne-derbyshire.gov.uk
 aspatria-tc.gov.uk:
   owner: Aspatria Town Council
   crown: false
@@ -470,10 +443,7 @@ atherstone-tc.gov.uk:
   owner: Atherstone Town Council
   crown: false
   agreement_signed: false
-aws.gov.uk:
-  owner: Worthing Borough Council
-  crown: false
-  agreement_signed: false
+aws.gov.uk: worthing.gov.uk
 axbridge-tc.gov.uk:
   owner: Axbridge Town Council
   crown: false
@@ -482,18 +452,12 @@ axminstertowncouncil.gov.uk:
   owner: Axminster Town Council
   crown: false
   agreement_signed: false
-aylesbury.gov.uk:
-  owner: Aylesbury Vale District Council
-  crown: false
-  agreement_signed: false
+aylesbury.gov.uk: aylesburyvale.gov.uk
 aylesburytowncouncil.gov.uk:
   owner: Aylesbury Town Council
   crown: false
   agreement_signed: false
-aylesburyvaledc.gov.uk:
-  owner: Aylesbury Vale District Council
-  crown: false
-  agreement_signed: false
+aylesburyvaledc.gov.uk: aylesburyvale.gov.uk
 aylesburyvale.gov.uk:
   owner: Aylesbury Vale District Council
   crown: false
@@ -508,10 +472,7 @@ babergh.gov.uk:
   owner: Babergh District Council
   crown: false
   agreement_signed: false
-baberghmidsuffolk.gov.uk:
-  owner: Babergh District Council
-  crown: false
-  agreement_signed: false
+baberghmidsuffolk.gov.uk: babergh.gov.uk
 bagilltcommunitycouncil.gov.uk:
   owner: Bagillt Community Council
   crown: false
@@ -577,10 +538,7 @@ bassetlaw.gov.uk:
   owner: Bassetlaw District Council
   crown: false
   agreement_signed: false
-batchworth-ecc.gov.uk:
-  owner: Batchworth Community Council
-  crown: false
-  agreement_signed: false
+batchworth-ecc.gov.uk: batchworth-pc.gov.uk
 batchworth-pc.gov.uk:
   owner: Batchworth Community Council
   crown: false
@@ -613,14 +571,8 @@ bedford.gov.uk:
   owner: Bedford Borough Council
   crown: false
   agreement_signed: false
-bedscc.gov.uk:
-  owner: Bedford Borough Council
-  crown: false
-  agreement_signed: false
-bedsparishes.gov.uk:
-  owner: Bedford Borough Council
-  crown: false
-  agreement_signed: false
+bedscc.gov.uk: bedford.gov.uk
+bedsparishes.gov.uk: bedford.gov.uk
 belfastcity.gov.uk:
   owner: Belfast City Council
   crown: false
@@ -641,10 +593,7 @@ berwick-tc.gov.uk:
   owner: Berwick-upon-Tweed Town Council
   crown: false
   agreement_signed: false
-betchworth-pc.gov.uk:
-  owner: Mole Valley District Council
-  crown: false
-  agreement_signed: false
+betchworth-pc.gov.uk: molevalley.gov.uk
 beverley.gov.uk:
   owner: Beverley Town Council
   crown: false
@@ -661,10 +610,7 @@ bideford-tc.gov.uk:
   owner: Bideford Town Council
   crown: false
   agreement_signed: false
-bidfordonavon-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+bidfordonavon-pc.gov.uk: stratford.gov.uk
 biggleswadetowncouncil.gov.uk:
   owner: Biggleswade Town Council
   crown: false
@@ -685,18 +631,12 @@ birmingham.gov.uk:
   owner: Birmingham City Council
   crown: false
   agreement_signed: false
-birminghamprepared.gov.uk:
-  owner: Birmingham City Council
-  crown: false
-  agreement_signed: false
+birminghamprepared.gov.uk: birmingham.gov.uk
 bishopauckland-tc.gov.uk:
   owner: Bishop Auckland Town Council
   crown: false
   agreement_signed: false
-bishopsitchington-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+bishopsitchington-pc.gov.uk: stratford.gov.uk
 bishopsstortfordtc.gov.uk:
   owner: Bishop's Stortford Town Council
   crown: false
@@ -811,22 +751,13 @@ braintree.gov.uk:
   owner: Braintree District Council
   crown: false
   agreement_signed: false
-bramshaw.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-breamore.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+bramshaw.gov.uk: newforest.gov.uk
+breamore.gov.uk: newforest.gov.uk
 breckland.gov.uk:
   owner: Breckland District Council
   crown: false
   agreement_signed: false
-breckland-sholland.gov.uk:
-  owner: Breckland District Council
-  crown: false
-  agreement_signed: false
+breckland-sholland.gov.uk: breckland.gov.uk
 brent.gov.uk:
   owner: Brent London Borough Council
   crown: false
@@ -867,10 +798,7 @@ brighton-hove.gov.uk:
   owner: Brighton & Hove City Council
   crown: false
   agreement_signed: true
-bristol-city.gov.uk:
-  owner: Bristol City Council
-  crown: false
-  agreement_signed: false
+bristol-city.gov.uk: bristol.gov.uk
 bristol.gov.uk:
   owner: Bristol City Council
   crown: false
@@ -887,15 +815,9 @@ broadstairs.gov.uk:
   owner: Broadstairs and St Peters Town Council
   crown: false
   agreement_signed: false
-brockenhurst.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+brockenhurst.gov.uk: newforest.gov.uk
 bromorgannwg.gov.uk: valeofglamorgan.gov.uk
-bromsgroveandredditch.gov.uk:
-  owner: Bromsgrove District Council
-  crown: false
-  agreement_signed: false
+bromsgroveandredditch.gov.uk: bromsgrove.gov.uk
 bromsgrove.gov.uk:
   owner: Bromsgrove District Council
   crown: false
@@ -936,20 +858,14 @@ buckingham-tc.gov.uk:
   owner: Buckingham Town Council
   crown: false
   agreement_signed: false
-bucksandsurreytradingstandards.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
+bucksandsurreytradingstandards.gov.uk: surreycc.gov.uk
 buckinghamshirepartnership.gov.uk: buckscc.gov.uk
 bucksalc.gov.uk: buckscc.gov.uk
 buckscc.gov.uk:
   owner: Buckinghamshire County Council
   crown: false
   agreement_signed: true
-buckshomechoice.gov.uk:
-  owner: Aylesbury Vale District Council
-  crown: false
-  agreement_signed: false
+buckshomechoice.gov.uk: aylesburyvale.gov.uk
 bude-stratton.gov.uk:
   owner: Bude Stratton Town Council
   crown: false
@@ -958,10 +874,7 @@ budleighsaltertontowncouncil.gov.uk:
   owner: Budleigh Salterton Town Council
   crown: false
   agreement_signed: false
-buildingcontrolpartnershiphants.gov.uk:
-  owner: Fareham Borough Council
-  crown: false
-  agreement_signed: false
+buildingcontrolpartnershiphants.gov.uk: fareham.gov.uk
 bungaytowncouncil.gov.uk:
   owner: Bungay Town Council
   crown: false
@@ -974,10 +887,7 @@ burgesshill.gov.uk:
   owner: Burgess Hill Town Council
   crown: false
   agreement_signed: false
-burleyparishcouncil.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+burleyparishcouncil.gov.uk: newforest.gov.uk
 burnhamoncrouchtowncouncil.gov.uk:
   owner: Burnham-On-Crouch Town Council
   crown: false
@@ -994,18 +904,9 @@ bury.gov.uk:
   owner: Bury Metropolitan Borough Council
   crown: false
   agreement_signed: false
-burystedmunds-tc.gov.uk:
-  owner: St Edmundsbury Borough Council
-  crown: false
-  agreement_signed: false
-caerdydd.gov.uk:
-  owner: Cardiff Council
-  crown: false
-  agreement_signed: false
-caerffili.gov.uk:
-  owner: Caerphilly County Borough Council
-  crown: false
-  agreement_signed: false
+burystedmunds-tc.gov.uk: westsuffolk.gov.uk
+caerdydd.gov.uk: cardiff.gov.uk
+caerffili.gov.uk: caerphilly.gov.uk
 caernarfontowncouncil.gov.uk:
   owner: Caernarfon Royal Town Council
   crown: false
@@ -1018,10 +919,7 @@ caiapark.gov.uk:
   owner: Caia Park Community Council
   crown: false
   agreement_signed: false
-cainscross-pc.gov.uk:
-  owner: Stroud District Council
-  crown: false
-  agreement_signed: false
+cainscross-pc.gov.uk: stroud.gov.uk
 calderdale.gov.uk:
   owner: Calderdale Metropolitan Borough Council
   crown: false
@@ -1066,10 +964,7 @@ canveyisland-tc.gov.uk:
   owner: Canvey Island Town Council
   crown: false
   agreement_signed: false
-capel-pc.gov.uk:
-  owner: Mole Valley District Council
-  crown: false
-  agreement_signed: false
+capel-pc.gov.uk: molevalley.gov.uk
 cardiff.gov.uk:
   owner: Cardiff Council
   crown: false
@@ -1082,14 +977,12 @@ carltoncolvilletowncouncil.gov.uk:
   owner: Carlton Colville Town Council
   crown: false
   agreement_signed: false
-carmarthenshire.gov.uk:
+carmarthenshire.gov.uk: carmarthenshire.gov.wales
+carmarthenshire.gov.wales:
   owner: Carmarthenshire County Council
   crown: false
   agreement_signed: true
-carmarthentowncouncil.gov.uk:
-  owner: Carmarthenshire County Council
-  crown: false
-  agreement_signed: false
+carmarthentowncouncil.gov.uk: carmarthenshire.gov.wales
 carterton-tc.gov.uk:
   owner: Carterton Town Council
   crown: false
@@ -1098,10 +991,7 @@ castlepoint.gov.uk:
   owner: Castle Point Borough Council
   crown: false
   agreement_signed: false
-causewaycoastandglens.gov.uk:
-  owner: Coleraine Borough Council
-  crown: false
-  agreement_signed: false
+causewaycoastandglens.gov.uk: colerainebc.gov.uk
 centralbedfordshire.gov.uk:
   owner: Central Bedfordshire Council
   crown: false
@@ -1111,10 +1001,7 @@ ceredigion.gov.uk:
   owner: Ceredigion County Council
   crown: false
   agreement_signed: false
-chalford-pc.gov.uk:
-  owner: Stroud District Council
-  crown: false
-  agreement_signed: false
+chalford-pc.gov.uk: stroud.gov.uk
 chard.gov.uk:
   owner: Chard Town Council
   crown: false
@@ -1135,14 +1022,8 @@ cheltenham.gov.uk:
   owner: Cheltenham Borough Council
   crown: false
   agreement_signed: false
-cherwellandsouthnorthants.gov.uk:
-  owner: South Northamptonshire Council
-  crown: false
-  agreement_signed: false
-cherwell-dc.gov.uk:
-  owner: Cherwell District Council
-  crown: false
-  agreement_signed: false
+cherwellandsouthnorthants.gov.uk: southnorthants.gov.uk
+cherwell-dc.gov.uk: cherwell.gov.uk
 cherwell.gov.uk:
   owner: Cherwell District Council
   crown: false
@@ -1159,30 +1040,18 @@ cheshire.gov.uk:
   owner: Cheshire West and Chester Council
   crown: false
   agreement_signed: false
-cheshireprepared.gov.uk:
-  owner: Cheshire West and Chester Council
-  crown: false
-  agreement_signed: false
+cheshireprepared.gov.uk: cheshire.gov.uk
 cheshiresharedservices.gov.uk:
   owner: Crewe & Nantwich Borough Council
   crown: false
   agreement_signed: false
-cheshirewestandchester.gov.uk:
-  owner: Cheshire West and Chester Council
-  crown: false
-  agreement_signed: false
-cheshirewest.gov.uk:
-  owner: Cheshire West and Chester Council
-  crown: false
-  agreement_signed: false
+cheshirewestandchester.gov.uk: cheshire.gov.uk
+cheshirewest.gov.uk: cheshire.gov.uk
 chesterfield.gov.uk:
   owner: Chesterfield Borough Council
   crown: false
   agreement_signed: false
-chester.gov.uk:
-  owner: Cheshire West and Chester Council
-  crown: false
-  agreement_signed: false
+chester.gov.uk: cheshire.gov.uk
 chichestercity.gov.uk:
   owner: Chichester City Council
   crown: false
@@ -1211,10 +1080,7 @@ chorley.gov.uk:
   owner: Chorley Borough Council
   crown: false
   agreement_signed: false
-christchurchandeastdorset.gov.uk:
-  owner: Christchurch Borough Council
-  crown: false
-  agreement_signed: false
+christchurchandeastdorset.gov.uk: christchurch.gov.uk
 christchurch.gov.uk:
   owner: Christchurch Borough Council
   crown: false
@@ -1223,10 +1089,7 @@ chudleigh-tc.gov.uk:
   owner: Chudleigh Town Council
   crown: false
   agreement_signed: false
-churchaston-pc.gov.uk:
-  owner: Telford & Wrekin Council
-  crown: false
-  agreement_signed: false
+churchaston-pc.gov.uk: telford.gov.uk
 churchstretton-tc.gov.uk:
   owner: Church Stretton Town Council
   crown: false
@@ -1243,10 +1106,7 @@ cirencester.gov.uk:
   owner: Cirencester Town Council
   crown: false
   agreement_signed: false
-cityofworcester.gov.uk:
-  owner: City of Worcester Council
-  crown: false
-  agreement_signed: false
+cityofworcester.gov.uk: worcester.gov.uk
 clacks.gov.uk:
   owner: Clackmannanshire Council
   crown: false
@@ -1263,14 +1123,8 @@ cmktowncouncil.gov.uk:
   owner: Central Milton Keynes Town Council
   crown: false
   agreement_signed: false
-cncbuildingcontrol.gov.uk:
-  owner: South Norfolk Council
-  crown: false
-  agreement_signed: false
-coastalwight.gov.uk:
-  owner: Isle of Wight Council
-  crown: false
-  agreement_signed: false
+cncbuildingcontrol.gov.uk: south-norfolk.gov.uk
+coastalwight.gov.uk: iow.gov.uk
 coedffranc-wcc.gov.uk:
   owner: Coedffranc Community Council
   crown: false
@@ -1315,10 +1169,7 @@ cookstown.gov.uk:
   owner: Cookstown District Council
   crown: false
   agreement_signed: false
-copelandbc.gov.uk:
-  owner: Copeland Borough Council
-  crown: false
-  agreement_signed: false
+copelandbc.gov.uk: copeland.gov.uk
 copeland.gov.uk:
   owner: Copeland Borough Council
   crown: false
@@ -1380,10 +1231,7 @@ crewkerne-tc.gov.uk:
   owner: Crewkerne Town Council
   crown: false
   agreement_signed: false
-cricklade-tc.gov.uk:
-  owner: Cricklade Town Council
-  crown: false
-  agreement_signed: false
+cricklade-tc.gov.uk: crickladetowncouncil.gov.uk
 crickladetowncouncil.gov.uk:
   owner: Cricklade Town Council
   crown: false
@@ -1408,18 +1256,9 @@ cullomptontowncouncil.gov.uk:
   owner: Cullompton Town Council
   crown: false
   agreement_signed: false
-culturalpropertyadvice.gov.uk:
-  owner: Arts Council England
-  crown: false
-  agreement_signed: false
-cumbriacc.gov.uk:
-  owner: Cumbria County Council
-  crown: false
-  agreement_signed: false
-cumbriafire.gov.uk:
-  owner: Cumbria County Council
-  crown: false
-  agreement_signed: false
+culturalpropertyadvice.gov.uk: artscouncil.org.uk
+cumbriacc.gov.uk: cumbria.gov.uk
+cumbriafire.gov.uk: cumbria.gov.uk
 cumbria.gov.uk:
   owner: Cumbria County Council
   crown: false
@@ -1428,18 +1267,9 @@ currie-scc.gov.uk:
   owner: Currie Community Council
   crown: false
   agreement_signed: false
-cwmbran.gov.uk:
-  owner: Torfaen County Borough Council
-  crown: false
-  agreement_signed: false
-cyngortrefcaerfyrddin.gov.uk:
-  owner: Carmarthenshire County Council
-  crown: false
-  agreement_signed: false
-cyngortrefrhuthun.gov.uk:
-  owner: Ruthin Town Council
-  crown: false
-  agreement_signed: false
+cwmbran.gov.uk: torfaen.gov.uk
+cyngortrefcaerfyrddin.gov.uk: carmarthenshire.gov.wales
+cyngortrefrhuthun.gov.uk: ruthintowncouncil.gov.uk
 cyngortrefybarri.gov.uk: valeofglamorgan.gov.uk
 dab-vjb.gov.uk: west-dunbarton.gov.uk
 dacorum.gov.uk:
@@ -1478,10 +1308,7 @@ denbighshire.gov.uk:
   owner: Denbighshire County Council
   crown: false
   agreement_signed: false
-denbightowncouncil.gov.uk:
-  owner: Denbighshire County Council
-  crown: false
-  agreement_signed: false
+denbightowncouncil.gov.uk: denbighshire.gov.uk
 derby.gov.uk:
   owner: Derby City Council
   crown: false
@@ -1498,10 +1325,7 @@ derbyshire.gov.uk:
   owner: Derbyshire County Council
   crown: false
   agreement_signed: false
-derbyshirepartnership.gov.uk:
-  owner: Derbyshire County Council
-  crown: false
-  agreement_signed: false
+derbyshirepartnership.gov.uk: derbyshire.gov.uk
 desboroughtowncouncil.gov.uk:
   owner: Desborough Town Council
   crown: false
@@ -1537,18 +1361,13 @@ dorsetcc.gov.uk:
   owner: Dorset County Council
   crown: false
   agreement_signed: true
-dorsetforyou.gov.uk:
-  owner: Weymouth and Portland Borough Council
-  crown: false
-  agreement_signed: false
+dorsetforyou.gov.uk: weymouth.gov.uk
 dorset.gov.uk:
   owner: West Dorset District Council
   crown: false
   agreement_signed: false
-dorsetwastepartnership.gov.uk:
-  owner: Dorset County Council
-  crown: false
-  agreement_signed: false
+dorsetwastepartnership.gov.uk: dorsetcc.gov.uk
+dorset.gov.uk: dorsetcc.gov.uk
 dover.gov.uk:
   owner: Dover District Council
   crown: false
@@ -1589,10 +1408,7 @@ dunstable.gov.uk:
   owner: Dunstable Town Council
   crown: false
   agreement_signed: false
-durhamcity.gov.uk:
-  owner: Durham County Council
-  crown: false
-  agreement_signed: false
+durhamcity.gov.uk: durham.gov.uk
 durham.gov.uk:
   owner: Durham County Council
   crown: false
@@ -1633,10 +1449,7 @@ eastdevon.gov.uk:
   owner: East Devon District Council
   crown: false
   agreement_signed: true
-eastdorsetdc.gov.uk:
-  owner: East Dorset District Council
-  crown: false
-  agreement_signed: false
+eastdorsetdc.gov.uk: eastdorset.gov.uk
 eastdorset.gov.uk:
   owner: East Dorset District Council
   crown: false
@@ -1657,10 +1470,7 @@ eastherts.gov.uk:
   owner: East Herts District Council
   crown: false
   agreement_signed: false
-eastkent.gov.uk:
-  owner: Thanet District Council
-  crown: false
-  agreement_signed: false
+eastkent.gov.uk: thanet.gov.uk
 eastleigh.gov.uk:
   owner: Eastleigh Borough Council
   crown: false
@@ -1689,19 +1499,13 @@ eaststaffsbc.gov.uk:
   owner: East Staffordshire Borough Council
   crown: false
   agreement_signed: false
-eastsuffolk.gov.uk:
-  owner: Waveney District Council
-  crown: false
-  agreement_signed: false
+eastsuffolk.gov.uk: waveney.gov.uk
 eastsussexcc.gov.uk: eastsussex.gov.uk
 eastsussex.gov.uk:
   owner: East Sussex County Council
   crown: false
   agreement_signed: true
-e-chorley.gov.uk:
-  owner: Chorley Borough Council
-  crown: false
-  agreement_signed: false
+e-chorley.gov.uk: chorley.gov.uk
 edenbridgetowncouncil.gov.uk:
   owner: Edenbridge Town Council
   crown: false
@@ -1714,14 +1518,8 @@ edinburgh.gov.uk:
   owner: The City of Edinburgh Council
   crown: false
   agreement_signed: true
-eldc.gov.uk:
-  owner: East Lindsey District Council
-  crown: false
-  agreement_signed: false
-e-lindsey.gov.uk:
-  owner: East Lindsey District Council
-  crown: false
-  agreement_signed: false
+eldc.gov.uk: eastlindsey.gov.uk
+e-lindsey.gov.uk: eastlindsey.gov.uk
 ellesmere-tc.gov.uk:
   owner: Ellesmere Town Council
   crown: false
@@ -1734,18 +1532,12 @@ elstreeborehamwood-tc.gov.uk:
   owner: Elstree & Borehamwood Town Council
   crown: false
   agreement_signed: false
-emergencynorthyorks.gov.uk:
-  owner: North Yorkshire County Council
-  crown: false
-  agreement_signed: false
+emergencynorthyorks.gov.uk: northyorks.gov.uk
 emersonsgreen-tc.gov.uk:
   owner: Emersons Green Town Council
   crown: false
   agreement_signed: false
-encor.gov.uk:
-  owner: Corby Borough Council
-  crown: false
-  agreement_signed: false
+encor.gov.uk: corby.gov.uk
 enfield.gov.uk:
   owner: Enfield London Borough Council
   crown: false
@@ -1780,10 +1572,7 @@ eveshamtowncouncil.gov.uk:
   owner: Evesham Town Council
   crown: false
   agreement_signed: false
-exeterandeastdevon.gov.uk:
-  owner: East Devon District Council
-  crown: false
-  agreement_signed: false
+exeterandeastdevon.gov.uk: eastdevon.gov.uk
 exeter.gov.uk:
   owner: Exeter City Council
   crown: false
@@ -1821,10 +1610,7 @@ favershamtowncouncil.gov.uk:
   owner: Faversham Town Council
   crown: false
   agreement_signed: false
-fdean.gov.uk:
-  owner: Forest Of Dean District Council
-  crown: false
-  agreement_signed: false
+fdean.gov.uk: forestofdean.gov.uk
 featherstone-tc.gov.uk:
   owner: Featherstone Town Council
   crown: false
@@ -1837,18 +1623,12 @@ fenland.gov.uk:
   owner: Fenland District Council
   crown: false
   agreement_signed: false
-fennycompton-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+fennycompton-pc.gov.uk: stratford.gov.uk
 ferndown.gov.uk:
   owner: Ferndown Town Council
   crown: false
   agreement_signed: false
-fernhurst-wsx-pc.gov.uk:
-  owner: Chichester District Council
-  crown: false
-  agreement_signed: false
+fernhurst-wsx-pc.gov.uk: chichester.gov.uk
 ferryhill.gov.uk:
   owner: Ferryhill Town Council
   crown: false
@@ -1861,14 +1641,8 @@ filtontowncouncil.gov.uk:
   owner: Filton Town Council
   crown: false
   agreement_signed: false
-fishbourne-pc.gov.uk:
-  owner: Chichester District Council
-  crown: false
-  agreement_signed: false
-flamborough-pc.gov.uk:
-  owner: East Riding of Yorkshire Council
-  crown: false
-  agreement_signed: false
+fishbourne-pc.gov.uk: chichester.gov.uk
+flamborough-pc.gov.uk: eastriding.gov.uk
 fleet-tc.gov.uk:
   owner: Fleet Town Council
   crown: false
@@ -1881,18 +1655,9 @@ flitwick.gov.uk:
   owner: Flitwick Town Council
   crown: false
   agreement_signed: false
-folkestone-tc.gov.uk:
-  owner: Shepway District Council
-  crown: false
-  agreement_signed: false
-fordingbridge.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-forest-heath.gov.uk:
-  owner: St Edmundsbury Borough Council
-  crown: false
-  agreement_signed: false
+folkestone-tc.gov.uk: shepway.gov.uk
+fordingbridge.gov.uk: newforest.gov.uk
+forest-heath.gov.uk: westsuffolk.gov.uk
 forestofdean.gov.uk:
   owner: Forest Of Dean District Council
   crown: false
@@ -1913,10 +1678,7 @@ fylde.gov.uk:
   owner: Fylde Borough Council
   crown: false
   agreement_signed: true
-galwgofal.gov.uk:
-  owner: Conwy County Borough Council
-  crown: false
-  agreement_signed: false
+galwgofal.gov.uk: conwy.gov.uk
 gateshead.gov.uk:
   owner: Gateshead Metropolitan Borough Council
   crown: false
@@ -1929,10 +1691,7 @@ gillinghamdorset-tc.gov.uk:
   owner: Gillingham Town Council
   crown: false
   agreement_signed: false
-glamarchives.gov.uk:
-  owner: Cardiff Council
-  crown: false
-  agreement_signed: false
+glamarchives.gov.uk: cardiff.gov.uk
 glasgow.gov.uk:
   owner: Glasgow City Council
   crown: false
@@ -1941,10 +1700,7 @@ glastonbury.gov.uk:
   owner: Glastonbury Town Council
   crown: false
   agreement_signed: false
-gloscc.gov.uk:
-  owner: Gloucestershire County Council
-  crown: false
-  agreement_signed: false
+gloscc.gov.uk: gloucestershire.gov.uk
 gloucester.gov.uk:
   owner: Gloucester City Council
   crown: false
@@ -1961,10 +1717,7 @@ godalming-jbc.gov.uk:
   owner: Godalming Town Council
   crown: false
   agreement_signed: false
-godalming-tc.gov.uk:
-  owner: Waverley Borough Council
-  crown: false
-  agreement_signed: false
+godalming-tc.gov.uk: waverley.gov.uk
 goole-tc.gov.uk:
   owner: Goole Town Council
   crown: false
@@ -1990,10 +1743,7 @@ gravesham.gov.uk:
   owner: Gravesham Borough Council
   crown: false
   agreement_signed: true
-greatalne-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+greatalne-pc.gov.uk: stratford.gov.uk
 great-aycliffe.gov.uk:
   owner: Great Aycliffe Town Council
   crown: false
@@ -2018,10 +1768,7 @@ guildford.gov.uk:
   owner: Guildford Borough Council
   crown: false
   agreement_signed: false
-gwentarchives.gov.uk:
-  owner: Blaenau Gwent County Borough Council
-  crown: false
-  agreement_signed: false
+gwentarchives.gov.uk: blaenau-gwent.gov.uk
 gwynedd.gov.uk:
   owner: Gwynedd County Council
   crown: false
@@ -2061,18 +1808,9 @@ hants.gov.uk:
   owner: Hampshire County Council
   crown: false
   agreement_signed: true
-hantsiowcaddie.gov.uk:
-  owner: Hampshire County Council
-  crown: false
-  agreement_signed: false
-hantsnet.gov.uk:
-  owner: Hampshire County Council
-  crown: false
-  agreement_signed: false
-hantsweb.gov.uk:
-  owner: Hampshire County Council
-  crown: false
-  agreement_signed: false
+hantsiowcaddie.gov.uk: hants.gov.uk
+hantsnet.gov.uk: hants.gov.uk
+hantsweb.gov.uk: hants.gov.uk
 harborough.gov.uk:
   owner: Harborough District Council
   crown: false
@@ -2097,10 +1835,7 @@ harrow.gov.uk:
   owner: Harrow London Borough Council
   crown: false
   agreement_signed: false
-hart.gov.uk:
-  owner: Hampshire County Council
-  crown: false
-  agreement_signed: false
+hart.gov.uk: hants.gov.uk
 hartlepool.gov.uk:
   owner: Hartlepool Borough Council
   crown: false
@@ -2109,10 +1844,7 @@ hastings.gov.uk:
   owner: Hastings Borough Council
   crown: false
   agreement_signed: false
-hatfield.gov.uk:
-  owner: Welwyn Hatfield Borough Council
-  crown: false
-  agreement_signed: false
+hatfield.gov.uk: welwyn.gov.uk
 hatfield-herts.gov.uk:
   owner: Hatfield Town Council
   crown: false
@@ -2145,10 +1877,7 @@ haywardsheath.gov.uk:
   owner: Haywards Heath Town Council
   crown: false
   agreement_signed: false
-headley-pc.gov.uk:
-  owner: Mole Valley District Council
-  crown: false
-  agreement_signed: false
+headley-pc.gov.uk: molevalley.gov.uk
 hedgeend-tc.gov.uk:
   owner: Hedge End Town Council
   crown: false
@@ -2165,18 +1894,12 @@ helston-tc.gov.uk:
   owner: Helston Town Council
   crown: false
   agreement_signed: false
-henley-in-arden-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+henley-in-arden-pc.gov.uk: stratford.gov.uk
 henleytowncouncil.gov.uk:
   owner: Henley-on-Thames Town Council
   crown: false
   agreement_signed: false
-heps.gov.uk:
-  owner: East Riding of Yorkshire Council
-  crown: false
-  agreement_signed: false
+heps.gov.uk: eastriding.gov.uk
 herefordcitycouncil.gov.uk:
   owner: Hereford City Council
   crown: false
@@ -2193,22 +1916,13 @@ hertfordshire.gov.uk:
   owner: Hertfordshire County Council
   crown: false
   agreement_signed: false
-hertscc.gov.uk:
-  owner: Hertfordshire County Council
-  crown: false
-  agreement_signed: false
-hertsfire.gov.uk:
-  owner: Hertfordshire County Council
-  crown: false
-  agreement_signed: false
+hertscc.gov.uk: hertfordshire.gov.uk
+hertsfire.gov.uk: hertfordshire.gov.uk
 hertsmere.gov.uk:
   owner: Hertsmere Borough Council
   crown: false
   agreement_signed: false
-hertspartnership-ala.gov.uk:
-  owner: East Herts District Council
-  crown: false
-  agreement_signed: false
+hertspartnership-ala.gov.uk: eastherts.gov.uk
 hessletowncouncil.gov.uk:
   owner: Hessle Town Council
   crown: false
@@ -2245,14 +1959,8 @@ hinckley-bosworth.gov.uk:
   owner: Hinckley & Bosworth Borough Council
   crown: false
   agreement_signed: false
-hiow.gov.uk:
-  owner: Hampshire County Council
-  crown: false
-  agreement_signed: false
-holmwood-pc.gov.uk:
-  owner: Mole Valley District Council
-  crown: false
-  agreement_signed: false
+hiow.gov.uk: hants.gov.uk
+holmwood-pc.gov.uk: molevalley.gov.uk
 holsworthytowncouncil.gov.uk:
   owner: Holsworthy Town Council
   crown: false
@@ -2297,18 +2005,12 @@ howden-tc.gov.uk:
   owner: Howden Town Council
   crown: false
   agreement_signed: false
-hullcc.gov.uk:
-  owner: Kingston Upon Hull City Council
-  crown: false
-  agreement_signed: false
+hullcc.gov.uk: hull.gov.uk
 hull.gov.uk:
   owner: Kingston Upon Hull City Council
   crown: false
   agreement_signed: false
-humberlrf.gov.uk:
-  owner: East Riding of Yorkshire Council
-  crown: false
-  agreement_signed: false
+humberlrf.gov.uk: eastriding.gov.uk
 hungerford-tc.gov.uk:
   owner: Hungerford Town Council
   crown: false
@@ -2325,30 +2027,15 @@ huntingdontown.gov.uk:
   owner: Huntingdon Town Council
   crown: false
   agreement_signed: false
-huntsdc.gov.uk:
-  owner: Huntingdonshire District Council
-  crown: false
-  agreement_signed: false
-hyde-pc.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-hyndburnbc.gov.uk:
-  owner: Hyndburn Borough Council
-  crown: false
-  agreement_signed: false
+huntsdc.gov.uk: huntingdonshire.gov.uk
+hyde-pc.gov.uk: newforest.gov.uk
+hyndburnbc.gov.uk: hyndburn.gov.uk
 hyndburn.gov.uk:
   owner: Hyndburn Borough Council
   crown: false
   agreement_signed: false
-hytheanddibden.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-hythe-tc.gov.uk:
-  owner: Hythe Town Council
-  crown: false
-  agreement_signed: false
+hytheanddibden.gov.uk: newforest.gov.uk
+hythe-tc.gov.uk: hythetowncouncil.gov.uk
 hythetowncouncil.gov.uk:
   owner: Hythe Town Council
   crown: false
@@ -2454,7 +2141,7 @@ kingston.gov.uk:
   crown: false
   agreement_signed: true
 kingtontowncouncil.gov.uk:
-  owner: KIngton Town Council
+  owner: Kington Town Council
   crown: false
   agreement_signed: false
 kirkbymoorsidetowncouncil.gov.uk:
@@ -2513,23 +2200,14 @@ launceston-tc.gov.uk:
   owner: Launceston Town Council
   crown: false
   agreement_signed: false
-lawhf.gov.uk:
-  owner: Telford & Wrekin Council
-  crown: false
-  agreement_signed: false
-lawleyoverdale-pc.gov.uk:
-  owner: Telford & Wrekin Council
-  crown: false
-  agreement_signed: false
+lawhf.gov.uk: telford.gov.uk
+lawleyoverdale-pc.gov.uk: telford.gov.uk
 lbbd.gov.uk: barking-dagenham.gov.uk
 lbhf.gov.uk:
   owner: Hammersmith and Fulham London Borough Council
   crown: false
   agreement_signed: false
-lbwf.gov.uk:
-  owner: Waltham Forest London Borough Council
-  crown: false
-  agreement_signed: false
+lbwf.gov.uk: walthamforest.gov.uk
 leamingtonspatowncouncil.gov.uk:
   owner: Royal Leamington Spa Town Council
   crown: false
@@ -2542,10 +2220,7 @@ leeds.gov.uk:
   owner: Leeds City Council
   crown: false
   agreement_signed: true
-leek-tc.gov.uk:
-  owner: Leek Town Council
-  crown: false
-  agreement_signed: false
+leek-tc.gov.uk: leektowncouncil.gov.uk
 leektowncouncil.gov.uk:
   owner: Leek Town Council
   crown: false
@@ -2558,18 +2233,12 @@ leicestershireandrutlandalc.gov.uk:
   owner: Leicestershire and Rutland Association of Local Councils
   crown: false
   agreement_signed: false
-leicestershire-fire.gov.uk:
-  owner: Leicestershire County Council
-  crown: false
-  agreement_signed: false
+leicestershire-fire.gov.uk: leicestershire.gov.uk
 leicestershire.gov.uk:
   owner: Leicestershire County Council
   crown: false
   agreement_signed: false
-leics.gov.uk:
-  owner: Leicestershire County Council
-  crown: false
-  agreement_signed: false
+leics.gov.uk: leicestershire.gov.uk
 leighonseatowncouncil.gov.uk:
   owner: Leigh-on-Sea Town Council
   crown: false
@@ -2586,10 +2255,7 @@ leominstertowncouncil.gov.uk:
   owner: Leominster Town Council
   crown: false
   agreement_signed: false
-lewes-eastbourne.gov.uk:
-  owner: Eastbourne Borough Council
-  crown: false
-  agreement_signed: false
+lewes-eastbourne.gov.uk: eastbourne.gov.uk
 lewes.gov.uk:
   owner: Lewes District Council
   crown: false
@@ -2606,10 +2272,7 @@ lg-em.gov.uk:
   owner: East Midlands Councils
   crown: false
   agreement_signed: false
-lgyh.gov.uk:
-  owner: Wakefield City Council
-  crown: false
-  agreement_signed: false
+lgyh.gov.uk: wakefield.gov.uk
 lichfielddc.gov.uk:
   owner: Lichfield District Council
   crown: false
@@ -2630,30 +2293,18 @@ lincolnshire.gov.uk:
   owner: Lincolnshire County Council
   crown: false
   agreement_signed: true
-lincsbc.gov.uk:
-  owner: East Lindsey District Council
-  crown: false
-  agreement_signed: false
+lincsbc.gov.uk: eastlindsey.gov.uk
 lisburncastlereagh.gov.uk:
   owner: Lisburn City Council
   crown: false
   agreement_signed: false
-lisburncityandcastlereagh.gov.uk:
-  owner: Lisburn City Council
-  crown: false
-  agreement_signed: false
+lisburncityandcastlereagh.gov.uk: lisburncastlereagh.gov.uk
 liskeard.gov.uk:
   owner: Liskeard Town Council
   crown: false
   agreement_signed: false
-littlechalfontparishcouncil.gov.uk:
-  owner: Chiltern District Council
-  crown: false
-  agreement_signed: false
-littlechalfont-pc.gov.uk:
-  owner: Chiltern District Council
-  crown: false
-  agreement_signed: false
+littlechalfontparishcouncil.gov.uk: chiltern.gov.uk
+littlechalfont-pc.gov.uk: chiltern.gov.uk
 littlehampton-tc.gov.uk:
   owner: Littlehampton Town Council
   crown: false
@@ -2707,26 +2358,14 @@ llwchwrtowncouncil.gov.uk:
   owner: Llwchwr Town Council
   crown: false
   agreement_signed: false
-localgovernmentjobsni.gov.uk:
-  owner: North Down Borough Council
-  crown: false
-  agreement_signed: false
-londoncareplacements.gov.uk:
-  owner: London Councils
-  crown: false
-  agreement_signed: false
+localgovernmentjobsni.gov.uk: ardsandnorthdown.gov.uk
+londoncareplacements.gov.uk: londoncouncils.gov.uk
 londoncouncils.gov.uk:
   owner: London Councils
   crown: false
   agreement_signed: false
-londontribunals.gov.uk:
-  owner: London Councils
-  crown: false
-  agreement_signed: false
-longcompton-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+londontribunals.gov.uk: londoncouncils.gov.uk
+longcompton-pc.gov.uk: stratford.gov.uk
 longridge-tc.gov.uk:
   owner: Longridge Town Council
   crown: false
@@ -2735,10 +2374,7 @@ looetowncouncil.gov.uk:
   owner: Looe Town Council
   crown: false
   agreement_signed: false
-lookinglocal.gov.uk:
-  owner: Kirklees Council
-  crown: false
-  agreement_signed: false
+lookinglocal.gov.uk: kirklees.gov.uk
 lostwithieltowncouncil.gov.uk:
   owner: Lostwithiel Town Council
   crown: false
@@ -2779,18 +2415,12 @@ macclesfield-tc.gov.uk:
   owner: Macclesfield Town Council
   crown: false
   agreement_signed: false
-maethugogleddcymru.gov.uk:
-  owner: Flintshire County Council
-  crown: false
-  agreement_signed: false
+maethugogleddcymru.gov.uk: flintshire.gov.uk
 maghull-tc.gov.uk:
   owner: Maghull Town Council
   crown: false
   agreement_signed: false
-maiden.gov.uk:
-  owner: Gloucestershire County Council
-  crown: false
-  agreement_signed: false
+maiden.gov.uk: gloucestershire.gov.uk
 maidstone.gov.uk:
   owner: Maidstone Borough Council
   crown: false
@@ -2832,14 +2462,8 @@ marketdrayton.gov.uk:
   owner: Market Drayton Town Council
   crown: false
   agreement_signed: false
-marketweightontowncouncil.gov.uk:
-  owner: East Riding of Yorkshire Council
-  crown: false
-  agreement_signed: false
-marlborough-tc.gov.uk:
-  owner: Marlborough Town Council
-  crown: false
-  agreement_signed: false
+marketweightontowncouncil.gov.uk: eastriding.gov.uk
+marlborough-tc.gov.uk: marlboroughtowncouncil.gov.uk
 marlboroughtowncouncil.gov.uk:
   owner: Marlborough Town Council
   crown: false
@@ -2848,10 +2472,7 @@ marlow-tc.gov.uk:
   owner: Marlow Town Council
   crown: false
   agreement_signed: false
-marstonsicca-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+marstonsicca-pc.gov.uk: stratford.gov.uk
 maryporttowncouncil.gov.uk:
   owner: Maryport Town Council
   crown: false
@@ -2900,10 +2521,7 @@ midhurst-tc.gov.uk:
   owner: Midhurst Town Council
   crown: false
   agreement_signed: false
-midkent.gov.uk:
-  owner: Swale Borough Council
-  crown: false
-  agreement_signed: false
+midkent.gov.uk: swale.gov.uk
 midlothian.gov.uk:
   owner: Midlothian Council
   crown: false
@@ -2916,27 +2534,18 @@ midsussex.gov.uk:
   owner: Mid Sussex District Council
   crown: false
   agreement_signed: true
-milland-wsx-pc.gov.uk:
-  owner: Chichester District Council
-  crown: false
-  agreement_signed: false
+milland-wsx-pc.gov.uk: chichester.gov.uk
 milton-keynes.gov.uk: miltonkeynes.gov.uk
 miltonkeynes.gov.uk:
   owner: Milton Keynes Council
   crown: false
   agreement_signed: true
-minstead.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+minstead.gov.uk: newforest.gov.uk
 mirfieldtowncouncil.gov.uk:
   owner: Mirfield Town Council
   crown: false
   agreement_signed: false
-mole-valley.gov.uk:
-  owner: Mole Valley District Council
-  crown: false
-  agreement_signed: false
+mole-valley.gov.uk: molevalley.gov.uk
 molevalley.gov.uk:
   owner: Mole Valley District Council
   crown: false
@@ -2949,10 +2558,7 @@ monmouthshire.gov.uk:
   owner: Monmouthshire County Council
   crown: false
   agreement_signed: false
-moray-edunet.gov.uk:
-  owner: Moray Council
-  crown: false
-  agreement_signed: false
+moray-edunet.gov.uk: moray.gov.uk
 moray.gov.uk:
   owner: Moray Council
   crown: false
@@ -2982,10 +2588,7 @@ mumbles.gov.uk:
   crown: false
   agreement_signed: false
 mynottingham.gov.uk: nottingham.gov.uk
-myoxfordshire.gov.uk:
-  owner: Oxfordshire County Council
-  crown: false
-  agreement_signed: false
+myoxfordshire.gov.uk: oxfordshire.gov.uk
 nafn.gov.uk: tameside.gov.uk
 nailseatowncouncil.gov.uk:
   owner: Nailsea Town Council
@@ -3003,10 +2606,7 @@ nantwichtowncouncil.gov.uk:
   owner: Nantwich Town Council
   crown: false
   agreement_signed: false
-neath-porttalbot.gov.uk:
-  owner: Neath Port Talbot County Borough Council
-  crown: false
-  agreement_signed: false
+neath-porttalbot.gov.uk: npt.gov.uk
 neathtowncouncil.gov.uk:
   owner: Neath Town Council
   crown: false
@@ -3015,10 +2615,7 @@ ne-derbyshire.gov.uk:
   owner: North East Derbyshire District Council
   crown: false
   agreement_signed: false
-ne-ifca.gov.uk:
-  owner: East Riding of Yorkshire Council
-  crown: false
-  agreement_signed: false
+ne-ifca.gov.uk: eastriding.gov.uk
 nelincs.gov.uk:
   owner: North East Lincolnshire Council
   crown: false
@@ -3031,10 +2628,7 @@ nelsontowncouncil.gov.uk:
   owner: Nelson Town Council
   crown: false
   agreement_signed: false
-netleymarsh-pc.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+netleymarsh-pc.gov.uk: newforest.gov.uk
 newark.gov.uk:
   owner: Newark Town Council
   crown: false
@@ -3067,18 +2661,9 @@ newenttowncouncil.gov.uk:
   owner: Newent Town Council
   crown: false
   agreement_signed: false
-newforestcouncil.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-newforestdc.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-newforestdistrict.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+newforestcouncil.gov.uk: newforest.gov.uk
+newforestdc.gov.uk: newforest.gov.uk
+newforestdistrict.gov.uk: newforest.gov.uk
 newforest.gov.uk:
   owner: New Forest District Council
   crown: false
@@ -3099,10 +2684,7 @@ newmillstowncouncil.gov.uk:
   owner: New Mills Town Council
   crown: false
   agreement_signed: false
-newmiltontowncouncil.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+newmiltontowncouncil.gov.uk: newforest.gov.uk
 newport.gov.uk:
   owner: Newport City Council
   crown: false
@@ -3119,10 +2701,7 @@ newtownabbey.gov.uk:
   owner: Newtownabbey Borough Council
   crown: false
   agreement_signed: false
-nfdc.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+nfdc.gov.uk: newforest.gov.uk
 n-kesteven.gov.uk:
   owner: North Kesteven District Council
   crown: false
@@ -3131,26 +2710,14 @@ norfolkalc.gov.uk:
   owner: Norfolk Association of Local Councils
   crown: false
   agreement_signed: false
-norfolkedunet.gov.uk:
-  owner: Norfolk County Council
-  crown: false
-  agreement_signed: false
-norfolkfireservice.gov.uk:
-  owner: Norfolk County Council
-  crown: false
-  agreement_signed: false
+norfolkedunet.gov.uk: norfolk.gov.uk
+norfolkfireservice.gov.uk: norfolk.gov.uk
 norfolk.gov.uk:
   owner: Norfolk County Council
   crown: false
   agreement_signed: false
-norfolkparishes.gov.uk:
-  owner: Norfolk County Council
-  crown: false
-  agreement_signed: false
-norfolkprepared.gov.uk:
-  owner: Norfolk County Council
-  crown: false
-  agreement_signed: false
+norfolkparishes.gov.uk: norfolk.gov.uk
+norfolkprepared.gov.uk: norfolk.gov.uk
 northallertontowncouncil.gov.uk:
   owner: Northallerton Town Council
   crown: false
@@ -3167,14 +2734,8 @@ northamtowncouncil.gov.uk:
   owner: Northam Town Council
   crown: false
   agreement_signed: false
-northants-ecl.gov.uk:
-  owner: Northamptonshire County Council
-  crown: false
-  agreement_signed: false
-northantslicensing.gov.uk:
-  owner: East Northamptonshire Council
-  crown: false
-  agreement_signed: false
+northants-ecl.gov.uk: northamptonshire.gov.uk
+northantslicensing.gov.uk: east-northamptonshire.gov.uk
 north-ayrshire.gov.uk:
   owner: North Ayrshire Council
   crown: false
@@ -3187,10 +2748,7 @@ north-dorset.gov.uk:
   owner: North Dorset District Council
   crown: false
   agreement_signed: false
-northeastca.gov.uk:
-  owner: Newcastle upon Tyne City Council
-  crown: false
-  agreement_signed: false
+northeastca.gov.uk: newcastle.gov.uk
 northeastcouncils.gov.uk:
   owner: Association of North East Councils Limited
   crown: false
@@ -3208,10 +2766,7 @@ northlanarkshire.gov.uk:
   owner: North Lanarkshire Council
   crown: false
   agreement_signed: false
-northlan.gov.uk:
-  owner: North Lanarkshire Council
-  crown: false
-  agreement_signed: false
+northlan.gov.uk: northlanarkshire.gov.uk
 northleach.gov.uk:
   owner: Northleach with Eastington Town Council
   crown: false
@@ -3237,10 +2792,7 @@ northumberland.gov.uk:
   crown: false
   agreement_signed: true
 northwalesadoption.gov.uk: wrexham.gov.uk
-northwalesfostering.gov.uk:
-  owner: Flintshire County Council
-  crown: false
-  agreement_signed: false
+northwalesfostering.gov.uk: flintshire.gov.uk
 northwarks.gov.uk:
   owner: North Warwickshire Borough Council
   crown: false
@@ -3267,10 +2819,7 @@ nottinghamshire.gov.uk:
   owner: Nottinghamshire County Council
   crown: false
   agreement_signed: false
-nottscc.gov.uk:
-  owner: Nottinghamshire County Council
-  crown: false
-  agreement_signed: false
+nottscc.gov.uk: nottinghamshire.gov.uk
 npt.gov.uk:
   owner: Neath Port Talbot County Borough Council
   crown: false
@@ -3284,22 +2833,13 @@ nwleicestershire.gov.uk:
   owner: North West Leicestershire District Council
   crown: false
   agreement_signed: false
-nwleicsdc.gov.uk:
-  owner: North West Leicestershire District Council
-  crown: false
-  agreement_signed: false
-nwleics.gov.uk:
-  owner: North West Leicestershire District Council
-  crown: false
-  agreement_signed: false
+nwleicsdc.gov.uk: nwleicestershire.gov.uk
+nwleics.gov.uk: nwleicestershire.gov.uk
 oadby-wigston.gov.uk:
   owner: Oadby and Wigston Borough Council
   crown: false
   agreement_signed: false
-oakengates-tc.gov.uk:
-  owner: Telford & Wrekin Council
-  crown: false
-  agreement_signed: false
+oakengates-tc.gov.uk: telford.gov.uk
 oakhamtowncouncil.gov.uk:
   owner: Oakham Town Council
   crown: false
@@ -3368,18 +2908,9 @@ oxfordshire.gov.uk:
   owner: Oxfordshire County Council
   crown: false
   agreement_signed: false
-oxfordshire-online.gov.uk:
-  owner: Oxfordshire County Council
-  crown: false
-  agreement_signed: false
-oxfordshireonline.gov.uk:
-  owner: Oxfordshire County Council
-  crown: false
-  agreement_signed: false
-oxon.gov.uk:
-  owner: Oxfordshire County Council
-  crown: false
-  agreement_signed: false
+oxfordshire-online.gov.uk: oxfordshire.gov.uk
+oxfordshireonline.gov.uk: oxfordshire.gov.uk
+oxon.gov.uk: oxfordshire.gov.uk
 padihamtowncouncil.gov.uk:
   owner: Padiham Town Council
   crown: false
@@ -3388,10 +2919,7 @@ padstow-tc.gov.uk:
   owner: Padstow Town Council
   crown: false
   agreement_signed: false
-paessex.gov.uk:
-  owner: Essex County Council
-  crown: false
-  agreement_signed: false
+paessex.gov.uk: essex.gov.uk
 patchwaytowncouncil.gov.uk:
   owner: Patchway Town Council
   crown: false
@@ -3428,14 +2956,12 @@ penworthamtowncouncil.gov.uk:
   owner: Penwortham Town Council
   crown: false
   agreement_signed: false
-peoplesnetwork.gov.uk:
+peoplesnetwork.gov.uk: artscouncil.org.uk
+artscouncil.org.uk:
   owner: Arts Council England
   crown: false
   agreement_signed: false
-pershore-tc.gov.uk:
-  owner: Pershore Town Council
-  crown: false
-  agreement_signed: false
+pershore-tc.gov.uk: pershoretowncouncil.gov.uk
 pershoretowncouncil.gov.uk:
   owner: Pershore Town Council
   crown: false
@@ -3460,10 +2986,7 @@ pickering.gov.uk:
   owner: Pickering Town Council
   crown: false
   agreement_signed: false
-pitchcombe-pc.gov.uk:
-  owner: Stroud District Council
-  crown: false
-  agreement_signed: false
+pitchcombe-pc.gov.uk: stroud.gov.uk
 pkc.gov.uk:
   owner: Perth & Kinross Council
   crown: false
@@ -3497,10 +3020,7 @@ ponthircommunitycouncil.gov.uk:
   owner: Ponthir Community Council
   crown: false
   agreement_signed: false
-pontypoolcc.gov.uk:
-  owner: Torfaen County Borough Council
-  crown: false
-  agreement_signed: false
+pontypoolcc.gov.uk: torfaen.gov.uk
 pontypriddtowncouncil.gov.uk:
   owner: Pontypridd Town Council
   crown: false
@@ -3538,18 +3058,12 @@ preston.gov.uk:
   owner: Preston City Council
   crown: false
   agreement_signed: false
-purbeck-dc.gov.uk:
-  owner: Purbeck District Council
-  crown: false
-  agreement_signed: false
+purbeck-dc.gov.uk: purbeck.gov.uk
 purbeck.gov.uk:
   owner: Purbeck District Council
   crown: false
   agreement_signed: false
-push.gov.uk:
-  owner: Hampshire County Council
-  crown: false
-  agreement_signed: false
+push.gov.uk: hants.gov.uk
 queensferrycommunitycouncil.gov.uk:
   owner: Queensferry and District Community Council
   crown: false
@@ -3566,10 +3080,7 @@ ramseytowncouncil.gov.uk:
   owner: Ramsey Town Council
   crown: false
   agreement_signed: false
-ratleyandupton-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+ratleyandupton-pc.gov.uk: stratford.gov.uk
 raunds-tc.gov.uk:
   owner: Raunds Town Council
   crown: false
@@ -3582,18 +3093,12 @@ rbkc.gov.uk:
   owner: Royal Borough of Kensington and Chelsea
   crown: false
   agreement_signed: true
-rctcbc.gov.uk:
-  owner: Rhondda Cynon Taf County Borough Council
-  crown: false
-  agreement_signed: false
+rctcbc.gov.uk: rhondda-cynon-taf.gov.uk
 reading.gov.uk:
   owner: Reading Borough Council
   crown: false
   agreement_signed: true
-readydumgal.gov.uk:
-  owner: Dumfries and Galloway Council
-  crown: false
-  agreement_signed: false
+readydumgal.gov.uk: dumgal.gov.uk
 redbridge.gov.uk:
   owner: Redbridge London Borough Council
   crown: false
@@ -3622,10 +3127,7 @@ renfrewshire.gov.uk:
   owner: Renfrewshire Council
   crown: false
   agreement_signed: false
-rhondda-cynon-taff.gov.uk:
-  owner: Rhondda Cynon Taf County Borough Council
-  crown: false
-  agreement_signed: false
+rhondda-cynon-taff.gov.uk: rhondda-cynon-taf.gov.uk
 rhondda-cynon-taf.gov.uk:
   owner: Rhondda Cynon Taf County Borough Council
   crown: false
@@ -3634,10 +3136,7 @@ rhosdducommunitycouncil.gov.uk:
   owner: Rhosddu Community Council
   crown: false
   agreement_signed: false
-rhuddlantowncouncil.gov.uk:
-  owner: Denbighshire County Council
-  crown: false
-  agreement_signed: false
+rhuddlantowncouncil.gov.uk: denbighshire.gov.uk
 ribblevalley.gov.uk:
   owner: Ribblevalley Borough Council
   crown: false
@@ -3672,10 +3171,7 @@ rochford.gov.uk:
   owner: Rochford District Council
   crown: false
   agreement_signed: false
-rossendalebc.gov.uk:
-  owner: Rossendale Borough Council
-  crown: false
-  agreement_signed: false
+rossendalebc.gov.uk: rossendale.gov.uk
 rossendale.gov.uk:
   owner: Rossendale Borough Council
   crown: false
@@ -3696,10 +3192,7 @@ royalgreenwich.gov.uk:
   owner: Royal Borough of Greenwich
   crown: false
   agreement_signed: false
-royalwoottonbassett.gov.uk:
-  owner: Wootton Bassett Town Council
-  crown: false
-  agreement_signed: false
+royalwoottonbassett.gov.uk: woottonbassett.gov.uk
 roystontowncouncil.gov.uk:
   owner: Royston Town Council
   crown: false
@@ -3748,10 +3241,7 @@ ryetowncouncil.gov.uk:
   owner: Rye Town Council
   crown: false
   agreement_signed: false
-saferderbyshire.gov.uk:
-  owner: Derbyshire County Council
-  crown: false
-  agreement_signed: false
+saferderbyshire.gov.uk: derbyshire.gov.uk
 saffronwalden.gov.uk:
   owner: Saffron Walden Town Council
   crown: false
@@ -3784,10 +3274,7 @@ sandhurst.gov.uk:
   owner: Sandhurst Town Council
   crown: false
   agreement_signed: false
-sandleheath.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+sandleheath.gov.uk: newforest.gov.uk
 sandowntowncouncil.gov.uk:
   owner: Sandown Town Council
   crown: false
@@ -3844,10 +3331,7 @@ seatonvalleycommunitycouncil.gov.uk:
   owner: Seaton Valley Council
   crown: false
   agreement_signed: false
-secouncils.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
+secouncils.gov.uk: surreycc.gov.uk
 sedgefieldtowncouncil.gov.uk:
   owner: Sedgefield Town Council
   crown: false
@@ -3864,18 +3348,12 @@ selby.gov.uk:
   owner: Selby District Council
   crown: false
   agreement_signed: false
-selbytowncouncil.gov.uk:
-  owner: Selby District Council
-  crown: false
-  agreement_signed: false
+selbytowncouncil.gov.uk: selby.gov.uk
 selseytowncouncil.gov.uk:
   owner: Selsey Town Council
   crown: false
   agreement_signed: false
-sesplan.gov.uk:
-  owner: The City of Edinburgh Council
-  crown: false
-  agreement_signed: false
+sesplan.gov.uk: edinburgh.gov.uk
 sevenoaks.gov.uk:
   owner: Sevenoaks District Council
   crown: false
@@ -3889,10 +3367,7 @@ shaftesbury-tc.gov.uk:
   owner: Shaftesbury Town Council
   crown: false
   agreement_signed: false
-sharedresourceservicewales.gov.uk:
-  owner: Torfaen County Borough Council
-  crown: false
-  agreement_signed: false
+sharedresourceservicewales.gov.uk: torfaen.gov.uk
 sheffield.gov.uk:
   owner: Sheffield City Council
   crown: false
@@ -3913,10 +3388,7 @@ shetland.gov.uk:
   owner: Shetland Islands Council
   crown: false
   agreement_signed: false
-shetland-library.gov.uk:
-  owner: Shetland Islands Council
-  crown: false
-  agreement_signed: false
+shetland-library.gov.uk: shetland.gov.uk
 shifnaltowncouncil.gov.uk:
   owner: Shifnal Town Council
   crown: false
@@ -3945,38 +3417,17 @@ sidmouth.gov.uk:
   owner: Sidmouth Town Council
   crown: false
   agreement_signed: false
-sigoma.gov.uk:
-  owner: Barnsley Metropolitan Borough Council
-  crown: false
-  agreement_signed: false
+sigoma.gov.uk: barnsley.gov.uk
 silloth-on-solway-tc.gov.uk:
   owner: Silloth-on-Solway Town Council
   crown: false
   agreement_signed: false
-sir-benfro.gov.uk:
-  owner: Pembrokeshire County Council
-  crown: false
-  agreement_signed: false
-sirddinbych.gov.uk:
-  owner: Denbighshire County Council
-  crown: false
-  agreement_signed: false
-sirfynwy.gov.uk:
-  owner: Monmouthshire County Council
-  crown: false
-  agreement_signed: false
-sirgaerfyrddin.gov.uk:
-  owner: Carmarthenshire County Council
-  crown: false
-  agreement_signed: false
-sirgar.gov.uk:
-  owner: Carmarthenshire County Council
-  crown: false
-  agreement_signed: false
-siryfflint.gov.uk:
-  owner: Flintshire County Council
-  crown: false
-  agreement_signed: false
+sir-benfro.gov.uk: pembrokeshire.gov.uk
+sirddinbych.gov.uk: denbighshire.gov.uk
+sirfynwy.gov.uk: monmouthshire.gov.uk
+sirgaerfyrddin.gov.uk: carmarthenshire.gov.wales
+sirgar.gov.uk: carmarthenshire.gov.wales
+siryfflint.gov.uk: flintshire.gov.uk
 skegness.gov.uk:
   owner: Skegness Town Council
   crown: false
@@ -3993,10 +3444,7 @@ slough.gov.uk:
   owner: Slough Borough Council
   crown: false
   agreement_signed: false
-s-norfolk.gov.uk:
-  owner: South Norfolk Council
-  crown: false
-  agreement_signed: false
+s-norfolk.gov.uk: south-norfolk.gov.uk
 sodburytowncouncil.gov.uk:
   owner: Sodbury Town Council
   crown: false
@@ -4017,10 +3465,7 @@ somertontowncouncil.gov.uk:
   owner: Somerton Town Council
   crown: false
   agreement_signed: false
-sopley.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
+sopley.gov.uk: newforest.gov.uk
 southamcouncil-warks.gov.uk:
   owner: Southam Town Council
   crown: false
@@ -4029,10 +3474,7 @@ southampton.gov.uk:
   owner: Southampton City Council
   crown: false
   agreement_signed: false
-southandvale.gov.uk:
-  owner: Vale of White Horse District Council
-  crown: false
-  agreement_signed: false
+southandvale.gov.uk: whitehorsedc.gov.uk
 south-ayrshire.gov.uk:
   owner: South Ayrshire Council
   crown: false
@@ -4049,18 +3491,12 @@ southend.gov.uk:
   owner: Southend-on-Sea Borough Council
   crown: false
   agreement_signed: true
-southernuplandway.gov.uk:
-  owner: Dumfries and Galloway Council
-  crown: false
-  agreement_signed: false
+southernuplandway.gov.uk: dumgal.gov.uk
 southglos.gov.uk:
   owner: South Gloucestershire Council
   crown: false
   agreement_signed: true
-south-hams-dc.gov.uk:
-  owner: South Hams District Council
-  crown: false
-  agreement_signed: false
+south-hams-dc.gov.uk: southhams.gov.uk
 southhams.gov.uk:
   owner: South Hams District Council
   crown: false
@@ -4097,10 +3533,7 @@ southribble.gov.uk:
   owner: South Ribble Borough Council
   crown: false
   agreement_signed: false
-southribbletourism.gov.uk:
-  owner: South Ribble Borough Council
-  crown: false
-  agreement_signed: false
+southribbletourism.gov.uk: southribble.gov.uk
 southsomerset.gov.uk:
   owner: South Somerset District Council
   crown: false
@@ -4117,22 +3550,13 @@ southwell-tc.gov.uk:
   owner: Southwell Town Council
   crown: false
   agreement_signed: false
-southwest-ra.gov.uk:
-  owner: Somerset County Council
-  crown: false
-  agreement_signed: false
+southwest-ra.gov.uk: somerset.gov.uk
 southwoodhamferrerstc.gov.uk:
   owner: South Woodham Ferrers Town Council
   crown: false
   agreement_signed: false
-southworcestershirebuildingcontrol.gov.uk:
-  owner: Malvern Hills District Council
-  crown: false
-  agreement_signed: false
-southworcestershirerevenues.gov.uk:
-  owner: Wychavon District Council
-  crown: false
-  agreement_signed: false
+southworcestershirebuildingcontrol.gov.uk: malvernhills.gov.uk
+southworcestershirerevenues.gov.uk: wychavon.gov.uk
 spelthorne.gov.uk:
   owner: Spelthorne Borough Council
   crown: false
@@ -4213,14 +3637,8 @@ stdonats-cc.gov.uk:
   owner: St Donats communitiy Council
   crown: false
   agreement_signed: false
-stedmundsbury.gov.uk:
-  owner: St Edmundsbury Borough Council
-  crown: false
-  agreement_signed: false
-stedsbc.gov.uk:
-  owner: St Edmundsbury Borough Council
-  crown: false
-  agreement_signed: false
+stedmundsbury.gov.uk: westsuffolk.gov.uk
+stedsbc.gov.uk: westsuffolk.gov.uk
 stevenage.gov.uk:
   owner: Stevenage Borough Council
   crown: false
@@ -4237,22 +3655,13 @@ stirling.gov.uk:
   owner: Stirling Council
   crown: false
   agreement_signed: true
-stives-tc.gov.uk:
-  owner: St Ives Town Council - Cornwall
-  crown: false
-  agreement_signed: false
-stivestowncouncil-cornwall.gov.uk:
-  owner: St Ives Town Council - Cornwall
-  crown: false
-  agreement_signed: false
+stives-tc.gov.uk: stivestowncouncil.gov.uk
+stivestowncouncil-cornwall.gov.uk: stivestowncouncil.gov.uk
 stivestowncouncil.gov.uk:
   owner: St Ives Town Council
   crown: false
   agreement_signed: false
-stmarybourne-pc.gov.uk:
-  owner: Basingstoke and Deane Borough Council
-  crown: false
-  agreement_signed: false
+stmarybourne-pc.gov.uk: basingstoke.gov.uk
 stneots-tc.gov.uk:
   owner: St Neots Town Council
   crown: false
@@ -4270,10 +3679,7 @@ stockton.gov.uk:
   owner: Stockton-on-Tees Borough Council
   crown: false
   agreement_signed: false
-stockton-warks-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+stockton-warks-pc.gov.uk: stratford.gov.uk
 stoke.gov.uk:
   owner: Stoke-on-Trent City Council
   crown: false
@@ -4286,10 +3692,7 @@ stonystratford.gov.uk:
   owner: Stony Stratford Town Council
   crown: false
   agreement_signed: false
-stoploansharks.gov.uk:
-  owner: Birmingham City Council
-  crown: false
-  agreement_signed: false
+stoploansharks.gov.uk: birmingham.gov.uk
 stotfoldtowncouncil.gov.uk:
   owner: Stotfold Town Council
   crown: false
@@ -4302,10 +3705,7 @@ stowonthewold-tc.gov.uk:
   owner: Stow-on-the-Wold Town Council
   crown: false
   agreement_signed: false
-stratford-dc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+stratford-dc.gov.uk: stratford.gov.uk
 stratford.gov.uk:
   owner: Stratford-on-Avon District Council
   crown: false
@@ -4327,14 +3727,8 @@ sturminsternewton-tc.gov.uk:
   crown: false
   agreement_signed: false
 s-tyneside-mbc.gov.uk: southtyneside.gov.uk
-suffolkcc.gov.uk:
-  owner: Suffolk County Council
-  crown: false
-  agreement_signed: false
-suffolkcoastal.gov.uk:
-  owner: Suffolk County Council
-  crown: false
-  agreement_signed: false
+suffolkcc.gov.uk: suffolk.gov.uk
+suffolkcoastal.gov.uk: suffolk.gov.uk
 suffolk.gov.uk:
   owner: Suffolk County Council
   crown: false
@@ -4343,51 +3737,24 @@ sunderland.gov.uk:
   owner: Sunderland City Metropolitan Borough Council
   crown: false
   agreement_signed: false
-supportwithconfidence.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
+supportwithconfidence.gov.uk: surreycc.gov.uk
 surreycc.gov.uk:
   owner: Surrey County Council
   crown: false
   agreement_signed: false
-surreycoroner.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
-surreycountycouncil.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
-surrey-fire.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
-surrey.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
+surreycoroner.gov.uk: surreycc.gov.uk
+surreycountycouncil.gov.uk: surreycc.gov.uk
+surrey-fire.gov.uk: surreycc.gov.uk
+surrey.gov.uk: surreycc.gov.uk
 surreyheath.gov.uk:
   owner: Surrey Heath Borough Council
   crown: false
   agreement_signed: false
-surreyheath-online.gov.uk:
-  owner: Surrey Heath Borough Council
-  crown: false
-  agreement_signed: false
-surreyheathonline.gov.uk:
-  owner: Surrey Heath Borough Council
-  crown: false
-  agreement_signed: false
-surreyi.gov.uk:
-  owner: Surrey County Council
-  crown: false
-  agreement_signed: false
+surreyheath-online.gov.uk: surreyheath.gov.uk
+surreyheathonline.gov.uk: surreyheath.gov.uk
+surreyi.gov.uk: surreycc.gov.uk
 surreylocalgovernment.gov.uk: woking.gov.uk
-sussexsaferroads.gov.uk:
-  owner: West Sussex County Council
-  crown: false
-  agreement_signed: false
+sussexsaferroads.gov.uk: westsussex.gov.uk
 suttoncoldfieldtowncouncil.gov.uk:
   owner: Sutton Coldfield Town Council
   crown: false
@@ -4416,14 +3783,8 @@ swanscombeandgreenhithetowncouncil.gov.uk:
   owner: Swanscombe & Greenhithe Town Council
   crown: false
   agreement_signed: false
-sway-pc.gov.uk:
-  owner: New Forest District Council
-  crown: false
-  agreement_signed: false
-swdevon.gov.uk:
-  owner: South Hams District Council
-  crown: false
-  agreement_signed: false
+sway-pc.gov.uk: newforest.gov.uk
+swdevon.gov.uk: southhams.gov.uk
 swindon.gov.uk:
   owner: Swindon Borough Council
   crown: false
@@ -4440,10 +3801,7 @@ tamworth.gov.uk:
   owner: Tamworth Borough Council
   crown: false
   agreement_signed: false
-tandridgedc.gov.uk:
-  owner: Tandridge District Council
-  crown: false
-  agreement_signed: false
+tandridgedc.gov.uk: tandridge.gov.uk
 tandridge.gov.uk:
   owner: Tandridge District Council
   crown: false
@@ -4456,22 +3814,10 @@ tavistock.gov.uk:
   owner: Tavistock Town Council
   crown: false
   agreement_signed: false
-tayplan-sdpa.gov.uk:
-  owner: Dundee City Council
-  crown: false
-  agreement_signed: false
-taysideprocurement.gov.uk:
-  owner: Dundee City Council
-  crown: false
-  agreement_signed: false
-teesvalley-ca.gov.uk:
-  owner: Stockton-on-Tees Borough Council
-  crown: false
-  agreement_signed: false
-teesvalleyunlimited.gov.uk:
-  owner: Stockton-on-Tees Borough Council
-  crown: false
-  agreement_signed: false
+tayplan-sdpa.gov.uk: dundeecity.gov.uk
+taysideprocurement.gov.uk: dundeecity.gov.uk
+teesvalley-ca.gov.uk: stockton.gov.uk
+teesvalleyunlimited.gov.uk: stockton.gov.uk
 teignbridge.gov.uk:
   owner: Teignbridge District Council
   crown: false
@@ -4504,10 +3850,7 @@ tetbury.gov.uk:
   owner: Tetbury Town Council
   crown: false
   agreement_signed: false
-tewkesburybc.gov.uk:
-  owner: Tewkesbury Borough Council
-  crown: false
-  agreement_signed: false
+tewkesburybc.gov.uk: tewkesbury.gov.uk
 tewkesbury.gov.uk:
   owner: Tewkesbury Borough Council
   crown: false
@@ -4528,10 +3871,7 @@ thatchamtowncouncil.gov.uk:
   owner: Thatcham Town Council
   crown: false
   agreement_signed: false
-themcmanus-dundee.gov.uk:
-  owner: Dundee City Council
-  crown: false
-  agreement_signed: false
+themcmanus-dundee.gov.uk: dundeecity.gov.uk
 thetfordtowncouncil.gov.uk:
   owner: Thetford Town Council
   crown: false
@@ -4564,10 +3904,7 @@ threerivers.gov.uk:
   owner: Three Rivers District Council
   crown: false
   agreement_signed: false
-thurrockfostering.gov.uk:
-  owner: Thurrock Council
-  crown: false
-  agreement_signed: false
+thurrockfostering.gov.uk: thurrock.gov.uk
 thurrock.gov.uk:
   owner: Thurrock Council
   crown: false
@@ -4584,10 +3921,7 @@ tmbc.gov.uk:
   owner: Tonbridge & Malling Borough Council
   crown: false
   agreement_signed: true
-tobaccoregisterni.gov.uk:
-  owner: Belfast City Council
-  crown: false
-  agreement_signed: false
+tobaccoregisterni.gov.uk: belfastcity.gov.uk
 torbay.gov.uk:
   owner: Torbay Council
   crown: false
@@ -4624,10 +3958,7 @@ towynkinmelbay-tc.gov.uk:
   owner: Towyn and Kinmel Bay Town Council
   crown: false
   agreement_signed: false
-tracc.gov.uk:
-  owner: Powys County Council
-  crown: false
-  agreement_signed: false
+tracc.gov.uk: powys.gov.uk
 trafford.gov.uk:
   owner: Trafford Metropolitan Borough Council
   crown: false
@@ -4641,10 +3972,7 @@ trowbridge.gov.uk:
   owner: Trowbridge Town Council
   crown: false
   agreement_signed: false
-truro-city.gov.uk:
-  owner: Truro City Council
-  crown: false
-  agreement_signed: false
+truro-city.gov.uk: truro.gov.uk
 truro.gov.uk:
   owner: Truro City Council
   crown: false
@@ -4657,14 +3985,8 @@ twfire.gov.uk:
   owner: Tyne and Wear Fire and Rescue Authority
   crown: false
   agreement_signed: true
-twict.gov.uk:
-  owner: Sunderland City Metropolitan Borough Council
-  crown: false
-  agreement_signed: false
-tyneandwearltp.gov.uk:
-  owner: Newcastle upon Tyne City Council
-  crown: false
-  agreement_signed: false
+twict.gov.uk: sunderland.gov.uk
+tyneandwearltp.gov.uk: newcastle.gov.uk
 uckfieldtc.gov.uk:
   owner: Uckfield Town Council
   crown: false
@@ -4673,10 +3995,7 @@ uppinghamtowncouncil.gov.uk:
   owner: Uppingham Town Council
   crown: false
   agreement_signed: false
-uptonstleonards-pc.gov.uk:
-  owner: Stroud District Council
-  crown: false
-  agreement_signed: false
+uptonstleonards-pc.gov.uk: stroud.gov.uk
 uttlesford.gov.uk:
   owner: Uttlesford District Council
   crown: false
@@ -4689,14 +4008,8 @@ verwood.gov.uk:
   owner: Verwood Town Council
   crown: false
   agreement_signed: false
-visitsaffronwalden.gov.uk:
-  owner: Saffron Walden Town Council
-  crown: false
-  agreement_signed: false
-visitsouthribble.gov.uk:
-  owner: South Ribble Borough Council
-  crown: false
-  agreement_signed: false
+visitsaffronwalden.gov.uk: saffronwalden.gov.uk
+visitsouthribble.gov.uk: southribble.gov.uk
 wadebridge-tc.gov.uk:
   owner: Wadebridge Town Council
   crown: false
@@ -4717,10 +4030,7 @@ walthamabbey-tc.gov.uk:
   owner: Waltham Abbey Town Council
   crown: false
   agreement_signed: false
-walthamforestclass.gov.uk:
-  owner: Waltham Forest London Borough Council
-  crown: false
-  agreement_signed: false
+walthamforestclass.gov.uk: walthamforest.gov.uk
 walthamforest.gov.uk:
   owner: Waltham Forest London Borough Council
   crown: false
@@ -4749,14 +4059,8 @@ warrington.gov.uk:
   owner: Warrington Borough Council
   crown: false
   agreement_signed: false
-warwick-dc.gov.uk:
-  owner: Warwick District Council
-  crown: false
-  agreement_signed: false
-warwickdc.gov.uk:
-  owner: Warwick District Council
-  crown: false
-  agreement_signed: false
+warwick-dc.gov.uk: warwick.gov.uk
+warwickdc.gov.uk: warwick.gov.uk
 warwick.gov.uk:
   owner: Warwick District Council
   crown: false
@@ -4769,10 +4073,7 @@ warwicktowncouncil.gov.uk:
   owner: Warwick Town Council
   crown: false
   agreement_signed: false
-watford-council.gov.uk:
-  owner: Watford Borough Council
-  crown: false
-  agreement_signed: false
+watford-council.gov.uk: watford.gov.uk
 watford.gov.uk:
   owner: Watford Borough Council
   crown: false
@@ -4793,14 +4094,8 @@ wealden.gov.uk:
   owner: Wealden District Council
   crown: false
   agreement_signed: true
-welfordonavon-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
-welhat.gov.uk:
-  owner: Welwyn Hatfield Borough Council
-  crown: false
-  agreement_signed: false
+welfordonavon-pc.gov.uk: stratford.gov.uk
+welhat.gov.uk: welwyn.gov.uk
 wellingborough.gov.uk:
   owner: Wellingborough Borough Council
   crown: false
@@ -4837,18 +4132,12 @@ westburytowncouncil.gov.uk:
   owner: Westbury Town Council
   crown: false
   agreement_signed: false
-westcumbria.gov.uk:
-  owner: Allerdale Borough Council
-  crown: false
-  agreement_signed: false
+westcumbria.gov.uk: allerdale.gov.uk
 westdevon.gov.uk:
   owner: West Devon Borough Council
   crown: false
   agreement_signed: false
-westdorset-dc.gov.uk:
-  owner: West Dorset District Council
-  crown: false
-  agreement_signed: false
+westdorset-dc.gov.uk: dorset.gov.uk
 westdorset-weymouth.gov.uk:
   owner: West Dorset District Council
   crown: false
@@ -4869,14 +4158,8 @@ westlancashire.gov.uk:
   owner: West Lancashire District Council
   crown: false
   agreement_signed: false
-westlancsdc.gov.uk:
-  owner: West Lancashire District Council
-  crown: false
-  agreement_signed: false
-westlancs.gov.uk:
-  owner: West Lancashire District Council
-  crown: false
-  agreement_signed: false
+westlancsdc.gov.uk: westlancashire.gov.uk
+westlancs.gov.uk: westlancashire.gov.uk
 west-lindsey.gov.uk:
   owner: West Lindsey District Council
   crown: false
@@ -4885,10 +4168,7 @@ westlothian.gov.uk:
   owner: West Lothian Council
   crown: false
   agreement_signed: true
-westmidlandsca.gov.uk:
-  owner: Wolverhampton City Council
-  crown: false
-  agreement_signed: false
+westmidlandsca.gov.uk: wolverhampton.gov.uk
 westminster.gov.uk:
   owner: Westminster City Council
   crown: false
@@ -4897,10 +4177,7 @@ west-norfolk.gov.uk:
   owner: Borough Council of King's Lynn & West Norfolk
   crown: false
   agreement_signed: false
-westofengland-ca.gov.uk:
-  owner: Bath and North East Somerset Council
-  crown: false
-  agreement_signed: false
+westofengland-ca.gov.uk: bathnes.gov.uk
 westoxon.gov.uk:
   owner: West Oxfordshire District Council
   crown: false
@@ -4909,10 +4186,7 @@ westsomerset.gov.uk:
   owner: West Somerset District Council
   crown: false
   agreement_signed: false
-westsomersetonline.gov.uk:
-  owner: West Somerset District Council
-  crown: false
-  agreement_signed: false
+westsomersetonline.gov.uk: westsomerset.gov.uk
 westsuffolk.gov.uk:
   owner: St Edmundsbury Borough Council
   crown: false
@@ -4921,14 +4195,8 @@ westsussex.gov.uk:
   owner: West Sussex County Council
   crown: false
   agreement_signed: false
-westwey.gov.uk:
-  owner: Weymouth and Portland Borough Council
-  crown: false
-  agreement_signed: false
-westyorkshire-pcp.gov.uk:
-  owner: Wakefield City Council
-  crown: false
-  agreement_signed: false
+westwey.gov.uk: weymouth.gov.uk
+westyorkshire-pcp.gov.uk: wakefield.gov.uk
 weymouth.gov.uk:
   owner: Weymouth and Portland Borough Council
   crown: false
@@ -4998,10 +4266,7 @@ wirksworth.gov.uk:
   owner: Wirksworth Town Council
   crown: false
   agreement_signed: false
-wirksworthtowncouncil.gov.uk:
-  owner: Wirksworth Town Council
-  crown: false
-  agreement_signed: false
+wirksworthtowncouncil.gov.uk: wirksworth.gov.uk
 wirral-mbc.gov.uk: wirral.gov.uk
 wirral.gov.uk:
   owner: Wirral Metropolitan Borough Council
@@ -5023,10 +4288,7 @@ wivenhoe.gov.uk:
   owner: Wivenhoe Town Council
   crown: false
   agreement_signed: false
-wixford-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+wixford-pc.gov.uk: stratford.gov.uk
 wmfs.net:
   owner: West Midlands Fire Service
   crown: false
@@ -5067,10 +4329,7 @@ woottonbassett.gov.uk:
   owner: Wootton Bassett Town Council
   crown: false
   agreement_signed: false
-woottonwawen-pc.gov.uk:
-  owner: Stratford-on-Avon District Council
-  crown: false
-  agreement_signed: false
+woottonwawen-pc.gov.uk: stratford.gov.uk
 worcester.gov.uk:
   owner: City of Worcester Council
   crown: false
@@ -5081,10 +4340,7 @@ worcestershire.gov.uk:
   agreement_signed: true
 worcestershirehub.gov.uk: worcestershire.gov.uk
 worcestershirets.gov.uk: worcestershire.gov.uk
-worcsregservices.gov.uk:
-  owner: Bromsgrove District Council
-  crown: false
-  agreement_signed: false
+worcsregservices.gov.uk: bromsgrove.gov.uk
 workingtontowncouncil.gov.uk:
   owner: Workington Town Council
   crown: false
@@ -5106,10 +4362,7 @@ wsm-tc.gov.uk:
   owner: Weston-super-Mare Town Council
   crown: false
   agreement_signed: false
-wsx-donnington-pc.gov.uk:
-  owner: Chichester District Council
-  crown: false
-  agreement_signed: false
+wsx-donnington-pc.gov.uk: chichester.gov.uk
 wychavon.gov.uk:
   owner: Wychavon District Council
   crown: false
@@ -5139,18 +4392,12 @@ yatetowncouncil.gov.uk:
   owner: Yate Town Council
   crown: false
   agreement_signed: false
-yeovil.gov.uk:
-  owner: South Somerset District Council
-  crown: false
-  agreement_signed: false
+yeovil.gov.uk: southsomerset.gov.uk
 yeoviltonparishcouncil.gov.uk:
   owner: Yeovil Town Council
   crown: false
   agreement_signed: false
-ynysmon.gov.uk:
-  owner: Isle of Anglesey County Council
-  crown: false
-  agreement_signed: true
+ynysmon.gov.uk: anglesey.gov.uk
 york.gov.uk:
   owner: City of York Council
   crown: false

--- a/app/utils.py
+++ b/app/utils.py
@@ -563,7 +563,10 @@ class AgreementInfo:
 
     def _get_info(self):
 
-        details = self.domains.get(self._match) or {}
+        details = self.domains.get(self._match)
+
+        if isinstance(details, None):
+            raise TypeError('Domain must have details ({})'.format(self._match))
 
         if isinstance(details, str):
             self.is_canonical = False

--- a/app/utils.py
+++ b/app/utils.py
@@ -563,10 +563,10 @@ class AgreementInfo:
 
     def _get_info(self):
 
-        details = self.domains.get(self._match)
+        details = self.domains.get(self._match, {})
 
-        if isinstance(details, None):
-            raise TypeError('Domain must have details ({})'.format(self._match))
+        if details is None:
+            raise TypeError('Domain must have details ({})'.format(self._domain))
 
         if isinstance(details, str):
             self.is_canonical = False

--- a/domains.py
+++ b/domains.py
@@ -3,9 +3,16 @@
 
 import os
 import yaml
+from itertools import chain
+from operator import itemgetter
+from sys import argv
 from app.utils import AgreementInfo
 
 _dir_path = os.path.dirname(os.path.realpath(__file__))
+
+
+if len(argv) < 2:
+    raise TypeError('Must specify `orgs` or `domains` as the first argument to this script')
 
 
 with open('{}/app/domains.yml'.format(_dir_path)) as source:
@@ -27,4 +34,19 @@ with open('{}/app/domains.yml'.format(_dir_path)) as source:
         if isinstance(details, dict)
     ]
 
-    print(yaml.dump(out_data))  # noqa
+    if argv[1] == 'orgs':
+        print(yaml.dump(out_data))  # noqa
+    elif argv[1] == 'domains':
+        print(  # noqa
+            sorted(
+                set(
+                    chain.from_iterable(
+                        map(
+                            itemgetter('domains'), out_data
+                        )
+                    )
+                )
+            )
+        )
+    else:
+        raise TypeError('Must specify `orgs` or `domains` as the first argument to this script')

--- a/domains.py
+++ b/domains.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import yaml
+from app.utils import AgreementInfo
+
+_dir_path = os.path.dirname(os.path.realpath(__file__))
+
+
+with open('{}/app/domains.yml'.format(_dir_path)) as source:
+
+    data = yaml.load(source)
+
+    for domain, details in data.items():
+        if isinstance(details, dict):
+            # We’re looking at the canonical domain
+            data[domain]['domains'] = [domain]
+
+    for domain, details in data.items():
+        if isinstance(details, str):
+            # This is an alias, let’s add it to the canonical domain
+            data[AgreementInfo(domain).canonical_domain]['domains'].append(domain)
+
+    out_data = [
+        details for domain, details in data.items()
+        if isinstance(details, dict)
+    ]
+
+    print(yaml.dump(out_data))  # noqa

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -391,6 +391,11 @@ def test_get_domain_info_for_branding_request():
     )
 
 
+def test_domains_are_lowercased():
+    for domain in AgreementInfo.domains.keys():
+        assert domain == domain.lower()
+
+
 def test_validate_government_domain_data():
 
     for domain in AgreementInfo.domains.keys():

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -403,11 +403,7 @@ def test_validate_government_domain_data():
             True, False, None
         }
 
-        assert (
-            agreement_info.owner is None
-        ) or (
-            isinstance(agreement_info.owner, str)
-        )
+        assert isinstance(agreement_info.owner, str) and agreement_info.owner.strip()
 
         assert agreement_info.agreement_signed in {
             True, False, None

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from csv import DictReader
 from io import StringIO
 from pathlib import Path
@@ -413,6 +413,18 @@ def test_validate_government_domain_data():
         assert agreement_info.agreement_signed in {
             True, False, None
         }
+
+
+def test_domain_data_is_canonicalized():
+    for owner, count in Counter(
+        AgreementInfo(domain).owner
+        for domain in AgreementInfo.domains.keys()
+        if AgreementInfo(domain).is_canonical
+    ).most_common():
+        if count > 1:
+            raise ValueError(
+                '{} entries in domains.yml for {}'.format(count, owner)
+            )
 
 
 def test_validate_email_domain_data():


### PR DESCRIPTION
This pull request does:
- stricter validation of the data in `domains.yml`
- canonicalisation of the data (ie all the entries with the same `owner` are mapped to the same entry)

This will make it easier, in the future, to import this data into the database. Running `./domains.py` outputs the data in this format:
```yaml
- agreement_signed: false
  crown: false
  domains: [denbighshire.gov.uk, sirddinbych.gov.uk, rhuddlantowncouncil.gov.uk, denbightowncouncil.gov.uk]
  owner: Denbighshire County Council
```

Compare to the format we currently store it in:
```yaml
denbighshire.gov.uk:
  owner: Denbighshire County Council
  crown: false
  agreement_signed: false
denbightowncouncil.gov.uk: denbighshire.gov.uk
rhuddlantowncouncil.gov.uk: denbighshire.gov.uk
sirddinbych.gov.uk: denbighshire.gov.uk
```