### PR TITLE
Put usage summary back on the dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -299,7 +299,14 @@ def get_dashboard_partials(service_id):
         )
         for key, value in dashboard_totals[0].items()
     )
-
+    free_sms_allowance = billing_api_client.get_free_sms_fragment_limit_for_year(
+        current_service.id,
+        get_current_financial_year(),
+    )
+    yearly_usage = billing_api_client.get_service_usage(
+        service_id,
+        get_current_financial_year(),
+    )
     return {
         'upcoming': render_template(
             'views/dashboard/_upcoming.html',
@@ -332,7 +339,12 @@ def get_dashboard_partials(service_id):
             'views/dashboard/_jobs.html',
             jobs=immediate_jobs
         ),
-        'has_jobs': bool(immediate_jobs)
+        'has_jobs': bool(immediate_jobs),
+        'usage': render_template(
+            'views/dashboard/_usage.html',
+            column_width=column_width,
+            **calculate_usage(yearly_usage, free_sms_allowance),
+        ),
     }
 
 

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,16 +1,16 @@
 {% from "components/big-number.html" import big_number %}
 
 <div class='grid-row ajax-block-container'>
-  <div class='column-half'>
+  <div class='{{ column_width }}'>
     <div class="keyline-block">
       {{ big_number("Unlimited", 'free email allowance', smaller=True) }}
     </div>
   </div>
-  <div class='column-half'>
+  <div class='{{ column_width }}'>
     <div class="keyline-block">
       {% if sms_chargeable %}
         {{ big_number(
-          total_sms_cost,
+          sms_chargeable * sms_rate,
           'spent on text messages',
           currency="£",
           smaller=True
@@ -18,6 +18,16 @@
       {% else %}
         {{ big_number(sms_allowance_remaining, 'free text messages left', smaller=True) }}
       {% endif %}
+    </div>
+  </div>
+  <div class='{{ column_width }}'>
+    <div class="keyline-block">
+      {{ big_number(
+        letter_cost,
+        'spent on letters',
+        currency="£",
+        smaller=True
+      ) }}
     </div>
   </div>
 </div>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -43,6 +43,15 @@
       ) }}
     {% endif %}
 
+    {% if current_user.has_permissions('manage_service') %}
+      <h2 class='heading-medium'>This year</h2>
+      {{ ajax_block(partials, updates_url, 'usage') }}
+      {{ show_more(
+        url_for(".usage", service_id=current_service['id']),
+        'See usage'
+      ) }}
+    {% endif %}
+
   </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -148,6 +148,8 @@ def test_accepting_invite_removes_invite_from_session(
     mock_get_service_statistics,
     mock_get_template_folders,
     mock_get_usage,
+    mock_get_billable_units,
+    mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     fake_uuid,
     user,
@@ -471,6 +473,7 @@ def test_new_invited_user_verifies_and_added_to_service(
     mock_get_users_by_service,
     mock_get_service_statistics,
     mock_get_usage,
+    mock_get_free_sms_fragment_limit,
     mock_create_event,
     mocker,
 ):

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -26,6 +26,7 @@ def test_sign_out_user(
     mock_get_template_statistics,
     mock_get_service_statistics,
     mock_get_usage,
+    mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
 ):
     with client_request.session_transaction() as session:


### PR DESCRIPTION
This reverts #1348, which removed the usage from the dashboard because it was causing performance problems:

> **The yearly usage section on the dashboard page takes too log as a result services with large yearly stats are timing out.**
>
> As a short term fix we have taken the yearly stats off the dashboard.
>
> There is a plan to create permanent statistic tables to warehouse the data.

The long term fix (the fact tables) is now in place, so it should be OK to bring this back.

This is part of a wider piece of work to refresh the dashboard page now that jobs are moving to their own page.