### PR TITLE
Update service with the user that requested to go live.

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -247,6 +247,8 @@ def submit_request_to_go_live(service_id):
         tags=current_service.request_to_go_live_tags,
     )
 
+    current_service.update(go_live_user=current_user.id)
+
     flash('Thanks for your request to go live. We’ll get back to you within one working day.', 'default')
     return redirect(url_for('.service_settings', service_id=service_id))
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -43,6 +43,8 @@ class Service(JSONModel):
         'volume_letter',
         'consent_to_research',
         'count_as_live',
+        'go_live_user',
+        'go_live_at'
     }
 
     TEMPLATE_TYPES = (

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
@@ -87,6 +88,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             'volume_letter',
             'consent_to_research',
             'count_as_live',
+            'go_live_user',
+            'go_live_at'
         }
         if disallowed_attributes:
             raise TypeError('Not allowed to update service attributes: {}'.format(
@@ -102,6 +105,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             service_id,
             message_limit=250000 if live else 50,
             restricted=(not live),
+            go_live_at=str(datetime.utcnow()) if live else None
         )
 
     # This method is not cached because it calls through to one which is

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -416,6 +416,7 @@ def test_show_restricted_service(
         assert not request_to_live_link
 
 
+@freeze_time("2017-04-01 11:09:00.061258")
 def test_switch_service_to_live(
     client_request,
     platform_admin_user,
@@ -437,7 +438,8 @@ def test_switch_service_to_live(
     mock_update_service.assert_called_with(
         SERVICE_ONE_ID,
         message_limit=250000,
-        restricted=False
+        restricted=False,
+        go_live_at="2017-04-01 11:09:00.061258"
     )
 
 
@@ -481,6 +483,7 @@ def test_switch_service_to_restricted(
         SERVICE_ONE_ID,
         message_limit=50,
         restricted=True,
+        go_live_at=None
     )
 
 
@@ -1303,7 +1306,7 @@ def test_non_gov_users_cant_request_to_go_live(
         [],
     ),
 ))
-@freeze_time("2012-12-21")
+@freeze_time("2012-12-21 13:12:12.12354")
 def test_should_redirect_after_request_to_go_live(
     client_request,
     mocker,
@@ -1315,6 +1318,7 @@ def test_should_redirect_after_request_to_go_live(
     mock_get_service_settings_page_common,
     mock_get_service_templates,
     mock_get_users_by_service,
+    mock_update_service,
     volumes,
     displayed_volumes,
     formatted_displayed_volumes,
@@ -1379,6 +1383,10 @@ def test_should_redirect_after_request_to_go_live(
     )
     assert normalize_spaces(page.select_one('h1').text) == (
         'Settings'
+    )
+    mock_update_service.assert_called_once_with(
+        SERVICE_ONE_ID,
+        go_live_user=active_user_with_permissions.id
     )
 
 


### PR DESCRIPTION
When a service is marked as live update the service with the go live datetime.

- [ ] https://github.com/alphagov/notifications-api/pull/2465