### PR TITLE
Revert bump to library to unblock functional tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/core": "7.4.0",
     "@babel/preset-env": "7.4.2",
     "diff-dom": "https://github.com/fiduswriter/diffDOM/archive/v3.1.0.tar.gz",
-    "govuk-elements-sass": "3.1.3",
+    "govuk-elements-sass": "3.1.2",
     "govuk_frontend_toolkit": "8.1.0",
     "govuk_template_jinja": "0.24.1",
     "gulp": "4.0.0",


### PR DESCRIPTION
Version 3.1.3 of govuk-elements-sass makes everything with the `heading-small` class `display: block`.

https://github.com/alphagov/govuk_elements/pull/552

This broke the functional tests because the email address here used `heading-small`:

![image](https://user-images.githubusercontent.com/87140/56201664-39c31780-6039-11e9-8904-e23c38fdc362.png)

...which pushed the text following it onto a new line:

![image](https://user-images.githubusercontent.com/87140/56202556-3cbf0780-603b-11e9-9837-30bc27ea3b1d.png)

This is adding a newline between the email address and the following text which breaks [this functional test](https://github.com/alphagov/notifications-functional-tests/blob/master/tests/test_utils.py#L287).

We don't much need for the features the bump to 3.1.3 brings in and we'll replace the library with GOVUK Frontend soon anyway, so this reverts it.