### PR TITLE
Make ‘Add a new service’ a button

### DIFF
--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -36,7 +36,9 @@
       {% endif %}
     </ul>
   {% if can_add_service %}
-    <a href="{{ url_for('.add_service') }}" class="browse-list-link">Add a new service…</a>
+    <div class="js-stick-at-bottom-when-scrolling">
+      <a href="{{ url_for('.add_service') }}" class="button-secondary">Add a new service</a>
+    </div>
   {% endif %}
 
 {% endblock %}

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -102,7 +102,7 @@ def test_choose_account_should_show_choose_accounts_page_if_no_services(
     assert len(links) == 1
     add_service_link = links[0]
     assert normalize_spaces(page.h1.text) == 'Choose service'
-    assert normalize_spaces(add_service_link.text) == 'Add a new service…'
+    assert normalize_spaces(add_service_link.text) == 'Add a new service'
     assert add_service_link['href'] == url_for('main.add_service')
 
 


### PR DESCRIPTION
This, along with putting it in a sticky footer, makes it consistent with the ‘Add template’ and ‘Invite team member’ buttons.

# Before 

![image](https://user-images.githubusercontent.com/355079/56956387-e920e380-6b3b-11e9-8a87-e68953a0f17d.png)

# After 

![image](https://user-images.githubusercontent.com/355079/56956364-d1e1f600-6b3b-11e9-91b7-f750e511818f.png)

![image](https://user-images.githubusercontent.com/355079/56956419-005fd100-6b3c-11e9-8b6c-b3fda2fc1443.png)

