### PR TITLE
 Allow non-gov email addresses to be changed to gov email addresses

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -716,6 +716,10 @@ class ChangeEmailForm(StripWhitespaceForm):
             raise ValidationError("The email address is already in use")
 
 
+class ChangeNonGovEmailForm(ChangeEmailForm):
+    email_address = email_address(gov_user=False)
+
+
 class ChangeMobileNumberForm(StripWhitespaceForm):
     mobile_number = international_phone_number()
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -504,10 +504,6 @@ class TwoFactorForm(StripWhitespaceForm):
         return True
 
 
-class EmailNotReceivedForm(StripWhitespaceForm):
-    email_address = email_address()
-
-
 class TextNotReceivedForm(StripWhitespaceForm):
     mobile_number = international_phone_number()
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -24,12 +24,13 @@ from app.main import main
 from app.main.forms import (
     ChangeEmailForm,
     ChangeMobileNumberForm,
+    ChangeNonGovEmailForm,
     InviteUserForm,
     PermissionsForm,
     SearchUsersForm,
 )
 from app.models.user import permissions
-from app.utils import redact_mobile_number, user_has_permissions
+from app.utils import is_gov_user, redact_mobile_number, user_has_permissions
 
 
 @main.route("/services/<service_id>/users")
@@ -164,7 +165,10 @@ def edit_user_email(service_id, user_id):
     def _is_email_already_in_use(email):
         return user_api_client.is_email_already_in_use(email)
 
-    form = ChangeEmailForm(_is_email_already_in_use, email_address=user_email)
+    if is_gov_user(user_email):
+        form = ChangeEmailForm(_is_email_already_in_use, email_address=user_email)
+    else:
+        form = ChangeNonGovEmailForm(_is_email_already_in_use, email_address=user_email)
 
     if request.form.get('email_address', '').strip() == user_email:
         return redirect(url_for('.manage_users', service_id=current_service.id))

--- a/app/templates/views/manage-users/edit-user-email.html
+++ b/app/templates/views/manage-users/edit-user-email.html
@@ -14,7 +14,7 @@
   <div class="grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper() %}
-        {{ textbox(form.email_address) }}
+        {{ textbox(form.email_address, safe_error_message=True) }}
         {{ page_footer(
           'Save',
           back_link=url_for('.edit_user_permissions', service_id=service_id, user_id=user.id),


### PR DESCRIPTION
When a user's email address is updated, we not allowing it to be changed
to a non-government email address. We now allow a non-gov email address
to be changed to another non-gov email address. Government email
addresses still cannot be changed to non-government email addresses.

Also fixed the link in the error message on the ChangeEmailAddress form:
_Before_
<img width="601" alt="Screen Shot 2019-04-18 at 16 12 00" src="https://user-images.githubusercontent.com/12881990/56371328-d67de480-61f4-11e9-8b94-25136ee3fe39.png">

_After_
<img width="638" alt="Screen Shot 2019-04-18 at 16 11 34" src="https://user-images.githubusercontent.com/12881990/56371342-daaa0200-61f4-11e9-89ea-5c911ca2d2c9.png">


[Pivotal story](https://www.pivotaltracker.com/story/show/165243060)