### PR TITLE
Fix rendering of scrollable tables

### DIFF
--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -25,7 +25,7 @@
 
     th,
     .table-field-error-label,
-    .table-field-center-aligned {
+    .table-field-left-aligned {
       white-space: nowrap;
     }
 
@@ -62,7 +62,7 @@
       display: none;
     }
 
-    .table-field-center-aligned {
+    .table-field-left-aligned {
       position: relative;
       z-index: 150;
       background: $white;
@@ -100,7 +100,7 @@
       visibility: hidden;
     }
 
-    .table-field-center-aligned {
+    .table-field-left-aligned {
       width: 0;
       position: relative;
       z-index: 100;


### PR DESCRIPTION
The scrollable tables code styles some of the cells in the target table by looking for the `table-field-center-aligned` class.

This class was renamed in 0512f40ad3d7fdb4d285a4f7e44659cca6f3e09f

This commit updates the scrollable tables code to refer to the new classname, which means that things should line up properly when drawing the table.

***

![image](https://user-images.githubusercontent.com/355079/59616081-a632c380-911b-11e9-96cb-d2f3964af096.png)
