### PR TITLE
Make ‘you must set organisation’ text shorter

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -292,7 +292,7 @@
           {% call row() %}
             {{ text_field('Live')}}
             {% if current_service.trial_mode and not current_service.organisation %}
-              {{ text_field('No (you need to assign this service to an organisation before you can make it live)') }}
+              {{ text_field('No (organisation must be set first)') }}
               {{ text_field('') }}
             {% else %}
               {{ boolean_field(not current_service.trial_mode) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -158,7 +158,7 @@ def test_no_go_live_link_for_service_without_organisation(
 
     assert page.find('h1').text == 'Settings'
     assert normalize_spaces(page.select('tr')[16].text) == (
-        'Live No (you need to assign this service to an organisation before you can make it live)'
+        'Live No (organisation must be set first)'
     )
     assert normalize_spaces(page.select('tr')[18].text) == (
         'Organisation Not set Change'


### PR DESCRIPTION
So it fits in the column:

![image](https://user-images.githubusercontent.com/355079/58032485-98891e80-7b1a-11e9-9b6d-b732d8efabb3.png)
