### PR TITLE
Fixes for check spreadsheet page

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -45,7 +45,7 @@
 {%- endmacro %}
 
 {% macro row(id=None) -%}
-  <tr class="table-row" {% if id %}id="{{id}}"{% endif %}>
+  <tr class="table-row" {% if id and id is string %}id="{{id}}"{% endif %}>
     {{ caller() }}
   </tr>
 {%- endmacro %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -704,6 +704,7 @@ def test_upload_valid_csv_shows_preview_and_table(
     ]):
         for index, cell in enumerate(row):
             row = page.select('table tbody tr')[row_index]
+            assert 'id' not in row
             assert normalize_spaces(str(row.select('td')[index + 1])) == cell
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -565,7 +565,14 @@ def test_upload_valid_csv_redirects_to_check_page(
         'main.send_messages', service_id=SERVICE_ONE_ID, template_id=fake_uuid,
         _data={'file': (BytesIO(''.encode('utf-8')), 'valid.csv')},
         _expected_status=302,
-        expected_redirect='foo'
+        _expected_redirect=url_for(
+            'main.check_messages',
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            upload_id=fake_uuid,
+            original_file_name='valid.csv',
+            _external=True,
+        ),
     )
 
 


### PR DESCRIPTION
Couple of small things we discovered while investigating something else:

# Fix incorrect argument name in test 

This test wasn’t checking the redirect because the argument name was missing the leading underscore.

# Only add the `id` attribute to a table row if it’s a string

If it’s something weird like an instance of a Python object let’s ignore it (else we get invalid HTML like
`id='<notifications_utils.columns.Cell object at 0x1126f4e80>'`).