### PR TITLE
Add tests for error tracking module

### DIFF
--- a/tests/javascripts/errorTracking.test.js
+++ b/tests/javascripts/errorTracking.test.js
@@ -1,0 +1,36 @@
+beforeAll(() => {
+  require('../../app/assets/javascripts/errorTracking.js');
+});
+
+afterAll(() => {
+  require('./support/teardown.js');
+});
+
+describe('Error tracking', () => {
+
+  beforeEach(() => {
+
+    // set up DOM
+    document.body.innerHTML = `<div data-module="track-error" data-error-type="validation" data-error-label="missing field"></div>`;
+
+  });
+
+  afterEach(() => {
+
+    document.body.innerHTML = '';
+
+  });
+
+  test("It should send the right data to Google Analytics", () => {
+
+    window.ga = jest.fn(() => {});
+
+    // start the module
+    window.GOVUK.modules.start();
+
+    expect(window.ga).toHaveBeenCalled();
+    expect(window.ga.mock.calls[0]).toEqual(['send', 'event', 'Error', 'validation', 'missing field']);
+
+  });
+
+});


### PR DESCRIPTION
Adds tests for the error tracking module, that sends information about an error, contained in the page, to Google Analytics.

This work forms part of the following story:

https://www.pivotaltracker.com/story/show/165409926

It's only one test but could be useful to track any changes to this module.

## How to run these tests

From the root of this repository, run:

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/`