### PR TITLE
Send precompiled letters with a postage value to the API

### DIFF
--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -63,6 +63,7 @@ class NotificationApiClient(NotifyAdminAPIClient):
         data = {
             'filename': filename,
             'file_id': file_id,
+            'postage': 'second',
         }
         data = _attach_current_user(data)
         return self.post(url='/service/{}/send-pdf-letter'.format(service_id), data=data)

--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -71,7 +71,8 @@ def test_send_precompiled_letter(mocker, logged_in_client, active_user_with_perm
         data={
             'filename': 'my_file.pdf',
             'file_id': 'file-ID',
-            'created_by': active_user_with_permissions['id']
+            'created_by': active_user_with_permissions['id'],
+            'postage': 'second',
         }
     )
 


### PR DESCRIPTION
We hardcode this as second class for the moment but eventually
will let the user pick.

Currently the API appears to do no validation, e.g. a json
schema, that rejects API calls with the extra key for postage.

Next steps will be to put a PR into the API that will expect a
postage value in the request and save it with the rest of the
notification. Then when that is done we can add the user interface
to the admin app to let the user pick the postage.

See https://github.com/alphagov/notifications-admin/pull/3144#issuecomment-541758150 for further details.