### PR TITLE
Say what the current email branding is

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -102,7 +102,7 @@
 
         {% call settings_row(if_has_permission='email') %}
           {{ text_field('Email branding') }}
-          {{ text_field('Your branding' if current_service.email_branding else 'GOV.UK') }}
+          {{ text_field('Your branding<br> ({})'.format(current_service.email_branding_name)|safe if current_service.email_branding else current_service.email_branding_name) }}
           {{ edit_field(
             'Change',
             url_for('.branding_request', service_id=current_service.id),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -152,7 +152,7 @@ def test_should_show_overview(
         'Label Value Action',
         'Send emails On Change',
         'Email reply-to addresses test@example.com Manage',
-        'Email branding GOV.UK Change',
+        'Email branding Your branding (Organisation name) Change',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -173,7 +173,7 @@ def test_should_show_overview(
         'Label Value Action',
         'Send emails On Change',
         'Email reply-to addresses test@example.com Manage',
-        'Email branding GOV.UK Change',
+        'Email branding Your branding (Organisation name) Change',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -220,6 +220,7 @@ def test_should_show_overview_for_service_with_more_things_set(
 ):
     client.login(active_user_with_permissions, mocker, service_one)
     service_one['permissions'] = permissions
+    service_one['email_branding'] = uuid4()
     response = client.get(url_for(
         'main.service_settings', service_id=service_one['id']
     ))


### PR DESCRIPTION
We keep getting people requesting branding when they already have the branding they want set. Seems like they don’t realise we’re doing it automatically. This might help.

***

![image](https://user-images.githubusercontent.com/355079/55473569-f1523580-5606-11e9-9bdc-2e408942dd7b.png)
