### PR TITLE
Add audit event when a service manager changes someones profile

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -3,18 +3,43 @@ from flask import request
 from app import events_api_client
 
 
-def on_user_logged_in(sender, user):
-    _send_event(sender, event_type='sucessful_login', user=user)
+def on_user_logged_in(_sender, user):
+    _send_event(event_type='sucessful_login', user_id=user.id)
 
 
-def _send_event(sender, **kwargs):
+def create_email_change_event(user_id, updated_by_id, original_email_address, new_email_address):
+    _send_event(
+        event_type='update_user_email',
+        user_id=user_id,
+        updated_by_id=updated_by_id,
+        original_email_address=original_email_address,
+        new_email_address=new_email_address)
+
+
+def create_mobile_number_change_event(user_id, updated_by_id, original_mobile_number, new_mobile_number):
+    _send_event(
+        event_type='update_user_mobile_number',
+        user_id=user_id,
+        updated_by_id=updated_by_id,
+        original_mobile_number=original_mobile_number,
+        new_mobile_number=new_mobile_number)
+
+
+def _send_event(**kwargs):
     if not kwargs.get('event_type'):
         return
 
     event_data = _construct_event_data(request)
+    event_fields = ('user_id',
+                    'updated_by_id',
+                    'original_email_address',
+                    'new_email_address',
+                    'original_mobile_number',
+                    'new_mobile_number')
 
-    if kwargs.get('user'):
-        event_data['user_id'] = kwargs.get('user').id
+    for field in event_fields:
+        if kwargs.get(field):
+            event_data[field] = kwargs[field]
 
     events_api_client.create_event(kwargs['event_type'], event_data)
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -16,6 +16,10 @@ from app import (
     service_api_client,
     user_api_client,
 )
+from app.event_handlers import (
+    create_email_change_event,
+    create_mobile_number_change_event,
+)
 from app.main import main
 from app.main.forms import (
     ChangeEmailForm,
@@ -196,6 +200,8 @@ def confirm_edit_user_email(service_id, user_id):
             user_api_client.update_user_attribute(str(user_id), email_address=new_email, updated_by=current_user.id)
         except HTTPError as e:
             abort(500, e)
+        else:
+            create_email_change_event(user.id, current_user.id, user.email_address, new_email)
         finally:
             session.pop('team_member_email_change', None)
 
@@ -254,6 +260,8 @@ def confirm_edit_user_mobile_number(service_id, user_id):
             user_api_client.update_user_attribute(str(user_id), mobile_number=new_number, updated_by=current_user.id)
         except HTTPError as e:
             abort(500, e)
+        else:
+            create_mobile_number_change_event(user.id, current_user.id, user.mobile_number, new_number)
         finally:
             session.pop('team_member_mobile_change', None)
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -240,7 +240,7 @@ class InvitedUser(object):
         self.created_at = created_at
         self.auth_type = auth_type
         self.permissions = translate_permissions_from_db_to_admin_roles(self.permissions)
-        self.folder_permissions = folder_permissions or []
+        self.folder_permissions = folder_permissions
 
     def has_permissions(self, *permissions):
         if self.status == 'cancelled':

--- a/tests/app/test_event_handlers.py
+++ b/tests/app/test_event_handlers.py
@@ -1,6 +1,11 @@
+import uuid
 from unittest.mock import ANY
 
-from app.event_handlers import on_user_logged_in
+from app.event_handlers import (
+    create_email_change_event,
+    create_mobile_number_change_event,
+    on_user_logged_in,
+)
 
 
 def test_on_user_logged_in_calls_events_api(app_, api_user_active, mock_events):
@@ -11,3 +16,37 @@ def test_on_user_logged_in_calls_events_api(app_, api_user_active, mock_events):
                                        {'browser_fingerprint':
                                         {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
                                         'ip_address': ANY, 'user_id': str(api_user_active.id)})
+
+
+def test_create_email_change_event_calls_events_api(app_, mock_events):
+    user_id = str(uuid.uuid4())
+    updated_by_id = str(uuid.uuid4())
+
+    with app_.test_request_context():
+        create_email_change_event(user_id, updated_by_id, 'original@example.com', 'new@example.com')
+
+        mock_events.assert_called_with('update_user_email',
+                                       {'browser_fingerprint':
+                                        {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
+                                        'ip_address': ANY,
+                                        'user_id': user_id,
+                                        'updated_by_id': updated_by_id,
+                                        'original_email_address': 'original@example.com',
+                                        'new_email_address': 'new@example.com'})
+
+
+def test_create_mobile_number_change_event_calls_events_api(app_, mock_events):
+    user_id = str(uuid.uuid4())
+    updated_by_id = str(uuid.uuid4())
+
+    with app_.test_request_context():
+        create_mobile_number_change_event(user_id, updated_by_id, '07700900000', '07700900999')
+
+        mock_events.assert_called_with('update_user_mobile_number',
+                                       {'browser_fingerprint':
+                                        {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
+                                        'ip_address': ANY,
+                                        'user_id': user_id,
+                                        'updated_by_id': updated_by_id,
+                                        'original_mobile_number': '07700900000',
+                                        'new_mobile_number': '07700900999'})


### PR DESCRIPTION
We should audit when a service manager changes a user profile that is not their own. This can be recorded in our events table, which is currently only used to record successful logins.

This adds two new types of event, `update_user_email` and `update_user_mobile_number` which store the:
- browser fingerprint
- IP address
- user id of the user being updated
- user id of the service manager  making the change
- original email address and new email address (for `update_user_email` events)
- original mobile number and new mobile number (for `update_user_mobile_number` events)

[Pivotal story](https://www.pivotaltracker.com/story/show/164434979)