### PR TITLE
Store all data about uploaded letters in the S3 metadata

### DIFF
--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -7,17 +7,22 @@ def get_transient_letter_file_location(service_id, upload_id):
     return 'service-{}/{}.pdf'.format(service_id, upload_id)
 
 
-def upload_letter_to_s3(data, file_location, status):
+def upload_letter_to_s3(data, *, file_location, status, page_count, filename):
     utils_s3upload(
         filedata=data,
         region=current_app.config['AWS_REGION'],
         bucket_name=current_app.config['TRANSIENT_UPLOADED_LETTERS'],
         file_location=file_location,
-        metadata={'status': status}
+        metadata={
+            'status': status,
+            'page_count': str(page_count),
+            'filename': filename,
+        }
     )
 
 
-def get_letter_pdf_and_metadata(file_location):
+def get_letter_pdf_and_metadata(service_id, file_id):
+    file_location = get_transient_letter_file_location(service_id, file_id)
     s3 = resource('s3')
     s3_object = s3.Object(current_app.config['TRANSIENT_UPLOADED_LETTERS'], file_location).get()
 
@@ -25,3 +30,11 @@ def get_letter_pdf_and_metadata(file_location):
     metadata = s3_object['Metadata']
 
     return pdf, metadata
+
+
+def get_letter_metadata(service_id, file_id):
+    file_location = get_transient_letter_file_location(service_id, file_id)
+    s3 = resource('s3')
+    s3_object = s3.Object(current_app.config['TRANSIENT_UPLOADED_LETTERS'], file_location).get()
+
+    return s3_object['Metadata']

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -28,7 +28,6 @@
           service_id=current_service.id,
         )}}" class='page-footer'>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="filename" value="{{ original_filename }}" />
         <input type="hidden" name="file_id" value="{{ file_id }}" />
         <button type="submit" class="button">Send 1 letter</button>
       </form>

--- a/tests/app/s3_client/test_s3_letter_upload_client.py
+++ b/tests/app/s3_client/test_s3_letter_upload_client.py
@@ -6,12 +6,17 @@ from app.s3_client.s3_letter_upload_client import upload_letter_to_s3
 def test_upload_letter_to_s3(mocker):
     s3_mock = mocker.patch('app.s3_client.s3_letter_upload_client.utils_s3upload')
 
-    upload_letter_to_s3('pdf_data', 'service_id/upload_id.pdf', 'valid')
+    upload_letter_to_s3(
+        'pdf_data',
+        file_location='service_id/upload_id.pdf',
+        status='valid',
+        page_count=3,
+        filename='my_doc')
 
     s3_mock.assert_called_once_with(
         bucket_name=current_app.config['TRANSIENT_UPLOADED_LETTERS'],
         file_location='service_id/upload_id.pdf',
         filedata='pdf_data',
-        metadata={'status': 'valid'},
+        metadata={'status': 'valid', 'page_count': '3', 'filename': 'my_doc'},
         region=current_app.config['AWS_REGION']
     )


### PR DESCRIPTION
We had been storing whether or not a file was valid in the S3 metadata, but using the query string of the URL to store the original filename and the page count. This meant that if you tried to view the preview letter page without the query string you would see a `500`. It was possible for this to happen if you were signed out of Notify while on the preview page - you would be redirected back to the preview page but without the query string, causing an error.