### PR TITLE
Style radio select component controls as buttons not links

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -30,7 +30,7 @@
             <label for="{{id}}">{{label}}</label>
           </div>
         {{/choices}}
-        <input type='button' class='js-reset-button js-reset-button-block' value='Back' />
+        <input type='button' class='js-reset-button js-reset-button-block' value='Done' />
       </div>
     `),
     'chosen': Hogan.compile(`

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -8,7 +8,6 @@
     vertical-align: top;
 
     .multiple-choice {
-      margin-right: 5px;
       padding-right: 10px;
       padding-left: 54px - 10px;
     }

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -18,28 +18,23 @@
   .js-reset-button,
   .js-category-button {
 
-    background: none;
-    text-decoration: underline;
-    color: $link-colour;
-    border: none;
-    display: inline-block;
-    vertical-align: top;
-    width: auto;
-    padding: 7px 20px 7px 10px;
-    margin-right: 5px;
-    cursor: pointer;
-
-    &:hover {
-      color: $link-hover-colour;
-    }
+    @include button($grey-3);
+    margin-right: $gutter-half;
 
   }
 
   .js-reset-button-block {
+
     display: block;
-    width: 100%;
-    text-align: left;
-    padding: 20px 20px $gutter 57px;
+    clear: both;
+    margin: 0 0 $gutter 0;
+    position: relative;
+    top: $gutter-half;
+
+    &:active {
+      top: $gutter-half + 2px;
+    }
+
   }
 
   .js-enabled & {


### PR DESCRIPTION
# Style radio select controls as buttons

For the upcoming user permissions enhancements we want to differentiate between actions that take the user to a new page (eg changing a user’s phone number or email address) and actions that reveal extra controls in the current page (which will be changing the folders a team member can see).

This change will be inconsistent with the interaction for scheduling a job, which uses links to reveal other controls in the page.

This pull request changes the scheduling interaction to use grey ‘secondary’ buttons for revealing extra controls in the page, for consistency with the upcoming folder permissions work.

# Say ‘done’ not ‘back’

We use ‘back’ to label a control which navigates to a previous page now. It could be confusing to keep this control labelled the same way. And in the future the folder permissions interaction definitely shouldn’t be using ‘back’, because it suggests undoing the selection you’ve made.

# Screenshots

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/57019873-8ef94e80-6c1f-11e9-931d-b7f5154da793.png) | ![image](https://user-images.githubusercontent.com/355079/57019809-6e30f900-6c1f-11e9-9efa-6856fad7dcc2.png)
![image](https://user-images.githubusercontent.com/355079/57019886-9c163d80-6c1f-11e9-85d3-ec01bdfb2621.png) | ![image](https://user-images.githubusercontent.com/355079/57019843-7ab55180-6c1f-11e9-94bf-6831364e5ce6.png)
![image](https://user-images.githubusercontent.com/355079/57019892-a6383c00-6c1f-11e9-987b-12e3077c87f6.png) | ![image](https://user-images.githubusercontent.com/355079/57019860-83a62300-6c1f-11e9-8240-710d273d8900.png)
