### PR TITLE
Prevent autofocus when page has scrolled

### DIFF
--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -2,14 +2,14 @@
   "use strict";
 
   Modules.Autofocus = function() {
-    this.start = function($component) {
-      var forceFocus = $component.data('forceFocus');
+    this.start = function(component) {
+      var forceFocus = $(component).data('forceFocus');
 
       // if the page loads with a scroll position, we can't assume the item to focus onload
       // is still where users intend to start
       if (($(window).scrollTop() > 0) && !forceFocus) { return; }
 
-      $('input, textarea, select', $component).eq(0).trigger('focus');
+      $('input, textarea, select', component).eq(0).trigger('focus');
 
     };
   };

--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -2,9 +2,14 @@
   "use strict";
 
   Modules.Autofocus = function() {
-    this.start = function(component) {
+    this.start = function($component) {
+      var forceFocus = $component.data('forceFocus');
 
-      $('input, textarea, select', component).eq(0).trigger('focus');
+      // if the page loads with a scroll position, we can't assume the item to focus onload
+      // is still where users intend to start
+      if (($(window).scrollTop() > 0) && !forceFocus) { return; }
+
+      $('input, textarea, select', $component).eq(0).trigger('focus');
 
     };
   };

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -17,7 +17,7 @@
   {% call form_wrapper(
     class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
     module="autofocus",
-    data_kwargs={'forceFocus': True}
+    data_kwargs={'force-focus': True}
   ) %}
     <div class="grid-row">
       <div class="column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -16,7 +16,8 @@
 
   {% call form_wrapper(
     class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
-    module="autofocus"
+    module="autofocus",
+    data_kwargs={'forceFocus': True}
   ) %}
     <div class="grid-row">
       <div class="column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">


### PR DESCRIPTION
On some pages, we focus some textboxes when the page loads. 

We got feedback from a user that doing this to the live-search textbox on /templates was causing problems. They were clicking on links to templates to see their contents and then using the back button to return to the list. When they returned to the list, focusing the textbox caused the page to scroll back up to the top, meaning they lost their place.

https://www.pivotaltracker.com/story/show/164781997

It seems sensible to assume that if the page has a non-zero scroll position when it loads, we're returning to it being in that state for a reason, like continuing a task, as above. In these cases, the assumption focusing the textbox is based on, that using it is the first thing the user wants to do, is wrong.

This adds a check to the autofocus JS which cancels it if the focused element is off-screen when the page loads. 
It includes the option to set a flag to force focus if needed. We have some pages where this is needed, for example those for entering template data before sending an email where the textbox for the email address is stuck to the top of the screen whatever the scroll position.

## Tested on these pages (on Chrome, on OSX)

- /services/<service_id>/send/<template_id>/one-off/step-0
- /two-factor
- /organisations/<org_id>/users

## Browser testing on /templates

- Chrome 73 on OSX High Sierrra
- Firefox 66 on OSX High Sierrra
- Safari 12 on OSX High Sierrra
- IE11 on Windows 10 and 7
- Edge on Windows 10
- Chrome 72 on Windows 10