### PR TITLE
Flag go live requests from DWP

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -440,6 +440,8 @@ class AgreementInfo:
 
     @property
     def as_human_readable(self):
+        if self.canonical_domain and 'dwp' in self.canonical_domain:
+            return 'DWP - Requires OED approval'
         if self.agreement_signed:
             return 'Yes, on behalf of {}'.format(self.owner)
         elif self.owner:

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -305,6 +305,18 @@ def test_get_valid_agreement_info_known_details(domain_or_email_address):
     )
 
 
+@pytest.mark.parametrize("domain_or_email_address", (
+    "test@dwp.gov.uk", "test@dwp.gsi.gov.uk",
+))
+def test_dwp_go_live_requests_are_flagged(domain_or_email_address):
+    agreement_info = AgreementInfo(domain_or_email_address)
+    assert agreement_info.owner == "Department for Work and Pensions"
+    assert agreement_info.agreement_signed is True
+    assert agreement_info.as_human_readable == (
+        'DWP - Requires OED approval'
+    )
+
+
 @pytest.mark.parametrize("domain_or_email_address, is_canonical", (
     ("test@dclgdatamart.co.uk", False),
     ("test@communities.gsi.gov.uk", False),


### PR DESCRIPTION
It’s not enough to check that they’ve signed the agreement. We have to make sure we inform them every time a service wants to go live.