### PR TITLE
Use relative dates for jobs on dashboard

### DIFF
--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -20,7 +20,7 @@
         <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
         <span class="file-list-hint">
           Sent {{
-            item.scheduled_for|format_datetime_short if item.scheduled_for else item.created_at|format_datetime_short
+            (item.scheduled_for if item.scheduled_for else item.created_at)|format_datetime_relative
           }}
         </span>
       </div>

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -774,7 +774,7 @@ def test_should_show_recent_jobs_on_dashboard(
             "thisisatest.csv",
     )):
         assert filename in table_rows[index].find_all('th')[0].text
-        assert 'Sent 1 January at 11:09' in table_rows[index].find_all('th')[0].text
+        assert 'Sent today at 11:09' in table_rows[index].find_all('th')[0].text
         for column_index, count in enumerate((1, 0, 0)):
             assert table_rows[index].find_all('td')[column_index].text.strip() == str(count)
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -24,19 +24,19 @@ from tests.conftest import (
         ),
         (
             'export 1/1/2016.xls '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'all email addresses.xlsx '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'applicants.ods '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'thisisatest.csv '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
     )),
     (active_caseworking_user, (
@@ -56,19 +56,19 @@ from tests.conftest import (
         ),
         (
             'export 1/1/2016.xls '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'all email addresses.xlsx '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'applicants.ods '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'thisisatest.csv '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
     )),
 ])
@@ -129,19 +129,19 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
         ),
         (
             'export 1/1/2016.xls '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'all email addresses.xlsx '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'applicants.ods '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
         (
             'thisisatest.csv '
-            'Sent 12 December at 12:12pm 1 0 0'
+            'Sent today at 12:12pm 1 0 0'
         ),
     )):
         assert normalize_spaces(page.select('tr')[index].text) == row


### PR DESCRIPTION
For scheduled files we say ‘sending today at 5:00pm’ or ‘sending tomorrow at 11:00am’. But once we’ve started processing these files we say ‘Sent 27 September at 5:00pm’. This makes it sound like 27 September is not today.

This commit makes the dates shown on the dashboard consistent, by saying ‘today’ and ‘yesterday’ instead of absolute dates.