### PR TITLE
Only show folders that user has permission to see

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -111,10 +111,10 @@ def start_tour(service_id, template_id):
 @user_has_permissions()
 def choose_template(service_id, template_type='all', template_folder_id=None):
 
-    template_list = TemplateList(current_service, template_type, template_folder_id)
+    template_list = TemplateList(current_service, template_type, template_folder_id, current_user.id)
 
     templates_and_folders_form = TemplateAndFoldersSelectionForm(
-        all_template_folders=current_service.all_template_folders,
+        all_template_folders=current_service.get_user_template_folders(current_user.id),
         template_list=template_list,
         template_type=template_type,
         allow_adding_letter_template=current_service.has_permission('letter'),
@@ -348,6 +348,7 @@ def choose_template_to_copy(
             services_templates_and_folders=TemplateList(
                 service,
                 template_folder_id=from_folder,
+                user_id=current_user.id
             ),
             template_folder_path=service.get_template_folder_path(from_folder),
             from_service=service,
@@ -360,7 +361,7 @@ def choose_template_to_copy(
             services_templates_and_folders=TemplateLists([
                 Service(service) for service in
                 user_api_client.get_services_for_user(current_user)
-            ]),
+            ], user_id=current_user.id),
             search_form=SearchByNameForm(),
         )
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -385,6 +385,19 @@ class Service():
         return {folder['id'] for folder in self.all_template_folders}
 
     def get_user_template_folders(self, user_id):
+        """Returns a modified list of folders a user has permission to view
+
+        For each folder, we do the following:
+        - if user has no permission to view the folder, skip it
+        - if folder is visible and its parent is visible, we add it to the list of folders
+        we later return without modifying anything
+        - if folder is visible, but the parent is not, we iterate through the parent until we
+        either find a visible parent or reach root folder. On each iteration we concatenate
+        invisible parent folder name to the front of our folder name, modifying the name, and we
+        change parent_folder_id attribute to a higher level parent. This flattens the path to the
+        folder making sure it displays in the closest visible parent.
+
+        """
         if not self.has_permission("edit_folder_permissions"):
             return self.all_template_folders
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -380,6 +380,9 @@ class Service():
         return {folder['id'] for folder in self.all_template_folders}
 
     def get_user_template_folders(self, user_id):
+        if not self.has_permission("edit_folder_permissions"):
+            return self.all_template_folders
+
         user_folders = []
         for folder in self.all_template_folders:
             if user_id not in folder.get("users_with_permission", []):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -392,12 +392,15 @@ class Service():
                     "id": folder["id"], "name": folder["name"], "parent_id": folder["parent_id"],
                     "users_with_permission": folder["users_with_permission"]
                 }
-                while parent is not None:
+                while folder_attrs["parent_id"] is not None:
                     folder_attrs["name"] = parent["name"] + "/" + folder_attrs["name"]
-                    parent = self.get_template_folder(parent["parent_id"])
-                    folder_attrs["parent_id"] = parent.get("id", None)
-                    if user_id in parent.get("users_with_permission", []):
-                        break
+                    if parent["parent_id"] is None:
+                        folder_attrs["parent_id"] = None
+                    else:
+                        parent = self.get_template_folder(parent["parent_id"])
+                        folder_attrs["parent_id"] = parent.get("id", None)
+                        if user_id in parent.get("users_with_permission", []):
+                            break
                 user_folders.append(folder_attrs)
         return user_folders
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -396,7 +396,7 @@ class Service():
                     "users_with_permission": folder["users_with_permission"]
                 }
                 while folder_attrs["parent_id"] is not None:
-                    folder_attrs["name"] = parent["name"] + "/" + folder_attrs["name"]
+                    folder_attrs["name"] = parent["name"] + " / " + folder_attrs["name"]
                     if parent["parent_id"] is None:
                         folder_attrs["parent_id"] = None
                     else:

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -424,7 +424,7 @@ class Service():
             folder for folder in folders
             if (
                 folder['parent_id'] == parent_folder_id
-                and self.is_folder_visible(folder['id'], template_type)
+                and self.is_folder_visible(folder['id'], template_type, user_id)
             )
         ]
 
@@ -437,7 +437,7 @@ class Service():
             }
         return self._get_by_id(self.all_template_folders, folder_id)
 
-    def is_folder_visible(self, template_folder_id, template_type='all'):
+    def is_folder_visible(self, template_folder_id, template_type='all', user_id=None):
 
         if template_type == 'all':
             return True
@@ -446,8 +446,8 @@ class Service():
             return True
 
         if any(
-            self.is_folder_visible(child_folder['id'], template_type)
-            for child_folder in self.get_template_folders(template_type, template_folder_id)
+            self.is_folder_visible(child_folder['id'], template_type, user_id)
+            for child_folder in self.get_template_folders(template_type, template_folder_id, user_id)
         ):
             return True
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -154,7 +154,12 @@ class Service():
     def all_template_ids(self):
         return {template['id'] for template in self.all_templates}
 
-    def get_templates(self, template_type='all', template_folder_id=None):
+    def get_templates(self, template_type='all', template_folder_id=None, user_id=None):
+        if user_id and template_folder_id and self.has_permission('edit_folder_permissions'):
+            folder = self.get_template_folder(template_folder_id)
+            if user_id not in folder.get("users_with_permission", []):
+                return []
+
         if isinstance(template_type, str):
             template_type = [template_type]
         if template_folder_id:

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -40,7 +40,7 @@ class TemplateList():
                 yield sub_item
 
         for item in self.service.get_templates(
-            template_type, template_folder_id
+            template_type, template_folder_id, user_id
         ):
             yield TemplateListTemplate(
                 item,

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -74,6 +74,7 @@ def test_get_user_template_folders_only_returns_folders_visible_to_user(
     mocker
 ):
     mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
+    service_one['permissions'] = ['edit_folder_permissions']
     service = Service(service_one)
     result = service.get_user_template_folders(active_user_with_permissions.id)
     assert result == [
@@ -117,6 +118,7 @@ def test_get_template_folders_shows_user_folders_when_user_id_passed_in(
     mocker
 ):
     mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
+    service_one['permissions'] = ['edit_folder_permissions']
     service = Service(service_one)
     result = service.get_template_folders(user_id=active_user_with_permissions.id)
     assert result == [

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -79,13 +79,13 @@ def test_get_user_template_folders_only_returns_folders_visible_to_user(
     result = service.get_user_template_folders(active_user_with_permissions.id)
     assert result == [
         {
-            'name': "Parent 1 - invisible/1's Visible child",
+            'name': "Parent 1 - invisible / 1's Visible child",
             'id': mocker.ANY,
             'parent_id': None,
             'users_with_permission': [active_user_with_permissions.id]
         },
         {
-            'name': "Parent 1 - invisible/1's Invisible child/1's Visible grandchild",
+            'name': "Parent 1 - invisible / 1's Invisible child / 1's Visible grandchild",
             'id': mocker.ANY,
             'parent_id': None,
             'users_with_permission': [active_user_with_permissions.id]
@@ -97,7 +97,7 @@ def test_get_user_template_folders_only_returns_folders_visible_to_user(
             'users_with_permission': [active_user_with_permissions.id]
         },
         {
-            'name': "2's Invisible child/2's Visible grandchild",
+            'name': "2's Invisible child / 2's Visible grandchild",
             'id': mocker.ANY,
             'parent_id': VIS_PARENT_FOLDER_ID,
             'users_with_permission': [active_user_with_permissions.id]
@@ -123,13 +123,13 @@ def test_get_template_folders_shows_user_folders_when_user_id_passed_in(
     result = service.get_template_folders(user_id=active_user_with_permissions.id)
     assert result == [
         {
-            'name': "Parent 1 - invisible/1's Visible child",
+            'name': "Parent 1 - invisible / 1's Visible child",
             'id': mocker.ANY,
             'parent_id': None,
             'users_with_permission': [active_user_with_permissions.id]
         },
         {
-            'name': "Parent 1 - invisible/1's Invisible child/1's Visible grandchild",
+            'name': "Parent 1 - invisible / 1's Invisible child / 1's Visible grandchild",
             'id': mocker.ANY,
             'parent_id': None,
             'users_with_permission': [active_user_with_permissions.id]

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -1,0 +1,172 @@
+import uuid
+
+from app.models.service import Service
+
+INV_PARENT_FOLDER_ID = '7e979e79-d970-43a5-ac69-b625a8d147b0'
+INV_CHILD_1_FOLDER_ID = '92ee1ee0-e4ee-4dcc-b1a7-a5da9ebcfa2b'
+VIS_PARENT_FOLDER_ID = 'bbbb222b-2b22-2b22-222b-b222b22b2222'
+INV_CHILD_2_FOLDER_ID = 'fafe723f-1d39-4a10-865f-e551e03d8886'
+
+
+def _get_all_folders(active_user_with_permissions):
+    return [
+        {
+            'name': "Invisible folder",
+            'id': str(uuid.uuid4()),
+            'parent_id': None,
+            'users_with_permission': []
+        },
+        {
+            'name': "Parent 1 - invisible",
+            'id': INV_PARENT_FOLDER_ID,
+            'parent_id': None,
+            'users_with_permission': []
+        },
+        {
+            'name': "1's Visible child",
+            'id': str(uuid.uuid4()),
+            'parent_id': INV_PARENT_FOLDER_ID,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "1's Invisible child",
+            'id': INV_CHILD_1_FOLDER_ID,
+            'parent_id': INV_PARENT_FOLDER_ID,
+            'users_with_permission': []
+        },
+        {
+            'name': "1's Visible grandchild",
+            'id': str(uuid.uuid4()),
+            'parent_id': INV_CHILD_1_FOLDER_ID,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "Parent 2 - visible",
+            'id': VIS_PARENT_FOLDER_ID,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "2's Visible child",
+            'id': str(uuid.uuid4()),
+            'parent_id': VIS_PARENT_FOLDER_ID,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "2's Invisible child",
+            'id': INV_CHILD_2_FOLDER_ID,
+            'parent_id': VIS_PARENT_FOLDER_ID,
+            'users_with_permission': []
+        },
+        {
+            'name': "2's Visible grandchild",
+            'id': str(uuid.uuid4()),
+            'parent_id': INV_CHILD_2_FOLDER_ID,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+    ]
+
+
+def test_get_user_template_folders_only_returns_folders_visible_to_user(
+    mock_get_template_folders,
+    service_one,
+    active_user_with_permissions,
+    mocker
+):
+    mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
+    service = Service(service_one)
+    result = service.get_user_template_folders(active_user_with_permissions.id)
+    assert result == [
+        {
+            'name': "Parent 1 - invisible/1's Visible child",
+            'id': mocker.ANY,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "Parent 1 - invisible/1's Invisible child/1's Visible grandchild",
+            'id': mocker.ANY,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "2's Visible child",
+            'id': mocker.ANY,
+            'parent_id': VIS_PARENT_FOLDER_ID,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "2's Invisible child/2's Visible grandchild",
+            'id': mocker.ANY,
+            'parent_id': VIS_PARENT_FOLDER_ID,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "Parent 2 - visible",
+            'id': VIS_PARENT_FOLDER_ID,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+    ]
+
+
+def test_get_template_folders_shows_user_folders_when_user_id_passed_in(
+    mock_get_template_folders,
+    service_one,
+    active_user_with_permissions,
+    mocker
+):
+    mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
+    service = Service(service_one)
+    result = service.get_template_folders(user_id=active_user_with_permissions.id)
+    assert result == [
+        {
+            'name': "Parent 1 - invisible/1's Visible child",
+            'id': mocker.ANY,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "Parent 1 - invisible/1's Invisible child/1's Visible grandchild",
+            'id': mocker.ANY,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+        {
+            'name': "Parent 2 - visible",
+            'id': VIS_PARENT_FOLDER_ID,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        },
+    ]
+
+
+def test_get_template_folders_shows_all_folders_when_user_id_not_passed_in(
+    mock_get_template_folders,
+    service_one,
+    active_user_with_permissions,
+    mocker
+):
+    mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
+    service = Service(service_one)
+    result = service.get_template_folders()
+    assert result == [
+        {
+            'name': "Invisible folder",
+            'id': mocker.ANY,
+            'parent_id': None,
+            'users_with_permission': []
+        },
+        {
+            'name': "Parent 1 - invisible",
+            'id': INV_PARENT_FOLDER_ID,
+            'parent_id': None,
+            'users_with_permission': []
+        },
+        {
+            'name': "Parent 2 - visible",
+            'id': VIS_PARENT_FOLDER_ID,
+            'parent_id': None,
+            'users_with_permission': [active_user_with_permissions.id]
+        }
+    ]


### PR DESCRIPTION
When a user accesses their templates, only show the folders (and templates within those folders) where the user has permission to see those folders.

If the child folder is visible, but the parent is not, move child folder up in the tree and add parent name to the child name, like this:
![screen shot 2019-03-07 at 16 45 33](https://user-images.githubusercontent.com/20957548/53973283-6447b980-40f8-11e9-9348-c07c7e83df86.png)


Pivotal ticket: https://www.pivotaltracker.com/story/show/163755337