### PR TITLE
Make organisation settings platform admin only

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -229,7 +229,6 @@ def edit_organisation_name(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-type", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def edit_organisation_type(org_id):
 
@@ -252,7 +251,6 @@ def edit_organisation_type(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-crown-status", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def edit_organisation_crown_status(org_id):
 
@@ -283,7 +281,6 @@ def edit_organisation_crown_status(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-agreement", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def edit_organisation_agreement(org_id):
 
@@ -314,7 +311,6 @@ def edit_organisation_agreement(org_id):
 
 @main.route("/organisations/<org_id>/settings/set-email-branding", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def edit_organisation_email_branding(org_id):
 
@@ -341,7 +337,6 @@ def edit_organisation_email_branding(org_id):
 
 @main.route("/organisations/<org_id>/settings/preview-email-branding", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def organisation_preview_email_branding(org_id):
 
@@ -412,7 +407,6 @@ def organisation_preview_letter_branding(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-organisation-domains", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def edit_organisation_domains(org_id):
 
@@ -471,7 +465,6 @@ def confirm_edit_organisation_name(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-go-live-notes", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
 @user_is_platform_admin
 def edit_organisation_go_live_notes(org_id):
 

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -180,7 +180,7 @@ def cancel_invited_org_user(org_id, invited_user_id):
 
 @main.route("/organisations/<org_id>/settings/", methods=['GET'])
 @login_required
-@user_has_permissions()
+@user_is_platform_admin
 def organisation_settings(org_id):
 
     email_branding = 'GOV.UK'
@@ -206,7 +206,7 @@ def organisation_settings(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-name", methods=['GET', 'POST'])
 @login_required
-@user_has_permissions()
+@user_is_platform_admin
 def edit_organisation_name(org_id):
     form = RenameOrganisationForm()
 

--- a/app/templates/views/organisations/organisation/settings/edit-agreement.html
+++ b/app/templates/views/organisations/organisation/settings/edit-agreement.html
@@ -1,5 +1,6 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 
 {% extends "org_template.html" %}
@@ -9,7 +10,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Data sharing and financial agreement</h1>
+  {{ page_header(
+    "Data sharing and financial agreement",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   <div class="grid-row">
     <div class="column-five-sixths">
       {% call form_wrapper() %}

--- a/app/templates/views/organisations/organisation/settings/edit-crown-status.html
+++ b/app/templates/views/organisations/organisation/settings/edit-crown-status.html
@@ -1,5 +1,6 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 
 {% extends "org_template.html" %}
@@ -9,7 +10,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Crown organisation</h1>
+  {{ page_header(
+    "Crown organisation",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   <div class="grid-row">
     <div class="column-five-sixths">
       {% call form_wrapper() %}

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -1,5 +1,6 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/list-entry.html" import list_entry %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Known email domains</h1>
+  {{ page_header(
+    "Known email domains",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   <div class="grid-row">
     <div class="column-five-sixths">
       <p>

--- a/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
@@ -1,5 +1,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/textbox.html" import textbox %}
 
 {% extends "org_template.html" %}
@@ -9,7 +10,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Edit request to go live notes</h1>
+  {{ page_header(
+    "Edit request to go live notes",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   <div class="grid-row">
     <div class="column-five-sixths">
       <p>

--- a/app/templates/views/organisations/organisation/settings/edit-type.html
+++ b/app/templates/views/organisations/organisation/settings/edit-type.html
@@ -10,7 +10,10 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ page_header("Organisation sector") }}
+  {{ page_header(
+    "Organisation sector",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   {% call form_wrapper() %}
     {{ radios(form.organisation_type) }}
     {{ page_footer('Save') }}

--- a/app/templates/views/organisations/organisation/settings/edit-type.html
+++ b/app/templates/views/organisations/organisation/settings/edit-type.html
@@ -1,21 +1,18 @@
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 
 {% extends "org_template.html" %}
 
 {% block org_page_title %}
-  Organisation type
+  Organisation sector
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Organisation type</h1>
-  <div class="grid-row">
-    <div class="column-five-sixths">
-      {% call form_wrapper() %}
-        {{ radios(form.organisation_type) }}
-        {{ page_footer('Save') }}
-      {% endcall %}
-    </div>
-  </div>
+  {{ page_header("Organisation sector") }}
+  {% call form_wrapper() %}
+    {{ radios(form.organisation_type) }}
+    {{ page_footer('Save') }}
+  {% endcall %}
 {% endblock %}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -23,102 +23,88 @@
           )
         }}
       {% endcall %}
+      {% call row() %}
+        {{ text_field('Organisation type') }}
+        {{ optional_text_field({
+          'central': 'Central government',
+          'local': 'Local government',
+          'nhs': 'NHS',
+        }.get(current_org.organisation_type)) }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_type', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
+      {% call row() %}
+        {{ text_field('Crown organisation') }}
+        {{ optional_text_field(
+            {
+              True: 'Yes',
+              False: 'No',
+            }.get(current_org.crown),
+            default='Not sure'
+        ) }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_crown_status', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
+      {% call row() %}
+        {{ text_field('Data sharing and financial agreement') }}
+        {{ text_field(
+          {
+            True: 'Signed',
+            False: 'Not signed',
+            None: 'Not signed (but we have some service-specific agreements in place)'
+          }.get(current_org.agreement_signed)
+        ) }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_agreement', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
+      {% call row() %}
+        {{ text_field('Request to go live notes') }}
+        {{ optional_text_field(current_org.request_to_go_live_notes, default='None') }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_go_live_notes', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
+      {% call row() %}
+        {{ text_field('Default email branding') }}
+        {{ text_field(email_branding) }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_email_branding', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
+      {% call row() %}
+        {{ text_field('Default letter branding') }}
+        {{ optional_text_field(
+          letter_branding,
+          default='No branding'
+        ) }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_letter_branding', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
+      {% call row() %}
+        {{ text_field('Known email domains') }}
+        {{ optional_text_field(current_org.domains or None, default='None') }}
+        {{ edit_field(
+            'Change',
+            url_for('.edit_organisation_domains', org_id=current_org.id)
+          )
+        }}
+      {% endcall %}
     {% endcall %}
   </div>
-
-
-  {% if current_user.platform_admin %}
-    <h2 class="heading-medium">Platform admin settings</h2>
-    <div class="settings-table body-copy-table">
-      {% call mapping_table(
-        caption='Platform admin settings',
-        field_headings=['Label', 'Value', 'Action'],
-        field_headings_visible=False,
-        caption_visible=False
-      ) %}
-        {% call row() %}
-          {{ text_field('Organisation type') }}
-          {{ optional_text_field({
-            'central': 'Central government',
-            'local': 'Local government',
-            'nhs': 'NHS',
-          }.get(current_org.organisation_type)) }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_type', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Crown organisation') }}
-          {{ optional_text_field(
-              {
-                True: 'Yes',
-                False: 'No',
-              }.get(current_org.crown),
-              default='Not sure'
-          ) }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_crown_status', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Data sharing and financial agreement') }}
-          {{ text_field(
-            {
-              True: 'Signed',
-              False: 'Not signed',
-              None: 'Not signed (but we have some service-specific agreements in place)'
-            }.get(current_org.agreement_signed)
-          ) }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_agreement', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Request to go live notes') }}
-          {{ optional_text_field(current_org.request_to_go_live_notes, default='None') }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_go_live_notes', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Default email branding') }}
-          {{ text_field(email_branding) }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_email_branding', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Default letter branding') }}
-          {{ optional_text_field(
-            letter_branding,
-            default='No branding'
-          ) }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_letter_branding', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-        {% call row() %}
-          {{ text_field('Known email domains') }}
-          {{ optional_text_field(current_org.domains or None, default='None') }}
-          {{ edit_field(
-              'Change',
-              url_for('.edit_organisation_domains', org_id=current_org.id)
-            )
-          }}
-        {% endcall %}
-      {% endcall %}
-    </div>
-  {% endif %}
 {% endblock %}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -15,7 +15,7 @@
       caption_visible=False
     ) %}
       {% call row() %}
-        {{ text_field('Organisation name') }}
+        {{ text_field('Name') }}
         {{ text_field(current_org.name) }}
         {{ edit_field(
             'Change',
@@ -24,7 +24,7 @@
         }}
       {% endcall %}
       {% call row() %}
-        {{ text_field('Organisation type') }}
+        {{ text_field('Sector') }}
         {{ optional_text_field({
           'central': 'Central government',
           'local': 'Local government',

--- a/app/templates/views/organisations/organisation/settings/set-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-email-branding.html
@@ -1,6 +1,7 @@
 {% extends "org_template.html" %}
 {% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,7 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Default email branding</h1>
+  {{ page_header(
+    "Default email branding",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'email'}) %}
     <div class="grid-row">
       <div class="column-full preview-pane">

--- a/app/templates/views/organisations/organisation/settings/set-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-letter-branding.html
@@ -2,6 +2,7 @@
 {% from "components/radios.html" import radios %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block org_page_title %}
@@ -10,7 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Default letter branding</h1>
+  {{ page_header(
+    "Default letter branding",
+    back_link=url_for('.organisation_settings', org_id=current_org.id)
+  ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'letter'}) %}
     <div class="grid-row">
       <div class="column-full preview-pane">

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -2,6 +2,7 @@
 
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -10,9 +11,10 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">
-    Invite a team member
-  </h1>
+  {{ page_header(
+    "Invite a team member",
+    back_link=url_for('.manage_org_users', org_id=current_org.id)
+  ) }}
   <div class="grid-row">
     {% call form_wrapper(class="column-three-quarters") %}
 	    {{ textbox(form.email_address, width='1-1', safe_error_message=True) }}

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -182,8 +182,6 @@ def test_organisation_settings_for_platform_admin(
     expected_rows = [
         'Label Value Action',
         'Organisation name Org 1 Change',
-
-        'Label Value Action',
         'Organisation type Not set Change',
         'Crown organisation Yes Change',
         'Data sharing and financial agreement Not signed Change',

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -181,8 +181,8 @@ def test_organisation_settings_for_platform_admin(
 ):
     expected_rows = [
         'Label Value Action',
-        'Organisation name Org 1 Change',
-        'Organisation type Not set Change',
+        'Name Org 1 Change',
+        'Sector Not set Change',
         'Crown organisation Yes Change',
         'Data sharing and financial agreement Not signed Change',
         'Request to go live notes None Change',

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -161,24 +161,16 @@ def test_organisation_trial_mode_services_doesnt_work_if_not_platform_admin(
     )
 
 
-def test_organisation_settings(
+def test_organisation_settings_platform_admin_only(
     client_request,
     mock_get_organisation,
     organisation_one
 ):
-    expected_rows = [
-        'Label Value Action',
-        'Organisation name Org 1 Change',
-    ]
-
-    page = client_request.get('.organisation_settings', org_id=organisation_one['id'])
-
-    assert page.find('h1').text == 'Settings'
-    rows = page.select('tr')
-    assert len(rows) == len(expected_rows)
-    for index, row in enumerate(expected_rows):
-        assert row == " ".join(rows[index].text.split())
-    mock_get_organisation.assert_called_with(organisation_one['id'])
+    client_request.get(
+        '.organisation_settings',
+        org_id=organisation_one['id'],
+        _expected_status=403,
+    )
 
 
 def test_organisation_settings_for_platform_admin(


### PR DESCRIPTION
At the moment the only setting that a normal organisation team member can change is the name of the organisation is its name. And we don’t even want them to be able to change this. So this pull request:
- hides the settings page entirely for non-platform-admin users
- performs some general code style/user interface patterns/language housekeeping on pages (see individual commits)