### PR TITLE
Ensure all service route have permission decorators

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -1,11 +1,11 @@
 from flask import current_app, redirect, render_template, session, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import billing_api_client, service_api_client
 from app.main import main
 from app.main.forms import CreateServiceForm
-from app.utils import email_safe, user_is_gov_user
+from app.utils import email_safe, user_is_gov_user, user_is_logged_in
 
 
 def _create_service(service_name, organisation_type, email_from, form):
@@ -44,7 +44,7 @@ def _create_example_template(service_id):
 
 
 @main.route("/add-service", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 @user_is_gov_user
 def add_service():
     form = CreateServiceForm(

--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -22,8 +22,8 @@ def agreement():
 
 
 @main.route('/services/<uuid:service_id>/agreement')
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_agreement(service_id):
     return render_template(
         'views/agreement/service-{}.html'.format(current_service.organisation.as_jinja_template),
@@ -32,8 +32,8 @@ def service_agreement(service_id):
 
 
 @main.route('/services/<uuid:service_id>/agreement.pdf')
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_download_agreement(service_id):
     return send_file(**get_mou(
         current_service.organisation.crown_status_or_404
@@ -41,8 +41,8 @@ def service_download_agreement(service_id):
 
 
 @main.route('/services/<uuid:service_id>/agreement/accept', methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_accept_agreement(service_id):
 
     if not current_service.organisation:
@@ -65,8 +65,8 @@ def service_accept_agreement(service_id):
 
 
 @main.route('/services/<uuid:service_id>/agreement/confirm', methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_confirm_agreement(service_id):
 
     if (

--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -1,18 +1,18 @@
 from datetime import datetime
 
 from flask import abort, redirect, render_template, request, send_file, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 from app import current_service
 from app.main import main
 from app.main.forms import AcceptAgreementForm
 from app.main.views.sub_navigation_dictionaries import features_nav
 from app.s3_client.s3_mou_client import get_mou
-from app.utils import user_has_permissions
+from app.utils import user_has_permissions, user_is_logged_in
 
 
 @main.route('/agreement')
-@login_required
+@user_is_logged_in
 def agreement():
     return render_template(
         'views/agreement/{}.html'.format(current_user.default_organisation.as_jinja_template),
@@ -23,7 +23,6 @@ def agreement():
 
 @main.route('/services/<uuid:service_id>/agreement')
 @user_has_permissions('manage_service')
-@login_required
 def service_agreement(service_id):
     return render_template(
         'views/agreement/service-{}.html'.format(current_service.organisation.as_jinja_template),
@@ -33,7 +32,6 @@ def service_agreement(service_id):
 
 @main.route('/services/<uuid:service_id>/agreement.pdf')
 @user_has_permissions('manage_service')
-@login_required
 def service_download_agreement(service_id):
     return send_file(**get_mou(
         current_service.organisation.crown_status_or_404
@@ -42,7 +40,6 @@ def service_download_agreement(service_id):
 
 @main.route('/services/<uuid:service_id>/agreement/accept', methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_accept_agreement(service_id):
 
     if not current_service.organisation:
@@ -66,7 +63,6 @@ def service_accept_agreement(service_id):
 
 @main.route('/services/<uuid:service_id>/agreement/confirm', methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_confirm_agreement(service_id):
 
     if (
@@ -87,7 +83,7 @@ def service_confirm_agreement(service_id):
 
 
 @main.route('/agreement.pdf')
-@login_required
+@user_is_logged_in
 def download_agreement():
     return send_file(**get_mou(
         current_user.default_organisation.crown_status_or_404

--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -23,6 +23,7 @@ def agreement():
 
 @main.route('/services/<uuid:service_id>/agreement')
 @login_required
+@user_has_permissions('manage_service')
 def service_agreement(service_id):
     return render_template(
         'views/agreement/service-{}.html'.format(current_service.organisation.as_jinja_template),
@@ -41,6 +42,7 @@ def service_download_agreement(service_id):
 
 @main.route('/services/<uuid:service_id>/agreement/accept', methods=['GET', 'POST'])
 @login_required
+@user_has_permissions('manage_service')
 def service_accept_agreement(service_id):
 
     if not current_service.organisation:
@@ -64,6 +66,7 @@ def service_accept_agreement(service_id):
 
 @main.route('/services/<uuid:service_id>/agreement/confirm', methods=['GET', 'POST'])
 @login_required
+@user_has_permissions('manage_service')
 def service_confirm_agreement(service_id):
 
     if (

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -33,8 +33,8 @@ dummy_bearer_token = 'bearer_token_set'
 
 
 @main.route("/services/<service_id>/api")
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def api_integration(service_id):
     callbacks_link = (
         '.api_callbacks' if current_service.has_permission('inbound_sms')
@@ -48,15 +48,15 @@ def api_integration(service_id):
 
 
 @main.route("/services/<service_id>/api/documentation")
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def api_documentation(service_id):
     return redirect(url_for('.documentation'), code=301)
 
 
 @main.route("/services/<service_id>/api/whitelist", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def whitelist(service_id):
     form = Whitelist()
     if form.validate_on_submit():
@@ -75,8 +75,8 @@ def whitelist(service_id):
 
 
 @main.route("/services/<service_id>/api/keys")
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def api_keys(service_id):
     return render_template(
         'views/api/keys.html',
@@ -84,8 +84,8 @@ def api_keys(service_id):
 
 
 @main.route("/services/<service_id>/api/keys/create", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_api_keys', restrict_admin_usage=True)
+@login_required
 def create_api_key(service_id):
     form = CreateKeyForm(current_service.api_keys)
     form.key_type.choices = [
@@ -125,8 +125,8 @@ def create_api_key(service_id):
 
 
 @main.route("/services/<service_id>/api/keys/revoke/<key_id>", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
     if request.method == 'GET':
@@ -168,8 +168,8 @@ def check_token_against_dummy_bearer(token):
 
 
 @main.route("/services/<service_id>/api/callbacks", methods=['GET'])
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def api_callbacks(service_id):
     if not current_service.has_permission('inbound_sms'):
         return redirect(url_for('.delivery_status_callback', service_id=service_id))
@@ -193,8 +193,8 @@ def get_delivery_status_callback_details():
 
 
 @main.route("/services/<service_id>/api/callbacks/delivery-status-callback", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
     back_link = (
@@ -256,8 +256,8 @@ def get_received_text_messages_callback():
 
 
 @main.route("/services/<service_id>/api/callbacks/received-text-messages-callback", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_api_keys')
+@login_required
 def received_text_messages_callback(service_id):
     if not current_service.has_permission('inbound_sms'):
         return redirect(url_for('.api_integration', service_id=service_id))

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -7,7 +7,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 from app import (
     api_key_api_client,
@@ -34,7 +34,6 @@ dummy_bearer_token = 'bearer_token_set'
 
 @main.route("/services/<service_id>/api")
 @user_has_permissions('manage_api_keys')
-@login_required
 def api_integration(service_id):
     callbacks_link = (
         '.api_callbacks' if current_service.has_permission('inbound_sms')
@@ -49,14 +48,12 @@ def api_integration(service_id):
 
 @main.route("/services/<service_id>/api/documentation")
 @user_has_permissions('manage_api_keys')
-@login_required
 def api_documentation(service_id):
     return redirect(url_for('.documentation'), code=301)
 
 
 @main.route("/services/<service_id>/api/whitelist", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
-@login_required
 def whitelist(service_id):
     form = Whitelist()
     if form.validate_on_submit():
@@ -76,7 +73,6 @@ def whitelist(service_id):
 
 @main.route("/services/<service_id>/api/keys")
 @user_has_permissions('manage_api_keys')
-@login_required
 def api_keys(service_id):
     return render_template(
         'views/api/keys.html',
@@ -85,7 +81,6 @@ def api_keys(service_id):
 
 @main.route("/services/<service_id>/api/keys/create", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys', restrict_admin_usage=True)
-@login_required
 def create_api_key(service_id):
     form = CreateKeyForm(current_service.api_keys)
     form.key_type.choices = [
@@ -126,7 +121,6 @@ def create_api_key(service_id):
 
 @main.route("/services/<service_id>/api/keys/revoke/<key_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
-@login_required
 def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
     if request.method == 'GET':
@@ -169,7 +163,6 @@ def check_token_against_dummy_bearer(token):
 
 @main.route("/services/<service_id>/api/callbacks", methods=['GET'])
 @user_has_permissions('manage_api_keys')
-@login_required
 def api_callbacks(service_id):
     if not current_service.has_permission('inbound_sms'):
         return redirect(url_for('.delivery_status_callback', service_id=service_id))
@@ -194,7 +187,6 @@ def get_delivery_status_callback_details():
 
 @main.route("/services/<service_id>/api/callbacks/delivery-status-callback", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
-@login_required
 def delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
     back_link = (
@@ -257,7 +249,6 @@ def get_received_text_messages_callback():
 
 @main.route("/services/<service_id>/api/callbacks/received-text-messages-callback", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
-@login_required
 def received_text_messages_callback(service_id):
     if not current_service.has_permission('inbound_sms'):
         return redirect(url_for('.api_integration', service_id=service_id))

--- a/app/main/views/choose_account.py
+++ b/app/main/views/choose_account.py
@@ -1,8 +1,8 @@
 from flask import redirect, render_template, session, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 from app.main import main
-from app.utils import PermanentRedirect
+from app.utils import PermanentRedirect, user_is_logged_in
 
 
 @main.route("/services")
@@ -16,7 +16,7 @@ def services_or_dashboard():
 
 
 @main.route("/accounts")
-@login_required
+@user_is_logged_in
 def choose_account():
     return render_template(
         'views/choose-account.html',

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -1,5 +1,5 @@
 from flask import jsonify, redirect, render_template, session, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils.recipients import format_phone_number_human_readable
 from notifications_utils.template import SMSPreviewTemplate
@@ -13,7 +13,6 @@ from app.utils import user_has_permissions
 
 @main.route("/services/<service_id>/conversation/<notification_id>")
 @user_has_permissions('view_activity')
-@login_required
 def conversation(service_id, notification_id):
 
     user_number = get_user_number(service_id, notification_id)
@@ -29,7 +28,6 @@ def conversation(service_id, notification_id):
 
 @main.route("/services/<service_id>/conversation/<notification_id>.json")
 @user_has_permissions('view_activity')
-@login_required
 def conversation_updates(service_id, notification_id):
 
     return jsonify(get_conversation_partials(
@@ -41,7 +39,6 @@ def conversation_updates(service_id, notification_id):
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with")
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with/from-folder/<uuid:from_folder>")
 @user_has_permissions('send_messages')
-@login_required
 def conversation_reply(
     service_id,
     notification_id,
@@ -64,7 +61,6 @@ def conversation_reply(
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with/<template_id>")
 @user_has_permissions('send_messages')
-@login_required
 def conversation_reply_with_template(
     service_id,
     notification_id,

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -12,8 +12,8 @@ from app.utils import user_has_permissions
 
 
 @main.route("/services/<service_id>/conversation/<notification_id>")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def conversation(service_id, notification_id):
 
     user_number = get_user_number(service_id, notification_id)
@@ -28,8 +28,8 @@ def conversation(service_id, notification_id):
 
 
 @main.route("/services/<service_id>/conversation/<notification_id>.json")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def conversation_updates(service_id, notification_id):
 
     return jsonify(get_conversation_partials(
@@ -40,8 +40,8 @@ def conversation_updates(service_id, notification_id):
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with")
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with/from-folder/<uuid:from_folder>")
-@login_required
 @user_has_permissions('send_messages')
+@login_required
 def conversation_reply(
     service_id,
     notification_id,
@@ -63,8 +63,8 @@ def conversation_reply(
 
 
 @main.route("/services/<service_id>/conversation/<notification_id>/reply-with/<template_id>")
-@login_required
 @user_has_permissions('send_messages')
+@login_required
 def conversation_reply_with_template(
     service_id,
     notification_id,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -12,7 +12,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from werkzeug.utils import redirect
 
 from app import (
@@ -43,7 +43,6 @@ from app.utils import (
 # to view history
 @main.route("/services/<service_id>/history")
 @user_has_permissions()
-@login_required
 def temp_service_history(service_id):
     data = service_api_client.get_service_history(service_id)['data']
     return render_template('views/temp-history.html',
@@ -54,14 +53,12 @@ def temp_service_history(service_id):
 
 @main.route("/services/<service_id>/dashboard")
 @user_has_permissions('view_activity', 'send_messages')
-@login_required
 def old_service_dashboard(service_id):
     return redirect(url_for('.service_dashboard', service_id=service_id))
 
 
 @main.route("/services/<service_id>")
 @user_has_permissions()
-@login_required
 def service_dashboard(service_id):
 
     if session.get('invited_user'):
@@ -80,14 +77,12 @@ def service_dashboard(service_id):
 
 @main.route("/services/<service_id>/dashboard.json")
 @user_has_permissions('view_activity')
-@login_required
 def service_dashboard_updates(service_id):
     return jsonify(**get_dashboard_partials(service_id))
 
 
 @main.route("/services/<service_id>/template-activity")
 @user_has_permissions('view_activity')
-@login_required
 def template_history(service_id):
 
     return redirect(url_for('main.template_usage', service_id=service_id), code=301)
@@ -95,7 +90,6 @@ def template_history(service_id):
 
 @main.route("/services/<service_id>/template-usage")
 @user_has_permissions('view_activity')
-@login_required
 def template_usage(service_id):
 
     year, current_financial_year = requested_and_current_financial_year(request)
@@ -145,7 +139,6 @@ def template_usage(service_id):
 
 @main.route("/services/<service_id>/usage")
 @user_has_permissions('manage_service', allow_org_user=True)
-@login_required
 def usage(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
 
@@ -176,7 +169,6 @@ def usage(service_id):
 
 @main.route("/services/<service_id>/monthly")
 @user_has_permissions('view_activity')
-@login_required
 def monthly(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
     return render_template(
@@ -195,7 +187,6 @@ def monthly(service_id):
 
 @main.route("/services/<service_id>/inbox")
 @user_has_permissions('view_activity')
-@login_required
 def inbox(service_id):
 
     return render_template(
@@ -207,7 +198,6 @@ def inbox(service_id):
 
 @main.route("/services/<service_id>/inbox.json")
 @user_has_permissions('view_activity')
-@login_required
 def inbox_updates(service_id):
 
     return jsonify(get_inbox_partials(service_id))
@@ -215,7 +205,6 @@ def inbox_updates(service_id):
 
 @main.route("/services/<service_id>/inbox.csv")
 @user_has_permissions('view_activity')
-@login_required
 def inbox_download(service_id):
     return Response(
         Spreadsheet.from_rows(

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -42,8 +42,8 @@ from app.utils import (
 # when product team makes decision about how/what/when
 # to view history
 @main.route("/services/<service_id>/history")
-@login_required
 @user_has_permissions()
+@login_required
 def temp_service_history(service_id):
     data = service_api_client.get_service_history(service_id)['data']
     return render_template('views/temp-history.html',
@@ -53,15 +53,15 @@ def temp_service_history(service_id):
 
 
 @main.route("/services/<service_id>/dashboard")
-@login_required
 @user_has_permissions('view_activity', 'send_messages')
+@login_required
 def old_service_dashboard(service_id):
     return redirect(url_for('.service_dashboard', service_id=service_id))
 
 
 @main.route("/services/<service_id>")
-@login_required
 @user_has_permissions()
+@login_required
 def service_dashboard(service_id):
 
     if session.get('invited_user'):
@@ -79,23 +79,23 @@ def service_dashboard(service_id):
 
 
 @main.route("/services/<service_id>/dashboard.json")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def service_dashboard_updates(service_id):
     return jsonify(**get_dashboard_partials(service_id))
 
 
 @main.route("/services/<service_id>/template-activity")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def template_history(service_id):
 
     return redirect(url_for('main.template_usage', service_id=service_id), code=301)
 
 
 @main.route("/services/<service_id>/template-usage")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def template_usage(service_id):
 
     year, current_financial_year = requested_and_current_financial_year(request)
@@ -144,8 +144,8 @@ def template_usage(service_id):
 
 
 @main.route("/services/<service_id>/usage")
-@login_required
 @user_has_permissions('manage_service', allow_org_user=True)
+@login_required
 def usage(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
 
@@ -175,8 +175,8 @@ def usage(service_id):
 
 
 @main.route("/services/<service_id>/monthly")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def monthly(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
     return render_template(
@@ -194,8 +194,8 @@ def monthly(service_id):
 
 
 @main.route("/services/<service_id>/inbox")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def inbox(service_id):
 
     return render_template(
@@ -206,16 +206,16 @@ def inbox(service_id):
 
 
 @main.route("/services/<service_id>/inbox.json")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def inbox_updates(service_id):
 
     return jsonify(get_inbox_partials(service_id))
 
 
 @main.route("/services/<service_id>/inbox.csv")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def inbox_download(service_id):
     return Response(
         Spreadsheet.from_rows(

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -43,6 +43,7 @@ from app.utils import (
 # to view history
 @main.route("/services/<service_id>/history")
 @login_required
+@user_has_permissions()
 def temp_service_history(service_id):
     data = service_api_client.get_service_history(service_id)['data']
     return render_template('views/temp-history.html',
@@ -78,6 +79,7 @@ def service_dashboard(service_id):
 
 
 @main.route("/services/<service_id>/dashboard.json")
+@login_required
 @user_has_permissions('view_activity')
 def service_dashboard_updates(service_id):
     return jsonify(**get_dashboard_partials(service_id))

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -1,5 +1,4 @@
 from flask import current_app, redirect, render_template, session, url_for
-from flask_login import login_required
 
 from app import email_branding_client
 from app.main import main
@@ -16,7 +15,6 @@ from app.utils import get_logo_cdn_domain, user_is_platform_admin
 
 
 @main.route("/email-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def email_branding():
     brandings = email_branding_client.get_all_email_branding(sort_key='name')
@@ -30,7 +28,6 @@ def email_branding():
 
 @main.route("/email-branding/<branding_id>/edit", methods=['GET', 'POST'])
 @main.route("/email-branding/<branding_id>/edit/<logo>", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def update_email_branding(branding_id, logo=None):
     email_branding = email_branding_client.get_email_branding(branding_id)['email_branding']
@@ -87,7 +84,6 @@ def update_email_branding(branding_id, logo=None):
 
 @main.route("/email-branding/create", methods=['GET', 'POST'])
 @main.route("/email-branding/create/<logo>", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def create_email_branding(logo=None):
     form = ServiceUpdateEmailBranding(brand_type='org')

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -1,5 +1,5 @@
 from flask import flash, redirect, render_template, request, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 from app import user_api_client
 from app.event_handlers import create_archive_user_event
@@ -10,7 +10,6 @@ from app.utils import user_is_platform_admin
 
 
 @main.route("/find-users-by-email", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def find_users_by_email():
     form = SearchUsersByEmailForm()
@@ -28,7 +27,6 @@ def find_users_by_email():
 
 
 @main.route("/users/<user_id>", methods=['GET'])
-@login_required
 @user_is_platform_admin
 def user_information(user_id):
     return render_template(
@@ -38,7 +36,6 @@ def user_information(user_id):
 
 
 @main.route("/users/<uuid:user_id>/archive", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def archive_user(user_id):
     if request.method == 'POST':

--- a/app/main/views/inbound_number.py
+++ b/app/main/views/inbound_number.py
@@ -1,5 +1,4 @@
 from flask import render_template
-from flask_login import login_required
 
 from app import inbound_number_client
 from app.main import main
@@ -7,7 +6,6 @@ from app.utils import user_is_platform_admin
 
 
 @main.route('/inbound-sms-admin', methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def inbound_sms_admin():
     data = inbound_number_client.get_all_inbound_sms_number_service()

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -6,7 +6,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_utils.international_billing_rates import (
     INTERNATIONAL_BILLING_RATES,
 )
@@ -17,7 +17,7 @@ from app.main import main
 from app.main.forms import FieldWithNoneOption, SearchByNameForm
 from app.main.views.feedback import QUESTION_TICKET_TYPE
 from app.main.views.sub_navigation_dictionaries import features_nav, pricing_nav
-from app.utils import get_logo_cdn_domain
+from app.utils import get_logo_cdn_domain, user_is_logged_in
 
 
 @main.route('/')
@@ -51,7 +51,7 @@ def error(status_code):
 
 
 @main.route("/verify-mobile")
-@login_required
+@user_is_logged_in
 def verify_mobile():
     return render_template('views/verify-mobile.html')
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -163,6 +163,7 @@ def cancel_job(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>.json")
 @user_has_permissions()
+@login_required
 def view_job_updates(service_id, job_id):
 
     job = job_api_client.get_job(service_id, job_id)['data']
@@ -205,6 +206,7 @@ def view_notifications(service_id, message_type=None):
 @main.route('/services/<service_id>/notifications.json', methods=['GET', 'POST'])
 @main.route('/services/<service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
 @user_has_permissions()
+@login_required
 def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(
         service_id, message_type, status_override=request.args.get('status')
@@ -213,6 +215,7 @@ def get_notifications_as_json(service_id, message_type=None):
 
 @main.route('/services/<service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
 @user_has_permissions()
+@login_required
 def get_notifications(service_id, message_type, status_override=None):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -10,7 +10,7 @@ from flask import (
     stream_with_context,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_utils.letter_timings import get_letter_timings
 from notifications_utils.template import Template, WithSubjectTemplate
 
@@ -39,7 +39,6 @@ from app.utils import (
 
 @main.route("/services/<service_id>/jobs")
 @user_has_permissions()
-@login_required
 def view_jobs(service_id):
     page = int(request.args.get('page', 1))
     jobs_response = job_api_client.get_page_of_jobs(service_id, page=page)
@@ -74,7 +73,6 @@ def view_jobs(service_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>")
 @user_has_permissions()
-@login_required
 def view_job(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     if job['job_status'] == 'cancelled':
@@ -120,7 +118,6 @@ def view_job(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>.csv")
 @user_has_permissions('view_activity')
-@login_required
 def view_job_csv(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     template = service_api_client.get_service_template(
@@ -155,7 +152,6 @@ def view_job_csv(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>", methods=['POST'])
 @user_has_permissions('send_messages')
-@login_required
 def cancel_job(service_id, job_id):
     job_api_client.cancel_job(service_id, job_id)
     return redirect(url_for('main.service_dashboard', service_id=service_id))
@@ -163,7 +159,6 @@ def cancel_job(service_id, job_id):
 
 @main.route("/services/<service_id>/jobs/<job_id>.json")
 @user_has_permissions()
-@login_required
 def view_job_updates(service_id, job_id):
 
     job = job_api_client.get_job(service_id, job_id)['data']
@@ -181,7 +176,6 @@ def view_job_updates(service_id, job_id):
 @main.route('/services/<service_id>/notifications', methods=['GET', 'POST'])
 @main.route('/services/<service_id>/notifications/<message_type>', methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def view_notifications(service_id, message_type=None):
     return render_template(
         'views/notifications.html',
@@ -206,7 +200,6 @@ def view_notifications(service_id, message_type=None):
 @main.route('/services/<service_id>/notifications.json', methods=['GET', 'POST'])
 @main.route('/services/<service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(
         service_id, message_type, status_override=request.args.get('status')
@@ -215,7 +208,6 @@ def get_notifications_as_json(service_id, message_type=None):
 
 @main.route('/services/<service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
 @user_has_permissions()
-@login_required
 def get_notifications(service_id, message_type, status_override=None):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -38,8 +38,8 @@ from app.utils import (
 
 
 @main.route("/services/<service_id>/jobs")
-@login_required
 @user_has_permissions()
+@login_required
 def view_jobs(service_id):
     page = int(request.args.get('page', 1))
     jobs_response = job_api_client.get_page_of_jobs(service_id, page=page)
@@ -73,8 +73,8 @@ def view_jobs(service_id):
 
 
 @main.route("/services/<service_id>/jobs/<job_id>")
-@login_required
 @user_has_permissions()
+@login_required
 def view_job(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     if job['job_status'] == 'cancelled':
@@ -119,8 +119,8 @@ def view_job(service_id, job_id):
 
 
 @main.route("/services/<service_id>/jobs/<job_id>.csv")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def view_job_csv(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
     template = service_api_client.get_service_template(
@@ -154,8 +154,8 @@ def view_job_csv(service_id, job_id):
 
 
 @main.route("/services/<service_id>/jobs/<job_id>", methods=['POST'])
-@login_required
 @user_has_permissions('send_messages')
+@login_required
 def cancel_job(service_id, job_id):
     job_api_client.cancel_job(service_id, job_id)
     return redirect(url_for('main.service_dashboard', service_id=service_id))
@@ -180,8 +180,8 @@ def view_job_updates(service_id, job_id):
 
 @main.route('/services/<service_id>/notifications', methods=['GET', 'POST'])
 @main.route('/services/<service_id>/notifications/<message_type>', methods=['GET', 'POST'])
-@login_required
 @user_has_permissions()
+@login_required
 def view_notifications(service_id, message_type=None):
     return render_template(
         'views/notifications.html',

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -7,7 +7,6 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import login_required
 from notifications_python_client.errors import HTTPError
 from requests import get as requests_get
 
@@ -33,7 +32,6 @@ from app.utils import get_logo_cdn_domain, user_is_platform_admin
 
 
 @main.route("/letter-branding", methods=['GET'])
-@login_required
 @user_is_platform_admin
 def letter_branding():
 
@@ -48,7 +46,6 @@ def letter_branding():
 
 @main.route("/letter-branding/<branding_id>/edit", methods=['GET', 'POST'])
 @main.route("/letter-branding/<branding_id>/edit/<path:logo>", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def update_letter_branding(branding_id, logo=None):
     letter_branding = letter_branding_client.get_letter_branding(branding_id)
@@ -128,7 +125,6 @@ def update_letter_branding(branding_id, logo=None):
 
 @main.route("/letter-branding/create", methods=['GET', 'POST'])
 @main.route("/letter-branding/create/<path:logo>", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def create_letter_branding(logo=None):
     file_upload_form = SVGFileUpload()

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -269,6 +269,7 @@ def confirm_edit_user_mobile_number(service_id, user_id):
 
 @main.route("/services/<service_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
 @user_has_permissions('manage_service')
+@login_required
 def cancel_invited_user(service_id, invited_user_id):
     current_service.cancel_invite(invited_user_id)
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -7,7 +7,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import current_service, service_api_client
@@ -31,7 +31,6 @@ from app.utils import is_gov_user, redact_mobile_number, user_has_permissions
 
 @main.route("/services/<service_id>/users")
 @user_has_permissions(allow_org_user=True)
-@login_required
 def manage_users(service_id):
     return render_template(
         'views/manage-users.html',
@@ -45,7 +44,6 @@ def manage_users(service_id):
 
 @main.route("/services/<service_id>/users/invite", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def invite_user(service_id):
 
     form = InviteUserForm(
@@ -82,7 +80,6 @@ def invite_user(service_id):
 
 @main.route("/services/<service_id>/users/<user_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def edit_user_permissions(service_id, user_id):
     service_has_email_auth = current_service.has_permission('email_auth')
     user = current_service.get_team_member(user_id)
@@ -123,7 +120,6 @@ def edit_user_permissions(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<user_id>/delete", methods=['POST'])
 @user_has_permissions('manage_service')
-@login_required
 def remove_user_from_service(service_id, user_id):
     try:
         service_api_client.remove_user_from_service(service_id, user_id)
@@ -145,7 +141,6 @@ def remove_user_from_service(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-email", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
     user_email = user.email_address
@@ -173,7 +168,6 @@ def edit_user_email(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-email/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def confirm_edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
     if 'team_member_email_change' in session:
@@ -208,7 +202,6 @@ def confirm_edit_user_email(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-mobile-number", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def edit_user_mobile_number(service_id, user_id):
     user = current_service.get_team_member(user_id)
     user_mobile_number = redact_mobile_number(user.mobile_number)
@@ -233,7 +226,6 @@ def edit_user_mobile_number(service_id, user_id):
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-mobile-number/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def confirm_edit_user_mobile_number(service_id, user_id):
     user = current_service.get_team_member(user_id)
     if 'team_member_mobile_change' in session:
@@ -269,7 +261,6 @@ def confirm_edit_user_mobile_number(service_id, user_id):
 
 @main.route("/services/<service_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
 @user_has_permissions('manage_service')
-@login_required
 def cancel_invited_user(service_id, invited_user_id):
     current_service.cancel_invite(invited_user_id)
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -30,8 +30,8 @@ from app.utils import is_gov_user, redact_mobile_number, user_has_permissions
 
 
 @main.route("/services/<service_id>/users")
-@login_required
 @user_has_permissions(allow_org_user=True)
+@login_required
 def manage_users(service_id):
     return render_template(
         'views/manage-users.html',
@@ -44,8 +44,8 @@ def manage_users(service_id):
 
 
 @main.route("/services/<service_id>/users/invite", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def invite_user(service_id):
 
     form = InviteUserForm(
@@ -81,8 +81,8 @@ def invite_user(service_id):
 
 
 @main.route("/services/<service_id>/users/<user_id>", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def edit_user_permissions(service_id, user_id):
     service_has_email_auth = current_service.has_permission('email_auth')
     user = current_service.get_team_member(user_id)
@@ -122,8 +122,8 @@ def edit_user_permissions(service_id, user_id):
 
 
 @main.route("/services/<service_id>/users/<user_id>/delete", methods=['POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def remove_user_from_service(service_id, user_id):
     try:
         service_api_client.remove_user_from_service(service_id, user_id)
@@ -144,8 +144,8 @@ def remove_user_from_service(service_id, user_id):
 
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-email", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
     user_email = user.email_address
@@ -172,8 +172,8 @@ def edit_user_email(service_id, user_id):
 
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-email/confirm", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def confirm_edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
     if 'team_member_email_change' in session:
@@ -207,8 +207,8 @@ def confirm_edit_user_email(service_id, user_id):
 
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-mobile-number", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def edit_user_mobile_number(service_id, user_id):
     user = current_service.get_team_member(user_id)
     user_mobile_number = redact_mobile_number(user.mobile_number)
@@ -232,8 +232,8 @@ def edit_user_mobile_number(service_id, user_id):
 
 
 @main.route("/services/<service_id>/users/<uuid:user_id>/edit-mobile-number/confirm", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def confirm_edit_user_mobile_number(service_id, user_id):
     user = current_service.get_team_member(user_id)
     if 'team_member_mobile_change' in session:

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -50,8 +50,8 @@ from app.utils import (
 
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>")
-@login_required
 @user_has_permissions('view_activity', 'send_messages')
+@login_required
 def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
     notification['template'].update({'reply_to_text': notification['reply_to_text']})
@@ -157,8 +157,8 @@ def view_notification(service_id, notification_id):
 
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>/cancel", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('view_activity', 'send_messages')
+@login_required
 def cancel_letter(service_id, notification_id):
 
     if request.method == 'POST':
@@ -188,8 +188,8 @@ def get_preview_error_image():
 
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>.<filetype>")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def view_letter_notification_as_preview(service_id, notification_id, filetype):
 
     if filetype not in ('pdf', 'png'):
@@ -254,8 +254,8 @@ def get_all_personalisation_from_notification(notification):
 
 
 @main.route("/services/<service_id>/download-notifications.csv")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def download_notifications_csv(service_id):
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -220,6 +220,7 @@ def view_letter_notification_as_preview(service_id, notification_id, filetype):
 
 @main.route("/services/<service_id>/notification/<notification_id>.json")
 @user_has_permissions('view_activity', 'send_messages')
+@login_required
 def view_notification_updates(service_id, notification_id):
     return jsonify(**get_single_notification_partials(
         notification_api_client.get_notification(service_id, notification_id)

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -16,7 +16,6 @@ from flask import (
     stream_with_context,
     url_for,
 )
-from flask_login import login_required
 from notifications_python_client.errors import APIError
 from notifications_utils.letter_timings import (
     get_letter_timings,
@@ -51,7 +50,6 @@ from app.utils import (
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>")
 @user_has_permissions('view_activity', 'send_messages')
-@login_required
 def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
     notification['template'].update({'reply_to_text': notification['reply_to_text']})
@@ -158,7 +156,6 @@ def view_notification(service_id, notification_id):
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>/cancel", methods=['GET', 'POST'])
 @user_has_permissions('view_activity', 'send_messages')
-@login_required
 def cancel_letter(service_id, notification_id):
 
     if request.method == 'POST':
@@ -189,7 +186,6 @@ def get_preview_error_image():
 
 @main.route("/services/<service_id>/notification/<uuid:notification_id>.<filetype>")
 @user_has_permissions('view_activity')
-@login_required
 def view_letter_notification_as_preview(service_id, notification_id, filetype):
 
     if filetype not in ('pdf', 'png'):
@@ -220,7 +216,6 @@ def view_letter_notification_as_preview(service_id, notification_id, filetype):
 
 @main.route("/services/<service_id>/notification/<notification_id>.json")
 @user_has_permissions('view_activity', 'send_messages')
-@login_required
 def view_notification_updates(service_id, notification_id):
     return jsonify(**get_single_notification_partials(
         notification_api_client.get_notification(service_id, notification_id)
@@ -255,7 +250,6 @@ def get_all_personalisation_from_notification(notification):
 
 @main.route("/services/<service_id>/download-notifications.csv")
 @user_has_permissions('view_activity')
-@login_required
 def download_notifications_csv(service_id):
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from flask import flash, redirect, render_template, request, session, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from werkzeug.exceptions import abort
 
@@ -38,7 +38,6 @@ from app.utils import user_has_permissions, user_is_platform_admin
 
 @main.route("/organisations", methods=['GET'])
 @user_is_platform_admin
-@login_required
 def organisations():
     return render_template(
         'views/organisations/index.html',
@@ -49,7 +48,6 @@ def organisations():
 
 @main.route("/organisations/add", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def add_organisation():
     form = CreateOrUpdateOrganisation()
 
@@ -68,7 +66,6 @@ def add_organisation():
 
 @main.route("/organisations/<org_id>", methods=['GET'])
 @user_has_permissions()
-@login_required
 def organisation_dashboard(org_id):
     return render_template(
         'views/organisations/organisation/index.html',
@@ -77,7 +74,6 @@ def organisation_dashboard(org_id):
 
 @main.route("/organisations/<org_id>/trial-services", methods=['GET'])
 @user_is_platform_admin
-@login_required
 def organisation_trial_mode_services(org_id):
     return render_template(
         'views/organisations/organisation/trial-mode-services.html',
@@ -87,7 +83,6 @@ def organisation_trial_mode_services(org_id):
 
 @main.route("/organisations/<org_id>/users", methods=['GET'])
 @user_has_permissions()
-@login_required
 def manage_org_users(org_id):
     return render_template(
         'views/organisations/organisation/users/index.html',
@@ -99,7 +94,6 @@ def manage_org_users(org_id):
 
 @main.route("/organisations/<org_id>/users/invite", methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def invite_org_user(org_id):
     form = InviteOrgUserForm(
         invalid_email_address=current_user.email_address
@@ -123,7 +117,6 @@ def invite_org_user(org_id):
 
 @main.route("/organisations/<org_id>/users/<user_id>", methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def edit_user_org_permissions(org_id, user_id):
     return render_template(
         'views/organisations/organisation/users/user/index.html',
@@ -133,7 +126,6 @@ def edit_user_org_permissions(org_id, user_id):
 
 @main.route("/organisations/<org_id>/users/<user_id>/delete", methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def remove_user_from_organisation(org_id, user_id):
     user = User.from_id(user_id)
     if request.method == 'POST':
@@ -163,7 +155,6 @@ def remove_user_from_organisation(org_id, user_id):
 
 @main.route("/organisations/<org_id>/cancel-invited-user/<invited_user_id>", methods=['GET'])
 @user_has_permissions()
-@login_required
 def cancel_invited_org_user(org_id, invited_user_id):
     org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
 
@@ -172,7 +163,6 @@ def cancel_invited_org_user(org_id, invited_user_id):
 
 @main.route("/organisations/<org_id>/settings/", methods=['GET'])
 @user_is_platform_admin
-@login_required
 def organisation_settings(org_id):
 
     email_branding = 'GOV.UK'
@@ -198,7 +188,6 @@ def organisation_settings(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-name", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_name(org_id):
     form = RenameOrganisationForm()
 
@@ -221,7 +210,6 @@ def edit_organisation_name(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-type", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_type(org_id):
 
     form = OrganisationOrganisationTypeForm(
@@ -243,7 +231,6 @@ def edit_organisation_type(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-crown-status", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_crown_status(org_id):
 
     form = OrganisationCrownStatusForm(
@@ -273,7 +260,6 @@ def edit_organisation_crown_status(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-agreement", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_agreement(org_id):
 
     form = OrganisationAgreementSignedForm(
@@ -303,7 +289,6 @@ def edit_organisation_agreement(org_id):
 
 @main.route("/organisations/<org_id>/settings/set-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_email_branding(org_id):
 
     email_branding = email_branding_client.get_all_email_branding()
@@ -329,7 +314,6 @@ def edit_organisation_email_branding(org_id):
 
 @main.route("/organisations/<org_id>/settings/preview-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def organisation_preview_email_branding(org_id):
 
     branding_style = request.args.get('branding_style', None)
@@ -352,7 +336,6 @@ def organisation_preview_email_branding(org_id):
 
 @main.route("/organisations/<org_id>/settings/set-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_letter_branding(org_id):
     letter_branding = letter_branding_client.get_all_letter_branding()
 
@@ -377,7 +360,6 @@ def edit_organisation_letter_branding(org_id):
 
 @main.route("/organisations/<org_id>/settings/preview-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def organisation_preview_letter_branding(org_id):
     branding_style = request.args.get('branding_style')
 
@@ -399,7 +381,6 @@ def organisation_preview_letter_branding(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-organisation-domains", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_domains(org_id):
 
     form = OrganisationDomainsForm()
@@ -424,7 +405,6 @@ def edit_organisation_domains(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-name/confirm", methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def confirm_edit_organisation_name(org_id):
     # Validate password for form
     def _check_password(pwd):
@@ -457,7 +437,6 @@ def confirm_edit_organisation_name(org_id):
 
 @main.route("/organisations/<org_id>/settings/edit-go-live-notes", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_organisation_go_live_notes(org_id):
 
     form = GoLiveNotesForm()

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -37,8 +37,8 @@ from app.utils import user_has_permissions, user_is_platform_admin
 
 
 @main.route("/organisations", methods=['GET'])
-@login_required
 @user_is_platform_admin
+@login_required
 def organisations():
     return render_template(
         'views/organisations/index.html',
@@ -48,8 +48,8 @@ def organisations():
 
 
 @main.route("/organisations/add", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def add_organisation():
     form = CreateOrUpdateOrganisation()
 
@@ -67,8 +67,8 @@ def add_organisation():
 
 
 @main.route("/organisations/<org_id>", methods=['GET'])
-@login_required
 @user_has_permissions()
+@login_required
 def organisation_dashboard(org_id):
     return render_template(
         'views/organisations/organisation/index.html',
@@ -76,8 +76,8 @@ def organisation_dashboard(org_id):
 
 
 @main.route("/organisations/<org_id>/trial-services", methods=['GET'])
-@login_required
 @user_is_platform_admin
+@login_required
 def organisation_trial_mode_services(org_id):
     return render_template(
         'views/organisations/organisation/trial-mode-services.html',
@@ -86,8 +86,8 @@ def organisation_trial_mode_services(org_id):
 
 
 @main.route("/organisations/<org_id>/users", methods=['GET'])
-@login_required
 @user_has_permissions()
+@login_required
 def manage_org_users(org_id):
     return render_template(
         'views/organisations/organisation/users/index.html',
@@ -98,8 +98,8 @@ def manage_org_users(org_id):
 
 
 @main.route("/organisations/<org_id>/users/invite", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions()
+@login_required
 def invite_org_user(org_id):
     form = InviteOrgUserForm(
         invalid_email_address=current_user.email_address
@@ -122,8 +122,8 @@ def invite_org_user(org_id):
 
 
 @main.route("/organisations/<org_id>/users/<user_id>", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions()
+@login_required
 def edit_user_org_permissions(org_id, user_id):
     return render_template(
         'views/organisations/organisation/users/user/index.html',
@@ -132,8 +132,8 @@ def edit_user_org_permissions(org_id, user_id):
 
 
 @main.route("/organisations/<org_id>/users/<user_id>/delete", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions()
+@login_required
 def remove_user_from_organisation(org_id, user_id):
     user = User.from_id(user_id)
     if request.method == 'POST':
@@ -162,8 +162,8 @@ def remove_user_from_organisation(org_id, user_id):
 
 
 @main.route("/organisations/<org_id>/cancel-invited-user/<invited_user_id>", methods=['GET'])
-@login_required
 @user_has_permissions()
+@login_required
 def cancel_invited_org_user(org_id, invited_user_id):
     org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
 
@@ -171,8 +171,8 @@ def cancel_invited_org_user(org_id, invited_user_id):
 
 
 @main.route("/organisations/<org_id>/settings/", methods=['GET'])
-@login_required
 @user_is_platform_admin
+@login_required
 def organisation_settings(org_id):
 
     email_branding = 'GOV.UK'
@@ -197,8 +197,8 @@ def organisation_settings(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-name", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_name(org_id):
     form = RenameOrganisationForm()
 
@@ -220,8 +220,8 @@ def edit_organisation_name(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-type", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_type(org_id):
 
     form = OrganisationOrganisationTypeForm(
@@ -242,8 +242,8 @@ def edit_organisation_type(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-crown-status", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_crown_status(org_id):
 
     form = OrganisationCrownStatusForm(
@@ -272,8 +272,8 @@ def edit_organisation_crown_status(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-agreement", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_agreement(org_id):
 
     form = OrganisationAgreementSignedForm(
@@ -302,8 +302,8 @@ def edit_organisation_agreement(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/set-email-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_email_branding(org_id):
 
     email_branding = email_branding_client.get_all_email_branding()
@@ -328,8 +328,8 @@ def edit_organisation_email_branding(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/preview-email-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def organisation_preview_email_branding(org_id):
 
     branding_style = request.args.get('branding_style', None)
@@ -351,8 +351,8 @@ def organisation_preview_email_branding(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/set-letter-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_letter_branding(org_id):
     letter_branding = letter_branding_client.get_all_letter_branding()
 
@@ -376,8 +376,8 @@ def edit_organisation_letter_branding(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/preview-letter-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def organisation_preview_letter_branding(org_id):
     branding_style = request.args.get('branding_style')
 
@@ -398,8 +398,8 @@ def organisation_preview_letter_branding(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-organisation-domains", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_domains(org_id):
 
     form = OrganisationDomainsForm()
@@ -423,8 +423,8 @@ def edit_organisation_domains(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-name/confirm", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions()
+@login_required
 def confirm_edit_organisation_name(org_id):
     # Validate password for form
     def _check_password(pwd):
@@ -456,8 +456,8 @@ def confirm_edit_organisation_name(org_id):
 
 
 @main.route("/organisations/<org_id>/settings/edit-go-live-notes", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_organisation_go_live_notes(org_id):
 
     form = GoLiveNotesForm()

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -339,8 +339,8 @@ def platform_admin_letter_validation_preview():
 
 
 @main.route("/services/<service_id>/letter-validation-preview", methods=["GET", "POST"])
-@login_required
 @user_has_permissions()
+@login_required
 def service_letter_validation_preview(service_id):
     return letter_validation_preview(from_platform_admin=False)
 

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -33,6 +33,7 @@ from app.utils import (
     generate_next_dict,
     generate_previous_dict,
     get_page_from_request,
+    user_has_permissions,
     user_is_platform_admin,
 )
 
@@ -339,6 +340,7 @@ def platform_admin_letter_validation_preview():
 
 @main.route("/services/<service_id>/letter-validation-preview", methods=["GET", "POST"])
 @login_required
+@user_has_permissions()
 def service_letter_validation_preview(service_id):
     return letter_validation_preview(from_platform_admin=False)
 

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from datetime import datetime
 
 from flask import abort, flash, redirect, render_template, request, url_for
-from flask_login import login_required
 from notifications_python_client.errors import HTTPError
 from requests import RequestException
 
@@ -43,7 +42,6 @@ ZERO_FAILURE_THRESHOLD = 0
 
 
 @main.route("/platform-admin")
-@login_required
 @user_is_platform_admin
 def platform_admin():
     form = DateFilterForm(request.args, meta={'csrf': False})
@@ -152,7 +150,6 @@ def make_columns(global_stats, complaints_number):
 
 @main.route("/platform-admin/live-services", endpoint='live_services')
 @main.route("/platform-admin/trial-services", endpoint='trial_services')
-@login_required
 @user_is_platform_admin
 def platform_admin_services():
     form = DateFilterForm(request.args)
@@ -191,7 +188,6 @@ def platform_admin_services():
 
 
 @main.route("/platform-admin/reports")
-@login_required
 @user_is_platform_admin
 def platform_admin_reports():
     return render_template(
@@ -200,7 +196,6 @@ def platform_admin_reports():
 
 
 @main.route("/platform-admin/reports/live-services.csv")
-@login_required
 @user_is_platform_admin
 def live_services_csv():
     results = service_api_client.get_live_services_data()["data"]
@@ -242,7 +237,6 @@ def live_services_csv():
 
 
 @main.route("/platform-admin/reports/performance-platform.xlsx")
-@login_required
 @user_is_platform_admin
 def performance_platform_xlsx():
     results = service_api_client.get_live_services_data()["data"]
@@ -270,7 +264,6 @@ def performance_platform_xlsx():
 
 
 @main.route("/platform-admin/complaints")
-@login_required
 @user_is_platform_admin
 def platform_admin_list_complaints():
     page = get_page_from_request()
@@ -297,7 +290,6 @@ def platform_admin_list_complaints():
 
 
 @main.route("/platform-admin/returned-letters", methods=["GET", "POST"])
-@login_required
 @user_is_platform_admin
 def platform_admin_returned_letters():
     form = ReturnedLettersForm()
@@ -332,7 +324,6 @@ def platform_admin_returned_letters():
 
 
 @main.route("/platform-admin/letter-validation-preview", methods=["GET", "POST"])
-@login_required
 @user_is_platform_admin
 def platform_admin_letter_validation_preview():
     return letter_validation_preview(from_platform_admin=True)
@@ -340,7 +331,6 @@ def platform_admin_letter_validation_preview():
 
 @main.route("/services/<service_id>/letter-validation-preview", methods=["GET", "POST"])
 @user_has_permissions()
-@login_required
 def service_letter_validation_preview(service_id):
     return letter_validation_preview(from_platform_admin=False)
 
@@ -392,7 +382,6 @@ def letter_validation_preview(from_platform_admin):
 
 
 @main.route("/platform-admin/clear-cache", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def clear_cache():
     # note: `service-{uuid}-templates` cache is cleared for both services and templates.

--- a/app/main/views/providers.py
+++ b/app/main/views/providers.py
@@ -1,5 +1,4 @@
 from flask import render_template, url_for
-from flask_login import login_required
 from werkzeug.utils import redirect
 
 from app import provider_client
@@ -9,7 +8,6 @@ from app.utils import user_is_platform_admin
 
 
 @main.route("/providers")
-@login_required
 @user_is_platform_admin
 def view_providers():
     providers = provider_client.get_all_providers()['provider_details']
@@ -41,7 +39,6 @@ def add_monthly_traffic(domestic_sms_providers):
 
 
 @main.route("/provider/<provider_id>/edit", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
 def edit_provider(provider_id):
     provider = provider_client.get_provider_by_id(provider_id)['provider_details']
@@ -55,7 +52,6 @@ def edit_provider(provider_id):
 
 
 @main.route("/provider/<provider_id>")
-@login_required
 @user_is_platform_admin
 def view_provider(provider_id):
     versions = provider_client.get_provider_versions(provider_id)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -100,8 +100,8 @@ def get_example_letter_address(key):
 
 
 @main.route("/services/<service_id>/send/<template_id>/csv", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def send_messages(service_id, template_id):
     # if there's lots of data in the session, lets log it for debugging purposes
     # TODO: Remove this once we're confident we have session size under control
@@ -185,8 +185,8 @@ def send_messages(service_id, template_id):
 
 
 @main.route("/services/<service_id>/send/<template_id>.csv", methods=['GET'])
-@login_required
 @user_has_permissions('send_messages', 'manage_templates')
+@login_required
 def get_example_csv(service_id, template_id):
     template = get_template(
         service_api_client.get_service_template(service_id, template_id)['data'], current_service
@@ -201,8 +201,8 @@ def get_example_csv(service_id, template_id):
 
 
 @main.route("/services/<service_id>/send/<template_id>/set-sender", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def set_sender(service_id, template_id):
     session['sender_id'] = None
     redirect_to_one_off = redirect(
@@ -290,8 +290,8 @@ def get_sender_details(service_id, template_type):
 
 @main.route("/services/<service_id>/send/<template_id>/test", endpoint='send_test')
 @main.route("/services/<service_id>/send/<template_id>/one-off", endpoint='send_one_off')
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def send_test(service_id, template_id):
     session['recipient'] = None
     session['placeholders'] = {}
@@ -341,8 +341,8 @@ def get_notification_check_endpoint(service_id, template):
     methods=['GET', 'POST'],
     endpoint='send_one_off_step',
 )
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def send_test_step(service_id, template_id, step_index):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(
@@ -472,8 +472,8 @@ def send_test_step(service_id, template_id, step_index):
 
 
 @main.route("/services/<service_id>/send/<template_id>/test.<filetype>", methods=['GET'])
-@login_required
 @user_has_permissions('send_messages')
+@login_required
 def send_test_preview(service_id, template_id, filetype):
 
     if filetype not in ('pdf', 'png'):
@@ -604,8 +604,8 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
 
 @main.route("/services/<service_id>/<uuid:template_id>/check/<upload_id>", methods=['GET'])
 @main.route("/services/<service_id>/<uuid:template_id>/check/<upload_id>/row-<int:row_index>", methods=['GET'])
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def check_messages(service_id, template_id, upload_id, row_index=2):
 
     data = _check_messages(service_id, template_id, upload_id, row_index)
@@ -657,8 +657,8 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
     "/services/<service_id>/<uuid:template_id>/check/<upload_id>/row-<int:row_index>.<filetype>",
     methods=['GET'],
 )
-@login_required
 @user_has_permissions('send_messages')
+@login_required
 def check_messages_preview(service_id, template_id, upload_id, filetype, row_index=2):
     if filetype == 'pdf':
         page = None
@@ -677,8 +677,8 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
     "/services/<service_id>/<uuid:template_id>/check.<filetype>",
     methods=['GET'],
 )
-@login_required
 @user_has_permissions('send_messages')
+@login_required
 def check_notification_preview(service_id, template_id, filetype):
     if filetype == 'pdf':
         page = None
@@ -694,8 +694,8 @@ def check_notification_preview(service_id, template_id, filetype):
 
 
 @main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def start_job(service_id, upload_id):
 
     job_api_client.create_job(
@@ -718,8 +718,8 @@ def start_job(service_id, upload_id):
 
 
 @main.route("/services/<service_id>/end-tour/<example_template_id>")
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def go_to_dashboard_after_tour(service_id, example_template_id):
 
     service_api_client.delete_service_template(service_id, example_template_id)
@@ -848,8 +848,8 @@ def get_back_link(service_id, template, step_index):
 
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def check_notification(service_id, template_id):
     return render_template(
         'views/notifications/check.html',
@@ -923,8 +923,8 @@ def get_template_error_dict(exception):
 
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['POST'])
-@login_required
 @user_has_permissions('send_messages', restrict_admin_usage=True)
+@login_required
 def send_notification(service_id, template_id):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -13,7 +13,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.columns import Columns
@@ -101,7 +101,6 @@ def get_example_letter_address(key):
 
 @main.route("/services/<service_id>/send/<template_id>/csv", methods=['GET', 'POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def send_messages(service_id, template_id):
     # if there's lots of data in the session, lets log it for debugging purposes
     # TODO: Remove this once we're confident we have session size under control
@@ -186,7 +185,6 @@ def send_messages(service_id, template_id):
 
 @main.route("/services/<service_id>/send/<template_id>.csv", methods=['GET'])
 @user_has_permissions('send_messages', 'manage_templates')
-@login_required
 def get_example_csv(service_id, template_id):
     template = get_template(
         service_api_client.get_service_template(service_id, template_id)['data'], current_service
@@ -202,7 +200,6 @@ def get_example_csv(service_id, template_id):
 
 @main.route("/services/<service_id>/send/<template_id>/set-sender", methods=['GET', 'POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def set_sender(service_id, template_id):
     session['sender_id'] = None
     redirect_to_one_off = redirect(
@@ -291,7 +288,6 @@ def get_sender_details(service_id, template_type):
 @main.route("/services/<service_id>/send/<template_id>/test", endpoint='send_test')
 @main.route("/services/<service_id>/send/<template_id>/one-off", endpoint='send_one_off')
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def send_test(service_id, template_id):
     session['recipient'] = None
     session['placeholders'] = {}
@@ -342,7 +338,6 @@ def get_notification_check_endpoint(service_id, template):
     endpoint='send_one_off_step',
 )
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def send_test_step(service_id, template_id, step_index):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(
@@ -473,7 +468,6 @@ def send_test_step(service_id, template_id, step_index):
 
 @main.route("/services/<service_id>/send/<template_id>/test.<filetype>", methods=['GET'])
 @user_has_permissions('send_messages')
-@login_required
 def send_test_preview(service_id, template_id, filetype):
 
     if filetype not in ('pdf', 'png'):
@@ -605,7 +599,6 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
 @main.route("/services/<service_id>/<uuid:template_id>/check/<upload_id>", methods=['GET'])
 @main.route("/services/<service_id>/<uuid:template_id>/check/<upload_id>/row-<int:row_index>", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def check_messages(service_id, template_id, upload_id, row_index=2):
 
     data = _check_messages(service_id, template_id, upload_id, row_index)
@@ -658,7 +651,6 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
     methods=['GET'],
 )
 @user_has_permissions('send_messages')
-@login_required
 def check_messages_preview(service_id, template_id, upload_id, filetype, row_index=2):
     if filetype == 'pdf':
         page = None
@@ -678,7 +670,6 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
     methods=['GET'],
 )
 @user_has_permissions('send_messages')
-@login_required
 def check_notification_preview(service_id, template_id, filetype):
     if filetype == 'pdf':
         page = None
@@ -695,7 +686,6 @@ def check_notification_preview(service_id, template_id, filetype):
 
 @main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def start_job(service_id, upload_id):
 
     job_api_client.create_job(
@@ -719,7 +709,6 @@ def start_job(service_id, upload_id):
 
 @main.route("/services/<service_id>/end-tour/<example_template_id>")
 @user_has_permissions('manage_templates')
-@login_required
 def go_to_dashboard_after_tour(service_id, example_template_id):
 
     service_api_client.delete_service_template(service_id, example_template_id)
@@ -849,7 +838,6 @@ def get_back_link(service_id, template, step_index):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def check_notification(service_id, template_id):
     return render_template(
         'views/notifications/check.html',
@@ -924,7 +912,6 @@ def get_template_error_dict(exception):
 
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-@login_required
 def send_notification(service_id, template_id):
     if {'recipient', 'placeholders'} - set(session.keys()):
         return redirect(url_for(

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -12,7 +12,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import (
@@ -73,7 +73,6 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
 
 @main.route("/services/<service_id>/service-settings")
 @user_has_permissions('manage_service', 'manage_api_keys')
-@login_required
 def service_settings(service_id):
     return render_template(
         'views/service-settings.html',
@@ -83,7 +82,6 @@ def service_settings(service_id):
 
 @main.route("/services/<service_id>/service-settings/name", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_name_change(service_id):
     form = RenameServiceForm()
 
@@ -112,7 +110,6 @@ def service_name_change(service_id):
 
 @main.route("/services/<service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_name_change_confirm(service_id):
     # Validate password for form
     def _check_password(pwd):
@@ -145,7 +142,6 @@ def service_name_change_confirm(service_id):
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live/estimate-usage", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def estimate_usage(service_id):
 
     form = EstimateUsageForm(
@@ -178,7 +174,6 @@ def estimate_usage(service_id):
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['GET'])
 @user_has_permissions('manage_service')
-@login_required
 def request_to_go_live(service_id):
 
     agreement_signed = current_service.organisation.agreement_signed
@@ -192,7 +187,6 @@ def request_to_go_live(service_id):
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['POST'])
 @user_has_permissions('manage_service')
-@login_required
 @user_is_gov_user
 def submit_request_to_go_live(service_id):
 
@@ -239,7 +233,6 @@ def submit_request_to_go_live(service_id):
 
 @main.route("/services/<service_id>/service-settings/switch-live", methods=["GET", "POST"])
 @user_is_platform_admin
-@login_required
 def service_switch_live(service_id):
     form = ServiceOnOffSettingForm(
         name="Make service live",
@@ -259,7 +252,6 @@ def service_switch_live(service_id):
 
 @main.route("/services/<service_id>/service-settings/switch-count-as-live", methods=["GET", "POST"])
 @user_is_platform_admin
-@login_required
 def service_switch_count_as_live(service_id):
 
     form = ServiceOnOffSettingForm(
@@ -282,7 +274,6 @@ def service_switch_count_as_live(service_id):
 
 @main.route("/services/<service_id>/service-settings/permissions/<permission>", methods=["GET", "POST"])
 @user_is_platform_admin
-@login_required
 def service_set_permission(service_id, permission):
     if permission not in PLATFORM_ADMIN_SERVICE_PERMISSIONS:
         abort(404)
@@ -307,7 +298,6 @@ def service_set_permission(service_id, permission):
 
 @main.route("/services/<service_id>/service-settings/can-upload-document", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def service_switch_can_upload_document(service_id):
     if current_service.contact_link:
         return redirect(url_for('.service_set_permission', service_id=service_id, permission='upload_document'))
@@ -328,7 +318,6 @@ def service_switch_can_upload_document(service_id):
 
 @main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def archive_service(service_id):
     if not current_service.active and (
         current_service.trial_mode or current_user.platform_admin
@@ -351,7 +340,6 @@ def archive_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/suspend", methods=["GET", "POST"])
 @user_has_permissions('manage_service')
-@login_required
 def suspend_service(service_id):
     if request.method == 'POST':
         service_api_client.suspend_service(service_id)
@@ -364,7 +352,6 @@ def suspend_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/resume", methods=["GET", "POST"])
 @user_has_permissions('manage_service')
-@login_required
 def resume_service(service_id):
     if request.method == 'POST':
         service_api_client.resume_service(service_id)
@@ -376,7 +363,6 @@ def resume_service(service_id):
 
 @main.route("/services/<service_id>/service-settings/contact-link", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_contact_link(service_id):
     form = ServiceContactDetailsForm()
 
@@ -401,21 +387,18 @@ def service_set_contact_link(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_reply_to_email(service_id):
     return redirect(url_for('.service_email_reply_to', service_id=service_id))
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
 @user_has_permissions('manage_service', 'manage_api_keys')
-@login_required
 def service_email_reply_to(service_id):
     return render_template('views/service-settings/email_reply_to.html')
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/add", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_add_email_reply_to(service_id):
     form = ServiceReplyToEmailForm()
     first_email_address = current_service.count_email_reply_to_addresses == 0
@@ -447,7 +430,6 @@ def service_add_email_reply_to(service_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<notification_id>/verify", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_verify_reply_to_address(service_id, notification_id):
     replace = request.args.get('replace', False)
     is_default = request.args.get('is_default', False)
@@ -464,7 +446,6 @@ def service_verify_reply_to_address(service_id, notification_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<notification_id>/verify.json")
 @user_has_permissions('manage_service')
-@login_required
 def service_verify_reply_to_address_updates(service_id, notification_id):
     return jsonify(**get_service_verify_reply_to_address_partials(service_id, notification_id))
 
@@ -530,7 +511,6 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
     endpoint="service_confirm_delete_email_reply_to"
 )
 @user_has_permissions('manage_service')
-@login_required
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = current_service.get_email_reply_to_address(reply_to_email_id)
@@ -576,7 +556,6 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/delete", methods=['POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_delete_email_reply_to(service_id, reply_to_email_id):
     service_api_client.delete_reply_to_email_address(
         service_id=current_service.id,
@@ -587,7 +566,6 @@ def service_delete_email_reply_to(service_id, reply_to_email_id):
 
 @main.route("/services/<service_id>/service-settings/set-inbound-number", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_inbound_number(service_id):
     available_inbound_numbers = inbound_number_client.get_available_inbound_sms_numbers()
     inbound_numbers_value_and_label = [
@@ -617,7 +595,6 @@ def service_set_inbound_number(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-prefix", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_sms_prefix(service_id):
 
     form = SMSPrefixForm(enabled=(
@@ -640,7 +617,6 @@ def service_set_sms_prefix(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_international_sms(service_id):
     form = InternationalSMSForm(
         enabled='on' if current_service.has_permission('international_sms') else 'off'
@@ -661,7 +637,6 @@ def service_set_international_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-inbound-sms", methods=['GET'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_inbound_sms(service_id):
     return render_template(
         'views/service-settings/set-inbound-sms.html',
@@ -670,7 +645,6 @@ def service_set_inbound_sms(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-letters", methods=['GET'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_letters(service_id):
     return redirect(
         url_for(
@@ -684,7 +658,6 @@ def service_set_letters(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-<channel>", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_channel(service_id, channel):
 
     if channel not in {'email', 'sms', 'letter'}:
@@ -712,7 +685,6 @@ def service_set_channel(service_id, channel):
 
 @main.route("/services/<service_id>/service-settings/set-auth-type", methods=['GET'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_auth_type(service_id):
     return render_template(
         'views/service-settings/set-auth-type.html',
@@ -721,7 +693,6 @@ def service_set_auth_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
 @user_has_permissions('manage_service', 'manage_api_keys')
-@login_required
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
     return render_template(
@@ -731,7 +702,6 @@ def service_letter_contact_details(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contact/add", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_add_letter_contact(service_id):
     form = ServiceLetterContactBlockForm()
     first_contact_block = current_service.count_letter_contact_details == 0
@@ -755,7 +725,6 @@ def service_add_letter_contact(service_id):
 
 @main.route("/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/edit", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_edit_letter_contact(service_id, letter_contact_id):
     letter_contact_block = current_service.get_letter_contact_block(letter_contact_id)
     form = ServiceLetterContactBlockForm(
@@ -779,7 +748,6 @@ def service_edit_letter_contact(service_id, letter_contact_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
 @user_has_permissions('manage_service', 'manage_api_keys')
-@login_required
 def service_sms_senders(service_id):
     return render_template(
         'views/service-settings/sms-senders.html',
@@ -788,7 +756,6 @@ def service_sms_senders(service_id):
 
 @main.route("/services/<service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
     first_sms_sender = current_service.count_sms_senders == 0
@@ -816,7 +783,6 @@ def service_add_sms_sender(service_id):
     endpoint="service_confirm_delete_sms_sender"
 )
 @user_has_permissions('manage_service')
-@login_required
 def service_edit_sms_sender(service_id, sms_sender_id):
     sms_sender = current_service.get_sms_sender(sms_sender_id)
     is_inbound_number = sms_sender['inbound_number_id']
@@ -851,7 +817,6 @@ def service_edit_sms_sender(service_id, sms_sender_id):
     methods=['POST'],
 )
 @user_has_permissions('manage_service')
-@login_required
 def service_delete_sms_sender(service_id, sms_sender_id):
     service_api_client.delete_sms_sender(
         service_id=current_service.id,
@@ -862,7 +827,6 @@ def service_delete_sms_sender(service_id, sms_sender_id):
 
 @main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def service_set_letter_contact_block(service_id):
 
     if not current_service.has_permission('letter'):
@@ -886,7 +850,6 @@ def service_set_letter_contact_block(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-organisation-type", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def set_organisation_type(service_id):
 
     form = OrganisationTypeForm(organisation_type=current_service.organisation_type)
@@ -910,7 +873,6 @@ def set_organisation_type(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-free-sms-allowance", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def set_free_sms_allowance(service_id):
 
     form = FreeSMSAllowance(free_sms_allowance=current_service.free_sms_fragment_limit)
@@ -928,7 +890,6 @@ def set_free_sms_allowance(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def service_set_email_branding(service_id):
     email_branding = email_branding_client.get_all_email_branding()
 
@@ -953,7 +914,6 @@ def service_set_email_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/preview-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def service_preview_email_branding(service_id):
     branding_style = request.args.get('branding_style', None)
 
@@ -975,7 +935,6 @@ def service_preview_email_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/set-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def service_set_letter_branding(service_id):
     letter_branding = letter_branding_client.get_all_letter_branding()
 
@@ -1000,7 +959,6 @@ def service_set_letter_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/preview-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def service_preview_letter_branding(service_id):
     branding_style = request.args.get('branding_style')
 
@@ -1022,7 +980,6 @@ def service_preview_letter_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/request-letter-branding", methods=['GET', 'POST'])
 @user_has_permissions('manage_service', 'manage_templates')
-@login_required
 def request_letter_branding(service_id):
     return render_template(
         'views/service-settings/request-letter-branding.html',
@@ -1032,7 +989,6 @@ def request_letter_branding(service_id):
 
 @main.route("/services/<service_id>/service-settings/link-service-to-organisation", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def link_service_to_organisation(service_id):
 
     all_organisations = organisations_client.get_organisations()
@@ -1060,7 +1016,6 @@ def link_service_to_organisation(service_id):
 
 @main.route("/services/<service_id>/branding-request/email", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-@login_required
 def branding_request(service_id):
 
     branding_type = 'govuk'
@@ -1109,7 +1064,6 @@ def branding_request(service_id):
 
 @main.route("/services/<service_id>/data-retention", methods=['GET'])
 @user_is_platform_admin
-@login_required
 def data_retention(service_id):
     return render_template(
         'views/service-settings/data-retention.html',
@@ -1118,7 +1072,6 @@ def data_retention(service_id):
 
 @main.route("/services/<service_id>/data-retention/add", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def add_data_retention(service_id):
     form = ServiceDataRetentionForm()
     if form.validate_on_submit():
@@ -1134,7 +1087,6 @@ def add_data_retention(service_id):
 
 @main.route("/services/<service_id>/data-retention/<data_retention_id>/edit", methods=['GET', 'POST'])
 @user_is_platform_admin
-@login_required
 def edit_data_retention(service_id, data_retention_id):
     data_retention_item = current_service.get_data_retention_item(data_retention_id)
     form = ServiceDataRetentionEditForm(days_of_retention=data_retention_item['days_of_retention'])

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -72,8 +72,8 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
 
 
 @main.route("/services/<service_id>/service-settings")
-@login_required
 @user_has_permissions('manage_service', 'manage_api_keys')
+@login_required
 def service_settings(service_id):
     return render_template(
         'views/service-settings.html',
@@ -82,8 +82,8 @@ def service_settings(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/name", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_name_change(service_id):
     form = RenameServiceForm()
 
@@ -111,8 +111,8 @@ def service_name_change(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_name_change_confirm(service_id):
     # Validate password for form
     def _check_password(pwd):
@@ -144,8 +144,8 @@ def service_name_change_confirm(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live/estimate-usage", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def estimate_usage(service_id):
 
     form = EstimateUsageForm(
@@ -177,8 +177,8 @@ def estimate_usage(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def request_to_go_live(service_id):
 
     agreement_signed = current_service.organisation.agreement_signed
@@ -191,8 +191,8 @@ def request_to_go_live(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 @user_is_gov_user
 def submit_request_to_go_live(service_id):
 
@@ -238,8 +238,8 @@ def submit_request_to_go_live(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/switch-live", methods=["GET", "POST"])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_switch_live(service_id):
     form = ServiceOnOffSettingForm(
         name="Make service live",
@@ -258,8 +258,8 @@ def service_switch_live(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/switch-count-as-live", methods=["GET", "POST"])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_switch_count_as_live(service_id):
 
     form = ServiceOnOffSettingForm(
@@ -281,8 +281,8 @@ def service_switch_count_as_live(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/permissions/<permission>", methods=["GET", "POST"])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_set_permission(service_id, permission):
     if permission not in PLATFORM_ADMIN_SERVICE_PERMISSIONS:
         abort(404)
@@ -306,8 +306,8 @@ def service_set_permission(service_id, permission):
 
 
 @main.route("/services/<service_id>/service-settings/can-upload-document", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_switch_can_upload_document(service_id):
     if current_service.contact_link:
         return redirect(url_for('.service_set_permission', service_id=service_id, permission='upload_document'))
@@ -327,8 +327,8 @@ def service_switch_can_upload_document(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def archive_service(service_id):
     if not current_service.active and (
         current_service.trial_mode or current_user.platform_admin
@@ -350,8 +350,8 @@ def archive_service(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/suspend", methods=["GET", "POST"])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def suspend_service(service_id):
     if request.method == 'POST':
         service_api_client.suspend_service(service_id)
@@ -363,8 +363,8 @@ def suspend_service(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/resume", methods=["GET", "POST"])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def resume_service(service_id):
     if request.method == 'POST':
         service_api_client.resume_service(service_id)
@@ -375,8 +375,8 @@ def resume_service(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/contact-link", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_contact_link(service_id):
     form = ServiceContactDetailsForm()
 
@@ -400,22 +400,22 @@ def service_set_contact_link(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_reply_to_email(service_id):
     return redirect(url_for('.service_email_reply_to', service_id=service_id))
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service', 'manage_api_keys')
+@login_required
 def service_email_reply_to(service_id):
     return render_template('views/service-settings/email_reply_to.html')
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/add", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_add_email_reply_to(service_id):
     form = ServiceReplyToEmailForm()
     first_email_address = current_service.count_email_reply_to_addresses == 0
@@ -446,8 +446,8 @@ def service_add_email_reply_to(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<notification_id>/verify", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_verify_reply_to_address(service_id, notification_id):
     replace = request.args.get('replace', False)
     is_default = request.args.get('is_default', False)
@@ -463,8 +463,8 @@ def service_verify_reply_to_address(service_id, notification_id):
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<notification_id>/verify.json")
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_verify_reply_to_address_updates(service_id, notification_id):
     return jsonify(**get_service_verify_reply_to_address_partials(service_id, notification_id))
 
@@ -529,8 +529,8 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
     methods=['GET'],
     endpoint="service_confirm_delete_email_reply_to"
 )
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = current_service.get_email_reply_to_address(reply_to_email_id)
@@ -575,8 +575,8 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
 
 
 @main.route("/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/delete", methods=['POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_delete_email_reply_to(service_id, reply_to_email_id):
     service_api_client.delete_reply_to_email_address(
         service_id=current_service.id,
@@ -586,8 +586,8 @@ def service_delete_email_reply_to(service_id, reply_to_email_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-inbound-number", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_inbound_number(service_id):
     available_inbound_numbers = inbound_number_client.get_available_inbound_sms_numbers()
     inbound_numbers_value_and_label = [
@@ -616,8 +616,8 @@ def service_set_inbound_number(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/sms-prefix", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_sms_prefix(service_id):
 
     form = SMSPrefixForm(enabled=(
@@ -639,8 +639,8 @@ def service_set_sms_prefix(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_international_sms(service_id):
     form = InternationalSMSForm(
         enabled='on' if current_service.has_permission('international_sms') else 'off'
@@ -660,8 +660,8 @@ def service_set_international_sms(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-inbound-sms", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_inbound_sms(service_id):
     return render_template(
         'views/service-settings/set-inbound-sms.html',
@@ -669,8 +669,8 @@ def service_set_inbound_sms(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-letters", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_letters(service_id):
     return redirect(
         url_for(
@@ -683,8 +683,8 @@ def service_set_letters(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-<channel>", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_channel(service_id, channel):
 
     if channel not in {'email', 'sms', 'letter'}:
@@ -711,8 +711,8 @@ def service_set_channel(service_id, channel):
 
 
 @main.route("/services/<service_id>/service-settings/set-auth-type", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_auth_type(service_id):
     return render_template(
         'views/service-settings/set-auth-type.html',
@@ -720,8 +720,8 @@ def service_set_auth_type(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service', 'manage_api_keys')
+@login_required
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
     return render_template(
@@ -730,8 +730,8 @@ def service_letter_contact_details(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/letter-contact/add", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_add_letter_contact(service_id):
     form = ServiceLetterContactBlockForm()
     first_contact_block = current_service.count_letter_contact_details == 0
@@ -754,8 +754,8 @@ def service_add_letter_contact(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/edit", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_edit_letter_contact(service_id, letter_contact_id):
     letter_contact_block = current_service.get_letter_contact_block(letter_contact_id)
     form = ServiceLetterContactBlockForm(
@@ -778,8 +778,8 @@ def service_edit_letter_contact(service_id, letter_contact_id):
 
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
-@login_required
 @user_has_permissions('manage_service', 'manage_api_keys')
+@login_required
 def service_sms_senders(service_id):
     return render_template(
         'views/service-settings/sms-senders.html',
@@ -787,8 +787,8 @@ def service_sms_senders(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
     first_sms_sender = current_service.count_sms_senders == 0
@@ -815,8 +815,8 @@ def service_add_sms_sender(service_id):
     methods=['GET'],
     endpoint="service_confirm_delete_sms_sender"
 )
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_edit_sms_sender(service_id, sms_sender_id):
     sms_sender = current_service.get_sms_sender(sms_sender_id)
     is_inbound_number = sms_sender['inbound_number_id']
@@ -850,8 +850,8 @@ def service_edit_sms_sender(service_id, sms_sender_id):
     "/services/<service_id>/service-settings/sms-sender/<sms_sender_id>/delete",
     methods=['POST'],
 )
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_delete_sms_sender(service_id, sms_sender_id):
     service_api_client.delete_sms_sender(
         service_id=current_service.id,
@@ -861,8 +861,8 @@ def service_delete_sms_sender(service_id, sms_sender_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def service_set_letter_contact_block(service_id):
 
     if not current_service.has_permission('letter'):
@@ -885,8 +885,8 @@ def service_set_letter_contact_block(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-organisation-type", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def set_organisation_type(service_id):
 
     form = OrganisationTypeForm(organisation_type=current_service.organisation_type)
@@ -909,8 +909,8 @@ def set_organisation_type(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-free-sms-allowance", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def set_free_sms_allowance(service_id):
 
     form = FreeSMSAllowance(free_sms_allowance=current_service.free_sms_fragment_limit)
@@ -927,8 +927,8 @@ def set_free_sms_allowance(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-email-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_set_email_branding(service_id):
     email_branding = email_branding_client.get_all_email_branding()
 
@@ -952,8 +952,8 @@ def service_set_email_branding(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/preview-email-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_preview_email_branding(service_id):
     branding_style = request.args.get('branding_style', None)
 
@@ -974,8 +974,8 @@ def service_preview_email_branding(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/set-letter-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_set_letter_branding(service_id):
     letter_branding = letter_branding_client.get_all_letter_branding()
 
@@ -999,8 +999,8 @@ def service_set_letter_branding(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/preview-letter-branding", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def service_preview_letter_branding(service_id):
     branding_style = request.args.get('branding_style')
 
@@ -1021,8 +1021,8 @@ def service_preview_letter_branding(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/request-letter-branding", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service', 'manage_templates')
+@login_required
 def request_letter_branding(service_id):
     return render_template(
         'views/service-settings/request-letter-branding.html',
@@ -1031,8 +1031,8 @@ def request_letter_branding(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/link-service-to-organisation", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def link_service_to_organisation(service_id):
 
     all_organisations = organisations_client.get_organisations()
@@ -1059,8 +1059,8 @@ def link_service_to_organisation(service_id):
 
 
 @main.route("/services/<service_id>/branding-request/email", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_service')
+@login_required
 def branding_request(service_id):
 
     branding_type = 'govuk'
@@ -1108,8 +1108,8 @@ def branding_request(service_id):
 
 
 @main.route("/services/<service_id>/data-retention", methods=['GET'])
-@login_required
 @user_is_platform_admin
+@login_required
 def data_retention(service_id):
     return render_template(
         'views/service-settings/data-retention.html',
@@ -1117,8 +1117,8 @@ def data_retention(service_id):
 
 
 @main.route("/services/<service_id>/data-retention/add", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def add_data_retention(service_id):
     form = ServiceDataRetentionForm()
     if form.validate_on_submit():
@@ -1133,8 +1133,8 @@ def add_data_retention(service_id):
 
 
 @main.route("/services/<service_id>/data-retention/<data_retention_id>/edit", methods=['GET', 'POST'])
-@login_required
 @user_is_platform_admin
+@login_required
 def edit_data_retention(service_id, data_retention_id):
     data_retention_item = current_service.get_data_retention_item(data_retention_id)
     form = ServiceDataRetentionEditForm(days_of_retention=data_retention_item['days_of_retention'])

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -3,7 +3,7 @@ from string import ascii_uppercase
 
 from dateutil.parser import parse
 from flask import abort, flash, redirect, render_template, request, url_for
-from flask_login import current_user, login_required
+from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from notifications_utils.formatters import nl2br
@@ -47,7 +47,6 @@ form_objects = {
 
 @main.route("/services/<service_id>/templates/<uuid:template_id>")
 @user_has_permissions()
-@login_required
 def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
     template_folder = current_service.get_template_folder(template['folder'])
@@ -88,7 +87,6 @@ def view_template(service_id, template_id):
 
 @main.route("/services/<service_id>/start-tour/<uuid:template_id>")
 @user_has_permissions('view_activity')
-@login_required
 def start_tour(service_id, template_id):
 
     template = current_service.get_template(template_id)
@@ -112,7 +110,6 @@ def start_tour(service_id, template_id):
 @main.route("/services/<service_id>/templates/<template_type>", methods=['GET', 'POST'])
 @main.route("/services/<service_id>/templates/<template_type>/folders/<template_folder_id>", methods=['GET', 'POST'])
 @user_has_permissions()
-@login_required
 def choose_template(service_id, template_type='all', template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
 
@@ -221,7 +218,6 @@ def get_template_nav_items(template_folder_id):
 
 @main.route("/services/<service_id>/templates/<template_id>.<filetype>")
 @user_has_permissions()
-@login_required
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -232,7 +228,6 @@ def view_letter_template_preview(service_id, template_id, filetype):
 
 
 @main.route("/templates/letter-preview-image/<filename>")
-@login_required
 @user_is_platform_admin
 def letter_branding_preview_image(filename):
     template = {
@@ -276,7 +271,6 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")
 @user_has_permissions()
-@login_required
 def view_template_version(service_id, template_id, version):
     return render_template(
         'views/templates/template_history.html',
@@ -286,7 +280,6 @@ def view_template_version(service_id, template_id, version):
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.<filetype>")
 @user_has_permissions()
-@login_required
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = current_service.get_template(template_id, version=version)
     return TemplatePreview.from_database_object(db_template, filetype)
@@ -338,7 +331,6 @@ def _add_template_by_type(template_type, template_folder_id):
 @main.route("/services/<service_id>/templates/copy/from-service/<uuid:from_service>")
 @main.route("/services/<service_id>/templates/copy/from-service/<uuid:from_service>/from-folder/<uuid:from_folder>")
 @user_has_permissions('manage_templates')
-@login_required
 def choose_template_to_copy(
     service_id,
     from_service=None,
@@ -374,7 +366,6 @@ def choose_template_to_copy(
 
 @main.route("/services/<service_id>/templates/copy/<uuid:template_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def copy_template(service_id, template_id):
     from_service = request.args.get('from_service')
 
@@ -418,7 +409,6 @@ def _get_template_copy_name(template, existing_templates):
 
 @main.route("/services/<service_id>/templates/action-blocked/<notification_type>/<return_to>/<template_id>")
 @user_has_permissions('manage_templates')
-@login_required
 def action_blocked(service_id, notification_type, return_to, template_id):
     if notification_type == 'sms':
         notification_type = 'text messages'
@@ -436,7 +426,6 @@ def action_blocked(service_id, notification_type, return_to, template_id):
 
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>/manage", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def manage_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
     form = TemplateFolderForm(
@@ -471,7 +460,6 @@ def manage_template_folder(service_id, template_folder_id):
 
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>/delete", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def delete_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
 
@@ -516,7 +504,6 @@ def delete_template_folder(service_id, template_folder_id):
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>/add-<template_type>",
             methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def add_service_template(service_id, template_type, template_folder_id=None):
 
     if template_type not in ['sms', 'email', 'letter']:
@@ -578,7 +565,6 @@ def abort_403_if_not_admin_user():
 
 @main.route("/services/<service_id>/templates/<template_id>/edit", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def edit_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     template['template_content'] = template['content']
@@ -661,7 +647,6 @@ def edit_service_template(service_id, template_id):
 
 @main.route("/services/<service_id>/templates/<template_id>/delete", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def delete_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
@@ -711,7 +696,6 @@ def delete_service_template(service_id, template_id):
 
 @main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET'])
 @user_has_permissions('manage_templates')
-@login_required
 def confirm_redact_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
@@ -736,7 +720,6 @@ def confirm_redact_template(service_id, template_id):
 
 @main.route("/services/<service_id>/templates/<template_id>/redact", methods=['POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def redact_template(service_id, template_id):
 
     service_api_client.redact_service_template(service_id, template_id)
@@ -755,7 +738,6 @@ def redact_template(service_id, template_id):
 
 @main.route('/services/<service_id>/templates/<template_id>/versions')
 @user_has_permissions('view_activity')
-@login_required
 def view_template_versions(service_id, template_id):
     return render_template(
         'views/templates/choose_history.html',
@@ -779,7 +761,6 @@ def view_template_versions(service_id, template_id):
 
 @main.route('/services/<service_id>/templates/<template_id>/set-template-sender', methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def set_template_sender(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     sender_details = get_template_sender_form_dict(service_id, template)
@@ -810,7 +791,6 @@ def set_template_sender(service_id, template_id):
 
 @main.route('/services/<service_id>/templates/<template_id>/edit-postage', methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
-@login_required
 def edit_template_postage(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     if template["template_type"] != "letter":

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -46,8 +46,8 @@ form_objects = {
 
 
 @main.route("/services/<service_id>/templates/<uuid:template_id>")
-@login_required
 @user_has_permissions()
+@login_required
 def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
     template_folder = current_service.get_template_folder(template['folder'])
@@ -87,8 +87,8 @@ def view_template(service_id, template_id):
 
 
 @main.route("/services/<service_id>/start-tour/<uuid:template_id>")
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def start_tour(service_id, template_id):
 
     template = current_service.get_template(template_id)
@@ -111,8 +111,8 @@ def start_tour(service_id, template_id):
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>", methods=['GET', 'POST'])
 @main.route("/services/<service_id>/templates/<template_type>", methods=['GET', 'POST'])
 @main.route("/services/<service_id>/templates/<template_type>/folders/<template_folder_id>", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions()
+@login_required
 def choose_template(service_id, template_type='all', template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
 
@@ -220,8 +220,8 @@ def get_template_nav_items(template_folder_id):
 
 
 @main.route("/services/<service_id>/templates/<template_id>.<filetype>")
-@login_required
 @user_has_permissions()
+@login_required
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ('pdf', 'png'):
         abort(404)
@@ -275,8 +275,8 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
 
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")
-@login_required
 @user_has_permissions()
+@login_required
 def view_template_version(service_id, template_id, version):
     return render_template(
         'views/templates/template_history.html',
@@ -285,8 +285,8 @@ def view_template_version(service_id, template_id, version):
 
 
 @main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.<filetype>")
-@login_required
 @user_has_permissions()
+@login_required
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = current_service.get_template(template_id, version=version)
     return TemplatePreview.from_database_object(db_template, filetype)
@@ -337,8 +337,8 @@ def _add_template_by_type(template_type, template_folder_id):
 @main.route("/services/<service_id>/templates/copy/from-folder/<uuid:from_folder>")
 @main.route("/services/<service_id>/templates/copy/from-service/<uuid:from_service>")
 @main.route("/services/<service_id>/templates/copy/from-service/<uuid:from_service>/from-folder/<uuid:from_folder>")
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def choose_template_to_copy(
     service_id,
     from_service=None,
@@ -373,8 +373,8 @@ def choose_template_to_copy(
 
 
 @main.route("/services/<service_id>/templates/copy/<uuid:template_id>", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def copy_template(service_id, template_id):
     from_service = request.args.get('from_service')
 
@@ -417,8 +417,8 @@ def _get_template_copy_name(template, existing_templates):
 
 
 @main.route("/services/<service_id>/templates/action-blocked/<notification_type>/<return_to>/<template_id>")
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def action_blocked(service_id, notification_type, return_to, template_id):
     if notification_type == 'sms':
         notification_type = 'text messages'
@@ -435,8 +435,8 @@ def action_blocked(service_id, notification_type, return_to, template_id):
 
 
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>/manage", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def manage_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
     form = TemplateFolderForm(
@@ -470,8 +470,8 @@ def manage_template_folder(service_id, template_folder_id):
 
 
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>/delete", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def delete_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
 
@@ -515,8 +515,8 @@ def delete_template_folder(service_id, template_folder_id):
 @main.route("/services/<service_id>/templates/add-<template_type>", methods=['GET', 'POST'])
 @main.route("/services/<service_id>/templates/folders/<template_folder_id>/add-<template_type>",
             methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def add_service_template(service_id, template_type, template_folder_id=None):
 
     if template_type not in ['sms', 'email', 'letter']:
@@ -577,8 +577,8 @@ def abort_403_if_not_admin_user():
 
 
 @main.route("/services/<service_id>/templates/<template_id>/edit", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def edit_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     template['template_content'] = template['content']
@@ -660,8 +660,8 @@ def edit_service_template(service_id, template_id):
 
 
 @main.route("/services/<service_id>/templates/<template_id>/delete", methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def delete_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
@@ -710,8 +710,8 @@ def delete_service_template(service_id, template_id):
 
 
 @main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def confirm_redact_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
@@ -735,8 +735,8 @@ def confirm_redact_template(service_id, template_id):
 
 
 @main.route("/services/<service_id>/templates/<template_id>/redact", methods=['POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def redact_template(service_id, template_id):
 
     service_api_client.redact_service_template(service_id, template_id)
@@ -754,8 +754,8 @@ def redact_template(service_id, template_id):
 
 
 @main.route('/services/<service_id>/templates/<template_id>/versions')
-@login_required
 @user_has_permissions('view_activity')
+@login_required
 def view_template_versions(service_id, template_id):
     return render_template(
         'views/templates/choose_history.html',
@@ -778,8 +778,8 @@ def view_template_versions(service_id, template_id):
 
 
 @main.route('/services/<service_id>/templates/<template_id>/set-template-sender', methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def set_template_sender(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     sender_details = get_template_sender_form_dict(service_id, template)
@@ -809,8 +809,8 @@ def set_template_sender(service_id, template_id):
 
 
 @main.route('/services/<service_id>/templates/<template_id>/edit-postage', methods=['GET', 'POST'])
-@login_required
 @user_has_permissions('manage_templates')
+@login_required
 def edit_template_postage(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     if template["template_type"] != "letter":

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -8,7 +8,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import current_user
 from notifications_utils.url_safe_token import check_token
 
 from app import user_api_client
@@ -23,7 +23,7 @@ from app.main.forms import (
     TwoFactorForm,
 )
 from app.models.user import User
-from app.utils import user_is_gov_user
+from app.utils import user_is_gov_user, user_is_logged_in
 
 NEW_EMAIL = 'new-email'
 NEW_MOBILE = 'new-mob'
@@ -31,7 +31,7 @@ NEW_MOBILE_PASSWORD_CONFIRMED = 'new-mob-password-confirmed'
 
 
 @main.route("/user-profile")
-@login_required
+@user_is_logged_in
 def user_profile():
     return render_template(
         'views/user-profile.html',
@@ -40,7 +40,7 @@ def user_profile():
 
 
 @main.route("/user-profile/name", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_name():
 
     form = ChangeNameForm(new_name=current_user.name)
@@ -57,7 +57,7 @@ def user_profile_name():
 
 
 @main.route("/user-profile/email", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 @user_is_gov_user
 def user_profile_email():
 
@@ -75,7 +75,7 @@ def user_profile_email():
 
 
 @main.route("/user-profile/email/authenticate", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_email_authenticate():
     # Validate password for form
     def _check_password(pwd):
@@ -99,7 +99,7 @@ def user_profile_email_authenticate():
 
 
 @main.route("/user-profile/email/confirm/<token>", methods=['GET'])
-@login_required
+@user_is_logged_in
 def user_profile_email_confirm(token):
     token_data = check_token(token,
                              current_app.config['SECRET_KEY'],
@@ -114,7 +114,7 @@ def user_profile_email_confirm(token):
 
 
 @main.route("/user-profile/mobile-number", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_mobile_number():
 
     form = ChangeMobileNumberForm(mobile_number=current_user.mobile_number)
@@ -131,7 +131,7 @@ def user_profile_mobile_number():
 
 
 @main.route("/user-profile/mobile-number/authenticate", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_mobile_number_authenticate():
 
     # Validate password for form
@@ -156,7 +156,7 @@ def user_profile_mobile_number_authenticate():
 
 
 @main.route("/user-profile/mobile-number/confirm", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_mobile_number_confirm():
 
     # Validate verify code for form
@@ -184,7 +184,7 @@ def user_profile_mobile_number_confirm():
 
 
 @main.route("/user-profile/password", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_password():
 
     # Validate password for form
@@ -203,7 +203,7 @@ def user_profile_password():
 
 
 @main.route("/user-profile/disable-platform-admin-view", methods=['GET', 'POST'])
-@login_required
+@user_is_logged_in
 def user_profile_disable_platform_admin_view():
     if not current_user.platform_admin and not session.get('disable_platform_admin_view'):
         abort(403)

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -19,7 +19,7 @@ from app.main.views.platform_admin import (
     sum_service_usage,
 )
 from tests import service_json
-from tests.conftest import mock_get_user, normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, mock_get_user, normalize_spaces
 
 
 @pytest.mark.parametrize('endpoint', [
@@ -767,7 +767,7 @@ def test_service_letter_validation_preview_renders_correctly(
         mock_has_no_jobs
 
 ):
-    page = client_request.get('main.service_letter_validation_preview', service_id="service_1")
+    page = client_request.get('main.service_letter_validation_preview', service_id=SERVICE_ONE_ID)
 
     assert page.find('h1').text.strip() == "Letter validation preview"
     assert page.find_all('input', class_='file-upload-field')
@@ -780,7 +780,7 @@ def test_service_letter_validation_preview_returns_400_if_file_is_too_big(
 
 ):
     with open('tests/test_pdf_files/big.pdf', 'rb') as file:
-        page = client_request.post('main.service_letter_validation_preview', service_id="service_1",
+        page = client_request.post('main.service_letter_validation_preview', service_id=SERVICE_ONE_ID,
                                    _data=dict(
                                        pdf_file=file,
                                    ),

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -1,6 +1,17 @@
 import pytest
 
-from app.models.user import User
+from app.models.user import AnonymousUser, User
+
+
+def test_anonymous_user(app_):
+    assert AnonymousUser().is_authenticated is False
+    assert AnonymousUser().logged_in_elsewhere() is False
+    assert AnonymousUser().default_organisation.name is None
+    assert AnonymousUser().default_organisation.crown is None
+    assert AnonymousUser().default_organisation.agreement_signed is None
+    assert AnonymousUser().default_organisation.domains == []
+    assert AnonymousUser().default_organisation.organisation_type is None
+    assert AnonymousUser().default_organisation.request_to_go_live_notes is None
 
 
 def test_user(app_):


### PR DESCRIPTION
We accidentally miss these sometimes. This code adds a test which inspects the code to automatically check that any function which:
- handles a route
- has `service_id` or `org_id` as one of its arguments

For each function it checks that the permissions decorator we’d expect are present.

Most of the introspection/AST code is adapted from here:
https://mvdwoord.github.io/exploration/2017/08/18/ast_explore.html