### PR TITLE
Precompiled show preview with overlay when validation fails

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -94,6 +94,17 @@ class NotificationApiClient(NotifyAdminAPIClient):
 
         return self.get(url=get_url)
 
+    def get_notification_letter_preview_with_overlay(self, service_id, notification_id, file_type, page=None):
+        get_url = '/service/{}/template/preview/{}/{}{}{}'.format(
+            service_id,
+            notification_id,
+            file_type,
+            '?overlay=1',
+            '&page={}'.format(page) if page else '',
+        )
+
+        return self.get(url=get_url)
+
     def update_notification_to_cancelled(self, service_id, notification_id):
         return self.post(
             url='/service/{}/notifications/{}/cancel'.format(service_id, notification_id),

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -456,6 +456,32 @@ def test_should_show_image_of_letter_notification(
     assert response.get_data(as_text=True) == 'foo'
 
 
+def test_should_show_image_of_letter_notification_that_failed_validation(
+    logged_in_client,
+    fake_uuid,
+    mocker
+):
+
+    mock_get_notification(mocker, fake_uuid, template_type='letter', notification_status='validation-failed')
+
+    mocker.patch(
+        'app.main.views.notifications.notification_api_client.get_notification_letter_preview_with_overlay',
+        return_value={
+            'content': base64.b64encode(b'foo').decode('utf-8')
+        }
+    )
+
+    response = logged_in_client.get(url_for(
+        'main.view_letter_notification_as_preview',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+        filetype='png'
+    ))
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == 'foo'
+
+
 def test_should_show_preview_error_image_letter_notification_on_preview_error(
     logged_in_client,
     fake_uuid,


### PR DESCRIPTION
Has to go after this template-preview PR: alphagov/notifications-template-preview#315
And this API PR: https://github.com/alphagov/notifications-api/pull/2437

Part of this story: https://www.pivotaltracker.com/story/show/164798738

#### Screenshots:
cursor on the postage sign:
<img width="988" alt="Screen Shot 2019-04-04 at 11 57 14" src="https://user-images.githubusercontent.com/20957548/55567556-d14d6f80-56f5-11e9-98a4-7b58a3af2622.png">

cursor not on the postage sign:
<img width="992" alt="Screen Shot 2019-04-04 at 11 57 05" src="https://user-images.githubusercontent.com/20957548/55567557-d14d6f80-56f5-11e9-9104-e33198eda6af.png">
