### PR TITLE
Update support thanks page

### DIFF
--- a/app/templates/views/support/thanks.html
+++ b/app/templates/views/support/thanks.html
@@ -13,15 +13,15 @@
     </h1>
     <p>
       {% if anonymous %}
-        We’ll look into it
+        If you provided an email address, we'll reply 
       {% else %}
-        We’ll get back to you
+        We’ll reply
       {% endif %}
 
       {% if urgent %}
-        within 30 minutes.
+        in the next 30 minutes.
       {% else %}
-        by the next working day.
+        within one working day.
       {% endif %}
     </p>
     <p>


### PR DESCRIPTION
The thank you page content does not reflect our latest commitment to user support.

This PR updates the:

- thank you page content so it's consistent with the support page
- _if-then_ rules so that the correct response time is shown in and out of office hours