### PR TITLE
Require more information when creating organisations

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -596,10 +596,13 @@ class OrganisationTypeForm(StripWhitespaceForm):
 
 class NewOrganisationForm(
     RenameOrganisationForm,
-    OrganisationTypeForm,
+    OrganisationOrganisationTypeForm,
     OrganisationCrownStatusForm,
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Don’t offer the ‘not sure’ choice
+        self.crown_status.choices = self.crown_status.choices[:-1]
 
 
 class FreeSMSAllowance(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -594,6 +594,14 @@ class OrganisationTypeForm(StripWhitespaceForm):
     organisation_type = organisation_type()
 
 
+class NewOrganisationForm(
+    RenameOrganisationForm,
+    OrganisationTypeForm,
+    OrganisationCrownStatusForm,
+):
+    pass
+
+
 class FreeSMSAllowance(StripWhitespaceForm):
     free_sms_allowance = IntegerField(
         'Numbers of text message fragments per year',
@@ -1037,11 +1045,6 @@ class PDFUploadForm(StripWhitespaceForm):
             DataRequired(message="You need to upload a file to submit")
         ]
     )
-
-
-class CreateOrUpdateOrganisation(StripWhitespaceForm):
-
-    name = StringField('Name', validators=[DataRequired()])
 
 
 class EmailFieldInWhitelist(EmailField, StripWhitespaceStringField):

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -31,7 +31,7 @@ from app.main.forms import (
     SetLetterBranding,
 )
 from app.main.views.service_settings import get_branding_as_value_and_label
-from app.models.organisation import Organisations
+from app.models.organisation import Organisation, Organisations
 from app.models.user import InvitedOrgUser, User
 from app.utils import user_has_permissions, user_is_platform_admin
 
@@ -54,17 +54,7 @@ def add_organisation():
     form = NewOrganisationForm()
 
     if form.validate_on_submit():
-        organisations_client.create_organisation(
-            name=form.name.data,
-            crown={
-                'crown': True,
-                'non-crown': False,
-                'unknown': None,
-            }.get(form.crown_status.data),
-            organisation_type=form.organisation_type.data,
-            agreement_signed=False,
-        )
-
+        Organisation.create_from_form(form)
         return redirect(url_for('.organisations'))
 
     return render_template(

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -54,8 +54,10 @@ def add_organisation():
     form = NewOrganisationForm()
 
     if form.validate_on_submit():
-        Organisation.create_from_form(form)
-        return redirect(url_for('.organisations'))
+        return redirect(url_for(
+            '.organisation_settings',
+            org_id=Organisation.create_from_form(form).id,
+        ))
 
     return render_template(
         'views/organisations/add-organisation.html',

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -16,9 +16,9 @@ from app import (
 from app.main import main
 from app.main.forms import (
     ConfirmPasswordForm,
-    CreateOrUpdateOrganisation,
     GoLiveNotesForm,
     InviteOrgUserForm,
+    NewOrganisationForm,
     OrganisationAgreementSignedForm,
     OrganisationCrownStatusForm,
     OrganisationDomainsForm,
@@ -51,11 +51,18 @@ def organisations():
 @login_required
 @user_is_platform_admin
 def add_organisation():
-    form = CreateOrUpdateOrganisation()
+    form = NewOrganisationForm()
 
     if form.validate_on_submit():
         organisations_client.create_organisation(
             name=form.name.data,
+            crown={
+                'crown': True,
+                'non-crown': False,
+                'unknown': None,
+            }.get(form.crown_status.data),
+            organisation_type=form.organisation_type.data,
+            agreement_signed=False,
         )
 
         return redirect(url_for('.organisations'))

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -38,6 +38,27 @@ class Organisation(JSONModel):
     def from_service(cls, service_id):
         return cls(organisations_client.get_service_organisation(service_id))
 
+    @classmethod
+    def create_from_form(cls, form):
+        return cls.create(
+            name=form.name.data,
+            crown={
+                'crown': True,
+                'non-crown': False,
+                'unknown': None,
+            }.get(form.crown_status.data),
+            organisation_type=form.organisation_type.data,
+        )
+
+    @classmethod
+    def create(cls, name, crown, organisation_type, agreement_signed=False):
+        return cls(organisations_client.create_organisation(
+            name=name,
+            crown=crown,
+            organisation_type=organisation_type,
+            agreement_signed=agreement_signed,
+        ))
+
     def __init__(self, _dict):
 
         super().__init__(_dict)

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -80,7 +80,6 @@ class HeaderNavigation(Navigation):
             'user_profile_disable_platform_admin_view',
         },
         'platform-admin': {
-            'add_organisation',
             'archive_user',
             'clear_cache',
             'create_email_branding',
@@ -120,6 +119,7 @@ class HeaderNavigation(Navigation):
         'accept_org_invite',
         'action_blocked',
         'add_data_retention',
+        'add_organisation',
         'add_service',
         'add_service_template',
         'agreement',

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -32,11 +32,16 @@ class OrganisationsClient(NotifyAdminAPIClient):
             raise error
 
     @cache.delete('organisations')
-    def create_organisation(self, name):
-        data = {
-            "name": name
-        }
-        return self.post(url="/organisations", data=data)
+    def create_organisation(self, name, crown, organisation_type, agreement_signed):
+        return self.post(
+            url="/organisations",
+            data={
+                "name": name,
+                "crown": crown,
+                "organisation_type": organisation_type,
+                "agreement_signed": agreement_signed,
+            }
+        )
 
     @cache.delete('domains')
     @cache.delete('organisations')

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -2,14 +2,11 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
+{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block per_page_title %}
-  Create an organisation
-{% endblock %}
-
-{% block org_page_title %}
-  Create an organisation
+  New organisation
 {% endblock %}
 
 {% block platform_admin_content %}
@@ -21,6 +18,8 @@
 
   {% call form_wrapper() %}
     {{textbox(form.name)}}
+    {{radios(form.organisation_type)}}
+    {{radios(form.crown_status)}}
     {{ page_footer('Save') }}
   {% endcall %}
 

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -1,4 +1,4 @@
-{% extends "views/platform-admin/_base_template.html" %}
+{% extends "withoutnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
@@ -9,18 +9,31 @@
   New organisation
 {% endblock %}
 
-{% block platform_admin_content %}
+{% block fullwidth_content %}
+  <div id="content">
+    <div class="navigation-service">
+      <div class="navigation-service-name">
+        <a href="{{ url_for('.organisations') }}">All organisations</a>
+      </div>
+      <a href="{{ url_for('main.choose_account') }}" class="navigation-service-switch">Switch service</a>
+    </div>
 
-  {{ page_header(
-    'New organisation',
-    back_link=url_for('.organisations')
-  ) }}
-
-  {% call form_wrapper() %}
-    {{textbox(form.name)}}
-    {{radios(form.organisation_type)}}
-    {{radios(form.crown_status)}}
-    {{ page_footer('Save') }}
-  {% endcall %}
+    <main role="main">
+      <div class="grid-row">
+        <div class="column-one-quarter">
+          &nbsp;
+        </div>
+        <div class="column-three-quarters">
+          {{ page_header('New organisation') }}
+          {% call form_wrapper() %}
+            {{textbox(form.name)}}
+            {{radios(form.organisation_type)}}
+            {{radios(form.crown_status)}}
+            {{ page_footer('Save') }}
+          {% endcall %}
+        </div>
+      </div>
+    </main>
+  </div>
 
 {% endblock %}

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -93,7 +93,6 @@ def test_page_to_create_new_organisation(
         ('radio', 'organisation_type', 'nhs'),
         ('radio', 'crown_status', 'crown'),
         ('radio', 'crown_status', 'non-crown'),
-        ('radio', 'crown_status', 'unknown'),
         ('hidden', 'csrf_token', ANY),
     ]
 

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -103,7 +103,8 @@ def test_create_new_organisation(
     mocker,
 ):
     mock_create_organisation = mocker.patch(
-        'app.organisations_client.create_organisation'
+        'app.organisations_client.create_organisation',
+        return_value=organisation_json(ORGANISATION_ID),
     )
 
     client_request.login(platform_admin_user)
@@ -113,7 +114,12 @@ def test_create_new_organisation(
             'name': 'new name',
             'organisation_type': 'local',
             'crown_status': 'non-crown',
-        }
+        },
+        _expected_redirect=url_for(
+            'main.organisation_settings',
+            org_id=ORGANISATION_ID,
+            _external=True,
+        ),
     )
 
     mock_create_organisation.assert_called_once_with(


### PR DESCRIPTION
Currently we set not-very-useful defaults for organisation type and crown status when creating an organisation. This commit adds two field to the form (in addition to the existing name field) to explicitly ask for:
- organisation type
- crown status

We need these for all organisations before we can make any of their services live.

This commit also records any new organisation as not having accepted the data sharing and financial agreement, because if we don’t know about the organisation already then they definitely won’t have signed it.

# Before 

![image](https://user-images.githubusercontent.com/355079/60425470-848d0e00-9bea-11e9-912b-f3dbdda51b7d.png)

# After 

![image](https://user-images.githubusercontent.com/355079/60450549-0187aa00-9c22-11e9-9968-085d2949a0f2.png)

