### PR TITLE
Update 'contact us on Slack' link

### DIFF
--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -20,7 +20,7 @@
       {{ page_footer('Continue') }}
     {% endcall %}
 
-    <p>You can also <a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">get in touch with us on Slack</a>.</p>
+    <p>You can also <a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">contact us on Slack</a>.</p>
     
     <h2 class="heading-medium">Office hours</h2>
     <p>Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>


### PR DESCRIPTION
Update 'contact us on Slack' link to make it consistent with all the other contact links on Notify.