### PR TITLE
Fix duplicated H1 on ‘New letter branding’ page

### DIFF
--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -3,9 +3,10 @@
   service_id,
   template_type,
   current_user,
-  link_current_item=False
+  link_current_item=False,
+  root_element='h1'
 ) %}
-  <h1 class="heading-medium folder-heading">
+  <{{ root_element }} class="heading-medium folder-heading">
     {% for folder in folders %}
       {% if loop.last and not link_current_item %}
         {% if folder.template_type or not folder.id %}
@@ -26,7 +27,7 @@
         {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
       {% endif %}
     {% endfor %}
-  </h1>
+  </{{ root_element }}>
 {% endmacro %}
 
 

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -11,7 +11,6 @@
 
 {% block platform_admin_content %}
 
-  <h1 class="heading-large">{{ '{} letter branding'.format('Update' if is_update else 'Add')}}</h1>
   {{ page_header(
     '{} letter branding'.format('Update' if is_update else 'Add'),
     back_link=url_for('main.letter_branding')

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -14,7 +14,7 @@
 
 <div class="bottom-gutter-1-2">
   <h1 class="heading-large">Choose a template</h1>
-  {{ folder_path(template_folder_path, current_service.id, template_type, current_user) }}
+  {{ folder_path(template_folder_path, current_service.id, template_type, current_user, root_element='h2') }}
 </div>
 
   {% if not templates_and_folders.templates_to_show %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -998,7 +998,7 @@ def test_send_test_step_redirects_if_session_not_setup(
 ):
     mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
     template_mock(mocker)
-    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
     with client_request.session_transaction() as session:
         assert 'recipient' not in session
@@ -1109,7 +1109,7 @@ def test_send_one_off_or_test_has_correct_page_titles(
 ):
     mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
     template_mock(mocker)
-    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
     response = logged_in_client.get(
         partial_url(service_id=service_one['id'], template_id=fake_uuid, step_index=0),
@@ -1224,7 +1224,7 @@ def test_send_one_off_has_skip_link(
 ):
     mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
     template_mock(mocker)
-    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
     page = client_request.get(
         'main.send_one_off_step',
@@ -1261,7 +1261,7 @@ def test_send_one_off_has_sticky_header_for_email_and_letter(
     expected_sticky,
 ):
     template_mock(mocker)
-    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
     page = client_request.get(
         'main.send_one_off_step',
@@ -1774,7 +1774,7 @@ def test_send_test_caches_page_count(
     fake_uuid,
 ):
 
-    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=99)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
     logged_in_client.get(
         url_for(
@@ -1785,7 +1785,7 @@ def test_send_test_caches_page_count(
         follow_redirects=True,
     )
     with logged_in_client.session_transaction() as session:
-        assert session['send_test_letter_page_count'] == 99
+        assert session['send_test_letter_page_count'] == 9
 
 
 def test_send_test_indicates_optional_address_columns(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2908,6 +2908,9 @@ def client_request(
                 assert resp.location == _expected_redirect
             page = BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
             if _test_page_title:
+                count_of_h1s = len(page.select('h1'))
+                if count_of_h1s != 1:
+                    raise AssertionError('Page should have one H1 ({} found)'.format(count_of_h1s))
                 page_title, h1 = (
                     normalize_spaces(page.find(selector).text) for selector in ('title', 'h1')
                 )


### PR DESCRIPTION
For accessibility reasons a page should have one (and only one) H1. This commit fixes an instance where the H1 was duplicated as a result of the work done to componentise our page headings.

It also adds an extra check to `client_request` so that we don’t introduce pages with multiple or no H1s in the future.