### PR TITLE
Make query string comparison ignore order

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from app import create_app
 from . import (
     TestClient,
     api_key_json,
+    assert_url_expected,
     generate_uuid,
     invite_json,
     job_json,
@@ -2875,6 +2876,9 @@ def client_request(
         def login(user, service=service_one):
             logged_in_client.login(user, mocker, service)
 
+        def logout():
+            logged_in_client.logout(None)
+
         @staticmethod
         def get(
             endpoint,
@@ -2939,7 +2943,7 @@ def client_request(
             )
             assert resp.status_code == _expected_status
             if _expected_redirect:
-                assert resp.location == _expected_redirect
+                assert_url_expected(resp.location, _expected_redirect)
             return BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
 
     return ClientRequest


### PR DESCRIPTION
Query string ordering is non-deterministic. This can cause tests to fail in a non helpful way when we’re comparing two URLs. The values in the query string can match, but the string won’t because the order is different. This commit adds some code to split up the URL and check that each part of it matches, rather than checking the thing as a whole.