### PR TITLE
Update pyexcel, pyexcel-io and werkzeug

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -634,7 +634,7 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
     @application.errorhandler(WerkzeugHTTPException)
     def handle_http_error(error):
         if error.code == 301:
-            # RequestRedirect exception
+            # PermanentRedirect exception
             return error
 
         return _error_response(error.code)

--- a/app/main/views/choose_account.py
+++ b/app/main/views/choose_account.py
@@ -1,19 +1,19 @@
 from flask import redirect, render_template, session, url_for
 from flask_login import current_user, login_required
-from werkzeug.routing import RequestRedirect
 
 from app import user_api_client
 from app.main import main
+from app.utils import PermanentRedirect
 
 
 @main.route("/services")
 def choose_service():
-    raise RequestRedirect(url_for('.choose_account'))
+    raise PermanentRedirect(url_for('.choose_account'))
 
 
 @main.route("/services-or-dashboard")
 def services_or_dashboard():
-    raise RequestRedirect(url_for('.show_accounts_or_dashboard'))
+    raise PermanentRedirect(url_for('.show_accounts_or_dashboard'))
 
 
 @main.route("/accounts")

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -24,7 +24,6 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.sanitise_text import SanitiseASCII
 from orderedset import OrderedSet
-from werkzeug.routing import RequestRedirect
 from xlrd.biffh import XLRDError
 from xlrd.xldate import XLDateError
 
@@ -49,6 +48,7 @@ from app.s3_client.s3_csv_client import (
 )
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
+    PermanentRedirect,
     Spreadsheet,
     email_or_sms_not_enabled,
     get_errors_for_csv,
@@ -512,7 +512,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         # If we just return a `redirect` (302) object here, we'll get
         # errors when we try and unpack in the check_messages route.
         # Rasing a werkzeug.routing redirect means that doesn't happen.
-        raise RequestRedirect(url_for(
+        raise PermanentRedirect(url_for(
             '.send_messages',
             service_id=service_id,
             template_id=template_id
@@ -875,7 +875,7 @@ def _check_notification(service_id, template_id, exception=None):
         )
         or not all_placeholders_in_session(template.placeholders)
     ):
-        raise RequestRedirect(back_link)
+        raise PermanentRedirect(back_link)
 
     template.values = get_recipient_and_placeholders_from_session(template.template_type)
     return dict(

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -64,7 +64,7 @@ def verify_email(token):
 
     session['user_details'] = {"email": user.email_address, "id": user.id}
     user_api_client.send_verify_code(user.id, 'sms', user.mobile_number)
-    return redirect('verify')
+    return redirect(url_for('main.verify'))
 
 
 def activate_user(user_id):

--- a/app/proxy_fix.py
+++ b/app/proxy_fix.py
@@ -3,7 +3,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 class CustomProxyFix(object):
     def __init__(self, app, forwarded_proto):
-        self.app = ProxyFix(app)
+        self.app = ProxyFix(app, x_for=1, x_proto=1, x_host=1, x_port=0, x_prefix=0)
         self.forwarded_proto = forwarded_proto
 
     def __call__(self, environ, start_response):

--- a/app/proxy_fix.py
+++ b/app/proxy_fix.py
@@ -1,4 +1,4 @@
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 class CustomProxyFix(object):

--- a/app/utils.py
+++ b/app/utils.py
@@ -36,6 +36,7 @@ from notifications_utils.template import (
 from notifications_utils.timezones import convert_utc_to_bst
 from orderedset._orderedset import OrderedSet
 from werkzeug.datastructures import MultiDict
+from werkzeug.routing import RequestRedirect
 
 SENDING_STATUSES = ['created', 'pending', 'sending', 'pending-virus-check']
 DELIVERED_STATUSES = ['delivered', 'sent', 'returned-letter']
@@ -680,3 +681,12 @@ def redact_mobile_number(mobile_number, spacing=""):
     for i in indices:
         mobile_number_list[i] = redact_character
     return "".join(mobile_number_list)
+
+
+class PermanentRedirect(RequestRedirect):
+    """
+    In Werkzeug 0.15.0 the status code for RequestRedirect changed from 301 to 308.
+    308 status codes are not supported when Internet Explorer is used with Windows 7
+    and Windows 8.1, so this class keeps the original status code of 301.
+    """
+    code = 301

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,7 +8,7 @@ Flask-Login==0.4.1
 
 blinker==1.4
 pyexcel==0.5.10
-pyexcel-io==0.5.14
+pyexcel-io==0.5.16
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.7
 pyexcel-ods3==0.5.3

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,7 +7,7 @@ Flask-WTF==0.14.2
 Flask-Login==0.4.1
 
 blinker==1.4
-pyexcel==0.5.10
+pyexcel==0.5.13
 pyexcel-io==0.5.16
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-Login==0.4.1
 
 blinker==1.4
 pyexcel==0.5.10
-pyexcel-io==0.5.14
+pyexcel-io==0.5.16
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.7
 pyexcel-ods3==0.5.3
@@ -28,10 +28,10 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/alphagov/notifications-utils.git@31.2.2#egg=notifications-utils==31.2.2
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.125
+awscli==1.16.129
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.115
+botocore==1.12.119
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
@@ -72,7 +72,7 @@ statsd==3.3.0
 texttable==1.6.1
 urllib3==1.24.1
 webencodings==0.5.1
-Werkzeug==0.14.1
+Werkzeug==0.15.1
 WTForms==2.2.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-WTF==0.14.2
 Flask-Login==0.4.1
 
 blinker==1.4
-pyexcel==0.5.10
+pyexcel==0.5.13
 pyexcel-io==0.5.16
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.7


### PR DESCRIPTION
Upgraded pyexcel-io and pyexcel, which don't introduce any significant changes.

However, these cause the Werkzeug version to increase from 0.14.1 to 0.15.0 which requires some changes:

* ProxyFix now needs to be imported from a different location
* The status code of RequestRedirect has changed from 301 to 308. Since
status code 308 is not currently supported on Internet Explorer with
Windows 7 and 8.1, this subclasses RequestRedirect to keep the status
code of 301.

[Werkzeug changelog](https://werkzeug.palletsprojects.com/en/0.15.x/changes/#version-0-15-0)

Closes #2847 

Closes #2857