### PR TITLE
Remove unused method

### DIFF
--- a/app/notify_client/billing_api_client.py
+++ b/app/notify_client/billing_api_client.py
@@ -22,10 +22,6 @@ class BillingAPIClient(NotifyAdminAPIClient):
         )
         return result['free_sms_fragment_limit']
 
-    def get_free_sms_fragment_limit_for_all_years(self, service_id, year=None):
-        return self.get(
-            '/service/{0}/billing/free-sms-fragment-limit'.format(service_id))
-
     def create_or_update_free_sms_fragment_limit(self, service_id, free_sms_fragment_limit, year=None):
         # year = None will update current and future year in the API
         data = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2969,15 +2969,6 @@ def mock_create_or_update_free_sms_fragment_limit(mocker):
                         return_value=sample_limit)
 
 
-@pytest.fixture(scope='function')
-def mock_get_free_sms_fragment_limit_for_all_years(mocker):
-    sample_limit = [{'financial_year_start': 2016, 'free_sms_fragment_limit': 250000},
-                    {'financial_year_start': 2017, 'free_sms_fragment_limit': 500000}]
-
-    return mocker.patch('app.billing_api_client.get_free_sms_fragment_limit_for_all_years',
-                        return_value=sample_limit)
-
-
 @contextmanager
 def set_config(app, name, value):
     old_val = app.config.get(name)


### PR DESCRIPTION
We use `.get_free_sms_fragment_limit_for_year()` instead, which functionally is the same thing (has a default argument of `year=None`).