### PR TITLE
Return to a template’s folder after deleting it

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -631,6 +631,7 @@ def delete_service_template(service_id, template_id):
         return redirect(url_for(
             '.choose_template',
             service_id=service_id,
+            template_folder_id=template['folder'],
         ))
 
     try:


### PR DESCRIPTION
It’s disconcerting going back to the root if a template is in a deeply nested folder. Especially if you’re trying to delete multiple templates.