### PR TITLE
Make text transparent on conditional placeholders

### DIFF
--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -39,7 +39,8 @@
     padding-bottom: $gutter-half;
     z-index: 10;
 
-    .placeholder {
+    .placeholder,
+    .placeholder-conditional {
       color: transparent;
     }
 


### PR DESCRIPTION
Otherwise you have a visible copy of the text underlapping the text in the textbox. Which, when they don’t quite align makes the text look bold. Seems to be more noticeable on some browsers/operating systems than others, but a bug all the same.

# Before

![image](https://user-images.githubusercontent.com/355079/66639461-c7f61000-ec0e-11e9-9aa2-ace47e4cbb7d.png)

# After 

![image](https://user-images.githubusercontent.com/355079/66639521-de03d080-ec0e-11e9-8cf1-8c8610055869.png)


***

Thanks to @edwardhorsford for the bug report.