### PR TITLE
Don’t ask for organisation type when we know it

### DIFF
--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -21,7 +21,9 @@
 
       {{ textbox(form.name, hint="You can change this later") }}
 
-      {{ radios(form.organisation_type) }}
+      {% if not current_user.default_organisation.organisation_type %}
+        {{ radios(form.organisation_type) }}
+      {% endif %}
 
       {{ page_footer('Add service') }}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,6 +194,7 @@ def organisation_json(
     domains=None,
     crown=True,
     agreement_signed=False,
+    organisation_type='',
 ):
     if users is None:
         users = []
@@ -208,7 +209,7 @@ def organisation_json(
         'created_at': created_at or str(datetime.utcnow()),
         'email_branding_id': email_branding_id,
         'letter_branding_id': letter_branding_id,
-        'organisation_type': '',
+        'organisation_type': organisation_type,
         'crown': crown,
         'agreement_signed': agreement_signed,
         'agreement_signed_at': None,

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -39,7 +39,9 @@ def test_sign_in_explains_other_browser(logged_in_client, api_user_active, mocke
 
 
 def test_doesnt_redirect_to_sign_in_if_no_session_info(
-    client_request, api_user_active
+    client_request,
+    api_user_active,
+    mock_get_organisation_by_domain,
 ):
     assert api_user_active.current_session_id is None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3143,6 +3143,7 @@ def mock_get_organisation_by_domain(
     name=False,
     crown=True,
     agreement_signed=False,
+    organisation_type='',
 ):
     def _get_organisation_by_domain(org_id):
         return organisation_json(
@@ -3150,6 +3151,7 @@ def mock_get_organisation_by_domain(
             name,
             crown=crown,
             agreement_signed=agreement_signed,
+            organisation_type=organisation_type,
         )
 
     return mocker.patch(


### PR DESCRIPTION
Every time someone adds a new service we ask them what kind of organisation they work for.

We can look this up based on the user’s email address now. So we should only ask the question if:
- we don’t recognise the domain in the user’s email address
- or we haven’t set what type of organisation it is (this shouldn’t be possible on production because we’ve populated the column for all existing organisations and it’s impossible to add a new one without
  setting it

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/56359587-e20fe200-61d9-11e9-9041-98af6a4b7d78.png) | ![image](https://user-images.githubusercontent.com/355079/56359604-f227c180-61d9-11e9-8420-1f87e88d6eaf.png)

***

Depends on:
- [x] https://github.com/alphagov/notifications-functional-tests/pull/238