### PR TITLE
Edit user folder permissions

### DIFF
--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -1,0 +1,44 @@
+.checkboxes-nested {
+
+  margin-bottom: 10px;
+
+  .multiple-choice {
+
+    $circle-diameter: 39px;
+    $border-thickness: 4px;
+    $border-indent: ($circle-diameter / 2) - ($border-thickness / 2);
+    $border-colour: $border-colour;
+
+    float: none;
+    position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: $border-indent;
+      width: $border-thickness;
+      height: 100%;
+      background: $border-colour;
+    }
+
+    label {
+      float: none;
+    }
+
+    [type=checkbox]+label::before {
+      // To overlap the grey inset line
+      background: $white;
+    }
+
+    ul {
+      // To equalise the spacing between the line and the top/bottom of
+      // the radio
+      margin-top: 5px;
+      margin-bottom: -5px;
+      padding-left: 12px;
+    }
+
+  }
+
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -47,6 +47,7 @@ $path: '/static/images/';
 @import 'components/api-key';
 @import 'components/vendor/previous-next-navigation';
 @import 'components/radios';
+@import 'components/checkboxes';
 @import 'components/pill';
 @import 'components/secondary-button';
 @import 'components/show-more';

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -418,6 +418,15 @@ PermissionsAbstract = type("PermissionsAbstract", (StripWhitespaceForm,), {
 
 
 class PermissionsForm(PermissionsAbstract):
+    def __init__(self, all_template_folders=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if all_template_folders:
+            self.folder_permissions.all_template_folders = all_template_folders
+            self.folder_permissions.choices = [
+                (item['id'], item['name']) for item in ([{'name': 'Templates', 'id': None}] + all_template_folders)
+            ]
+
+    folder_permissions = NestedCheckboxesField('Folder permissions')
 
     login_authentication = RadioField(
         'Sign in using',
@@ -437,8 +446,9 @@ class PermissionsForm(PermissionsAbstract):
         return (getattr(self, permission) for permission, _ in permissions)
 
     @classmethod
-    def from_user(cls, user, service_id):
+    def from_user(cls, user, service_id, **kwargs):
         return cls(
+            **kwargs,
             **{
                 role: user.has_permission_for_service(service_id, role)
                 for role in roles.keys()

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -420,7 +420,7 @@ PermissionsAbstract = type("PermissionsAbstract", (StripWhitespaceForm,), {
 class PermissionsForm(PermissionsAbstract):
     def __init__(self, all_template_folders=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if all_template_folders:
+        if all_template_folders is not None:
             self.folder_permissions.all_template_folders = all_template_folders
             self.folder_permissions.choices = [
                 (item['id'], item['name']) for item in ([{'name': 'Templates', 'id': None}] + all_template_folders)

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -426,7 +426,7 @@ class PermissionsForm(PermissionsAbstract):
                 (item['id'], item['name']) for item in ([{'name': 'Templates', 'id': None}] + all_template_folders)
             ]
 
-    folder_permissions = NestedCheckboxesField('Folder permissions')
+    folder_permissions = NestedCheckboxesField('Folders this team member can see')
 
     login_authentication = RadioField(
         'Sign in using',

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -255,6 +255,78 @@ def organisation_type():
     )
 
 
+class FieldWithNoneOption():
+
+    # This is a special value that is specific to our forms. This is
+    # more expicit than casting `None` to a string `'None'` which can
+    # have unexpected edge cases
+    NONE_OPTION_VALUE = '__NONE__'
+
+    # When receiving Python data, eg when instantiating the form object
+    # we want to convert that data to our special value, so that it gets
+    # recognised as being one of the valid choices
+    def process_data(self, value):
+        self.data = self.NONE_OPTION_VALUE if value is None else value
+
+    # After validation we want to convert it back to a Python `None` for
+    # use elsewhere, eg posting to the API
+    def post_validate(self, form, validation_stopped):
+        if self.data == self.NONE_OPTION_VALUE and not validation_stopped:
+            self.data = None
+
+
+class RadioFieldWithNoneOption(FieldWithNoneOption, RadioField):
+    pass
+
+
+class NestedFieldMixin:
+    def children(self):
+        # start map with root option as a single child entry
+        child_map = {None: [option for option in self
+                            if option.data == self.NONE_OPTION_VALUE]}
+
+        # add entries for all other children
+        for option in self:
+            if option.data == self.NONE_OPTION_VALUE:
+                child_ids = [
+                    folder['id'] for folder in self.all_template_folders
+                    if folder['parent_id'] is None]
+                key = self.NONE_OPTION_VALUE
+            else:
+                child_ids = [
+                    folder['id'] for folder in self.all_template_folders
+                    if folder['parent_id'] == option.data]
+                key = option.data
+
+            child_map[key] = [option for option in self if option.data in child_ids]
+
+        return child_map
+
+
+class NestedRadioField(RadioFieldWithNoneOption, NestedFieldMixin):
+    pass
+
+
+class NestedCheckboxesField(SelectMultipleField, NestedFieldMixin):
+    NONE_OPTION_VALUE = None
+
+
+class HiddenFieldWithNoneOption(FieldWithNoneOption, HiddenField):
+    pass
+
+
+class RadioFieldWithRequiredMessage(RadioField):
+    def __init__(self, *args, required_message='Not a valid choice', **kwargs):
+        self.required_message = required_message
+        super().__init__(*args, **kwargs)
+
+    def pre_validate(self, form):
+        try:
+            return super().pre_validate(form)
+        except ValueError:
+            raise ValueError(self.required_message)
+
+
 class StripWhitespaceForm(Form):
     class Meta:
         def bind_field(self, form, unbound_field, options):
@@ -811,78 +883,6 @@ class ServiceSwitchChannelForm(ServiceOnOffSettingForm):
         }.get(channel))
 
         super().__init__(name, *args, **kwargs)
-
-
-class FieldWithNoneOption():
-
-    # This is a special value that is specific to our forms. This is
-    # more expicit than casting `None` to a string `'None'` which can
-    # have unexpected edge cases
-    NONE_OPTION_VALUE = '__NONE__'
-
-    # When receiving Python data, eg when instantiating the form object
-    # we want to convert that data to our special value, so that it gets
-    # recognised as being one of the valid choices
-    def process_data(self, value):
-        self.data = self.NONE_OPTION_VALUE if value is None else value
-
-    # After validation we want to convert it back to a Python `None` for
-    # use elsewhere, eg posting to the API
-    def post_validate(self, form, validation_stopped):
-        if self.data == self.NONE_OPTION_VALUE and not validation_stopped:
-            self.data = None
-
-
-class RadioFieldWithNoneOption(FieldWithNoneOption, RadioField):
-    pass
-
-
-class NestedFieldMixin:
-    def children(self):
-        # start map with root option as a single child entry
-        child_map = {None: [option for option in self
-                            if option.data == self.NONE_OPTION_VALUE]}
-
-        # add entries for all other children
-        for option in self:
-            if option.data == self.NONE_OPTION_VALUE:
-                child_ids = [
-                    folder['id'] for folder in self.all_template_folders
-                    if folder['parent_id'] is None]
-                key = self.NONE_OPTION_VALUE
-            else:
-                child_ids = [
-                    folder['id'] for folder in self.all_template_folders
-                    if folder['parent_id'] == option.data]
-                key = option.data
-
-            child_map[key] = [option for option in self if option.data in child_ids]
-
-        return child_map
-
-
-class NestedRadioField(RadioFieldWithNoneOption, NestedFieldMixin):
-    pass
-
-
-class NestedCheckboxesField(SelectMultipleField, NestedFieldMixin):
-    pass
-
-
-class HiddenFieldWithNoneOption(FieldWithNoneOption, HiddenField):
-    pass
-
-
-class RadioFieldWithRequiredMessage(RadioField):
-    def __init__(self, *args, required_message='Not a valid choice', **kwargs):
-        self.required_message = required_message
-        super().__init__(*args, **kwargs)
-
-    def pre_validate(self, form):
-        try:
-            return super().pre_validate(form)
-        except ValueError:
-            raise ValueError(self.required_message)
 
 
 class ServiceSetEmailBranding(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -837,10 +837,7 @@ class RadioFieldWithNoneOption(FieldWithNoneOption, RadioField):
     pass
 
 
-class NestedRadioField(RadioFieldWithNoneOption):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+class NestedFieldMixin:
     def children(self):
         # start map with root option as a single child entry
         child_map = {None: [option for option in self
@@ -862,6 +859,14 @@ class NestedRadioField(RadioFieldWithNoneOption):
             child_map[key] = [option for option in self if option.data in child_ids]
 
         return child_map
+
+
+class NestedRadioField(RadioFieldWithNoneOption, NestedFieldMixin):
+    pass
+
+
+class NestedCheckboxesField(SelectMultipleField, NestedFieldMixin):
+    pass
 
 
 class HiddenFieldWithNoneOption(FieldWithNoneOption, HiddenField):

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -84,7 +84,11 @@ def edit_user_permissions(service_id, user_id):
     if user.mobile_number:
         mobile_number = redact_mobile_number(user.mobile_number, " ")
 
-    form = PermissionsForm.from_user(user, service_id)
+    form = PermissionsForm.from_user(
+        user,
+        service_id,
+        all_template_folders=current_service.all_template_folders
+    )
 
     if form.validate_on_submit():
         user_api_client.set_user_permissions(

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -87,6 +87,10 @@ def edit_user_permissions(service_id, user_id):
     form = PermissionsForm.from_user(
         user,
         service_id,
+        folder_permissions=[
+            f['id'] for f in current_service.all_template_folders
+            if user_id in f.get('users_with_permission', [])
+        ],
         all_template_folders=current_service.all_template_folders
     )
 
@@ -94,6 +98,10 @@ def edit_user_permissions(service_id, user_id):
         user_api_client.set_user_permissions(
             user_id, service_id,
             permissions=form.permissions,
+            folder_permissions=(
+                form.folder_permissions.data
+                if current_service.has_permission('edit_folder_permissions') else None
+            ),
         )
         if service_has_email_auth:
             user_api_client.update_user_attribute(user_id, auth_type=form.login_authentication.data)

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -161,12 +161,16 @@ class UserApiClient(NotifyAdminAPIClient):
         resp = self.post('/organisations/{}/users/{}'.format(org_id, user_id), data={})
         return User(resp['data'], max_failed_login_count=self.max_failed_login_count)
 
+    @cache.delete('service-{service_id}-template-folders')
     @cache.delete('user-{user_id}')
-    def set_user_permissions(self, user_id, service_id, permissions):
+    def set_user_permissions(self, user_id, service_id, permissions, folder_permissions=None):
         # permissions passed in are the combined admin roles, not db permissions
         data = {
-            'permissions': [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
+            'permissions': [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)],
         }
+
+        if folder_permissions is not None:
+            data['folder_permissions'] = folder_permissions
 
         endpoint = '/user/{}/service/{}/permission'.format(user_id, service_id)
         self.post(endpoint, data=data)

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -1,3 +1,5 @@
+{% from "components/select-input.html" import select_nested %}
+
 {% macro checkbox(
   field,
   hint=False,
@@ -14,6 +16,11 @@
       {% endif %}
     </label>
   </div>
+{% endmacro %}
+
+
+{% macro checkboxes_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False) %}
+  {{ select_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, input="checkbox") }}
 {% endmacro %}
 
 

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -1,111 +1,27 @@
-{% macro radios(
-  field,
-  hint=None,
-  disable=[],
-  option_hints={},
-  hide_legend=False
-) %}
-  {% call radios_wrapper(
-    field, hint, disable, option_hints, hide_legend
-  ) %}
-    {% for option in field %}
-      {{ radio(option, disable, option_hints) }}
-    {% endfor %}
-  {% endcall %}
+{% from "components/select-input.html" import select, select_list, select_nested, select_wrapper %}
+
+{% macro radios(field, hint=None, disable=[], option_hints={}, hide_legend=False) %}
+  {{ select(field, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") }}
 {% endmacro %}
 
 
-{% macro radio_list(
-    options,
-    child_map,
-    disable=[],
-    option_hints={}
-) %}
-    <ul>
-    {% for option in options %}
-      {% if child_map[option.data] %}
-        {% call radio(option, disable, option_hints, as_list_item=True) %}
-          {{ radio_list(child_map[option.data], child_map, disable, option_hints) }}
-        {% endcall %}
-      {% else %}
-          {{ radio(option, disable, option_hints, as_list_item=True) }}
-      {% endif %}
-    {% endfor %}
-    </ul>
+{% macro radio_list(options, child_map, disable=[], option_hints={}) %}
+  {{ select_list(options, child_map, disable=[], option_hints={}, input="radio") }}
 {% endmacro %}
 
 
-{% macro radios_nested(
-  field,
-  child_map,
-  hint=None,
-  disable=[],
-  option_hints={},
-  hide_legend=False
-) %}
-  {% call radios_wrapper(
-    field, hint, disable, option_hints, hide_legend
-  ) %}
-    <div class="radios-nested">
-      {{ radio_list(child_map[None], child_map, disable, option_hints) }}
-    </div>
-  {% endcall %}
+{% macro radios_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False) %}
+  {{ select_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") }}
 {% endmacro %}
+
 
 {% macro radios_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False) %}
-  <div class="form-group {% if field.errors %} form-group-error{% endif %}">
-    <fieldset>
-      <legend class="{{ 'form-label' if not hide_legend else '' }}">
-        {% if hide_legend %}<span class="visually-hidden">{% endif %}
-          {{ field.label.text|safe }}
-        {% if hide_legend %}</span>{% endif %}
-        {% if hint %}
-          <span class="form-hint">
-            {{ hint }}
-          </span>
-        {% endif %}
-        {% if field.errors %}
-          <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
-            {{ field.errors[0] }}
-          </span>
-        {% endif %}
-      </legend>
-      {{ caller() }}
-    </fieldset>
-  </div>
+  {{ select_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") }}
 {% endmacro %}
 
+
 {% macro radio(option, disable=[], option_hints={}, data_target=None, as_list_item=False) %}
-  {% if as_list_item %}
-  <li class="multiple-choice" {% if data_target %}data-target="{{ data_target }}"{% endif %}>
-  {% else %}
-  <div class="multiple-choice" {% if data_target %}data-target="{{ data_target }}"{% endif %}>
-  {% endif %}
-    <input
-      id="{{ option.id }}" name="{{ option.name }}" type="radio" value="{{ option.data }}"
-      {% if option.data in disable %}
-        disabled
-      {% endif %}
-      {% if option.checked %}
-        checked
-      {% endif %}
-    >
-    <label class="block-label" for="{{ option.id }}">
-      {{ option.label.text }}
-      {% if option_hints[option.data] %}
-        <div class="block-label-hint">
-          {{ option_hints[option.data] }}
-        </div>
-      {% endif %}
-    </label>
-    {% if caller %}
-        {{ caller() }}
-    {% endif %}
-  {% if as_list_item %}
-  </li>
-  {% else %}
-  </div>
-  {% endif %}
+  {{ select_input(option, disable=[], option_hints={}, data_target=None, as_list_item=False, input="radio") }}
 {% endmacro %}
 
 

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -1,27 +1,22 @@
-{% from "components/select-input.html" import select, select_list, select_nested, select_wrapper %}
+{% from "components/select-input.html" import select, select_list, select_nested, select_wrapper, select_input %}
 
 {% macro radios(field, hint=None, disable=[], option_hints={}, hide_legend=False) %}
-  {{ select(field, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") }}
+  {{ select(field, hint, disable, option_hints, hide_legend, input="radio") }}
 {% endmacro %}
 
 
 {% macro radio_list(options, child_map, disable=[], option_hints={}) %}
-  {{ select_list(options, child_map, disable=[], option_hints={}, input="radio") }}
+  {{ select_list(options, child_map, disable, option_hints, input="radio") }}
 {% endmacro %}
 
 
 {% macro radios_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False) %}
-  {{ select_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") }}
-{% endmacro %}
-
-
-{% macro radios_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False) %}
-  {{ select_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") }}
+  {{ select_nested(field, child_map, hint, disable, option_hints, hide_legend, input="radio") }}
 {% endmacro %}
 
 
 {% macro radio(option, disable=[], option_hints={}, data_target=None, as_list_item=False) %}
-  {{ select_input(option, disable=[], option_hints={}, data_target=None, as_list_item=False, input="radio") }}
+  {{ select_input(option, disable, option_hints, data_target, as_list_item, input="radio") }}
 {% endmacro %}
 
 

--- a/app/templates/components/select-input.html
+++ b/app/templates/components/select-input.html
@@ -1,0 +1,92 @@
+{% macro select(field, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") %}
+  {% call select_wrapper(
+    field, hint, disable, option_hints, hide_legend
+  ) %}
+    {% for option in field %}
+      {{ select_input(option, disable, option_hints, input=input) }}
+    {% endfor %}
+  {% endcall %}
+{% endmacro %}
+
+
+{% macro select_list(options, child_map, disable=[], option_hints={}, input="radio") %}
+    <ul>
+    {% for option in options %}
+      {% if child_map[option.data] %}
+        {% call select_input(option, disable, option_hints, as_list_item=True, input=input) %}
+          {{ select_list(child_map[option.data], child_map, disable, option_hints, input=input) }}
+        {% endcall %}
+      {% else %}
+          {{ select_input(option, disable, option_hints, as_list_item=True, input=input) }}
+      {% endif %}
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+
+{% macro select_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, input="radio") %}
+  {% call select_wrapper(
+    field, hint, disable, option_hints, hide_legend
+  ) %}
+  <div class="{{ "radios" if input == "radio" else "checkboxes" }}-nested">
+      {{ select_list(child_map[None], child_map, disable, option_hints, input=input) }}
+    </div>
+  {% endcall %}
+{% endmacro %}
+
+
+{% macro select_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False) %}
+  <div class="form-group {% if field.errors %} form-group-error{% endif %}">
+    <fieldset>
+      <legend class="{{ 'form-label' if not hide_legend else '' }}">
+        {% if hide_legend %}<span class="visually-hidden">{% endif %}
+          {{ field.label.text|safe }}
+        {% if hide_legend %}</span>{% endif %}
+        {% if hint %}
+          <span class="form-hint">
+            {{ hint }}
+          </span>
+        {% endif %}
+        {% if field.errors %}
+          <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
+            {{ field.errors[0] }}
+          </span>
+        {% endif %}
+      </legend>
+      {{ caller() }}
+    </fieldset>
+  </div>
+{% endmacro %}
+
+{% macro select_input(option, disable=[], option_hints={}, data_target=None, as_list_item=False, input="radio") %}
+  {% if as_list_item %}
+  <li class="multiple-choice" {% if data_target %}data-target="{{ data_target }}"{% endif %}>
+  {% else %}
+  <div class="multiple-choice" {% if data_target %}data-target="{{ data_target }}"{% endif %}>
+  {% endif %}
+    <input
+      id="{{ option.id }}" name="{{ option.name }}" type="{{ input }}" value="{{ option.data }}"
+      {% if option.data in disable %}
+        disabled
+      {% endif %}
+      {% if option.checked %}
+        checked
+      {% endif %}
+    >
+    <label class="block-label" for="{{ option.id }}">
+      {{ option.label.text }}
+      {% if option_hints[option.data] %}
+        <div class="block-label-hint">
+          {{ option_hints[option.data] }}
+        </div>
+      {% endif %}
+    </label>
+    {% if caller %}
+        {{ caller() }}
+    {% endif %}
+  {% if as_list_item %}
+  </li>
+  {% else %}
+  </div>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -1,5 +1,5 @@
-{% from "components/checkbox.html" import checkbox %}
-{% from "components/radios.html" import radio, radios, radios_wrapper, conditional_radio_panel %}
+{% from "components/checkbox.html" import checkbox, checkboxes_nested %}
+{% from "components/radios.html" import radio, radios, conditional_radio_panel %}
 
 <fieldset class="form-group">
   <legend class="form-label">
@@ -13,6 +13,10 @@
 <p class="bottom-gutter">
   All team members can see sent messages.
 </p>
+
+{% if current_service.has_permission("edit_folder_permissions") %}
+  {{ checkboxes_nested(form.folder_permissions, form.folder_permissions.children()) }}
+{% endif %}
 
 {% if service_has_email_auth %}
   {% if not mobile_number %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -14,7 +14,7 @@
   All team members can see sent messages.
 </p>
 
-{% if current_service.has_permission("edit_folder_permissions") %}
+{% if current_service.has_permission("edit_folder_permissions") and form.folder_permissions.all_template_folders %}
   {{ checkboxes_nested(form.folder_permissions, form.folder_permissions.children()) }}
 {% endif %}
 

--- a/app/templates/views/service-settings/contact_link.html
+++ b/app/templates/views/service-settings/contact_link.html
@@ -1,7 +1,8 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radio, radios_wrapper %}
+{% from "components/radios.html" import radio %}
+{% from "components/select-input.html" import select_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -21,7 +22,7 @@
       </p>
       {% call form_wrapper() %}
 
-        {% call radios_wrapper(form.contact_details_type, hide_legend=true) %}
+        {% call select_wrapper(form.contact_details_type, hide_legend=true) %}
           {% for option in form.contact_details_type %}
             {% set data_target = option.data.replace('_', '-') ~ "-type" %}
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -228,6 +228,7 @@ def test_service_with_no_email_auth_hides_auth_type_options(
     auth_options_hidden,
     service_one,
     mock_get_users_by_service,
+    mock_get_template_folders
 ):
     if service_has_email_auth:
         service_one['permissions'].append('email_auth')
@@ -249,6 +250,7 @@ def test_service_with_no_email_auth_hides_auth_type_options(
 def test_service_without_caseworking_doesnt_show_admin_vs_caseworker(
     client_request,
     mock_get_users_by_service,
+    mock_get_template_folders,
     endpoint,
     service_has_caseworking,
     extra_args,
@@ -304,6 +306,7 @@ def test_manage_users_page_shows_member_auth_type_if_service_has_email_auth_acti
 def test_user_with_no_mobile_number_cant_be_set_to_sms_auth(
     client_request,
     mock_get_users_by_service,
+    mock_get_template_folders,
     user,
     sms_option_disabled,
     expected_label,
@@ -353,6 +356,7 @@ def test_user_with_no_mobile_number_cant_be_set_to_sms_auth(
 def test_should_show_page_for_one_user(
     client_request,
     mock_get_users_by_service,
+    mock_get_template_folders,
     endpoint,
     extra_args,
     expected_checkboxes,
@@ -419,6 +423,7 @@ def test_edit_user_permissions(
     mock_get_users_by_service,
     mock_get_invites_for_service,
     mock_set_user_permissions,
+    mock_get_template_folders,
     fake_uuid,
     submitted_permissions,
     permissions_sent_to_api,
@@ -474,7 +479,8 @@ def test_edit_user_permissions_including_authentication_with_email_auth_service(
     mock_set_user_permissions,
     mock_update_user_attribute,
     service_one,
-    auth_type
+    auth_type,
+    mock_get_template_folders
 ):
     service_one['permissions'].append('email_auth')
 


### PR DESCRIPTION
<img width="640" alt="screen shot 2019-02-28 at 14 03 34" src="https://user-images.githubusercontent.com/246664/53571812-af465780-3b61-11e9-8bbe-64a628e18e33.png">

### Make radio form components reusable for nested checkboxes

For the template folders permission editing we need a nested checkboxes form that is similar to "move folder" input, except it's using checkboxes instead of radio buttons.

This moves most of the macros into a shared "select-input" components file, which are wrapped by the existing radios.html by setting the required input type.

### Move field definitions before form definitions


### Display nested folders permissions form on user permissions page

We're reusing the logic for the `move_to` nested radios field for the user folder permissions nested checkboxes.

The main difference between the two forms (aside from the different input type) is that "Move" form contains the root "Templates" as an option, whereas the folder permissions doesn't.

It turns out that, because of the way NestedFieldMixin.children and select_nested macro are implemented the easiest way to get the desired folder permissions behaviour is to add the root folder as a choice with a `None` value and `NONE_OPTION_VALUE = None` set on the field, which allows the `child_map` to be constructed but doesn't display the root folder checkbox itself since it gets overwritten in the final `child_map`.

### Add checkboxes-nested CSS rules


### Send updated user folder permissions to the API

Integrates the folder permissions form with the updated API endpoint to store changes in the user folders.

Since user folder permissions are returned in the full list of template folders for the service we need to invalidate the cache key for it each time we update user permissions.
