### PR TITLE
Remove spacing tweak on loading indicator

### DIFF
--- a/app/assets/stylesheets/components/loading-indicator.scss
+++ b/app/assets/stylesheets/components/loading-indicator.scss
@@ -12,7 +12,5 @@
     animation: ellipsis steps(4,end) 1.5s infinite;
     content: "\2026"; // ellipsis
     width: 0;
-    position: relative;
-    left: -0.15em;
   }
 }


### PR DESCRIPTION
It’s not needed when there’s no whitespace around the text.