### PR TITLE
Fix order of placeholders in the tour

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -386,11 +386,7 @@ def send_test_step(service_id, template_id, step_index):
     )
 
     try:
-        if request.endpoint == 'main.send_test_step':
-            current_placeholder = placeholders[step_index - 1]
-        else:
-            current_placeholder = placeholders[step_index]
-
+        current_placeholder = placeholders[step_index]
     except IndexError:
         if all_placeholders_in_session(placeholders):
             return get_notification_check_endpoint(service_id, template)
@@ -812,7 +808,7 @@ def get_back_link(service_id, template, step_index):
                 service_id=service_id,
                 template_id=template.id,
             )
-    elif is_current_user_the_recipient() and step_index > 1:
+    elif is_current_user_the_recipient() and step_index >= 1:
         return url_for(
             'main.send_test_step',
             service_id=service_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -846,6 +846,20 @@ def mock_get_service_template_with_placeholders(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_service_template_with_multiple_placeholders(mocker):
+    def _get(service_id, template_id, version=None):
+        template = template_json(
+            service_id, template_id, "Two week reminder", "sms", "((one)) ((two)) ((three))"
+        )
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template',
+        side_effect=_get
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_service_template_with_placeholders_same_as_recipient(mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(


### PR DESCRIPTION
Doing a lookup with `step_index - 1` means that on step `0` we were looking up `placeholders[-1]`, ie we were making people fill in the last placeholder first.

Fixing this reintroduces the bug fixed by this pull request: https://github.com/alphagov/notifications-admin/pull/2551

So this commit also re-fixes that bug but in a different way.