### PR TITLE
Add GOVUK Frontend Jinja Flask extension

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from numbers import Number
 from time import monotonic
 
 import ago
+import jinja2
 from flask import (
     current_app,
     flash,
@@ -22,6 +23,7 @@ from flask.globals import _lookup_req_object, _request_ctx_stack
 from flask_login import LoginManager, current_user
 from flask_wtf import CSRFProtect
 from flask_wtf.csrf import CSRFError
+from govuk_frontend_jinja.flask_ext import init_govuk_frontend
 from itsdangerous import BadSignature
 from notifications_python_client.errors import HTTPError
 from notifications_utils import formatters, logging, request_helper
@@ -115,6 +117,9 @@ def create_app(application):
     asset_fingerprinter._asset_root = application.config['ASSET_PATH']
 
     init_app(application)
+
+    init_govuk_frontend(application)
+    init_jinja(application)
 
     for client in (
 
@@ -701,3 +706,13 @@ def add_template_filters(application):
         id_safe,
     ]:
         application.add_template_filter(fn)
+
+
+def init_jinja(application):
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    template_folders = [
+        os.path.join(repo_root, 'app/templates'),
+        os.path.join(repo_root, 'node_modules/govuk-frontend'),
+    ]
+    jinja_loader = jinja2.FileSystemLoader(template_folders)
+    application.jinja_loader = jinja_loader

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/preset-env": "7.4.2",
     "diff-dom": "2.5.1",
     "govuk-elements-sass": "3.1.2",
+    "govuk-frontend": "2.13.0",
     "govuk_frontend_toolkit": "8.1.0",
     "govuk_template_jinja": "0.24.1",
     "gulp": "4.0.0",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,3 +24,4 @@ awscli-cwlogs>=1.4,<1.5
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/notifications-utils.git@34.1.0#egg=notifications-utils==34.1.0
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,13 +26,14 @@ awscli-cwlogs>=1.4,<1.5
 itsdangerous==0.24  # pyup: <1.0.0
 
 git+https://github.com/alphagov/notifications-utils.git@34.1.0#egg=notifications-utils==34.1.0
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.233
+awscli==1.16.251
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.223
-certifi==2019.6.16
+botocore==1.12.241
+certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
@@ -70,9 +71,9 @@ six==1.12.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.2
-urllib3==1.25.3
+urllib3==1.25.6
 webencodings==0.5.1
-Werkzeug==0.15.6
+Werkzeug==0.16.0
 WTForms==2.2.1
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
GOVUK Frontend (the frontend code libraries for the GOV.UK Design System) uses [Nunjucks](https://mozilla.github.io/nunjucks/) for its templating. 
Our app uses Jinja, which Nunjucks is based on but with enough differences that we can't use the originals directly.

The Digital Marketplace team have written a Flask extension for converting the GOVUK Frontend Nunjucks templates into Jinja: https://github.com/alphagov/govuk-frontend-jinja

This adds their extension, which should let us use GOVUK Frontend without any extra work.

Part of https://www.pivotaltracker.com/story/show/161594893

The same change on the Digital Marketplace, for reference:

https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/551

## How do I test this?

Try adding a component from the [GOV.UK Design System components page](https://design-system.service.gov.uk/components/) to a page in the app. It shouldn't be styled, we're only testing the HTML rendering.

I've pushed an example to help: https://design-system.service.gov.uk/components/

You'll need to run `./scripts/bootstrap.sh` to get the Flask extension and `npm install` to get the GOVUK Frontend libraries.