### PR TITLE
Fix permissions check when service ID is a UUID

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -35,11 +35,11 @@ permissions = (
 
 
 def _get_service_id_from_view_args():
-    return request.view_args.get('service_id', None)
+    return str(request.view_args.get('service_id', '')) or None
 
 
 def _get_org_id_from_view_args():
-    return request.view_args.get('org_id', None)
+    return str(request.view_args.get('org_id', '')) or None
 
 
 def translate_permissions_from_db_to_admin_roles(permissions):


### PR DESCRIPTION
If you define a route with the service ID as a typed parameter, ie
```
@main.route('/services/<uuid:service_id>/agreement')
```

then `type(service_id)` returns `<class 'uuid.UUID'>`.

This is a problem when the permissions dictionary stores service IDs as strings, because trying to look up a user’s permissions with the UUID fails silently (that key isn’t in the dictionary).

This commit makes sure we always cast the service ID to a string before using it to check permissions.