### PR TITLE
Fix alignment of links in sticky footer

### DIFF
--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -42,7 +42,7 @@
 
   &-delete-link-without-button {
     @include core-19;
-    padding-left: 0;
+    padding: 0;
     display: inline-block;
   }
 


### PR DESCRIPTION
The delete link was inheriting 1px of extra top padding meant to align it when displayed alongside a button. In this case it’s not being displayed alongside a button, so doesn’t need the extra padding.

# Before 

![image](https://user-images.githubusercontent.com/355079/55390095-67cf3480-552e-11e9-8662-9f23088b72cf.png)

# After 

![image](https://user-images.githubusercontent.com/355079/55390062-5a19af00-552e-11e9-9a5b-47e8e673ec7c.png)
