### PR TITLE
 add count of folders visible per user to the team members page 

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -169,6 +169,19 @@ class User(UserMixin):
 
         return self.id in template_folder.get("users_with_permission", [])
 
+    def template_folders_for_service(self, service=None):
+        """
+        Returns list of template folders that a user can view for a given service
+        """
+        if not service.has_permission('edit_folder_permissions'):
+            return service.all_template_folders
+
+        return [
+            template_folder
+            for template_folder in service.all_template_folders
+            if self.id in template_folder.get("users_with_permission", [])
+        ]
+
     def belongs_to_service(self, service_id):
         return str(service_id) in self.services
 
@@ -267,6 +280,10 @@ class InvitedUser(object):
         else:
             data['permissions'] = sorted(self.permissions)
         return data
+
+    def template_folders_for_service(self, service=None):
+        # only used on the manage users page to display the count, so okay to not be fully fledged for now
+        return [{'id': x} for x in self.folder_permissions]
 
 
 class InvitedOrgUser(object):

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -57,6 +57,20 @@
                 {% endif %}
               </div>
             {% endif %}
+            {# only show if the service has folders #}
+            {% if current_service.has_permission('edit_folder_permissions')  and current_service.all_template_folders %}
+              <div class="tick-cross-list-hint">
+                {% set folder_count = user.template_folders_for_service(current_service) | length %}
+
+                {% if folder_count == 0 %}
+                  Cannot see any folders
+                {% elif folder_count != current_service.all_template_folders | length %}
+                  Can see {{ folder_count }} folder{% if folder_count > 1 %}s{% endif %}
+                {% else %}
+                  Can see all folders
+                {% endif%}
+              </div>
+            {% endif %}
           </div>
           {% if current_user.has_permissions('manage_service') %}
             <li class="tick-cross-list-edit-link">

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.2#egg=notifications-utils==31.2.2
+git+https://github.com/alphagov/notifications-utils.git@31.2.4#egg=notifications-utils==31.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.2#egg=notifications-utils==31.2.2
+git+https://github.com/alphagov/notifications-utils.git@31.2.4#egg=notifications-utils==31.2.4
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.130
+awscli==1.16.136
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.120
+botocore==1.12.126
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
@@ -48,7 +48,7 @@ jdcal==1.4
 Jinja2==2.10
 jmespath==0.9.4
 lml==0.0.9
-lxml==4.3.2
+lxml==4.3.3
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
@@ -61,7 +61,7 @@ PyJWT==1.7.1
 PyPDF2==1.26.0
 python-dateutil==2.8.0
 python-json-logger==0.1.10
-PyYAML==3.12
+PyYAML==3.13
 redis==3.2.1
 requests==2.21.0
 rsa==3.4.2


### PR DESCRIPTION
Shows a count of how many folders that user can see - this doesn't do
anything smart with parent folder stuff, it's just "how many checkboxes
are ticked on the edit page".

* doesn't show if service has no folders
* doesn't show if service hasn't got folder permissions enabled

![image](https://user-images.githubusercontent.com/5020841/55574422-4627a600-5704-11e9-9b41-a47aefcf8b03.png)
