### PR TITLE
Update email_domains.yml

### DIFF
--- a/app/email_domains.yml
+++ b/app/email_domains.yml
@@ -57,3 +57,4 @@
 - unifiedgov.co.uk
 - tfwm.org.uk
 - wmca.org.uk
+- suttonmail.org


### PR DESCRIPTION
Adding suttonmail.org (domain provided by London Grid for Learning) - a network of state-funded schools in Sutton