### PR TITLE
Update the errors seen when uploading a letter

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1111,8 +1111,8 @@ class PDFUploadForm(StripWhitespaceForm):
     file = FileField_wtf(
         'Upload a letter in PDF format',
         validators=[
-            FileAllowed(['pdf'], 'Letters must be saved as a PDF'),
-            DataRequired(message="You need to upload a file to submit")
+            FileAllowed(['pdf'], 'Save your letter as a PDF and try again.'),
+            DataRequired(message="You need to choose a file to upload")
         ]
     )
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -181,7 +181,7 @@ def view_letter_upload_as_preview(service_id, file_id):
 
     page = request.args.get('page')
 
-    if metadata['status'] == 'invalid':
+    if metadata.get('message') == 'content-outside-printable-area':
         return TemplatePreview.from_invalid_pdf_file(pdf_file, page)
     else:
         return TemplatePreview.from_valid_pdf_file(pdf_file, page)

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -1,3 +1,5 @@
+import json
+
 from boto3 import resource
 from flask import current_app
 from notifications_utils.s3 import s3upload as utils_s3upload
@@ -7,17 +9,23 @@ def get_transient_letter_file_location(service_id, upload_id):
     return 'service-{}/{}.pdf'.format(service_id, upload_id)
 
 
-def upload_letter_to_s3(data, *, file_location, status, page_count, filename):
+def upload_letter_to_s3(data, *, file_location, status, page_count, filename, message=None, invalid_pages=None):
+    metadata = {
+        'status': status,
+        'page_count': str(page_count),
+        'filename': filename,
+    }
+    if message:
+        metadata['message'] = message
+    if invalid_pages:
+        metadata['invalid_pages'] = json.dumps(invalid_pages)
+
     utils_s3upload(
         filedata=data,
         region=current_app.config['AWS_REGION'],
         bucket_name=current_app.config['TRANSIENT_UPLOADED_LETTERS'],
         file_location=file_location,
-        metadata={
-            'status': status,
-            'page_count': str(page_count),
-            'filename': filename,
-        }
+        metadata=metadata,
     )
 
 

--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -4,10 +4,11 @@
   button_text="Choose file",
   alternate_link=None,
   alternate_link_text=None,
-  hint=None
+  hint=None,
+  show_errors=True
 
 ) %}
-  <form method="post" enctype="multipart/form-data" {% if action %}action="{{ action }}"{% endif %} class="{% if field.errors %}form-group-error{% endif %}" data-module="file-upload">
+  <form method="post" enctype="multipart/form-data" {% if action %}action="{{ action }}"{% endif %} class="{% if field.errors and show_errors %}form-group-error{% endif %}" data-module="file-upload">
     <label class="file-upload-label" for="{{ field.name }}">
       <span class="visually-hidden">{{ field.label.text }}</span>
       {% if hint %}
@@ -15,7 +16,7 @@
           {{ hint }}
         </span>
       {% endif %}
-      {% if field.errors %}
+      {% if field.errors and show_errors %}
         <span class="error-message">
           {{ field.errors[0] }}
         </span>

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -29,7 +29,7 @@
 
   <h3 class="heading heading-small">Upload your own letters</h3>
   <p>You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>
-  <p>Use the <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf">letter specification document</a> to help you set up your letter, save it as a PDF, then upload it to Notify.<p>
+  <p>Use the <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf">letter specification document</a> to help you set up your letter, save it as a PDF, then upload it to Notify.<p>
   <p>Read our <a href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>

--- a/app/templates/views/letter-validation-preview.html
+++ b/app/templates/views/letter-validation-preview.html
@@ -37,7 +37,7 @@
         </p>
         <p>The content of your letter must appear inside the printable area.</p>
         <p>
-        <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf">
+        <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf">
             Download the letter specification</a> for more information.
         </p>
         </div>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -21,7 +21,7 @@
     )}}
   </p>
   <p>You can upload a single letter as a PDF.</p>
-  <p>Your file must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf">letter specification</a>.</p>
+  <p>Your file must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf">letter specification</a>.</p>
 
   </div>
 </div>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/banner.html" import banner_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
 
@@ -9,15 +10,26 @@
 {% block maincolumn_content %}
 <div class="grid-row">
   <div class="column-five-sixths">
-    {{ page_header(
+    {% if error %}
+      {% call banner_wrapper(type='dangerous') %}
+        <h1 class="banner-title">{{ error.title }}</h1>
+        {% if error.detail %}
+          <p>{{ error.detail | safe }}</p>
+        {% endif %}
+      {% endcall %}
+    {% else %}
+      {{ page_header(
         'Upload a letter',
         back_link=url_for('main.uploads', service_id=current_service.id)
     ) }}
+    {% endif %}
 
   <p>
     {{ file_upload(
       form.file,
-      action = url_for('main.upload_letter', service_id=current_service.id),
+      action=url_for('main.upload_letter', service_id=current_service.id),
+      button_text='Upload your file again' if error else 'Choose file',
+      show_errors=False
     )}}
   </p>
   <p>You can upload a single letter as a PDF.</p>

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 
 {% block service_page_title %}
@@ -6,16 +7,19 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-    {{ page_header(
+  {% if status == 'invalid' and error %}
+    {% call banner_wrapper(type='dangerous') %}
+      <h1 class="banner-title">{{ error.title }}</h1>
+      {% if error.detail %}
+        <p>{{ error.detail | safe }}</p>
+      {% endif %}
+    {% endcall %}
+  {% else %}
+      {{ page_header(
         original_filename,
         back_link=url_for('main.upload_letter', service_id=current_service.id)
-    ) }}
-
-    {% if status == 'invalid' %}
-    <p class="notification-status-cancelled" id="validation-error-message">
-      Validation failed
-    </p>
-    {% endif %}
+      ) }}
+  {% endif %}
 
     <div class="letter-sent">
       {{ template|string }}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -789,7 +789,7 @@ def test_letter_validation_preview_doesnt_call_template_preview_when_no_file(moc
     validate_letter.assert_not_called()
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.find('span', class_='error-message').text.strip() == "You need to upload a file to submit"
+    assert page.find('span', class_='error-message').text.strip() == "You need to choose a file to upload"
 
 
 def test_letter_validation_preview_doesnt_call_template_preview_when_file_not_pdf(mocker, platform_admin_client):
@@ -805,7 +805,7 @@ def test_letter_validation_preview_doesnt_call_template_preview_when_file_not_pd
     antivirus_scan.assert_not_called()
     validate_letter.assert_not_called()
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.find('span', class_='error-message').text.strip() == "Letters must be saved as a PDF"
+    assert page.find('span', class_='error-message').text.strip() == "Save your letter as a PDF and try again."
 
 
 def test_letter_validation_preview_doesnt_call_template_preview_when_file_doesnt_pass_virus_scan(

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -23,6 +23,7 @@ def test_get_upload_letter(client_request):
     assert page.find('h1').text == 'Upload a letter'
     assert page.find('input', class_='file-upload-field')
     assert page.select('button[type=submit]')
+    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Choose file'
 
 
 def test_post_upload_letter_redirects_for_valid_file(mocker, client_request):
@@ -88,6 +89,7 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(mocker, client_r
             _follow_redirects=True,
         )
 
+    assert page.find('h1').text == 'tests/test_pdf_files/one_page_pdf.pdf'
     assert len(page.select('.letter-postage')) == 1
     assert normalize_spaces(page.select_one('.letter-postage').text) == ('Postage: second class')
     assert page.select_one('.letter-postage')['class'] == ['letter-postage', 'letter-postage-second']
@@ -111,7 +113,9 @@ def test_post_upload_letter_shows_error_when_file_is_not_a_pdf(client_request):
             _data={'file': file},
             _expected_status=200
         )
-    assert page.find('span', class_='error-message').text.strip() == "Letters must be saved as a PDF"
+    assert page.find('h1').text == 'Wrong file type'
+    assert page.find('div', class_='banner-dangerous').find('p').text == 'Save your letter as a PDF and try again.'
+    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
 
 
 def test_post_upload_letter_shows_error_when_no_file_uploaded(client_request):
@@ -121,7 +125,8 @@ def test_post_upload_letter_shows_error_when_no_file_uploaded(client_request):
         _data={'file': ''},
         _expected_status=200
     )
-    assert page.find('span', class_='error-message').text.strip() == "You need to upload a file to submit"
+    assert page.find('div', class_='banner-dangerous').find('h1').text == 'You need to choose a file to upload'
+    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
 
 
 def test_post_upload_letter_shows_error_when_file_contains_virus(mocker, client_request):
@@ -134,8 +139,8 @@ def test_post_upload_letter_shows_error_when_file_contains_virus(mocker, client_
             _data={'file': file},
             _expected_status=400
         )
-    assert page.find('h1').text == 'Upload a letter'
-    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == 'Your file has failed the virus check'
+    assert page.find('div', class_='banner-dangerous').find('h1').text == 'Your file contains a virus'
+    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
 
 
 def test_post_choose_upload_file_when_file_is_too_big(mocker, client_request):
@@ -148,8 +153,9 @@ def test_post_choose_upload_file_when_file_is_too_big(mocker, client_request):
             _data={'file': file},
             _expected_status=400
         )
-    assert page.find('h1').text == 'Upload a letter'
-    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == 'Your file must be smaller than 2MB'
+    assert page.find('div', class_='banner-dangerous').find('h1').text == 'Your file is too big'
+    assert page.find('div', class_='banner-dangerous').find('p').text == 'Files must be smaller than 2MB.'
+    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
 
 
 def test_post_choose_upload_file_when_file_is_malformed(mocker, client_request):
@@ -162,8 +168,11 @@ def test_post_choose_upload_file_when_file_is_malformed(mocker, client_request):
             _data={'file': file},
             _expected_status=400
         )
-    assert page.find('h1').text == 'Upload a letter'
-    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == 'Your file must be a valid PDF'
+    assert page.find('div', class_='banner-dangerous').find('h1').text == "There’s a problem with your file"
+    assert page.find(
+        'div', class_='banner-dangerous'
+    ).find('p').text == 'Notify cannot read this PDF.Save a new copy of your file and try again.'
+    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
 
 
 def test_post_upload_letter_with_invalid_file(mocker, client_request):
@@ -173,10 +182,15 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request):
 
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
+    mock_sanitise_response.json = lambda: {
+        "message": "content-outside-printable-area",
+        "invalid_pages": [1]
+    }
     mocker.patch('app.main.views.uploads.sanitise_letter', return_value=mock_sanitise_response)
     mocker.patch('app.main.views.uploads.service_api_client.get_precompiled_template')
     mocker.patch('app.main.views.uploads.get_letter_metadata', return_value={
-        'filename': 'tests/test_pdf_files/one_page_pdf.pdf', 'page_count': '1', 'status': 'invalid'})
+        'filename': 'tests/test_pdf_files/one_page_pdf.pdf', 'page_count': '1', 'status': 'invalid',
+        'message': 'content-outside-printable-area', 'invalid_pages': '[1]'})
 
     with open('tests/test_pdf_files/one_page_pdf.pdf', 'rb') as file:
         file_contents = file.read()
@@ -194,13 +208,16 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request):
             file_location='service-{}/fake-uuid.pdf'.format(SERVICE_ONE_ID),
             status='invalid',
             page_count=1,
-            filename='tests/test_pdf_files/one_page_pdf.pdf'
+            filename='tests/test_pdf_files/one_page_pdf.pdf',
+            invalid_pages=[1],
+            message='content-outside-printable-area'
         )
 
-    assert page.find('h1').text == 'tests/test_pdf_files/one_page_pdf.pdf'
-    assert normalize_spaces(
-        page.find(id='validation-error-message').text
-    ) == 'Validation failed'
+    assert page.find('div', class_='banner-dangerous').find('h1').text == 'We cannot print your letter'
+    assert page.find(
+        'div', class_='banner-dangerous').find('p').text == (
+        'The content appears outside the printable area on page 1 Files must meet our letter specification.'
+    )
     assert not page.find('button', {'type': 'submit'})
 
 
@@ -216,10 +233,12 @@ def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client
     mocker.patch('app.main.views.uploads.upload_letter_to_s3')
     mock_sanitise_response = Mock()
     mock_sanitise_response.raise_for_status.side_effect = RequestException(response=Mock(status_code=400))
+    mock_sanitise_response.json = lambda: {"message": "template preview error"}
     mocker.patch('app.main.views.uploads.sanitise_letter', return_value=mock_sanitise_response)
     mocker.patch('app.main.views.uploads.service_api_client.get_precompiled_template', return_value=letter_template)
     mocker.patch('app.main.views.uploads.get_letter_metadata', return_value={
-        'filename': 'tests/test_pdf_files/one_page_pdf.pdf', 'page_count': '1', 'status': 'invalid'})
+        'filename': 'tests/test_pdf_files/one_page_pdf.pdf', 'page_count': '1', 'status': 'invalid',
+        'message': 'template-preview-error'})
 
     with open('tests/test_pdf_files/one_page_pdf.pdf', 'rb') as file:
         page = client_request.post(
@@ -274,6 +293,7 @@ def test_uploaded_letter_preview(mocker, client_request):
         original_filename='my_letter.pdf',
         page_count=1,
         status='valid',
+        error={}
     )
 
     assert page.find('h1').text == 'my_letter.pdf'
@@ -334,7 +354,8 @@ def test_send_uploaded_letter_when_metadata_states_pdf_is_invalid(mocker, servic
     mock_send = mocker.patch('app.main.views.uploads.notification_api_client.send_precompiled_letter')
     mocker.patch(
         'app.main.views.uploads.get_letter_metadata',
-        return_value={'filename': 'my_file.pdf', 'page_count': '3', 'status': 'invalid'}
+        return_value={'filename': 'my_file.pdf', 'page_count': '3', 'status': 'invalid',
+                      'message': 'error', 'invalid_pages': '[1]'}
     )
 
     service_one['permissions'] = ['letter', 'upload_letters']

--- a/tests/app/s3_client/test_s3_letter_upload_client.py
+++ b/tests/app/s3_client/test_s3_letter_upload_client.py
@@ -20,3 +20,30 @@ def test_upload_letter_to_s3(mocker):
         metadata={'status': 'valid', 'page_count': '3', 'filename': 'my_doc'},
         region=current_app.config['AWS_REGION']
     )
+
+
+def test_upload_letter_to_s3_with_message_and_invalid_pages(mocker):
+    s3_mock = mocker.patch('app.s3_client.s3_letter_upload_client.utils_s3upload')
+
+    upload_letter_to_s3(
+        'pdf_data',
+        file_location='service_id/upload_id.pdf',
+        status='invalid',
+        page_count=3,
+        filename='my_doc',
+        message='This file failed',
+        invalid_pages=[1, 2, 5])
+
+    s3_mock.assert_called_once_with(
+        bucket_name=current_app.config['TRANSIENT_UPLOADED_LETTERS'],
+        file_location='service_id/upload_id.pdf',
+        filedata='pdf_data',
+        metadata={
+            'status': 'invalid',
+            'page_count': '3',
+            'filename': 'my_doc',
+            'message': 'This file failed',
+            'invalid_pages': '[1, 2, 5]'
+        },
+        region=current_app.config['AWS_REGION']
+    )

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -14,6 +14,7 @@ from app.utils import (
     generate_notifications_csv,
     generate_previous_dict,
     get_letter_printing_statement,
+    get_letter_validation_error,
     get_logo_cdn_domain,
     printing_today_or_tomorrow,
 )
@@ -404,3 +405,25 @@ def test_get_letter_printing_statement_for_letter_that_has_been_sent(created_at,
     statement = get_letter_printing_statement('delivered', created_at)
 
     assert statement == 'Printed {} at 5:30pm'.format(print_day)
+
+
+def test_get_letter_validation_error_for_unknown_error():
+    assert get_letter_validation_error('Unknown error') == {
+        'title': 'Validation failed'
+    }
+
+
+@pytest.mark.parametrize('error_message, expected_title, expected_content', [
+    ('letter-not-a4-portrait-oriented', 'We cannot print your letter', 'A4 portrait size on page 2'),
+    ('content-outside-printable-area', 'We cannot print your letter', 'outside the printable area on page 2'),
+    ('letter-too-long', 'Your letter is too long', 'letter is 13 pages long.')
+])
+def test_get_letter_validation_error_for_known_errors(
+    error_message,
+    expected_title,
+    expected_content,
+):
+    error = get_letter_validation_error(error_message, invalid_pages=[2], page_count=13)
+
+    assert error['title'] == expected_title
+    assert expected_content in error['detail']


### PR DESCRIPTION
The error content has been updated and we now use the pattern of showing a box at the top of the page with the error which has a heading and can have additional details.

Also updated the version of the letter specification everywhere from 2.3 to 2.4.

[Pivotal story](https://www.pivotaltracker.com/story/show/168869338)

## Errors before
<img width="796" alt="Screen Shot 2019-10-04 at 09 37 59" src="https://user-images.githubusercontent.com/12881990/66195987-aedde400-e68f-11e9-87b3-5d88c36f30c0.png">

<img width="630" alt="Screen Shot 2019-10-04 at 09 37 31" src="https://user-images.githubusercontent.com/12881990/66196057-ca48ef00-e68f-11e9-9bfd-38c21bb4a5dd.png">


## Errors after
<img width="716" alt="Screen Shot 2019-10-04 at 09 35 12" src="https://user-images.githubusercontent.com/12881990/66195999-b2716b00-e68f-11e9-8242-950d7590bfb7.png">

<img width="717" alt="Screen Shot 2019-10-04 at 09 35 27" src="https://user-images.githubusercontent.com/12881990/66196082-d8970b00-e68f-11e9-9e20-ac91758debc9.png">

<img width="850" alt="Screen Shot 2019-10-04 at 09 35 41" src="https://user-images.githubusercontent.com/12881990/66196096-dcc32880-e68f-11e9-8963-a82661089c5c.png">