### PR TITLE
Remove redundant info from go live emails

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -209,37 +209,17 @@ def submit_request_to_go_live(service_id):
             '\nConsent to research: {research_consent}'
             '\nOther live services: {existing_live}'
             '\n'
-            '\n---'
-            '\n'
-            '{service_id}, '
-            '{organisation}, '
-            '{service_name}, '
-            '{user_name}, '
-            '{user_email}, '
-            '-, '
-            '{date}, '
-            '{volume_sms}, '
-            '{volume_email}, '
-            '{volume_letter}'
         ).format(
             service_name=current_service.name,
             service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
             organisation_type=str(current_service.organisation_type).title(),
             agreement=current_service.organisation.as_human_readable(current_user.email_domain),
             checklist=current_service.go_live_checklist_completed_as_yes_no,
-            volume_email=print_if_number(current_service.volume_email),
             volume_email_formatted=format_if_number(current_service.volume_email),
-            volume_sms=print_if_number(current_service.volume_sms),
             volume_sms_formatted=format_if_number(current_service.volume_sms),
-            volume_letter=print_if_number(current_service.volume_letter),
             volume_letter_formatted=format_if_number(current_service.volume_letter),
             research_consent='Yes' if current_service.consent_to_research else 'No',
             existing_live='Yes' if user_api_client.user_has_live_services(current_user) else 'No',
-            service_id=current_service.id,
-            organisation=current_service.organisation.name,
-            user_name=current_user.name,
-            user_email=current_user.email_address,
-            date=datetime.now(tz=pytz.timezone('Europe/London')).strftime('%d/%m/%Y'),
         ),
         ticket_type=zendesk_client.TYPE_QUESTION,
         user_email=current_user.email_address,
@@ -1067,10 +1047,6 @@ def check_contact_details_type(contact_details):
         return 'email_address'
     else:
         return 'phone_number'
-
-
-def print_if_number(value):
-    return value if isinstance(value, int) else ''
 
 
 def format_if_number(value):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -206,6 +206,9 @@ def submit_request_to_go_live(service_id):
             '\nConsent to research: {research_consent}'
             '\nOther live services: {existing_live}'
             '\n'
+            '\n---'
+            '\nRequest sent by {email_address}'
+            '\n'
         ).format(
             service_name=current_service.name,
             service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
@@ -216,6 +219,7 @@ def submit_request_to_go_live(service_id):
             volume_letter_formatted=format_if_number(current_service.volume_letter),
             research_consent='Yes' if current_service.consent_to_research else 'No',
             existing_live='Yes' if user_api_client.user_has_live_services(current_user) else 'No',
+            email_address=current_user.email_address,
         ),
         ticket_type=zendesk_client.TYPE_QUESTION,
         user_email=current_user.email_address,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
-from datetime import datetime
 
-import pytz
 from flask import (
     abort,
     current_app,
@@ -202,7 +200,6 @@ def submit_request_to_go_live(service_id):
             '\n---'
             '\nOrganisation type: {organisation_type}'
             '\nAgreement signed: {agreement}'
-            '\nChecklist completed: {checklist}'
             '\nEmails in next year: {volume_email_formatted}'
             '\nText messages in next year: {volume_sms_formatted}'
             '\nLetters in next year: {volume_letter_formatted}'
@@ -214,7 +211,6 @@ def submit_request_to_go_live(service_id):
             service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
             organisation_type=str(current_service.organisation_type).title(),
             agreement=current_service.organisation.as_human_readable(current_user.email_domain),
-            checklist=current_service.go_live_checklist_completed_as_yes_no,
             volume_email_formatted=format_if_number(current_service.volume_email),
             volume_sms_formatted=format_if_number(current_service.volume_sms),
             volume_letter_formatted=format_if_number(current_service.volume_letter),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1384,6 +1384,9 @@ def test_should_redirect_after_request_to_go_live(
         '{formatted_displayed_volumes}'
         'Consent to research: Yes\n'
         'Other live services: No\n'
+        '\n'
+        '---\n'
+        'Request sent by test@user.gov.uk\n'
     ).format(
         service_id=SERVICE_ONE_ID,
         displayed_volumes=displayed_volumes,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1385,10 +1385,6 @@ def test_should_redirect_after_request_to_go_live(
         '{formatted_displayed_volumes}'
         'Consent to research: Yes\n'
         'Other live services: No\n'
-        '\n'
-        '---\n'
-        '{service_id}, None, service one, Test User, test@user.gov.uk, -, 21/12/2012, '
-        '{displayed_volumes}'
     ).format(
         service_id=SERVICE_ONE_ID,
         displayed_volumes=displayed_volumes,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1381,7 +1381,6 @@ def test_should_redirect_after_request_to_go_live(
         '---\n'
         'Organisation type: Central\n'
         'Agreement signed: Can’t tell (domain is user.gov.uk)\n'
-        'Checklist completed: No\n'
         '{formatted_displayed_volumes}'
         'Consent to research: Yes\n'
         'Other live services: No\n'


### PR DESCRIPTION
# Remove copy-pasteable version of go live info

We’ve automated this now so we don’t need it in a format that’s easy to copy and paste into a spreadsheet.

# Remove line about checklist from go live email

It’s impossible for people to go live without technically completing the checklist now.