### PR TITLE
Allow replacing a revoked key

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -612,6 +612,7 @@ class CreateKeyForm(StripWhitespaceForm):
     def __init__(self, existing_keys, *args, **kwargs):
         self.existing_key_names = [
             key['name'].lower() for key in existing_keys
+            if not key['expiry_date']
         ]
         super().__init__(*args, **kwargs)
 

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -4,17 +4,34 @@ from werkzeug.datastructures import MultiDict
 from app.main.forms import CreateKeyForm
 
 
-def test_return_validation_error_when_key_name_exists(client):
+@pytest.mark.parametrize('expiry_date, expected_errors', (
+    (None, ['A key with this name already exists']),
+    ('2001-01-01 01:01:01', None),
+))
+def test_return_validation_error_when_key_name_exists(
+    client,
+    expiry_date,
+    expected_errors,
+):
     _existing_keys = [
-        {'name': 'some key'},
-        {'name': 'another key'},
+        {
+            'name': 'some key',
+            'expiry_date': expiry_date,
+        },
+        {
+            'name': 'another key',
+            'expiry_date': None,
+        },
     ]
 
-    form = CreateKeyForm(_existing_keys,
-                         formdata=MultiDict([('key_name', 'Some key')]))
+    form = CreateKeyForm(
+        _existing_keys,
+        formdata=MultiDict([('key_name', 'Some key')])
+    )
+
     form.key_type.choices = [('a', 'a'), ('b', 'b')]
     form.validate()
-    assert form.errors['key_name'] == ['A key with this name already exists']
+    assert form.errors.get('key_name') == expected_errors
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We had someone wondering why they couldn’t do this. Seems legit to allow it, especially since revoked API keys never get completely deleted.