### PR TITLE
Delete service cache when changing an organisation's sector

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -216,8 +216,11 @@ def edit_organisation_type(org_id):
     )
 
     if form.validate_on_submit():
+        org_service_ids = [service['id'] for service in current_organisation.services]
+
         organisations_client.update_organisation(
             current_organisation.id,
+            cached_service_ids=org_service_ids,
             organisation_type=form.organisation_type.data,
         )
         return redirect(url_for('.organisation_settings', org_id=org_id))

--- a/app/notify_client/cache.py
+++ b/app/notify_client/cache.py
@@ -61,9 +61,12 @@ def delete(key_format):
 
         @wraps(client_method)
         def new_client_method(client_instance, *args, **kwargs):
-            redis_key = _make_key(key_format, client_method, args, kwargs)
-            redis_client.delete(redis_key)
-            return client_method(client_instance, *args, **kwargs)
+            try:
+                api_response = client_method(client_instance, *args, **kwargs)
+            finally:
+                redis_key = _make_key(key_format, client_method, args, kwargs)
+                redis_client.delete(redis_key)
+            return api_response
 
         return new_client_method
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -97,12 +97,6 @@ class JobApiClient(NotifyAdminAPIClient):
         return bool(self.get_jobs(service_id)['data'])
 
     def create_job(self, job_id, service_id, scheduled_for=None):
-        redis_client.set(
-            'has_jobs-{}'.format(service_id),
-            b'true',
-            ex=cache.TTL,
-        )
-
         data = {"id": job_id}
 
         if scheduled_for:
@@ -110,6 +104,12 @@ class JobApiClient(NotifyAdminAPIClient):
 
         data = _attach_current_user(data)
         job = self.post(url='/service/{}/job'.format(service_id), data=data)
+
+        redis_client.set(
+            'has_jobs-{}'.format(service_id),
+            b'true',
+            ex=cache.TTL,
+        )
 
         stats = self.__convert_statistics(job['data'])
         job['data']['notifications_sent'] = stats['delivered'] + stats['failed']

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -85,6 +85,6 @@ def test_update_email_branding(mocker, fake_uuid):
         data=org_data
     )
     assert mock_redis_delete.call_args_list == [
-        call('email_branding'),
         call('email_branding-{}'.format(fake_uuid)),
+        call('email_branding'),
     ]

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -68,6 +68,6 @@ def test_update_letter_branding(mocker, fake_uuid):
         data=branding
     )
     assert mock_redis_delete.call_args_list == [
-        call('letter_branding'),
         call('letter_branding-{}'.format(fake_uuid)),
+        call('letter_branding'),
     ]

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -150,7 +150,7 @@ def test_update_organisation_when_not_updating_org_type(mocker, fake_uuid):
         url='/organisations/{}'.format(fake_uuid),
         data={'foo': 'bar'}
     )
-    assert mock_redis_delete.call_args_list == [call('domains'), call('organisations')]
+    assert mock_redis_delete.call_args_list == [call('organisations'), call('domains')]
 
 
 def test_update_organisation_when_updating_org_type_and_org_has_services(mocker, fake_uuid):
@@ -168,9 +168,9 @@ def test_update_organisation_when_updating_org_type_and_org_has_services(mocker,
         data={'organisation_type': 'central'}
     )
     assert mock_redis_delete.call_args_list == [
-        call('domains'),
-        call('organisations'),
         call('service-a', 'service-b', 'service-c'),
+        call('organisations'),
+        call('domains'),
     ]
 
 
@@ -189,6 +189,6 @@ def test_update_organisation_when_updating_org_type_but_org_has_no_services(mock
         data={'organisation_type': 'central'}
     )
     assert mock_redis_delete.call_args_list == [
-        call('domains'),
         call('organisations'),
+        call('domains'),
     ]

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -138,3 +138,57 @@ def test_deletes_domain_cache(
 
     assert call('domains') in mock_redis_delete.call_args_list
     assert len(mock_request.call_args_list) == 1
+
+
+def test_update_organisation_when_not_updating_org_type(mocker, fake_uuid):
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')
+
+    organisations_client.update_organisation(fake_uuid, foo='bar')
+
+    mock_post.assert_called_with(
+        url='/organisations/{}'.format(fake_uuid),
+        data={'foo': 'bar'}
+    )
+    assert mock_redis_delete.call_args_list == [call('domains'), call('organisations')]
+
+
+def test_update_organisation_when_updating_org_type_and_org_has_services(mocker, fake_uuid):
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')
+
+    organisations_client.update_organisation(
+        fake_uuid,
+        cached_service_ids=['a', 'b', 'c'],
+        organisation_type='central',
+    )
+
+    mock_post.assert_called_with(
+        url='/organisations/{}'.format(fake_uuid),
+        data={'organisation_type': 'central'}
+    )
+    assert mock_redis_delete.call_args_list == [
+        call('domains'),
+        call('organisations'),
+        call('service-a', 'service-b', 'service-c'),
+    ]
+
+
+def test_update_organisation_when_updating_org_type_but_org_has_no_services(mocker, fake_uuid):
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')
+
+    organisations_client.update_organisation(
+        fake_uuid,
+        cached_service_ids=[],
+        organisation_type='central',
+    )
+
+    mock_post.assert_called_with(
+        url='/organisations/{}'.format(fake_uuid),
+        data={'organisation_type': 'central'}
+    )
+    assert mock_redis_delete.call_args_list == [
+        call('domains'),
+        call('organisations'),
+    ]

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -388,29 +388,29 @@ def test_deletes_service_cache(
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template', [FAKE_TEMPLATE_ID, 'foo', 'sms', 'bar', SERVICE_ONE_ID], [
-        'service-{}-templates'.format(SERVICE_ONE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'template-{}-versions'.format(FAKE_TEMPLATE_ID),
+        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
+        'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('redact_service_template', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID], [
-        'service-{}-templates'.format(SERVICE_ONE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'template-{}-versions'.format(FAKE_TEMPLATE_ID),
+        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
+        'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template_sender', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 'foo'], [
-        'service-{}-templates'.format(SERVICE_ONE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'template-{}-versions'.format(FAKE_TEMPLATE_ID),
+        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
+        'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template_postage', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 'first'], [
-        'service-{}-templates'.format(SERVICE_ONE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'template-{}-versions'.format(FAKE_TEMPLATE_ID),
+        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
+        'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('delete_service_template', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID], [
-        'service-{}-templates'.format(SERVICE_ONE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'template-{}-versions'.format(FAKE_TEMPLATE_ID),
+        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
+        'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
 ])
 def test_deletes_caches_when_modifying_templates(

--- a/tests/app/notify_client/test_template_folder_client.py
+++ b/tests/app/notify_client/test_template_folder_client.py
@@ -73,13 +73,13 @@ def test_move_templates_and_folders(mocker):
         },
     )
     assert mock_redis_delete.call_args_list == [
-        call('service-{}-template-folders'.format(some_service_id)),
-        call('service-{}-templates'.format(some_service_id)),
         call(
             'template-a-version-None',
             'template-b-version-None',
             'template-c-version-None',
         ),
+        call('service-{}-templates'.format(some_service_id)),
+        call('service-{}-template-folders'.format(some_service_id)),
     ]
 
 

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -234,7 +234,7 @@ def test_add_user_to_service_calls_correct_endpoint_and_deletes_keys_from_cache(
 
     mock_post.assert_called_once_with(expected_url, data=data)
     assert mock_redis_delete.call_args_list == [
-        call('service-{service_id}'.format(service_id=service_id)),
-        call('service-{service_id}-template-folders'.format(service_id=service_id)),
         call('user-{user_id}'.format(user_id=user_id)),
+        call('service-{service_id}-template-folders'.format(service_id=service_id)),
+        call('service-{service_id}'.format(service_id=service_id)),
     ]


### PR DESCRIPTION
When we change an organisation's sector we now also change the sector of all its services, so we need to delete those services from Redis.

This also changes the order of the code to ensure that we only add / delete things from Redis if an api request was successful.