### PR TITLE
Remove use of spread operator

### DIFF
--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -34,7 +34,7 @@
     );
 
     setTimeout(
-      () => poll(...arguments), interval
+      () => poll.apply(window, arguments), interval
     );
   };
 


### PR DESCRIPTION
This is a temporary fix for the fact that the babel helper that transforms uses of the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) has a function in its call stack that assumes [Symbols](https://developer.mozilla.org/en-US/docs/Glossary/Symbol) are supported.

IE11 and below don't support Symbols so this causes an error when it runs our JS.

This swaps out use of the spread operator for a use of [apply](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply) to unpack the `arguments` object.

Related issue on babel:

https://github.com/babel/babel/issues/7597