### PR TITLE
Don’t error if email address hasn’t changed

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -146,6 +146,10 @@ def edit_user_email(service_id, user_id):
         return user_api_client.is_email_already_in_use(email)
 
     form = ChangeEmailForm(_is_email_already_in_use, email_address=user_email)
+
+    if request.form.get('email_address', '').strip() == user_email:
+        return redirect(url_for('.manage_users', service_id=current_service.id))
+
     if form.validate_on_submit():
         session['team_member_email_change'] = form.email_address.data
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -813,6 +813,29 @@ def test_edit_user_email_redirects_to_confirmation(
     )
 
 
+def test_edit_user_email_without_changing_goes_back_to_team_members(
+    client_request,
+    active_user_with_permissions,
+    mock_get_user,
+    mock_update_user_attribute,
+):
+    client_request.post(
+        'main.edit_user_email',
+        service_id=SERVICE_ONE_ID,
+        user_id=active_user_with_permissions.id,
+        _data={
+            'email_address': active_user_with_permissions.email_address
+        },
+        _expected_status=302,
+        _expected_redirect=url_for(
+            'main.manage_users',
+            service_id=SERVICE_ONE_ID,
+            _external=True
+        ),
+    )
+    assert mock_update_user_attribute.called is False
+
+
 def test_confirm_edit_user_email_page(
     logged_in_client,
     active_user_with_permissions,


### PR DESCRIPTION
When updating a user’s email address you currently get an validation error if you save without changing it. Instead it should just obey your command. And no need for the confirmation step because nothing is actually changing.