### PR TITLE
Make 'contact us' links consistent

### DIFF
--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -35,7 +35,7 @@
     <!--<li>you can track when the recipient downloads your document</li>-->
     <li>email attachments are often marked as spam</li>
   </ul>
-  <p><a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact the team</a> and ask us to turn this feature on for your service.</p>
+  <p><a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> if you want to send files by email.</p>
   <p>Read our <a href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h3 class="heading heading-small">Add a reply-to address</h3>

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -24,7 +24,7 @@
   <h3 class="heading heading-small">Receive text messages</h3>
   <p>Let people send messages to your service or reply to your texts.</p>
   <p>You can see and reply to the messages you receive, or set up your own automated processes to manage replies.</p>
-  <p><a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact the team</a> to request a unique number for text message replies.</p>
+  <p><a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> to request a unique number for text message replies.</p>
 
   <h3 class="heading heading-small">Show people who your texts are from</h3>
   <p>When you send a text message with Notify, the sender name tells people who it's from.</p>

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -11,7 +11,7 @@
 
   <p>The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
   <p>Notify is in public beta. This means it’s fully operational and supported, but we’re regularly adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
-  <p>You can <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> for more detail about these features, or to suggest something else you’d like Notify to offer.</p>
+  <p>You can <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
   <h2 class="heading-medium">January to March 2019</h2>
 

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -50,7 +50,7 @@
     <li>your email address and password</li>
     <li>a text message code that Notify sends to your phone</li>
   </ul>
-  <p>If receiving text messages at work is a problem for your team, <a href="https://www.notifications.service.gov.uk/">contact us</a> about using an email link instead.</p>
+  <p>If signing in with a text message is a problem for your team, <a href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
 
   <h2 class="heading-medium">Information risk management</h2>
   <p>Our approach to information risk management follows National Cyber Security Centre (NCSC) guidance. It assesses:</p>

--- a/app/templates/views/service-settings/request-letter-branding.html
+++ b/app/templates/views/service-settings/request-letter-branding.html
@@ -29,7 +29,7 @@
           Your letters do not have a logo.
         </p>
         <p>
-          <a href="{{ url_for('main.feedback', ticket_type='ask-question-give-feedback', body='letter-branding') }}">Contact support</a>
+          <a href="{{ url_for('main.feedback', ticket_type='ask-question-give-feedback', body='letter-branding') }}">Contact us</a>
           if you want to add your organisation’s logo.
         </p>
       {% endif %}

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -34,8 +34,7 @@
           Your team members sign in with a text message code.
         </p>
         <p>
-          If signing in with a text message is a problem for your team,
-          please <a href="{{ url_for('.support') }}">contact us</a>.
+          <a href="{{ url_for('.support') }}">Contact us</a> if signing in with a text message is a problem for your team.
         </p>
       {% endif %}
     </div>

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -20,8 +20,7 @@
           Your service can receive text messages sent to {{ current_service.inbound_number }}.
         </p>
         <p>
-          If you want to switch this feature off,
-          <a href="{{ url_for('.support') }}">get in touch with the GOV.UK&nbsp;Notify team</a>.
+          <a href="{{ url_for('.support') }}">Contact us</a> if you want to switch this feature off.
         </p>
         {% if current_user.has_permissions('manage_api_keys') %}
           <p>
@@ -31,8 +30,7 @@
         {% endif %}
       {% else %}
         <p>
-          If you want to be able to receive text messages from your users, please
-          <a href="{{ url_for('.support') }}">get in touch</a>.
+          <a href="{{ url_for('.support') }}">Contact us</a> if you want to be able to receive text messages from your users.
         </p>
         <p>
           We’ll create a special phone number for your users to contact. You'll be able to see

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -176,7 +176,7 @@
           and is supported 24 hours a day, 7 days a week.
         </p>
         <p>
-          <a href="{{ url_for('main.support') }}">Contact the team</a> if you have a question or want
+          <a href="{{ url_for('main.support') }}">Contact us</a> if you have a question or want
           to give feedback.
         </p>
       </div>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4004,7 +4004,7 @@ def test_contact_link_is_not_displayed_without_the_upload_document_permission(
         'main.service_set_inbound_sms',
         ['sms'],
         (
-            'If you want to be able to receive text messages from your users, please get in touch.'
+            'Contact us if you want to be able to receive text messages from your users.'
         )
     ),
     (
@@ -4085,12 +4085,12 @@ def test_set_inbound_sms_when_inbound_number_is_not_set(
 @pytest.mark.parametrize('user, expected_paragraphs', [
     (active_user_with_permissions, [
         'Your service can receive text messages sent to 07700900123.',
-        'If you want to switch this feature off, get in touch with the GOV.UK Notify team.',
+        'Contact us if you want to switch this feature off.',
         'You can set up callbacks for received text messages on the API integration page.',
     ]),
     (active_user_no_api_key_permission, [
         'Your service can receive text messages sent to 07700900123.',
-        'If you want to switch this feature off, get in touch with the GOV.UK Notify team.',
+        'Contact us if you want to switch this feature off.',
     ]),
 ])
 def test_set_inbound_sms_when_inbound_number_is_set(


### PR DESCRIPTION
We should be as consistent as possible in the way we ask users to contact the Notify team.

At the moment we use the following:
• contact us (4)
• contact the team (3)
• contact the GOV.UK Notify team (1)
• contact support (1)
• get in touch with us (1)
• get in touch (1)

`Get in touch` is friendly and less formal, but it's a bit idiomatic. `Contact` is more direct and feels more Plain English.

We probably don't need to refer to `the GOV.UK Notify team` because users will see these links in context on Notify service pages. `Support` could make it sound a bit like another team, separate from Notify. `The team` is good, but `us` is shorter and a bit more versatile.

Suggest we go with `us` for now, and review as we find or add more links in the future. In some cases, this means rewriting the rest of the sentence containing the link.