### PR TITLE
Put template type navigation in correct order

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -39,8 +39,8 @@ class Service():
     }
 
     TEMPLATE_TYPES = (
-        'sms',
         'email',
+        'sms',
         'letter',
     )
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -55,7 +55,7 @@ def _template(template_type, name, parent=None, template_id=None):
             'Templates',
             [],
             {},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [
                 'folder_one 2 folders',
                 'folder_one / folder_one_one 1 template, 1 folder',
@@ -132,7 +132,7 @@ def _template(template_type, name, parent=None, template_id=None):
             'Templates / folder_one',
             [{'template_type': 'all'}],
             {'template_folder_id': PARENT_FOLDER_ID},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [
                 'folder_one_one 1 template, 1 folder',
                 'folder_one_one / folder_one_one_one 1 template',
@@ -193,7 +193,7 @@ def _template(template_type, name, parent=None, template_id=None):
                 {'template_type': 'all', 'template_folder_id': PARENT_FOLDER_ID},
             ],
             {'template_folder_id': CHILD_FOLDER_ID},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [
                 'folder_one_one_one 1 template',
                 'folder_one_one_one / sms_template_nested Text message template',
@@ -219,7 +219,7 @@ def _template(template_type, name, parent=None, template_id=None):
                 {'template_type': 'all', 'template_folder_id': CHILD_FOLDER_ID},
             ],
             {'template_folder_id': GRANDCHILD_FOLDER_ID},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [
                 'sms_template_nested Text message template',
             ],
@@ -254,7 +254,7 @@ def _template(template_type, name, parent=None, template_id=None):
             'Templates / folder_two',
             [{'template_type': 'all'}],
             {'template_folder_id': FOLDER_TWO_ID},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [],
             [],
             [],

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -96,7 +96,7 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
             active_user_view_permissions,
             'Templates',
             {},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [
                 'sms_template_one',
                 'sms_template_two',
@@ -124,14 +124,14 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
             active_user_view_permissions,
             'Templates',
             {'template_type': 'letter'},
-            ['All', 'Text message', 'Email'],
+            ['All', 'Email', 'Text message'],
             ['letter_template_one', 'letter_template_two'],
         ),
         (
             active_caseworking_user,
             'Templates',
             {},
-            ['Text message', 'Email', 'Letter'],
+            ['Email', 'Text message', 'Letter'],
             [
                 'sms_template_one',
                 'sms_template_two',


### PR DESCRIPTION
We always talk about the things you can send using Notify as _emails, text messages and letters_, in that order:

![image](https://user-images.githubusercontent.com/355079/53259084-1da09b00-36c6-11e9-8314-035e43864c7a.png)

The navigation should reflect this.

## Before 

![image](https://user-images.githubusercontent.com/355079/53259121-35781f00-36c6-11e9-85af-73509d953013.png)

## After

![image](https://user-images.githubusercontent.com/355079/53259102-285b3000-36c6-11e9-95d2-6caf4d0840dd.png)
