### PR TITLE
Fix the logic about showing extra task list items

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -200,6 +200,18 @@ class Service():
     def has_sms_templates(self):
         return len(self.get_templates('sms')) > 0
 
+    @property
+    def intending_to_send_email(self):
+        if self.volume_email is None:
+            return self.has_email_templates
+        return self.volume_email > 0
+
+    @property
+    def intending_to_send_sms(self):
+        if self.volume_sms is None:
+            return self.has_sms_templates
+        return self.volume_sms > 0
+
     @cached_property
     def email_reply_to_addresses(self):
         return service_api_client.get_reply_to_email_addresses(self.id)
@@ -226,7 +238,7 @@ class Service():
 
     @property
     def needs_to_add_email_reply_to_address(self):
-        return self.volume_email and not self.has_email_reply_to_address
+        return self.intending_to_send_email and not self.has_email_reply_to_address
 
     @property
     def shouldnt_use_govuk_as_sms_sender(self):
@@ -269,7 +281,7 @@ class Service():
     @property
     def needs_to_change_sms_sender(self):
         return all((
-            self.volume_sms,
+            self.intending_to_send_sms,
             self.shouldnt_use_govuk_as_sms_sender,
             self.sms_sender_is_govuk,
         ))

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -27,10 +27,7 @@
           'Add templates with examples of the content you plan to send',
           url_for('main.choose_template', service_id=current_service.id),
         ) }}
-        {% if (
-          current_service.has_email_templates
-          and (current_service.volume_email != 0)
-        ) %}
+        {% if current_service.intending_to_send_email %}
           {{ task_list_item(
             current_service.has_email_reply_to_address,
             'Add an email reply-to address',
@@ -38,9 +35,8 @@
           ) }}
         {% endif %}
         {% if (
-          current_service.has_sms_templates
+          current_service.intending_to_send_sms
           and current_service.shouldnt_use_govuk_as_sms_sender
-          and (current_service.volume_sms != 0)
         ) %}
           {{ task_list_item(
             not current_service.sms_sender_is_govuk,


### PR DESCRIPTION
It should be:
- if they have said they are going to send by a certain channel, show the extra required task(s) for that channel
- if they haven’t said, infer from which templates they have