### PR TITLE
Announce selection count to assistive tech

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -139,10 +139,10 @@
       'default': 'Nothing selected',
       'selected': numSelected => `${numSelected} selected`,
       'update': numSelected => {
-        let liveRegionHTML = (numSelected > 0) ? this.selectionStatus.selected(numSelected) : this.selectionStatus.default;
+        let message = (numSelected > 0) ? this.selectionStatus.selected(numSelected) : this.selectionStatus.default;
 
-        $('.template-list-selected-counter-count').html(numSelected);
-        this.$liveRegionCounter.html(liveRegionHTML);
+        $('.template-list-selected-counter__count').html(message);
+        this.$liveRegionCounter.html(message);
       }
     };
 
@@ -198,8 +198,10 @@
         <div class="js-stick-at-bottom-when-scrolling">
           <button class="button-secondary" value="add-new-template">New template</button>
           <button class="button-secondary" value="add-new-folder">New folder</button>
-          <div class="template-list-selected-counter" aria-hidden="true">
-            ${this.selectionStatus.default}
+          <div class="template-list-selected-counter">
+            <span class="template-list-selected-counter__count" aria-hidden="true">
+              ${this.selectionStatus.default}
+            </span>
           </div>
         </div>
       </div>
@@ -211,7 +213,9 @@
           <button class="button-secondary" value="move-to-existing-folder">Move</button>
           <button class="button-secondary" value="move-to-new-folder">Add to new folder</button>
           <div class="template-list-selected-counter" aria-hidden="true">
-            ${this.selectionStatus.selected(1)}
+            <span class="template-list-selected-counter__count" aria-hidden="true">
+              ${this.selectionStatus.selected(1)}
+            </span>
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -11,6 +11,7 @@
       this.$form.find('button[value=unknown]').remove();
 
       this.$stickyBottom = this.$form.find('#sticky_template_forms');
+      this.$liveRegionCounter = this.$form.find('.selection-counter');
 
       this.$stickyBottom.append(this.nothingSelectedButtons);
       this.$stickyBottom.append(this.itemsSelectedButtons);
@@ -135,6 +136,17 @@
       this.render();
     };
 
+    this.selectionStatus = {
+      'default': 'Nothing selected',
+      'selected': numSelected => `${numSelected} selected`,
+      'update': numSelected => {
+        let liveRegionHTML = (numSelected > 0) ? this.selectionStatus.selected(numSelected) : this.selectionStatus.default;
+
+        $('.template-list-selected-counter-count').html(numSelected);
+        this.$liveRegionCounter.html(liveRegionHTML);
+      }
+    };
+
     this.templateFolderCheckboxChanged = function() {
       let numSelected = this.countSelectedCheckboxes();
 
@@ -148,7 +160,7 @@
 
       this.render();
 
-      $('.template-list-selected-counter-count').html(numSelected);
+      this.selectionStatus.update(numSelected);
 
       $('.template-list-selected-counter').toggle(this.hasCheckboxes());
 
@@ -188,7 +200,7 @@
           <button class="button-secondary" value="add-new-template">New template</button>
           <button class="button-secondary" value="add-new-folder">New folder</button>
           <div class="template-list-selected-counter">
-            Nothing selected
+            ${this.selectionStatus.default}
           </div>
         </div>
       </div>
@@ -200,7 +212,7 @@
           <button class="button-secondary" value="move-to-existing-folder">Move</button>
           <button class="button-secondary" value="move-to-new-folder">Add to new folder</button>
           <div class="template-list-selected-counter">
-            <span class="template-list-selected-counter-count">1</span> selected
+            ${this.selectionStatus.selected(1)}
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -35,7 +35,7 @@
       // first off show the new template / new folder buttons
       this.currentState = this.$form.data('prev-state') || 'unknown';
       if (this.currentState === 'unknown') {
-        this.selectActionButtons(false);
+        this.selectActionButtons();
       } else {
         this.render();
       }
@@ -90,13 +90,14 @@
     };
 
     this.addClearButton = function(state) {
-
+      let selector = 'button[value=add-new-template]';
       let $clear = this.makeButton('Clear', () => {
+
         // uncheck all templates and folders
         this.$form.find('input:checkbox').prop('checked', false);
 
         // go back to action buttons
-        this.selectActionButtons();
+        this.selectActionButtons(selector);
       });
 
       state.$el.find('.template-list-selected-counter').append($clear);

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -10,11 +10,10 @@
       // which field is visible.
       this.$form.find('button[value=unknown]').remove();
 
-      this.$stickyBottom = this.$form.find('#sticky_template_forms');
       this.$liveRegionCounter = this.$form.find('.selection-counter');
 
-      this.$stickyBottom.append(this.nothingSelectedButtons);
-      this.$stickyBottom.append(this.itemsSelectedButtons);
+      this.$liveRegionCounter.before(this.nothingSelectedButtons);
+      this.$liveRegionCounter.before(this.itemsSelectedButtons);
 
       // all the diff states that we want to show or hide
       this.states = [
@@ -180,7 +179,7 @@
 
       // detach everything, unless they are the currentState
       this.states.forEach(
-        state => (state.key === this.currentState ? this.$stickyBottom.append(state.$el) : state.$el.detach())
+        state => (state.key === this.currentState ? this.$liveRegionCounter.before(state.$el) : state.$el.detach())
       );
 
       // use dialog mode for states which contain more than one form control
@@ -199,7 +198,7 @@
         <div class="js-stick-at-bottom-when-scrolling">
           <button class="button-secondary" value="add-new-template">New template</button>
           <button class="button-secondary" value="add-new-folder">New folder</button>
-          <div class="template-list-selected-counter">
+          <div class="template-list-selected-counter" aria-hidden="true">
             ${this.selectionStatus.default}
           </div>
         </div>
@@ -211,7 +210,7 @@
         <div class="js-stick-at-bottom-when-scrolling">
           <button class="button-secondary" value="move-to-existing-folder">Move</button>
           <button class="button-secondary" value="move-to-new-folder">Add to new folder</button>
-          <div class="template-list-selected-counter">
+          <div class="template-list-selected-counter" aria-hidden="true">
             ${this.selectionStatus.selected(1)}
           </div>
         </div>

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -76,45 +76,61 @@
 
     this.addCancelButton = function(state) {
       let selector = `[value=${state.key}]`;
-      let $cancel = this.makeButton('Cancel', () => {
+      let $cancel = this.makeButton('Cancel', {
+        'onclick': () => {
 
-        // clear existing data
-        state.$el.find('input:radio').prop('checked', false);
-        state.$el.find('input:text').val('');
+          // clear existing data
+          state.$el.find('input:radio').prop('checked', false);
+          state.$el.find('input:text').val('');
 
-        // go back to action buttons
-        this.selectActionButtons(selector);
-      }, selector);
+          // go back to action buttons
+          this.selectActionButtons(selector);
+        },
+        'cancelSelector': selector,
+        'nonvisualText': "this step"
+      });
 
       state.$el.find('[type=submit]').after($cancel);
     };
 
     this.addClearButton = function(state) {
       let selector = 'button[value=add-new-template]';
-      let $clear = this.makeButton('Clear', () => {
+      let $clear = this.makeButton('Clear', {
+        'onclick': () => {
 
-        // uncheck all templates and folders
-        this.$form.find('input:checkbox').prop('checked', false);
+          // uncheck all templates and folders
+          this.$form.find('input:checkbox').prop('checked', false);
 
-        // go back to action buttons
-        this.selectActionButtons(selector);
+          // go back to action buttons
+          this.selectActionButtons(selector);
+        },
+        'nonvisualText': "selection"
       });
 
       state.$el.find('.template-list-selected-counter').append($clear);
     };
 
-    this.makeButton = (text, fn, cancelSelector) => $('<a></a>')
-      .html(text)
-      .addClass('js-cancel')
-      .data('target', cancelSelector) // isn't set if cancelSelector is undefined
-      .attr('tabindex', '0')
-      .on('click keydown', event => {
-        // space, enter or no keyCode (must be mouse input)
-        if ([13, 32, undefined].indexOf(event.keyCode) > -1) {
-          event.preventDefault();
-          fn();
+    this.makeButton = (text, opts) => {
+      let $btn = $('<a href=""></a>')
+                    .html(text)
+                    .addClass('js-cancel')
+                    // isn't set if cancelSelector is undefined
+                    .data('target', opts.cancelSelector || undefined)
+                    .attr('tabindex', '0')
+                    .on('click keydown', event => {
+                      // space, enter or no keyCode (must be mouse input)
+                      if ([13, 32, undefined].indexOf(event.keyCode) > -1) {
+                        event.preventDefault();
+                        if (opts.hasOwnProperty('onclick')) { opts.onclick(); }
+                      }
+                    });
+
+        if (opts.hasOwnProperty('nonvisualText')) {
+          $btn.append(`<span class="visuallyhidden"> ${opts.nonvisualText}</span>`);
         }
-      });
+
+        return $btn;
+    };
 
     this.selectActionButtons = function (targetSelector) {
       // If we want to show one of the grey choose actions state, we can pretend we're in the choose actions state,

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -131,10 +131,15 @@
   }
 
   &-selected-counter {
-    position: absolute;
-    right: 0;
-    top: $gutter - 1px;
     color: $secondary-text-colour;
+    margin: $gutter-half 0;
+
+    @include media(tablet) {
+      position: absolute;
+      right: 0;
+      top: $gutter - 1px;
+      margin: 0;
+    }
 
     .content-fixed & {
       right: $gutter-half;

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -36,4 +36,7 @@
     {{ page_footer('Continue', button_name='operation', button_value='add-new-template') }}
     </div>
   </div>
+  <div class="selection-counter visuallyhidden" role="status" aria-live="polite">
+    Nothing selected
+  </div>
 </div>


### PR DESCRIPTION
Wrapping the text that counts how many templates/folders you've selected in a live-region means  assistive technologies are notified of changes to it. If you use a screen reader, for example, it can tell you the total count as you go, just like we do for users of our visual UI.

https://www.pivotaltracker.com/story/show/162986227

Here's what Voiceover (the screen reader on IOS and OSX), announces when you select a checkbox:

<img width="1145" alt="live_region_1_selected" src="https://user-images.githubusercontent.com/87140/52854461-61b7fc80-3116-11e9-94d1-2107a23d5f64.png">

Here's what it announces when you deselect the last checkbox you had selected:

<img width="1160" alt="live_region_nothing_selected" src="https://user-images.githubusercontent.com/87140/52854501-7b594400-3116-11e9-9ac8-406d252d8c96.png">

Also includes fixes for some other accessibility-related things I found while working on this:
- focus being lost when you clear your selection (missed out of https://github.com/alphagov/notifications-admin/pull/2741)
- fix selection counter on smaller screens (it overlapped the buttons)
- add more text to 'Cancel' and 'Clear' links so they make sense of their context in the page