### PR TITLE
move rest api docs to new url

### DIFF
--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -25,6 +25,6 @@
     <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
   <h2 class="heading-medium">Integrate directly with the API</h2>
     <p>If you cannot use the client libraries, you can integrate directly with the API instead.</p>
-<p>Read the <a href="https://docs.notifications.service.gov.uk/api_doc_template.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
+<p>Read the <a href="https://docs.notifications.service.gov.uk/rest-api.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
 
 {% endblock %}


### PR DESCRIPTION
(requires https://github.com/alphagov/notifications-tech-docs/pull/93 first)