### PR TITLE
Fix adding a service when organisation is unknown

### DIFF
--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -25,7 +25,11 @@ class Organisation(JSONModel):
         super().__init__(_dict)
 
         if self._dict == {}:
-            self.name, self.crown, self.agreement_signed, self.domains = None, None, None, []
+            self.name = None
+            self.crown = None
+            self.agreement_signed = None
+            self.domains = []
+            self.organisation_type = None
 
     def as_human_readable(self, fallback_domain):
         if 'dwp.' in ''.join(self.domains):

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -2,6 +2,7 @@ import pytest
 from flask import session, url_for
 
 from app.utils import is_gov_user
+from tests import organisation_json
 from tests.conftest import mock_get_organisation_by_domain
 
 
@@ -18,10 +19,19 @@ def test_non_gov_user_cannot_see_add_service_button(
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize('org_json', (
+    None,
+    organisation_json(organisation_type=None),
+))
 def test_get_should_render_add_service_template(
     client_request,
-    mock_get_organisation_by_domain,
+    mocker,
+    org_json,
 ):
+    mocker.patch(
+        'app.organisations_client.get_organisation_by_domain',
+        return_value=org_json,
+    )
     page = client_request.get('main.add_service')
     assert page.select_one('h1').text.strip() == 'About your service'
     assert page.select_one('input[name=name]')['value'] == ''


### PR DESCRIPTION
An ‘unknown’ organisation can either be:
- one where we know it exists but don’t know much about it (in which case the API returns some JSON with the info we do know)
- one we’ve never come across (in which case the API will return `None`)

This commit fixes a bug where we were trying to access the organisation type in the latter case.