### PR TITLE
Put current email branding in new branding request

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -955,16 +955,18 @@ def branding_request(service_id):
         zendesk_client.create_ticket(
             subject='Email branding request - {}'.format(current_service.name),
             message=(
-                'Organisation: {}\n'
-                'Service: {}\n'
-                '{}\n'
+                'Organisation: {organisation}\n'
+                'Service: {service_name}\n'
+                '{dashboard_url}\n'
                 '\n---'
-                '\nBranding requested: {}'
+                '\nCurrent branding: {current_branding}'
+                '\nBranding requested: {branding_requested}'
             ).format(
-                AgreementInfo.from_current_user().as_info_for_branding_request,
-                current_service.name,
-                url_for('main.service_dashboard', service_id=current_service.id, _external=True),
-                branding_options_dict[form.options.data],
+                organisation=AgreementInfo.from_current_user().as_info_for_branding_request,
+                service_name=current_service.name,
+                dashboard_url=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
+                current_branding=current_service.email_branding_name,
+                branding_requested=branding_options_dict[form.options.data],
             ),
             ticket_type=zendesk_client.TYPE_QUESTION,
             user_email=current_user.email_address,

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -363,6 +363,12 @@ class Service():
             return email_branding_client.get_email_branding(self.email_branding_id)['email_branding']
         return None
 
+    @cached_property
+    def email_branding_name(self):
+        if self.email_branding is None:
+            return 'GOV.UK'
+        return self.email_branding['name']
+
     @property
     def letter_branding_id(self):
         return self._dict['letter_branding']

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -311,7 +311,7 @@
         {% endcall %}
         {% call row() %}
           {{ text_field('Email branding' )}}
-          {{ text_field(current_service.email_branding.name or 'GOV.UK') }}
+          {{ text_field(current_service.email_branding_name) }}
           {{ edit_field('Change', url_for('.service_set_email_branding', service_id=current_service.id)) }}
         {% endcall %}
         {% call row() %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3662,7 +3662,8 @@ def test_submit_email_branding_request(
             'http://localhost/services/596364a0-858e-42c8-9062-a8fe822260eb',
             '',
             '---',
-            'Branding requested: {}'
+            'Current branding: GOV.UK',
+            'Branding requested: {}',
         ]).format(requested_branding),
         subject='Email branding request - service one',
         ticket_type='question',


### PR DESCRIPTION
When we get a request for new branding it’s helpful to quickly see what the service’s current branding is, so we can get a better sense of why they want to change it.