### PR TITLE
Let users archive their own trial mode services

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -39,7 +39,7 @@
   margin-top: $gutter * 4 / 3;
 }
 
-.top-gutter-2-3 {
+.top-gutter-1-2 {
   @extend %top-gutter;
   margin-top: $gutter-half;
 }

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -330,11 +330,22 @@ def service_switch_can_upload_document(service_id):
 @login_required
 @user_has_permissions('manage_service')
 def archive_service(service_id):
+    if not current_service.active and (
+        current_service.trial_mode or current_user.platform_admin
+    ):
+        abort(403)
     if request.method == 'POST':
         service_api_client.archive_service(service_id)
-        return redirect(url_for('.service_settings', service_id=service_id))
+        flash(
+            '‘{}’ was deleted'.format(current_service.name),
+            'default_with_tick',
+        )
+        return redirect(url_for('.choose_account'))
     else:
-        flash('There\'s no way to reverse this! Are you sure you want to archive this service?', 'delete')
+        flash(
+            'Are you sure you want to delete ‘{}’? There’s no way to undo this.'.format(current_service.name),
+            'delete',
+        )
         return service_settings(service_id)
 
 

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -4,7 +4,7 @@
 
 <div class="ajax-block-container">
   {% if messages %}
-    <p class="bottom-gutter-2-3 top-gutter-2-3">
+    <p class="bottom-gutter-2-3 top-gutter-1-2">
       <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="heading-small">Download these messages</a>
     </p>
   {% endif %}
@@ -37,4 +37,3 @@
 
   {{ previous_next_navigation(prev_page, next_page) }}
 </div>
-

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -353,32 +353,39 @@
 
         {% endcall %}
 
-        <p>
-          {% if current_service.active %}
-            <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a href="{{ url_for('.archive_service', service_id=current_service.id) }}">
-                Archive service
-              </a>
-            </span>
-            <span class="page-footer-delete-link">
-              <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="page-footer-delete-link">
-                  Suspend service
-                </a>
-            </span>
-          {% else %}
-            <div class="hint bottom-gutter-1-2">
-              Service suspended
-            </div>
-            <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a href="{{ url_for('.resume_service', service_id=current_service.id) }}">
-                Resume service
-              </a>
-            </span>
-          {% endif %}
-        </p>
       </div>
 
     {% endif %}
+
+    {% if current_service.active and (current_service.trial_mode or current_user.platform_admin) %}
+      <p class="top-gutter-1-2">
+        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+          <a href="{{ url_for('.archive_service', service_id=current_service.id) }}">
+            Delete this service
+          </a>
+        </span>
+        {% if current_user.platform_admin %}
+          <span class="page-footer-delete-link">
+            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="page-footer-delete-link">
+                Suspend service
+              </a>
+          </span>
+        {% endif %}
+      </p>
+    {% endif %}
+    {% if (not current_service.active) and current_user.platform_admin %}
+      <p>
+        <div class="hint bottom-gutter-1-2">
+          Service suspended
+        </div>
+        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+          <a href="{{ url_for('.resume_service', service_id=current_service.id) }}">
+            Resume service
+          </a>
+        </span>
+      </p>
+    {% endif %}
+
 
 {% endblock %}
 }

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -2,7 +2,7 @@
 
 {% block fullwidth_content %}
   <div id="content">
-    {% if current_service and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}
+    {% if current_service and current_service.active and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}
     <div class="navigation-service">
       <a href="{{ url_for('main.show_accounts_or_dashboard') }}">Back to {{ current_service.name }}</a>
     </div>

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -144,6 +144,25 @@ def test_choose_account_should_not_show_back_to_service_link_if_not_signed_in(
     assert page.select_one('.navigation-service a') is None
 
 
+@pytest.mark.parametrize('active', (
+    False,
+    pytest.param(True, marks=pytest.mark.xfail(raises=AssertionError)),
+))
+def test_choose_account_should_not_show_back_to_service_link_if_service_archived(
+    client_request,
+    service_one,
+    mock_get_orgs_and_services,
+    active,
+):
+    service_one['active'] = active
+    with client_request.session_transaction() as session:
+        session['service_id'] = service_one['id']
+    page = client_request.get('main.choose_account')
+
+    assert normalize_spaces(page.select_one('h1').text) == 'Choose service'
+    assert page.select_one('.navigation-service a') is None
+
+
 @pytest.mark.parametrize('service, expected_status, page_text', (
     (service_one, 200, (
         'Test Service   Switch service '

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -83,7 +83,7 @@ def test_service_setting_toggles_show(get_service_settings_page, service_one, se
 
 
 @pytest.mark.parametrize('service_fields, endpoint, index, text', [
-    ({'active': True}, '.archive_service', 0, 'Archive service'),
+    ({'active': True}, '.archive_service', 0, 'Delete this service'),
     ({'active': True}, '.suspend_service', 1, 'Suspend service'),
     ({'active': False}, '.resume_service', 0, 'Resume service'),
     pytest.param(


### PR DESCRIPTION
At the moment we have a blanket rule that users can’t archive their own services, to prevent someone accidentally deleting a real live service, because that would be Very Bad.

But the tickets we get from users asking us to delete services are for services they set up when they were just trying out Notify. There’s not much harm in letting users delete these services, the consequences of  doing so are much lower than those of deleting a live service. And it should mean fewer support tickets for us to deal with.

***

![image](https://user-images.githubusercontent.com/355079/58624900-31612c00-82c9-11e9-852b-f01f3c4e284e.png)

***

![image](https://user-images.githubusercontent.com/355079/58624909-3aea9400-82c9-11e9-9579-f76db5350dce.png)

***

![image](https://user-images.githubusercontent.com/355079/58624980-61a8ca80-82c9-11e9-9bb3-7e91c2727d0c.png)
