### PR TITLE
Make folder name textbox full width

### DIFF
--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -24,7 +24,7 @@
   </div>
 
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
-    {{ textbox(form.name) }}
+    {{ textbox(form.name, width='1-1') }}
     {% if current_service.has_permission("edit_folder_permissions") %}
       {% if current_user.has_permissions("manage_service") and form.users_with_permission.all_service_users %}
         {{ checkboxes(form.users_with_permission) }}


### PR DESCRIPTION
Folder names can be quite long. It’s annoying if they get cut off.