### PR TITLE
Edit members who see folder

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1285,15 +1285,15 @@ class ReturnedLettersForm(StripWhitespaceForm):
 
 
 class TemplateFolderForm(StripWhitespaceForm):
-    def __init__(self, users_with_permission=None, *args, **kwargs):
+    def __init__(self, all_service_users=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if users_with_permission is not None:
-            self.viewing_permissions.users_with_permission = users_with_permission
-            self.viewing_permissions.choices = [
-                (item.id, item.name) for item in users_with_permission
+        if all_service_users is not None:
+            self.users_with_permission.all_service_users = all_service_users
+            self.users_with_permission.choices = [
+                (item.id, item.name) for item in all_service_users
             ]
 
-    viewing_permissions = MultiCheckboxField('Users who can see this folder:')
+    users_with_permission = MultiCheckboxField('Users who can see this folder:')
     name = StringField('Folder name', validators=[DataRequired(message='Can’t be empty')])
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1285,6 +1285,15 @@ class ReturnedLettersForm(StripWhitespaceForm):
 
 
 class TemplateFolderForm(StripWhitespaceForm):
+    def __init__(self, users_with_permission=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if users_with_permission is not None:
+            self.viewing_permissions.users_with_permission = users_with_permission
+            self.viewing_permissions.choices = [
+                (item.id, item.name) for item in users_with_permission
+            ]
+
+    viewing_permissions = MultiCheckboxField('Users who can see this folder:')
     name = StringField('Folder name', validators=[DataRequired(message='Can’t be empty')])
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -430,9 +430,13 @@ def action_blocked(service_id, notification_type, return_to, template_id):
 @login_required
 @user_has_permissions('manage_templates')
 def manage_template_folder(service_id, template_folder_id):
-
+    current_folder = current_service.get_template_folder(template_folder_id)
+    users_with_folder_permission = [
+        current_service.get_team_member(user_id) for user_id in current_folder['users_with_permission']
+    ]
     form = TemplateFolderForm(
-        name=current_service.get_template_folder(template_folder_id)['name']
+        name=current_folder['name'],
+        users_with_permission=users_with_folder_permission
     )
 
     if form.validate_on_submit():
@@ -449,7 +453,7 @@ def manage_template_folder(service_id, template_folder_id):
         template_folder_path=current_service.get_template_folder_path(template_folder_id),
         current_service_id=current_service.id,
         template_folder_id=template_folder_id,
-        template_type="all"
+        template_type="all",
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -438,10 +438,12 @@ def manage_template_folder(service_id, template_folder_id):
         name=current_folder['name'],
         users_with_permission=users_with_folder_permission
     )
-
     if form.validate_on_submit():
         template_folder_api_client.update_template_folder(
-            current_service.id, template_folder_id, name=form.name.data
+            current_service.id,
+            template_folder_id,
+            name=form.name.data,
+            users_with_permission=form.viewing_permissions.data
         )
         return redirect(
             url_for('.choose_template', service_id=service_id, template_folder_id=template_folder_id)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -431,19 +431,18 @@ def action_blocked(service_id, notification_type, return_to, template_id):
 @user_has_permissions('manage_templates')
 def manage_template_folder(service_id, template_folder_id):
     current_folder = current_service.get_template_folder(template_folder_id)
-    users_with_folder_permission = [
-        current_service.get_team_member(user_id) for user_id in current_folder['users_with_permission']
-    ]
     form = TemplateFolderForm(
         name=current_folder['name'],
-        users_with_permission=users_with_folder_permission
+        users_with_permission=current_folder.get('users_with_permission', None),
+        all_service_users=[user for user in current_service.active_users if user.id != current_user.id]
     )
     if form.validate_on_submit():
+        users_with_permission = form.users_with_permission.data + [current_user.id]
         template_folder_api_client.update_template_folder(
             current_service.id,
             template_folder_id,
             name=form.name.data,
-            users_with_permission=form.viewing_permissions.data
+            users_with_permission=users_with_permission
         )
         return redirect(
             url_for('.choose_template', service_id=service_id, template_folder_id=template_folder_id)

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -42,10 +42,13 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
             ))
 
     @cache.delete('service-{service_id}-template-folders')
-    def update_template_folder(self, service_id, template_folder_id, name):
+    def update_template_folder(self, service_id, template_folder_id, name, users_with_permission=None):
+        data = {"name": name}
+        if users_with_permission:
+            data["users_with_permission"] = users_with_permission
         self.post(
             '/service/{}/template-folder/{}'.format(service_id, template_folder_id),
-            {"name": name}
+            data
         )
 
     @cache.delete('service-{service_id}-template-folders')

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -3,10 +3,11 @@
 {% macro checkbox(
   field,
   hint=False,
-  width='2-3'
+  width='2-3',
+  value='y'
 ) %}
   <div class="multiple-choice">
-    {{ checkbox_input(field.id, field.name, field.data) }}
+    {{ checkbox_input(field.id, field.name, field.data, value) }}
     <label for="{{ field.id }}">
       {{ field.label.text }}
       {% if hint %}
@@ -42,14 +43,17 @@
 
 {% macro checkbox_group(
   legend,
-  fields
+  fields,
+  set_value=False
 ) %}
   <fieldset class="form-group">
     <legend class="form-label">
       {{ legend }}
     </legend>
-    {% for field in fields %}
-      {{ checkbox(field) }}
-    {% endfor %}
+    {% if set_value %}
+      {% for field in fields %}
+        {{ checkbox(field, value=field.data) }}
+      {% endfor %}
+    {% endif %}
   </fieldset>
 {% endmacro %}

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -1,13 +1,12 @@
-{% from "components/select-input.html" import select_nested %}
+{% from "components/select-input.html" import select_nested, select %}
 
 {% macro checkbox(
   field,
   hint=False,
-  width='2-3',
-  value='y'
+  width='2-3'
 ) %}
   <div class="multiple-choice">
-    {{ checkbox_input(field.id, field.name, field.data, value) }}
+    {{ checkbox_input(field.id, field.name, field.data) }}
     <label for="{{ field.id }}">
       {{ field.label.text }}
       {% if hint %}
@@ -21,7 +20,12 @@
 
 
 {% macro checkboxes_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False) %}
-  {{ select_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, input="checkbox") }}
+  {{ select_nested(field, child_map, hint, disable, option_hints, hide_legend, input="checkbox") }}
+{% endmacro %}
+
+
+{% macro checkboxes(field, hint=None, disable=[], option_hints={}, hide_legend=False) %}
+  {{ select(field, hint, disable, option_hints, hide_legend, input="checkbox") }}
 {% endmacro %}
 
 
@@ -39,21 +43,4 @@
     {{ checkbox_input(id, name, data, value) }}
     <label></label>
   </div>
-{% endmacro %}
-
-{% macro checkbox_group(
-  legend,
-  fields,
-  set_value=False
-) %}
-  <fieldset class="form-group">
-    <legend class="form-label">
-      {{ legend }}
-    </legend>
-    {% if set_value %}
-      {% for field in fields %}
-        {{ checkbox(field, value=field.data) }}
-      {% endfor %}
-    {% endif %}
-  </fieldset>
 {% endmacro %}

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/checkbox.html" import checkbox, checkbox_group %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -24,8 +25,9 @@
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name) }}
     {% if current_service.has_permission("edit_folder_permissions") %}
-      <p id="users-with-permissions">Users who can see this folder:</p>
+      {{ checkbox_group("Users who can see this folder:", form.viewing_permissions) }}
     {% endif %}
+
     {{ page_footer(
       'Save',
       delete_link=url_for(

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -25,7 +25,7 @@
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name) }}
     {% if current_service.has_permission("edit_folder_permissions") %}
-      {{ checkbox_group("Users who can see this folder:", form.viewing_permissions) }}
+      {{ checkbox_group("Users who can see this folder:", form.viewing_permissions, set_value=True) }}
     {% endif %}
 
     {{ page_footer(

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox, checkbox_group %}
+{% from "components/checkbox.html" import checkbox, checkboxes %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -25,7 +25,7 @@
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name) }}
     {% if current_service.has_permission("edit_folder_permissions") %}
-      {{ checkbox_group("Users who can see this folder:", form.viewing_permissions, set_value=True) }}
+      {{ checkboxes(form.users_with_permission) }}
     {% endif %}
 
     {{ page_footer(

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -23,6 +23,9 @@
 
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name) }}
+    {% if current_service.has_permission("edit_folder_permissions") %}
+      <p id="users-with-permissions">Users who can see this folder:</p>
+    {% endif %}
     {{ page_footer(
       'Save',
       delete_link=url_for(

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -111,13 +111,13 @@ def test_update_template_folder_calls_correct_api_endpoint(mocker):
     some_service_id = uuid.uuid4()
     template_folder_id = uuid.uuid4()
     expected_url = '/service/{}/template-folder/{}'.format(some_service_id, template_folder_id)
-    data = {'name': 'foo'}
+    data = {'name': 'foo', 'users_with_permission': ['some_id']}
 
     client = TemplateFolderAPIClient()
 
     mock_post = mocker.patch('app.notify_client.template_folder_api_client.TemplateFolderAPIClient.post')
 
-    client.update_template_folder(some_service_id, template_folder_id, name='foo')
+    client.update_template_folder(some_service_id, template_folder_id, name='foo', users_with_permission=['some_id'])
 
     mock_post.assert_called_once_with(expected_url, data)
     mock_redis_delete.assert_called_once_with('service-{}-template-folders'.format(some_service_id))


### PR DESCRIPTION
In this PR we let people with manage_templates permission to manage viewing permissions from the level of manage_folder page.

Pivotal ticket: https://www.pivotaltracker.com/story/show/163755347

Needs to be merged after: https://github.com/alphagov/notifications-api/pull/2401

![Screen Shot 2019-03-18 at 16 45 39](https://user-images.githubusercontent.com/20957548/54547210-35a1cc80-499d-11e9-9daa-bfd30c24cc24.png)
