### PR TITLE
Update Pricing information

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -118,10 +118,8 @@
 
   <h2 class="heading-medium" id="letters">Letters</h2>
   <p>The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
-  <div class="panel panel-border-wide">
-    <p>Current prices will increase by 5 pence on Tuesday 1 October.</p>
-  </div>
-  <div class="bottom-gutter-3-2">
+  
+  <div>
     {% call mapping_table(
       caption='Letter pricing',
       field_headings=['Paper', 'Second class', 'First class'],
@@ -143,12 +141,15 @@
       {% endfor %}
     {% endcall %}
   </div>
+  <div class="panel panel-border-wide">
+    <p>These prices will increase by 5 pence plus VAT on 1 October 2019.</p>
+  </div>
   <p>Prices include:</p>
-  <ul class="list list-bullet">
-     <li>paper</li>
+   <ul class="list list-bullet">
+      <li>paper</li>
      <li>double-sided colour printing</li>
      <li>C5 size envelopes with an address window</li>
      <li>first or second class postage</li>
-  </ul>
+   </ul>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -142,14 +142,14 @@
     {% endcall %}
   </div>
   <div class="panel panel-border-wide">
-    <p>These prices will increase by 5 pence plus VAT on 1 October 2019.</p>
+    <p>These prices will increase by 5 pence (plus VAT) on 1 October 2019.</p>
   </div>
   <p>Prices include:</p>
-   <ul class="list list-bullet">
-      <li>paper</li>
+  <ul class="list list-bullet">
+     <li>paper</li>
      <li>double-sided colour printing</li>
      <li>C5 size envelopes with an address window</li>
      <li>first or second class postage</li>
-   </ul>
+  </ul>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -18,9 +18,13 @@
     <li>no procurement cost</li>
   </ul>
 
-  {% if not current_user.is_authenticated %}
-    <p><a href="{{ url_for('main.register') }}">Create an account</a> then set up as many different services as you need to. Each service has its own free text message allowance.</p>
-  {% endif %}
+  <p>
+    {% if not current_user.is_authenticated %}
+      <a href="{{ url_for('main.register') }}">Create an account</a> then set up as many different services as you need to.</p>
+    {% else %}
+      You can set up as many different services as you need to.
+    {% endif %}
+  </p>
 
   <p>When you set up a new service it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
 
@@ -28,12 +32,14 @@
   <p>It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium">Text messages</h2>
-  <p>Each service you set up in Notify has a free annual allowance. The allowance is:</p>
+  <p>Every service you set up has an annual allowance of free text messages.</p>
+  <p>If your organisation has more than one service on Notify, they each have a separate allowance.</p>
+  <p>The allowance is:</p>
   <ul class="list list-bullet">
     <li>250,000 free text messages for central government services</li>
     <li>25,000 free text messages for other public sector services</li>
   </ul>
-  <p>It costs 1.58 pence (plus VAT) for each text message you send after your free allowance.</p>
+  <p>It costs 1.58 pence (plus VAT) for each text message you send after you've used your free allowance.</p>
   <p>See <a href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
   <h3 class="heading-small">Long text messages</h3>
@@ -112,6 +118,9 @@
 
   <h2 class="heading-medium" id="letters">Letters</h2>
   <p>The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
+  <div class="panel panel-border-wide">
+    <p>Current prices will increase by 5 pence on Tuesday 1 October.</p>
+  </div>
   <div class="bottom-gutter-3-2">
     {% call mapping_table(
       caption='Letter pricing',


### PR DESCRIPTION
This pull request:
- makes it clearer that the free text message allowance is per service (not per organisation)
- warns users that the price of sending letters will go up by 5p +VAT in October
- removes information about the text message allowance from the introduction (repetition)
- adds a new line to the introduction that's only displayed when users are signed-in