### PR TITLE
Say ‘team member’ not ‘user’

### DIFF
--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -40,7 +40,7 @@
         {{ page_footer(
           'Save',
           delete_link=url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id, delete='yes'),
-          delete_link_text='Remove user from service'
+          delete_link_text='Remove team member from service'
         ) }}
 
     {% endcall %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -40,7 +40,7 @@
         {{ page_footer(
           'Save',
           delete_link=url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id, delete='yes'),
-          delete_link_text='Remove team member from service'
+          delete_link_text='Remove this team member'
         ) }}
 
     {% endcall %}


### PR DESCRIPTION
This is currently inconsistent with the language we use everywhere else.