### PR TITLE
Stop allowing uploaded letters to be sent for trial mode services

### DIFF
--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -14,6 +14,14 @@
         <p>{{ error.detail | safe }}</p>
       {% endif %}
     {% endcall %}
+  {% elif current_service.trial_mode %}
+    {% call banner_wrapper(type='dangerous') %}
+      {% with
+        count_of_recipients=1
+      %}
+        {% include "partials/check/trying-to-send-letters-in-trial-mode.html" %}
+      {% endwith %}
+    {% endcall %}
   {% else %}
       {{ page_header(
         original_filename,
@@ -25,7 +33,7 @@
       {{ template|string }}
     </div>
 
-    {% if status == 'valid' %}
+    {% if status == 'valid' and current_service.live %}
     <div class="js-stick-at-bottom-when-scrolling">
       <form method="post" enctype="multipart/form-data" action="{{url_for(
           'main.send_uploaded_letter',


### PR DESCRIPTION
We weren't checking if a service was in trial mode when they try to send
an uploaded file. If a service is in trial mode, we now show a banner at
the top of the preview page and no send button.