### PR TITLE
Send a file by email – reintroduce instructions

### DIFF
--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -9,5 +9,4 @@
     Download your document at: ((link_to_document))
   </p>
 </div>
-  Next, use the API to upload your document.<!--<p> Follow the instructions to send a document by email in the <a href="https://www.notifications.service.gov.uk/documentation">API client documentation</a>.
-</p>-->
+  Next, use the API to upload your document. Follow the instructions to send a document by email in the <a href="https://www.notifications.service.gov.uk/documentation">API documentation</a>.

--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -9,4 +9,4 @@
     Download your document at: ((link_to_document))
   </p>
 </div>
-  Next, use the API to upload your document. Follow the instructions to send a document by email in the <a href="https://www.notifications.service.gov.uk/documentation">API documentation</a>.
+  Next, use the API to upload your document. Follow the instructions to send a document by email in the <a href="{{ url_for('main.documentation') }}">API documentation</a>.


### PR DESCRIPTION
Reintroduce the instructions that were commented out as part of https://github.com/alphagov/notifications-admin/pull/2270

We're able to do this now because we've added:

- 'Send a document' content to all client docs
- channel-specific features pages with 'Send files by email' content