### PR TITLE
Fix back links in tour

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -101,8 +101,13 @@ def view_notification(service_id, notification_id):
     show_cancel_button = notification['notification_type'] == 'letter' and \
         letter_can_be_cancelled(notification['status'], notification_created)
 
-    if request.args.get('help') == '0':
-        back_link = None
+    if get_help_argument():
+        back_link = url_for(
+            'main.send_test',
+            service_id=current_service.id,
+            template_id=template.id,
+            help='2',
+        )
     elif request.args.get('from_job'):
         back_link = url_for(
             'main.view_job',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -800,7 +800,20 @@ def get_back_link(service_id, template, step_index):
                 help=get_help_argument()
             )
         else:
-            return None
+            if step_index == 0:
+                return url_for(
+                    'main.start_tour',
+                    service_id=service_id,
+                    template_id=template.id,
+                )
+            elif step_index > 0:
+                return url_for(
+                    'main.send_test_step',
+                    service_id=service_id,
+                    template_id=template.id,
+                    step_index=step_index - 1,
+                    help=2,
+                )
     elif step_index == 0:
         if should_skip_template_page(template.template_type):
             return url_for(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -125,12 +125,22 @@ def test_notification_status_page_respects_redaction(
         partial(url_for, 'main.view_job', job_id='job_id'),
     ),
     (
-        {'help': '0'},
-        None,
+        {'help': '0'},  # not a valid help step
+        partial(url_for, 'main.view_notifications', message_type='sms', status='sending,delivered,failed'),
     ),
     (
         {'help': '0', 'from_job': 'job_id'},
-        None,
+        partial(url_for, 'main.view_job', job_id='job_id'),
+    ),
+    (
+        {'help': '1'},
+        partial(
+            url_for,
+            'main.send_test',
+            service_id=SERVICE_ONE_ID,
+            template_id='5407f4db-51c7-4150-8758-35412d42186a',
+            help='2'
+        ),
     ),
 ])
 def test_notification_status_shows_expected_back_link(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1676,6 +1676,50 @@ def test_send_test_sms_message_back_link_with_multiple_placeholders(
     )
 
 
+@pytest.mark.parametrize('step_index, expected_back_link', (
+    (0, partial(
+        url_for,
+        'main.start_tour',
+    )),
+    (1, partial(
+        url_for,
+        'main.send_test_step',
+        step_index=0,
+        help=2,
+    )),
+    (2, partial(
+        url_for,
+        'main.send_test_step',
+        step_index=1,
+        help=2,
+    ))
+))
+def test_send_test_sms_message_back_link_in_tour(
+    client_request,
+    mock_get_service_template_with_multiple_placeholders,
+    mock_has_no_jobs,
+    step_index,
+    expected_back_link,
+):
+    with client_request.session_transaction() as session:
+        session['recipient'] = '07900900123'
+        session['placeholders'] = {'phone number': '07900900123', 'one': 'bar'}
+        session['send_test_letter_page_count'] = None
+
+    page = client_request.get(
+        'main.send_test_step',
+        service_id=SERVICE_ONE_ID,
+        template_id=unchanging_fake_uuid,
+        step_index=step_index,
+        help=2,
+    )
+
+    assert page.select_one('.govuk-back-link')['href'] == expected_back_link(
+        service_id=SERVICE_ONE_ID,
+        template_id=unchanging_fake_uuid,
+    )
+
+
 def test_send_test_letter_clears_previous_page_cache(
     logged_in_platform_admin_client,
     mocker,


### PR DESCRIPTION
# Add back links to all steps of tour

For consistency, because some of the steps have them already.

# Fix url of back link on ‘sent’ page in tour

If the user wants to go back from here they need to be sent back to the start of entering the placeholders, because we won’t have their previous personalisation in the session still

I think the back link on this page was introduced by accident. But it’s good to still have it on this page, because it keeps consistency with the previous pages.