### PR TITLE
Link to dashboard if user has access to service

### DIFF
--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -12,7 +12,11 @@
   <ul>
   {% for service in current_org.live_services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('main.usage', service_id=service.id) }}" class="browse-list-link">{{ service['name'] }}</a>
+      {% if current_user.belongs_to_service(service.id) or current_user.platform_admin %}
+        <a href="{{ url_for('main.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service['name'] }}</a>
+      {% else %}
+        <a href="{{ url_for('main.usage', service_id=service.id) }}" class="browse-list-link">{{ service['name'] }}</a>
+      {% endif %}
     </li>
   {% endfor %}
   </ul>


### PR DESCRIPTION
It feels weird to deep link into the usage page. Normally navigating to a service takes you to the dashboard. It should only work differently if you don’t have access to the dashboard.