### PR TITLE
Fix email branding request page with only textbox

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1368,8 +1368,8 @@ class BrandingOptionsEmail(StripWhitespaceForm):
     def __init__(self, service, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.options.choices = tuple(self.get_available_choices(service))
-        if not self.something_else_is_only_option:
-            self.options.validators.append(DataRequired())
+        if self.something_else_is_only_option:
+            self.options.data = self.FALLBACK_OPTION_VALUE
 
     @staticmethod
     def get_available_choices(service):

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4657,6 +4657,39 @@ def test_submit_email_branding_request(
     )
 
 
+def test_submit_email_branding_when_something_else_is_only_option(
+    client_request,
+    service_one,
+    mocker,
+    mock_get_service_settings_page_common,
+    mock_get_email_branding,
+):
+    mocker.patch(
+        'app.organisations_client.get_service_organisation',
+        return_value=None,
+    )
+
+    zendesk = mocker.patch(
+        'app.main.views.service_settings.zendesk_client.create_ticket',
+        autospec=True,
+    )
+
+    client_request.post(
+        '.branding_request',
+        service_id=SERVICE_ONE_ID,
+        _data={
+            'something_else': 'Homer Simpson',
+        },
+    )
+
+    assert (
+        'Current branding: GOV.UK\n'
+        'Branding requested: Something else\n'
+        '\n'
+        'Homer Simpson'
+    ) in zendesk.call_args_list[0][1]['message']
+
+
 def test_show_service_data_retention(
         platform_admin_client,
         service_one,


### PR DESCRIPTION
If there aren’t a range of options (normally presented as radio buttons) to show the user on the email branding request page then we just show the textbox. But we were still doing form validation on the radio buttons, even though the user couldn’t see them to click them. This stopped the user from being able to submit the form.

This commit fixes the problem by, in this specific case, pre-ticking the ‘Something else’ radio button.