### PR TITLE
Use new ‘add’ buttons on branding management pages

### DIFF
--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -1,4 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 
 {% block per_page_title %}
@@ -7,14 +8,7 @@
 
 {% block platform_admin_content %}
 
-  <div class="grid-row bottom-gutter-2-3">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Email branding</h1>
-    </div>
-    <div class="column-one-third">
-      <a href="{{ url_for('.create_email_branding') }}" class="button align-with-heading">Add new brand</a>
-    </div>
-  </div>
+  {{ page_header('Email branding') }}
   {{ live_search(target_selector='.email-brand', show=True, form=search_form) }}
   <nav>
     {% for brand in email_brandings %}
@@ -27,5 +21,8 @@
       </div>
     {% endfor %}
   </nav>
+  <div class="js-stick-at-bottom-when-scrolling">
+    <a href="{{ url_for('.create_email_branding') }}" class="button-secondary">New brand</a>
+  </div>
 
 {% endblock %}

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -1,4 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 
 {% block per_page_title %}
@@ -7,14 +8,7 @@
 
 {% block platform_admin_content %}
 
-  <div class="grid-row bottom-gutter-2-3">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Letter branding</h1>
-    </div>
-    <div class="column-one-third">
-      <a href="{{ url_for('.create_letter_branding') }}" class="button align-with-heading">Add new brand</a>
-    </div>
-  </div>
+  {{ page_header('Letter branding') }}
   {{ live_search(target_selector='.letter-brand', show=True, form=search_form) }}
   <nav>
     {% for brand in letter_brandings %}
@@ -27,5 +21,8 @@
       </div>
     {% endfor %}
   </nav>
+  <div class="js-stick-at-bottom-when-scrolling">
+    <a href="{{ url_for('.create_letter_branding') }}" class="button-secondary">New brand</a>
+  </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -33,7 +33,7 @@ def test_email_branding_page_shows_full_branding_list(
         page.select_one('h1').text
     ) == "Email branding"
 
-    assert page.select_one('.column-three-quarters a')['href'] == url_for('main.create_email_branding')
+    assert page.select('.column-three-quarters a')[-1]['href'] == url_for('main.create_email_branding')
 
     assert brand_names == [
         'org 1',

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -33,7 +33,7 @@ def test_letter_branding_page_shows_full_branding_list(
         page.select_one('h1').text
     ) == "Letter branding"
 
-    assert page.select_one('.column-three-quarters a')['href'] == url_for('main.create_letter_branding')
+    assert page.select('.column-three-quarters a')[-1]['href'] == url_for('main.create_letter_branding')
 
     assert brand_names == [
         'HM Government',


### PR DESCRIPTION
‘Add’ buttons are generally:
- at the bottom of the page
- sticky
- grey

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/58031524-7e4e4100-7b18-11e9-85fa-4e5d393f29cb.png) | ![image](https://user-images.githubusercontent.com/355079/58031493-72fb1580-7b18-11e9-8710-5f0f93bf2525.png)
