### PR TITLE
REP-340: Use PaaS hosted stats exporter

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,9 @@ class Config(object):
     TEMPLATE_PREVIEW_API_KEY = os.environ.get('TEMPLATE_PREVIEW_API_KEY', 'my-secret-key')
 
     # Hosted graphite statsd prefix
+    STATSD_ENABLED = False
+    STATSD_HOST = os.getenv('STATSD_HOST')
+    STATSD_PORT = 8125
     STATSD_PREFIX = os.getenv('STATSD_PREFIX')
 
     # Logging
@@ -65,9 +68,6 @@ class Config(object):
     ACTIVITY_STATS_LIMIT_DAYS = 7
     TEST_MESSAGE_FILENAME = 'Report'
 
-    STATSD_ENABLED = False
-    STATSD_HOST = "statsd.hostedgraphite.com"
-    STATSD_PORT = 8125
     NOTIFY_ENVIRONMENT = 'development'
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'
     MOU_BUCKET_NAME = 'local-mou'

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -49,6 +49,7 @@ applications:
       ANTIVIRUS_API_HOST: '{{ ANTIVIRUS_API_HOST }}'
       ANTIVIRUS_API_KEY: '{{ ANTIVIRUS_API_KEY }}'
 
+      STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'
       STATSD_PREFIX: '{{ STATSD_PREFIX }}'
 
       ZENDESK_API_KEY: '{{ ZENDESK_API_KEY }}'


### PR DESCRIPTION
- We are running the statsd exporter on PaaS now and we can route to it
  on apps.internal
- Send metrics there instead so they end up in Prometheus