### PR TITLE
Add space between email address and edit link

### DIFF
--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -13,6 +13,7 @@ $item-top-padding: $gutter-half;
 
     h3 {
 
+      padding-right: $gutter-half;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
It was all getting a bit cramped with the new text of the edit link.

# Before 

![image](https://user-images.githubusercontent.com/355079/53347059-78c5ce00-3910-11e9-9b77-25bf85aaf8cf.png)

# After 

![image](https://user-images.githubusercontent.com/355079/53347103-50d66a80-3910-11e9-8151-d0d8c7be0f8f.png)
