### PR TITLE
Try to render AJAX updates one final time if error

### DIFF
--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -30,7 +30,12 @@
     ).done(
       response => flushQueue(queue, response)
     ).fail(
-      () => poll = function(){}
+      response => {
+        if (response.responseJSON) {
+          flushQueue(queue, response.responseJSON);
+        }
+        poll = function(){};
+      }
     );
 
     setTimeout(


### PR DESCRIPTION
When we return a HTTP error we still want to display what the error is. So we should assume that when returning some JSON with an error status that we should still try to render the updates to the page before switching off the polling (which is what setting it to an empty function does).

For a `500` error the JSON will be `undefined`, so the Javascript will not try to update the page.