### PR TITLE
Update free text message allowance content

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -28,12 +28,12 @@
   <p>It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium">Text messages</h2>
-  <p>Each service you set up in Notify has an annual allowance of free text messages. Your organisation can set up multiple services.</p>
-  <p>The allowance for each service is:</p>
+  <p>Each service you set up in Notify has a yearly allowance of:</p>
   <ul class="list list-bullet">
     <li>250,000 free text messages for central government organisations</li>
     <li>25,000 free text messages for other public sector organisations</li>
   </ul>
+  <p>Your organisation can set up multiple services.</p>
   <p>It costs 1.58 pence (plus VAT) for each text message you send after your free allowance.</p>
   <p>See <a href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -28,10 +28,11 @@
   <p>It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium">Text messages</h2>
-  <p>Each service you set up in Notify has a free annual allowance. The allowance is:</p>
+  <p>Each service you set up in Notify has an annual allowance of free text messages. Your organisation can set up multiple services.</p>
+  <p>The allowance for each service is:</p>
   <ul class="list list-bullet">
-    <li>250,000 free text messages for central government services</li>
-    <li>25,000 free text messages for other public sector services</li>
+    <li>250,000 free text messages for central government organisations</li>
+    <li>25,000 free text messages for other public sector organisations</li>
   </ul>
   <p>It costs 1.58 pence (plus VAT) for each text message you send after your free allowance.</p>
   <p>See <a href="{{ url_for('main.how_to_pay') }}">how to pay</a>.


### PR DESCRIPTION
Update free text message allowance content to clarify that the allowance is per service, not per organisation.

We're changing this content in response to feedback from a user.