### PR TITLE
Change the format of the user_permissions data that gets sent

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -164,7 +164,10 @@ class UserApiClient(NotifyAdminAPIClient):
     @cache.delete('user-{user_id}')
     def set_user_permissions(self, user_id, service_id, permissions):
         # permissions passed in are the combined admin roles, not db permissions
-        data = [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
+        data = {
+            'permissions': [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
+        }
+
         endpoint = '/user/{}/service/{}/permission'.format(user_id, service_id)
         self.post(endpoint, data=data)
 

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -141,7 +141,7 @@ def test_client_converts_admin_permissions_to_db_permissions_on_edit(app_, mocke
 
     user_api_client.set_user_permissions('user_id', 'service_id', permissions={'send_messages', 'view_activity'})
 
-    assert sorted(mock_post.call_args[1]['data'], key=lambda x: x['permission']) == sorted([
+    assert sorted(mock_post.call_args[1]['data']['permissions'], key=lambda x: x['permission']) == sorted([
         {'permission': 'send_texts'},
         {'permission': 'send_emails'},
         {'permission': 'send_letters'},


### PR DESCRIPTION
The endpoint for setting permissions in api will now be used for both
user permissions and a user's folder permissions, so this changes the
format of the data we pass through.

This needs to be deployed after https://github.com/alphagov/notifications-api/pull/2370