### PR TITLE
Add upload letters permission to service settings page

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -68,6 +68,7 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
     ('inbound_sms', {'title': 'Receive inbound SMS', 'requires': 'sms', 'endpoint': '.service_set_inbound_number'}),
     ('email_auth', {'title': 'User auth type editing'}),
     ('upload_document', {'title': 'Uploading documents', 'endpoint': '.service_switch_can_upload_document'}),
+    ('upload_letters', {'title': 'Uploading letters', 'requires': 'letter'}),
 ])
 
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -74,12 +74,14 @@ def test_service_set_permission(
     ({'permissions': []},
      '.service_switch_can_upload_document', {}, 'Uploading documents Off Change'),
     ({'permissions': ['sms']}, '.service_set_inbound_number', {}, 'Receive inbound SMS Off Change'),
+    ({'permissions': ['letter']},
+     '.service_set_permission', {'permission': 'upload_letters'}, 'Uploading letters Off Change'),
 ])
 def test_service_setting_toggles_show(get_service_settings_page, service_one, service_fields, endpoint, kwargs, text):
-    button_url = url_for(endpoint, **kwargs, service_id=service_one['id'])
+    link_url = url_for(endpoint, **kwargs, service_id=service_one['id'])
     service_one.update(service_fields)
     page = get_service_settings_page()
-    assert normalize_spaces(page.find('a', {'href': button_url}).find_parent('tr').text.strip()) == text
+    assert normalize_spaces(page.find('a', {'href': link_url}).find_parent('tr').text.strip()) == text
 
 
 @pytest.mark.parametrize('service_fields, endpoint, index, text', [


### PR DESCRIPTION
The `upload_letters` permission can only be changed by Platform Admin users. It works in a similar way to the `inbound_sms` nested permission - you only see the row in the table if you have the `letter` permission, but the `letter` and `upload_letters` are still separate permissions and changing one does not affect the other.

[Pivotal story](https://www.pivotaltracker.com/story/show/167533242)

Needs to be deployed after https://github.com/alphagov/notifications-api/pull/2574