### PR TITLE
Replace 'email reply-to address' with 'reply-to email address'

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -891,7 +891,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
 
 
 class ServiceReplyToEmailForm(StripWhitespaceForm):
-    email_address = email_address(label='Email reply-to address', gov_user=False)
+    email_address = email_address(label='Reply-to email address', gov_user=False)
     is_default = BooleanField("Make this email address the default")
 
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -532,7 +532,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
                 service_id, form.email_address.data
             )["data"]["id"]
         except HTTPError as e:
-            error_msg = "Your service already uses ‘{}’ as an email reply-to address.".format(form.email_address.data)
+            error_msg = "Your service already uses ‘{}’ as a reply-to email address.".format(form.email_address.data)
             if e.status_code == 400 and error_msg == e.message:
                 flash(error_msg, 'error')
                 return redirect(url_for('.service_email_reply_to', service_id=service_id))
@@ -547,7 +547,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
         ))
 
     if (request.endpoint == "main.service_confirm_delete_email_reply_to"):
-        flash("Are you sure you want to delete this email reply-to address?", 'delete')
+        flash("Are you sure you want to delete this reply-to email address?", 'delete')
     return render_template(
         'views/service-settings/email-reply-to/edit.html',
         form=form,

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -82,7 +82,7 @@
         {% endcall %}
 
         {% call settings_row(if_has_permission='email') %}
-          {{ text_field('Email reply-to addresses') }}
+          {{ text_field('Reply-to email addresses') }}
           {% call field(status='default' if current_service.count_email_reply_to_addresses == 0 else '') %}
             {{ current_service.default_email_reply_to_address or 'Not set' }}
             {% if current_service.count_email_reply_to_addresses > 1 %}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -6,13 +6,13 @@
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
-  Add email reply-to address
+  Add reply-to email address
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    'Add email reply-to address',
+    'Add reply-to email address',
     back_link=url_for('main.service_email_reply_to', service_id=current_service.id)
   ) }}
 

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -7,13 +7,13 @@
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
- Change email reply to address
+ Change reply-to email address
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    'Change email reply to address',
+    'Change reply-to email address',
     back_link=url_for('main.service_email_reply_to', service_id=current_service.id)
   ) }}
   {% call form_wrapper() %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -5,20 +5,20 @@
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 
 {% block service_page_title %}
-  Email reply-to addresses
+  Reply-to email addresses
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    'Email reply-to addresses',
+    'Reply-to email addresses',
     back_link=url_for('main.service_settings', service_id=current_service.id)
   ) }}
 
   <div class="user-list">
     {% if not current_service.email_reply_to_addresses %}
       <div class="user-list-item">
-        <span class="hint">You haven’t added any email reply-to addresses yet</span>
+        <span class="hint">You haven’t added any reply-to email addresses yet</span>
       </div>
     {% endif %}
     {% for item in current_service.email_reply_to_addresses %}
@@ -43,7 +43,7 @@
     <div class="column-whole">
       {% if current_user.has_permissions('manage_service') %}
         <div class="js-stick-at-bottom-when-scrolling">
-          <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button">Add email reply-to address</a>
+          <a href="{{ url_for('.service_add_email_reply_to', service_id=current_service.id) }}" class="button">Add reply-to email address</a>
         </div>
       {% endif %}
     </div>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -34,7 +34,7 @@
         {% if current_service.intending_to_send_email %}
           {{ task_list_item(
             current_service.has_email_reply_to_address,
-            'Add an email reply-to address',
+            'Add a reply-to email address',
             url_for('main.service_email_reply_to', service_id=current_service.id),
           ) }}
         {% endif %}

--- a/app/templates/views/service-settings/set-reply-to-email.html
+++ b/app/templates/views/service-settings/set-reply-to-email.html
@@ -5,13 +5,13 @@
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
-  Email reply-to address
+  Reply-to email address
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    'Email reply-to address',
+    'Reply-to email address',
     back_link=url_for('.service_settings', service_id=current_service.id)
   ) }}
 
@@ -19,7 +19,7 @@
     Your emails will be sent from
     {{ current_service.email_from }}@notifications.service.gov.uk.
     This is so they have the best chance of being delivered.
-    This email address can’t receive replies.
+    This email address cannot receive replies.
   </p>
   <p>
     Set up a separate email address to receive replies from
@@ -27,7 +27,7 @@
   </p>
   {% if current_service.trial_mode %}
     <p>
-      Your service can’t go live until you’ve done this.
+      Your service cannot go live until you’ve done this.
     </p>
   {% endif %}
   {% call form () %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -65,7 +65,7 @@ def mock_get_service_settings_page_common(
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply-to addresses Not set Change',
+        'Reply-to email addresses Not set Change',
         'Email branding GOV.UK Change',
 
         'Label Value Action',
@@ -87,7 +87,7 @@ def mock_get_service_settings_page_common(
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply-to addresses Not set Change',
+        'Reply-to email addresses Not set Change',
         'Email branding GOV.UK Change',
 
         'Label Value Action',
@@ -175,7 +175,7 @@ def test_no_go_live_link_for_service_without_organisation(
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply-to addresses test@example.com Manage',
+        'Reply-to email addresses test@example.com Manage',
         'Email branding Your branding (Organisation name) Change',
 
         'Label Value Action',
@@ -196,7 +196,7 @@ def test_no_go_live_link_for_service_without_organisation(
 
         'Label Value Action',
         'Send emails On Change',
-        'Email reply-to addresses test@example.com Manage',
+        'Reply-to email addresses test@example.com Manage',
         'Email branding Your branding (Organisation name) Change',
 
         'Label Value Action',
@@ -698,12 +698,12 @@ def test_should_check_if_estimated_volumes_provided(
 ), [
     pytest.param(None, 0, [], '', marks=pytest.mark.xfail(raises=IndexError)),
     pytest.param(0, 0, [], '', marks=pytest.mark.xfail(raises=IndexError)),
-    (None, 1, [], 'Add an email reply-to address Not completed'),
-    (None, 1, [{}], 'Add an email reply-to address Completed'),
-    (1, 1, [], 'Add an email reply-to address Not completed'),
-    (1, 1, [{}], 'Add an email reply-to address Completed'),
-    (1, 0, [], 'Add an email reply-to address Not completed'),
-    (1, 0, [{}], 'Add an email reply-to address Completed'),
+    (None, 1, [], 'Add a reply-to email address Not completed'),
+    (None, 1, [{}], 'Add a reply-to email address Completed'),
+    (1, 1, [], 'Add a reply-to email address Not completed'),
+    (1, 1, [{}], 'Add a reply-to email address Completed'),
+    (1, 0, [], 'Add a reply-to email address Not completed'),
+    (1, 0, [{}], 'Add a reply-to email address Completed'),
 ])
 def test_should_check_for_sending_things_right(
     client_request,
@@ -1821,7 +1821,7 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
             page.select('tbody tr')[index].text
         )
 
-    assert get_row(page, 3) == "Email reply-to addresses test@example.com …and 2 more Manage"
+    assert get_row(page, 3) == "Reply-to email addresses test@example.com …and 2 more Manage"
     assert get_row(page, 6) == "Text message sender Example …and 2 more Manage"
     assert get_row(page, 11) == "Sender addresses 1 Example Street …and 2 more Manage"
 
@@ -1906,7 +1906,7 @@ def test_default_option_shows_for_default_sender(
     (
         'main.service_email_reply_to',
         no_reply_to_email_addresses,
-        'You haven’t added any email reply-to addresses yet'
+        'You haven’t added any reply-to email addresses yet'
     ),
     (
         'main.service_letter_contact_details',
@@ -2359,7 +2359,7 @@ def test_confirm_delete_reply_to_email_address(
     )
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
-        'Are you sure you want to delete this email reply-to address? '
+        'Are you sure you want to delete this reply-to email address? '
         'Yes, delete'
     )
     assert 'action' not in page.select_one('.banner-dangerous form')


### PR DESCRIPTION
We should replace `email reply-to address` with `reply-to email address`.

'Reply-to address' seems to be the most common term, but it doesn't give the user any context about what type of address we're referring to.

'Reply-to email address' is less common, but a bit more specific. It also sounds more natural than 'email reply-to address'.

I couldn't find examples of 'email reply-to address' on other sites and services.

Suggest we always use `reply-to email address` in the first instance, then `reply-to address` when we want to keep things brief and avoid repetition.