### PR TITLE
Update slack link

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -78,7 +78,7 @@
             <li><a href="{{ url_for('main.support') }}">Support</a></li>
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
-            <li><a href="https://app.slack.com/client/T04V6EBTR/C0E1ADVPC">Slack channel</a></li>
+            <li><a href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">Slack channel</a></li>
             <li><a href="https://gds.blog.gov.uk/category/notify/">Blog</a></li>
           </ul>
         </div>

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -78,7 +78,7 @@
             <li><a href="{{ url_for('main.support') }}">Support</a></li>
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
             <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
-            <li><a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">Slack channel</a></li>
+            <li><a href="https://app.slack.com/client/T04V6EBTR/C0E1ADVPC">Slack channel</a></li>
             <li><a href="https://gds.blog.gov.uk/category/notify/">Blog</a></li>
           </ul>
         </div>

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -20,7 +20,7 @@
       {{ page_footer('Continue') }}
     {% endcall %}
 
-    <p>You can also <a href="https://app.slack.com/client/T04V6EBTR/C0E1ADVPC">contact us on Slack</a>.</p>
+    <p>You can also <a href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">contact us on Slack</a>.</p>
     
     <h2 class="heading-medium">Office hours</h2>
     <p>Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -20,7 +20,7 @@
       {{ page_footer('Continue') }}
     {% endcall %}
 
-    <p>You can also <a href="https://ukgovernmentdigital.slack.com/messages/govuk-notify">get in touch with us on Slack</a>.</p>
+    <p>You can also <a href="https://app.slack.com/client/T04V6EBTR/C0E1ADVPC">contact us on Slack</a>.</p>
     
     <h2 class="heading-medium">Office hours</h2>
     <p>Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>


### PR DESCRIPTION
Updates the Slack links in the footer and on the Support page to use the Notify channel's unique ID.

This is needed because the current link uses the channel name, which isn't recognised. Instead of opening the Notify channel, the link opens the GDS slack and defaults to the main channel (announcements).