### PR TITLE
Update blog link in light of ‘Government as a Platform’ being retired

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -79,7 +79,7 @@
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
             <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Slack channel</a></li>
-            <li><a href="https://governmentasaplatform.blog.gov.uk/category/gov-uk-notify/">Blog</a></li>
+            <li><a href="https://gds.blog.gov.uk/category/notify/">Blog</a></li>
           </ul>
         </div>
         <div class="column-one-quarter">


### PR DESCRIPTION
> we will be closing this blog and putting all future Government as a Platform (GaaP) news on the GDS blog.

– https://governmentasaplatform.blog.gov.uk/2019/04/18/this-blog-is-now-closed/