### PR TITLE
Don’t let services go live without an organisation

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -288,8 +288,13 @@
 
         {% call row() %}
           {{ text_field('Live')}}
-          {{ boolean_field(not current_service.trial_mode) }}
-          {{ edit_field('Change', url_for('.service_switch_live', service_id=current_service.id)) }}
+          {% if current_service.trial_mode and not current_service.organisation %}
+            {{ text_field('No (you need to assign this service to an organisation before you can make it live)') }}
+            {{ text_field('') }}
+          {% else %}
+            {{ boolean_field(not current_service.trial_mode) }}
+            {{ edit_field('Change', url_for('.service_switch_live', service_id=current_service.id)) }}
+          {% endif %}
         {% endcall %}
 
         {% call row() %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -144,6 +144,29 @@ def test_should_show_overview(
     app.service_api_client.get_service.assert_called_with(service_one['id'])
 
 
+def test_no_go_live_link_for_service_without_organisation(
+    client_request,
+    mocker,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    mock_get_service_organisation,
+    single_sms_sender,
+    platform_admin_user,
+    mock_get_service_settings_page_common,
+):
+    mocker.patch('app.organisations_client.get_service_organisation', return_value=None)
+    client_request.login(platform_admin_user)
+    page = client_request.get('main.service_settings', service_id=SERVICE_ONE_ID)
+
+    assert page.find('h1').text == 'Settings'
+    assert normalize_spaces(page.select('tr')[16].text) == (
+        'Live No (you need to assign this service to an organisation before you can make it live)'
+    )
+    assert normalize_spaces(page.select('tr')[18].text) == (
+        'Organisation Not set Change'
+    )
+
+
 @pytest.mark.parametrize('permissions, expected_rows', [
     (['email', 'sms', 'inbound_sms', 'international_sms'], [
 


### PR DESCRIPTION
We shouldn’t be making services live without an agreement in place. In order to have an agreement in place we need to know what organisation operates the service.

If a service comes along but belongs to an organisation we don’t know about then we should create that organisation. This commits removes the link, which should force this to happen.

***

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/2896