### PR TITLE
Set folder permissions when creating and accepting invites

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -70,7 +70,8 @@ def accept_invite(token):
                 user_api_client.update_user_attribute(existing_user.id, auth_type=invited_user.auth_type)
             user_api_client.add_user_to_service(invited_user.service,
                                                 existing_user.id,
-                                                invited_user.permissions)
+                                                invited_user.permissions,
+                                                invited_user.folder_permissions)
             return redirect(url_for('main.service_dashboard', service_id=invited_user.service))
     else:
         return redirect(url_for('main.register_from_invite'))

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -58,6 +58,11 @@ def invite_user(service_id):
         form.login_authentication.data = 'sms_auth'
 
     if form.validate_on_submit():
+        if current_service.has_permission('edit_folder_permissions'):
+            folder_permissions = form.folder_permissions.data
+        else:
+            folder_permissions = list(current_service.all_template_folder_ids)
+
         email_address = form.email_address.data
         invited_user = invite_api_client.create_invite(
             current_user.id,
@@ -65,10 +70,7 @@ def invite_user(service_id):
             email_address,
             form.permissions,
             form.login_authentication.data,
-            folder_permissions=(
-                form.folder_permissions.data
-                if current_service.has_permission('edit_folder_permissions') else []
-            ),
+            folder_permissions,
         )
 
         flash('Invite sent to {}'.format(invited_user.email_address), 'default_with_tick')

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -47,7 +47,11 @@ def manage_users(service_id):
 @user_has_permissions('manage_service')
 def invite_user(service_id):
 
-    form = InviteUserForm(invalid_email_address=current_user.email_address)
+    form = InviteUserForm(
+        invalid_email_address=current_user.email_address,
+        all_template_folders=current_service.all_template_folders,
+        folder_permissions=[f['id'] for f in current_service.all_template_folders]
+    )
 
     service_has_email_auth = current_service.has_permission('email_auth')
     if not service_has_email_auth:
@@ -60,7 +64,11 @@ def invite_user(service_id):
             service_id,
             email_address,
             form.permissions,
-            form.login_authentication.data
+            form.login_authentication.data,
+            folder_permissions=(
+                form.folder_permissions.data
+                if current_service.has_permission('edit_folder_permissions') else []
+            ),
         )
 
         flash('Invite sent to {}'.format(invited_user.email_address), 'default_with_tick')

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -94,5 +94,5 @@ def _add_invited_user_to_service(invited_user):
     invitation = InvitedUser(**invited_user)
     user = user_api_client.get_user(session['user_id'])
     service_id = invited_user['service']
-    user_api_client.add_user_to_service(service_id, user.id, invitation.permissions)
+    user_api_client.add_user_to_service(service_id, user.id, invitation.permissions, invitation.folder_permissions)
     return service_id

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -193,7 +193,7 @@ class InvitedUser(object):
                  status,
                  created_at,
                  auth_type,
-                 folder_permissions=None):
+                 folder_permissions):
         self.id = id
         self.service = str(service)
         self.from_user = from_user
@@ -209,6 +209,7 @@ class InvitedUser(object):
         self.created_at = created_at
         self.auth_type = auth_type
         self.permissions = translate_permissions_from_db_to_admin_roles(self.permissions)
+        self.folder_permissions = folder_permissions or []
 
     def has_permissions(self, *permissions):
         if self.status == 'cancelled':
@@ -240,7 +241,8 @@ class InvitedUser(object):
                 'email_address': self.email_address,
                 'status': self.status,
                 'created_at': str(self.created_at),
-                'auth_type': self.auth_type
+                'auth_type': self.auth_type,
+                'folder_permissions': self.folder_permissions
                 }
         if permissions_as_string:
             data['permissions'] = ','.join(self.permissions)

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -12,7 +12,13 @@ class InviteApiClient(NotifyAdminAPIClient):
 
         self.admin_url = app.config['ADMIN_BASE_URL']
 
-    def create_invite(self, invite_from_id, service_id, email_address, permissions, auth_type):
+    def create_invite(self,
+                      invite_from_id,
+                      service_id,
+                      email_address,
+                      permissions,
+                      auth_type,
+                      folder_permissions):
         data = {
             'service': str(service_id),
             'email_address': email_address,
@@ -20,6 +26,7 @@ class InviteApiClient(NotifyAdminAPIClient):
             'permissions': ','.join(sorted(translate_permissions_from_admin_roles_to_db(permissions))),
             'auth_type': auth_type,
             'invite_link_host': self.admin_url,
+            'folder_permissions': folder_permissions,
         }
         data = _attach_current_user(data)
         resp = self.post(url='/service/{}/invite'.format(service_id), data=data)

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -150,11 +150,12 @@ class UserApiClient(NotifyAdminAPIClient):
 
     @cache.delete('service-{service_id}')
     @cache.delete('user-{user_id}')
-    def add_user_to_service(self, service_id, user_id, permissions):
+    def add_user_to_service(self, service_id, user_id, permissions, folder_permissions):
         # permissions passed in are the combined admin roles, not db permissions
         endpoint = '/service/{}/users/{}'.format(service_id, user_id)
         data = {
-            'permissions': [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)]
+            'permissions': [{'permission': x} for x in translate_permissions_from_admin_roles_to_db(permissions)],
+            'folder_permissions': folder_permissions,
         }
 
         self.post(endpoint, data=data)

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -149,6 +149,7 @@ class UserApiClient(NotifyAdminAPIClient):
         return [User(data) for data in resp['data']]
 
     @cache.delete('service-{service_id}')
+    @cache.delete('service-{service_id}-template-folders')
     @cache.delete('user-{user_id}')
     def add_user_to_service(self, service_id, user_id, permissions, folder_permissions):
         # permissions passed in are the combined admin roles, not db permissions

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -272,7 +272,15 @@ def api_key_json(id_, name, expiry_date=None):
             }
 
 
-def invite_json(id_, from_user, service_id, email_address, permissions, created_at, status, auth_type):
+def invite_json(id_,
+                from_user,
+                service_id,
+                email_address,
+                permissions,
+                created_at,
+                status,
+                auth_type,
+                folder_permissions):
     return {
         'id': id_,
         'from_user': from_user,
@@ -281,7 +289,8 @@ def invite_json(id_, from_user, service_id, email_address, permissions, created_
         'status': status,
         'permissions': permissions,
         'created_at': created_at,
-        'auth_type': auth_type
+        'auth_type': auth_type,
+        'folder_permissions': folder_permissions,
     }
 
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -578,12 +578,37 @@ def test_should_show_page_for_inviting_user(
     logged_in_client,
     active_user_with_permissions,
     mocker,
+    mock_get_template_folders,
 ):
     service = create_sample_service(active_user_with_permissions)
     response = logged_in_client.get(url_for('main.invite_user', service_id=service['id']))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-    assert 'Invite a team member' in response.get_data(as_text=True)
+    assert 'Invite a team member' in page.find('h1').text.strip()
     assert response.status_code == 200
+    assert not page.find('div', class_='checkboxes-nested')
+
+
+def test_should_show_folder_permission_form_if_service_has_folder_permissions_enabled(
+    logged_in_client,
+    mocker,
+    mock_get_template_folders,
+    service_one
+):
+    service_one['permissions'].append('edit_folder_permissions')
+    mock_get_template_folders.return_value = [
+        {'id': 'folder-id-1', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
+        {'id': 'folder-id-2', 'name': 'folder_two', 'parent_id': None, 'users_with_permission': []},
+        {'id': 'folder-id-3', 'name': 'folder_three', 'parent_id': 'folder-id-1', 'users_with_permission': []},
+    ]
+    response = logged_in_client.get(url_for('main.invite_user', service_id=service_one['id']))
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert 'Invite a team member' in page.find('h1').text.strip()
+    assert response.status_code == 200
+
+    folder_checkboxes = page.find('div', class_='checkboxes-nested').find_all('li')
+    assert len(folder_checkboxes) == 3
 
 
 @pytest.mark.parametrize('email_address, gov_user', [
@@ -597,6 +622,7 @@ def test_invite_user(
     sample_invite,
     email_address,
     gov_user,
+    mock_get_template_folders,
 ):
     service = create_sample_service(active_user_with_permissions)
     sample_invite['email_address'] = 'test@example.gov.uk'
@@ -629,7 +655,8 @@ def test_invite_user(
                                                                 sample_invite['service'],
                                                                 email_address,
                                                                 expected_permissions,
-                                                                'sms_auth')
+                                                                'sms_auth',
+                                                                folder_permissions=sample_invite['folder_permissions'])
 
 
 @pytest.mark.parametrize('auth_type', [
@@ -648,7 +675,8 @@ def test_invite_user_with_email_auth_service(
     gov_user,
     mocker,
     service_one,
-    auth_type
+    auth_type,
+    mock_get_template_folders,
 ):
     service_one['permissions'].append('email_auth')
     sample_invite['email_address'] = 'test@example.gov.uk'
@@ -682,7 +710,8 @@ def test_invite_user_with_email_auth_service(
                                                                 sample_invite['service'],
                                                                 email_address,
                                                                 expected_permissions,
-                                                                auth_type)
+                                                                auth_type,
+                                                                folder_permissions=sample_invite['folder_permissions'])
 
 
 def test_cancel_invited_user_cancels_user_invitations(
@@ -785,6 +814,7 @@ def test_user_cant_invite_themselves(
     mocker,
     active_user_with_permissions,
     mock_create_invite,
+    mock_get_template_folders,
 ):
     service = create_sample_service(active_user_with_permissions)
     response = logged_in_client.post(

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -198,7 +198,7 @@ def test_shows_registration_page_from_invite(
             ["manage_users"],
             "pending",
             datetime.utcnow(),
-            'sms_auth',
+            'sms_auth', []
         ).serialize()
     page = client_request.get('main.register_from_invite')
     assert page.select_one('input[name=name]')['value'] == expected_value
@@ -217,7 +217,8 @@ def test_register_from_invite(
                                ["manage_users"],
                                "pending",
                                datetime.utcnow(),
-                               'sms_auth')
+                               'sms_auth',
+                               [])
     with client.session_transaction() as session:
         session['invited_user'] = invited_user.serialize()
     response = client.post(
@@ -253,7 +254,8 @@ def test_register_from_invite_when_user_registers_in_another_browser(
                                ["manage_users"],
                                "pending",
                                datetime.utcnow(),
-                               'sms_auth')
+                               'sms_auth',
+                               [])
     with client.session_transaction() as session:
         session['invited_user'] = invited_user.serialize()
     response = client.post(

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -16,12 +16,12 @@ def test_client_creates_invite(
         'app.invite_api_client.post',
         return_value={'data': dict.fromkeys({
             'id', 'service', 'from_user', 'email_address',
-            'permissions', 'status', 'created_at', 'auth_type'
+            'permissions', 'status', 'created_at', 'auth_type', 'folder_permissions'
         })}
     )
 
     invite_api_client.create_invite(
-        '12345', '67890', 'test@example.com', {'send_messages'}, 'sms_auth'
+        '12345', '67890', 'test@example.com', {'send_messages'}, 'sms_auth', [fake_uuid]
     )
 
     mock_post.assert_called_once_with(
@@ -34,6 +34,7 @@ def test_client_creates_invite(
             'created_by': ANY,
             'permissions': 'send_emails,send_letters,send_texts',
             'invite_link_host': 'http://localhost:6012',
+            'folder_permissions': [fake_uuid]
         }
     )
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -362,7 +362,7 @@ def test_returns_value_from_cache(
     (service_api_client, 'delete_sms_sender', [SERVICE_ONE_ID, ''], {}),
     (service_api_client, 'update_service_callback_api', [SERVICE_ONE_ID] + [''] * 4, {}),
     (service_api_client, 'create_service_callback_api', [SERVICE_ONE_ID] + [''] * 3, {}),
-    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, uuid4(), []], {}),
+    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, uuid4(), [], []], {}),
     (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, uuid4()], {}),
 ])
 def test_deletes_service_cache(

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -152,7 +152,10 @@ def test_client_converts_admin_permissions_to_db_permissions_on_edit(app_, mocke
 def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(app_, mocker):
     mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post', return_value={'data': {}})
 
-    user_api_client.add_user_to_service('service_id', 'user_id', permissions={'send_messages', 'view_activity'})
+    user_api_client.add_user_to_service('service_id',
+                                        'user_id',
+                                        permissions={'send_messages', 'view_activity'},
+                                        folder_permissions=[])
 
     assert sorted(mock_post.call_args[1]['data']['permissions'], key=lambda x: x['permission']) == sorted([
         {'permission': 'send_texts'},
@@ -237,14 +240,14 @@ def test_returns_value_from_cache(
 
 
 @pytest.mark.parametrize('client, method, extra_args, extra_kwargs', [
-    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, sample_uuid(), []], {}),
+    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, sample_uuid(), [], []], {}),
     (user_api_client, 'update_user_attribute', [user_id], {}),
     (user_api_client, 'reset_failed_login_count', [user_id], {}),
     (user_api_client, 'update_user_attribute', [user_id], {}),
     (user_api_client, 'update_password', [user_id, 'hunter2'], {}),
     (user_api_client, 'verify_password', [user_id, 'hunter2'], {}),
     (user_api_client, 'check_verify_code', [user_id, '', ''], {}),
-    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, user_id, []], {}),
+    (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, user_id, [], []], {}),
     (user_api_client, 'add_user_to_organisation', [sample_uuid(), user_id], {}),
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),
     (user_api_client, 'activate_user', [api_user_pending(sample_uuid())], {}),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2211,7 +2211,7 @@ def sample_invite(mocker, service_one, status='pending'):
     permissions = 'view_activity,send_messages,manage_service,manage_api_keys'
     created_at = str(datetime.utcnow())
     auth_type = 'sms_auth'
-    folder_permissions = [str(sample_uuid())]
+    folder_permissions = []
 
     return invite_json(
         id_, from_user, service_id, email_address, permissions, created_at, status, auth_type, folder_permissions)
@@ -2224,12 +2224,13 @@ def sample_invited_user(mocker, sample_invite):
 
 @pytest.fixture(scope='function')
 def mock_create_invite(mocker, sample_invite):
-    def _create_invite(from_user, service_id, email_address, permissions):
+    def _create_invite(from_user, service_id, email_address, permissions, folder_permissions):
         sample_invite['from_user'] = from_user
         sample_invite['service'] = service_id
         sample_invite['email_address'] = email_address
         sample_invite['status'] = 'pending'
         sample_invite['permissions'] = permissions
+        sample_invite['folder_permissions'] = folder_permissions
         return InvitedUser(**sample_invite)
 
     return mocker.patch('app.invite_api_client.create_invite', side_effect=_create_invite)
@@ -2268,7 +2269,7 @@ def mock_accept_invite(mocker, sample_invite):
 
 @pytest.fixture(scope='function')
 def mock_add_user_to_service(mocker, service_one, api_user_active):
-    def _add_user(service_id, user_id, permissions):
+    def _add_user(service_id, user_id, permissions, folder_permissions):
         return
 
     return mocker.patch('app.user_api_client.add_user_to_service', side_effect=_add_user)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2211,8 +2211,10 @@ def sample_invite(mocker, service_one, status='pending'):
     permissions = 'view_activity,send_messages,manage_service,manage_api_keys'
     created_at = str(datetime.utcnow())
     auth_type = 'sms_auth'
+    folder_permissions = [str(sample_uuid())]
 
-    return invite_json(id_, from_user, service_id, email_address, permissions, created_at, status, auth_type)
+    return invite_json(
+        id_, from_user, service_id, email_address, permissions, created_at, status, auth_type, folder_permissions)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
#### Set folder permissions when inviting users
Added a folder permissions form to the page to invite users to services.
This only shows if the service has 'edit_folder_permissions' enabled,
and all folder checkboxes are checked by default. This change means that
InviteApiClient.create_invite now sends folder_permissions through to
notifications_api (so invites get created with folder permissions).

#### Set folder permissions when accepting invites
Started passing the folder_permissions through to notifications-api when
accepting an invite. This changes UserApiClient.add_user_to_service to
send folder_permissions to notifications_api so that new users get folder
permissions when they are added to the service.

[Pivotal story](https://www.pivotaltracker.com/story/show/163756170)