### PR TITLE
Fix order of steps in send/send test journeys

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -386,10 +386,7 @@ def send_test_step(service_id, template_id, step_index):
     )
 
     try:
-        if request.endpoint == 'main.send_test_step':
-            current_placeholder = placeholders[step_index - 1]
-        else:
-            current_placeholder = placeholders[step_index]
+        current_placeholder = placeholders[step_index]
     except IndexError:
         if all_placeholders_in_session(placeholders):
             return get_notification_check_endpoint(service_id, template)
@@ -449,7 +446,7 @@ def send_test_step(service_id, template_id, step_index):
     ):
         skip_link = (
             'Use my {}'.format(first_column_headings[template.template_type][0]),
-            url_for('.send_test_step', service_id=service_id, template_id=template.id, step_index=1),
+            url_for('.send_test', service_id=service_id, template_id=template.id),
         )
     else:
         skip_link = None

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1126,9 +1126,15 @@ def test_send_one_off_or_test_has_correct_page_titles(
 @pytest.mark.parametrize('endpoint, step_index, prefilled, expected_field_label', [
     (
         'main.send_test_step',
-        1,
+        0,
         {'phone number': '07900900123'},
         'one',
+    ),
+    (
+        'main.send_test_step',
+        1,
+        {'phone number': '07900900123', 'one': 'one'},
+        'two',
     ),
     (
         'main.send_one_off_step',
@@ -1137,22 +1143,10 @@ def test_send_one_off_or_test_has_correct_page_titles(
         'phone number',
     ),
     (
-        'main.send_test_step',
-        2,
-        {'phone number': '07900900123', 'one': 'foo'},
-        'two',
-    ),
-    (
         'main.send_one_off_step',
         1,
         {'phone number': '07900900123'},
         'one',
-    ),
-    (
-        'main.send_test_step',
-        3,
-        {'phone number': '07900900123', 'one': 'foo', 'two': 'foo'},
-        'three',
     ),
     (
         'main.send_one_off_step',
@@ -1191,13 +1185,13 @@ def test_send_one_off_or_test_shows_placeholders_in_correct_order(
         active_user_with_permissions,
         mock_get_service_template,
         'Use my phone number',
-        partial(url_for, 'main.send_test_step')
+        partial(url_for, 'main.send_test')
     ),
     (
         active_user_with_permissions,
         mock_get_service_email_template,
         'Use my email address',
-        partial(url_for, 'main.send_test_step')
+        partial(url_for, 'main.send_test')
     ),
     (
         active_user_with_permissions,
@@ -1241,7 +1235,6 @@ def test_send_one_off_has_skip_link(
         assert skip_links[0]['href'] == expected_link_url(
             service_id=service_one['id'],
             template_id=fake_uuid,
-            step_index=1
         )
     else:
         assert not skip_links
@@ -1809,7 +1802,7 @@ def test_send_test_indicates_optional_address_columns(
     )
 
     assert normalize_spaces(page.select('label')[0].text) == (
-        'address line 3 '
+        'address line 4 '
         'Optional'
     )
     assert page.select('.govuk-back-link')[0]['href'] == url_for(


### PR DESCRIPTION
This fixes the bug where if you have three placeholders:
> ((one)) ((two)) ((three))

The first one you are asked to fill in is `((three))` (ie `template.placeholders[-1]`).

This reintroduces a bug where if you use the ‘Use my phone number’ link you skip straight to filling in `((two))` and can never proceed because you’re never given the chance to fill in `((one))`. This  commit also fixes that bug.