### PR TITLE
Bump utils to 33.2.4

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.1.0#egg=notifications-utils==33.1.0
+git+https://github.com/alphagov/notifications-utils.git@33.2.4#egg=notifications-utils==33.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.1.0#egg=notifications-utils==33.1.0
+git+https://github.com/alphagov/notifications-utils.git@33.2.4#egg=notifications-utils==33.2.4
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.192
+awscli==1.16.199
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.182
+botocore==1.12.189
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -72,7 +72,7 @@ statsd==3.3.0
 texttable==1.6.2
 urllib3==1.25.3
 webencodings==0.5.1
-Werkzeug==0.15.4
+Werkzeug==0.15.5
 WTForms==2.2.1
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
This brings in validation for the length of the local part of email addresses.

[Pivotal story](https://www.pivotaltracker.com/story/show/167170104)