### PR TITLE
Get notification count from api instead of getting list of notifications from api

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -176,10 +176,10 @@ def cancel_job(service_id, job_id):
 def cancel_letter_job(service_id, job_id):
     if request.method == 'POST':
         job = job_api_client.get_job(service_id, job_id)['data']
-        notifications = notification_api_client.get_notifications_for_service(
-            job['service'], job['id']
-        )['notifications']
-        if job['job_status'] != 'finished' or len(notifications) < job['notification_count']:
+        notification_count = notification_api_client.get_notification_count_for_job_id(
+            service_id=service_id, job_id=job_id
+        )
+        if job['job_status'] != 'finished' or notification_count < job['notification_count']:
             flash("We are still processing these letters, please try again in a minute.", 'try again')
             return view_job(service_id, job_id)
         try:

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -127,5 +127,8 @@ class NotificationApiClient(NotifyAdminAPIClient):
             }
         )
 
+    def get_notification_count_for_job_id(self, *, service_id, job_id):
+        return self.get(url='/service/{}/job/{}/notification_count'.format(service_id, job_id))["count"]
+
 
 notification_api_client = NotificationApiClient()

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -504,10 +504,8 @@ def test_should_cancel_letter_job(
     mocker.patch('app.job_api_client.get_job', side_effect=[{"data": job}])
     notifications_json = notification_json(SERVICE_ONE_ID, job=job, status="created", template_type="letter")
     mocker.patch('app.job_api_client.get_job', side_effect=[{"data": job}])
-    mocker.patch(
-        'app.notification_api_client.get_notifications_for_service',
-        side_effect=[notifications_json]
-    )
+    mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications_json)
+    mocker.patch('app.notification_api_client.get_notification_count_for_job_id', return_value=5)
     mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_letter_job', return_value=5)
     client_request.post(
         'main.cancel_letter_job',
@@ -623,9 +621,9 @@ def test_dont_cancel_letter_job_when_to_early_to_cancel(
     notifications_json = notification_json(
         SERVICE_ONE_ID, job=job, status="created", template_type="letter", rows=number_of_processed_notifications
     )
+    mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications_json)
     mocker.patch(
-        'app.notification_api_client.get_notifications_for_service',
-        side_effect=[notifications_json, notifications_json]
+        'app.notification_api_client.get_notification_count_for_job_id', return_value=number_of_processed_notifications
     )
 
     mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_letter_job')

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -118,3 +118,11 @@ def test_update_notification_to_cancelled(mocker):
         url='/service/foo/notifications/bar/cancel',
         data={},
     )
+
+
+def test_get_notification_count_for_job_id(mocker):
+    mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
+    NotificationApiClient().get_notification_count_for_job_id(service_id='foo', job_id='bar')
+    mock_get.assert_called_once_with(
+        url='/service/foo/job/bar/notification_count',
+    )


### PR DESCRIPTION
Get notification count from api instead of getting list of notifications from api when checking if job can be cancelled.

This makes query lighter, less likely to fall over if job is large and removes pagination bug (where only first page of notifications is returned form API and when job is large, this makes it impossible to cancel as the count from job.notification_count does not match).

API part: https://github.com/alphagov/notifications-api/pull/2617
Bug: https://www.pivotaltracker.com/story/show/168734905