### PR TITLE
Let textareas resize automatically without having to highlight placeholders

### DIFF
--- a/app/assets/javascripts/enhancedTextbox.js
+++ b/app/assets/javascripts/enhancedTextbox.js
@@ -7,7 +7,7 @@
 
   const tagPattern = /\(\(([^\)\((\?)]+)(\?\?)?([^\)\(]*)\)\)/g;
 
-  Modules.HighlightTags = function() {
+  Modules.EnhancedTextbox = function() {
 
     this.start = function(textarea) {
 

--- a/app/assets/javascripts/highlightTags.js
+++ b/app/assets/javascripts/highlightTags.js
@@ -11,6 +11,13 @@
 
     this.start = function(textarea) {
 
+      let visibleTextbox;
+
+      this.highlightPlaceholders = (
+        typeof textarea.data('highlightPlaceholders') === 'undefined' ||
+        !!textarea.data('highlightPlaceholders')
+      );
+
       this.$textbox = $(textarea)
         .wrap(`
           <div class='textbox-highlight-wrapper' />
@@ -20,12 +27,18 @@
         `))
         .on("input", this.update);
 
-      this.initialHeight = this.$textbox.height();
+      visibleTextbox = this.$textbox.clone().appendTo("body").css({
+        position: 'absolute',
+        visibility: 'hidden',
+        display: 'block'
+      });
+      this.initialHeight = visibleTextbox.height();
 
       this.$background.css({
-        'width': this.$textbox.outerWidth(),
         'border-width': this.$textbox.css('border-width')
       });
+
+      visibleTextbox.remove();
 
       this.$textbox
         .trigger("input");
@@ -33,6 +46,8 @@
     };
 
     this.resize = () => {
+
+      this.$background.width(this.$textbox.outerWidth());
 
       this.$textbox.height(
         Math.max(
@@ -47,17 +62,23 @@
 
     };
 
-    this.escapedMessage = () => $('<div/>').text(this.$textbox.val()).html();
+    this.contentEscaped = () => $('<div/>').text(this.$textbox.val()).html();
 
-    this.replacePlaceholders = () => this.$background.html(
-      this.escapedMessage().replace(
-        tagPattern, (match, name, separator, value) => value && separator ?
-          `<span class='placeholder-conditional'>((${name}??</span>${value}))` :
-          `<span class='placeholder'>((${name}${value}))</span>`
-      )
+    this.contentReplaced = () => this.contentEscaped().replace(
+      tagPattern, (match, name, separator, value) => value && separator ?
+        `<span class='placeholder-conditional'>((${name}??</span>${value}))` :
+        `<span class='placeholder'>((${name}${value}))</span>`
     );
 
-    this.update = () => this.replacePlaceholders() && this.resize();
+    this.update = () => {
+
+      this.$background.html(
+        this.highlightPlaceholders ? this.contentReplaced() : this.contentEscaped()
+      );
+
+      this.resize();
+
+    };
 
   };
 

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -4,6 +4,7 @@
   hint=False,
   highlight_tags=False,
   autofocus=False,
+  autosize=False,
   colour_preview=False,
   help_link=None,
   help_link_text=None,
@@ -47,7 +48,8 @@
     %}
     {{ field(
       class=field_class,
-      data_module='highlight-tags' if highlight_tags else '',
+      data_module='highlight-tags' if highlight_tags or autosize else '',
+      data_highlight_placeholders='true' if highlight_tags else 'false',
       rows=rows|string,
       **kwargs
     ) }}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -2,7 +2,7 @@
   field,
   label=None,
   hint=False,
-  highlight_tags=False,
+  highlight_placeholders=False,
   autofocus=False,
   autosize=False,
   colour_preview=False,
@@ -35,7 +35,7 @@
       {% endif %}
     </label>
     {%
-      if highlight_tags
+      if highlight_placeholders or autosize
     %}
       {% set field_class = 'form-control-{} textbox-highlight-textbox'.format(width) %}
     {% else %}
@@ -48,8 +48,8 @@
     %}
     {{ field(
       class=field_class,
-      data_module='highlight-tags' if highlight_tags or autosize else '',
-      data_highlight_placeholders='true' if highlight_tags else 'false',
+      data_module='enhanced-textbox' if highlight_placeholders or autosize else '',
+      data_highlight_placeholders='true' if highlight_placeholders else 'false',
       rows=rows|string,
       **kwargs
     ) }}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -20,8 +20,8 @@
       <div class="grid-row">
         <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this', rows=10) }}
-          {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
-          {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
+          {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
+          {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
           {% if current_user.platform_admin %}
              {{ radios(form.process_type) }}
           {% endif %}

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -20,8 +20,8 @@
       <div class="grid-row">
         <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this', rows=10) }}
-          {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
-          {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
+          {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
+          {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
           {{ sticky_page_footer(
             'Save'
           ) }}

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -22,7 +22,7 @@
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this') }}
         </div>
         <div class="column-two-thirds">
-          {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=5) }}
+          {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=5) }}
           {% if current_user.platform_admin %}
             {{ radios(form.process_type) }}
           {% endif %}

--- a/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
@@ -21,7 +21,7 @@
         belonging to this organisation requests to go live.
       </p>
       {% call form_wrapper() %}
-        {{ textbox(form.request_to_go_live_notes, width='1-1', rows=3) }}
+        {{ textbox(form.request_to_go_live_notes, width='1-1', rows=3, autosize=True) }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/platform-admin/returned-letters.html
+++ b/app/templates/views/platform-admin/returned-letters.html
@@ -13,7 +13,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large">Submit returned letters</h1>
     {% call form_wrapper() %}
-      {{ textbox(form.references, width='1-1', rows=8) }}
+      {{ textbox(form.references, width='1-1', rows=8, autosize=True) }}
       {{ page_footer("Submit") }}
     {% endcall %}
   </div>

--- a/app/templates/views/service-settings/branding/email-options.html
+++ b/app/templates/views/service-settings/branding/email-options.html
@@ -45,6 +45,7 @@
           form.something_else,
           hint='Include links to your brand guidelines or examples of how to use your branding',
           width='1-1',
+          autosize=True,
         ) }}
       {% endcall %}
     {% endif %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -24,7 +24,7 @@
             hint='10 lines maximum',
             width='1-2',
             rows=10,
-            highlight_tags=True
+            highlight_placeholders=True
           ) }}
         {% if not first_contact_block %}
           <div class="form-group">

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -22,7 +22,7 @@
       hint='10 lines maximum',
       width='1-2',
       rows=10,
-      highlight_tags=True
+      highlight_placeholders=True
     ) }}
 
 

--- a/app/templates/views/service-settings/set-letter-contact-block.html
+++ b/app/templates/views/service-settings/set-letter-contact-block.html
@@ -22,7 +22,7 @@
         hint='10 lines maximum',
         width='1-1',
         rows=10,
-        highlight_tags=True
+        highlight_placeholders=True
       ) }}
       {{ page_footer('Save') }}
     {% endcall %}

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -181,7 +181,7 @@
   <h2 class="heading-large">Textbox</h2>
   {{ textbox(form.username) }}
   {{ textbox(form.password) }}
-  {{ textbox(form.message, highlight_tags=True) }}
+  {{ textbox(form.message, highlight_placeholders=True) }}
   {{ textbox(form.code, width='1-8') }}
 
   <h2 class="heading-large">File upload</h2>

--- a/app/templates/views/support/ask-question-give-feedback.html
+++ b/app/templates/views/support/ask-question-give-feedback.html
@@ -17,7 +17,7 @@
     <div class="grid-row">
       <div class="column-two-thirds">
         {% call form_wrapper() %}
-            {{ textbox(form.feedback, width='1-1', hint='', rows=10) }}
+            {{ textbox(form.feedback, width='1-1', hint='', rows=10, autosize=True) }}
             {% if not current_user.is_authenticated %}
               <h3 class="heading-medium">Do you want a reply?</h3>
               <p>Leave your details below if you’d like a response.</p>

--- a/app/templates/views/support/report-problem.html
+++ b/app/templates/views/support/report-problem.html
@@ -24,7 +24,7 @@
           </p>
         </div>
         {% call form_wrapper() %}
-            {{ textbox(form.feedback, width='1-1', hint='', rows=10) }}
+            {{ textbox(form.feedback, width='1-1', hint='', rows=10, autosize=True) }}
             {% if not current_user.is_authenticated %}
               {{ textbox(form.name, width='1-1') }}
               {{ textbox(form.email_address, width='1-1') }}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ const javascripts = () => {
       paths.src + 'javascripts/detailsPolyfill.js',
       paths.src + 'javascripts/apiKey.js',
       paths.src + 'javascripts/autofocus.js',
-      paths.src + 'javascripts/highlightTags.js',
+      paths.src + 'javascripts/enhancedTextbox.js',
       paths.src + 'javascripts/fileUpload.js',
       paths.src + 'javascripts/radioSelect.js',
       paths.src + 'javascripts/updateContent.js',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "test": "gulp lint && jest --config tests/javascripts/jest.config.js tests/javascripts",
+    "test-watch": "jest --watch --config tests/javascripts/jest.config.js tests/javascripts",
     "build": "gulp",
     "watch": "gulp watch"
   },

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -346,6 +346,8 @@ def test_should_show_page_for_one_template(
     assert "Template &lt;em&gt;content&lt;/em&gt; with &amp; entity" in str(
         page.select_one('textarea')
     )
+    assert page.select_one('textarea')['data-module'] == 'enhanced-textbox'
+    assert page.select_one('textarea')['data-highlight-placeholders'] == 'true'
     assert "priority" not in str(page.select_one('main'))
     mock_get_service_template.assert_called_with(SERVICE_ONE_ID, template_id, None)
 

--- a/tests/javascripts/enhancedTextbox.test.js
+++ b/tests/javascripts/enhancedTextbox.test.js
@@ -1,14 +1,14 @@
 const helpers = require('./support/helpers.js');
 
 beforeAll(() => {
-  require('../../app/assets/javascripts/highlightTags.js');
+  require('../../app/assets/javascripts/enhancedTextbox.js');
 });
 
 afterAll(() => {
   require('./support/teardown.js');
 });
 
-describe('Highlight tags', () => {
+describe('Enhanced textbox', () => {
 
   let input;
   let textarea;
@@ -38,11 +38,11 @@ describe('Highlight tags', () => {
     document.body.innerHTML = `
       <div class="form-group">
         <label for="subject">Subject</label>
-        <input class="form-control textbox-highlight-textbox" data-module="highlight-tags" type="text" name="subject" id="subject" />
+        <input class="form-control textbox-highlight-textbox" data-module="enhanced-textbox" type="text" name="subject" id="subject" />
       </div>
       <div class="form-group">
         <label for="template_content">Message</label>
-        <textarea class="form-control form-control-1-1 textbox-highlight-textbox" data-module="highlight-tags" id="template_content" name="template_content" rows="8">
+        <textarea class="form-control form-control-1-1 textbox-highlight-textbox" data-module="enhanced-textbox" id="template_content" name="template_content" rows="8">
         </textarea>
       </div>`;
 

--- a/tests/javascripts/highlightTags.test.js
+++ b/tests/javascripts/highlightTags.test.js
@@ -125,6 +125,34 @@ describe('Highlight tags', () => {
 
     });
 
+    describe("The element's width should match even when the textbox is initially hidden", () => {
+
+      beforeEach(() => {
+
+        let setDisplayPropertyOfFormGroups = function(property) {
+          Array.prototype.forEach.call(
+            document.getElementsByClassName('form-group'),
+            element => element.style.display = property
+          );
+        };
+
+        setDisplayPropertyOfFormGroups('none');
+
+        window.GOVUK.modules.start();
+
+        setDisplayPropertyOfFormGroups('block');
+
+      });
+
+      test("If the textbox is an <textarea>", () => {
+
+        backgroundEl = textarea.nextElementSibling;
+        expect(backgroundEl.style.width).toEqual('582px');
+
+      });
+
+    });
+
     test("The element should be hidden from assistive technologies", () => {
 
       expect(backgroundEl.getAttribute('aria-hidden')).toEqual('true');
@@ -164,6 +192,22 @@ describe('Highlight tags', () => {
         expect(highlightTags.length).toEqual(2);
         expect(highlightTags[0].textContent).toEqual('((title))');
         expect(highlightTags[1].textContent).toEqual('((name))');
+
+      });
+
+      test("Unless a data attribute is set to turn this feature off", () => {
+
+        textarea.textContent  = "Dear ((title)) ((name))";
+        textarea.setAttribute('data-highlight-placeholders', 'false')
+
+        // start module
+        window.GOVUK.modules.start();
+
+        backgroundEl = textarea.nextElementSibling;
+
+        const highlightTags = backgroundEl.querySelectorAll('.placeholder');
+
+        expect(highlightTags.length).toEqual(0);
 
       });
 


### PR DESCRIPTION
Scrolling within `<textarea>`s on the page is a bit grim. Which is why we don’t do it for the textboxes that people use to edit templates.

This pull request extends the auto-resizing of `<textarea>`s to those which don’t need the highlighting of placeholders.

***

![awanp](https://user-images.githubusercontent.com/355079/67001939-b7dca580-f0d2-11e9-94fc-eb6b07a0df44.gif)

***

![image](https://user-images.githubusercontent.com/355079/67003352-a0eb8280-f0d5-11e9-9f1a-81e57129ccd7.png)
