### PR TITLE
Use new organisation and services fields

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -31,6 +31,7 @@ from app.main.forms import (
     SetLetterBranding,
 )
 from app.main.views.service_settings import get_branding_as_value_and_label
+from app.models.organisation import Organisations
 from app.models.user import InvitedOrgUser, User
 from app.utils import user_has_permissions, user_is_platform_admin
 
@@ -39,11 +40,9 @@ from app.utils import user_has_permissions, user_is_platform_admin
 @login_required
 @user_is_platform_admin
 def organisations():
-    orgs = organisations_client.get_organisations()
-
     return render_template(
         'views/organisations/index.html',
-        organisations=orgs,
+        organisations=Organisations(),
         search_form=SearchByNameForm(),
     )
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -12,6 +12,12 @@ class JSONModel():
     def __bool__(self):
         return self._dict != {}
 
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
     def __getattr__(self, attr):
         if attr in self.ALLOWED_PROPERTIES:
             return self._dict[attr]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,6 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
 from flask import abort
 
 
@@ -31,6 +34,31 @@ class JSONModel():
             return next(thing for thing in things if thing['id'] == str(id))
         except StopIteration:
             abort(404)
+
+
+class ModelList(ABC, Sequence):
+
+    @property
+    @abstractmethod
+    def client():
+        pass
+
+    @property
+    @abstractmethod
+    def model():
+        pass
+
+    def __init__(self):
+        self.items = self.client()
+
+    def __getitem__(self, index):
+        return self.model(self.items[index])
+
+    def __len__(self):
+        return len(self.items)
+
+    def __add__(self, other):
+        return list(self) + list(other)
 
 
 class InviteTokenError(Exception):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -21,6 +21,7 @@ class Organisation(JSONModel):
         'agreement_signed_version',
         'domains',
         'request_to_go_live_notes',
+        'count_of_live_services',
     }
 
     @classmethod

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -1,7 +1,7 @@
 from flask import Markup, abort
 from werkzeug.utils import cached_property
 
-from app.models import JSONModel
+from app.models import JSONModel, ModelList
 from app.notify_client.organisations_api_client import organisations_client
 
 
@@ -155,3 +155,8 @@ class Organisation(JSONModel):
             self.invited_users + self.active_users,
             key=lambda user: user.email_address.lower(),
         )
+
+
+class Organisations(ModelList):
+    client = organisations_client.get_organisations
+    model = Organisation

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -402,6 +402,10 @@ class Service(JSONModel):
     def organisation(self):
         return Organisation.from_service(self.id)
 
+    @property
+    def organisation_id(self):
+        return self._dict['organisation']
+
     @cached_property
     def inbound_number(self):
         return inbound_number_client.get_inbound_sms_number_for_service(self.id)['data'].get('number', '')

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,11 +1,9 @@
-from collections.abc import Sequence
-
 from flask import abort, current_app, request, session
 from flask_login import AnonymousUserMixin, UserMixin, login_user
 from notifications_python_client.errors import HTTPError
 from werkzeug.utils import cached_property
 
-from app.models import JSONModel
+from app.models import JSONModel, ModelList
 from app.models.organisation import Organisation
 from app.models.roles_and_permissions import (
     all_permissions,
@@ -590,22 +588,13 @@ class AnonymousUser(AnonymousUserMixin):
         return Organisation(None)
 
 
-class Users(Sequence):
+class Users(ModelList):
 
     client = user_api_client.get_users_for_service
     model = User
 
     def __init__(self, service_id):
-        self.users = self.client(service_id)
-
-    def __getitem__(self, index):
-        return self.model(self.users[index])
-
-    def __len__(self):
-        return len(self.users)
-
-    def __add__(self, other):
-        return list(self) + list(other)
+        self.items = self.client(service_id)
 
 
 class OrganisationUsers(Users):
@@ -618,7 +607,7 @@ class InvitedUsers(Users):
     model = InvitedUser
 
     def __init__(self, service_id):
-        self.users = [
+        self.items = [
             user for user in self.client(service_id)
             if user['status'] != 'accepted'
         ]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -294,7 +294,7 @@ class User(JSONModel, UserMixin):
     @property
     def organisations(self):
         return [
-            Organisation.from_id(organisation['id'])
+            Organisation(organisation)
             for organisation in self.orgs_and_services['organisations']
         ]
 

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -22,8 +22,8 @@
     <li class="browse-list-item">
       <a href="{{ url_for('.organisation_dashboard', org_id=org.id) }}" class="browse-list-link">{{ org.name }}</a>
       <p class="browse-list-hint">
-        {{ org.live_services|length }}
-        live service{% if org.live_services|length != 1 %}s{% endif %}
+        {{ org.count_of_live_services }}
+        live service{% if org.count_of_live_services != 1 %}s{% endif %}
       </p>
     </li>
   {% endfor %}

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -32,8 +32,8 @@
             <ul>
               {% for org in organisations %}
                 <li class="browse-list-item">
-                  <a href="{{ url_for('main.organisation_dashboard', org_id=org['id']) }}" class="browse-list-link">{{ org['name'] }}</a>
-                  {% if not org['active'] %}
+                  <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="browse-list-link">{{ org.name }}</a>
+                  {% if not org.active %}
                     <span class="table-field-status-default heading-medium">- archived</span>
                   {% endif %}
                 </li>

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -33,6 +33,10 @@
               {% for org in organisations %}
                 <li class="browse-list-item">
                   <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="browse-list-link">{{ org.name }}</a>
+                  <p class="browse-list-hint">
+                    {{ org.count_of_live_services }}
+                    live service{% if org.count_of_live_services != 1 %}s{% endif %}
+                  </p>
                   {% if not org.active %}
                     <span class="table-field-status-default heading-medium">- archived</span>
                   {% endif %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -139,6 +139,7 @@ def service_json(
     organisation_type='central',
     prefix_sms=True,
     contact_link=None,
+    organisation_id=None,
 ):
     if users is None:
         users = []
@@ -173,6 +174,7 @@ def service_json(
         'volume_letter': 333333,
         'consent_to_research': True,
         'count_as_live': True,
+        'organisation': organisation_id,
     }
 
 
@@ -200,7 +202,6 @@ def organisation_json(
         'name': 'Test Organisation' if name is False else name,
         'active': active,
         'users': users,
-        'services': services,
         'created_at': created_at or str(datetime.utcnow()),
         'email_branding_id': email_branding_id,
         'letter_branding_id': letter_branding_id,
@@ -211,6 +212,7 @@ def organisation_json(
         'agreement_signed_by': None,
         'domains': domains or [],
         'request_to_go_live_notes': request_to_go_live_notes,
+        'count_of_live_services': len(services),
     }
 
 

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -20,14 +20,17 @@ SAMPLE_DATA = {
         {
             'name': 'org_1',
             'id': 'o1',
+            'count_of_live_services': 1,
         },
         {
             'name': 'org_2',
             'id': 'o2',
+            'count_of_live_services': 2,
         },
         {
             'name': 'org_3',
             'id': 'o3',
+            'count_of_live_services': 0,
         }
     ],
     'services': [
@@ -96,14 +99,14 @@ def test_choose_account_should_show_choose_accounts_page(
     assert outer_list_items[0].a.text == 'Org 1'
     assert outer_list_items[0].a['href'] == url_for('.organisation_dashboard', org_id='o1')
     assert normalize_spaces(outer_list_items[0].select_one('.browse-list-hint').text) == (
-        '0 live services'
+        '1 live service'
     )
 
     # second org
     assert outer_list_items[1].a.text == 'Org 2'
     assert outer_list_items[1].a['href'] == url_for('.organisation_dashboard', org_id='o2')
     assert normalize_spaces(outer_list_items[1].select_one('.browse-list-hint').text) == (
-        '0 live services'
+        '2 live services'
     )
 
     # third org
@@ -127,7 +130,7 @@ def test_choose_account_should_show_choose_accounts_page(
     assert trial_services_list_items[1].a.text == 'service three'
     assert trial_services_list_items[1].a['href'] == url_for('.service_dashboard', service_id='abcde')
 
-    assert len(mock_get_organisation.call_args_list) == 21
+    assert mock_get_organisation.call_args_list == []
 
 
 def test_choose_account_should_show_choose_accounts_page_if_no_services(
@@ -155,7 +158,6 @@ def test_choose_account_should_should_organisations_link_for_platform_admin(
     client_request,
     platform_admin_user,
     mock_get_orgs_and_services,
-    mock_get_organisation,
     mock_get_organisation_services,
 ):
     client_request.login(platform_admin_user)

--- a/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
+++ b/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
@@ -29,7 +29,7 @@ def user_with_orgs_and_services(num_orgs, num_services, platform_admin=False):
 def test_show_accounts_or_dashboard_redirects_to_choose_account_or_service_dashboard(
     client,
     mocker,
-    mock_get_non_empty_organisations_and_services_for_user,
+    mock_get_organisations_and_services_for_user,
     num_orgs,
     num_services,
     endpoint,
@@ -78,7 +78,7 @@ def test_show_accounts_or_dashboard_redirects_if_org_in_session(client, mocker):
 def test_show_accounts_or_dashboard_doesnt_redirect_to_service_dashboard_if_user_not_part_of_service_in_session(
     client,
     mocker,
-    mock_get_non_empty_organisations_and_services_for_user,
+    mock_get_organisations_and_services_for_user,
     mock_get_service
 ):
     client.login(user_with_orgs_and_services(num_orgs=1, num_services=1), mocker=mocker)
@@ -95,7 +95,7 @@ def test_show_accounts_or_dashboard_doesnt_redirect_to_service_dashboard_if_user
 def test_show_accounts_or_dashboard_doesnt_redirect_to_org_dashboard_if_user_not_part_of_org_in_session(
     client,
     mocker,
-    mock_get_non_empty_organisations_and_services_for_user,
+    mock_get_organisations_and_services_for_user,
 ):
     client.login(user_with_orgs_and_services(num_orgs=1, num_services=1), mocker=mocker)
     with client.session_transaction() as session:

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -26,7 +26,7 @@ def test_organisation_page_shows_all_organisations(
     ]
 
     mocker.patch(
-        'app.organisations_client.get_organisations', return_value=orgs
+        'app.models.organisation.Organisations.client', return_value=orgs
     )
     response = logged_in_platform_admin_client.get(
         url_for('.organisations')

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -100,7 +100,7 @@ def test_user_information_page_shows_information_about_user(
 
     mocker.patch(
         'app.user_api_client.get_organisations_and_services_for_user',
-        return_value={'organisations': [], 'services_without_organisations': [
+        return_value={'organisations': [], 'services': [
             {"id": 1, "name": "Fresh Orchard Juice", "restricted": True},
             {"id": 2, "name": "Nature Therapy", "restricted": False},
         ]},
@@ -138,7 +138,7 @@ def test_user_information_page_displays_if_there_are_failed_login_attempts(
 
     mocker.patch(
         'app.user_api_client.get_organisations_and_services_for_user',
-        return_value={'organisations': [], 'services_without_organisations': [
+        return_value={'organisations': [], 'services': [
             {"id": 1, "name": "Fresh Orchard Juice", "restricted": True},
             {"id": 2, "name": "Nature Therapy", "restricted": True},
         ]},

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -840,7 +840,7 @@ def test_choose_a_template_to_copy(
     client_request,
     mock_get_service_templates,
     mock_get_template_folders,
-    mock_get_non_empty_organisations_and_services_for_user,
+    mock_get_just_services_for_user,
 ):
     page = client_request.get(
         'main.choose_template_to_copy',
@@ -850,62 +850,6 @@ def test_choose_a_template_to_copy(
     assert page.select('.folder-heading') == []
 
     expected = [
-        (
-            'Org 1 service 1 '
-            '6 templates'
-        ),
-        (
-            'Org 1 service 1 / sms_template_one '
-            'Text message template'
-        ),
-        (
-            'Org 1 service 1 / sms_template_two '
-            'Text message template'
-        ),
-        (
-            'Org 1 service 1 / email_template_one '
-            'Email template'
-        ),
-        (
-            'Org 1 service 1 / email_template_two '
-            'Email template'
-        ),
-        (
-            'Org 1 service 1 / letter_template_one '
-            'Letter template'
-        ),
-        (
-            'Org 1 service 1 / letter_template_two '
-            'Letter template'
-        ),
-        (
-            'Org 1 service 2 '
-            '6 templates'
-        ),
-        (
-            'Org 1 service 2 / sms_template_one '
-            'Text message template'
-        ),
-        (
-            'Org 1 service 2 / sms_template_two '
-            'Text message template'
-        ),
-        (
-            'Org 1 service 2 / email_template_one '
-            'Email template'
-        ),
-        (
-            'Org 1 service 2 / email_template_two '
-            'Email template'
-        ),
-        (
-            'Org 1 service 2 / letter_template_one '
-            'Letter template'
-        ),
-        (
-            'Org 1 service 2 / letter_template_two '
-            'Letter template'
-        ),
         (
             'Service 1 '
             '6 templates'


### PR DESCRIPTION
Uses alphagov/notifications-api#2539 to reduce the number of API calls we make.

Adds count of live services to the organisations page, now that we have this information:

![image](https://user-images.githubusercontent.com/355079/59354069-3b991680-8d1c-11e9-8d41-45ed02711a89.png)
