### PR TITLE
Update Documentation content

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -7,9 +7,9 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Documentation</h1>
-    <p>Use the GOV.UK Notify API to send messages automatically.</p>
+    <p>This documentation is for developers who want to integrate the GOV.UK Notify API with a web application or back office system.</p>
   <h2 class="heading-medium">Clients</h2>
-    <p>Choose a client to integrate our API with your web application or back-office system. Links to documentation open in a new tab.</p>
+    <p>Links to documentation open in a new tab.</p>
   <ul class="list list-bullet">
     {% for key, label in [
       ('java', 'Java'),
@@ -22,5 +22,5 @@
       <li><a href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
-
+    <p>You can work directly with the API, but this may be complicated to set up. <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> for more information.</p>
 {% endblock %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -30,5 +30,5 @@
     <li>what the API client does</li>
     <li>what development work you'll need to do</li>
   </ul>
-  <p>To send a message you'll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
+  <p>To send a message you’ll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
 {% endblock %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -8,7 +8,7 @@
 
   <h1 class="heading-large">Documentation</h1>
     <p>This documentation is for developers who want to integrate the GOV.UK Notify API with a web application or back office system.</p>
-  <h2 class="heading-medium">Clients</h2>
+  <h2 class="heading-medium">Client libraries</h2>
     <p>Links to documentation open in a new tab.</p>
   <ul class="list list-bullet">
     {% for key, label in [
@@ -24,8 +24,8 @@
   </ul>
     <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
   <h2>Integrating directly with the API</h2>
-    <p>We recommend using our client documentation rather than integrating directly with the API.</p>
-    <p>There’s no documentation for using the API in this way. You'll still need to read the client documentation to understand:</p>
+    <p>We recommend using the client libraries rather than integrating directly with the API.</p>
+    <p>There’s no documentation for using the API in this way. You’ll still need to read the client documentation to understand:</p>
   <ul class="list list-bullet">
     <li>what the API client does</li>
     <li>what development work you’ll need to do</li>

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -24,7 +24,6 @@
   </ul>
     <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration might take a couple of days.</p>
   <h2>Integrating directly with the API</h2>
-    <p>You can integrate directly with the Notify API.</p>
+    <p>You can integrate directly with the Notify API. Reading the client documentation will help you to do this.</p>
     <p>To send a message you'll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
-    <p>Reading the client documentation will help you to do this.</p>
 {% endblock %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -22,13 +22,13 @@
       <li><a href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
-    <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration might take a couple of days.</p>
+    <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you're using.</p>
   <h2>Integrating directly with the API</h2>
-    <p>You can integrate directly with the Notify API.</p>
-    <p>To send a message you'll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
-    <p>You should also read the client documentation to understand:</p>
+    <p>We recommend using our client documentation rather than integrating directly with the API.</p>
+    <p>There's no documentation for using the API in this way. You'll still need to read the client documentation to understand:</p>
   <ul class="list list-bullet">
     <li>what the API client does</li>
     <li>what development work you'll need to do</li>
   </ul>
+  <p>To send a message you'll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
 {% endblock %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -24,6 +24,11 @@
   </ul>
     <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration might take a couple of days.</p>
   <h2>Integrating directly with the API</h2>
-    <p>You can integrate directly with the Notify API. Reading the client documentation will help you to do this.</p>
+    <p>You can integrate directly with the Notify API.</p>
     <p>To send a message you'll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
+    <p>You should also read the client documentation to understand:</p>
+  <ul class="list list-bullet">
+    <li>what the API client does</li>
+    <li>what development work you'll need to do</li>
+  </ul>
 {% endblock %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -25,7 +25,7 @@
     <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
   <h2>Integrating directly with the API</h2>
     <p>We recommend using our client documentation rather than integrating directly with the API.</p>
-    <p>There's no documentation for using the API in this way. You'll still need to read the client documentation to understand:</p>
+    <p>There’s no documentation for using the API in this way. You'll still need to read the client documentation to understand:</p>
   <ul class="list list-bullet">
     <li>what the API client does</li>
     <li>what development work you'll need to do</li>

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -22,5 +22,9 @@
       <li><a href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
-    <p>You can work directly with the API, but this may be complicated to set up. <a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> for more information.</p>
+    <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration might take a couple of days.</p>
+  <h2>Integrating directly with the API</h2>
+    <p>You can integrate directly with the Notify API.</p>
+    <p>To send a message you'll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
+    <p>Reading the client documentation will help you to do this.</p>
 {% endblock %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -22,7 +22,7 @@
       <li><a href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
-    <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you're using.</p>
+    <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
   <h2>Integrating directly with the API</h2>
     <p>We recommend using our client documentation rather than integrating directly with the API.</p>
     <p>There's no documentation for using the API in this way. You'll still need to read the client documentation to understand:</p>

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -28,7 +28,7 @@
     <p>There’s no documentation for using the API in this way. You'll still need to read the client documentation to understand:</p>
   <ul class="list list-bullet">
     <li>what the API client does</li>
-    <li>what development work you'll need to do</li>
+    <li>what development work you’ll need to do</li>
   </ul>
   <p>To send a message you’ll need to create an HTTPS request and add an authorisation header with your API key. The API key is encoded with JSON Web Tokens (JWT).</p>
 {% endblock %}


### PR DESCRIPTION
This PR updates the Documentation page to:
- make the target user and purpose of the page clearer
- tell users how long it might take to integrate with the API
- tell users they can integrate directly with the API
- provide important information about integrating directly with the API