### PR TITLE
Update links to trial mode guidance

### DIFF
--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -7,6 +7,6 @@
   {%- endif %}
 </h1>
 <p>
-  In <a href="{{ url_for('.using_notify') }}#trial-mode">trial mode</a> you can only
+  In <a href="{{ url_for('.trial_mode_new') }}">trial mode</a> you can only
   send to yourself and members of your team
 </p>

--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -8,7 +8,7 @@
 <p>
   You can only send {{ current_service.message_limit }} messages per day
   {%- if current_service.trial_mode %}
-    in <a href="{{ url_for('.using_notify')}}#trial-mode">trial mode</a>
+    in <a href="{{ url_for('.trial_mode_new')}}">trial mode</a>
   {%- endif -%}
   .
 </p>

--- a/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
+++ b/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
@@ -3,6 +3,6 @@
   {{ 'this letter' if count_of_recipients == 1 else 'these letters' }}
 </h1>
 <p>
-  In <a href="{{ url_for('.using_notify') }}#trial-mode">trial mode</a> you
+  In <a href="{{ url_for('.trial_mode_new') }}">trial mode</a> you
   can only preview how your letters will look
 </p>


### PR DESCRIPTION
These links used to be on the ‘using Notify’ page which has been broken up. So there’s now a standalone page about trial mode that we can link to.