### PR TITLE
Add js tests for template folder form

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -19,10 +19,10 @@
       this.states = [
         {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false},
         {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false},
-        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios legend', true)},
+        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios fieldset', true)},
         {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_new_folder_name', false)},
         {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_folder_name', false)},
-        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form legend', true)}
+        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form fieldset', true)}
       ];
 
       // cancel/clear buttons only relevant if JS enabled, so

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -48,6 +48,10 @@ $sticky-padding: $gutter * 2 / 3;
     margin-top: ($sticky-padding * 2) * -1;
   }
 
+  fieldset:focus {
+    outline: none;
+  }
+
   .page-footer {
     margin-bottom: 0;
     min-height: 50px;

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -13,6 +13,7 @@ exports.RangeMock = domInterfaces.RangeMock;
 exports.SelectionMock = domInterfaces.SelectionMock;
 exports.getRadioGroup = html.getRadioGroup;
 exports.getRadios = html.getRadios;
+exports.templatesAndFoldersCheckboxes = html.templatesAndFoldersCheckboxes;
 exports.element = elements.element;
 exports.WindowMock = rendering.WindowMock;
 exports.ScreenMock = rendering.ScreenMock;

--- a/tests/javascripts/support/helpers/html.js
+++ b/tests/javascripts/support/helpers/html.js
@@ -33,5 +33,31 @@ function getRadioGroup (data) {
     return radioGroup;
 };
 
+function templatesAndFoldersCheckboxes (hierarchy) {
+  let result = '';
+
+  hierarchy.forEach((node, idx) => {
+
+    result += `
+      <div class="template-list-item template-list-item-with-checkbox  template-list-item-without-ancestors">
+        <div class="multiple-choice">
+          <input id="templates-or-folder-${idx}" name="templates_and_folders" type="checkbox" value="templates-or-folder-${idx}">
+          <label></label>
+        </div>
+        <h2 class="message-name">
+          <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/templates/all/folders/3d057d9a-51fc-45ea-8b63-0003206350a6" class="template-list-${node.type === 'folder' ? 'folder' : 'template'}">
+            <span class="live-search-relevant">${node.label}</span>
+          </a>
+        </h2>
+        ${node.meta}
+      </div>`;
+
+  });
+
+  return result;
+
+};
+
 exports.getRadios = getRadios;
 exports.getRadioGroup = getRadioGroup;
+exports.templatesAndFoldersCheckboxes = templatesAndFoldersCheckboxes;

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -231,7 +231,7 @@ describe('TemplateFolderForm', () => {
   
     // We need parts of the module to be made sticky, but by the module code,
     // not the sticky JS code that operates on the HTML at page load.
-    // Because of this, they wll need to be marked with classes
+    // Because of this, they will need to be marked with classes
     test("the HTML for the module should contain placeholder classes on each part that needs to be sticky", () => {
 
       expect(templateFolderForm.querySelectorAll('#move_to_folder_radios > .js-will-stick-at-bottom-when-scrolling').length).toEqual(2);

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -1,0 +1,645 @@
+const helpers = require('./support/helpers');
+
+function setFixtures (hierarchy) {
+
+  function templatesAndFoldersCheckboxesHTML () {
+    let result = '';
+
+    hierarchy.forEach((node, idx) => {
+
+      result += `
+        <div class="template-list-item template-list-item-with-checkbox  template-list-item-without-ancestors">
+          <div class="multiple-choice">
+            <input id="templates-or-folder-${idx}" name="templates_and_folders" type="checkbox" value="templates-or-folder-${idx}">
+            <label></label>
+          </div>
+          <h2 class="message-name">
+            <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/templates/all/folders/3d057d9a-51fc-45ea-8b63-0003206350a6" class="template-list-${node.type === 'folder' ? 'folder' : 'template'}">
+              <span class="live-search-relevant">${node.label}</span>
+            </a>
+          </h2>
+          ${node.meta}
+        </div>`;
+
+    });
+
+    return result;
+
+  };
+
+  const foldersCheckboxesHTML = function (filter) {
+    let count = 0;
+
+    // use closure to give all calls access to count
+    return function (nodes) {
+      let result = '';
+
+      nodes
+        .filter(node => node.type === 'folder')
+        .forEach(node => {
+          result += `<li class="multiple-choice">
+                      <input id="node-${count}" name="move_to" type="radio" value="node-${count}">
+                      <label class="block-label" for="node-${count}">
+                        ${node.label}
+                      </label>
+                      ${node.children ? foldersCheckboxesHTML(node.children) : ''}
+                    </li>`;
+          count++;
+        });
+
+      return `<ul>${result}</ul>`;
+    };
+
+  }();
+
+  function controlsHTML () {
+
+    return `<div id="sticky_template_forms">
+              <button type="submit" name="operation" value="unknown" hidden=""></button>
+              <div id="move_to_folder_radios">
+                <div class="js-will-stick-at-bottom-when-scrolling">
+                  <div class="form-group ">
+                    <fieldset id="move_to">
+                      <legend class="form-label">
+                        Choose a folder
+                      </legend>
+                      <div class="radios-nested">
+                        ${foldersCheckboxesHTML(hierarchy)}
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+                <div class="js-will-stick-at-bottom-when-scrolling">
+                  <div class="page-footer">
+                    <button type="submit" class="button" name="operation" value="move-to-existing-folder">Move</button>
+                  </div>
+                </div>
+              </div>
+              <div id="move_to_new_folder_form">
+                <fieldset class="js-will-stick-at-bottom-when-scrolling">
+                  <legend class="visuallyhidden">Add to new folder</legend>
+                  <div class="form-group">
+                    <label class="form-label" for="move_to_new_folder_name">
+                      Folder name
+                    </label>
+                    <input class="form-control form-control-1-1 " id="move_to_new_folder_name" name="move_to_new_folder_name" rows="8" type="text" value="">
+                  </div>
+                  <div class="page-footer">
+                    <button type="submit" class="button" name="operation" value="move-to-new-folder">Add to new folder</button>
+                  </div>
+                </fieldset>
+              </div>
+              <div id="add_new_folder_form">
+                <fieldset class="js-will-stick-at-bottom-when-scrolling">
+                  <legend class="visuallyhidden">Add new folder</legend>
+                  <div class="form-group">
+                    <label class="form-label" for="add_new_folder_name">
+                      Folder name
+                    </label>
+                    <input class="form-control form-control-1-1 " id="add_new_folder_name" name="add_new_folder_name" rows="8" type="text" value="">
+                  </div>
+                  <div class="page-footer">
+                    <button type="submit" class="button" name="operation" value="add-new-folder">Add new folder</button>
+                  </div>
+                </fieldset>
+              </div>
+              <div id="add_new_template_form">
+                <div class="js-will-stick-at-bottom-when-scrolling">
+                  <div class="form-group ">
+                    <fieldset id="add_template_by_template_type">
+                      <legend class="form-label">
+                        New template
+                      </legend>
+                      <div class="multiple-choice">
+                        <input id="add_template_by_template_type-0" name="add_template_by_template_type" type="radio" value="email">
+                        <label class="block-label" for="add_template_by_template_type-0">
+                          Email
+                        </label>
+                      </div>
+                      <div class="multiple-choice">
+                        <input id="add_template_by_template_type-1" name="add_template_by_template_type" type="radio" value="sms">
+                        <label class="block-label" for="add_template_by_template_type-1">
+                          Text message
+                        </label>
+                      </div>
+                      <div class="multiple-choice">
+                        <input id="add_template_by_template_type-2" name="add_template_by_template_type" type="radio" value="letter">
+                        <label class="block-label" for="add_template_by_template_type-2">
+                          Letter
+                        </label>
+                      </div>
+                      <div class="multiple-choice">
+                        <input id="add_template_by_template_type-3" name="add_template_by_template_type" type="radio" value="copy-existing">
+                        <label class="block-label" for="add_template_by_template_type-3">
+                          Copy an existing template
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+                <div class="js-will-stick-at-bottom-when-scrolling">
+                  <div class="page-footer">
+                    <button type="submit" class="button" name="operation" value="add-new-template">Continue</button>
+                  </div>
+                </div>
+              </div>
+              <div class="selection-counter visuallyhidden" role="status" aria-live="polite">
+                Nothing selected
+              </div>
+            </div>`
+  };
+
+  document.body.innerHTML = `
+    <form method="post" data-module="template-folder-form">
+      ${templatesAndFoldersCheckboxesHTML()}
+      ${controlsHTML()}
+    </form>`;
+
+};
+
+beforeAll(() => {
+  require('../../app/assets/javascripts/templateFolderForm.js');
+});
+
+afterAll(() => {
+  require('./support/teardown.js');
+});
+
+describe('TemplateFolderForm', () => {
+
+  const hierarchy = [
+    {
+      'label': 'Folder 1',
+      'type': 'folder',
+      'meta': '1 template, 1 folder',
+      'children': [
+        {
+          'label': 'Template 3',
+          'type': 'template',
+          'meta': 'Email template'
+        },
+        {
+          'label': 'Folder 2',
+          'type': 'folder',
+          'meta': 'Empty',
+          'children': []
+        }
+      ]
+    },
+    {
+      'label': 'Template 1',
+      'type': 'Email template',
+      'meta': 'Email template'
+    },
+    {
+      'label': 'Template 2',
+      'type': 'template',
+      'meta': 'Email template'
+    }
+  ];
+
+  let templateFolderForm;
+  let formControls;
+  let visibleCounter;
+  let hiddenCounter;
+
+  beforeAll(() => {
+
+    // stub out calls to sticky JS
+    GOVUK.stickAtBottomWhenScrolling = {
+      setMode: jest.fn(),
+      recalculate: jest.fn()
+    };
+
+  });
+
+  afterAll(() => {
+
+    GOVUK.stickAtBottomWhenScrolling = undefined;
+
+  });
+
+  beforeEach(() => {
+
+    setFixtures(hierarchy);
+
+    templateFolderForm = document.querySelector('form[data-module=template-folder-form]');
+
+  });
+
+  afterEach(() => {
+
+    document.body.innerHTML = '';
+
+  });
+
+  function getTemplateFolderCheckboxes () {
+    return templateFolderForm.querySelectorAll('input[type=checkbox]');
+  };
+
+  function getVisibleCounter () {
+    return formControls.querySelector('.template-list-selected-counter__count');
+  };
+
+  function getHiddenCounter () {
+    return formControls.querySelector('[role=status]');
+  };
+
+  describe("When the page loads", () => {
+
+    beforeEach(() => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      formControls = templateFolderForm.querySelector('#sticky_template_forms');
+      visibleCounter = getVisibleCounter();
+
+    });
+
+    test("the default controls and the counter should be showing", () => {
+
+      expect(document.querySelector('button[value=add-new-template]')).not.toBeNull();
+      expect(document.querySelector('button[value=add-new-folder]')).not.toBeNull();
+      expect(visibleCounter).not.toBeNull();
+
+    });
+
+    // Our counter needs to be wrapped in an ARIA live region so changes to its content are
+    // communicated to assistive tech'.
+    // ARIA live regions need to be in the HTML before JS loads.
+    // Because of this, we have a counter, in a live region, in the page when it loads, and
+    // a duplicate, visible, one in the HTML the module adds to the page.
+    // We hide the one in the live region to avoid duplication of it's content.
+    describe("Selection counter", () => {
+
+      beforeEach(() => {
+
+        hiddenCounter = getHiddenCounter();
+
+      })
+
+      test("the visible counter should be hidden from assistive tech", () => {
+
+        expect(visibleCounter.getAttribute('aria-hidden')).toEqual("true");
+
+      });
+
+      test("the content of both visible and hidden counters should match", () => {
+
+        expect(visibleCounter.textContent.trim()).toEqual(hiddenCounter.textContent.trim());
+
+      });
+
+    });
+
+  });
+
+  describe("Clicking 'New template'", () => {
+
+    beforeEach(() => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      formControls = templateFolderForm.querySelector('#sticky_template_forms');
+
+      helpers.triggerEvent(formControls.querySelector('[value=add-new-template]'), 'click');
+
+    });
+
+    test("should show options for all the types of template", () => {
+
+      const options = [
+        'Email', 'Text message', 'Letter', 'Copy an existing template'
+      ];
+
+      const labels = Array.from(formControls.querySelectorAll('label'));
+      const radios = Array.from(formControls.querySelectorAll('input[type=radio]'));
+
+      options.forEach(option => {
+        let matchingLabels = labels.filter(label => label.textContent.trim() === option);
+
+        expect(matchingLabels.length > 0).toBe(true);
+
+        let matchingRadio = formControls.querySelector(`#${matchingLabels[0].getAttribute('for')}`)
+
+        expect(matchingRadio).not.toBeNull();
+      });;
+
+    });
+
+    test("should show a 'Cancel' link", () => {
+
+      const cancelLink = formControls.querySelector('.js-cancel');
+
+      expect(cancelLink).not.toBeNull();
+
+    });
+
+    test("should focus the fieldset", () => {
+
+      expect(document.activeElement).toBe(formControls.querySelector('fieldset'));
+
+    });
+
+    describe("When the 'Cancel' link is clicked", () => {
+
+      let addNewTemplateButton;
+
+      beforeEach(() => {
+
+        helpers.triggerEvent(formControls.querySelector('.js-cancel'), 'click');
+
+        addNewTemplateButton = formControls.querySelector('[value=add-new-template]');
+
+      });
+
+      test("the controls should reset", () => {
+
+        expect(addNewTemplateButton).not.toBeNull();
+
+      });
+
+      test("the add new template control should be focused", () => {
+
+        expect(document.activeElement).toBe(addNewTemplateButton);
+
+      });
+
+    });
+
+  });
+
+  describe("Clicking 'New folder'", () => {
+
+    let textbox;
+
+    beforeEach(() => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      formControls = templateFolderForm.querySelector('#sticky_template_forms');
+
+      helpers.triggerEvent(formControls.querySelector('[value=add-new-folder]'), 'click');
+
+      textbox = formControls.querySelector('input[type=text]');
+
+    });
+
+    test("should show a textbox for the folder name", () => {
+
+      expect(textbox).not.toBeNull();
+
+      // check textbox has a label
+      expect(formControls.querySelector(`label[for=${textbox.getAttribute('id')}]`)).not.toBeNull();
+
+    });
+
+    test("should focus the textbox", () => {
+
+      expect(document.activeElement).toBe(textbox);
+
+    });
+
+    describe("When the 'Cancel' link is clicked", () => {
+
+      let addNewFolderButton;
+
+      beforeEach(() => {
+
+        helpers.triggerEvent(formControls.querySelector('.js-cancel'), 'click');
+
+        addNewFolderButton = formControls.querySelector('button[value=add-new-folder]');
+
+      });
+
+      test("the controls should reset", () => {
+
+        expect(addNewFolderButton).not.toBeNull();
+
+      });
+
+      test("the control for adding a new folder should be focused", () => {
+
+        expect(document.activeElement).toBe(addNewFolderButton);
+
+      });
+
+    });
+
+  });
+
+  describe("When some templates/folders are selected", () => {
+
+    let templateFolderCheckboxes;
+
+    beforeEach(() => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      templateFolderCheckboxes = getTemplateFolderCheckboxes();
+
+      formControls = templateFolderForm.querySelector('#sticky_template_forms');
+
+      helpers.triggerEvent(templateFolderCheckboxes[0], 'click');
+      helpers.triggerEvent(templateFolderCheckboxes[2], 'click');
+
+    });
+
+    test("the buttons for moving to a new or existing folder are showing", () => {
+
+      expect(formControls.querySelector('button[value=move-to-new-folder]')).not.toBeNull();
+      expect(formControls.querySelector('button[value=move-to-existing-folder]')).not.toBeNull();
+
+    });
+
+    describe("Clear link", () => {
+
+      let clearLink;
+
+      beforeEach(() => {
+
+        clearLink = formControls.querySelector('.js-cancel');
+
+      });
+
+      test("the link has been added with the right text", () => {
+
+        expect(clearLink).not.toBeNull();
+        expect(clearLink.textContent.trim()).toEqual('Clear selection');
+
+      });
+
+      test("clicking the link clears the selection", () => {
+
+        helpers.triggerEvent(clearLink, 'click');
+
+        const checkedCheckboxes = Array.from(templateFolderCheckboxes).filter(checkbox => checkbox.checked);
+
+        expect(checkedCheckboxes.length === 0).toBe(true);
+
+      });
+
+    });
+
+    describe("Selection counter", () => {
+
+      let visibleCounterText;
+      let hiddenCounterText;
+
+      beforeEach(() => {
+
+        visibleCounterText = getVisibleCounter().textContent.trim();
+        hiddenCounterText = getHiddenCounter().textContent.trim();
+
+      });
+
+      test("the content of both visible and hidden counters should match", () => {
+
+        expect(visibleCounterText).toEqual(hiddenCounterText);
+
+      });
+
+      test("the content of the counter should reflect the selection", () => {
+      
+        expect(visibleCounterText).toEqual('2 selected');
+      
+      });
+      
+    });
+
+    describe("Clicking the 'Move' button", () => {
+
+      beforeEach(() => {
+
+        helpers.triggerEvent(formControls.querySelector('[value=move-to-existing-folder]'), 'click');
+
+      });
+
+      test("should show radios for all the folders in the hierarchy", () => {
+
+        const foldersInHierarchy = [];
+
+        function getFolders (nodes) {
+
+          nodes.forEach(node => {
+            if (node.type === 'folder') {
+
+              foldersInHierarchy.push(node.label);
+              if (node.children.length) { getFolders(node.children) }
+
+            }
+          });
+
+        };
+
+        getFolders(hierarchy);
+
+        const folderLabels = Array.from(formControls.querySelectorAll('#move_to label'))
+                                  .filter(label => label.textContent.trim() !== 'Templates');
+
+        expect(folderLabels.map(label => label.textContent.trim())).toEqual(foldersInHierarchy);
+
+        const radiosForLabels = folderLabels
+                                  .map(label => formControls.querySelector(`#${label.getAttribute('for')}`))
+                                  .filter(radio => radio !== null);
+
+        expect(radiosForLabels.length).toEqual(foldersInHierarchy.length);
+
+      });
+
+      test("focus the 'Choose a folder' fieldset", () => {
+
+        expect(document.activeElement).toBe(formControls.querySelector('#move_to'));
+
+      });
+
+      describe("When the 'Cancel' link is clicked", () => {
+
+        let moveToFolderButton;
+
+        beforeEach(() => {
+
+          helpers.triggerEvent(formControls.querySelector('.js-cancel'), 'click');
+
+          moveToFolderButton = formControls.querySelector('button[value=move-to-existing-folder]');
+
+        });
+
+        test("the controls should reset", () => {
+
+          expect(moveToFolderButton).not.toBeNull();
+
+        });
+
+        test("the control for moving to an existing folder should be focused", () => {
+
+          expect(document.activeElement).toBe(moveToFolderButton);
+
+        });
+
+      });
+
+    });
+
+    describe("Clicking the 'Add to new folder' button", () => {
+
+      let textbox;
+
+      beforeEach(() => {
+
+        helpers.triggerEvent(formControls.querySelector('[value=move-to-new-folder]'), 'click');
+
+        textbox = formControls.querySelector('input[type=text]');
+
+      });
+
+      test("should show a textbox for the folder name", () => {
+
+        expect(textbox).not.toBeNull();
+
+        // check textbox has a label
+        expect(formControls.querySelector(`label[for=${textbox.getAttribute('id')}]`)).not.toBeNull();
+
+      });
+
+      test("should focus the textbox", () => {
+
+        expect(document.activeElement).toBe(textbox);
+
+      });
+
+      describe("When the 'Cancel' link is clicked", () => {
+
+        let moveToNewFolderButton;
+
+        beforeEach(() => {
+
+          helpers.triggerEvent(formControls.querySelector('.js-cancel'), 'click');
+
+          moveToNewFolderButton = formControls.querySelector('button[value=move-to-new-folder]');
+
+        });
+
+        test("the controls should reset", () => {
+
+          expect(moveToNewFolderButton).not.toBeNull();
+
+        });
+
+        test("the control for adding a new folder should be focused", () => {
+
+          expect(document.activeElement).toBe(moveToNewFolderButton);
+
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -157,6 +157,13 @@ function setFixtures (hierarchy) {
 
 };
 
+function resetStickyMocks () {
+
+  GOVUK.stickAtBottomWhenScrolling.recalculate.mockClear();
+  GOVUK.stickAtBottomWhenScrolling.setMode.mockClear();
+
+};
+
 beforeAll(() => {
   require('../../app/assets/javascripts/templateFolderForm.js');
 });
@@ -245,6 +252,22 @@ describe('TemplateFolderForm', () => {
     return formControls.querySelector('[role=status]');
   };
 
+  describe("Before the page loads", () => {
+  
+    // We need parts of the module to be made sticky, but by the module code,
+    // not the sticky JS code that operates on the HTML at page load.
+    // Because of this, they wll need to be marked with classes
+    test("the HTML for the module should contain placeholder classes on each part that needs to be sticky", () => {
+
+      expect(templateFolderForm.querySelectorAll('#move_to_folder_radios > .js-will-stick-at-bottom-when-scrolling').length).toEqual(2);
+      expect(templateFolderForm.querySelector('#move_to_new_folder_form > .js-will-stick-at-bottom-when-scrolling')).not.toBeNull();
+      expect(templateFolderForm.querySelector('#add_new_folder_form > .js-will-stick-at-bottom-when-scrolling')).not.toBeNull();
+      expect(templateFolderForm.querySelectorAll('#add_new_template_form > .js-will-stick-at-bottom-when-scrolling').length).toEqual(2);
+
+    });
+  
+  });
+
   describe("When the page loads", () => {
 
     beforeEach(() => {
@@ -256,6 +279,8 @@ describe('TemplateFolderForm', () => {
       visibleCounter = getVisibleCounter();
 
     });
+
+    afterEach(() => resetStickyMocks());
 
     test("the default controls and the counter should be showing", () => {
 
@@ -293,6 +318,20 @@ describe('TemplateFolderForm', () => {
 
     });
 
+    test("should make the current controls sticky", () => {
+
+      // the class the sticky JS hooks into should be present
+      expect(formControls.querySelector('#nothing_selected .js-stick-at-bottom-when-scrolling')).not.toBeNull();
+
+      // .recalculate should have been called so the sticky JS picks up the controls
+      expect(GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toEqual(1);
+
+      // mode should have been set to 'default' as the controls only have one part
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls.length).toEqual(1);
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls[0][0]).toEqual('default');
+
+    });
+
   });
 
   describe("Clicking 'New template'", () => {
@@ -304,9 +343,14 @@ describe('TemplateFolderForm', () => {
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
 
+      // reset sticky JS mocks called when the module starts
+      resetStickyMocks();
+
       helpers.triggerEvent(formControls.querySelector('[value=add-new-template]'), 'click');
 
     });
+
+    afterEach(() => resetStickyMocks());
 
     test("should show options for all the types of template", () => {
 
@@ -325,7 +369,7 @@ describe('TemplateFolderForm', () => {
         let matchingRadio = formControls.querySelector(`#${matchingLabels[0].getAttribute('for')}`)
 
         expect(matchingRadio).not.toBeNull();
-      });;
+      });
 
     });
 
@@ -343,11 +387,28 @@ describe('TemplateFolderForm', () => {
 
     });
 
+    test("should make the current controls sticky", () => {
+
+      // the classes the sticky JS hooks into should be present for both parts
+      expect(formControls.querySelectorAll('#add_new_template_form .js-stick-at-bottom-when-scrolling').length).toEqual(2);
+
+      // .recalculate should have been called so the sticky JS picks up the controls
+      expect(GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toEqual(1);
+
+      // the mode should be set to 'dialog' so both parts can be sticky
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls.length).toEqual(1);
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls[0][0]).toEqual('dialog');
+
+    });
+
     describe("When the 'Cancel' link is clicked", () => {
 
       let addNewTemplateButton;
 
       beforeEach(() => {
+
+        // reset sticky JS mocks called when the new template state loaded
+        resetStickyMocks();
 
         helpers.triggerEvent(formControls.querySelector('.js-cancel'), 'click');
 
@@ -375,12 +436,17 @@ describe('TemplateFolderForm', () => {
 
     let textbox;
 
+    afterEach(() => resetStickyMocks());
+
     beforeEach(() => {
 
       // start module
       window.GOVUK.modules.start();
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
+
+      // reset sticky JS mocks called when the module starts
+      resetStickyMocks();
 
       helpers.triggerEvent(formControls.querySelector('[value=add-new-folder]'), 'click');
 
@@ -400,6 +466,20 @@ describe('TemplateFolderForm', () => {
     test("should focus the textbox", () => {
 
       expect(document.activeElement).toBe(textbox);
+
+    });
+
+    test("should make the current controls sticky", () => {
+
+      // the class the sticky JS hooks into should be present
+      expect(formControls.querySelector('#add_new_folder_form .js-stick-at-bottom-when-scrolling')).not.toBeNull();
+
+      // .recalculate should have been called so the sticky JS picks up the controls
+      expect(GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toEqual(1);
+
+      // mode should have been set to 'default' as the controls only have one part
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls.length).toEqual(1);
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls[0][0]).toEqual('default');
 
     });
 
@@ -444,15 +524,34 @@ describe('TemplateFolderForm', () => {
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
 
+      // reset sticky JS mocks called when the module starts
+      resetStickyMocks();
+
       helpers.triggerEvent(templateFolderCheckboxes[0], 'click');
       helpers.triggerEvent(templateFolderCheckboxes[2], 'click');
 
     });
 
+    afterEach(() => resetStickyMocks());
+
     test("the buttons for moving to a new or existing folder are showing", () => {
 
       expect(formControls.querySelector('button[value=move-to-new-folder]')).not.toBeNull();
       expect(formControls.querySelector('button[value=move-to-existing-folder]')).not.toBeNull();
+
+    });
+
+    test("should make the current controls sticky", () => {
+
+      // the class the sticky JS hooks into should be present
+      expect(formControls.querySelector('#items_selected .js-stick-at-bottom-when-scrolling')).not.toBeNull();
+
+      // .recalculate should have been called so the sticky JS picks up the controls
+      expect(GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toEqual(1);
+
+      // mode should have been set to 'default' as the controls only have one part
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls.length).toEqual(1);
+      expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls[0][0]).toEqual('default');
 
     });
 
@@ -515,6 +614,9 @@ describe('TemplateFolderForm', () => {
 
       beforeEach(() => {
 
+      // reset sticky JS mocks called when a selection was made
+      resetStickyMocks();
+
         helpers.triggerEvent(formControls.querySelector('[value=move-to-existing-folder]'), 'click');
 
       });
@@ -557,6 +659,20 @@ describe('TemplateFolderForm', () => {
 
       });
 
+      test("should make the current controls sticky", () => {
+
+        // the classes the sticky JS hooks into should be present for both parts
+        expect(formControls.querySelectorAll('#move_to_folder_radios .js-stick-at-bottom-when-scrolling').length).toEqual(2);
+
+        // .recalculate should have been called so the sticky JS picks up the controls
+        expect(GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toEqual(1);
+
+        // the mode should be set to 'dialog' so both parts can be sticky
+        expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls.length).toEqual(1);
+        expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls[0][0]).toEqual('dialog');
+
+      });
+
       describe("When the 'Cancel' link is clicked", () => {
 
         let moveToFolderButton;
@@ -591,6 +707,9 @@ describe('TemplateFolderForm', () => {
 
       beforeEach(() => {
 
+        // reset sticky JS mocks called when a selection was made
+        resetStickyMocks();
+
         helpers.triggerEvent(formControls.querySelector('[value=move-to-new-folder]'), 'click');
 
         textbox = formControls.querySelector('input[type=text]');
@@ -609,6 +728,20 @@ describe('TemplateFolderForm', () => {
       test("should focus the textbox", () => {
 
         expect(document.activeElement).toBe(textbox);
+
+      });
+
+      test("should make the current controls sticky", () => {
+
+        // the class the sticky JS hooks into should be present
+        expect(formControls.querySelector('#move_to_new_folder_form .js-stick-at-bottom-when-scrolling')).not.toBeNull();
+
+        // .recalculate should have been called so the sticky JS picks up the controls
+        expect(GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toEqual(1);
+
+        // mode should have been set to 'default' as the controls only have one part
+        expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls.length).toEqual(1);
+        expect(GOVUK.stickAtBottomWhenScrolling.setMode.mock.calls[0][0]).toEqual('default');
 
       });
 

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -376,7 +376,7 @@ describe('TemplateFolderForm', () => {
 
     });
 
-    describe("When the 'Cancel' link is clicked", () => {
+    describe("When the 'Cancel' link is clicked after choosing to add a new template", () => {
 
       let addNewTemplateButton;
 
@@ -458,7 +458,7 @@ describe('TemplateFolderForm', () => {
 
     });
 
-    describe("When the 'Cancel' link is clicked", () => {
+    describe("When the 'Cancel' link is clicked after choosing to add a new folder", () => {
 
       let addNewFolderButton;
 
@@ -648,7 +648,7 @@ describe('TemplateFolderForm', () => {
 
       });
 
-      describe("When the 'Cancel' link is clicked", () => {
+      describe("When the 'Cancel' link is clicked after choosing to move a template or folder", () => {
 
         let moveToFolderButton;
 
@@ -720,7 +720,7 @@ describe('TemplateFolderForm', () => {
 
       });
 
-      describe("When the 'Cancel' link is clicked", () => {
+      describe("When the 'Cancel' link is clicked after choosing to add a template or folder to a new folder", () => {
 
         let moveToNewFolderButton;
 

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -2,31 +2,6 @@ const helpers = require('./support/helpers');
 
 function setFixtures (hierarchy) {
 
-  function templatesAndFoldersCheckboxesHTML () {
-    let result = '';
-
-    hierarchy.forEach((node, idx) => {
-
-      result += `
-        <div class="template-list-item template-list-item-with-checkbox  template-list-item-without-ancestors">
-          <div class="multiple-choice">
-            <input id="templates-or-folder-${idx}" name="templates_and_folders" type="checkbox" value="templates-or-folder-${idx}">
-            <label></label>
-          </div>
-          <h2 class="message-name">
-            <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/templates/all/folders/3d057d9a-51fc-45ea-8b63-0003206350a6" class="template-list-${node.type === 'folder' ? 'folder' : 'template'}">
-              <span class="live-search-relevant">${node.label}</span>
-            </a>
-          </h2>
-          ${node.meta}
-        </div>`;
-
-    });
-
-    return result;
-
-  };
-
   const foldersCheckboxesHTML = function (filter) {
     let count = 0;
 
@@ -151,7 +126,7 @@ function setFixtures (hierarchy) {
 
   document.body.innerHTML = `
     <form method="post" data-module="template-folder-form">
-      ${templatesAndFoldersCheckboxesHTML()}
+      ${helpers.templatesAndFoldersCheckboxes(hierarchy)}
       ${controlsHTML()}
     </form>`;
 

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -530,7 +530,7 @@ describe('TemplateFolderForm', () => {
 
     });
 
-    describe("Clear link", () => {
+    describe("'Clear selection' link", () => {
 
       let clearLink;
 


### PR DESCRIPTION
Adds tests for the JS template folder form module which controls all actions you can perform on the templates/folders hierarchy.

![image](https://user-images.githubusercontent.com/87140/61138402-5e575000-a4bf-11e9-90d3-dac1766a3e85.png)

This work forms part of this story:

https://www.pivotaltracker.com/story/show/165409973

## How's it meant to work?

The initial PR for the module explains it pretty well: https://github.com/alphagov/notifications-admin/pull/2559

## Where can I find it?

This module only exists on the templates page: /services/<service_id>/templates

## How to run these tests

From the root of the repository, run:

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/templateFolderForm.test.js`

### Other work included

[A bug was found when using the JAWS screenreader](https://www.pivotaltracker.com/story/show/165565088) when the /templates page was tested by the accessibility team. When focus is shifted to the legend of a fieldset, its contents should be announced but this doesn't happen.

This includes [some work to move focus to the parent fieldset](https://github.com/alphagov/notifications-admin/commit/9eed032f9f0ed8986dae58e39cd329041b318dd4) instead. This will need more testing but, even if it doesn't work, won't effect the current experience negatively.