### PR TITLE
Remove edit_folder_permissions service setting (feature flag)

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -63,11 +63,6 @@ def invite_user(service_id):
         form.login_authentication.data = 'sms_auth'
 
     if form.validate_on_submit():
-        if current_service.has_permission('edit_folder_permissions'):
-            folder_permissions = form.folder_permissions.data
-        else:
-            folder_permissions = list(current_service.all_template_folder_ids)
-
         email_address = form.email_address.data
         invited_user = invite_api_client.create_invite(
             current_user.id,
@@ -75,7 +70,7 @@ def invite_user(service_id):
             email_address,
             form.permissions,
             form.login_authentication.data,
-            folder_permissions,
+            form.folder_permissions.data,
         )
 
         flash('Invite sent to {}'.format(invited_user.email_address), 'default_with_tick')
@@ -114,10 +109,7 @@ def edit_user_permissions(service_id, user_id):
         user_api_client.set_user_permissions(
             user_id, service_id,
             permissions=form.permissions,
-            folder_permissions=(
-                form.folder_permissions.data
-                if current_service.has_permission('edit_folder_permissions') else None
-            ),
+            folder_permissions=form.folder_permissions.data,
         )
         if service_has_email_auth:
             user_api_client.update_user_attribute(user_id, auth_type=form.login_authentication.data)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -62,7 +62,6 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
     ('inbound_sms', {'title': 'Receive inbound SMS', 'requires': 'sms', 'endpoint': '.service_set_inbound_number'}),
     ('email_auth', {'title': 'User auth type editing'}),
     ('upload_document', {'title': 'Uploading documents', 'endpoint': '.service_switch_can_upload_document'}),
-    ('edit_folder_permissions', {'title': 'Folder permissions'}),
 ])
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -53,10 +53,7 @@ def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
     template_folder = current_service.get_template_folder(template['folder'])
 
-    if not current_service.has_permission("edit_folder_permissions"):
-        user_has_template_permission = True
-    else:
-        user_has_template_permission = current_user.has_template_folder_permission(template_folder)
+    user_has_template_permission = current_user.has_template_folder_permission(template_folder)
 
     if should_skip_template_page(template['template_type']):
         return redirect(url_for(
@@ -120,10 +117,7 @@ def start_tour(service_id, template_id):
 def choose_template(service_id, template_type='all', template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
 
-    if not current_service.has_permission("edit_folder_permissions"):
-        user_has_template_folder_permission = True
-    else:
-        user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
+    user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
 
     template_list = TemplateList(current_service, template_type, template_folder_id, current_user)
 
@@ -393,10 +387,7 @@ def copy_template(service_id, template_id):
     template = service_api_client.get_service_template(from_service, str(template_id))['data']
 
     template_folder = template_folder_api_client.get_template_folder(from_service, template['folder'])
-    if (
-        current_service.has_permission('edit_folder_permissions') and
-        not current_user.has_template_folder_permission(template_folder)
-    ):
+    if not current_user.has_template_folder_permission(template_folder):
         abort(403)
 
     if request.method == 'POST':

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -154,7 +154,7 @@ class Service(JSONModel):
         return {template['id'] for template in self.all_templates}
 
     def get_templates(self, template_type='all', template_folder_id=None, user=None):
-        if user and template_folder_id and self.has_permission('edit_folder_permissions'):
+        if user and template_folder_id:
             folder = self.get_template_folder(template_folder_id)
             if not user.has_template_folder_permission(folder):
                 return []
@@ -174,9 +174,6 @@ class Service(JSONModel):
 
     def get_template_folder_with_user_permission_or_403(self, folder_id, user):
         template_folder = self.get_template_folder(folder_id)
-
-        if not self.has_permission("edit_folder_permissions"):
-            return template_folder
 
         if not user.has_template_folder_permission(template_folder):
             abort(403)
@@ -438,9 +435,6 @@ class Service(JSONModel):
         folder making sure it displays in the closest visible parent.
 
         """
-        if not self.has_permission("edit_folder_permissions"):
-            return self.all_template_folders
-
         user_folders = []
         for folder in self.all_template_folders:
             if not user.has_template_folder_permission(folder, service=self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -155,14 +155,6 @@ class User(UserMixin):
         return permission in self._permissions.get(service_id, [])
 
     def has_template_folder_permission(self, template_folder, service=None):
-        from app import current_service
-
-        if service is None:
-            service = current_service
-
-        if not service.has_permission('edit_folder_permissions'):
-            return True
-
         if self.platform_admin:
             return True
 

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -13,7 +13,7 @@
   {% endfor %}
 </fieldset>
 
-{% if current_service.has_permission("edit_folder_permissions") and form.folder_permissions.all_template_folders %}
+{% if form.folder_permissions.all_template_folders %}
   {{ checkboxes_nested(form.folder_permissions, form.folder_permissions.children(), hide_legend=True, collapsible_opts={ 'field': 'folder' }) }}
 {% elif user and user.platform_admin %}
   <p class="bottom-gutter">

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -25,10 +25,8 @@
 
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name, width='1-1') }}
-    {% if current_service.has_permission("edit_folder_permissions") %}
-      {% if current_user.has_permissions("manage_service") and form.users_with_permission.all_service_users %}
-        {{ checkboxes(form.users_with_permission, collapsible_opts={ 'field': 'team member' }) }}
-      {% endif %}
+    {% if current_user.has_permissions("manage_service") and form.users_with_permission.all_service_users %}
+      {{ checkboxes(form.users_with_permission, collapsible_opts={ 'field': 'team member' }) }}
     {% endif %}
 
     {{ page_footer(

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -44,8 +44,6 @@ def test_service_set_permission_requires_platform_admin(
     ('inbound_sms', 'False', False),
     ('email_auth', 'True', True),
     ('email_auth', 'False', False),
-    ('edit_folder_permissions', 'True', True),
-    ('edit_folder_permissions', 'False', False),
 ])
 def test_service_set_permission(
     mocker,

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -287,7 +287,6 @@ def test_conversation_reply_shows_templates(
     service_one
 ):
 
-    service_one["permissions"] += ["edit_folder_permissions"]
     all_templates = {'data': [
         _template('sms', 'sms_template_one', parent=INV_PARENT_FOLDER_ID),
         _template('sms', 'sms_template_two'),

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -459,7 +459,7 @@ def test_edit_user_permissions(
         fake_uuid,
         SERVICE_ONE_ID,
         permissions=permissions_sent_to_api,
-        folder_permissions=None
+        folder_permissions=[]
     )
 
 
@@ -473,7 +473,6 @@ def test_edit_user_folder_permissions(
     mock_get_template_folders,
     fake_uuid,
 ):
-    service_one['permissions'] = ['edit_folder_permissions']
     mock_get_template_folders.return_value = [
         {'id': 'folder-id-1', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
         {'id': 'folder-id-2', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
@@ -626,7 +625,7 @@ def test_edit_user_permissions_including_authentication_with_email_auth_service(
             'manage_service',
             'manage_api_keys',
         },
-        folder_permissions=None
+        folder_permissions=[]
     )
     mock_update_user_attribute.assert_called_with(
         str(active_user_with_permissions.id),
@@ -653,7 +652,6 @@ def test_should_show_folder_permission_form_if_service_has_folder_permissions_en
     mock_get_template_folders,
     service_one
 ):
-    service_one['permissions'].append('edit_folder_permissions')
     mock_get_template_folders.return_value = [
         {'id': 'folder-id-1', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
         {'id': 'folder-id-2', 'name': 'folder_two', 'parent_id': None, 'users_with_permission': []},
@@ -772,40 +770,6 @@ def test_invite_user_with_email_auth_service(
                                                                 expected_permissions,
                                                                 auth_type,
                                                                 [])
-
-
-def test_invite_user_sends_invite_with_all_folders_if_folder_permissions_not_enabled(
-    client_request,
-    mocker,
-    mock_get_template_folders,
-    service_one
-):
-    mocker.patch('app.invite_api_client.get_invites_for_service')
-    mocker.patch('app.user_api_client.get_users_for_service')
-    mock_get_template_folders.return_value = [
-        {'id': 'folder-id-1', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
-        {'id': 'folder-id-2', 'name': 'folder_two', 'parent_id': None, 'users_with_permission': []},
-        {'id': 'folder-id-3', 'name': 'folder_three', 'parent_id': 'folder-id-1', 'users_with_permission': []},
-    ]
-    invite_mock = mocker.patch('app.invite_api_client.create_invite')
-
-    client_request.post(
-        'main.invite_user',
-        service_id=SERVICE_ONE_ID,
-        _data={
-            'email_address': 'user@example.com',
-            'send_messages': 'y',
-        },
-        _follow_redirects=True,
-        _expected_status=200,
-    )
-
-    folder_data_sent = invite_mock.call_args[0][-1]
-
-    assert len(folder_data_sent) == 3
-    assert 'folder-id-1' in folder_data_sent
-    assert 'folder-id-2' in folder_data_sent
-    assert 'folder-id-3' in folder_data_sent
 
 
 def test_cancel_invited_user_cancels_user_invitations(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -110,8 +110,6 @@ def mock_get_service_settings_page_common(
         'Receive inbound SMS Off Change',
         'User auth type editing Off Change',
         'Uploading documents Off Change',
-        'Folder permissions Off Change',
-
     ]),
 ])
 def test_should_show_overview(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1783,7 +1783,7 @@ def test_should_redirect_when_deleting_a_template(
 ):
 
     mock_get_template_folders.return_value = [
-        {'id': PARENT_FOLDER_ID, 'name': 'Folder', 'parent': None, 'users_with_permission': []}
+        {'id': PARENT_FOLDER_ID, 'name': 'Folder', 'parent': None, 'users_with_permission': [ANY]}
     ]
     mock_get_service_template = mocker.patch(
         'app.service_api_client.get_service_template',

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -74,7 +74,6 @@ def test_get_user_template_folders_only_returns_folders_visible_to_user(
     mocker
 ):
     mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
-    service_one['permissions'] = ['edit_folder_permissions']
     service = Service(service_one)
     result = service.get_user_template_folders(active_user_with_permissions)
     assert result == [
@@ -118,7 +117,6 @@ def test_get_template_folders_shows_user_folders_when_user_id_passed_in(
     mocker
 ):
     mock_get_template_folders.return_value = _get_all_folders(active_user_with_permissions)
-    service_one['permissions'] = ['edit_folder_permissions']
     service = Service(service_one)
     result = service.get_template_folders(user=active_user_with_permissions)
     assert result == [


### PR DESCRIPTION
This removes the edit_folder_permission checks from the code, enabling the folder permissions for all services.

This also fixes folder-related tests to set up appropriate user permissions.

❗️This should only be merged right after alphagov/notifications-api#2428, when all other permission stories are done.