### PR TITLE
Look at service’s organisation on agreement page

### DIFF
--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -1,6 +1,7 @@
 from flask import abort, render_template, request, send_file, url_for
 from flask_login import current_user, login_required
 
+from app import current_service
 from app.main import main
 from app.main.views.sub_navigation_dictionaries import features_nav
 from app.s3_client.s3_mou_client import get_mou
@@ -20,8 +21,8 @@ def agreement():
 @login_required
 def service_agreement(service_id):
     return render_template(
-        'views/agreement/service-{}.html'.format(current_user.default_organisation.as_jinja_template),
-        owner=current_user.default_organisation.name,
+        'views/agreement/service-{}.html'.format(current_service.organisation.as_jinja_template),
+        owner=current_service.organisation.name,
     )
 
 

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -4,7 +4,11 @@ from io import BytesIO
 import pytest
 from flask import url_for
 
-from tests.conftest import SERVICE_ONE_ID, mock_get_organisation_by_domain
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    mock_get_organisation_by_domain,
+    mock_get_service_organisation,
+)
 
 
 class _MockS3Object():
@@ -16,16 +20,18 @@ class _MockS3Object():
         return {'Body': BytesIO(self.data)}
 
 
-@pytest.mark.parametrize('endpoint, extra_args, link_selector, expected_back_links', [
+@pytest.mark.parametrize('endpoint, extra_args, organisation_mock, link_selector, expected_back_links', [
     (
         'main.agreement',
         {},
+        mock_get_organisation_by_domain,
         'main .column-two-thirds a',
         []
     ),
     (
         'main.service_agreement',
         {'service_id': SERVICE_ONE_ID},
+        mock_get_service_organisation,
         'main .column-five-sixths a',
         [
             partial(url_for, 'main.request_to_go_live', service_id=SERVICE_ONE_ID)
@@ -66,10 +72,11 @@ def test_show_agreement_page(
     expected_links,
     endpoint,
     extra_args,
+    organisation_mock,
     link_selector,
     expected_back_links,
 ):
-    mock_get_organisation_by_domain(
+    organisation_mock(
         mocker,
         crown=crown,
         agreement_signed=agreement_signed,


### PR DESCRIPTION
Usually the service’s organisation and the user’s current organisation will be the same. But this won’t be the case when:
- someone with a non-government email address is looking at the page
- someone from our team, as a platform admin user, is looking at the page (it will show Cabinet Office instead)

This commit fixes these problems by explicitly looking at the service’s organisation. We couldn’t do this previously because when this page wasn’t service-specific `current_service` was not guaranteed to be set.