### PR TITLE
Update new template titles

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -294,7 +294,7 @@ def _add_template_by_type(template_type, template_folder_id):
 
     if template_type == 'letter':
         blank_letter = service_api_client.create_service_template(
-            'Untitled',
+            'New letter template',
             'letter',
             'Body',
             current_service.id,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -558,7 +558,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
             'views/edit-{}-template.html'.format(template_type),
             form=form,
             template_type=template_type,
-            heading_action='Add',
+            heading_action='New',
         )
 
 


### PR DESCRIPTION
To keep the H1 titles of new templates consistent with the sticky menu options:

* change `Add email template` to `New email template`
* change `Add text message template` to `New text message template`
* change default letter template name `Untitled` to `New letter template`