### PR TITLE
Fix hint text for list entry being rendered twice

### DIFF
--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -24,11 +24,6 @@
           {% endif %}
         </label>
       </legend>
-      {% if hint %}
-        <span class="hint">
-          {{ hint }}
-        </span>
-      {% endif %}
       <div class="input-list" data-module="list-entry" data-list-item-name="{{ item_name }}" id="list-entry-{{ field.name }}">
         {% for index in range(0, field.entries|length) %}
           <div class="list-entry">


### PR DESCRIPTION
The better place for it, semantically, is inside the legend.