### PR TITLE
Add tests for colour preview

### DIFF
--- a/tests/javascripts/colourPreview.test.js
+++ b/tests/javascripts/colourPreview.test.js
@@ -1,0 +1,139 @@
+const helpers = require('./support/helpers.js');
+
+beforeAll(() => {
+  require('../../app/assets/javascripts/colourPreview.js');
+});
+
+afterAll(() => {
+  require('./support/teardown.js');
+});
+
+describe('Colour preview', () => {
+
+  let field;
+  let textbox;
+  let swatchEl;
+
+  beforeEach(() => {
+
+    // set up DOM
+    document.body.innerHTML = `
+      <div class="form-group" data-module="colour-preview">
+        <label class="form-label" for="colour">
+          Colour
+        </label>
+        <input class="form-control form-control-1-4" id="colour" name="colour" rows="8" type="text" value="">
+      </div>`;
+
+    field = document.querySelector('.form-group');
+    textbox = document.querySelector('input[type=text]');
+
+  });
+
+  afterEach(() => {
+
+    document.body.innerHTML = '';
+
+  });
+
+  describe("When the page loads", () => {
+
+    test("It should add a swatch element for the preview", () => {
+
+      // start the module
+      window.GOVUK.modules.start();
+
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+      expect(swatchEl).not.toBeNull();
+
+    });
+
+    test("If the textbox is empty it should make the swatch white", () => {
+
+      // start the module
+      window.GOVUK.modules.start();
+
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+      // textbox defaults to empty
+      // colours are output in RGB
+      expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
+
+    });
+
+    test("If the textbox has a value which is a hex code it should add that colour to the swatch", () => {
+
+      textbox.setAttribute('value', '#00FF00');
+
+      // start the module
+      window.GOVUK.modules.start();
+
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+      // colours are output in RGB
+      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
+
+    });
+
+    test("If the textbox has a value which isn't a hex code it should make the swatch white", () => {
+
+      textbox.setAttribute('value', 'green');
+
+      // start the module
+      window.GOVUK.modules.start();
+
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+      // colours are output in RGB
+      expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
+
+    });
+
+  });
+
+  describe("When input is added to the textbox", () => {
+
+    beforeEach(() => {
+
+      // start the module
+      window.GOVUK.modules.start();
+
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+    });
+
+    test("If the textbox is empty it should make the swatch white", () => {
+
+      helpers.triggerEvent(document.querySelector('input[type=text]'), 'input');
+
+      // textbox defaults to empty
+      expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
+
+    });
+
+    test("If the textbox has a value which is a hex code it should add that colour to the swatch", () => {
+
+      textbox.setAttribute('value', '#00FF00');
+
+      helpers.triggerEvent(document.querySelector('input[type=text]'), 'input');
+
+      // textbox defaults to empty
+      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
+
+    });
+
+    test("If the textbox has a value which isn't a hex code it should make the swatch white", () => {
+
+      textbox.setAttribute('value', 'green');
+
+      helpers.triggerEvent(document.querySelector('input[type=text]'), 'input');
+
+      // textbox defaults to empty
+      expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds tests for the colour preview module, that shows you the colour for any hex value entered.

![colour_preview](https://user-images.githubusercontent.com/87140/62877228-7ddfd380-bd1e-11e9-9fd7-467f1bdb26c5.gif)

This work forms part of this story:

https://www.pivotaltracker.com/story/show/165409926

## How to run these tests

From the root of this repository, run:

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/colourPreview.test.js`