### PR TITLE
Even out the spacing on the settings page

### DIFF
--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -54,6 +54,10 @@
   margin-top: $gutter * 2 / 3;
 }
 
+.top-gutter-0 {
+  margin-top: 0;
+}
+
 %bottom-gutter,
 .bottom-gutter {
   @extend %contain-floats;

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -77,6 +77,10 @@ a {
   > .heading-medium {
     margin: $gutter-half 0 ($gutter / 3 * 2) 0;
     word-wrap: break-word;
+
+    &.top-gutter-0 {
+      margin-top: 0;
+    }
   }
 
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -55,6 +55,7 @@
 
   table {
     table-layout: fixed;
+    margin-bottom: $gutter / 6;
   }
 
   th {
@@ -89,6 +90,10 @@
       margin-bottom: 5px;
     }
 
+  }
+
+  .table-heading {
+    margin-bottom: 20px;
   }
 
 }

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -244,7 +244,7 @@
     </div>
 
     {% if current_service.trial_mode %}
-      <h2 class="heading-medium">Your service is in trial mode</h2>
+      <h2 class="heading-medium top-gutter-0">Your service is in trial mode</h2>
 
       <ul class='list list-bullet'>
         <li>you can only send messages to yourself</li>
@@ -262,7 +262,7 @@
         </p>
 
     {% else %}
-      <h2 class="heading-medium">Your service is live</h2>
+      <h2 class="heading-medium top-gutter-0">Your service is live</h2>
 
       <p>
         You can send up to


### PR DESCRIPTION
This makes the spacing above and below each heading on the settings page consistent.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/61626429-34e3b480-ac75-11e9-80fb-89167a3909c1.png) | ![image](https://user-images.githubusercontent.com/355079/61626416-29908900-ac75-11e9-986c-7c429cbb5421.png)
