### PR TITLE
Rationalise heading sizes and ‘Back’ links

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -104,7 +104,7 @@
 
 .align-with-heading-copy-right {
   display: block;
-  margin-top: 35px;
+  margin: 21px 0 19px 0;
   text-align: right;
 }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -75,7 +75,7 @@ a {
 
   .heading-large,
   > .heading-medium {
-    margin: 10px 0 15px 0;
+    margin: ($gutter / 3) 0 ($gutter / 3 * 2) 0;
     word-wrap: break-word;
   }
 
@@ -273,4 +273,8 @@ details .arrow {
 
 .nowrap {
   white-space: nowrap;
+}
+
+.heading-upcoming-jobs {
+  margin-top: $gutter / 3;
 }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -238,7 +238,7 @@
     text-align: right;
     padding: $gutter-two-thirds 0 0 0;
     position: relative;
-    top: -1px;
+    top: -6px;
   }
 
 }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -151,10 +151,6 @@
 
 .folder-heading {
 
-  .column-main>.grid-row:first-child &.heading-medium {
-    margin-top: $gutter-half;
-  }
-
   a,
   &-folder,
   &-subfolder {
@@ -241,6 +237,8 @@
     display: block;
     text-align: right;
     padding: $gutter-two-thirds 0 0 0;
+    position: relative;
+    top: -1px;
   }
 
 }

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -3,20 +3,6 @@
   position: relative;
   margin-bottom: 30px;
 
-  &-back-link {
-
-    @include button($grey-1);
-    display: inline-block;
-
-    @include media('mobile') {
-      box-sizing: border-box;
-      width: 100%;
-      margin-top: $gutter-half;
-      text-align: center;
-    }
-
-  }
-
   &-delete-link {
 
     line-height: 40px;

--- a/app/assets/stylesheets/components/vendor/govuk-back-link.scss
+++ b/app/assets/stylesheets/components/vendor/govuk-back-link.scss
@@ -32,4 +32,22 @@
     left: 0;
     margin: auto;
   }
+
+  &:after {
+    content: "";
+    position: absolute;
+    top: -$gutter-half;
+    left: -3px;
+    width: 100%;
+    height: 100%;
+    border-style: solid;
+    border-width: $gutter-half $gutter $gutter-half 3px;
+    border-color: transparent;
+  }
+
+  &:focus {
+    &:after {
+      border-color: $yellow
+    }
+  }
 }

--- a/app/assets/stylesheets/components/vendor/govuk-back-link.scss
+++ b/app/assets/stylesheets/components/vendor/govuk-back-link.scss
@@ -1,0 +1,35 @@
+.govuk-back-link {
+
+  @include core-16;
+  color: $text-colour;
+  display: inline-block;
+  position: relative;
+  margin-top: $gutter-half;
+  margin-bottom: $gutter / 3;
+  padding-left: $gutter-half - 1px;
+  border-bottom: 1px solid $text-colour;
+  text-decoration: none;
+
+  &:link,
+  &:visited {
+    color: $text-colour;
+  }
+
+  &:before {
+    display: block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+    clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+    border-width: 5px 6px 5px 0;
+    border-right-color: inherit;
+    content: "";
+    position: absolute;
+    top: -1px;
+    bottom: 1px;
+    left: 0;
+    margin: auto;
+  }
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -65,6 +65,7 @@ $path: '/static/images/';
 @import 'components/vendor/responsive-embed';
 @import 'components/preview-pane';
 @import 'components/task-list';
+@import 'components/vendor/govuk-back-link';
 
 @import 'views/dashboard';
 @import 'views/users';

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -409,7 +409,7 @@ def copy_template(service_id, template_id):
     return render_template(
         'views/edit-{}-template.html'.format(template['template_type']),
         form=form,
-        template_type=template['template_type'],
+        template=template,
         heading_action='Add',
         services=user_api_client.get_service_ids_for_user(current_user),
     )
@@ -570,6 +570,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
             '.action_blocked',
             service_id=service_id,
             notification_type=template_type,
+            template_folder_id=template_folder_id,
             return_to='templates',
             template_id='0'
         ))
@@ -578,6 +579,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
             'views/edit-{}-template.html'.format(template_type),
             form=form,
             template_type=template_type,
+            template_folder_id=template_folder_id,
             heading_action='New',
         )
 
@@ -665,8 +667,7 @@ def edit_service_template(service_id, template_id):
         return render_template(
             'views/edit-{}-template.html'.format(template['template_type']),
             form=form,
-            template_id=template_id,
-            template_type=template['template_type'],
+            template=template,
             heading_action='Edit',
         )
 

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -8,7 +8,7 @@
   link_current_item=False
 ) %}
   {% if show_fallback_page_title %}
-    <h1 class="heading-large">
+    <h1 class="heading-medium">
       {{ fallback_page_title }}
     </h1>
   {% else %}

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -3,8 +3,6 @@
   button_name=None,
   button_value=None,
   destructive=False,
-  back_link=False,
-  back_link_text="Back",
   secondary_link=False,
   secondary_link_text=None,
   delete_link=False,
@@ -21,9 +19,6 @@
       >
         {{- button_text -}}
       </button>
-    {% endif %}
-    {% if back_link %}
-      <a class="page-footer-back-link" href="{{ back_link }}">{{ back_link_text }}</a>
     {% endif %}
     {% if delete_link %}
       <span class="page-footer-delete-link {% if not button_text %}page-footer-delete-link-without-button{% endif %}">

--- a/app/templates/components/page-header.html
+++ b/app/templates/components/page-header.html
@@ -1,0 +1,19 @@
+{% macro page_header(
+  h1,
+  back_link=None
+) %}
+
+  {% if back_link %}
+    {{ govuk_back_link(back_link) }}
+  {% endif %}
+
+  <h1 class="heading-large">{{ h1 }}</h1>
+
+{% endmacro %}
+
+
+{% macro govuk_back_link(back_link) %}
+
+  <a class="govuk-back-link" href="{{ back_link }}">Back</a>
+
+{% endmacro %}

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -1,6 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/radios.html" import radios %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -13,9 +14,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
 
-    <h1 class="heading-large">
-      About your service
-    </h1>
+    {{ page_header('About your service') }}
 
     {% call form_wrapper() %}
 

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -22,13 +22,13 @@
 	    caption_visible=False
 	  ) %}
 	    {% call row() %}
-	      {{ text_field('Callbacks for delivery receipts') }}
+	      {{ text_field('Delivery receipts') }}
 	      {{ optional_text_field(delivery_status_callback, truncate=true) }}
 	      {{ edit_field('Change', url_for('.delivery_status_callback', service_id=current_service.id)) }}
 	    {% endcall %}
 
 	    {% call row() %}
-	      {{ text_field('Callbacks for received text messages') }}
+	      {{ text_field('Received text messages') }}
           {{ optional_text_field(received_text_messages_callback, truncate=true) }}
 	   	  {{ edit_field('Change', url_for('.received_text_messages_callback', service_id=current_service.id)) }}
 	    {% endcall %}

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field with context %}
 
@@ -9,7 +10,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Callbacks</h1>
+  {{ page_header(
+    'Callbacks',
+    back_link=url_for('main.api_integration', service_id=current_service.id)
+  ) }}
   <div class="bottom-gutter-3-2 dashboard-table body-copy-table">
 		{% call mapping_table(
 	    caption='General',
@@ -30,8 +34,4 @@
 	    {% endcall %}
 	  {% endcall %}
 	</div>
-  {{ page_footer(
-    secondary_link=url_for('.api_integration', service_id=current_service.id),
-    secondary_link_text='Back to API integration'
-  ) }}
 {% endblock %}

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,12 @@
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Callbacks for delivery receipts</h1>
+
+      {{ page_header(
+        'Callbacks for delivery receipts',
+        back_link=url_for(back_link, service_id=current_service.id)
+      ) }}
+
       <p>
         When you send an email or text message, we can tell you if Notify was able to deliver it.
         Check the <a href="{{ url_for('.callbacks') }}"> callback documentation </a> for more information.
@@ -27,11 +33,6 @@
           width='1-1',
           hint='At least 10 characters',
           autocomplete='new-password'
-        ) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for(back_link, service_id=current_service.id),
-          back_link_text='Back to settings'
         ) }}
       {% endcall %}
     </div>

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -8,7 +9,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Callbacks for received text messages</h1>
+  {{ page_header(
+    'Callbacks for received text messages',
+    back_link=url_for('.api_callbacks', service_id=current_service.id)
+  ) }}
   <div class="grid-row">
     <div class="column-five-sixths">
       <p>
@@ -28,11 +32,7 @@
           hint='At least 10 characters',
           autocomplete='new-password'
         ) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.api_callbacks', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large bottom-gutter">
+  <h1 class="heading-medium bottom-gutter-3-2">
     API integration
   </h1>
 
@@ -28,7 +28,7 @@
 
   <div class="grid-row">
     <div class="column-half">
-      <h2 class="heading-medium">
+      <h2 class="heading-small">
         Message log
       </h2>
     </div>

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -2,6 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/api-key.html" import api_key %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    API keys
-  </h1>
+  {{ page_header(
+    'API keys',
+    back_link=url_for('main.api_integration', service_id=current_service.id)
+  ) }}
 
   <div class="body-copy-table">
     {% call(item, row_number) list_table(

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/radios.html" import radios %}
@@ -11,9 +12,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Create an API key
-  </h1>
+  {{ page_header(
+    'Create an API key',
+    back_link=url_for('main.api_keys', service_id=current_service.id)
+  ) }}
 
   {% call form_wrapper() %}
     {{ textbox(form.key_name, label='Name for this key') }}

--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -2,6 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/api-key.html" import api_key %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list-entry.html" import list_entry %}
 {% from "components/form.html" import form_wrapper %}
@@ -32,9 +33,10 @@
       </ul>
     {% endcall %}
   {% else %}
-    <h1 class="heading-large">
-      Whitelist
-    </h1>
+    {{ page_header(
+      'Whitelist',
+      back_link=url_for('main.api_integration', service_id=current_service.id)
+    ) }}
   {% endif %}
 
   <p>
@@ -63,11 +65,7 @@
       </div>
     </div>
 
-    {{ page_footer(
-      'Save',
-      secondary_link=url_for('.api_integration', service_id=current_service.id),
-      secondary_link_text='Back to API integration'
-    ) }}
+    {{ page_footer('Save') }}
 
   {% endcall %}
 

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import govuk_back_link %}
 {% from "components/message-count-label.html" import message_count_label %}
 
 {% set file_contents_header_id = 'file-preview' %}
@@ -19,7 +19,9 @@
 
 {% block maincolumn_content %}
 
-  <div class="bottom-gutter">
+  {{ govuk_back_link(back_link) }}
+
+  <div class="bottom-gutter-1-2">
     {% call banner_wrapper(type='dangerous') %}
 
       {% if recipients.too_many_rows %}
@@ -135,9 +137,7 @@
 
   <div class="js-stick-at-top-when-scrolling">
     <div class="form-group">
-      {% if request.args.from_test %}
-        <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
-      {% else %}
+      {% if not request.args.from_test %}
         {{ file_upload(
           form.file,
           action=url_for('.send_messages', service_id=current_service.id, template_id=template.id),

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -3,6 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/message-count-label.html" import message_count_label %}
 
@@ -19,9 +20,11 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Preview of {{ template.name }}
-  </h1>
+  {{ page_header(
+    'Preview of {}'.format(template.name),
+    back_link=back_link
+  ) }}
+
   {{ skip_to_file_contents() }}
 
   {{ template|string }}
@@ -41,7 +44,6 @@
       {% else %}
         <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_id=template.id, upload_id=upload_id, filetype='pdf') }}" download class="button">Download as a PDF</a>
       {% endif %}
-      <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
     </form>
   </div>
 

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import govuk_back_link %}
 {% from "components/message-count-label.html" import message_count_label %}
 
 {% set file_contents_header_id = 'file-preview' %}
@@ -18,6 +18,8 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+
+  {{ govuk_back_link(back_link) }}
 
   <div class="bottom-gutter-1-2">
     {% call banner_wrapper(type='dangerous') %}

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -6,7 +6,7 @@
   {% if scheduled_jobs %}
     <div class='dashboard-table'>
       {% if not hide_heading %}
-        <h2 class="heading-medium">
+        <h2 class="heading-medium heading-upcoming-jobs">
           In the next few days
         </h2>
       {% endif %}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ heading_action }} email template
-    </h1>
+    {{ page_header(
+      '{} email template'.format(heading_action),
+      back_link=url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    ) }}
 
     {% call form_wrapper() %}
       <div class="grid-row">

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ heading_action }} letter template
-    </h1>
+    {{ page_header(
+      '{} letter template'.format(heading_action),
+      back_link=url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    ) }}
 
     {% call form_wrapper() %}
       <div class="grid-row">

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ heading_action }} text message template
-    </h1>
+    {{ page_header(
+      '{} text message template'.format(heading_action),
+      back_link=url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    ) }}
 
     {% call form_wrapper() %}
       <div class="grid-row">

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
@@ -18,9 +19,10 @@
     ) }}
   {% endif %}
 
-  <h1 class="heading-large">
-    {{ user.name or user.email_localpart }}
-  </h1>
+  {{ page_header(
+    user.name or user.email_localpart,
+    back_link=url_for('main.manage_users', service_id=current_service.id)
+  ) }}
 
   <p>
     {{ user.email_address }}&emsp;<a href="{{ url_for('.edit_user_email', service_id=current_service.id, user_id=user.id)}}">Change</a>

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -1,5 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/file-upload.html" import file_upload %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/radios.html" import radios %}
@@ -11,7 +12,10 @@
 
 {% block platform_admin_content %}
 
-  <h1 class="heading-large">{{ '{} email branding'.format('Update' if email_branding else 'Add')}}</h1>
+  {{ page_header(
+    '{} email branding'.format('Update' if email_branding else 'Add'),
+    back_link=url_for('.email_branding')
+  ) }}
   <div class="grid-row">
     <div class="column-three-quarters">
       {% if logo %}
@@ -32,9 +36,7 @@
           {{ page_footer(
             'Save',
             button_name='operation',
-            button_value='email-branding-details',
-            back_link=url_for('.email_branding'),
-            back_link_text='Back to email branding selection',
+            button_value='email-branding-details'
           ) }}
         </div>
       {% endcall %}

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/checkbox.html" import checkbox %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Invite a team member
-  </h1>
+  {{ page_header(
+    'Invite a team member',
+    back_link=url_for('main.manage_users', service_id=current_service.id)
+  ) }}
 
   {% call form_wrapper() %}
 

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -1,5 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/file-upload.html" import file_upload %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/form.html" import form_wrapper %}
@@ -11,6 +12,10 @@
 {% block platform_admin_content %}
 
   <h1 class="heading-large">{{ '{} letter branding'.format('Update' if is_update else 'Add')}}</h1>
+  {{ page_header(
+    '{} letter branding'.format('Update' if is_update else 'Add'),
+    back_link=url_for('main.letter_branding')
+  ) }}
   <div class="grid-row">
     <div class="column-three-quarters">
       {% if logo %}
@@ -28,9 +33,7 @@
           {{ page_footer(
             'Save',
             button_name='operation',
-            button_value='branding-details',
-            back_link=url_for('main.letter_branding'),
-            back_link_text='Back to letter branding selection',
+            button_value='branding-details'
           ) }}
         </div>
       {% endcall %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
+  <h1 class="heading-medium">
     Team members
   </h1>
 

--- a/app/templates/views/manage-users/confirm-edit-user-email.html
+++ b/app/templates/views/manage-users/confirm-edit-user-email.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -8,7 +9,10 @@
 
 {% block maincolumn_content %}
 
-<h1 class="heading-large">Confirm change of email address</h1>
+{{ page_header(
+  'Confirm change of email address',
+  url_for('.edit_user_email', service_id=service_id, user_id=user.id)
+) }}
 
 <div class="grid-row">
   <div class="column-whole">
@@ -18,11 +22,7 @@
       <p>{{ new_email }}</p>
     </div>
     <p>We will send {{ user.name }} an email to tell them about the change.</p>
-    {{ page_footer(
-      'Confirm',
-      destructive=destructive,
-      back_link=url_for('.edit_user_email', service_id=service_id, user_id=user.id)
-    ) }}
+    {{ page_footer('Confirm') }}
   {% endcall %}
   </div>
 </div>

--- a/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
+++ b/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -8,7 +9,10 @@
 
 {% block maincolumn_content %}
 
-<h1 class="heading-large">Confirm change of mobile number</h1>
+{{ page_header(
+  'Confirm change of mobile number',
+  back_link=url_for('.edit_user_mobile_number', service_id=service_id, user_id=user.id)
+) }}
 
 <div class="grid-row">
   <div class="column-whole">
@@ -18,11 +22,7 @@
       <p>{{ new_mobile_number }}</p>
     </div>
     <p>We will send {{ user.name }} a text message to tell them about the change.</p>
-    {{ page_footer(
-      'Confirm',
-      destructive=destructive,
-      back_link=url_for('.edit_user_mobile_number', service_id=service_id, user_id=user.id)
-    ) }}
+    {{ page_footer('Confirm') }}
   {% endcall %}
   </div>
 </div>

--- a/app/templates/views/manage-users/edit-user-email.html
+++ b/app/templates/views/manage-users/edit-user-email.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,19 +10,15 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change team member’s email address</h1>
+  {{ page_header(
+    'Change team member’s email address',
+    back_link=url_for('main.edit_user_permissions', service_id=current_service.id, user_id=user.id)
+  ) }}
+
   <p id="user_name">This will change the email address for {{ user.name }}.</p>
-  <div class="grid-row">
-    <div class="column-three-quarters">
-      {% call form_wrapper() %}
-        {{ textbox(form.email_address, safe_error_message=True) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.edit_user_permissions', service_id=service_id, user_id=user.id),
-          back_link_text="Back"
-        ) }}
-      {% endcall %}
-    </div>
-  </div>
+  {% call form_wrapper() %}
+    {{ textbox(form.email_address, width='1-1', safe_error_message=True) }}
+    {{ page_footer('Save') }}
+  {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/manage-users/edit-user-mobile.html
+++ b/app/templates/views/manage-users/edit-user-mobile.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,17 +10,17 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change team member’s mobile number</h1>
+  {{ page_header(
+    'Change team member’s mobile number',
+    back_link=url_for('main.edit_user_permissions', service_id=current_service.id, user_id=user.id)
+  ) }}
+
   <p id="user_name">This will change the mobile number for {{ user.name }}.</p>
   <div class="grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper(class="extra-tracking") %}
         {{ textbox(form.mobile_number) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.edit_user_permissions', service_id=service_id, user_id=user.id),
-          back_link_text="Back"
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/message-count-label.html" import message_count_label %}
+{% from "components/page-header.html" import govuk_back_link, page_header %}
 
 {% block service_page_title %}
   {{ "Error" if error else "Preview of ‘{}’".format(template.name) }}
@@ -8,6 +9,7 @@
 
 {% block maincolumn_content %}
   {% if template.template_type == 'letter' and current_service.trial_mode %}
+    {{ govuk_back_link(back_link) }}
     {% set error = 'trial-mode-letters' %}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
@@ -19,6 +21,7 @@
       {% endcall %}
     </div>
   {% elif error == 'not-allowed-to-send-to' %}
+    {{ govuk_back_link(back_link) }}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% with
@@ -32,6 +35,7 @@
       {% endcall %}
     </div>
   {% elif error == 'too-many-messages' %}
+    {{ govuk_back_link(back_link) }}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% include "partials/check/too-many-messages.html" %}
@@ -39,15 +43,17 @@
     </div>
   {% elif error == 'message-too-long' %}
     {# the only row_errors we can get when sending one off messages is that the message is too long #}
+    {{ govuk_back_link(back_link) }}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% include "partials/check/message-too-long.html" %}
       {% endcall %}
     </div>
   {% else %}
-    <h1 class="heading-large">
-      Preview of ‘{{ template.name }}’
-    </h1>
+    {{ page_header(
+      'Preview of ‘{}’'.format(template.name),
+      back_link=back_link
+    ) }}
   {% endif %}
 
   {{ template|string }}
@@ -63,7 +69,6 @@
       {% if not error %}
         <button type="submit" class="button">Send 1 {{ message_count_label(1, template.template_type, suffix='') }}</button>
       {% endif %}
-      <a href="{{ back_link }}" class="page-footer-back-link">Back</a>
       {% if template.template_type == 'letter' %}
         <a href="{{ url_for('main.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="page-footer-right-aligned-link">Download as a PDF</a>
       {% endif %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -2,6 +2,7 @@
 {% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/message-count-label.html" import message_count_label %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ message_count_label(1, template.template_type, suffix='') | capitalize }}
-    </h1>
+    {{ page_header(
+      message_count_label(1, template.template_type, suffix='') | capitalize,
+      back_link=None if request.args.get('help') == '0' else url_for('main.view_notifications', service_id=current_service.id, message_type=template.template_type)
+    ) }}
 
     <p>
       {% if is_precompiled_letter %}

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -1,4 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/form.html" import form_wrapper %}
@@ -13,14 +14,14 @@
 
 {% block platform_admin_content %}
 
-  <h1 class="heading-large">New organisation</h1>
+  {{ page_header(
+    'New organisation',
+    back_link=url_for('.organisations')
+  ) }}
+
   {% call form_wrapper() %}
     {{textbox(form.name)}}
-    {{ page_footer(
-      'Save',
-      back_link=url_for('.organisations'),
-      back_link_text='Back to organisations',
-    ) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -6,7 +6,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
+  <h1 class="heading-medium">
     Services
   </h1>
   <ul>

--- a/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
@@ -1,5 +1,6 @@
 {% extends "org_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,7 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Confirm organisation name change</h1>
+  {{ page_header(
+    'Confirm organisation name change',
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
 
   <div class="grid-row">
     <div class="column-three-quarters">
@@ -17,11 +21,7 @@
     {% call form_wrapper() %}
       {{ textbox(form.password) }}
       <p> Your organisation name will be changed from {{ current_org.name }} to {{ new_name }} </p>
-      {{ page_footer(
-        'Confirm',
-        destructive=destructive,
-        back_link=url_for('.organisation_settings', org_id=current_org.id)
-      ) }}
+      {{ page_footer('Confirm') }}
     {% endcall %}
     </div>
   </div>

--- a/app/templates/views/organisations/organisation/settings/edit-name/index.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/index.html
@@ -1,4 +1,5 @@
 {% extends "org_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/form.html" import form_wrapper %}
@@ -9,14 +10,14 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change organisation name</h1>
+  {{ page_header(
+    'Change organisation name',
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
+
   {% call form_wrapper() %}
     {{textbox(form.name)}}
-    {{ page_footer(
-      'Save',
-      back_link=url_for('.organisation_settings', org_id=current_org.id),
-      back_link_text='Back to settings',
-    ) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Settings</h1>
+  <h1 class="heading-medium">Settings</h1>
   <div class="bottom-gutter-3-2 settings-table body-copy-table">
     {% call mapping_table(
       caption='General',

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
+  <h1 class="heading-medium">
     Team members
   </h1>
 

--- a/app/templates/views/organisations/organisation/users/user/index.html
+++ b/app/templates/views/organisations/organisation/users/user/index.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,9 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    {{ user.name or user.email_localpart }}
-  </h1>
+  {{ page_header(
+    user.name or user.email_localpart,
+    back_link=url_for('.manage_org_users', org_id=current_org.id)
+  ) }}
 
   <p>
     {{ user.email_address }}
@@ -20,8 +22,6 @@
   {% call form_wrapper(class="column-three-quarters") %}
       {{ page_footer(
         'Save',
-        back_link=url_for('.manage_org_users', org_id=current_org.id),
-        back_link_text="Back",
         delete_link=url_for('.remove_user_from_organisation', org_id=current_org.id, user_id=user.id) if user or None,
         delete_link_text='Remove user from organisation'
       ) }}

--- a/app/templates/views/providers/edit-provider.html
+++ b/app/templates/views/providers/edit-provider.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -12,7 +13,10 @@ Provider - {{provider.display_name}}
 <div class="grid-row">
     <div class="column-three-quarters">
 
-        <h1 class="heading-large">{{provider.display_name}}</h1>
+        {{ page_header(
+          provider.display_name,
+          back_link=url_for('.view_providers')
+        ) }}
 
         <p>Update provider:</p>
 
@@ -22,7 +26,7 @@ Provider - {{provider.display_name}}
 
         {% call form_wrapper() %}
             {{ textbox(form.priority) }}
-            {{ page_footer('Save', back_link=url_for('.view_providers'), back_link_text="Back to providers") }}
+            {{ page_footer('Save') }}
         {% endcall %}
 
     </div>

--- a/app/templates/views/providers/provider.html
+++ b/app/templates/views/providers/provider.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
@@ -9,8 +10,12 @@ Provider versions
 {% block maincolumn_content %}
 
 <div class="grid-row">
-    <div class="column-two-thirds">
-        <h1 class="heading-large">{{ provider_versions[0].display_name }}</h1>
+  <div class="column-two-thirds">
+
+    {{ page_header(
+      provider_versions[0].display_name,
+      back_link=url_for('main.view_providers')
+    ) }}
 
     {% call(item, row_number) list_table(
         provider_versions,
@@ -40,11 +45,6 @@ Provider versions
         {{ text_field(item.active) }}
 
       {% endcall %}
-
-    {{ page_footer(
-      back_link=url_for('main.view_providers'),
-      back_link_text="Back to providers"
-    ) }}
 
     </div>
 </div>

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/message-count-label.html" import recipient_count_label %}
 {% from "components/textbox.html" import textbox %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    {{ page_title }}
-  </h1>
+  {{ page_header(
+    page_title,
+    back_link=back_link
+  ) }}
 
   {% call form_wrapper(
     class='js-stick-at-top-when-scrolling send-one-off-form' if template.template_type != 'sms' else 'send-one-off-form',
@@ -40,7 +42,7 @@
         </a>
       </p>
     {% endif %}
-    {{ page_footer('Continue', back_link=back_link) }}
+    {{ page_footer('Continue') }}
   {% endcall %}
 
   {{ template|string }}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/message-count-label.html" import recipient_count_label %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Upload a list of {{ recipient_count_label(999, template.template_type) }}
-  </h1>
+  {{ page_header(
+    'Upload a list of {}'.format(recipient_count_label(999, template.template_type)),
+    back_link=url_for('main.send_one_off', service_id=current_service.id, template_id=template.id)
+  ) }}
 
   <div class="page-footer bottom-gutter">
     {{file_upload(

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -8,7 +8,7 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">Settings</h1>
+    <h1 class="heading-medium">Settings</h1>
 
     <div class="bottom-gutter-3-2 settings-table body-copy-table">
 
@@ -61,7 +61,7 @@
       {% endcall %}
 
       {% call mapping_table(
-        caption='Email',
+        caption='Email settings',
         field_headings=['Label', 'Value', 'Action'],
         field_headings_visible=False,
         caption_visible=True
@@ -113,7 +113,7 @@
       {% endcall %}
 
       {% call mapping_table(
-        caption='Text messages',
+        caption='Text message settings',
         field_headings=['Label', 'Value', 'Action'],
         field_headings_visible=False,
         caption_visible=True
@@ -191,7 +191,7 @@
       {% endcall %}
 
       {% call mapping_table(
-        caption='Letters',
+        caption='Letter settings',
         field_headings=['Label', 'Value', 'Action'],
         field_headings_visible=False,
         caption_visible=True

--- a/app/templates/views/service-settings/branding/email-options.html
+++ b/app/templates/views/service-settings/branding/email-options.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radio %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Email branding</h1>
+  {{ page_header(
+    'Email branding',
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
 
   {% call form_wrapper() %}
     <fieldset class="form-group {% if form.options.errors %}form-group-error{% endif %} top-gutter">
@@ -37,11 +41,7 @@
       We’ll email you once your branding’s ready to use, or if we need any
       more info.
     </p>
-    {{ page_footer(
-      'Request new branding',
-      destructive=destructive,
-      back_link=url_for('.service_settings', service_id=current_service.id)
-    ) }}
+    {{ page_footer('Request new branding') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,7 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">{{ heading }}</h1>
+  {{ page_header(
+    heading,
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
 
   <div class="grid-row">
     <div class="column-three-quarters">
@@ -18,8 +22,7 @@
       {{ textbox(form.password) }}
       {{ page_footer(
         'Confirm',
-        destructive=destructive,
-        back_link=url_for('.service_settings', service_id=current_service.id)
+        destructive=destructive
       ) }}
     {% endcall %}
     </div>

--- a/app/templates/views/service-settings/contact_link.html
+++ b/app/templates/views/service-settings/contact_link.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radio %}
 {% from "components/select-input.html" import select_wrapper %}
@@ -12,9 +13,10 @@
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">
-        {{ 'Change' if 'upload_document' in current_service.permissions else 'Add' }} contact details for ‘Download your document’ page
-      </h1>
+      {{ page_header(
+        '{} contact details for ‘Download your document’ page'.format('Change' if 'upload_document' in current_service.permissions else 'Add'),
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       <p>
         When you send users a document to download, you need to include the contact details for your service
         on the download page. This is so users can contact you if there’s a problem (for example,
@@ -33,11 +35,7 @@
           {% endfor %}
         {% endcall %}
 
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/data-retention/add.html
+++ b/app/templates/views/service-settings/data-retention/add.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/radios.html" import radios %}
@@ -10,16 +11,15 @@
 
 {% block maincolumn_content %}
 
+    {{ page_header(
+      'Set data retention',
+      back_link=url_for('.add_data_retention', service_id=current_service.id)
+    ) }}
 
-  <h1 class="heading-large">Set data retention</h1>
     {% call form_wrapper() %}
       {{ radios(form.notification_type) }}
-      {{  textbox(form.days_of_retention) }}
-      {{ page_footer(
-      'Add',
-      back_link=url_for('.add_data_retention', service_id=current_service.id),
-      back_link_text='Back'
-    ) }}
+      {{ textbox(form.days_of_retention) }}
+      {{ page_footer('Add') }}
     {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/data-retention/edit.html
+++ b/app/templates/views/service-settings/data-retention/edit.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/radios.html" import radios %}
@@ -10,16 +11,14 @@
 
 {% block maincolumn_content %}
 
-
-  <h1 class="heading-large">Set data retention</h1>
+    {{ page_header(
+      'Set data retention',
+      back_link=url_for('.edit_data_retention', service_id=current_service.id, data_retention_id=data_retention_id)
+    ) }}
     {% call form_wrapper() %}
       {{ notification_type | capitalize}}
       {{  textbox(form.days_of_retention) }}
-      {{ page_footer(
-      'Save',
-      back_link=url_for('.edit_data_retention', service_id=current_service.id, data_retention_id=data_retention_id),
-      back_link_text='Back'
-    ) }}
+      {{ page_footer('Save') }}
     {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/checkbox.html" import checkbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Add email reply-to address
-  </h1>
+  {{ page_header(
+    'Add email reply-to address',
+    back_link=url_for('main.service_email_reply_to', service_id=current_service.id)
+  ) }}
   <p>
     Let recipients send replies to a shared inbox that’s managed by your team.
   </p>
@@ -30,11 +32,7 @@
         {{ checkbox(form.is_default) }}
       </div>
     {% endif %}
-    {{ page_footer(
-      'Add',
-      back_link=url_for('.service_email_reply_to', service_id=current_service.id),
-      back_link_text='Back'
-    ) }}
+    {{ page_footer('Add') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -2,6 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/checkbox.html" import checkbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -11,9 +12,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Edit email reply to address
-  </h1>
+  {{ page_header(
+    'Edit email reply to address',
+    back_link=url_for('main.service_email_reply_to', service_id=current_service.id)
+  ) }}
   {% call form_wrapper() %}
     {{ textbox(
       form.email_address,
@@ -24,19 +26,13 @@
       <p class="form-group">
         This is the default reply-to address for {{ current_service.name }} emails
       </p>
-      {{ page_footer(
-        'Save',
-        back_link=url_for('.service_email_reply_to', service_id=current_service.id),
-        back_link_text='Back'
-      ) }}
+      {{ page_footer('Save') }}
     {% else %}
       <div class="form-group">
         {{ checkbox(form.is_default) }}
       </div>
       {{ page_footer(
         'Save',
-        back_link=url_for('.service_email_reply_to', service_id=current_service.id),
-        back_link_text='Back',
         delete_link=url_for('.service_confirm_delete_email_reply_to', service_id=current_service.id, reply_to_email_id=reply_to_email_address_id),
         delete_link_text='Delete'
       ) }}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/api-key.html" import api_key %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
@@ -9,9 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Email reply-to addresses
-  </h1>
+  {{ page_header(
+    'Email reply-to addresses',
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
 
   <div class="user-list">
     {% if not current_service.email_reply_to_addresses %}

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radios %}
 {% from "components/textbox.html" import textbox %}
@@ -19,7 +20,10 @@
           </h1>
         {% endcall %}
       {% else %}
-        <h1 class="heading-large">Tell us how many messages you expect to send</h1>
+        {{ page_header(
+          'Tell us how many messages you expect to send',
+          back_link=url_for('main.request_to_go_live', service_id=current_service.id)
+        ) }}
       {% endif %}
       {% call form_wrapper() %}
         <div class="form-group">

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/api-key.html" import api_key %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
@@ -9,12 +10,11 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row bottom-gutter">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">
-        Sender addresses
-      </h1>
-    </div>
+  <div class="bottom-gutter">
+    {{ page_header(
+      'Sender addresses',
+      back_link=url_for('main.service_settings', service_id=current_service.id)
+    ) }}
   </div>
   <div class="user-list">
     {% if not letter_contact_details %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/checkbox.html" import checkbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Add a new address
-  </h1>
+  {{ page_header(
+    'Add a new address',
+    back_link=None if request.args.get('from_template') else url_for('.service_letter_contact_details', service_id=current_service.id)
+  ) }}
   <div class="grid-row">
     <div class="column-whole">
       {% call form_wrapper() %}
@@ -29,11 +31,7 @@
             {{ checkbox(form.is_default) }}
           </div>
         {% endif %}
-        {{ page_footer(
-          'Add',
-          back_link=None if request.args.get('from_template') else url_for('.service_letter_contact_details', service_id=current_service.id),
-          back_link_text='Back'
-        ) }}
+        {{ page_footer('Add') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/checkbox.html" import checkbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,34 +11,29 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Edit an address
-  </h1>
-  <div class="grid-row">
-    {% call form_wrapper() %}
-      {{ textbox(
-        form.letter_contact_block,
-        label='This will appear as the ‘sender’ address on your letters.'|safe,
-        hint='10 lines maximum',
-        width='1-1',
-        rows=10,
-        highlight_tags=True
-      ) }}
-      {% if form.is_default.data %}
-        <p class="form-group">
-          This is currently your default address for {{ current_service.name }}
-        </p>
-      {% else %}
-        <div class="form-group">
-          {{ checkbox(form.is_default) }}
-        </div>
-      {% endif %}
-      {{ page_footer(
-        'Save',
-        back_link=None if request.args.get('from_template') else url_for('.service_letter_contact_details', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
-    {% endcall %}
-  </div>
+  {{ page_header(
+    'Edit an address',
+    back_link=None if request.args.get('from_template') else url_for('.service_letter_contact_details', service_id=current_service.id)
+  ) }}
+  {% call form_wrapper() %}
+    {{ textbox(
+      form.letter_contact_block,
+      label='This will appear as the ‘sender’ address on your letters.'|safe,
+      hint='10 lines maximum',
+      width='1-2',
+      rows=10,
+      highlight_tags=True
+    ) }}
+    {% if form.is_default.data %}
+      <p class="form-group">
+        This is currently your default address for {{ current_service.name }}
+      </p>
+    {% else %}
+      <div class="form-group">
+        {{ checkbox(form.is_default) }}
+      </div>
+    {% endif %}
+    {{ page_footer('Save') }}
+  {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/link-service-to-organisation.html
+++ b/app/templates/views/service-settings/link-service-to-organisation.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -11,20 +12,17 @@
 
   <div class="grid-row bottom-gutter">
     <div class="column-two-thirds">
-      <h1 class="heading-large">
-        Link service to organisation
-      </h1>
+      {{ page_header(
+        'Link service to organisation',
+        back_link=url_for('.service_settings', service_id=current_service.id)
+      ) }}
       {% call form_wrapper() %}
         {% if has_organisations %}
           {{ radios(form.organisations) }}
+          {{ page_footer('Save') }}
         {% else %}
         <p> No organisations </p>
         {% endif %}
-        {{ page_footer(
-          'Save' if has_organisations,
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -1,6 +1,7 @@
 
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change your service name</h1>
+  {{ page_header(
+    'Change your service name',
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
 
   <div class="form-group">
     {% if current_service.prefix_sms %}
@@ -26,11 +30,7 @@
 
   {% call form_wrapper() %}
     {{ textbox(form.name) }}
-    {{ page_footer(
-      'Save',
-      back_link=url_for('.service_settings', service_id=current_service.id),
-      back_link_text='Back to settings'
-    ) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/request-letter-branding.html
+++ b/app/templates/views/service-settings/request-letter-branding.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -8,7 +9,11 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Letter branding</h1>
+  {{ page_header(
+    'Letter branding',
+    back_link=url_for('.view_template', service_id=current_service.id, template_id=from_template) if from_template else url_for('.service_settings', service_id=current_service.id)
+  ) }}
+
   <div class="grid-row">
     <div class="column-three-quarters">
       {% if current_service.letter_branding_id %}
@@ -27,17 +32,6 @@
           <a href="{{ url_for('main.feedback', ticket_type='ask-question-give-feedback', body='letter-branding') }}">Contact support</a>
           if you want to add your organisation’s logo.
         </p>
-      {% endif %}
-      {% if from_template %}
-        {{ page_footer(
-          back_link=url_for('.view_template', service_id=current_service.id, template_id=from_template),
-          back_link_text='Back to template'
-        ) }}
-      {% else %}
-        {{ page_footer(
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
       {% endif %}
     </div>
   </div>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/task-list.html" import task_list_wrapper, task_list_item %}
 
@@ -10,7 +11,10 @@
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-whole">
-      <h1 class="heading-large">Before you request to go live</h1>
+      {{ page_header(
+        'Before you request to go live',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       {% call task_list_wrapper() %}
         {{ task_list_item(
           current_service.has_estimated_usage,

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -10,7 +11,10 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Sign-in method</h1>
+      {{ page_header(
+        'Sign-in method',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       {% if 'email_auth' in current_service.permissions %}
         <p class="heading-small bottom-gutter-2-3">
           Email link or text message code
@@ -34,10 +38,6 @@
           please <a href="{{ url_for('.support') }}">contact us</a>.
         </p>
       {% endif %}
-      {{ page_footer(
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
     </div>
   </div>
 

--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer, sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Set email branding</h1>
+  {{ page_header(
+    'Set email branding',
+    back_link=url_for('.service_settings', service_id=current_service.id)
+  ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'email'}) %}
     <div class="grid-row">
       <div class="column-full preview-pane">
@@ -22,13 +26,7 @@
         {{ radios(form.branding_style) }}
       </div>
     </div>
-    <div class="js-stick-at-bottom-when-scrolling">
-      {{ page_footer(
-        'Preview',
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
-    </div>
+    {{ sticky_page_footer('Preview') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radios %}
 
@@ -11,17 +12,16 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Send emails</h1>
+      {{ page_header(
+        'Send emails',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       <p>
         It’s free to send emails through GOV.UK Notify.
       </p>
       {% call form_wrapper() %}
         {{ radios(form.enabled) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/set-free-sms-allowance.html
+++ b/app/templates/views/service-settings/set-free-sms-allowance.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,13 +11,12 @@
 {% block maincolumn_content %}
 
   {% call form_wrapper() %}
-    <h1 class="heading-large">Free text message allowance</h1>
-    {{ textbox(form.free_sms_allowance) }}
-    {{ page_footer(
-      'Save',
-      back_link=url_for('.service_settings', service_id=current_service.id),
-      back_link_text='Back to settings'
+    {{ page_header(
+      'Free text message allowance',
+      back_link=url_for('.service_settings', service_id=current_service.id)
     ) }}
+    {{ textbox(form.free_sms_allowance) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/set-inbound-number.html
+++ b/app/templates/views/service-settings/set-inbound-number.html
@@ -1,35 +1,27 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radios%}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
-  Set Inbound Number
+  Set inbound number
 {% endblock %}
 
 {% block maincolumn_content %}
-    <h1 class="heading-large">Set Inbound Number</h1>
+    {{ page_header(
+      'Set inbound number',
+      back_link=url_for('.service_settings', service_id=current_service.id)
+    ) }}
     {% if current_service.has_inbound_number %}
     <p> This service already has an inbound number </p>
-    {{ page_footer(
-	    back_link=url_for('.service_settings', service_id=current_service.id),
-	    back_link_text='Back to settings'
-	  ) }}
     {% elif no_available_numbers %}
     <p> No available inbound numbers </p>
-    {{ page_footer(
-	    back_link=url_for('.service_settings', service_id=current_service.id),
-	    back_link_text='Back to settings'
-	  ) }}
     {% else %}
     {% call form_wrapper() %}
 	    {{ radios(form.inbound_number) }}
-	    {{ page_footer(
-		    'Save',
-		    back_link=url_for('.service_settings', service_id=current_service.id),
-		    back_link_text='Back'
-  	 	) }}
+	    {{ page_footer('Save') }}
   	{% endcall %}
 	{% endif %}
 

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -10,14 +11,17 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Receive text messages</h1>
+      {{ page_header(
+        'Receive text messages',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       {% if 'inbound_sms' in current_service.permissions %}
         <p>
           Your service can receive text messages sent to {{ current_service.inbound_number }}.
         </p>
         <p>
-          If you want to turn this feature off,
-          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+          If you want to switch this feature off,
+          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK&nbsp;Notify team</a>.
         </p>
         {% if current_user.has_permissions('manage_api_keys') %}
           <p>
@@ -38,10 +42,6 @@
           messaging a mobile number.
         </p>
       {% endif %}
-      {{ page_footer(
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
     </div>
   </div>
 

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -11,7 +12,10 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">International text messages</h1>
+      {{ page_header(
+        'International text messages',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       <p>
         Messages to international mobile numbers are charged at 1, 2, or
         3 times the cost of messages to UK mobile numbers.</p>
@@ -21,11 +25,7 @@
       </p>
       {% call form_wrapper() %}
         {{ radios(form.enabled) }}
-        {{ page_footer(
-          button_text="Save",
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/set-letter-branding.html
+++ b/app/templates/views/service-settings/set-letter-branding.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
 {% from "components/live-search.html" import live_search %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Set letter branding</h1>
+  {{ page_header(
+    'Set letter branding',
+    back_link=url_for('.service_settings', service_id=current_service.id)
+  ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'letter'}) %}
     <div class="grid-row">
       <div class="column-full preview-pane">
@@ -23,11 +27,7 @@
       </div>
     </div>
     <div class="js-stick-at-bottom-when-scrolling">
-      {{ page_footer(
-        'Preview',
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
+      {{ page_footer('Preview') }}
     </div>
   {% endcall %}
 

--- a/app/templates/views/service-settings/set-letter-contact-block.html
+++ b/app/templates/views/service-settings/set-letter-contact-block.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,9 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Letter contact details
-  </h1>
+  {{ page_header(
+    'Letter contact details',
+    back_link=None if request.args.get('from_template') else url_for('.service_settings', service_id=current_service.id)
+  ) }}
   <div class="grid-row">
     {% call form_wrapper(class="column-half") %}
       {{ textbox(
@@ -22,11 +24,7 @@
         rows=10,
         highlight_tags=True
       ) }}
-      {{ page_footer(
-        'Save',
-        back_link=None if request.args.get('from_template') else url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
+      {{ page_footer('Save') }}
     {% endcall %}
   </div>
 

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -11,7 +12,10 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Send letters</h1>
+      {{ page_header(
+        'Send letters',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       <p>
         It costs between 30p and 76p to send a letter using Notify.
       </p>
@@ -21,11 +25,7 @@
       </p>
       {% call form_wrapper() %}
         {{ radios(form.enabled) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/set-organisation-type.html
+++ b/app/templates/views/service-settings/set-organisation-type.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,15 +10,14 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Set organisation type</h1>
+    {{ page_header(
+      'Set organisation type',
+      back_link=url_for('.service_settings', service_id=current_service.id)
+    ) }}
+
     {% call form_wrapper() %}
       {{ radios(form.organisation_type) }}
-      {{ page_footer(
-        'Save',
-        back_link=url_for('.service_settings', service_id=current_service.id),
-        back_link_text='Back to settings'
-      ) }}
+      {{ page_footer('Save') }}
     {% endcall %}
-  </div>
 
 {% endblock %}

--- a/app/templates/views/service-settings/set-reply-to-email.html
+++ b/app/templates/views/service-settings/set-reply-to-email.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,9 +10,11 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Email reply-to address
-  </h1>
+  {{ page_header(
+    'Email reply-to address',
+    back_link=url_for('.service_settings', service_id=current_service.id)
+  ) }}
+
   <p>
     Your emails will be sent from
     {{ current_service.email_from }}@notifications.service.gov.uk.
@@ -33,11 +36,7 @@
       width='2-3',
       safe_error_message=True
     ) }}
-    {{ page_footer(
-      'Save',
-      back_link=url_for('.service_settings', service_id=current_service.id),
-      back_link_text='Back to settings'
-    ) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/set-service-setting.html
+++ b/app/templates/views/service-settings/set-service-setting.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -11,14 +12,13 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">{{ title }}</h1>
+      {{ page_header(
+        title,
+        back_link=url_for('.service_settings', service_id=current_service.id)
+      ) }}
       {% call form_wrapper() %}
         {{ radios(form.enabled, hide_legend=True) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radios %}
 
@@ -11,7 +12,10 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">Send text messages</h1>
+      {{ page_header(
+        'Send text messages',
+        back_link=url_for('main.service_settings', service_id=current_service.id)
+      ) }}
       <p>
         You have a free allowance of
         {{ '{:,}'.format(current_service.free_sms_fragment_limit) }} text messages each
@@ -26,11 +30,7 @@
       </p>
       {% call form_wrapper() %}
         {{ radios(form.enabled) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/sms-prefix.html
+++ b/app/templates/views/service-settings/sms-prefix.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,14 +10,14 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Text messages start with service name</h1>
+  {{ page_header(
+    'Text messages start with service name',
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
+
   {% call form_wrapper() %}
     {{ radios(form.enabled) }}
-    {{ page_footer(
-      button_text="Save",
-      back_link=url_for('.service_settings', service_id=current_service.id),
-      back_link_text='Back to settings'
-    ) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/checkbox.html" import checkbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,11 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Add text message sender</h1>
+  {{ page_header(
+    'Add text message sender',
+    back_link=url_for('main.service_sms_senders', service_id=current_service.id)
+  ) }}
+
   {% call form_wrapper() %}
     {{ textbox(
       form.sms_sender,
@@ -22,11 +27,7 @@
         {{ checkbox(form.is_default) }}
       </div>
     {% endif %}
-    {{ page_footer(
-      'Save',
-      back_link=url_for('.service_sms_senders', service_id=current_service.id),
-      back_link_text='Back'
-    ) }}
+    {{ page_footer('Save') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -2,6 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/checkbox.html" import checkbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -11,9 +12,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Edit text message sender
-  </h1>
+  {{ page_header(
+    'Edit text message sender',
+    back_link=None if request.args.get('from_template') else url_for('.service_sms_senders', service_id=current_service.id)
+  ) }}
   {% call form_wrapper() %}
     {% if inbound_number %}
       <p>
@@ -31,26 +33,16 @@
       <p class="form-group">
         This is the default text message sender
       </p>
-      {{ page_footer(
-        'Save',
-        back_link=None if request.args.get('from_template') else url_for('.service_sms_senders', service_id=current_service.id),
-        back_link_text='Back'
-      ) }}
+      {{ page_footer('Save') }}
     {% else %}
       <div class="form-group">
         {{ checkbox(form.is_default) }}
       </div>
       {% if inbound_number %}
-        {{ page_footer(
-          'Save',
-          back_link=None if request.args.get('from_template') else url_for('.service_sms_senders', service_id=current_service.id),
-          back_link_text='Back'
-        ) }}
+        {{ page_footer('Save') }}
       {% else %}
         {{ page_footer(
           'Save',
-          back_link=None if request.args.get('from_template') else url_for('.service_sms_senders', service_id=current_service.id),
-          back_link_text='Back',
           delete_link=url_for('.service_confirm_delete_sms_sender', service_id=current_service.id, sms_sender_id=sms_sender_id),
           delete_link_text='Delete'
         ) }}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/api-key.html" import api_key %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context%}
 
@@ -9,9 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Text message senders
-  </h1>
+  {{ page_header(
+    'Text message senders',
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
 
   <div class="user-list">
     {% if not current_service.sms_senders %}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -101,7 +101,7 @@
   ) }}
 
   {{ page_footer(
-    button_text='Send', back_link='http://example.com', back_link_text="Back to dashboard"
+    button_text='Send'
   ) }}
 
   {{ page_footer(

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
@@ -10,7 +11,21 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      <h1 class="heading-large">{{ notification_type.capitalize() }} are disabled</h1>
+      {% set
+        back_link_dict = {
+          'add_new_template': '.choose_template',
+          'templates': '.choose_template',
+          'view_template': '.view_template'
+        }
+      %}
+      {{ page_header(
+        '{} are disabled'.format(notification_type.capitalize()),
+        back_link=url_for(
+          back_link_dict[return_to],
+          service_id=current_service.id,
+          template_id=template_id
+        )
+      ) }}
       <p>
         Sending {{ notification_type }} has been disabled for your service.
       </p>
@@ -18,28 +33,6 @@
         If you need to send {{ notification_type }}
         <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
       </p>
-
-      {% set
-        back_link_dict = {
-          'add_new_template': {
-            'url' : '.choose_template', 'text': 'Back to templates'
-          },
-          'templates': {
-            'url' : '.choose_template', 'text' : 'Back to templates'
-          },
-          'view_template': {
-            'url' :'.view_template', 'text' : 'Back to the template'
-          }
-        }
-      %}
-
-      {{ page_footer(
-        back_link=url_for(
-          back_link_dict[return_to]['url'],
-          service_id=current_service.id,
-          template_id=template_id),
-        back_link_text=back_link_dict[return_to]['text']
-        ) }}
 
     </div>
   </div>

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
 {% from "components/list.html" import list_of_placeholders %}
@@ -11,7 +12,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Confirm changes</h1>
+  {{ page_header(
+    'Confirm changes',
+    back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id)
+  ) }}
 
   <div class="bottom-gutter">
     {% if template_change.placeholders_removed %}
@@ -33,11 +37,7 @@
     <input type="hidden" name="template_id" value="{{ new_template.id }}" />
 
     <input type="hidden" name="confirm" value="true" />
-    {{ page_footer(
-      'Save changes to template',
-      back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id),
-      back_link_text="Back"
-    ) }}
+    {{ page_footer('Save changes to template') }}
   {% endcall %}
 
   <p>

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -47,7 +47,7 @@
 
   {% else %}
 
-    <div class="grid-row {% if current_service.all_template_folders %}bottom-gutter-1-2{% else %}bottom-gutter-2-3{% endif %}">
+    <div class="grid-row">
       <div class="{% if current_user.has_permissions('manage_templates') %} column-five-sixths {% else %} column-two-thirds {% endif %}">
         {{ folder_path(
           folders=template_folder_path,
@@ -66,7 +66,7 @@
     </div>
   {% endif %}
     {% if show_template_nav %}
-      <div class="bottom-gutter">
+      <div class="bottom-gutter-2-3">
         {{ pill(template_nav_items, current_value=template_type, show_count=False) }}
       </div>
     {% endif %}

--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
@@ -9,18 +10,15 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      Change postage
-    </h1>
+    {{ page_header(
+      'Change postage',
+      back_link=url_for('.view_template', service_id=service_id, template_id=template_id)
+    ) }}
     {% call form_wrapper() %}
       <div class="grid-row">
         <div class="column-five-sixths">
           {{ radios(form.postage) }}
-          {{ page_footer(
-            'Save',
-            back_link=url_for('.view_template', service_id=service_id, template_id=template_id),
-            back_link_text='Back to template'
-          ) }}
+          {{ page_footer('Save') }}
         </div>
         <aside class="column-three-quarters">
           {% include "partials/templates/guidance-postage.html" %}

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,7 +10,11 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">{{sender_context['title']}}</h1>
+  {{ page_header(
+    sender_context.title,
+    back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
+  ) }}
+
   <div class="grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper() %}
@@ -18,11 +23,7 @@
           option_hints=option_hints,
           hide_legend=True
         ) }}
-        {{ page_footer(
-          'Continue',
-          back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id),
-          back_link_text='Back to template'
-        ) }}
+        {{ page_footer('Continue') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -1,5 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,7 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Set letter contact block</h1>
+  {{ page_header(
+    'Set letter contact block',
+    back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
+  ) }}
   <div class="grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper() %}
@@ -18,11 +22,7 @@
           option_hints=option_hints,
           hide_legend=True
         ) }}
-        {{ page_footer(
-          'Continue',
-          back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id),
-          back_link_text='Back to template'
-        ) }}
+        {{ page_footer('Continue') }}
         {% if no_senders %}
           <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id, from_template=template_id) }}">Add new sender</a>
         {% endif %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -29,7 +29,7 @@
       {% endcall %}
     </div>
   {% else %}
-    <div class="grid-row bottom-gutter-1-2">
+    <div class="grid-row">
       <div class="column-whole">
         {{ folder_path(
           folders=current_service.get_template_path(template._template),

--- a/app/templates/views/usage-with-letters.html
+++ b/app/templates/views/usage-with-letters.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-    <h1 class='heading-large'>Usage</h1>
+    <h1 class='heading-medium'>Usage</h1>
 
     <div class="bottom-gutter">
       {{ pill(years, selected_year, big_number_args={'smallest': True}) }}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-    <h1 class='heading-large'>Usage</h1>
+    <h1 class='heading-medium'>Usage</h1>
 
     <div class="bottom-gutter">
       {{ pill(years, selected_year, big_number_args={'smallest': True}) }}

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,17 +10,17 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change your {{ thing }}</h1>
+  {{ page_header(
+    'Change your {}'.format(thing),
+    back_link=back_link
+  ) }}
 
   <div class="grid-row">
     <div class="column-three-quarters">
 
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.password) }}
-      {{ page_footer(
-        'Confirm',
-        back_link=back_link
-      ) }}
+      {{ page_footer('Confirm') }}
     {% endcall %}
     </div>
   </div>

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,18 +10,17 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">Change your password</h1>
+  {{ page_header(
+    'Change your password',
+    back_link=url_for('.user_profile')
+  ) }}
 
   <div class="grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper(autocomplete=True) %}
         {{ textbox(form.old_password) }}
         {{ textbox(form.new_password) }}
-        {{ page_footer(
-          'Save',
-          secondary_link=url_for('.user_profile'),
-          secondary_link_text="Back to your profile"
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,22 +10,16 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change your {{ thing }}</h1>
+  {{ page_header(
+    'Change your {}'.format(thing),
+    back_link=url_for('.user_profile')
+  ) }}
 
   <div class="grid-row">
-    {% if preamble %}
-      <p>
-        {{ preamble }}
-      </p>
-    {% endif %}
     <div class="column-three-quarters">
       {% call form_wrapper() %}
         {{ textbox(form_field, safe_error_message=True) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.user_profile'),
-          back_link_text="Back to your profile"
-        ) }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -1,5 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -9,7 +10,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Change your {{ thing }}</h1>
+  {{ page_header(
+    'Change your {}'.format(thing),
+    back_link=url_for('.user_profile')
+  ) }}
 
   <div class="grid-row">
     <div class="column-three-quarters">
@@ -22,11 +26,7 @@
           width='5em',
           autofocus=True
         ) }}
-        {{ page_footer(
-          'Confirm',
-          destructive=destructive,
-          back_link=url_for('.user_profile')
-        ) }}
+        {{ page_footer('Confirm') }}
       {% endcall %}
     </div>
   </div>

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -66,7 +66,7 @@ def test_view_organisation_shows_the_correct_organisation(
         org_id=ORGANISATION_ID,
     )
 
-    assert normalize_spaces(page.select_one('.heading-large').text) == 'Services'
+    assert normalize_spaces(page.select_one('h1').text) == 'Services'
 
 
 def test_create_new_organisation(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -646,7 +646,7 @@ def test_back_link_directs_to_api_integration_from_delivery_callback_if_no_inbou
         _follow_redirects=True,
     )
 
-    assert page.select_one('.page-footer-back-link')['href'] == url_for(
+    assert page.select_one('.govuk-back-link')['href'] == url_for(
         expected_link, service_id=service_one['id']
     )
 

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -798,21 +798,21 @@ def test_update_delivery_status_and_receive_text_message_callbacks_without_chang
 @pytest.mark.parametrize('service_callback_api, delivery_url, expected_1st_table_row', [
     (
         None, {},
-        'Callbacks for delivery receipts Not set Change'
+        'Delivery receipts Not set Change'
     ),
     (
         sample_uuid(), {'url': 'https://delivery.receipts'},
-        'Callbacks for delivery receipts https://delivery.receipts Change'
+        'Delivery receipts https://delivery.receipts Change'
     ),
 ])
 @pytest.mark.parametrize('inbound_api, inbound_url, expected_2nd_table_row', [
     (
         None, {},
-        'Callbacks for received text messages Not set Change'
+        'Received text messages Not set Change'
     ),
     (
         sample_uuid(), {'url': 'https://inbound.sms'},
-        'Callbacks for received text messages https://inbound.sms Change'
+        'Received text messages https://inbound.sms Change'
     ),
 ])
 def test_callbacks_page_works_when_no_apis_set(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -261,8 +261,8 @@ def test_should_not_allow_files_to_be_uploaded_without_the_correct_permission(
     )
 
     assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
-    assert page.select(".page-footer-back-link")[0].text == "Back to the template"
-    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.view_template',
         service_id=service_one['id'],
         template_id=template_id,
@@ -1033,8 +1033,8 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     )
 
     assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
-    assert page.select(".page-footer-back-link")[0].text == "Back to the template"
-    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.view_template',
         service_id=service_one['id'],
         template_id=template_id,
@@ -1239,8 +1239,8 @@ def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(
 
 
 @pytest.mark.parametrize('user, link_index', (
-    (active_user_with_permissions, 1),
-    (active_caseworking_user, 0),
+    (active_user_with_permissions, 2),
+    (active_caseworking_user, 1),
 ))
 def test_send_one_off_offers_link_to_upload(
     client_request,
@@ -1259,7 +1259,10 @@ def test_send_one_off_offers_link_to_upload(
         _follow_redirects=True,
     )
 
+    back_link = page.select('main a')[0]
     link = page.select('main a')[link_index]
+
+    assert back_link.text.strip() == 'Back'
 
     assert link.text.strip() == 'Upload a list of phone numbers'
     assert link['href'] == url_for(
@@ -1576,7 +1579,7 @@ def test_send_test_sms_message_with_placeholders_shows_first_field(
 
     assert page.select('label')[0].text.strip() == 'name'
     assert page.select('input')[0]['name'] == 'placeholder_value'
-    assert page.select('.page-footer-back-link')[0]['href'] == url_for(
+    assert page.select('.govuk-back-link')[0]['href'] == url_for(
         expected_back_link_endpoint,
         service_id=SERVICE_ONE_ID,
         **extra_args
@@ -1721,7 +1724,7 @@ def test_send_test_indicates_optional_address_columns(
         'address line 3 '
         'Optional'
     )
-    assert page.select('.page-footer-back-link')[0]['href'] == url_for(
+    assert page.select('.govuk-back-link')[0]['href'] == url_for(
         'main.send_one_off_step',
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
@@ -2393,7 +2396,7 @@ def test_check_messages_back_link(
     )
 
     assert (
-        page.findAll('a', {'class': 'page-footer-back-link'})[0]['href']
+        page.findAll('a', {'class': 'govuk-back-link'})[0]['href']
     ) == expected_url(service_id=SERVICE_ONE_ID, template_id=fake_uuid)
 
 
@@ -2923,7 +2926,7 @@ def test_send_one_off_letter_errors_in_trial_mode(
     assert len(page.select('.letter img')) == 5
 
     assert not page.select('[type=submit]')
-    assert page.select_one('.page-footer-back-link').text == 'Back'
+    assert page.select_one('.govuk-back-link').text == 'Back'
     assert page.select_one('a[download]').text == 'Download as a PDF'
 
 
@@ -3048,7 +3051,7 @@ def test_check_notification_shows_preview(
 
     assert page.h1.text.strip() == 'Preview of ‘Two week reminder’'
     assert (
-        page.findAll('a', {'class': 'page-footer-back-link'})[0]['href']
+        page.findAll('a', {'class': 'govuk-back-link'})[0]['href']
     ) == url_for(
         'main.send_one_off_step',
         service_id=service_one['id'],
@@ -3089,7 +3092,7 @@ def test_check_notification_shows_help(
         template_id=fake_uuid,
         help='3'
     )
-    assert page.select_one('.page-footer-back-link')['href'] == url_for(
+    assert page.select_one('.govuk-back-link')['href'] == url_for(
         'main.send_test',
         service_id=service_one['id'],
         template_id=fake_uuid,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1275,8 +1275,8 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
         _follow_redirects=True,
     )
     assert normalize_spaces(page.select('main p')[0].text) == expected_error
-    assert page.select(".page-footer-back-link")[0].text == "Back to templates"
-    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.choose_template',
         service_id=SERVICE_ONE_ID,
         template_id='0',
@@ -1301,8 +1301,8 @@ def test_should_not_allow_creation_of_a_template_without_correct_permission(
     )
     assert page.select('main p')[0].text.strip() == \
         "Sending {} has been disabled for your service.".format(template_description[type_of_template])
-    assert page.select(".page-footer-back-link")[0].text == "Back to templates"
-    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.choose_template',
         service_id=service_one['id'],
         template_id='0',
@@ -1418,8 +1418,8 @@ def test_should_not_allow_template_edits_without_correct_permission(
     )
 
     assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
-    assert page.select(".page-footer-back-link")[0].text == "Back to the template"
-    assert page.select(".page-footer-back-link")[0]['href'] == url_for(
+    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.view_template',
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
@@ -1539,7 +1539,7 @@ def test_should_show_interstitial_when_making_breaking_change(
     )
 
     assert page.h1.string.strip() == "Confirm changes"
-    assert page.find('a', {'class': 'page-footer-back-link'})['href'] == url_for(
+    assert page.find('a', {'class': 'govuk-back-link'})['href'] == url_for(
         ".edit_service_template",
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,


### PR DESCRIPTION
This pull request makes two main changes to rationalise our page layouts:
- consistency in heading sizes
- use of GOV.UK Design System back links

The reason for making these changes now is to de-clutter the area around the green buttons. The folder permissions work presents a design challenge where multiple levels of interaction are happening in the same form. Removing the dark grey ‘Back’ buttons should mean that, in these complicated forms, there’s one fewer thing to compete for the user’s attention.

# Consistency in heading sizes 

We were using `heading-large` (`36px`) everywhere, except on templates pages. On template pages we started using `24px` sized headings, to make space for displaying long folder names. This meant that when surfing the navigation, headings 

# Use of GOV.UK Design System back links

The Design System has standardised on back links being at the top of the page, decorated with a small text-coloured arrow.

I think this makes more sense than having them as buttons at the bottom of the page, because it suggests, in some way, being able to go back before committing to any of the forms on the page. The things at the bottom of the page feel like they should be performing actions on what’s in the page.

I’ve componentised the back links into a `page_header` macro so that the change is easier to roll out and maintain.

# Result

This consolidates our page templates into one of two fundamental types:

## ‘Hub‘ pages

These have `24px` headings, and no back link. They are:
- linked to from the left-hand navigation (or are filtered views of pages linked to from the left hand navigation)
- pages you move through to get to another page
- pages where where you don’t modify 

## ‘Spoke’ pages 

These have `36px` headings, and a back link. The back link either goes to the associated ‘hub’ page, or the previous page in the journey (if there are multiple steps). They are:
- not linked to directly from the left-hand navigation
- pages which modify state, for example by changing a setting or sending a message

# Screenshots

## Settings pages 

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/56950946-7c531c80-6b2e-11e9-9e84-350bd9507418.png) | ![image](https://user-images.githubusercontent.com/355079/56950814-431aac80-6b2e-11e9-9f80-0b4b8fb9779e.png)
![image](https://user-images.githubusercontent.com/355079/56950904-6a717980-6b2e-11e9-962c-8e796e25d09f.png) | ![image](https://user-images.githubusercontent.com/355079/56950858-5b8ac700-6b2e-11e9-8b0d-0662a83b51f2.png)

## Team pages

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/56951009-a0aef900-6b2e-11e9-9150-3307a7dd7a8a.png) | ![image](https://user-images.githubusercontent.com/355079/56951034-b45a5f80-6b2e-11e9-8213-c38afdc0ca5d.png)
![image](https://user-images.githubusercontent.com/355079/56951017-a86e9d80-6b2e-11e9-8478-c802caadfba8.png) | ![image](https://user-images.githubusercontent.com/355079/56951048-bcb29a80-6b2e-11e9-956b-e6aab322378d.png)

## Templates and sending pages

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/56951158-fedbdc00-6b2e-11e9-8e62-6598835174b8.png) | ![image](https://user-images.githubusercontent.com/355079/56951158-fedbdc00-6b2e-11e9-8e62-6598835174b8.png)
![image](https://user-images.githubusercontent.com/355079/56951126-eec3fc80-6b2e-11e9-936d-d8c7c39ca240.png) | ![image](https://user-images.githubusercontent.com/355079/56951112-e4a1fe00-6b2e-11e9-8af6-c9ec6ded5057.png)
![image](https://user-images.githubusercontent.com/355079/56951195-174bf680-6b2f-11e9-8846-0fcf4dfdc322.png) | ![image](https://user-images.githubusercontent.com/355079/56951220-22068b80-6b2f-11e9-8a91-b0cd6264236d.png)
![image](https://user-images.githubusercontent.com/355079/56951688-68101f00-6b30-11e9-99dd-bd3d2ffccb83.png) | ![image](https://user-images.githubusercontent.com/355079/56951667-59296c80-6b30-11e9-90a2-2e9e4395fcbd.png) 
