### PR TITLE
Wrap get org methods in class method on model

### DIFF
--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -27,6 +27,14 @@ class Organisation(JSONModel):
     def from_id(cls, org_id):
         return cls(organisations_client.get_organisation(org_id))
 
+    @classmethod
+    def from_domain(cls, domain):
+        return cls(organisations_client.get_organisation_by_domain(domain))
+
+    @classmethod
+    def from_service(cls, service_id):
+        return cls(organisations_client.get_service_organisation(service_id))
+
     def __init__(self, _dict):
 
         super().__init__(_dict)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -12,7 +12,6 @@ from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
 from app.notify_client.letter_branding_client import letter_branding_client
-from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.service_api_client import service_api_client
 from app.notify_client.template_folder_api_client import (
     template_folder_api_client,
@@ -398,9 +397,7 @@ class Service(JSONModel):
 
     @cached_property
     def organisation(self):
-        return Organisation(
-            organisations_client.get_service_organisation(self.id)
-        )
+        return Organisation.from_service(self.id)
 
     @cached_property
     def inbound_number(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -14,7 +14,6 @@ from app.models.roles_and_permissions import (
 from app.notify_client import InviteTokenError
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.org_invite_api_client import org_invite_api_client
-from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.user_api_client import user_api_client
 from app.utils import is_gov_user
 
@@ -239,9 +238,7 @@ class User(JSONModel, UserMixin):
 
     @cached_property
     def default_organisation(self):
-        return Organisation(
-            organisations_client.get_organisation_by_domain(self.email_domain)
-        )
+        return Organisation.from_domain(self.email_domain)
 
     @property
     def default_organisation_type(self):


### PR DESCRIPTION
This means the service and user models have to import one fewer thing, and matches what we’re doing with the `from_id` class method.