### PR TITLE
Pass API correct attribute to search inbound SMS

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -297,7 +297,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             '/service/{}/inbound-sms'.format(
                 service_id,
             ),
-            data={'user_number': user_number}
+            data={'phone_number': user_number}
         )
 
     def get_most_recent_inbound_sms(self, service_id, page=None):


### PR DESCRIPTION
It’s `phone_number` here:
https://github.com/alphagov/notifications-api/blob/1250e47cc7c34356f33079a7490c8e548ebd0f3f/app/inbound_sms/rest.py#L33