### PR TITLE
Check folder permissions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -203,7 +203,7 @@ def init_app(application):
 
     @application.context_processor
     def _attach_current_user():
-        return{'current_user': current_user}
+        return {'current_user': current_user}
 
     @application.context_processor
     def _nav_selected():

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -52,7 +52,7 @@ def conversation_reply(
         templates_and_folders=TemplateList(
             current_service,
             template_folder_id=from_folder,
-            user_id=current_user.id,
+            user=current_user,
             template_type='sms'
         ),
         template_folder_path=current_service.get_template_folder_path(from_folder),

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -100,7 +100,7 @@ def edit_user_permissions(service_id, user_id):
         service_id,
         folder_permissions=[
             f['id'] for f in current_service.all_template_folders
-            if user_id in f.get('users_with_permission', [])
+            if user.has_template_folder_permission(f)
         ],
         all_template_folders=current_service.all_template_folders
     )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -51,6 +51,12 @@ form_objects = {
 @user_has_permissions()
 def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
+    template_folder = current_service.get_template_folder(template['folder'])
+
+    if not current_service.has_permission("edit_folder_permissions"):
+        user_has_template_permission = True
+    else:
+        user_has_template_permission = current_user.has_template_folder_permission(template_folder)
 
     if should_skip_template_page(template['template_type']):
         return redirect(url_for(
@@ -79,6 +85,7 @@ def view_template(service_id, template_id):
             page_count=get_page_count_for_letter(template),
         ),
         template_postage=template["postage"],
+        user_has_template_permission=user_has_template_permission,
         default_letter_contact_block_id=default_letter_contact_block_id,
     )
 
@@ -111,6 +118,12 @@ def start_tour(service_id, template_id):
 @login_required
 @user_has_permissions()
 def choose_template(service_id, template_type='all', template_folder_id=None):
+    template_folder = current_service.get_template_folder(template_folder_id)
+
+    if not current_service.has_permission("edit_folder_permissions"):
+        user_has_template_folder_permission = True
+    else:
+        user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
 
     template_list = TemplateList(current_service, template_type, template_folder_id, current_user)
 
@@ -155,6 +168,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         search_form=SearchByNameForm(),
         templates_and_folders_form=templates_and_folders_form,
         move_to_children=templates_and_folders_form.move_to.children(),
+        user_has_template_folder_permission=user_has_template_folder_permission,
         option_hints=option_hints
     )
 
@@ -702,6 +716,7 @@ def delete_service_template(service_id, template_id):
             ),
             show_recipient=True,
         ),
+        user_has_template_permission=True,
     )
 
 
@@ -725,6 +740,7 @@ def confirm_redact_template(service_id, template_id):
             ),
             show_recipient=True,
         ),
+        user_has_template_permission=True,
         show_redaction_message=True,
     )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -160,6 +160,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
 
 
 def process_folder_management_form(form, current_folder_id):
+    current_service.get_template_folder_with_user_permission_or_403(current_folder_id, current_user)
     new_folder_id = None
 
     if form.is_add_template_op:
@@ -438,10 +439,10 @@ def action_blocked(service_id, notification_type, return_to, template_id):
 @login_required
 @user_has_permissions('manage_templates')
 def manage_template_folder(service_id, template_folder_id):
-    current_folder = current_service.get_template_folder(template_folder_id)
+    template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
     form = TemplateFolderForm(
-        name=current_folder['name'],
-        users_with_permission=current_folder.get('users_with_permission', None),
+        name=template_folder['name'],
+        users_with_permission=template_folder.get('users_with_permission', None),
         all_service_users=[user for user in current_service.active_users if user.id != current_user.id]
     )
     if form.validate_on_submit():
@@ -470,7 +471,7 @@ def manage_template_folder(service_id, template_folder_id):
 @login_required
 @user_has_permissions('manage_templates')
 def delete_template_folder(service_id, template_folder_id):
-    template_folder = current_service.get_template_folder(template_folder_id)
+    template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
 
     if len(current_service.get_template_folders_and_templates(
         template_type="all", template_folder_id=template_folder_id

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -379,6 +379,13 @@ def copy_template(service_id, template_id):
         str(template_id),
     )['data']
 
+    template_folder = template_folder_api_client.get_template_folder(service_id, template['folder'])
+    if (
+        current_service.has_permission('edit_folder_permissions') and
+        not current_user.has_template_folder_permission(template_folder)
+    ):
+        abort(403)
+
     if request.method == 'POST':
         return add_service_template(service_id, template['template_type'])
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -111,10 +111,10 @@ def start_tour(service_id, template_id):
 @user_has_permissions()
 def choose_template(service_id, template_type='all', template_folder_id=None):
 
-    template_list = TemplateList(current_service, template_type, template_folder_id, current_user.id)
+    template_list = TemplateList(current_service, template_type, template_folder_id, current_user)
 
     templates_and_folders_form = TemplateAndFoldersSelectionForm(
-        all_template_folders=current_service.get_user_template_folders(current_user.id),
+        all_template_folders=current_service.get_user_template_folders(current_user),
         template_list=template_list,
         template_type=template_type,
         allow_adding_letter_template=current_service.has_permission('letter'),
@@ -348,7 +348,7 @@ def choose_template_to_copy(
             services_templates_and_folders=TemplateList(
                 service,
                 template_folder_id=from_folder,
-                user_id=current_user.id
+                user=current_user
             ),
             template_folder_path=service.get_template_folder_path(from_folder),
             from_service=service,
@@ -361,7 +361,7 @@ def choose_template_to_copy(
             services_templates_and_folders=TemplateLists([
                 Service(service) for service in
                 user_api_client.get_services_for_user(current_user)
-            ], user_id=current_user.id),
+            ], user=current_user),
             search_form=SearchByNameForm(),
         )
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -174,16 +174,21 @@ class Service():
     def get_template(self, template_id, version=None):
         return service_api_client.get_service_template(self.id, str(template_id), version)['data']
 
-    def get_template_with_user_permission_or_403(self, template_id, user):
-        template = self.get_template(template_id)
+    def get_template_folder_with_user_permission_or_403(self, folder_id, user):
+        template_folder = self.get_template_folder(folder_id)
 
         if not self.has_permission("edit_folder_permissions"):
-            return template
-
-        template_folder = self.get_template_folder(template["folder"])
+            return template_folder
 
         if not user.has_template_folder_permission(template_folder):
             abort(403)
+
+        return template_folder
+
+    def get_template_with_user_permission_or_403(self, template_id, user):
+        template = self.get_template(template_id)
+
+        self.get_template_folder_with_user_permission_or_403(template['folder'], user)
 
         return template
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -443,10 +443,10 @@ class Service():
 
         user_folders = []
         for folder in self.all_template_folders:
-            if not user.has_template_folder_permission(folder):
+            if not user.has_template_folder_permission(folder, service=self):
                 continue
             parent = self.get_template_folder(folder["parent_id"])
-            if user.has_template_folder_permission(parent):
+            if user.has_template_folder_permission(parent, service=self):
                 user_folders.append(folder)
             else:
                 folder_attrs = {
@@ -460,7 +460,7 @@ class Service():
                     else:
                         parent = self.get_template_folder(parent["parent_id"])
                         folder_attrs["parent_id"] = parent.get("id", None)
-                        if user.has_template_folder_permission(parent):
+                        if user.has_template_folder_permission(parent, service=self):
                             break
                 user_folders.append(folder_attrs)
         return user_folders

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -155,10 +155,10 @@ class Service():
     def all_template_ids(self):
         return {template['id'] for template in self.all_templates}
 
-    def get_templates(self, template_type='all', template_folder_id=None, user_id=None):
-        if user_id and template_folder_id and self.has_permission('edit_folder_permissions'):
+    def get_templates(self, template_type='all', template_folder_id=None, user=None):
+        if user and template_folder_id and self.has_permission('edit_folder_permissions'):
             folder = self.get_template_folder(template_folder_id)
-            if user_id not in folder.get("users_with_permission", []):
+            if not user.has_template_folder_permission(folder):
                 return []
 
         if isinstance(template_type, str):
@@ -403,7 +403,7 @@ class Service():
     def all_template_folder_ids(self):
         return {folder['id'] for folder in self.all_template_folders}
 
-    def get_user_template_folders(self, user_id):
+    def get_user_template_folders(self, user):
         """Returns a modified list of folders a user has permission to view
 
         For each folder, we do the following:
@@ -422,10 +422,10 @@ class Service():
 
         user_folders = []
         for folder in self.all_template_folders:
-            if user_id not in folder.get("users_with_permission", []):
+            if not user.has_template_folder_permission(folder):
                 continue
             parent = self.get_template_folder(folder["parent_id"])
-            if user_id in parent.get("users_with_permission", []):
+            if user.has_template_folder_permission(parent):
                 user_folders.append(folder)
             else:
                 folder_attrs = {
@@ -439,14 +439,14 @@ class Service():
                     else:
                         parent = self.get_template_folder(parent["parent_id"])
                         folder_attrs["parent_id"] = parent.get("id", None)
-                        if user_id in parent.get("users_with_permission", []):
+                        if user.has_template_folder_permission(parent):
                             break
                 user_folders.append(folder_attrs)
         return user_folders
 
-    def get_template_folders(self, template_type='all', parent_folder_id=None, user_id=None):
-        if user_id:
-            folders = self.get_user_template_folders(user_id)
+    def get_template_folders(self, template_type='all', parent_folder_id=None, user=None):
+        if user:
+            folders = self.get_user_template_folders(user)
         else:
             folders = self.all_template_folders
         if parent_folder_id:
@@ -456,7 +456,7 @@ class Service():
             folder for folder in folders
             if (
                 folder['parent_id'] == parent_folder_id
-                and self.is_folder_visible(folder['id'], template_type, user_id)
+                and self.is_folder_visible(folder['id'], template_type, user)
             )
         ]
 
@@ -469,7 +469,7 @@ class Service():
             }
         return self._get_by_id(self.all_template_folders, folder_id)
 
-    def is_folder_visible(self, template_folder_id, template_type='all', user_id=None):
+    def is_folder_visible(self, template_folder_id, template_type='all', user=None):
 
         if template_type == 'all':
             return True
@@ -478,8 +478,8 @@ class Service():
             return True
 
         if any(
-            self.is_folder_visible(child_folder['id'], template_type, user_id)
-            for child_folder in self.get_template_folders(template_type, template_folder_id, user_id)
+            self.is_folder_visible(child_folder['id'], template_type, user)
+            for child_folder in self.get_template_folders(template_type, template_folder_id, user)
         ):
             return True
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -171,6 +171,22 @@ class Service():
             and template.get('folder') == template_folder_id
         ]
 
+    def get_template(self, template_id, version=None):
+        return service_api_client.get_service_template(self.id, str(template_id), version)['data']
+
+    def get_template_with_user_permission_or_403(self, template_id, user):
+        template = self.get_template(template_id)
+
+        if not self.has_permission("edit_folder_permissions"):
+            return template
+
+        template_folder = self.get_template_folder(template["folder"])
+
+        if not user.has_template_folder_permission(template_folder):
+            abort(403)
+
+        return template
+
     @property
     def available_template_types(self):
         return list(filter(self.has_permission, self.TEMPLATE_TYPES))

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -5,28 +5,28 @@ class TemplateList():
         service,
         template_type='all',
         template_folder_id=None,
-        user_id=None,
+        user=None,
     ):
         self.service = service
         self.template_type = template_type
         self.template_folder_id = template_folder_id
-        self.user_id = user_id
+        self.user = user
 
     def __iter__(self):
         for item in self.get_templates_and_folders(
-            self.template_type, self.template_folder_id, self.user_id, ancestors=[]
+            self.template_type, self.template_folder_id, self.user, ancestors=[]
         ):
             yield item
 
-    def get_templates_and_folders(self, template_type, template_folder_id, user_id, ancestors):
+    def get_templates_and_folders(self, template_type, template_folder_id, user, ancestors):
 
         for item in self.service.get_template_folders(
-            template_type, template_folder_id, user_id,
+            template_type, template_folder_id, user,
         ):
             yield TemplateListFolder(
                 item,
                 folders=self.service.get_template_folders(
-                    template_type, item['id'], user_id
+                    template_type, item['id'], user
                 ),
                 templates=self.service.get_templates(
                     template_type, item['id']
@@ -35,12 +35,12 @@ class TemplateList():
                 service_id=self.service.id,
             )
             for sub_item in self.get_templates_and_folders(
-                template_type, item['id'], user_id, ancestors + [item]
+                template_type, item['id'], user, ancestors + [item]
             ):
                 yield sub_item
 
         for item in self.service.get_templates(
-            template_type, template_folder_id, user_id
+            template_type, template_folder_id, user
         ):
             yield TemplateListTemplate(
                 item,
@@ -59,24 +59,24 @@ class TemplateList():
     @property
     def folder_is_empty(self):
         return not any(self.get_templates_and_folders(
-            'all', self.template_folder_id, self.user_id, []
+            'all', self.template_folder_id, self.user, []
         ))
 
 
 class TemplateLists():
 
-    def __init__(self, services, user_id=None):
+    def __init__(self, services, user=None):
         self.services = sorted(
             services,
             key=lambda service: service.name.lower(),
         )
-        self.user_id = user_id
+        self.user = user
 
     def __iter__(self):
 
         if len(self.services) == 1:
 
-            for template_or_folder in TemplateList(self.services[0], user_id=self.user_id):
+            for template_or_folder in TemplateList(self.services[0], user=self.user):
                 yield template_or_folder
 
             return
@@ -88,11 +88,11 @@ class TemplateLists():
             yield template_list_service
 
             for service_templates_and_folders in TemplateList(
-                service, user_id=self.user_id
+                service, user=self.user
             ).get_templates_and_folders(
                 template_type='all',
                 template_folder_id=None,
-                user_id=self.user_id,
+                user=self.user,
                 ancestors=[template_list_service],
             ):
                 yield service_templates_and_folders

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -156,7 +156,7 @@ class User(UserMixin):
             return True
 
         # Top-level templates are always visible
-        if template_folder is None:
+        if template_folder is None or template_folder['id'] is None:
             return True
 
         return self.id in template_folder.get("users_with_permission", [])

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -151,7 +151,15 @@ class User(UserMixin):
     def has_permission_for_service(self, service_id, permission):
         return permission in self._permissions.get(service_id, [])
 
-    def has_template_folder_permission(self, template_folder):
+    def has_template_folder_permission(self, template_folder, service=None):
+        from app import current_service
+
+        if service is None:
+            service = current_service
+
+        if not service.has_permission('edit_folder_permissions'):
+            return True
+
         if self.platform_admin:
             return True
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -155,6 +155,10 @@ class User(UserMixin):
         if self.platform_admin:
             return True
 
+        # Top-level templates are always visible
+        if template_folder is None:
+            return True
+
         return self.id in template_folder.get("users_with_permission", [])
 
     def belongs_to_service(self, service_id):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -151,6 +151,12 @@ class User(UserMixin):
     def has_permission_for_service(self, service_id, permission):
         return permission in self._permissions.get(service_id, [])
 
+    def has_template_folder_permission(self, template_folder):
+        if self.platform_admin:
+            return True
+
+        return self.id in template_folder.get("users_with_permission", [])
+
     def belongs_to_service(self, service_id):
         return str(service_id) in self.services
 

--- a/app/notify_client/template_folder_api_client.py
+++ b/app/notify_client/template_folder_api_client.py
@@ -21,6 +21,19 @@ class TemplateFolderAPIClient(NotifyAdminAPIClient):
     def get_template_folders(self, service_id):
         return self.get('/service/{}/template-folder'.format(service_id))['template_folders']
 
+    def get_template_folder(self, service_id, folder_id):
+        if folder_id is None:
+            return {
+                'id': None,
+                'name': 'Templates',
+                'parent_id': None,
+            }
+        else:
+            return next(
+                folder for folder in self.get_template_folders(service_id)
+                if folder['id'] == str(folder_id)
+            )
+
     @cache.delete('service-{service_id}-template-folders')
     @cache.delete('service-{service_id}-templates')
     def move_to_folder(self, service_id, folder_id, template_ids, folder_ids):

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -2,6 +2,7 @@
   folders,
   service_id,
   template_type,
+  current_user,
   fallback_page_title=None,
   show_fallback_page_title=False,
   link_current_item=False
@@ -21,7 +22,11 @@
           {% endif %}
         {% else %}
           {% if folder.id %}
-            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
+            {% if current_user.has_template_folder_permission(folder) %}
+              <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
+            {% else %}
+              <span class="folder-heading-folder">{{ folder.name }}</span>
+            {% endif %}
           {% else %}
             <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="{% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
           {% endif %}
@@ -36,7 +41,8 @@
 {% macro copy_folder_path(
   folder_path,
   current_service_id,
-  from_service
+  from_service,
+  current_user
 ) %}
   {% if folder_path %}
     <h2 class="heading-medium folder-heading">
@@ -51,7 +57,12 @@
           </span>
         {% else %}
           {% if folder.id %}
-            <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="folder-heading-folder">{{ folder.name }}</a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+            {% if current_user.has_template_folder_permission(folder) %}
+              <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="folder-heading-folder">{{ folder.name }}</a>
+             {% else %}
+              <span class="folder-heading-folder">{{ folder.name }}</span>
+            {% endif %}
+            {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% elif folder.parent_id == None %}
             <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="folder-heading-folder">{{ from_service.name }}</a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% else %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -5,7 +5,7 @@
     <p class="hint">
       This template was deleted {{ template._template.updated_at|format_datetime_relative }}.
     </p>
-  {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', 'manage_templates', 'manage_service') %}
+  {% elif not current_user.has_permissions('send_messages', 'manage_api_keys', 'manage_templates', 'manage_service') or not user_has_template_permission %}
     <p class="top-gutter-1-3 {% if template.template_type != 'sms' %}bottom-gutter{% endif %}">
       If you need to send this
       {{ message_count_label(1, template.template_type, suffix='') }}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -14,7 +14,7 @@
 
 <div class="bottom-gutter-1-2">
   <h1 class="heading-large">Choose a template</h1>
-  {{ folder_path(template_folder_path, current_service.id, template_type) }}
+  {{ folder_path(template_folder_path, current_service.id, template_type, current_user) }}
 </div>
 
   {% if not templates_and_folders.templates_to_show %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -57,7 +57,7 @@
           show_fallback_page_title=not current_service.all_template_folders
         ) }}
       </div>
-      {% if current_user.has_permissions('manage_templates') and current_template_folder_id %}
+      {% if current_user.has_permissions('manage_templates') and current_template_folder_id and user_has_template_folder_permission %}
         <div class="column-one-sixth">
           <a href="{{ url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="folder-heading-manage-link">Manage</a>
         </div>
@@ -72,7 +72,7 @@
 
     {{ live_search(target_selector='#template-list .template-list-item', show=show_search_box, form=search_form) }}
 
-    {% if current_user.has_permissions('manage_templates') %}
+    {% if current_user.has_permissions('manage_templates') and user_has_template_folder_permission %}
       {% call form_wrapper(
           class='sticky-scroll-area',
           module='template-folder-form',

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -53,6 +53,7 @@
           folders=template_folder_path,
           service_id=current_service.id,
           template_type=template_type,
+          current_user=current_user,
           fallback_page_title=page_title,
           show_fallback_page_title=not current_service.all_template_folders
         ) }}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -11,7 +11,7 @@
 
     <div class="bottom-gutter-1-2">
       <h1 class="heading-large">Copy an existing template</h1>
-      {{ copy_folder_path(template_folder_path, current_service.id, from_service) }}
+      {{ copy_folder_path(template_folder_path, current_service.id, from_service, current_user) }}
     </div>
     {% if not services_templates_and_folders.templates_to_show %}
       <p class="template-list-empty">

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -17,6 +17,7 @@
         folders=template_folder_path,
         service_id=current_service.id,
         template_type='all',
+        current_user=current_user,
         link_current_item=True
       ) }}
     </div>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -64,7 +64,7 @@
       &emsp;
       <br/>
     {% endif %}
-    {% if current_user.has_permissions('manage_templates') %}
+    {% if current_user.has_permissions('manage_templates') and user_has_template_permission %}
       {% if not template._template.archived %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
           <a href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -35,6 +35,7 @@
           folders=current_service.get_template_path(template._template),
           service_id=current_service.id,
           template_type='all',
+          current_user=current_user,
           fallback_page_title=template.name,
           show_fallback_page_title=not current_service.all_template_folders
         ) }}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1481,7 +1481,7 @@ def test_send_test_sms_message_redirects_with_help_argument(
     user,
 ):
     mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
-    template = {'data': {'template_type': 'sms'}}
+    template = {'data': {'template_type': 'sms', 'folder': None}}
     mocker.patch('app.service_api_client.get_service_template', return_value=template)
 
     client_request.get(
@@ -1839,7 +1839,7 @@ def test_send_test_clears_session(
     service_one,
     fake_uuid,
 ):
-    template = {'data': {'template_type': 'sms'}}
+    template = {'data': {'template_type': 'sms', 'folder': None}}
     mocker.patch('app.service_api_client.get_service_template', return_value=template)
 
     with client_request.session_transaction() as session:

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1823,7 +1823,7 @@ def test_send_test_works_as_letter_preview(
         )
     )
 
-    mock_get_service_letter_template.assert_called_with(service_id, template_id)
+    mock_get_service_letter_template.assert_called_with(service_id, template_id, None)
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'foo'
@@ -2187,7 +2187,7 @@ def test_should_show_preview_letter_message(
         )
     )
 
-    mock_get_service_letter_template.assert_called_with(service_id, template_id)
+    mock_get_service_letter_template.assert_called_with(service_id, template_id, None)
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'foo'
@@ -3121,6 +3121,7 @@ def test_send_notification_submits_data(
     client_request,
     fake_uuid,
     mock_send_notification,
+    mock_get_service_template,
     template,
     recipient,
     placeholders,
@@ -3150,6 +3151,7 @@ def test_send_notification_clears_session(
     service_one,
     fake_uuid,
     mock_send_notification,
+    mock_get_service_template,
 ):
     with client_request.session_transaction() as session:
         session['recipient'] = '07700900001'
@@ -3195,6 +3197,7 @@ def test_send_notification_redirects_to_view_page(
     client_request,
     fake_uuid,
     mock_send_notification,
+    mock_get_service_template,
     extra_args,
     extra_redirect_args
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -347,7 +347,7 @@ def test_should_show_page_for_one_template(
         page.select_one('textarea')
     )
     assert "priority" not in str(page.select_one('main'))
-    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, template_id)
+    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, template_id, None)
 
 
 def test_caseworker_redirected_to_one_off(
@@ -703,13 +703,14 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
     platform_admin_user,
     mocker,
     mock_get_service_template,
+    service_one,
     fake_uuid,
 ):
     mocker.patch('app.user_api_client.get_users_for_service', return_value=[platform_admin_user])
     template_id = fake_uuid
     response = logged_in_platform_admin_client.get(url_for(
         '.edit_service_template',
-        service_id='1234',
+        service_id=service_one['id'],
         template_id=template_id,
     ))
 
@@ -717,7 +718,7 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
     assert "Two week reminder" in response.get_data(as_text=True)
     assert "Template &lt;em&gt;content&lt;/em&gt; with &amp; entity" in response.get_data(as_text=True)
     assert "Use priority queue?" in response.get_data(as_text=True)
-    mock_get_service_template.assert_called_with('1234', template_id)
+    mock_get_service_template.assert_called_with(service_one['id'], template_id, None)
 
 
 @pytest.mark.parametrize('filetype', ['pdf', 'png'])
@@ -752,7 +753,7 @@ def test_should_show_preview_letter_templates(
 
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'foo'
-    mock_get_service_email_template.assert_called_with(service_id, template_id, **extra_view_args)
+    mock_get_service_email_template.assert_called_with(service_id, template_id, extra_view_args.get('version'))
     assert mocked_preview.call_args[0][0]['id'] == template_id
     assert mocked_preview.call_args[0][0]['service'] == service_id
     assert mocked_preview.call_args[0][1] == filetype
@@ -1661,7 +1662,7 @@ def test_should_show_delete_template_page_with_time_block(
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'
     )
-    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid)
+    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
 def test_should_show_delete_template_page_with_time_block_for_empty_notification(
@@ -1691,7 +1692,7 @@ def test_should_show_delete_template_page_with_time_block_for_empty_notification
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'
     )
-    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid)
+    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
 def test_should_show_delete_template_page_with_never_used_block(
@@ -1716,7 +1717,7 @@ def test_should_show_delete_template_page_with_never_used_block(
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'
     )
-    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid)
+    mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
 @pytest.mark.parametrize('parent', (
@@ -1749,7 +1750,7 @@ def test_should_redirect_when_deleting_a_template(
     )
 
     mock_get_service_template.assert_called_with(
-        SERVICE_ONE_ID, TEMPLATE_ONE_ID
+        SERVICE_ONE_ID, TEMPLATE_ONE_ID, None
     )
     mock_delete_service_template.assert_called_with(
         SERVICE_ONE_ID, TEMPLATE_ONE_ID
@@ -1780,7 +1781,7 @@ def test_should_show_page_for_a_deleted_template(
     assert page.select('p.hint')[0].text.strip() == 'This template was deleted today at 3:00pm.'
     assert 'Delete this template' not in page.select_one('main').text
 
-    mock_get_deleted_template.assert_called_with(SERVICE_ONE_ID, template_id)
+    mock_get_deleted_template.assert_called_with(SERVICE_ONE_ID, template_id, None)
 
 
 @pytest.mark.parametrize('route', [

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1727,8 +1727,13 @@ def test_should_redirect_when_deleting_a_template(
     mocker,
     client_request,
     mock_delete_service_template,
+    mock_get_template_folders,
     parent,
 ):
+
+    mock_get_template_folders.return_value = [
+        {'id': PARENT_FOLDER_ID, 'name': 'Folder', 'parent': None, 'users_with_permission': []}
+    ]
     mock_get_service_template = mocker.patch(
         'app.service_api_client.get_service_template',
         return_value={'data': _template(

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -76,7 +76,7 @@ def test_get_user_template_folders_only_returns_folders_visible_to_user(
     mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
     service_one['permissions'] = ['edit_folder_permissions']
     service = Service(service_one)
-    result = service.get_user_template_folders(active_user_with_permissions.id)
+    result = service.get_user_template_folders(active_user_with_permissions)
     assert result == [
         {
             'name': "Parent 1 - invisible / 1's Visible child",
@@ -120,7 +120,7 @@ def test_get_template_folders_shows_user_folders_when_user_id_passed_in(
     mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
     service_one['permissions'] = ['edit_folder_permissions']
     service = Service(service_one)
-    result = service.get_template_folders(user_id=active_user_with_permissions.id)
+    result = service.get_template_folders(user=active_user_with_permissions)
     assert result == [
         {
             'name': "Parent 1 - invisible / 1's Visible child",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -835,7 +835,7 @@ def mock_get_template_versions(mocker, fake_uuid, user=None):
 
 @pytest.fixture(scope='function')
 def mock_get_service_template_with_placeholders(mocker):
-    def _get(service_id, template_id):
+    def _get(service_id, template_id, version=None):
         template = template_json(
             service_id, template_id, "Two week reminder", "sms", "((name)), Template <em>content</em> with & entity"
         )
@@ -849,7 +849,7 @@ def mock_get_service_template_with_placeholders(mocker):
 
 @pytest.fixture(scope='function')
 def mock_get_service_template_with_placeholders_same_as_recipient(mocker):
-    def _get(service_id, template_id):
+    def _get(service_id, template_id, version=None):
         template = template_json(
             service_id, template_id, "Two week reminder", "sms", "((name)) ((date)) ((PHONENUMBER))"
         )


### PR DESCRIPTION
### Add a user method to check folder permission

User model is the most natural place for a permission check method, however this means that we need to pass the full user object to service model methods and TemplateList instead of user_id.

### Add folder permissions input to the "delete team member" page


### Make sure users always have permission to access top-level templates


### Add a helper Service method to get a template given user has permission

Checks if the user has access to the template's parent folder and either returns the template or a 403 response.

This method should be used instead of calling service_api_client from the views.

### Replace sevice api client get template calls with Service methods

Instead of using the API client directly views are now calling one of two Service model methods:

`get_template` is used for view actions, where the user should see the template page even if they don't have access to the template folder (since all templates are still inked from the dashboard or the sent notifications pages).

`get_template_with_user_permission_or_403` will check if the user has access to the template's folder first and return 403 otherwise. This method is used for any endpoints that result in an action: editing template attributes, deleting templates or sending messages.

### Add folder permission check to copy template endpoint

Copying a template from another service is one place where we can't use the `current_service` method since the source template can belong to a different service the user has access to, so we're using an API client method.

### Add user permission check to template folder actions


### Hide template and folder action links if user doesn't have folder access

Hides action links ('Send', 'Edit', 'Delete' and 'Redact' fro templates and 'Manage' for template folders) and buttons ('New template', 'New folder') if the user doesn't have permission to view current folder or template's parent folder.

![Screen Shot 2019-03-20 at 15 42 09](https://user-images.githubusercontent.com/246664/54706569-25255980-4b37-11e9-9e49-afae797a9e05.png)

![Screen Shot 2019-03-20 at 16 06 45](https://user-images.githubusercontent.com/246664/54706580-29ea0d80-4b37-11e9-93a2-362cf0c9fd15.png)

