### PR TITLE
Set autocomplete and spellcheck attributes on email field

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -121,7 +121,7 @@ def email_address(label='Email address', gov_user=True, required=True):
     if required:
         validators.append(DataRequired(message='Can’t be empty'))
 
-    return EmailField(label, validators)
+    return EmailField(label, validators, render_kw={'spellcheck': 'false'})
 
 
 class UKMobileNumber(TelField):

--- a/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
@@ -19,7 +19,7 @@
     <div class="column-three-quarters">
 
     {% call form_wrapper() %}
-      {{ textbox(form.password) }}
+      {{ textbox(form.password, autocomplete='current-password') }}
       <p> Your organisation name will be changed from {{ current_org.name }} to {{ new_name }} </p>
       {{ page_footer('Confirm') }}
     {% endcall %}

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -23,7 +23,7 @@ Create an account
           {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
         </div>
       {% endif %}
-      {{ textbox(form.password, hint="At least 8 characters", width='3-4') }}
+      {{ textbox(form.password, hint="At least 8 characters", width='3-4', autocomplete='new-password') }}
       {{ page_footer("Continue") }}
       {{form.service}}
       {{form.email_address}}

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -18,7 +18,7 @@ Create an account
       <div class="extra-tracking">
         {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       </div>
-      {{ textbox(form.password, hint="At least 8 characters", width='3-4') }}
+      {{ textbox(form.password, hint="At least 8 characters", width='3-4', autocomplete='new-password') }}
       {{ page_footer("Continue") }}
       {{form.organisation}}
       {{form.email_address}}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -19,7 +19,7 @@ Create an account
         {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       </div>
       <input class="visually-hidden" aria-hidden="true" tabindex="-1" id="defeat-chrome-autocomplete">
-      {{ textbox(form.password, hint="At least 8 characters", width='3-4') }}
+      {{ textbox(form.password, hint="At least 8 characters", width='3-4', autocomplete='new-password') }}
       {{form.auth_type}}
       {{ page_footer("Continue") }}
     {% endcall %}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -14,7 +14,7 @@ Create an account
     <h1 class="heading-large">Create an account</h1>
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.name, width='3-4') }}
-      {{ textbox(form.email_address, hint="Must be from a government organisation", width='3-4', safe_error_message=True) }}
+      {{ textbox(form.email_address, hint="Must be from a government organisation", width='3-4', safe_error_message=True, autocomplete='email') }}
       <div class="extra-tracking">
         {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       </div>

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -19,7 +19,7 @@
     <div class="column-three-quarters">
 
     {% call form_wrapper() %}
-      {{ textbox(form.password) }}
+      {{ textbox(form.password, autocomplete='current-password') }}
       {{ page_footer(
         'Confirm',
         destructive=destructive

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -33,7 +33,7 @@
 
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.email_address, autocomplete='email') }}
-      {{ textbox(form.password) }}
+      {{ textbox(form.password, autocomplete='current-password') }}
       {{ page_footer("Continue", secondary_link=url_for('.forgot_password'), secondary_link_text="Forgot your password?") }}
     {% endcall %}
   </div>

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -32,7 +32,7 @@
     {% endif %}
 
     {% call form_wrapper(autocomplete=True) %}
-      {{ textbox(form.email_address) }}
+      {{ textbox(form.email_address, autocomplete='email') }}
       {{ textbox(form.password) }}
       {{ page_footer("Continue", secondary_link=url_for('.forgot_password'), secondary_link_text="Forgot your password?") }}
     {% endcall %}

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -19,7 +19,7 @@
     <div class="column-three-quarters">
 
     {% call form_wrapper(autocomplete=True) %}
-      {{ textbox(form.password) }}
+      {{ textbox(form.password, autocomplete='current-password') }}
       {{ page_footer('Confirm') }}
     {% endcall %}
     </div>

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -387,6 +387,16 @@ def test_invite_user_allows_to_choose_auth(
     assert sms_auth_radio_button.has_attr("disabled") is False
 
 
+def test_invite_user_has_correct_email_field(
+    client_request,
+    mock_get_users_by_service,
+    mock_get_template_folders,
+):
+    email_field = client_request.get('main.invite_user', service_id=SERVICE_ONE_ID).select_one('#email_address')
+    assert email_field['spellcheck'] == 'false'
+    assert 'autocomplete' not in email_field
+
+
 def test_should_not_show_page_for_non_team_member(
     client_request,
     mock_get_users_by_service,

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -16,6 +16,7 @@ def test_render_register_returns_template_with_form(client):
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.find('input', attrs={'name': 'auth_type'}).attrs['value'] == 'sms_auth'
     assert page.select_one('#email_address')['spellcheck'] == 'false'
+    assert page.select_one('#email_address')['autocomplete'] == 'email'
     assert 'Create an account' in response.get_data(as_text=True)
 
 

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -17,6 +17,7 @@ def test_render_register_returns_template_with_form(client):
     assert page.find('input', attrs={'name': 'auth_type'}).attrs['value'] == 'sms_auth'
     assert page.select_one('#email_address')['spellcheck'] == 'false'
     assert page.select_one('#email_address')['autocomplete'] == 'email'
+    assert page.select_one('#password')['autocomplete'] == 'new-password'
     assert 'Create an account' in response.get_data(as_text=True)
 
 

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -15,6 +15,7 @@ def test_render_register_returns_template_with_form(client):
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.find('input', attrs={'name': 'auth_type'}).attrs['value'] == 'sms_auth'
+    assert page.select_one('#email_address')['spellcheck'] == 'false'
     assert 'Create an account' in response.get_data(as_text=True)
 
 


### PR DESCRIPTION
# Don’t spellcheck email addresses  …
The GOV.UK Design System recommends:
> setting the spellcheck attribute to false so that browsers do not spellcheck the email address

# Add autocomplete to email address on register form

GOV.UK Design System recommends:
> You should also set the autocomplete attribute to email. This lets browsers autofill the email address on a user’s behalf if they’ve entered it previously.

Only doing this on the register form because it’s unlikely to be helpful where a user is trying to enter someone else’s email address.