### PR TITLE
Bump utils to add alt text to email branding

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -112,19 +112,21 @@ def email_template():
         branding_type = email_branding['brand_type']
 
     if branding_type == 'govuk':
-        brand_name = None
+        brand_text = None
         brand_colour = None
         brand_logo = None
         govuk_banner = True
         brand_banner = False
+        brand_name = None
     else:
         colour = email_branding['colour']
-        brand_name = email_branding['text']
+        brand_text = email_branding['text']
         brand_colour = colour
         brand_logo = ('https://{}/{}'.format(get_logo_cdn_domain(), email_branding['logo'])
                       if email_branding['logo'] else None)
         govuk_banner = branding_type in ['govuk', 'both']
         brand_banner = branding_type == 'org_banner'
+        brand_name = email_branding['name']
 
     template = {
         'subject': 'foo',
@@ -174,10 +176,11 @@ def email_template():
         resp = make_response(str(HTMLEmailTemplate(
             template,
             govuk_banner=govuk_banner,
-            brand_name=brand_name,
+            brand_text=brand_text,
             brand_colour=brand_colour,
             brand_logo=brand_logo,
             brand_banner=brand_banner,
+            brand_name=brand_name,
         )))
 
     resp.headers['X-Frame-Options'] = 'SAMEORIGIN'

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@32.0.1#egg=notifications-utils==32.0.1
+git+https://github.com/alphagov/notifications-utils.git@33.0.0#egg=notifications-utils==33.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@32.0.1#egg=notifications-utils==32.0.1
+git+https://github.com/alphagov/notifications-utils.git@33.0.0#egg=notifications-utils==33.0.0
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.181
+awscli==1.16.185
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.171
+botocore==1.12.175
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -61,7 +61,7 @@ PyJWT==1.7.1
 PyPDF2==1.26.0
 python-dateutil==2.8.0
 python-json-logger==0.1.11
-PyYAML==3.13
+PyYAML==4.2b1
 redis==3.2.1
 requests==2.22.0
 rsa==3.4.2


### PR DESCRIPTION
notifications-utils version 33.0.0 adds alt text to email branding - the `HTMLEmailTemplate` now initializes slightly differently as a result (with both `branding_name` and `branding_text`).

[Pivotal story](https://www.pivotaltracker.com/story/show/166089275)