### PR TITLE
Fix heading size on empty templates page

### DIFF
--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -3,38 +3,30 @@
   service_id,
   template_type,
   current_user,
-  fallback_page_title=None,
-  show_fallback_page_title=False,
   link_current_item=False
 ) %}
-  {% if show_fallback_page_title %}
-    <h1 class="heading-medium">
-      {{ fallback_page_title }}
-    </h1>
-  {% else %}
-    <h1 class="heading-medium folder-heading">
-      {% for folder in folders %}
-        {% if loop.last and not link_current_item %}
-          {% if folder.template_type or not folder.id %}
-            <span class="folder-heading-template">{{ folder.name }}</span>
+  <h1 class="heading-medium folder-heading">
+    {% for folder in folders %}
+      {% if loop.last and not link_current_item %}
+        {% if folder.template_type or not folder.id %}
+          <span class="folder-heading-template">{{ folder.name }}</span>
+        {% else %}
+          <span class="folder-heading-folder">{{ folder.name }}</span>
+        {% endif %}
+      {% else %}
+        {% if folder.id %}
+          {% if current_user.has_template_folder_permission(folder) %}
+            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
           {% else %}
             <span class="folder-heading-folder">{{ folder.name }}</span>
           {% endif %}
         {% else %}
-          {% if folder.id %}
-            {% if current_user.has_template_folder_permission(folder) %}
-              <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
-            {% else %}
-              <span class="folder-heading-folder">{{ folder.name }}</span>
-            {% endif %}
-          {% else %}
-            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="{% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
-          {% endif %}
-          {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+          <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="{% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
         {% endif %}
-      {% endfor %}
-    </h1>
-  {% endif %}
+        {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+      {% endif %}
+    {% endfor %}
+  </h1>
 {% endmacro %}
 
 
@@ -75,21 +67,13 @@
 {% endmacro %}
 
 
-{% macro page_title_folder_path(
-  folders,
-  fallback_page_title=None,
-  show_fallback_page_title=False
-) %}
-  {% if show_fallback_page_title %}
-    {{ fallback_page_title }}
-  {% else %}
-    {% for folder in folders|reverse %}
-      {{ folder.name }}
-      {% if not loop.last %}
-        –
-      {% endif %}
-    {% endfor %}
-  {% endif %}
+{% macro page_title_folder_path(folders) %}
+  {% for folder in folders|reverse %}
+    {{ folder.name }}
+    {% if not loop.last %}
+      –
+    {% endif %}
+  {% endfor %}
 {% endmacro %}
 
 

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -4,7 +4,6 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/page-footer.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% extends "withnav_template.html" %}
@@ -50,9 +49,7 @@
           folders=template_folder_path,
           service_id=current_service.id,
           template_type=template_type,
-          current_user=current_user,
-          fallback_page_title=page_title,
-          show_fallback_page_title=not current_service.all_template_folders
+          current_user=current_user
         ) }}
       </div>
       {% if current_user.has_permissions('manage_templates') and current_template_folder_id and user_has_template_folder_permission %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -4,6 +4,7 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% extends "withnav_template.html" %}
@@ -11,18 +12,14 @@
 {% set page_title = 'Templates' %}
 
 {% block service_page_title %}
-  {{ page_title_folder_path(
-    template_folder_path,
-    fallback_page_title=page_title,
-    show_fallback_page_title=not current_service.all_template_folders
-  ) }}
+  {{ page_title_folder_path(template_folder_path) }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {% if (not current_service.all_templates) and (not current_service.all_template_folders) %}
 
-    <h1 class="heading-large">
+    <h1 class="heading-medium">
       {{ page_title }}
     </h1>
     {% if current_user.has_permissions('manage_templates') %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -1,12 +1,12 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/folder-path.html" import folder_path %}
+{% from "components/folder-path.html" import folder_path, page_title_folder_path %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/api-key.html" import api_key %}
 
 {% block service_page_title %}
-  {{ template.name }}
+  {{ page_title_folder_path(current_service.get_template_path(template._template)) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -35,9 +35,7 @@
           folders=current_service.get_template_path(template._template),
           service_id=current_service.id,
           template_type='all',
-          current_user=current_user,
-          fallback_page_title=template.name,
-          show_fallback_page_title=not current_service.all_template_folders
+          current_user=current_user
         ) }}
       </div>
     </div>

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -176,6 +176,7 @@ def test_should_not_show_back_to_service_if_user_doesnt_belong_to_service(
         service_id=mock_get_service.return_value['id'],
         template_id=fake_uuid,
         _expected_status=expected_status,
+        _test_page_title=False,
     )
 
     assert normalize_spaces(

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -163,7 +163,7 @@ def test_accepting_invite_removes_invite_from_session(
         token='thisisnotarealtoken',
         _follow_redirects=True,
     )
-    assert normalize_spaces(page.h1.string) == landing_page_title
+    assert normalize_spaces(page.select_one('h1').text) == landing_page_title
 
     with client_request.session_transaction() as session:
         assert 'invited_user' not in session


### PR DESCRIPTION
This is a special case which I missed when doing the rationalisation in https://github.com/alphagov/notifications-admin/pull/2937

***

![image](https://user-images.githubusercontent.com/355079/56972017-2b5d1b80-6b62-11e9-92b4-2a722f31b8a6.png)
