### PR TITLE
Use tabular font for numeric fields

### DIFF
--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -56,6 +56,7 @@
 }
 
 .extra-tracking .form-control {
+  @include core-19($tabular-numbers: true);
   padding-left: 5px;
   letter-spacing: 0.04em;
 }


### PR DESCRIPTION
When you’re entering numbers into a field we already add some extra tracking to make it easier to read.

With this extra tracking the kerning looks a bit more even with the tabular, not lining numbers. This makes sense because tabular numbers are designed to be used where the content is numeric-only. Lining numbers (the default) are more appropriate for numbers that are used in passages of text.

# Before

![image](https://user-images.githubusercontent.com/355079/53636086-ef1b4680-3c16-11e9-9045-dedf9076d2b9.png)

# After 

![image](https://user-images.githubusercontent.com/355079/53636073-e62a7500-3c16-11e9-813d-e2a00882b38f.png)

***

Borrowed from https://github.com/alphagov/govuk-frontend/pull/1222