### PR TITLE
Fix ie11 JS issue

### DIFF
--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -2,7 +2,7 @@
   "use strict";
 
   var queues = {};
-  var dd = new diffDOM.DiffDOM();
+  var dd = new diffDOM();
 
   var getRenderer = $component => response => dd.apply(
     $component.get(0),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,7 @@ const javascripts = () => {
       paths.npm + 'hogan.js/dist/hogan-3.0.2.js',
       paths.npm + 'jquery/dist/jquery.min.js',
       paths.npm + 'query-command-supported/dist/queryCommandSupported.min.js',
-      paths.npm + 'diff-dom/browser/diffDOM.js',
+      paths.npm + 'diff-dom/diffDOM.js',
       paths.npm + 'timeago/jquery.timeago.js',
       paths.npm + 'textarea-caret/index.js'
     ]))

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/core": "7.4.0",
     "@babel/preset-env": "7.4.2",
-    "diff-dom": "https://github.com/fiduswriter/diffDOM/archive/v3.1.0.tar.gz",
+    "diff-dom": "2.3.1",
     "govuk-elements-sass": "3.1.2",
     "govuk_frontend_toolkit": "8.1.0",
     "govuk_template_jinja": "0.24.1",
@@ -45,8 +45,5 @@
     "gulp-sass-lint": "1.4.0",
     "jshint": "2.10.2",
     "jshint-stylish": "2.2.1"
-  },
-  "peerDependencies": {
-    "rollup": "1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@babel/core": "7.4.0",
     "@babel/preset-env": "7.4.2",
-    "diff-dom": "2.3.1",
+    "diff-dom": "2.5.1",
     "govuk-elements-sass": "3.1.2",
     "govuk_frontend_toolkit": "8.1.0",
     "govuk_template_jinja": "0.24.1",


### PR DESCRIPTION
When the diffDOM NPM package was bumped, it brought in use of [Object.entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries) which is not supported in IE11.

This shouldn't be a problem if we polyfill it but our frontend pipeline just isn't currently set up to polyfill NPM packages.

I've written a story around making it work with our pipeline:

https://www.pivotaltracker.com/story/show/165380360

...but until then, this reverts the original bump and updates it to the latest version that works.