### PR TITLE
Stop Pyup trying to upgrade us to Pytest 4

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 isort==4.3.16
-pytest==3.10.1
+pytest==3.10.1  # pyup: <4.0.0
 pytest-env==0.6.2
 pytest-mock==1.10.1
 pytest-cov==2.6.1


### PR DESCRIPTION
There’s no point until we’ve changed our code to conform.