### PR TITLE
Add 'Uploads' hub and navigation

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -33,6 +33,7 @@ from app.main.views import (  # noqa isort:skip
     styleguide,
     templates,
     two_factor,
+    uploads,
     user_profile,
     verify,
 )

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -1,0 +1,10 @@
+from flask import render_template
+
+from app.main import main
+from app.utils import user_has_permissions
+
+
+@main.route("/services/<service_id>/uploads")
+@user_has_permissions('send_messages')
+def uploads(service_id):
+    return render_template('views/uploads/index.html')

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -300,6 +300,7 @@ class HeaderNavigation(Navigation):
         'template_history',
         'template_usage',
         'trial_mode',
+        'uploads',
         'usage',
         'view_job',
         'view_job_csv',
@@ -358,6 +359,9 @@ class MainNavigation(Navigation):
             'view_template',
             'view_template_version',
             'view_template_versions',
+        },
+        'uploads': {
+            'uploads',
         },
         'team-members': {
             'confirm_edit_user_email',
@@ -844,6 +848,7 @@ class CaseworkNavigation(Navigation):
         'two_factor_email_sent',
         'update_email_branding',
         'update_letter_branding',
+        'uploads',
         'usage',
         'user_information',
         'user_profile',
@@ -1118,6 +1123,7 @@ class OrgNavigation(Navigation):
         'two_factor_email_sent',
         'update_email_branding',
         'update_letter_branding',
+        'uploads',
         'usage',
         'user_information',
         'user_profile',

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -15,6 +15,9 @@
       {% endif %}
     {% endif %}
   {% endif %}
+  {% if current_user.has_permissions('send_messages') and current_service.has_permission('letter') and current_service.has_permission('upload_letters') %}
+    <li><a href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ main_navigation.is_selected('uploads') }}>Uploads</a></li>
+  {% endif %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
   {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>

--- a/app/templates/views/uploads/index.html
+++ b/app/templates/views/uploads/index.html
@@ -1,0 +1,16 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block service_page_title %}
+  Uploads
+{% endblock %}
+
+{% block maincolumn_content %}
+<div class="grid-row">
+  <div class="column-two-thirds">
+    {{ page_header('Uploads') }}
+
+    <p>Upload a letter and Notify will print, pack and post it for you.</p>
+  </div>
+</div>
+{% endblock %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -960,6 +960,8 @@ def test_menu_send_messages(
     mock_get_inbound_sms_summary,
     mock_get_free_sms_fragment_limit,
 ):
+    service_one['permissions'] = ['email', 'sms', 'letter', 'upload_letters']
+
     with app_.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
@@ -972,11 +974,36 @@ def test_menu_send_messages(
             'main.choose_template',
             service_id=service_one['id'],
         ) in page
+        assert url_for('main.uploads', service_id=service_one['id']) in page
         assert url_for('main.manage_users', service_id=service_one['id']) in page
 
         assert url_for('main.service_settings', service_id=service_one['id']) not in page
         assert url_for('main.api_keys', service_id=service_one['id']) not in page
         assert url_for('main.view_providers') not in page
+
+
+def test_menu_send_messages_when_service_does_not_have_upload_letters_permission(
+    mocker,
+    app_,
+    api_user_active,
+    service_one,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_template_statistics,
+    mock_get_service_statistics,
+    mock_get_usage,
+    mock_get_inbound_sms_summary,
+    mock_get_free_sms_fragment_limit,
+):
+    with app_.test_request_context():
+        resp = _test_dashboard_menu(
+            mocker,
+            app_,
+            api_user_active,
+            service_one,
+            ['view_activity', 'send_messages'])
+        page = resp.get_data(as_text=True)
+        assert url_for('main.uploads', service_id=service_one['id']) not in page
 
 
 def test_menu_manage_service(

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -1,0 +1,5 @@
+from tests.conftest import SERVICE_ONE_ID
+
+
+def test_get_upload_hub_page(client_request):
+    client_request.get('main.uploads', service_id=SERVICE_ONE_ID)


### PR DESCRIPTION
The uploads hub is just a page with text for now - there are no actions available on the page. It is linked to from a new 'Uploads' menu item on the left of the page which is only visible if your service has the `letter` and `upload_letters` permissions and if the current user has permissions to send messages.

[Pivotal story](https://www.pivotaltracker.com/story/show/167533429)

<img width="1018" alt="Screen Shot 2019-08-09 at 11 23 37" src="https://user-images.githubusercontent.com/12881990/62772721-347e5280-ba98-11e9-82aa-744cbbbac00e.png">
