### PR TITLE
Allow more space for values in settings tables

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -59,7 +59,7 @@
 
   th {
 
-    &.table-field-heading-first {
+    &:first-child {
       width: 35%;  // 33.33% + fudge
     }
 

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -85,6 +85,10 @@
       text-overflow: ellipsis;
     }
 
+    ul li {
+      margin-bottom: 5px;
+    }
+
   }
 
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -69,7 +69,7 @@
 
   }
 
-  td {
+  td.table-field-center-aligned {
 
     &:first-child {
 

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -69,7 +69,7 @@
 
   }
 
-  td.table-field-center-aligned {
+  td.table-field-left-aligned {
 
     &:first-child {
 

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -51,6 +51,44 @@
 
 }
 
+.settings-table {
+
+  table {
+    table-layout: fixed;
+  }
+
+  th {
+
+    &.table-field-heading-first {
+      width: 35%;  // 33.33% + fudge
+    }
+
+    &:last-child {
+      width: 17.5%  // 16.67% + fudge
+    }
+
+  }
+
+  td {
+
+    &:first-child {
+
+      div {
+        white-space: normal;
+      }
+
+    }
+
+    div {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+  }
+
+}
+
 %table-field,
 .table-field {
 

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -90,7 +90,7 @@
 {% macro text_field(text, status='', truncate=false) -%}
   {% call field(status=status) %}
     {% if text is iterable and text is not string %}
-      <ul class="list list-bullet">
+      <ul>
         {% for item in text %}
           {% if item %}
             <li>{{ item }}</li>

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -67,7 +67,7 @@
 
 {% macro field(align='left', status='', border=True) -%}
 
-    {% set field_alignment = 'table-field-right-aligned' if align == 'right' else 'table-field-center-aligned' %}
+    {% set field_alignment = 'table-field-right-aligned' if align == 'right' else 'table-field-left-aligned' %}
     {% set border = '' if border else 'table-field-noborder' %}
 
     <td class="{{ [field_alignment, border]|join(' ') }}">

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -29,7 +29,7 @@
 
   {% if current_user.platform_admin %}
     <h2 class="heading-medium">Platform admin settings</h2>
-    <div class="bottom-gutter-3-2 settings-table body-copy-table">
+    <div class="settings-table body-copy-table">
       {% call mapping_table(
         caption='Platform admin settings',
         field_headings=['Label', 'Value', 'Action'],

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -29,7 +29,7 @@
 
   {% if current_user.platform_admin %}
     <h2 class="heading-medium">Platform admin settings</h2>
-    <div class="bottom-gutter-3-2 dashboard-table body-copy-table">
+    <div class="bottom-gutter-3-2 settings-table body-copy-table">
       {% call mapping_table(
         caption='Platform admin settings',
         field_headings=['Label', 'Value', 'Action'],

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -353,26 +353,29 @@
 
         {% endcall %}
 
-        <ul>
+        <p>
           {% if current_service.active %}
-            <li class="bottom-gutter">
-              <a href="{{ url_for('.archive_service', service_id=current_service.id) }}" class="button">
+            <span class="page-footer-delete-link page-footer-delete-link-without-button">
+              <a href="{{ url_for('.archive_service', service_id=current_service.id) }}">
                 Archive service
               </a>
-            </li>
-            <li class="bottom-gutter">
-              <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="button">
-                Suspend service
-              </a>
-            </li>
+            </span>
+            <span class="page-footer-delete-link">
+              <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="page-footer-delete-link">
+                  Suspend service
+                </a>
+            </span>
           {% else %}
-            <li class="bottom-gutter">
-              <a href="{{ url_for('.resume_service', service_id=current_service.id) }}" class="button">
+            <div class="hint bottom-gutter-1-2">
+              Service suspended
+            </div>
+            <span class="page-footer-delete-link page-footer-delete-link-without-button">
+              <a href="{{ url_for('.resume_service', service_id=current_service.id) }}">
                 Resume service
               </a>
-            </li>
+            </span>
           {% endif %}
-        </ul>
+        </p>
       </div>
 
     {% endif %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -10,7 +10,7 @@
 
     <h1 class="heading-large">Settings</h1>
 
-    <div class="bottom-gutter-3-2 dashboard-table body-copy-table">
+    <div class="bottom-gutter-3-2 settings-table body-copy-table">
 
       {% call mapping_table(
         caption='General',

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -278,98 +278,102 @@
 
     {% if current_user.platform_admin %}
 
-      <h2 class="heading-medium">Platform admin settings</h2>
-      {% call mapping_table(
-        caption='Settings',
-        field_headings=['Label', 'Value', 'Action'],
-        field_headings_visible=False,
-        caption_visible=False
-      ) %}
+      <div class="settings-table body-copy-table top-gutter-4-3">
 
-        {% call row() %}
-          {{ text_field('Live')}}
-          {% if current_service.trial_mode and not current_service.organisation %}
-            {{ text_field('No (you need to assign this service to an organisation before you can make it live)') }}
-            {{ text_field('') }}
-          {% else %}
-            {{ boolean_field(not current_service.trial_mode) }}
-            {{ edit_field('Change', url_for('.service_switch_live', service_id=current_service.id)) }}
-          {% endif %}
-        {% endcall %}
+        <h2 class="heading-medium">Platform admin settings</h2>
 
-        {% call row() %}
-          {{ text_field('Count in list of live services')}}
-          {{ text_field('Yes' if current_service.count_as_live else 'No') }}
-          {{ edit_field('Change', url_for('.service_switch_count_as_live', service_id=current_service.id)) }}
-        {% endcall %}
+        {% call mapping_table(
+          caption='Settings',
+          field_headings=['Label', 'Value', 'Action'],
+          field_headings_visible=False,
+          caption_visible=False
+        ) %}
 
-        {% call row() %}
-          {{ text_field('Organisation')}}
-          {{ optional_text_field(current_service.organisation.name) }}
-          {{ edit_field('Change', url_for('.link_service_to_organisation', service_id=current_service.id)) }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Organisation type')}}
-          {{ optional_text_field(
-            (current_service.organisation_type or '')|title
-          ) }}
-          {{ edit_field('Change', url_for('.set_organisation_type', service_id=current_service.id)) }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Free text message allowance')}}
-          {{ text_field('{:,}'.format(current_service.free_sms_fragment_limit)) }}
-          {{ edit_field('Change', url_for('.set_free_sms_allowance', service_id=current_service.id)) }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Email branding' )}}
-          {{ text_field(current_service.email_branding_name) }}
-          {{ edit_field('Change', url_for('.service_set_email_branding', service_id=current_service.id)) }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Letter branding')}}
-          {{ optional_text_field(current_service.letter_branding.name) }}
-          {{ edit_field('Change', url_for('.service_set_letter_branding', service_id=current_service.id)) }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Data retention')}}
-          {% call field() %}
-              {{ current_service.data_retention | join(', ', attribute='notification_type') }}
+          {% call row() %}
+            {{ text_field('Live')}}
+            {% if current_service.trial_mode and not current_service.organisation %}
+              {{ text_field('No (you need to assign this service to an organisation before you can make it live)') }}
+              {{ text_field('') }}
+            {% else %}
+              {{ boolean_field(not current_service.trial_mode) }}
+              {{ edit_field('Change', url_for('.service_switch_live', service_id=current_service.id)) }}
+            {% endif %}
           {% endcall %}
-          {{ edit_field('Change', url_for('.data_retention', service_id=current_service.id)) }}
+
+          {% call row() %}
+            {{ text_field('Count in list of live services')}}
+            {{ text_field('Yes' if current_service.count_as_live else 'No') }}
+            {{ edit_field('Change', url_for('.service_switch_count_as_live', service_id=current_service.id)) }}
+          {% endcall %}
+
+          {% call row() %}
+            {{ text_field('Organisation')}}
+            {{ optional_text_field(current_service.organisation.name) }}
+            {{ edit_field('Change', url_for('.link_service_to_organisation', service_id=current_service.id)) }}
+          {% endcall %}
+          {% call row() %}
+            {{ text_field('Organisation type')}}
+            {{ optional_text_field(
+              (current_service.organisation_type or '')|title
+            ) }}
+            {{ edit_field('Change', url_for('.set_organisation_type', service_id=current_service.id)) }}
+          {% endcall %}
+          {% call row() %}
+            {{ text_field('Free text message allowance')}}
+            {{ text_field('{:,}'.format(current_service.free_sms_fragment_limit)) }}
+            {{ edit_field('Change', url_for('.set_free_sms_allowance', service_id=current_service.id)) }}
+          {% endcall %}
+          {% call row() %}
+            {{ text_field('Email branding' )}}
+            {{ text_field(current_service.email_branding_name) }}
+            {{ edit_field('Change', url_for('.service_set_email_branding', service_id=current_service.id)) }}
+          {% endcall %}
+          {% call row() %}
+            {{ text_field('Letter branding')}}
+            {{ optional_text_field(current_service.letter_branding.name) }}
+            {{ edit_field('Change', url_for('.service_set_letter_branding', service_id=current_service.id)) }}
+          {% endcall %}
+          {% call row() %}
+            {{ text_field('Data retention')}}
+            {% call field() %}
+                {{ current_service.data_retention | join(', ', attribute='notification_type') }}
+            {% endcall %}
+            {{ edit_field('Change', url_for('.data_retention', service_id=current_service.id)) }}
+          {% endcall %}
+
+          {% for permission in service_permissions %}
+            {% if not service_permissions[permission].requires or current_service.has_permission(service_permissions[permission].requires) %}
+              {% call row() %}
+                {{ text_field(service_permissions[permission].title)}}
+                {{ boolean_field(current_service.has_permission(permission)) }}
+                {{ edit_field('Change', url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None)) }}
+              {% endcall %}
+            {% endif %}
+          {% endfor %}
+
         {% endcall %}
 
-        {% for permission in service_permissions %}
-          {% if not service_permissions[permission].requires or current_service.has_permission(service_permissions[permission].requires) %}
-            {% call row() %}
-              {{ text_field(service_permissions[permission].title)}}
-              {{ boolean_field(current_service.has_permission(permission)) }}
-              {{ edit_field('Change', url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None)) }}
-            {% endcall %}
+        <ul>
+          {% if current_service.active %}
+            <li class="bottom-gutter">
+              <a href="{{ url_for('.archive_service', service_id=current_service.id) }}" class="button">
+                Archive service
+              </a>
+            </li>
+            <li class="bottom-gutter">
+              <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="button">
+                Suspend service
+              </a>
+            </li>
+          {% else %}
+            <li class="bottom-gutter">
+              <a href="{{ url_for('.resume_service', service_id=current_service.id) }}" class="button">
+                Resume service
+              </a>
+            </li>
           {% endif %}
-        {% endfor %}
-
-      {% endcall %}
-
-      <ul>
-        {% if current_service.active %}
-          <li class="bottom-gutter">
-            <a href="{{ url_for('.archive_service', service_id=current_service.id) }}" class="button">
-              Archive service
-            </a>
-          </li>
-          <li class="bottom-gutter">
-            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="button">
-              Suspend service
-            </a>
-          </li>
-        {% else %}
-          <li class="bottom-gutter">
-            <a href="{{ url_for('.resume_service', service_id=current_service.id) }}" class="button">
-              Resume service
-            </a>
-          </li>
-        {% endif %}
-      </ul>
+        </ul>
+      </div>
 
     {% endif %}
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -92,16 +92,29 @@ def test_service_setting_toggles_show(get_service_settings_page, service_one, se
     assert normalize_spaces(page.find('a', {'href': button_url}).find_parent('tr').text.strip()) == text
 
 
-@pytest.mark.parametrize('service_fields, endpoint, kwargs, text', [
-    ({'active': True}, '.archive_service', {}, 'Archive service'),
-    ({'active': True}, '.suspend_service', {}, 'Suspend service'),
-    ({'active': False}, '.resume_service', {}, 'Resume service'),
+@pytest.mark.parametrize('service_fields, endpoint, index, text', [
+    ({'active': True}, '.archive_service', 0, 'Archive service'),
+    ({'active': True}, '.suspend_service', 1, 'Suspend service'),
+    ({'active': False}, '.resume_service', 0, 'Resume service'),
+    pytest.param(
+        {'active': False}, '.archive_service', 1, 'Resume service',
+        marks=pytest.mark.xfail(raises=IndexError)
+    )
 ])
-def test_service_setting_button_toggles(get_service_settings_page, service_one, service_fields, endpoint, kwargs, text):
-    button_url = url_for(endpoint, **kwargs, service_id=service_one['id'])
+def test_service_setting_button_toggles(
+    get_service_settings_page,
+    service_one,
+    service_fields,
+    endpoint,
+    index,
+    text,
+):
+    button_url = url_for(endpoint, service_id=service_one['id'])
     service_one.update(service_fields)
     page = get_service_settings_page()
-    assert normalize_spaces(page.find('a', {'class': 'button', 'href': button_url}).text.strip()) == text
+    link = page.select('.page-footer-delete-link a')[index]
+    assert normalize_spaces(link.text) == text
+    assert link['href'] == button_url
 
 
 @pytest.mark.parametrize('permissions,permissions_text,visible', [

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -569,7 +569,7 @@ def test_monthly_shows_letters_in_breakdown(
         service_id=service_one['id']
     )
 
-    columns = page.select('.table-field-center-aligned .big-number-label')
+    columns = page.select('.table-field-left-aligned .big-number-label')
 
     assert normalize_spaces(columns[0].text) == 'emails'
     assert normalize_spaces(columns[1].text) == 'text messages'

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -656,10 +656,10 @@ def test_upload_valid_csv_shows_preview_and_table(
 
     for row_index, row in enumerate([
         (
-            '<td class="table-field-center-aligned"> <div class=""> 07700900001 </div> </td>',
-            '<td class="table-field-center-aligned"> <div class=""> A </div> </td>',
+            '<td class="table-field-left-aligned"> <div class=""> 07700900001 </div> </td>',
+            '<td class="table-field-left-aligned"> <div class=""> A </div> </td>',
             (
-                '<td class="table-field-center-aligned"> '
+                '<td class="table-field-left-aligned"> '
                 '<div class="table-field-status-default"> '
                 '<ul> '
                 '<li>foo</li> <li>foo</li> <li>foo</li> '
@@ -669,10 +669,10 @@ def test_upload_valid_csv_shows_preview_and_table(
             )
         ),
         (
-            '<td class="table-field-center-aligned"> <div class=""> 07700900002 </div> </td>',
-            '<td class="table-field-center-aligned"> <div class=""> B </div> </td>',
+            '<td class="table-field-left-aligned"> <div class=""> 07700900002 </div> </td>',
+            '<td class="table-field-left-aligned"> <div class=""> B </div> </td>',
             (
-                '<td class="table-field-center-aligned"> '
+                '<td class="table-field-left-aligned"> '
                 '<div class="table-field-status-default"> '
                 '<ul> '
                 '<li>foo</li> <li>foo</li> <li>foo</li> '
@@ -682,10 +682,10 @@ def test_upload_valid_csv_shows_preview_and_table(
             )
         ),
         (
-            '<td class="table-field-center-aligned"> <div class=""> 07700900003 </div> </td>',
-            '<td class="table-field-center-aligned"> <div class=""> C </div> </td>',
+            '<td class="table-field-left-aligned"> <div class=""> 07700900003 </div> </td>',
+            '<td class="table-field-left-aligned"> <div class=""> C </div> </td>',
             (
-                '<td class="table-field-center-aligned"> '
+                '<td class="table-field-left-aligned"> '
                 '<div class="table-field-status-default"> '
                 '<ul> '
                 '<li>foo</li> <li>foo</li> '

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -661,7 +661,7 @@ def test_upload_valid_csv_shows_preview_and_table(
             (
                 '<td class="table-field-center-aligned"> '
                 '<div class="table-field-status-default"> '
-                '<ul class="list list-bullet"> '
+                '<ul> '
                 '<li>foo</li> <li>foo</li> <li>foo</li> '
                 '</ul> '
                 '</div> '
@@ -674,7 +674,7 @@ def test_upload_valid_csv_shows_preview_and_table(
             (
                 '<td class="table-field-center-aligned"> '
                 '<div class="table-field-status-default"> '
-                '<ul class="list list-bullet"> '
+                '<ul> '
                 '<li>foo</li> <li>foo</li> <li>foo</li> '
                 '</ul> '
                 '</div> '
@@ -687,7 +687,7 @@ def test_upload_valid_csv_shows_preview_and_table(
             (
                 '<td class="table-field-center-aligned"> '
                 '<div class="table-field-status-default"> '
-                '<ul class="list list-bullet"> '
+                '<ul> '
                 '<li>foo</li> <li>foo</li> '
                 '</ul> '
                 '</div> '


### PR DESCRIPTION
Before | After
---|---
![b4](https://user-images.githubusercontent.com/355079/56669246-c0669d00-66a8-11e9-8fc9-856a96d517aa.png) | ![localhost_6012_services_42a9d4f2-1444-4e22-9133-52d9e406213f_service-settings(iPad) (1)](https://user-images.githubusercontent.com/355079/56670850-792ddb80-66ab-11e9-8b04-679e3770b83c.png)

Most of the content of our ‘settings’ tables is in the value, not the key. The value is in the middle column. So we should allocate the most space to the value.

The previous layout was based on the premise that most pages divided the grid like this:
```
 _______ _______ _______ _______ _______ _______ _______ _______
|  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |
|               |               |               |               |
|      2/8      |      2/8      |      2/8      |      2/8      |
|               |               |               |               |
|–Navigation––––|–Main column–––––––––––––––––––––––––––––––––––|
|               |                       |                       |
|               |          3/8          |          3/8          |
|               |                       |                       |
|               | Label                 | Value            Link |
|               |                       |                       |
|_______________|_______________________|_______________________|
```

This was because a lot of pages had a left column for emails, and a right column for text messages, so it felt consistent for tables to always default to 50% of the width of the main column.

This consistency has faded with time, especially as we added letters.

So this commit changes these tables to allocate more space to the central column, but still sticking to the grid like this:

```
 _______ _______ _______ _______ _______ _______ _______ _______
|  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |  1/8  |
|       |       |       |       |       |       |       |       |
|      2/8      |      2/8      |              4/8              |
|               |               |                               |
|–Navigation––––|–Main column–––––––––––––––––––––––––––––––––––|
|               |               |                       |       |
|               |      2/8      |          3/8          |  1/8  |
|               |               |                       |       |
|               | Label         | Value                 |   Link|
|               |               |                       |       |
|_______________|_______________|_______________________|_______|
```

Since there’s more space to display the value of a setting this commit also truncates settings that are too long to fit in the width of the column (for example a long email address) rather than the previous
behaviour of truncating them. This all just makes things look a bit cleaner.

