### PR TITLE
Add tests for fileUpload module

### DIFF
--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -1,0 +1,83 @@
+const helpers = require('./support/helpers.js');
+
+beforeAll(() => {
+  require('../../app/assets/javascripts/fileUpload.js');
+});
+
+afterAll(() => {
+  require('./support/teardown.js');
+});
+
+describe('File upload', () => {
+
+  let form;
+  let fileUpload;
+
+  beforeEach(() => {
+
+    // set up DOM
+    document.body.innerHTML = `
+      <form method="post" enctype="multipart/form-data" class="" data-module="file-upload">
+        <label class="file-upload-label" for="file">
+          <span class="visually-hidden">Upload a PNG logo</span>
+        </label>
+        <input class="file-upload-field" id="file" name="file" type="file">
+        <label class="file-upload-button" for="file">
+          Upload logo
+        </label>
+        <label class="file-upload-filename" for="file"></label>
+        <button type="submit" class="file-upload-submit">Submit</button>
+      </form>`;
+
+    form = document.querySelector('form');
+    uploadControl = form.querySelector('input[type=file]');
+
+  });
+
+  afterEach(() => {
+
+    document.body.innerHTML = '';
+
+  });
+
+  test("If the page loads, from a new or existing navigation, the form should reset", () => {
+
+    form.reset = jest.fn(() => {});
+
+    // start module
+    window.GOVUK.modules.start();
+
+    helpers.triggerEvent(window, 'pageshow');
+
+    expect(form.reset).toHaveBeenCalled();
+
+  });
+
+  describe("If the state of the upload form control changes", () => {
+
+    beforeEach(() => {
+
+      form.submit = jest.fn(() => {});
+
+      // start module
+      window.GOVUK.modules.start();
+
+      helpers.triggerEvent(uploadControl, 'change', { eventInit: { bubbles: true } });
+
+    });
+
+    test("The form should submit", () => {
+
+      expect(form.submit).toHaveBeenCalled();
+
+    });
+
+    test("It should add a link to cancel the upload by reloading the page", () => {
+
+      expect(form.querySelector("a[href='']")).not.toBeNull();
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds tests for the file upload module, that automates the upload so it can be part of a larger form.

![file_upload](https://user-images.githubusercontent.com/87140/63175678-649b9780-c03c-11e9-85f4-d3107fd0973b.gif)

This work forms part of the following story:

https://www.pivotaltracker.com/story/show/165409926

## How's it meant to work?

There's a better explanation in the original PR: https://github.com/alphagov/notifications-admin/pull/148

## Where can I find it?

On the 'Add email branding' page, in the platform admin section: /email-branding/create

## How to run these tests

`npx jest --config tests/javascripts/jest.config.js tests/javascripts/fileUpload.test.js`