### PR TITLE
Use standard back link on new API key page

### DIFF
--- a/app/templates/views/api/keys/show.html
+++ b/app/templates/views/api/keys/show.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/api-key.html" import api_key %}
 
 {% block service_page_title %}
@@ -8,10 +8,10 @@
 
 {% block maincolumn_content %}
 
-
-    <h1 class="heading-large">
-      New API key
-    </h1>
+    {{ page_header(
+      'New API key',
+      back_link=url_for('main.api_keys', service_id=current_service.id)
+    ) }}
 
     <p>
       Copy your key to somewhere safe.
@@ -25,11 +25,6 @@
       {{ api_key(
         '{}-{}-{}'.format(key_name, service_id, secret),
         'API key'
-      ) }}
-
-      {{ page_footer(
-        secondary_link=url_for('.api_keys', service_id=current_service.id),
-        secondary_link_text='Back to API keys'
       ) }}
 
     </div>


### PR DESCRIPTION
Missed this one before because it was using a link, not a dark grey button.