### PR TITLE
When going live, make reply-to address and text message sender dependent on estimated sending volumes

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -269,7 +269,7 @@ class Service():
     @property
     def needs_to_change_sms_sender(self):
         return all((
-            self.has_sms_templates,
+            self.volume_sms,
             self.shouldnt_use_govuk_as_sms_sender,
             self.sms_sender_is_govuk,
         ))

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -226,7 +226,7 @@ class Service():
 
     @property
     def needs_to_add_email_reply_to_address(self):
-        return self.has_email_templates and not self.has_email_reply_to_address
+        return self.volume_email and not self.has_email_reply_to_address
 
     @property
     def shouldnt_use_govuk_as_sms_sender(self):

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -27,14 +27,21 @@
           'Add templates with examples of the content you plan to send',
           url_for('main.choose_template', service_id=current_service.id),
         ) }}
-        {% if current_service.has_email_templates %}
+        {% if (
+          current_service.has_email_templates
+          and (current_service.volume_email != 0)
+        ) %}
           {{ task_list_item(
             current_service.has_email_reply_to_address,
             'Add an email reply-to address',
             url_for('main.service_email_reply_to', service_id=current_service.id),
           ) }}
         {% endif %}
-        {% if current_service.has_sms_templates and current_service.shouldnt_use_govuk_as_sms_sender %}
+        {% if (
+          current_service.has_sms_templates
+          and current_service.shouldnt_use_govuk_as_sms_sender
+          and (current_service.volume_sms != 0)
+        ) %}
           {{ task_list_item(
             not current_service.sms_sender_is_govuk,
             'Change your text message sender name',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1160,7 +1160,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             True,
             True,
-            1, 1, 1,
+            1, 0, 0,
             'Yes',
             True,
             [
@@ -1194,7 +1194,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             True,
             False,
-            1, 1, 1,
+            0, 1, 0,
             'Yes',
             True,
             [
@@ -1210,7 +1210,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             True,
             True,
-            1, 1, 1,
+            0, 1, 0,
             'No',
             True,
             [
@@ -1246,7 +1246,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             True,
             False,
-            1, 1, 1,
+            0, 1, 0,
             'No',
             True,
             [
@@ -1256,7 +1256,7 @@ def test_should_redirect_after_request_to_go_live(
                 'notify_request_to_go_live_incomplete_template_content',
             ],
         ),
-        (  # Everything is wrong
+        (  # Not done anything yet
             False,
             False,
             True,
@@ -1273,7 +1273,6 @@ def test_should_redirect_after_request_to_go_live(
                 'notify_request_to_go_live_incomplete_volumes',
                 'notify_request_to_go_live_incomplete_checklist',
                 'notify_request_to_go_live_incomplete_mou',
-                'notify_request_to_go_live_incomplete_email_reply_to',
                 'notify_request_to_go_live_incomplete_team_member',
                 'notify_request_to_go_live_incomplete_template_content',
                 'notify_request_to_go_live_incomplete_sms_sender',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1176,7 +1176,7 @@ def test_should_redirect_after_request_to_go_live(
             False,
             True,
             True,
-            1, 1, 1,
+            1, 0, 1,
             'No',
             True,
             [
@@ -1228,7 +1228,7 @@ def test_should_redirect_after_request_to_go_live(
             True,
             True,
             False,
-            1, 1, 1,
+            1, 0, 0,
             'No',
             True,
             [
@@ -1275,7 +1275,6 @@ def test_should_redirect_after_request_to_go_live(
                 'notify_request_to_go_live_incomplete_mou',
                 'notify_request_to_go_live_incomplete_team_member',
                 'notify_request_to_go_live_incomplete_template_content',
-                'notify_request_to_go_live_incomplete_sms_sender',
             ],
         ),
     ),


### PR DESCRIPTION
We have a number of go live requests where people have said they’re sending text messages, but haven’t changed the text message sender from the default of `GOVUK` (we ask teams who aren’t central government to do this). Or they say they’re sending emails but have no email templates, or any email reply-to addresses.

At the moment we don’t prompt them to, because we look at what kinds of templates they have to indicate what kinds of messages they’re going to send.

Now that we explicitly ask for their estimated sending volumes we should use this to determine what we prompt them about because it’s a stronger signal of intent than what templates they’ve set up.

For templates we’re going to ask that they at least have one kind of template of the sort they intend to send. We could be even stricter and say they have to have at least one of each type they
expect to send, but we think that we can get a pretty good idea from just looking at one template whether they’re doing something sensible.