### PR TITLE
Change permissions data format

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -184,7 +184,16 @@ class User(UserMixin):
 
 class InvitedUser(object):
 
-    def __init__(self, id, service, from_user, email_address, permissions, status, created_at, auth_type):
+    def __init__(self,
+                 id,
+                 service,
+                 from_user,
+                 email_address,
+                 permissions,
+                 status,
+                 created_at,
+                 auth_type,
+                 folder_permissions=None):
         self.id = id
         self.service = str(service)
         self.from_user = from_user

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -153,7 +153,10 @@ class UserApiClient(NotifyAdminAPIClient):
     def add_user_to_service(self, service_id, user_id, permissions):
         # permissions passed in are the combined admin roles, not db permissions
         endpoint = '/service/{}/users/{}'.format(service_id, user_id)
-        data = [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
+        data = {
+            'permissions': [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
+        }
+
         self.post(endpoint, data=data)
 
     @cache.delete('user-{user_id}')

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -154,7 +154,7 @@ def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(a
 
     user_api_client.add_user_to_service('service_id', 'user_id', permissions={'send_messages', 'view_activity'})
 
-    assert sorted(mock_post.call_args[1]['data'], key=lambda x: x['permission']) == sorted([
+    assert sorted(mock_post.call_args[1]['data']['permissions'], key=lambda x: x['permission']) == sorted([
         {'permission': 'send_texts'},
         {'permission': 'send_emails'},
         {'permission': 'send_letters'},


### PR DESCRIPTION
A couple of small changes which need to be deployed first for the story to specify folder permissions when inviting team members:

#### Allow InvitedUser to be initialised with folder_permissions
The `folder_permissions` property has no effect and is not used yet, but
it needs to be added before we add a `folder_permissions` column to the
`InvitedUser` model in notifications-api. This is because we initialize
the InvitedUser class with the response from notifications-api.

#### Change format of data sent to api when adding user to service
The endpoint for adding a user to a service in api will now deal with
both user permissions and a user's folder permissions, so this changes
the format of the data we pass through.

This needs to be deployed after https://github.com/alphagov/notifications-api/pull/2395

Part 2 of this [Pivotal story](https://www.pivotaltracker.com/story/show/163756170)