### PR TITLE
Add 'Printed' status for letters and update postage information

### DIFF
--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -25,7 +25,7 @@
   <h3 class="heading-small">Choose your postage</h3>
   <p>Notify can send letters by first or second class post.</p>
   <p>First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched.</p>
-  <p>Letters sent before 5:30pm are dispatched the next working day (Monday to Friday). Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
+  <p>Letters are printed at 5.30pm and dispatched the next working day (Monday to Friday). Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
 
   <h3 class="heading heading-small">Upload your own letters</h3>
   <p>You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -81,7 +81,7 @@
     ) %}
       {% for message_length, charge in [
         ('Sent', 'Notify has sent the letter to the provider to be printed.'),
-        ('Printed', 'The provider has printed the letter. Letters are printed at 5:30pm and dispatched the next working day.'), 
+        ('Printed', 'The provider has printed the letter. Printing starts at 5:30pm and letters are dispatched the next working day.'), 
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
         ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
       ] %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -81,6 +81,7 @@
     ) %}
       {% for message_length, charge in [
         ('Sent', 'Notify has sent the letter to the provider to be printed.'),
+        ('Printed', 'The provider has printed the letter. Letters are printed at 5:30pm and dispatched the next working day.'), 
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
         ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
       ] %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -81,7 +81,7 @@
     ) %}
       {% for message_length, charge in [
         ('Sent', 'Notify has sent the letter to the provider to be printed.'),
-        ('Printed', 'The provider has printed the letter. Letters printed at 5:30pm are dispatched the next working day.'), 
+        ('Printed', 'The provider has printed the letter. Letters are printed at 5.30pm and dispatched the next working day.'), 
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
         ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
       ] %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -81,7 +81,7 @@
     ) %}
       {% for message_length, charge in [
         ('Sent', 'Notify has sent the letter to the provider to be printed.'),
-        ('Printed', 'The provider has printed the letter. Printing starts at 5:30pm and letters are dispatched the next working day.'), 
+        ('Printed', 'The provider has printed the letter. Letters printed at 5:30pm are dispatched the next working day.'), 
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
         ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
       ] %}


### PR DESCRIPTION
This PR:

- updates the postage information on the Features page
- adds a description of the 'Printed' status for letters on the Message statuses page

These small changes should make it easier for users to understand what happens when they send a letter.