### PR TITLE
Update utils to remove toggle for expanding email previews

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -79,7 +79,6 @@ def view_notification(service_id, notification_id):
             notification_id=notification_id,
             filetype='png',
         ),
-        expand_emails=True,
         page_count=page_count,
         show_recipient=True,
         redact_missing_personalisation=True,

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -133,7 +133,6 @@ def send_messages(service_id, template_id):
         db_template,
         current_service,
         show_recipient=True,
-        expand_emails=True,
         letter_preview_url=url_for(
             '.view_letter_template_preview',
             service_id=service_id,
@@ -363,7 +362,6 @@ def send_test_step(service_id, template_id, step_index):
         db_template,
         current_service,
         show_recipient=True,
-        expand_emails=True,
         letter_preview_url=url_for(
             '.send_test_preview',
             service_id=service_id,
@@ -528,7 +526,6 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         db_template,
         current_service,
         show_recipient=True,
-        expand_emails=True,
         letter_preview_url=url_for(
             '.check_messages_preview',
             service_id=service_id,
@@ -857,7 +854,6 @@ def _check_notification(service_id, template_id, exception=None):
         db_template,
         current_service,
         show_recipient=True,
-        expand_emails=True,
         email_reply_to=email_reply_to,
         sms_sender=sms_sender,
         letter_preview_url=url_for(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -63,7 +63,6 @@ def view_template(service_id, template_id):
         template=get_template(
             template,
             current_service,
-            expand_emails=True,
             letter_preview_url=url_for(
                 '.view_letter_template_preview',
                 service_id=service_id,
@@ -251,7 +250,6 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
     return dict(template=get_template(
         current_service.get_template(template_id, version=version),
         current_service,
-        expand_emails=True,
         letter_preview_url=url_for(
             '.view_template_version_preview',
             service_id=service_id,
@@ -674,7 +672,6 @@ def delete_service_template(service_id, template_id):
         template=get_template(
             template,
             current_service,
-            expand_emails=True,
             letter_preview_url=url_for(
                 '.view_letter_template_preview',
                 service_id=service_id,
@@ -697,7 +694,6 @@ def confirm_redact_template(service_id, template_id):
         template=get_template(
             template,
             current_service,
-            expand_emails=True,
             letter_preview_url=url_for(
                 '.view_letter_template_preview',
                 service_id=service_id,
@@ -738,7 +734,6 @@ def view_template_versions(service_id, template_id):
             get_template(
                 template,
                 current_service,
-                expand_emails=True,
                 letter_preview_url=url_for(
                     '.view_template_version_preview',
                     service_id=service_id,

--- a/app/utils.py
+++ b/app/utils.py
@@ -343,7 +343,6 @@ def get_template(
     template,
     service,
     show_recipient=False,
-    expand_emails=False,
     letter_preview_url=None,
     page_count=1,
     redact_missing_personalisation=False,

--- a/app/utils.py
+++ b/app/utils.py
@@ -355,7 +355,6 @@ def get_template(
             template,
             from_name=service.name,
             from_address='{}@notifications.service.gov.uk'.format(service.email_from),
-            expanded=expand_emails,
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,4 +23,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.9#egg=notifications-utils==33.2.9
+git+https://github.com/alphagov/notifications-utils.git@34.0.0#egg=notifications-utils==34.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,13 +25,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.9#egg=notifications-utils==33.2.9
+git+https://github.com/alphagov/notifications-utils.git@34.0.0#egg=notifications-utils==34.0.0
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.228
+awscli==1.16.230
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.218
+botocore==1.12.220
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -55,7 +55,7 @@ monotonic==1.5
 openpyxl==2.5.14
 orderedset==2.0.1
 phonenumbers==8.10.13
-pyasn1==0.4.6
+pyasn1==0.4.7
 pyexcel-ezodf==0.3.4
 PyJWT==1.7.1
 PyPDF2==1.26.0


### PR DESCRIPTION
We stopped showing this toggle control ages ago because the problems it solves are better addressed by sticky footers.

The associated Javascript was removed in https://github.com/alphagov/notifications-admin/pull/3108

The code were calling will be removed by alphagov/notifications-utils#643
