### PR TITLE
Don’t show template statistics on dashboard if only one template has been used

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -334,7 +334,6 @@ def get_dashboard_partials(service_id):
                 [row['count'] for row in template_statistics] or [0]
             ),
         ),
-        'has_template_statistics': bool(template_statistics),
         'jobs': render_template(
             'views/dashboard/_jobs.html',
             jobs=immediate_jobs

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -33,13 +33,7 @@
       'See messages sent per month'
     ) }}
 
-    {% if partials['has_template_statistics'] %}
-      {{ ajax_block(partials, updates_url, 'template-statistics', interval=5) }}
-      {{ show_more(
-        url_for('.template_usage', service_id=current_service.id),
-        'See templates used by month'
-      ) }}
-    {% endif %}
+    {{ ajax_block(partials, updates_url, 'template-statistics', interval=5) }}
 
     {% if partials['has_jobs'] %}
       {{ ajax_block(partials, updates_url, 'jobs', interval=5) }}

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -34,18 +34,7 @@
           </span>
           {% endif %}
         {% endcall %}
-        {% if template_statistics|length > 1 %}
-          {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
-        {% else %}
-          {% call field() %}
-            <span id='{{item.template_id}}' class="heading-small">
-              {{ big_number(
-                item.count,
-                smallest=True
-              ) }}
-            </span>
-          {% endcall %}
-        {% endif %}
+        {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
       {% endcall %}
       {{ show_more(
         url_for('.template_usage', service_id=current_service.id),

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -2,46 +2,55 @@
 {% from "components/message-count-label.html" import message_count_label %}
 {% from "components/big-number.html" import big_number %}
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
+{% from "components/show-more.html" import show_more %}
 
-<div class='dashboard-table'>
-  {% call(item, row_number) list_table(
-    template_statistics,
-    caption="Templates used",
-    caption_visible=False,
-    empty_message='',
-    field_headings=[
-      'Template',
-      'Messages sent'
-    ],
-    field_headings_visible=True
-  ) %}
+<div class="ajax-block-container">
+  {% if template_statistics|length > 1 %}
+    <div class='dashboard-table'>
+      {% call(item, row_number) list_table(
+        template_statistics,
+        caption="Templates used",
+        caption_visible=False,
+        empty_message='',
+        field_headings=[
+          'Template',
+          'Messages sent'
+        ],
+        field_headings_visible=True
+      ) %}
 
-    {% call row_heading() %}
-      {% if item.is_precompiled_letter %}
-      <span class="file-list-filename">
-      Provided as PDF
-      </span>
-      <span class="file-list-hint">
-        Letter
-      </span>
-      {% else %}
-      <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
-      <span class="file-list-hint">
-        {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
-      </span>
-      {% endif %}
-    {% endcall %}
-    {% if template_statistics|length > 1 %}
-      {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
-    {% else %}
-      {% call field() %}
-        <span id='{{item.template_id}}' class="heading-small">
-          {{ big_number(
-            item.count,
-            smallest=True
-          ) }}
-        </span>
+        {% call row_heading() %}
+          {% if item.is_precompiled_letter %}
+          <span class="file-list-filename">
+          Provided as PDF
+          </span>
+          <span class="file-list-hint">
+            Letter
+          </span>
+          {% else %}
+          <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
+          <span class="file-list-hint">
+            {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
+          </span>
+          {% endif %}
+        {% endcall %}
+        {% if template_statistics|length > 1 %}
+          {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
+        {% else %}
+          {% call field() %}
+            <span id='{{item.template_id}}' class="heading-small">
+              {{ big_number(
+                item.count,
+                smallest=True
+              ) }}
+            </span>
+          {% endcall %}
+        {% endif %}
       {% endcall %}
-    {% endif %}
-  {% endcall %}
+      {{ show_more(
+        url_for('.template_usage', service_id=current_service.id),
+        'See templates used by month'
+      ) }}
+    </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
If you’ve only used one template then this section of the page isn’t doing its job, which is to show a comparison of the different kinds of message you’re showing.

I think our initial assumption was that everyone would be using multiple templates, so it was good to show this part of the page during the onboarding, to show users where the information was going to appear.

But we have lots of services who only send one template now, typically where they’re populating the contents of the template themselves. In which case this part of the page doesn’t offer them any value.

***

Stops this from happening:

![image](https://user-images.githubusercontent.com/355079/67856413-62f65180-fb0c-11e9-9e86-48e3c61391b9.png)

***

This is part of a wider piece of work to refresh the dashboard page now that jobs are moving to their own page.

***

I recommend reviewing these changes [with `w=1`](https://github.com/alphagov/notifications-admin/pull/3167/files?w=1) for a cleaner diff.