### PR TITLE
Hide back link when you’ve just sent a message

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -101,13 +101,11 @@ def view_notification(service_id, notification_id):
     show_cancel_button = notification['notification_type'] == 'letter' and \
         letter_can_be_cancelled(notification['status'], notification_created)
 
-    if get_help_argument():
-        back_link = url_for(
-            'main.send_test',
-            service_id=current_service.id,
-            template_id=template.id,
-            help='2',
-        )
+    if get_help_argument() or request.args.get('help') == '0':
+        # help=0 is set when you’ve just sent a notification. We
+        # only want to show the back link when you’ve navigated to a
+        # notification, not when you’ve just sent it.
+        back_link = None
     elif request.args.get('from_job'):
         back_link = url_for(
             'main.view_job',

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -125,22 +125,16 @@ def test_notification_status_page_respects_redaction(
         partial(url_for, 'main.view_job', job_id='job_id'),
     ),
     (
-        {'help': '0'},  # not a valid help step
-        partial(url_for, 'main.view_notifications', message_type='sms', status='sending,delivered,failed'),
-    ),
-    (
-        {'help': '0', 'from_job': 'job_id'},
-        partial(url_for, 'main.view_job', job_id='job_id'),
+        {'help': '0'},
+        None,
     ),
     (
         {'help': '1'},
-        partial(
-            url_for,
-            'main.send_test',
-            service_id=SERVICE_ONE_ID,
-            template_id='5407f4db-51c7-4150-8758-35412d42186a',
-            help='2'
-        ),
+        None,
+    ),
+    (
+        {'help': '2'},
+        None,
     ),
 ])
 def test_notification_status_shows_expected_back_link(


### PR DESCRIPTION
Changed this yesterday. Changing it again now because I think it’s confusing.

There’s really no going ‘back’ once you’ve sent a message – you can’t undo it. If you want to get back to the template you used, well, that link is in the page.

This commit changes the back link logic so it only appears when you’ve navigated to a notification, not when you’ve just sent it.