### PR TITLE
Change method of hiding extra table layer

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -44,7 +44,7 @@
             .clone()
             .addClass('fullscreen-fixed-table')
             .removeClass('fullscreen-scrollable-table')
-            .attr('role', 'presentation')
+            .attr('aria-hidden', true)
         )
         .append(
           '<div class="fullscreen-right-shadow" />'

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -123,7 +123,7 @@ describe('FullscreenTable', () => {
 
       expect(tableFrame).not.toBeNull();
       expect(numberColumnFrame).not.toBeNull();
-      expect(numberColumnFrame.getAttribute('role')).toEqual('presentation');
+      expect(numberColumnFrame.getAttribute('aria-hidden')).toEqual('true');
 
     });
 


### PR DESCRIPTION
The fullscreenTable module creates a clone of the existing table as an extra layer which sits on top of it. This allows the row headers to sit above the table content when it scrolls.

We were setting `role=presentation` on the extra table to hide it from assistive technologies.

It seems that this wasn't working. From the spec' `role=presentation` should remove the semantics of the table but leave the content.

Testing in Safari with Voiceover, this isn't happening and the extra table is still being reported as a table:

<img width="884" alt="two_tables" src="https://user-images.githubusercontent.com/87140/63179318-c01d5380-c043-11e9-91eb-58763b3186d1.png">

This changes to the `aria-hidden` attribute, to
make sure the extra table is ignored:

<img width="924" alt="one_table" src="https://user-images.githubusercontent.com/87140/63179596-66695900-c044-11e9-9058-43c4f25877dc.png">
