### PR TITLE
Hide template folder permission editing for platform admin users

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -418,6 +418,7 @@ PermissionsAbstract = type("PermissionsAbstract", (StripWhitespaceForm,), {
 class PermissionsForm(PermissionsAbstract):
     def __init__(self, all_template_folders=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.folder_permissions.choices = []
         if all_template_folders is not None:
             self.folder_permissions.all_template_folders = all_template_folders
             self.folder_permissions.choices = [

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -103,11 +103,11 @@ def edit_user_permissions(service_id, user_id):
     form = PermissionsForm.from_user(
         user,
         service_id,
-        folder_permissions=[
+        folder_permissions=None if user.platform_admin else [
             f['id'] for f in current_service.all_template_folders
             if user.has_template_folder_permission(f)
         ],
-        all_template_folders=current_service.all_template_folders
+        all_template_folders=None if user.platform_admin else current_service.all_template_folders
     )
 
     if form.validate_on_submit():

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -15,6 +15,10 @@
 
 {% if current_service.has_permission("edit_folder_permissions") and form.folder_permissions.all_template_folders %}
   {{ checkboxes_nested(form.folder_permissions, form.folder_permissions.children(), hide_legend=True, collapsible_opts={ 'field': 'folder' }) }}
+{% elif user and user.platform_admin %}
+  <p class="bottom-gutter">
+    Platform admin users can access all template folders.
+  </p>
 {% endif %}
 
 {% if service_has_email_auth %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -17,6 +17,7 @@ from tests.conftest import (
     active_user_view_permissions,
     active_user_with_permissions,
     normalize_spaces,
+    platform_admin_user,
     sample_uuid,
 )
 
@@ -478,6 +479,54 @@ def test_edit_user_folder_permissions(
         {'id': 'folder-id-2', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
         {'id': 'folder-id-3', 'name': 'folder_one', 'parent_id': 'folder-id-1', 'users_with_permission': []},
     ]
+    client_request.post(
+        'main.edit_user_permissions',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+        _data=dict(
+            folder_permissions=['folder-id-1', 'folder-id-3']
+        ),
+        _expected_status=302,
+        _expected_redirect=url_for(
+            'main.manage_users',
+            service_id=SERVICE_ONE_ID,
+            _external=True,
+        ),
+    )
+    mock_set_user_permissions.assert_called_with(
+        fake_uuid,
+        SERVICE_ONE_ID,
+        permissions=set(),
+        folder_permissions=['folder-id-1', 'folder-id-3']
+    )
+
+
+def test_cant_edit_user_folder_permissions_for_platform_admin_users(
+    client_request,
+    mocker,
+    service_one,
+    mock_get_users_by_service,
+    mock_get_invites_for_service,
+    mock_set_user_permissions,
+    mock_get_template_folders,
+    fake_uuid,
+):
+    service_one['permissions'] = ['edit_folder_permissions']
+    mocker.patch(
+        'app.user_api_client.get_user', return_value=platform_admin_user(fake_uuid)
+    )
+    mock_get_template_folders.return_value = [
+        {'id': 'folder-id-1', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
+        {'id': 'folder-id-2', 'name': 'folder_one', 'parent_id': None, 'users_with_permission': []},
+        {'id': 'folder-id-3', 'name': 'folder_one', 'parent_id': 'folder-id-1', 'users_with_permission': []},
+    ]
+    page = client_request.get(
+        'main.edit_user_permissions',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+    )
+    assert page.select_one('main p').text == 'foo'
+    assert page.select('') is False
     client_request.post(
         'main.edit_user_permissions',
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
Platform admin users can access all template folders, so the folder permissions form always displays everything as checked for them, which makes it look like the form isn't actually working. We could do the check based on folder data, but the field still wouldn't have any effect on permissions. So instead, we hide it completely for platform admin users.

Submitting the form will remove any folder permissions from the DB for the platform admin user (which can still be created by changing permissions on the template folder 'Manage' page), but that's only relevant if a user stops being a platform admin but keeps their Notify services.
