### PR TITLE
Cache organisations, not just domains in Redis

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -417,7 +417,12 @@ def clear_cache():
         ('letter_branding', [
             'letter_branding',
             'letter_branding-????????-????-????-????-????????????',
-        ])
+        ]),
+        ('organisation', [
+            'organisations',
+            'domains',
+            'live-service-and-organisation-counts',
+        ]),
     ])
 
     form = ClearCacheForm()

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -7,6 +7,7 @@ from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
 class OrganisationsClient(NotifyAdminAPIClient):
 
+    @cache.set('organisations')
     def get_organisations(self):
         return self.get(url='/organisations')
 
@@ -30,6 +31,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
                 return None
             raise error
 
+    @cache.delete('organisations')
     def create_organisation(self, name):
         data = {
             "name": name
@@ -37,6 +39,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
         return self.post(url="/organisations", data=data)
 
     @cache.delete('domains')
+    @cache.delete('organisations')
     def update_organisation(self, org_id, **kwargs):
         return self.post(url="/organisations/{}".format(org_id), data=kwargs)
 


### PR DESCRIPTION
This should make the ‘All organisations’ page load a lil’ bit quicker. Still worth caching the domains separately so the response is smaller when we only care about domains. This is because the code that uses the domains is part of the sign up flow, so it’s really important that it’s snappy.