### PR TITLE
Use proper icon for breadcrumb

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -40,6 +40,16 @@
 
   }
 
+  &-breadcrumb {
+    display: inline-block;
+    width: 6px;
+    height: 11px;
+    margin: 0 5px;
+    background-image: file-url("separator-2x.png");
+    background-size: 6px 11px;
+    background-repeat: no-repeat;
+  }
+
   li {
     @include core-19;
     margin: 0;

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -10,7 +10,7 @@
       <div class="navigation-service-name">
         {% if current_user.platform_admin %}
           <a href="{{ url_for('.organisations') }}">Organisations</a>
-          &gt;
+          <span class="navigation-breadcrumb"></span>
         {% endif %}
         {{ current_org.name }}
       </div>


### PR DESCRIPTION
Uses the asset from the GOV.UK Frontend Toolkit.

![image](https://user-images.githubusercontent.com/355079/56971606-732f7300-6b61-11e9-807f-650f008633a4.png)
