### PR TITLE
Fix inviting existing users

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -65,7 +65,7 @@ def accept_invite(token):
                 invited_user.auth_type == 'email_auth'
             ):
                 existing_user.update(auth_type=invited_user.auth_type)
-            invited_user.add_to_service()
+            invited_user.add_to_service(existing_user_id=existing_user.id)
             return redirect(url_for('main.service_dashboard', service_id=service.id))
     else:
         return redirect(url_for('main.register_from_invite'))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -348,10 +348,10 @@ class InvitedUser(JSONModel):
     def accept_invite(self):
         invite_api_client.accept_invite(self.service, self.id)
 
-    def add_to_service(self):
+    def add_to_service(self, existing_user_id):
         user_api_client.add_user_to_service(
             self.service,
-            self.id,
+            existing_user_id,
             self.permissions,
             self.folder_permissions,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1652,6 +1652,7 @@ def mock_verify_password(mocker):
 @pytest.fixture(scope='function')
 def mock_update_user_password(mocker, api_user_active):
     def _update(user_id, password):
+        api_user_active['id'] = user_id
         return api_user_active
 
     return mocker.patch('app.user_api_client.update_password', side_effect=_update)
@@ -1660,6 +1661,7 @@ def mock_update_user_password(mocker, api_user_active):
 @pytest.fixture(scope='function')
 def mock_update_user_attribute(mocker, api_user_active):
     def _update(user_id, **kwargs):
+        api_user_active['id'] = user_id
         return api_user_active
 
     return mocker.patch('app.user_api_client.update_user_attribute', side_effect=_update)
@@ -1668,6 +1670,7 @@ def mock_update_user_attribute(mocker, api_user_active):
 @pytest.fixture
 def mock_activate_user(mocker, api_user_active):
     def _activate(user_id):
+        api_user_active['id'] = user_id
         return {'data': api_user_active}
 
     return mocker.patch('app.user_api_client.activate_user', side_effect=_activate)


### PR DESCRIPTION
The API needs the id of the user, not the id of the invite.

The problem with the tests is that the update mock returned a different user ID than the user it was being passed. So the tests didn’t catch this.