### PR TITLE
Bump utils to 31.2.5

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.4#egg=notifications-utils==31.2.4
+git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@31.2.4#egg=notifications-utils==31.2.4
+git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.140
+awscli==1.16.145
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.130
+botocore==1.12.135
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
@@ -44,7 +44,7 @@ Flask-Redis==0.3.0
 future==0.17.1
 greenlet==0.4.15
 idna==2.8
-jdcal==1.4
+jdcal==1.4.1
 Jinja2==2.10.1
 jmespath==0.9.4
 lml==0.0.9
@@ -70,7 +70,7 @@ six==1.12.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.1
-urllib3==1.24.1
+urllib3==1.24.2
 webencodings==0.5.1
 Werkzeug==0.15.2
 WTForms==2.2.1


### PR DESCRIPTION
This will ensure that both api and admin are using the same version of the RecipientCSV class from notifications-utils.