### PR TITLE
Stop sending service domain to the API

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -13,7 +13,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         restricted,
         user_id,
         email_from,
-        service_domain,
     ):
         """
         Create a service and return the json.
@@ -26,7 +25,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "user_id": user_id,
             "restricted": restricted,
             "email_from": email_from,
-            "service_domain": service_domain
         }
         data = _attach_current_user(data)
         return self.post("/service", data)['data']['id']

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -74,7 +74,6 @@ def test_client_creates_service_with_correct_data(
         True,
         fake_uuid,
         'test@example.com',
-        'nhs.uk'
     )
     mock_post.assert_called_once_with(
         '/service',
@@ -90,7 +89,6 @@ def test_client_creates_service_with_correct_data(
             restricted=True,
             user_id=fake_uuid,
             email_from='test@example.com',
-            service_domain='nhs.uk'
         ),
     )
 

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -253,7 +253,7 @@ def test_returns_value_from_cache(
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),
     (user_api_client, 'activate_user', [api_user_pending(sample_uuid())], {}),
     (service_api_client, 'remove_user_from_service', [SERVICE_ONE_ID, user_id], {}),
-    (service_api_client, 'create_service', ['', '', 0, False, user_id, sample_uuid(), ''], {}),
+    (service_api_client, 'create_service', ['', '', 0, False, user_id, sample_uuid()], {}),
     (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, user_id], {}),
 ])
 def test_deletes_user_cache(


### PR DESCRIPTION
The API doesn’t look at it, and the rest of the admin code isn’t calling the method with this argument any more.