### PR TITLE
Show organisation breadcrumbs

### DIFF
--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -8,6 +8,12 @@
   <div id="content">
     <div class="navigation-service">
       <div class="navigation-service-name">
+        {% if current_service.organisation_id %}
+          {% if current_user.platform_admin or current_user.belongs_to_organisation(current_service.organisation_id) %}
+            <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation.id) }}">{{ current_service.organisation.name }}</a>
+            <span class="navigation-breadcrumb"></span>
+          {% endif %}
+        {% endif %}
         {{ current_service.name }}
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="navigation-service-switch">Switch service</a>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2847,10 +2847,8 @@ def os_environ():
 @pytest.fixture
 def client_request(
     logged_in_client,
-    active_user_with_permissions,
     mocker,
     service_one,
-    fake_uuid,
 ):
     class ClientRequest:
 


### PR DESCRIPTION
Added a breadcrumb link to a service's organisation to the `withnav_template.html`. This will only show if a service has an organisation and the current user is also a member of that org, or the current user is a platform admin user.

Also removed a couple of unused fixtures from the `client_request` fixture.

[Pivotal story](https://www.pivotaltracker.com/story/show/166056773)