### PR TITLE
Correct typo and remove sub-heading

### DIFF
--- a/app/templates/views/letter-validation-preview.html
+++ b/app/templates/views/letter-validation-preview.html
@@ -30,13 +30,12 @@
     </div>
       {%if not pages %}
         <div>
-        <h1 class="heading-medium">Check your file meets the letter specification </h1>
         <p>Your file must be:
         <li>a PDF</li>
         <li>no more than 10 pages long</li>
         <li>less than 2 MB</li>
         </p>
-        <p>The content of your letter mut appear inside the printable area.</p>
+        <p>The content of your letter must appear inside the printable area.</p>
         <p>
         <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf">
             Download the letter specification</a> for more information.


### PR DESCRIPTION
Correct typo in line 39

Remove sub-heading because it's probably not needed on the _Letter validation preview_ page