### PR TITLE
Fix organisation nav

### DIFF
--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -4,7 +4,7 @@
     <li><a href="{{ url_for('.manage_org_users', org_id=current_org.id) }}" {{ org_navigation.is_selected('team-members') }}>Team members</a></li>
     {% if current_user.platform_admin %}
     <li><a href="{{ url_for('.organisation_settings', org_id=current_org.id) }}" {{ org_navigation.is_selected('settings') }}>Settings</a></li>
-    <li><a href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}" {{ org_navigation.is_selected('trial-services') }}>Trial services</a></li>
+    <li><a href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}" {{ org_navigation.is_selected('trial-services') }}>Trial mode services</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -2,8 +2,8 @@
   <ul>
   	<li><a href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}" {{ org_navigation.is_selected('dashboard') }}>Services</a></li>
     <li><a href="{{ url_for('.manage_org_users', org_id=current_org.id) }}" {{ org_navigation.is_selected('team-members') }}>Team members</a></li>
-    <li><a href="{{ url_for('.organisation_settings', org_id=current_org.id) }}" {{ org_navigation.is_selected('settings') }}>Settings</a></li>
     {% if current_user.platform_admin %}
+    <li><a href="{{ url_for('.organisation_settings', org_id=current_org.id) }}" {{ org_navigation.is_selected('settings') }}>Settings</a></li>
     <li><a href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}" {{ org_navigation.is_selected('trial-services') }}>Trial services</a></li>
     {% endif %}
   </ul>


### PR DESCRIPTION
- make settings link platform admin only (only platform admins can view this page now)
- say trial _mode_ services (that’s the `h1` of the page)