### PR TITLE
Say ‘team members’ not ‘users’ for permissions

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1353,7 +1353,7 @@ class TemplateFolderForm(StripWhitespaceForm):
                 (item.id, item.name) for item in all_service_users
             ]
 
-    users_with_permission = MultiCheckboxField('Users who can see this folder:')
+    users_with_permission = MultiCheckboxField('Team members who can see this folder')
     name = StringField('Folder name', validators=[DataRequired(message='Can’t be empty')])
 
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -464,7 +464,7 @@ def test_get_manage_folder_viewing_permissions_for_users(
         'folder_two – Templates – service one – GOV.UK Notify'
     )
     form_labels = page.select('legend[class=form-label]')
-    assert "Users who can see this folder:" in form_labels[0].text
+    assert normalize_spaces(form_labels[0].text) == "Team members who can see this folder"
     checkboxes = page.select('input[name=users_with_permission]')
 
     assert len(checkboxes) == 2


### PR DESCRIPTION
This is consistent with the language we use elsewhere.

Also removes the colon (it’s considered implicit in a form label).

***

![image](https://user-images.githubusercontent.com/355079/55343548-3e1cfb80-54a3-11e9-9a1b-2998a522714e.png)
