### PR TITLE
Prevent sticky controls overlapping focus

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -42,8 +42,11 @@
 
   // Constructor for objects holding data for each element to have sticky behaviour
   var StickyElement = function ($el, sticky) {
+    var $scrollArea = $el.closest('.sticky-scroll-area');
+
     this._sticky = sticky;
     this.$fixedEl = $el;
+    this.$scrollArea = $scrollArea.length ? $scrollArea : $el.parent();
     this._initialFixedClass = 'content-fixed-onload';
     this._fixedClass = 'content-fixed';
     this._appliedClass = null;
@@ -390,7 +393,7 @@
   };
   Sticky.prototype.setElWidth = function (el) {
     var $el = el.$fixedEl;
-    var width = $el.parent().width();
+    var width = el.$scrollArea.width();
 
     el.horizontalSpace = width;
     // if stuck, element won't inherit width from parent so set explicitly

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -33,10 +33,11 @@
       this.activateStickyElements();
 
       // first off show the new template / new folder buttons
-      this.currentState = this.$form.data('prev-state') || 'unknown';
-      if (this.currentState === 'unknown') {
+      this._lastState = this.$form.data('prev-state');
+      if (this._lastState === undefined) {
         this.selectActionButtons();
       } else {
+        this.currentState = this._lastState;
         this.render();
       }
 
@@ -144,11 +145,21 @@
       }
     };
 
+    // method that checks the state against the last one, used prior to render() to see if needed
+    this.stateChanged = function() {
+      let changed = this.currentState !== this._lastState;
+
+      this._lastState = this.currentState;
+      return changed;
+    };
+
     this.actionButtonClicked = function(event) {
       event.preventDefault();
       this.currentState = $(event.currentTarget).val();
 
-      this.render();
+      if (this.stateChanged()) {
+        this.render();
+      }
     };
 
     this.selectionStatus = {
@@ -173,7 +184,9 @@
         this.currentState = 'nothing-selected-buttons';
       }
 
-      this.render();
+      if (this.stateChanged()) {
+        this.render();
+      }
 
       this.selectionStatus.update(numSelected);
 

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -74,6 +74,7 @@
 
     {% if current_user.has_permissions('manage_templates') %}
       {% call form_wrapper(
+          class='sticky-scroll-area',
           module='template-folder-form',
           data_kwargs={'prev-state': templates_and_folders_form.op or None}
       ) %}


### PR DESCRIPTION
When tabbing through the `/templates` page, the focus can shift to an element underneath the sticky controls.

https://www.pivotaltracker.com/story/show/162986313

This scrolls the page to reveal the focused element when that happens.

## Before

![sticky_focus_overlap_before](https://user-images.githubusercontent.com/87140/54201267-18648e00-44c5-11e9-9a0a-e816128a1f28.gif)

## After

![sticky_focus_overlap_after](https://user-images.githubusercontent.com/87140/54201272-20243280-44c5-11e9-95aa-70212ed48449.gif)

## Extras

This pull request also includes a fix for this problem:

If you selected/deselected items in the template/folder list when the controls were in a state which wasn't effected by this (ie, 'add to a new folder'), focus would sometimes move to the controls.

Full details in the [commit message for the fix](https://github.com/alphagov/notifications-admin/commit/987fa01fb8cc10ebc2b5d43ddb793a23619931a6).

## Browser testing

This is tested in the following browser/OS combinations:
- IE8 on Windows 7 - done
- IE9 on Windows 7 - done
- IE11 on Windows 7 - done
- Chrome 72 on Windows 7 - done
- Firefox 63 on Windows 10
- IE11 on Windows 10 - done
- Edge on Windows 10
- Chrome 72 on Windows 10
- Firefox 63 on Windows 10
- Firefox 65 on Mac OSX High Sierra
- Chrome 72 on Mac OSX High Sierra
- Safari 12 on IOS (iPhone)

## How to test it yourself

Try tabbing through the `/templates` page on the master branch. You should see the element focused disappear below the sticky controls. Try it again with this branch.