### PR TITLE
Update documentation.html

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -25,6 +25,7 @@
       <li><a href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
+    <p>We recommend that you use these client libraries rather than use the <a href="https://github.com/alphagov/notifications-api" target="blank">GOV.UK Notify API</a> directly, as there is no documentation for using the API in this way.</p>
   </div>
 </div>
 


### PR DESCRIPTION
There have been multiple support tickets asking how to use the API directly instead of the API clients. This PR adds a statement recommending that users use the API clients instead of the API directly due to lack of documentation.