### PR TITLE
Correct time formatting

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -92,7 +92,7 @@ def view_job(service_id, job_id):
         version=job['template_version']
     )['data']
 
-    just_sent_message = 'Your {} been sent. Printing starts {} at 5.30pm.'.format(
+    just_sent_message = 'Your {} been sent. Printing starts {} at 5:30pm.'.format(
         'letter has' if job['notification_count'] == 1 else 'letters have',
         printing_today_or_tomorrow()
     )

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -153,7 +153,7 @@ def get_letter_printing_statement(status, created_at):
     created_at_dt = parser.parse(created_at).replace(tzinfo=None)
 
     if letter_can_be_cancelled(status, created_at_dt):
-        return 'Printing starts {} at 5.30pm'.format(printing_today_or_tomorrow())
+        return 'Printing starts {} at 5:30pm'.format(printing_today_or_tomorrow())
     else:
         printed_datetime = utc_string_to_aware_gmt_datetime(created_at) + timedelta(hours=6, minutes=30)
         printed_date = _format_datetime_short(printed_datetime)

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -360,7 +360,7 @@ def test_should_show_letter_job_with_banner_after_sending_before_1730(
 
     assert page.select('p.bottom-gutter') == []
     assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
-        'Your letter has been sent. Printing starts today at 5.30pm.'
+        'Your letter has been sent. Printing starts today at 5:30pm.'
     )
 
 
@@ -383,7 +383,7 @@ def test_should_show_letter_job_with_banner_when_there_are_multiple_CSV_rows(
 
     assert page.select('p.bottom-gutter') == []
     assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
-        'Your letters have been sent. Printing starts today at 5.30pm.'
+        'Your letters have been sent. Printing starts today at 5:30pm.'
     )
 
 
@@ -406,7 +406,7 @@ def test_should_show_letter_job_with_banner_after_sending_after_1730(
 
     assert page.select('p.bottom-gutter') == []
     assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
-        'Your letter has been sent. Printing starts tomorrow at 5.30pm.'
+        'Your letter has been sent. Printing starts tomorrow at 5:30pm.'
     )
 
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -416,7 +416,7 @@ def test_notification_page_shows_page_for_first_class_letter_notification(
         notification_id=fake_uuid,
     )
 
-    assert normalize_spaces(page.select('main p:nth-of-type(2)')[0].text) == 'Printing starts tomorrow at 5.30pm'
+    assert normalize_spaces(page.select('main p:nth-of-type(2)')[0].text) == 'Printing starts tomorrow at 5:30pm'
     assert normalize_spaces(page.select('main p:nth-of-type(3)')[0].text) == 'Estimated delivery date: 5 January'
     assert normalize_spaces(page.select_one('.letter-postage').text) == (
         'Postage: first class'
@@ -716,14 +716,14 @@ def test_should_show_image_of_precompiled_letter_notification(
 @pytest.mark.parametrize('created_at, current_datetime', [
     ('2017-07-07T12:00:00+00:00', '2017-07-07 16:29:00'),  # created today, summer
     ('2017-12-12T12:00:00+00:00', '2017-12-12 17:29:00'),  # created today, winter
-    ('2017-12-12T21:30:00+00:00', '2017-12-13 17:29:00'),  # created after 5.30 yesterday
+    ('2017-12-12T21:30:00+00:00', '2017-12-13 17:29:00'),  # created after 5:30 yesterday
     ('2017-03-25T17:30:00+00:00', '2017-03-26 16:29:00'),  # over clock change period on 2017-03-26
 ])
 def test_get_letter_printing_statement_when_letter_prints_today(created_at, current_datetime):
     with freeze_time(current_datetime):
         statement = get_letter_printing_statement('created', created_at)
 
-    assert statement == 'Printing starts today at 5.30pm'
+    assert statement == 'Printing starts today at 5:30pm'
 
 
 @pytest.mark.parametrize('created_at, current_datetime', [
@@ -734,7 +734,7 @@ def test_get_letter_printing_statement_when_letter_prints_tomorrow(created_at, c
     with freeze_time(current_datetime):
         statement = get_letter_printing_statement('created', created_at)
 
-    assert statement == 'Printing starts tomorrow at 5.30pm'
+    assert statement == 'Printing starts tomorrow at 5:30pm'
 
 
 @pytest.mark.parametrize('created_at, print_day', [

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -167,7 +167,7 @@ def test_notification_page_shows_page_for_letter_notification(
         "‘sample template’ was sent by Test User on 1 January at 1:01am"
     )
     assert normalize_spaces(page.select('main p:nth-of-type(2)')[0].text) == (
-        'Printing starts today at 5.30pm'
+        'Printing starts today at 5:30pm'
     )
     assert normalize_spaces(page.select('main p:nth-of-type(3)')[0].text) == (
         'Estimated delivery date: 6 January'


### PR DESCRIPTION
Make the formatting of postage times consistent with the rest of the service, and the GOV.UK style guide.