### PR TITLE
Set free allowance for GP surgeries

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -43,6 +43,7 @@ class Config(object):
         'local': 25000,
         'nhs_central': 250000,
         'nhs_local': 25000,
+        'nhs_gp': 25000,
         'emergency_service': 25000,
         'school_or_college': 25000,
         'other': 25000,

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -80,6 +80,13 @@ def test_get_should_not_render_radios_if_org_type_known(
 ))
 @pytest.mark.parametrize('inherited, posted, persisted, sms_limit', (
     (None, 'central', 'central', 250000),
+    (None, 'nhs_central', 'nhs_central', 250000),
+    (None, 'nhs_gp', 'nhs_gp', 25000),
+    (None, 'nhs_local', 'nhs_local', 25000),
+    (None, 'local', 'local', 25000),
+    (None, 'emergency_service', 'emergency_service', 25000),
+    (None, 'school_or_college', 'school_or_college', 25000),
+    (None, 'other', 'other', 25000),
     ('central', None, 'central', 250000),
     ('nhs_central', None, 'nhs_central', 250000),
     ('nhs_local', None, 'nhs_local', 25000),


### PR DESCRIPTION
This also tests that a user from an unknown organisation can pick any of the available options and get the right allowance.

***

At the moment this is blocking anyone from a GP surgery from creating a service.