### PR TITLE
Use `client_request` fixture where possible

### DIFF
--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Text message sender
+  Sign-in method
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  Emails
+  {{ notification_type.capitalize() }} are disabled
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/tests/app/main/views/service_settings/test_inbound_sms_setting.py
+++ b/tests/app/main/views/service_settings/test_inbound_sms_setting.py
@@ -1,13 +1,10 @@
-from flask import url_for
-
-from tests.conftest import normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 def test_set_inbound_sms_sets_a_number_for_service(
-    logged_in_client,
+    client_request,
     mock_add_sms_sender,
     multiple_available_inbound_numbers,
-    service_one,
     fake_uuid,
     mock_no_inbound_number_for_service,
     mocker
@@ -17,14 +14,15 @@ def test_set_inbound_sms_sets_a_number_for_service(
         "inbound_number": "781d9c60-7a7e-46b7-9896-7b045b992fa5",
     }
 
-    response = logged_in_client.post(
-        url_for('main.service_set_inbound_number', service_id=service_one['id']),
-        data=data
+    client_request.post(
+        'main.service_set_inbound_number',
+        service_id=SERVICE_ONE_ID,
+        _data=data,
+        _expected_status=302,
     )
 
-    assert response.status_code == 302
     mock_add_sms_sender.assert_called_once_with(
-        service_one['id'],
+        SERVICE_ONE_ID,
         sms_sender="781d9c60-7a7e-46b7-9896-7b045b992fa5",
         is_default=True,
         inbound_number_id="781d9c60-7a7e-46b7-9896-7b045b992fa5"

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -32,17 +32,21 @@ def test_non_logged_in_user_can_see_homepage(
 
 
 def test_logged_in_user_redirects_to_choose_account(
-    logged_in_client,
+    client_request,
     api_user_active,
     mock_get_user,
     mock_get_user_by_email,
     mock_login,
 ):
-    response = logged_in_client.get(url_for('main.index'))
-    assert response.status_code == 302
-
-    response = logged_in_client.get(url_for('main.sign_in', follow_redirects=True))
-    assert response.location == url_for('main.show_accounts_or_dashboard', _external=True)
+    client_request.get(
+        'main.index',
+        _expected_status=302,
+    )
+    client_request.get(
+        'main.sign_in',
+        _expected_status=302,
+        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True)
+    )
 
 
 def test_robots(client):
@@ -76,16 +80,18 @@ def test_static_pages(
     ('trial_mode', 'trial-mode'),
 ])
 def test_old_static_pages_redirect_to_using_notify_with_anchor(
-    client,
+    client_request,
     view,
     expected_anchor,
 ):
-    response = client.get(url_for('main.{}'.format(view)))
-    assert response.status_code == 301
-    assert response.location == url_for(
-        'main.using_notify',
-        _anchor=expected_anchor,
-        _external=True
+    client_request.get(
+        'main.{}'.format(view),
+        _expected_status=301,
+        _expected_redirect=url_for(
+            'main.using_notify',
+            _anchor=expected_anchor,
+            _external=True
+        ),
     )
 
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -39,15 +39,14 @@ def test_sign_in_explains_other_browser(logged_in_client, api_user_active, mocke
 
 
 def test_doesnt_redirect_to_sign_in_if_no_session_info(
-    logged_in_client, api_user_active
+    client_request, api_user_active
 ):
     assert api_user_active.current_session_id is None
 
-    with logged_in_client.session_transaction() as session:
+    with client_request.session_transaction() as session:
         session['current_session_id'] = None
 
-    response = logged_in_client.get(url_for('main.add_service'))
-    assert response.status_code == 200
+    client_request.get('main.add_service')
 
 
 @pytest.mark.parametrize('db_sess_id, cookie_sess_id', [

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -1,5 +1,7 @@
 from flask import url_for
 
+from tests.conftest import SERVICE_ONE_ID
+
 
 def test_render_sign_out_redirects_to_sign_in(
     client
@@ -12,7 +14,7 @@ def test_render_sign_out_redirects_to_sign_in(
 
 
 def test_sign_out_user(
-    logged_in_client,
+    client_request,
     mock_get_service,
     api_user_active,
     mock_get_user,
@@ -26,15 +28,20 @@ def test_sign_out_user(
     mock_get_usage,
     mock_get_inbound_sms_summary,
 ):
-    with logged_in_client.session_transaction() as session:
+    with client_request.session_transaction() as session:
         assert session.get('user_id') is not None
     # Check we are logged in
-    response = logged_in_client.get(
-        url_for('main.service_dashboard', service_id="123"))
-    assert response.status_code == 200
-    response = logged_in_client.get(url_for('main.sign_out'))
-    assert response.status_code == 302
-    assert response.location == url_for(
-        'main.index', _external=True)
-    with logged_in_client.session_transaction() as session:
+    client_request.get(
+        'main.service_dashboard',
+        service_id=SERVICE_ONE_ID,
+    )
+    client_request.get(
+        'main.sign_out',
+        _expected_status=302,
+        _expected_redirect=url_for(
+            'main.index',
+            _external=True,
+        )
+    )
+    with client_request.session_transaction() as session:
         assert session.get('user_id') is None


### PR DESCRIPTION
It:
- saves repetetive boilerplate code
- does some extra checks (eg checking for a `200` response)
- makes the codebase less confusing to consistently do the same thing in the same way