### PR TITLE
Add js tests for sticky js

### DIFF
--- a/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -710,20 +710,35 @@
     this.recalculate();
   };
   Sticky.prototype.setEvents = function () {
-    var self = this;
+    this._scrollEvent = this.onScroll.bind(this);
+    this._resizeEvent = this.onResize.bind(this);
 
     // flag when scrolling takes place and check (and re-position) sticky elements relative to
     // window position
-    if (self._scrollTimeout === false) {
-      $(global).scroll(function (e) { self.onScroll(); });
-      self._scrollTimeout = global.setInterval(function (e) { self.checkScroll(); }, 50);
+    if (this._scrollTimeout === false) {
+      $(global).scroll(this._scrollEvent);
+      this._scrollTimeout = global.setInterval(this.checkScroll.bind(this), 50);
     }
 
     // Recalculate all dimensions when the window resizes
-    if (self._resizeTimeout === false) {
-      $(global).resize(function (e) { self.onResize(); });
-      self._resizeTimeout = global.setInterval(function (e) { self.checkResize(); }, 50);
+    if (this._resizeTimeout === false) {
+      $(global).resize(this._resizeEvent);
+      this._resizeTimeout = global.setInterval(this.checkResize.bind(this), 50);
     }
+  };
+  Sticky.prototype.clearEvents = function () {
+    if (this._scrollTimeout !== false) {
+      $(global).off('scroll', this._scrollEvent);
+      global.clearInterval(this._scrollTimeout);
+      this._scrollTimeout = false;
+    }
+
+    if (this._resizeTimeout !== false) {
+      $(global).off('resize', this._resizeEvent);
+      global.clearInterval(this._resizeTimeout);
+      this._resizeTimeout = false;
+    }
+
   };
   Sticky.prototype.viewportIsWideEnough = function (windowWidth) {
     return windowWidth > 768;

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -181,7 +181,7 @@ describe('FullscreenTable', () => {
     test("when the page has scrolled", () => {
 
       // scroll the window so the table fills the height of the window (768px)
-      windowMock.scrollBy(500);
+      windowMock.scrollTo(500);
 
       // the frames should crop to the window height
       expect(window.getComputedStyle(tableFrame)['height']).toEqual('768px');

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -109,16 +109,36 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
     });
 
-    test("if top of viewport is below top of element but still in the scroll area on load, the element should be marked as already sticky", () => {
+    describe("if top of viewport is below top of element but still in the scroll area on load", () => {
 
-      // scroll past the top of the form
-      screenMock.scrollTo(inputForm.offsetTop + 10);
+      beforeEach(() => {
 
-      window.GOVUK.stickAtTopWhenScrolling.init();
+        // scroll past the top of the form
+        screenMock.scrollTo(inputForm.offsetTop + 10);
 
-      // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
-      expect(inputForm.classList.contains('content-fixed-onload')).toBe(true);
-      expect(inputForm.classList.contains('content-fixed')).toBe(false);
+        window.GOVUK.stickAtTopWhenScrolling.init();
+
+      });
+
+      test("the element should be marked as already sticky", () => {
+
+        // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
+        expect(inputForm.classList.contains('content-fixed-onload')).toBe(true);
+        expect(inputForm.classList.contains('content-fixed')).toBe(false);
+
+      });
+
+      test("a 'shim' element with dimensions matching the sticky element should be added to the document to take up the space it no longer occupies", () => {
+
+        const shim = inputForm.previousElementSibling;
+
+        expect(shim).not.toBeNull();
+        expect(shim.classList.contains('shim')).toBe(true);
+        expect(shim.style.height).toEqual(`${inputForm.offsetHeight}px`);
+        expect(shim.style.marginTop).toEqual(''); // 0px would return an empty string
+        expect(shim.style.marginBottom).toEqual(''); // 0px would return an empty string
+
+      });
 
     });
 
@@ -511,14 +531,33 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
     });
 
-    test("if bottom of viewport is above bottom of element on load, the element should be marked as already sticky", () => {
+    describe("if bottom of viewport is above bottom of element on load", () => {
 
-      // scroll position defaults to 0 so bottom of window starts at 940px. Element bottom defaults to 1160px.
+      beforeEach(() => {
 
-      window.GOVUK.stickAtBottomWhenScrolling.init();
+        // scroll position defaults to 0 so bottom of window starts at 940px. Element bottom defaults to 1160px.
+        window.GOVUK.stickAtBottomWhenScrolling.init();
 
-      expect(pageFooter.classList.contains('content-fixed-onload')).toBe(true);
-      expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+      });
+
+      test("the element should be marked as already sticky", () => {
+
+        expect(pageFooter.classList.contains('content-fixed-onload')).toBe(true);
+        expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+
+      });
+
+      test("a 'shim' element with dimensions matching the sticky element should be added to the document to take up the space it no longer occupies", () => {
+
+        const shim = pageFooter.nextElementSibling;
+
+        expect(shim).not.toBeNull();
+        expect(shim.classList.contains('shim')).toBe(true);
+        expect(shim.style.height).toEqual(`${pageFooter.offsetHeight}px`);
+        expect(shim.style.marginTop).toEqual(''); // 0px would return an empty string
+        expect(shim.style.marginBottom).toEqual(''); // 0px would return an empty string
+
+      });
 
     });
 

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -157,6 +157,23 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
     });
 
+    test("if the window is 768px or less wide and the top of the viewport is below top of element on load, the element should not be marked as sticky", () => {
+
+      screenMock.window.resizeTo({
+        height: windowHeight,
+        width: 768
+      });
+
+      // scroll past top of form
+      screenMock.scrollTo(inputForm.offsetTop + 10);
+
+      window.GOVUK.stickAtTopWhenScrolling.init();
+
+      expect(inputForm.classList.contains('content-fixed')).toBe(false);
+      expect(inputForm.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+    });
+
     describe("if top of viewport is below top of element but still in the scroll area on load", () => {
 
       beforeEach(() => {
@@ -742,6 +759,25 @@ describe("Stick to top/bottom of window when scrolling", () => {
       // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
       expect(pageFooter.classList.contains('content-fixed-onload')).toBe(false);
       expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+
+    });
+
+    test("if the window is 768px or less wide and the bottom of the viewport is above bottom of element on load, the element should not be marked as sticky", () => {
+
+      const pageFooterBottom = getScreenItemBottomPosition(pageFooter);
+
+      screenMock.window.resizeTo({
+        height: windowHeight,
+        width: 768
+      });
+
+      // scroll past top of form
+      screenMock.scrollTo(pageFooterBottom - 10);
+
+      window.GOVUK.stickAtTopWhenScrolling.init();
+
+      expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+      expect(pageFooter.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
 
     });
 

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -1,0 +1,433 @@
+const helpers = require('./support/helpers');
+const STOP_PADDING = 10;
+function getScreenItemBottomPosition (screenItem) {
+  return screenItem.offsetTop + screenItem.offsetHeight;
+};
+
+beforeAll(() => {
+  require('../../app/assets/javascripts/stick-to-window-when-scrolling.js');
+});
+
+afterAll(() => {
+  require('./support/teardown.js');
+});
+
+describe("Stick to top/bottom of window when scrolling", () => {
+
+  let screenMock;
+
+  describe("If intending to stick to the top", () => {
+
+    let inputForm;
+    let formFooter;
+    let footer;
+    let windowHeight;
+
+    beforeEach(() => {
+
+      document.body.innerHTML = `
+        <div class="grid-row">
+          <main class="column-three-quarters column-main">
+            <form method="post" autocomplete="off">
+              <div class="grid-row js-stick-at-top-when-scrolling">
+                <div class="column-two-thirds ">
+                  <div class="form-group" data-module="">
+                    <label class="form-label" for="placeholder_value">
+                      name
+                    </label>
+                    <input class="form-control form-control-1-1 " data-module="" id="placeholder_value" name="placeholder_value" required="" rows="8" type="text" value="">
+                  </div>
+                </div>
+              </div>
+              <div class="page-footer">
+                <button type="submit" class="button">Continue</button>
+              </div>
+            </form>
+          </main>
+        </div>
+        <footer class="js-footer"></footer>`;
+
+      inputForm = document.querySelector('form > .grid-row');
+      formFooter = document.querySelector('.page-footer');
+      footer = document.querySelector('.js-footer');
+
+      windowHeight = 940;
+
+      // mock the rendering of all components
+      screenMock = new helpers.ScreenMock(jest);
+      screenMock.setWindow({
+        width: 1990,
+        height: windowHeight,
+        scrollTop: 0
+      });
+      screenMock.mockPositionAndDimension('inputForm', inputForm, {
+        offsetHeight: 168,
+        offsetWidth: 727,
+        offsetTop: 238
+      });
+      screenMock.mockPositionAndDimension('formFooter', formFooter, {
+        offsetHeight: 200,
+        offsetWidth: 727,
+        offsetTop: inputForm.offsetTop + 200
+      });
+      screenMock.mockPositionAndDimension('footer', footer, {
+        offsetHeight: 535,
+        offsetWidth: 1990,
+        offsetTop: formFooter.offsetTop + formFooter.offsetHeight
+      });
+
+      getFurthestTopPoint = (stickysHeight) => {
+        return footer.offsetTop - PADDING_BEFORE_STOPPING_POINT - stickysHeight;
+      };
+
+      // the sticky JS polls for changes to position/dimension so we need to fake setTimeout and setInterval
+      jest.useFakeTimers();
+
+    });
+
+    afterEach(() => {
+
+      document.body.innerHTML = '';
+
+      window.GOVUK.stickAtTopWhenScrolling.clearEvents();
+
+      screenMock.reset();
+
+    });
+
+    test("if top of viewport is above top of element on load, the element should not be marked as sticky", () => {
+
+      // scroll position defaults to 0, element top defaults to 138px
+
+      window.GOVUK.stickAtTopWhenScrolling.init();
+
+      expect(inputForm.classList.contains('content-fixed-onload')).toBe(false);
+      expect(inputForm.classList.contains('content-fixed')).toBe(false);
+
+    });
+
+    test("if top of viewport is below top of element but still in the scroll area on load, the element should be marked as already sticky", () => {
+
+      // scroll past the top of the form
+      screenMock.scrollTo(inputForm.offsetTop + 10);
+
+      window.GOVUK.stickAtTopWhenScrolling.init();
+
+      // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
+      expect(inputForm.classList.contains('content-fixed-onload')).toBe(true);
+      expect(inputForm.classList.contains('content-fixed')).toBe(false);
+
+    });
+
+    test("if top of viewport is below the furthest point the top of the element can go in the scroll area on load, the element should be marked as stopped", () => {
+
+      // the element should stop a set distance from the stopping point
+      const furthestPoint = (footer.offsetTop - inputForm.offsetHeight) - STOP_PADDING;
+
+      // scroll past the furthest point
+      screenMock.scrollTo(furthestPoint + 10);
+
+      window.GOVUK.stickAtTopWhenScrolling.init();
+
+      // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
+      expect(inputForm.classList.contains('content-fixed-onload')).toBe(true);
+      expect(inputForm.classList.contains('content-fixed')).toBe(false);
+
+      // elements are stopped by adding inline styles
+      expect(inputForm.style.position).toEqual('absolute');
+      expect(inputForm.style.top).toEqual(`${furthestPoint}px`);
+
+    });
+
+    describe("if viewport top starts above element top", () => {
+
+      beforeEach(() => {
+
+        // default scroll position is above top of form
+        window.GOVUK.stickAtTopWhenScrolling.init();
+
+      });
+
+      test("if window is scrolled so top of it is below the top of the element, the element should be marked so it becomes sticky to the user", () => {
+
+        // scroll past top of form
+        screenMock.scrollTo(inputForm.offsetTop + 10);
+        jest.advanceTimersByTime(60); // fake advance of time to something similar to that for a scroll
+
+        // `content-fixed` fades the drop-shadow in to show it became sticky from user interaction
+        expect(inputForm.classList.contains('content-fixed')).toBe(true);
+        expect(inputForm.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+      });
+
+      test("if window is scrolled so top of it is below the furthest point the top of the element can go in the scroll area, the element should be stopped", () => {
+
+        const furthestPoint = (footer.offsetTop - inputForm.offsetHeight) - STOP_PADDING;
+
+        // scroll past top of form
+        screenMock.scrollTo(furthestPoint + 10);
+        jest.advanceTimersByTime(60); // fake advance of time to something similar to that for a scroll
+
+        // `content-fixed` fades the drop-shadow in to show it became sticky from user interaction
+        expect(inputForm.classList.contains('content-fixed')).toBe(true);
+        expect(inputForm.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+        // elements are stopped by adding inline styles
+        expect(inputForm.style.position).toEqual('absolute');
+        expect(inputForm.style.top).toEqual(`${furthestPoint}px`);
+
+      });
+
+    });
+
+    describe("if viewport top starts below element top", () => {
+
+      beforeEach(() => {
+
+        // scroll past top of form
+        screenMock.scrollTo(inputForm.offsetTop + 10);
+
+        window.GOVUK.stickAtTopWhenScrolling.init();
+
+      });
+
+      test("if window is scrolled so top of it is above the top of the element, the element should be made not sticky", () => {
+
+        // scroll to top
+        screenMock.scrollTo(0);
+        jest.advanceTimersByTime(60); // fake advance of time to something similar to that for a scroll
+
+        expect(inputForm.classList.contains('content-fixed')).toBe(false);
+        expect(inputForm.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+      });
+
+    });
+
+  });
+
+  describe("If intending to stick to the bottom", () => {
+
+    let header;
+    let content;
+    let pageFooter;
+    let windowHeight;
+    let furthestBottomPoint;
+
+    beforeEach(() => {
+
+      document.body.innerHTML = `
+        <main role="main" class="column-three-quarters column-main">
+          <a class="govuk-back-link" href="">Back</a>
+          <h1 class="heading-large js-header">
+            Preview of ‘Content email’
+          </h1>
+          <div class="wrapper">
+            <div class="email-message-body">
+              <h2>This is the title</h2>
+              <p>This is a paragraph, defined as a block of content where the contents run horizontally across lines.</p>
+              <table role="presentation">
+                <tbody>
+                  <tr>
+                    <td>
+                      <ul>
+                        <li>these</li>
+                        <li>are</li>
+                        <li>bullet points</li>
+                      </ul>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <blockquote>
+                <p>This block of text is formatted to stand out from the rest</p>
+              </blockquote>
+              <p>This is a paragraph with a horizontal line underneath.</p>
+              <hr>
+              <p>This is a paragraph with a horizontal line above.</p>
+              <p>This paragraph has a link in it: <a href="https://www.gov.uk">https://www.gov.uk</a>.</p>
+            </div>
+            <div class="page-footer js-stick-at-bottom-when-scrolling">
+              <form method="post" action="">
+                  <button type="submit" class="button">Send 1 email </button>
+              </form>
+            </div>
+          </div>
+        </main>`;
+
+      heading = document.querySelector('.js-header');
+      content = document.querySelector('.email-message-body');
+      pageFooter = document.querySelector('.page-footer');
+
+      windowHeight = 940;
+
+      // mock the rendering of all components
+      screenMock = new helpers.ScreenMock(jest);
+      screenMock.setWindow({
+        width: 1990,
+        height: windowHeight,
+        scrollTop: 0
+      });
+      screenMock.mockPositionAndDimension('heading', heading, {
+        offsetHeight: 75,
+        offsetWidth: 727,
+        offsetTop: 185
+      });
+      screenMock.mockPositionAndDimension('content', content, {
+        offsetHeight: 900,
+        offsetWidth: 727,
+        offsetTop: heading.offsetTop + heading.offsetHeight
+      });
+      screenMock.mockPositionAndDimension('pageFooter', pageFooter, {
+        offsetHeight: 50,
+        offsetWidth: 727,
+        offsetTop: content.offsetTop + content.offsetHeight
+      });
+
+      furthestBottomPoint = () => {
+        const headingBottom = getScreenItemBottomPosition(headingItem);
+
+        // the element should stop so its top at the bottom of the heading, with a set amount of padding to separate them
+        return (headingBottom + pageFooterItem.height) + STOP_PADDING;
+      };
+
+      // the sticky JS polls for changes to position/dimension so we need to fake setTimeout and setInterval
+      jest.useFakeTimers();
+
+    });
+
+    afterEach(() => {
+
+      window.GOVUK.stickAtBottomWhenScrolling.clearEvents();
+
+    });
+
+    test("if bottom of viewport is below bottom of element on load, the element should not be marked as sticky", () => {
+
+      const pageFooterBottom = getScreenItemBottomPosition(pageFooter);
+
+      // scroll so the bottom of the window goes past the bottom of the element
+      screenMock.scrollTo((pageFooterBottom - windowHeight) + 10);
+
+      window.GOVUK.stickAtBottomWhenScrolling.init();
+
+      // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
+      expect(pageFooter.classList.contains('content-fixed-onload')).toBe(false);
+      expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+
+    });
+
+    test("if bottom of viewport is above bottom of element on load, the element should be marked as already sticky", () => {
+
+      // scroll position defaults to 0 so bottom of window starts at 940px. Element bottom defaults to 1160px.
+
+      window.GOVUK.stickAtBottomWhenScrolling.init();
+
+      expect(pageFooter.classList.contains('content-fixed-onload')).toBe(true);
+      expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+
+    });
+
+    test("if bottom of viewport is above the furthest point the bottom of the element can go in the scroll area on load, the element should be marked as stopped", () => {
+
+      // change window size so its bottom can go past stopping position
+      const windowHeight = 200;
+
+      screenMock.window.setHeightTo(windowHeight);
+
+      // scroll the window bottom past the furthest point
+      screenMock.scrollTo((furthestBottomPoint() - windowHeight) - 10);
+
+      window.GOVUK.stickAtBottomWhenScrolling.init();
+
+      // `.content-fixed-onload` adds the drop-shadow without fading in to show it did not become sticky from user interaction
+      expect(pageFooter.classList.contains('content-fixed-onload')).toBe(true);
+      expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+
+      // elements are stopped by adding inline styles
+      expect(pageFooter.style.position).toEqual('absolute');
+      expect(pageFooter.style.top).toEqual(`${furthestBottomPoint() - pageFooter.offsetHeight}px`);
+
+    });
+
+    describe("if viewport bottom starts below element bottom", () => {
+
+      let pageFooterBottom;
+
+      beforeEach(() => {
+
+        pageFooterBottom = getScreenItemBottomPosition(pageFooter);
+
+        // change window size so its bottom can go past stopping position
+        const windowHeight = 600;
+
+        screenMock.window.setHeightTo(windowHeight);
+
+        // scroll to just below the element
+        screenMock.scrollTo((pageFooterBottom - windowHeight) + 10);
+
+        // default scroll position is above top of form
+        window.GOVUK.stickAtBottomWhenScrolling.init();
+
+      });
+
+      test("if window is scrolled so bottom of it is above the bottom of the element, the element should be marked so it becomes sticky to the user", () => {
+
+        // scroll above bottom of sticky element
+        screenMock.scrollTo((pageFooterBottom - windowHeight) - 10);
+        jest.advanceTimersByTime(60); // fake advance of time to something similar to that for a scroll
+
+        // `content-fixed` fades the drop-shadow in to show it became sticky from user interaction
+        expect(pageFooter.classList.contains('content-fixed')).toBe(true);
+        expect(pageFooter.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+      });
+
+      test("if window is scrolled so bottom of it is above the furthest point the bottom of the element can go in the scroll area, the element should be stopped", () => {
+
+        // scroll past top of content
+        screenMock.scrollTo((furthestBottomPoint() - windowHeight) - 10);
+        jest.advanceTimersByTime(60); // fake advance of time to something similar to that for a scroll
+
+        // `content-fixed` fades the drop-shadow in to show it became sticky from user interaction
+        expect(pageFooter.classList.contains('content-fixed')).toBe(true);
+        expect(pageFooter.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+        // elements are stopped by adding inline styles
+        expect(pageFooter.style.position).toEqual('absolute');
+        expect(pageFooter.style.top).toEqual(`${furthestBottomPoint() pageFooter.offsetHeight}px`);
+
+      });
+
+    });
+
+    describe("if viewport bottom starts above element bottom", () => {
+
+      let pageFooterBottom;
+
+      beforeEach(() => {
+
+        // scroll position defaults to 0 so bottom of window starts at 940px. Element bottom defaults to 1160px so will be sticky on load.
+
+        pageFooterBottom = getScreenItemBottomPosition(pageFooter);
+
+        window.GOVUK.stickAtBottomWhenScrolling.init();
+
+      });
+
+      test("if window is scrolled so bottom of it is below the bottom of the element, the element should be made not sticky", () => {
+
+        // scroll so bottom of window is below bottom of element
+        screenMock.scrollTo((pageFooterBottom - windowHeight) + 10);
+        jest.advanceTimersByTime(60); // fake advance of time to something similar to that for a scroll
+
+        expect(pageFooter.classList.contains('content-fixed')).toBe(false);
+        expect(pageFooter.classList.contains('content-fixed-onload')).toBe(false); // check the class for onload isn't applied
+
+      });
+
+    });
+
+  });
+
+});

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -228,6 +228,7 @@ class WindowMock {
     };
     this._jest = jest;
     this._setSpies();
+    this._plugJSDOM();
   }
 
   get top () {
@@ -257,6 +258,27 @@ class WindowMock {
 
     // remove calls to document.documentElement.clientWidth when jQuery is gone. It's called to support older browsers like IE8
     this.spies.document.clientWidth = this._jest.spyOn(document.documentElement, 'clientWidth', 'get').mockImplementation(() => window.innerWidth);
+
+  }
+
+  _plugJSDOM () {
+
+    const self = this;
+
+    // JSDOM doesn't support .scrollTo
+    window.scrollTo = function () {
+      let y;
+
+      // data sent as props in an object
+      if (arguments.length === 1) {
+        y = arguments[0].y;
+      } else {
+        y = arguments[1];
+      }
+
+      self.scrollTo(y);
+
+    };
 
   }
 

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -1,3 +1,20 @@
+function getDescriptorForProperty (prop, obj) {
+  const descriptors = Object.getOwnPropertyDescriptors(obj);
+  const prototype = Object.getPrototypeOf(obj);
+
+  if ((descriptors !== {}) && (prop in descriptors)) {
+    return descriptors[prop];
+  }
+
+  // if not in this object's descriptors, check the prototype chain
+  if (prototype !== null) {
+    return getDescriptorForProperty(prop, prototype);
+  }
+
+  // no descriptor for this prop and no prototypes left in the chain
+  return null;
+};
+
 const triggerEvent = (el, evtType, options) => {
   const eventInit = {
     bubbles: true,
@@ -235,6 +252,7 @@ class WindowMock {
     document.documentElement.scrollTop = scrollPosition;
     window.scrollY = scrollPosition;
     window.pageYOffset = scrollPosition;
+
     triggerEvent(window, 'scroll');
 
   }
@@ -297,6 +315,162 @@ class SelectionMock extends DOMInterfaceMock {
   }
 
 }
+class ScreenRenderItem {
+  constructor (jest, node) {
+
+    this._jest = jest;
+    this._node = node;
+    this._storeProps();
+    this._mockAPICalls();
+
+  }
+
+  setData (itemData) {
+
+    // check all the item data is present
+    const itemProps = Object.keys(itemData);
+    const missingKeys = ScreenRenderItem.REQUIRED_PROPS.filter(prop => !itemProps.includes(prop));
+
+    this._data = {};
+
+    if (missingKeys.length) {
+      throw Error(`${itemData.name ? itemData.name : itemProps.join(', ')} is missing these properties: ${missingKeys.join(', ')}`);
+    }
+
+    // default left if not set
+    if (!('offsetLeft' in itemData)) { itemData.offsetLeft = 0; }
+
+    // copy onto internal store
+    Object.assign(this._data, itemData);
+
+  }
+
+  _getBoundingClientRect () {
+    const {offsetHeight, offsetWidth, offsetTop, offsetLeft} = this._data;
+    const x = offsetLeft - window.scrollX;
+    const y = offsetTop - window.scrollY;
+
+    return {
+      'x': x,
+      'y': y,
+      'top': (offsetHeight < 0) ? y + offsetHeight : y,
+      'left': (offsetWidth < 0) ? x + offsetWidth : x,
+      'bottom': (offsetTop + offsetHeight) - window.scrollY,
+      'right': (offsetLeft + offsetWidth) - window.scrollX,
+    };
+
+  }
+
+  reset () {
+
+    // reset DOMRect mock
+    this._node.getBoundingClientRect.mockClear();
+
+    ScreenRenderItem.OFFSET_PROPS.forEach(prop => {
+
+      if (prop in this._propStore) {
+        // replace property implementation
+        Object.defineProperty(this._node, prop, this._propStore[prop]);
+      }
+
+    });
+
+  }
+
+  _storeProps () {
+
+    this._propStore = {};
+
+    ScreenRenderItem.OFFSET_PROPS.forEach(prop => {
+      const descriptor = getDescriptorForProperty(prop, this._node);
+
+      if (descriptor !== null) {
+        this._propStore[prop] = descriptor;
+      }
+    });
+
+  }
+
+  // mock any calls to the node's DOM API for position/dimension
+  _mockAPICalls () {
+
+    // proxy boundingClientRect property calls to item data
+    this._jest.spyOn(this._node, 'getBoundingClientRect').mockImplementation(() => this._getBoundingClientRect());
+
+    // handle calls to offset properties
+    ScreenRenderItem.OFFSET_PROPS.forEach(prop => {
+
+      this._jest.spyOn(this._node, prop, 'get').mockImplementation(() => this._data[prop]);
+
+      // proxy DOM API sets for offsetValues (not possible to mock directly)
+      Object.defineProperty(this._node, prop, {
+        configurable: true,
+        set: jest.fn(value => {
+          this._data[prop] = value;
+          return true;
+        })
+      });
+
+    });
+
+  }
+
+}
+ScreenRenderItem.OFFSET_PROPS = ['offsetHeight', 'offsetWidth', 'offsetTop', 'offsetLeft'];
+ScreenRenderItem.REQUIRED_PROPS = ['name', 'offsetHeight', 'offsetHeight', 'offsetWidth', 'offsetTop'];
+
+class ScreenMock {
+  constructor (jest) {
+
+    this._jest = jest
+    this._items = {};
+
+  }
+
+  mockPositionAndDimension (itemName, node, itemData) {
+
+    if (itemName in this._items) { throw new Error(`${itemName} already has its position and dimension mocked`); }
+
+    const data = Object.assign({ 'name': itemName }, itemData);
+    const item = new ScreenRenderItem(this._jest, node);
+
+    item.setData(data);
+
+    this._items[itemName] = item;
+
+  }
+
+  setWindow (windowData) {
+
+    this.window = new WindowMock(this._jest);
+
+    // check all the window data is present
+    const missingKeys = Object.keys(windowData).filter(key => !ScreenMock.REQUIRED_WINDOW_PROPS.includes(key));
+
+    if (missingKeys.length) {
+      throw Error(`Window definition is missing these properties: ${missingKeys.join(', ')}`);
+    }
+
+    this.window.setHeightTo(windowData.height);
+    this.window.setWidthTo(windowData.width);
+    this.window.scrollTo(windowData.scrollTop);
+
+  }
+
+  scrollTo (scrollTop) {
+
+    this.window.scrollTo(scrollTop);
+
+  }
+
+  reset () {
+
+    Object.keys(this._items).forEach(itemName => this._items[itemName].reset());
+
+  }
+
+}
+ScreenMock.REQUIRED_WINDOW_PROPS = ['height', 'width', 'scrollTop'];
 
 // function to ask certain questions of a DOM Element
 const element = function (el) {
@@ -311,3 +485,4 @@ exports.RangeMock = RangeMock;
 exports.SelectionMock = SelectionMock;
 exports.element = element;
 exports.WindowMock = WindowMock;
+exports.ScreenMock = ScreenMock;

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -86,6 +86,39 @@ const triggerEvent = (el, evtType, options) => {
   el.dispatchEvent(evt);
 };
 
+function getRadios (fields) {
+  const result = '';
+
+  return fields.map((field, idx) => {
+    const count = idx + 1;
+
+    return `
+      <div class="multiple-choice">
+        <input id="choose-${field.name}-1" name="choose-${field.name}-1" type="radio" value="${field.value}" ${field.checked ? 'checked' : ''}>
+        <label class="block-label" for="choose-${field.name}-1">
+          ${field.label}
+        </label>
+      </div>`;
+  }).join("\n");
+};
+
+function getRadioGroup (data) {
+  let radioGroup = document.createElement('div');
+
+  data.cssClasses.forEach(cssClass => radioGroup.classList.add(cssClass));
+  radioGroup.innerHTML = `
+    <div class="form-group ">
+      <fieldset id="choose-${data.name}">
+        <legend class="form-label">
+           Choose ${data.label}
+        </legend>
+        ${getRadios(data.fields)}
+      </fieldset>
+    </div>`;
+
+    return radioGroup;
+};
+
 function clickElementWithMouse (el) {
   triggerEvent(el, 'mousedown');
   triggerEvent(el, 'mouseup');
@@ -483,6 +516,8 @@ exports.moveSelectionToRadio = moveSelectionToRadio;
 exports.activateRadioWithSpace = activateRadioWithSpace;
 exports.RangeMock = RangeMock;
 exports.SelectionMock = SelectionMock;
+exports.getRadioGroup = getRadioGroup;
+exports.getRadios = getRadios;
 exports.element = element;
 exports.WindowMock = WindowMock;
 exports.ScreenMock = ScreenMock;

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -173,27 +173,52 @@ class WindowMock {
       height: window.innerHeight,
       width: window.innerWidth
     };
-    this._spies = {
+    this.spies = {
       document: {}
     };
     this._jest = jest;
+    this._setSpies();
+  }
+
+  get top () {
+    return window.scrollY;
+  }
+
+  get bottom () {
+    return window.scrollY + window.innerHeight;
+  }
+
+  get height () {
+    return window.innerHeight;
+  }
+
+  get width () {
+    return window.innerWidth
+  }
+
+  get scrollPosition () {
+    return window.scrollY;
+  }
+
+  _setSpies () {
+
+    // remove calls to document.documentElement.clientHeight when jQuery is gone. It's called to support older browsers like IE8
+    this.spies.document.clientHeight = this._jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementation(() => window.innerHeight);
+
+    // remove calls to document.documentElement.clientWidth when jQuery is gone. It's called to support older browsers like IE8
+    this.spies.document.clientWidth = this._jest.spyOn(document.documentElement, 'clientWidth', 'get').mockImplementation(() => window.innerWidth);
+
   }
 
   setHeightTo (height) {
 
-    // mock DOM calls for window height
     window.innerHeight = height;
-    // remove calls to document.documentElement.clientHeight  when jQuery is gone. It's called to support older browsers like IE8
-    this._spies.document.clientHeight = this._jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementation(() => height);
 
   }
 
   setWidthTo (width) {
 
-    // mock DOM calls for window width
     window.innerWidth = width;
-    // remove calls to document.documentElement.clientWidth  when jQuery is gone. It's called to support older browsers like IE8
-    this._spies.document.clientWidth = this._jest.spyOn(document.documentElement, 'clientWidth', 'get').mockImplementation(() => height);
 
   }
 
@@ -205,9 +230,11 @@ class WindowMock {
 
   }
 
-  scrollBy (scrollPosition) {
+  scrollTo (scrollPosition) {
 
     document.documentElement.scrollTop = scrollPosition;
+    window.scrollY = scrollPosition;
+    window.pageYOffset = scrollPosition;
     triggerEvent(window, 'scroll');
 
   }
@@ -216,11 +243,11 @@ class WindowMock {
 
     window.innerHeight = this._defaults.height;
     window.innerWidth = this._defaults.width;
-    document.documentElement.scrollTop = 0;
+    this.scrollTo(0);
 
     // reset all spies
-    Object.keys(this._spies).forEach(key => {
-      const objectSpies = this._spies[key];
+    Object.keys(this.spies).forEach(key => {
+      const objectSpies = this.spies[key];
       Object.keys(objectSpies).forEach(key => objectSpies[key].mockClear());
     });
 

--- a/tests/javascripts/support/helpers.js
+++ b/tests/javascripts/support/helpers.js
@@ -224,7 +224,8 @@ class WindowMock {
       width: window.innerWidth
     };
     this.spies = {
-      document: {}
+      document: {},
+      window: {}
     };
     this._jest = jest;
     this._setSpies();
@@ -266,7 +267,7 @@ class WindowMock {
     const self = this;
 
     // JSDOM doesn't support .scrollTo
-    window.scrollTo = function () {
+    this.spies.window.scrollTo = this._jest.fn(function () {
       let y;
 
       // data sent as props in an object
@@ -278,7 +279,9 @@ class WindowMock {
 
       self.scrollTo(y);
 
-    };
+    });
+
+     window.scrollTo = this.spies.window.scrollTo;
 
   }
 


### PR DESCRIPTION
Add tests for the sticky JS.

<img width="772" alt="sticky_element" src="https://user-images.githubusercontent.com/87140/62628891-0e37a600-b924-11e9-843c-91498e79e67a.png">

The work forms part of this story:

https://www.pivotaltracker.com/story/show/165409973

## How's it meant to work?

Like the native [position: sticky](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning) but with a few important differences:

1. if an element receiving focus, or the caret, is underneath a sticky element, the page will scroll to show it
2. if multiple elements are made sticky in the same scroll area, they will be stacked in page order
3. if a stack of sticky elements is too big for the window, only those that fit will be kept as sticky

These features are explained in the following pull requests:
- [prevent sticky elements overlapping focus](https://github.com/alphagov/notifications-admin/pull/2843)
- [prevent stack of sticky elements overflowing screen](https://github.com/alphagov/notifications-admin/pull/2682)
- [prevent sticky elements overlapping caret](https://github.com/alphagov/notifications-admin/pull/2876)

## How to run these tests

From the root of the repository, run:

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/stick-to-window-when-scrolling.test.js`
