### PR TITLE
Recipient email/number works as placeholder in test send one off journey

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -740,8 +740,12 @@ def fields_to_fill_in(template, prefill_current_user=False):
 
     if 'letter' == template.template_type or not prefill_current_user:
         return recipient_columns + list(template.placeholders)
-
-    session['recipient'] = current_user.mobile_number if template.template_type == 'sms' else current_user.email_address
+    if template.template_type == 'sms':
+        session['recipient'] = current_user.mobile_number
+        session['placeholders']['phone number'] = current_user.mobile_number
+    else:
+        session['recipient'] = current_user.email_address
+        session['placeholders']['email address'] = current_user.email_address
 
     return list(template.placeholders)
 


### PR DESCRIPTION
While writing functional tests I discovered that in test one-off journey (when user sends to themselves) the 'email address' and 'phone number' placeholders do not get auto-filled. This PR fixes it.

It will be tested by functional tests I'm currently writing.