### PR TITLE
Update explanation of inbound SMS

### DIFF
--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -33,7 +33,7 @@
           <a href="{{ url_for('.support') }}">Contact us</a> if you want to be able to receive text messages from your users.
         </p>
         <p>
-          We’ll create a unique phone number for your service that users can reply to.
+          We’ll create a unique phone number for your service that they can reply to.
         </p>
         <p>
           Text messages you send will come from this phone number instead of your sender name (currently {{ current_service.default_sms_sender }}).

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -33,9 +33,18 @@
           <a href="{{ url_for('.support') }}">Contact us</a> if you want to be able to receive text messages from your users.
         </p>
         <p>
-          We’ll create a special phone number for them to contact. You'll be able to see
-          the messages on your dashboard, or get them using the API.
+          We’ll create a unique phone number for your service that users can reply to.
         </p>
+        <p>
+          Text messages you send will come from this phone number instead of your sender name (’CURRENT NAME’.
+        </p>
+        <p>
+          You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.
+        </p>
+        <p>
+          You can see and reply to the messages you receive when you sign in to Notify, or get them using the API.
+        </p>
+        <p>
           It does not cost you anything to receive text messages. Users will pay their standard text message rate.
         </p>
       {% endif %}

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -20,6 +20,9 @@
           Your service can receive text messages sent to {{ current_service.inbound_number }}.
         </p>
         <p>
+          You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.
+        </p>
+        <p>
           <a href="{{ url_for('.support') }}">Contact us</a> if you want to switch this feature off.
         </p>
         {% if current_user.has_permissions('manage_api_keys') %}

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -36,7 +36,7 @@
           We’ll create a unique phone number for your service that users can reply to.
         </p>
         <p>
-          Text messages you send will come from this phone number instead of your sender name (’CURRENT NAME’.
+          Text messages you send will come from this phone number instead of your sender name (currently {SENDER NAME}).
         </p>
         <p>
           You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -36,7 +36,7 @@
           We’ll create a unique phone number for your service that users can reply to.
         </p>
         <p>
-          Text messages you send will come from this phone number instead of your sender name (currently {SENDER NAME}).
+          Text messages you send will come from this phone number instead of your sender name (currently {{ current_service.default_sms_sender }}).
         </p>
         <p>
           You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4100,6 +4100,7 @@ def test_invitation_pages(
     client_request,
     service_one,
     mock_get_inbound_number_for_service,
+    single_sms_sender,
     endpoint,
     permissions,
     expected_p,
@@ -4138,6 +4139,7 @@ def test_set_inbound_sms_when_inbound_number_is_not_set(
     service_one,
     single_reply_to_email_address,
     single_letter_contact_block,
+    single_sms_sender,
     mocker,
     mock_get_all_letter_branding,
 ):
@@ -4152,11 +4154,15 @@ def test_set_inbound_sms_when_inbound_number_is_not_set(
 @pytest.mark.parametrize('user, expected_paragraphs', [
     (active_user_with_permissions, [
         'Your service can receive text messages sent to 07700900123.',
+        'You can still send text messages from a sender name if you '
+        'need to, but users will not be able to reply to those messages.',
         'Contact us if you want to switch this feature off.',
         'You can set up callbacks for received text messages on the API integration page.',
     ]),
     (active_user_no_api_key_permission, [
         'Your service can receive text messages sent to 07700900123.',
+        'You can still send text messages from a sender name if you '
+        'need to, but users will not be able to reply to those messages.',
         'Contact us if you want to switch this feature off.',
     ]),
 ])


### PR DESCRIPTION
The PR updates the explanation of how inbound SMS works.

We're adding the following based on support queries:

- the phone number replaces the sender name for outbound SMS
- the service can revert to using the sender name for outbound SMS
- recipient can only reply to SMS from the phone number, not the sender name