### PR TITLE
Fix misaligned checkboxes

### DIFF
--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -12,7 +12,7 @@
 {% else %}
   <nav id=template-list>
     {% for item in template_list %}
-      <div class="template-list-item {% if can_manage_folders %}template-list-item-with-checkbox{% endif %} {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
+      <div class="template-list-item {% if current_user.has_permissions('manage_templates') %}template-list-item-with-checkbox{% endif %} {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
         {% if current_user.has_permissions('manage_templates') %}
           {{ unlabelled_checkbox(
             id='templates-or-folder-{}'.format(item.id),

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -339,6 +339,10 @@ def test_should_show_templates_folder_page(
         assert links_in_page[index].text.strip() == expected_link
 
     all_page_items = page.select('.template-list-item')
+    all_page_items_styled_with_checkboxes = page.select('.template-list-item-with-checkbox')
+
+    assert len(all_page_items) == len(all_page_items_styled_with_checkboxes)
+
     checkboxes = page.select('input[name=templates_and_folders]')
     unique_checkbox_values = set(item['value'] for item in checkboxes)
     assert len(all_page_items) == len(expected_items)


### PR DESCRIPTION
The template list wasn’t getting the right class applied because the check was referring to an undefined variable (`can_manage_folders`) that should have been removed when all other references to it were.