### PR TITLE
Fix choosing auth type when inviting new user

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -69,7 +69,8 @@ def invite_user(service_id):
     return render_template(
         'views/invite-user.html',
         form=form,
-        service_has_email_auth=service_has_email_auth
+        service_has_email_auth=service_has_email_auth,
+        mobile_number=True,
     )
 
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -372,6 +372,19 @@ def test_should_show_page_for_one_user(
         assert checkboxes[index].has_attr('checked') == expected_checked
 
 
+def test_invite_user_allows_to_choose_auth(
+    client_request,
+    mock_get_users_by_service,
+    mock_get_template_folders,
+    service_one,
+):
+    service_one['permissions'].append('email_auth')
+    page = client_request.get('main.invite_user', service_id=SERVICE_ONE_ID)
+
+    sms_auth_radio_button = page.select_one('input[value="sms_auth"]')
+    assert sms_auth_radio_button.has_attr("disabled") is False
+
+
 def test_should_not_show_page_for_non_team_member(
     client_request,
     mock_get_users_by_service,


### PR DESCRIPTION
### Description:

`.invite_user` and `.edit_user_permissions` share templates between themselves. Recently, when we introduced changes to `.edit_user_permissions`, by accident we introduced a bug to `.invite_user`: 
if someone had email-auth permissions on their service and tried to invite a new user, they could only choose email auth, and not sms auth. 

This was because we changed a boolean variable `user_has_no_mobile_number` set in `.edit_user_permissions` view to be an actual user's (redacted) mobile number or None. This variable was not explicitly set in `.invite_user` , but it influenced the flow, and changing it had unintended consequences.

### Lesons learned:
- when changing a template, check if it is only used by the view you are working on, or maybe it is shared with a different view
- if it it shared with a different view, go through that other flow to check if everything works correctly after the changes

Pivotal ticket: https://www.pivotaltracker.com/story/show/164498747