### PR TITLE
Create the app once per run, not once per test

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -37,5 +37,5 @@ npm test
 display_result $? 3 "Front end code style check"
 
 ## Code coverage
-py.test -n4 --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict -p no:warnings
+py.test -n auto --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict -p no:warnings
 display_result $? 4 "Code coverage"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class ElementNotFound(Exception):
     pass
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def app_(request):
     app = Flask('app')
     create_app(app)
@@ -46,8 +46,6 @@ def app_(request):
 
     app.test_client_class = TestClient
     yield app
-
-    ctx.pop()
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Turns out our tests spent a lot of time recreating the app for each test case, which is quite intense.

This commit moves the app-creating code outside the fixture, so the fixture re-uses the same app for every test.

This cuts down the time taken to run the test suite to about 50 seconds.

It also makes the tests more parallelizable. Before this change going from 4 to 8 processes made the tests slower. Now it cuts them down from about 50 seconds to about 35 seconds<sup>1</sup>. So this commit also lets Pytest choose the best number of processes to run, since on my machine it chooses 8, which is the fastest.

Overall this means the tests take about 15% of the time they used to. Assuming each person on the teams runs the tests on average once a day, this will save 15 hours per person, per year.

# Before 

![image](https://user-images.githubusercontent.com/355079/65048144-92d20700-d95b-11e9-88d0-4b8610d1cedc.png)

![image](https://user-images.githubusercontent.com/355079/65048736-7edad500-d95c-11e9-9c7c-9101dcca7bc7.png)


# After 

![image](https://user-images.githubusercontent.com/355079/65048102-7f26a080-d95b-11e9-905a-0d38d290185a.png)

![image](https://user-images.githubusercontent.com/355079/65048073-6e762a80-d95b-11e9-89a8-5a2319dabf07.png)

***

1. Based on a 2.2GHz quad-core Intel Core i7 processor on a 2015 MacBook Pro