### PR TITLE
Show users why their precompiled letter failed validation

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from flask import abort, flash, redirect, render_template, request, url_for
 from notifications_python_client.errors import HTTPError
+from notifications_utils import LETTER_MAX_PAGE_COUNT
 from requests import RequestException
 
 from app import (
@@ -34,6 +35,7 @@ from app.utils import (
     Spreadsheet,
     generate_next_dict,
     generate_previous_dict,
+    get_letter_validation_error,
     get_page_from_request,
     user_has_permissions,
     user_is_platform_admin,
@@ -425,7 +427,18 @@ def letter_validation_preview(from_platform_admin):
             response = validate_letter(pdf_file)
             response.raise_for_status()
             if response.status_code == 200:
-                pages, message, result = response.json()["pages"], response.json()["message"], response.json()["result"]
+                pages, message = response.json()["pages"], response.json()["message"],
+                passed_validation = response.json()["result"]
+                invalid_pages = response.json().get('invalid_pages')
+                page_count = len(pages)
+                if page_count > LETTER_MAX_PAGE_COUNT:
+                    message = "letter-too-long"
+                    passed_validation = False
+
+                if not passed_validation:
+                    message = get_letter_validation_error(
+                        message, invalid_pages=invalid_pages, page_count=page_count
+                    )
         except RequestException as error:
             if error.response and error.response.status_code == 400:
                 message = "Something was wrong with the file you tried to upload. Please upload a valid PDF file."

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -399,7 +399,7 @@ def service_letter_validation_preview(service_id):
 
 
 def letter_validation_preview(from_platform_admin):
-    message, pages, result = None, [], None
+    message, pages, passed_validation, error_code = None, [], None, None
     form = PDFUploadForm()
 
     view_location = 'views/platform-admin/letter-validation-preview.html' \
@@ -412,7 +412,8 @@ def letter_validation_preview(from_platform_admin):
         if not virus_free:
             return render_template(
                 view_location,
-                form=form, message="Document did not pass the virus scan", pages=pages, result=result
+                form=form, message="Document did not pass the virus scan",
+                pages=pages, passed_validation=passed_validation
             ), 400
 
         try:
@@ -421,7 +422,7 @@ def letter_validation_preview(from_platform_admin):
                     view_location,
                     form=form,
                     message="File must be less than 2MB",
-                    pages=pages, result=result
+                    pages=pages, passed_validation=passed_validation
                 ), 400
             pdf_file.seek(0)
             response = validate_letter(pdf_file)
@@ -436,6 +437,7 @@ def letter_validation_preview(from_platform_admin):
                     passed_validation = False
 
                 if not passed_validation:
+                    error_code = message
                     message = get_letter_validation_error(
                         message, invalid_pages=invalid_pages, page_count=page_count
                     )
@@ -444,14 +446,14 @@ def letter_validation_preview(from_platform_admin):
                 message = "Something was wrong with the file you tried to upload. Please upload a valid PDF file."
                 return render_template(
                     view_location,
-                    form=form, message=message, pages=pages, result=result
+                    form=form, message=message, pages=pages, passed_validation=passed_validation
                 ), 400
             else:
                 raise error
 
     return render_template(
         view_location,
-        form=form, message=message, pages=pages, result=result
+        form=form, message=message, pages=pages, passed_validation=passed_validation, error_code=error_code
     )
 
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -145,13 +145,13 @@ def uploaded_letter_preview(service_id, file_id):
     original_filename = metadata.get('filename')
     page_count = metadata.get('page_count')
     status = metadata.get('status')
-    error_message = metadata.get('message')
+    error_shortcode = metadata.get('message')
     invalid_pages = metadata.get('invalid_pages')
 
     if invalid_pages:
         invalid_pages = json.loads(invalid_pages)
 
-    error = get_letter_validation_error(error_message, invalid_pages, page_count)
+    error_message = get_letter_validation_error(error_shortcode, invalid_pages, page_count)
     template_dict = service_api_client.get_precompiled_template(service_id)
     # Override pre compiled letter template postage to none as it has not yet been picked even though
     # the pre compiled letter template has its postage set as second class as the DB currently requires
@@ -177,7 +177,8 @@ def uploaded_letter_preview(service_id, file_id):
         template=template,
         status=status,
         file_id=file_id,
-        error=error,
+        message=error_message,
+        error_code=error_shortcode,
         form=form,
     )
 

--- a/app/notify_client/notification_api_client.py
+++ b/app/notify_client/notification_api_client.py
@@ -103,17 +103,6 @@ class NotificationApiClient(NotifyAdminAPIClient):
 
         return self.get(url=get_url)
 
-    def get_notification_letter_preview_with_overlay(self, service_id, notification_id, file_type, page=None):
-        get_url = '/service/{}/template/preview/{}/{}{}{}'.format(
-            service_id,
-            notification_id,
-            file_type,
-            '?overlay=1',
-            '&page={}'.format(page) if page else '',
-        )
-
-        return self.get(url=get_url)
-
     def update_notification_to_cancelled(self, service_id, notification_id):
         return self.post(
             url='/service/{}/notifications/{}/cancel'.format(service_id, notification_id),

--- a/app/templates/partials/check/letter-too-long.html
+++ b/app/templates/partials/check/letter-too-long.html
@@ -1,4 +1,4 @@
-<h1 class='banner-title' data-module="track-error" data-error-type="Trying to send a letter that's too long" data-error-label="{{ upload_id }}">
+<h1 class='banner-title' data-module="track-error" data-error-type="Trying to send a letter that's too long" data-error-label="service_id: {{ current_service.id }}">
   Your letter is too long
 </h1>
 <p>

--- a/app/templates/partials/check/letter-too-long.html
+++ b/app/templates/partials/check/letter-too-long.html
@@ -1,4 +1,4 @@
-<h1 class='banner-title' data-module="track-error" data-error-type="Trying to send a letter that's too long" data-error-label="service_id: {{ current_service.id }}">
+<h1 h1 class="banner-title" data-module="track-error" data-error-type="letter-too-long" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
   Your letter is too long
 </h1>
 <p>

--- a/app/templates/partials/check/letter-validation-failed-banner.html
+++ b/app/templates/partials/check/letter-validation-failed-banner.html
@@ -1,0 +1,14 @@
+{% from "components/banner.html" import banner_wrapper %}
+
+{% call banner_wrapper(type='dangerous') %}
+  {% if message is string %}
+    <h1 class="banner-title">{{ message }}</h1>
+  {% else %}
+    <h1 class="banner-title">{{ message.title }}</h1>
+    {% if message.detail %}
+      <p>
+        {{ message.detail | safe }}
+      </p>
+    {% endif %}
+  {% endif %}
+{% endcall %}

--- a/app/templates/partials/check/letter-validation-failed-banner.html
+++ b/app/templates/partials/check/letter-validation-failed-banner.html
@@ -2,9 +2,13 @@
 
 {% call banner_wrapper(type='dangerous') %}
   {% if message is string %}
-    <h1 class="banner-title">{{ message }}</h1>
+    <h1 class="banner-title">
+      {{ message }}
+    </h1>
   {% else %}
-    <h1 class="banner-title">{{ message.title }}</h1>
+    <h1 class="banner-title" data-module="track-error" data-error-type="{{ error_code }}" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
+      {{ message.title }}
+    </h1>
     {% if message.detail %}
       <p>
         {{ message.detail | safe }}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -26,7 +26,7 @@
   ) }}
 
   {% if letter_too_long %}
-    {% call banner_wrapper(type='dangerous', id='letter-too-long') %}
+    {% call banner_wrapper(type='dangerous') %}
         {% include "partials/check/letter-too-long.html" %}
     {% endcall %}
   {% endif %}

--- a/app/templates/views/letter-validation-preview.html
+++ b/app/templates/views/letter-validation-preview.html
@@ -14,10 +14,10 @@
 
 <div class="grid-row">
   <div class="column-whole">
-    {% if result %}
+    {% if passed_validation %}
       {{ banner(message, with_tick=True) }}
     {% elif message %}
-      {{ banner(message, 'dangerous')}}
+      {% include "partials/check/letter-validation-failed-banner.html" %}
     {% endif %}
 
       <h1 class="heading-large">Letter validation preview</h1>

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -53,7 +53,7 @@
     {% set error = 'letter-too-long' %}
     {{ govuk_back_link(back_link) }}
     <div class="bottom-gutter">
-      {% call banner_wrapper(type='dangerous', id='letter-too-long') %}
+      {% call banner_wrapper(type='dangerous') %}
           {% include "partials/check/letter-too-long.html" %}
       {% endcall %}
     </div>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -15,7 +15,6 @@
       message_count_label(1, template.template_type, suffix='') | capitalize,
       back_link=back_link
     ) }}
-
     <p>
       {% if is_precompiled_letter %}
         Provided as PDF
@@ -45,7 +44,7 @@
         </p>
       {% elif notification_status == 'validation-failed' %}
         <p class="notification-status-cancelled">
-          Validation failed – content is outside the printable area
+          Validation failed. {{ message.detail | safe }}
         </p>
       {% elif notification_status == 'technical-failure' %}
         <p class="notification-status-cancelled">

--- a/app/templates/views/platform-admin/letter-validation-preview.html
+++ b/app/templates/views/platform-admin/letter-validation-preview.html
@@ -21,10 +21,10 @@
     )}}
   </div>
   <div class="column-whole template-container">
-    {% if result %}
+    {% if passed_validation %}
       {{ banner(message, with_tick=True) }}
     {% elif message %}
-      {{ banner(message, 'dangerous')}}
+      {% include "partials/check/letter-validation-failed-banner.html" %}
     {% endif %}
 
     {% for page in pages %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -17,7 +17,7 @@
       <div class="grid-row">
         {% if template.template_type == 'letter' %}
         {% if letter_too_long %}
-          {% call banner_wrapper(type='dangerous', id='letter-too-long') %}
+          {% call banner_wrapper(type='dangerous') %}
               {% include "partials/check/letter-too-long.html" %}
           {% endcall %}
         {% endif %}

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -9,13 +9,8 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {% if status == 'invalid' and error %}
-    {% call banner_wrapper(type='dangerous') %}
-      <h1 class="banner-title">{{ error.title }}</h1>
-      {% if error.detail %}
-        <p>{{ error.detail | safe }}</p>
-      {% endif %}
-    {% endcall %}
+  {% if status == 'invalid' and message %}
+    {% include "partials/check/letter-validation-failed-banner.html" %}
   {% elif current_service.trial_mode %}
     {% call banner_wrapper(type='dangerous') %}
       {% with

--- a/app/utils.py
+++ b/app/utils.py
@@ -557,7 +557,7 @@ LETTER_VALIDATION_MESSAGES = {
     },
     'content-outside-printable-area': {
         'title': 'We cannot print your letter',
-        'detail': 'The content appears outside the printable area on {invalid_pages} <br>'
+        'detail': 'The content appears outside the printable area on {invalid_pages}.<br>'
                   'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
                   'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     },

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -748,9 +748,12 @@ def test_letter_validation_preview_renders_correctly(mocker, platform_admin_clie
     assert page.find_all('input', class_='file-upload-field')
 
 
-@pytest.mark.parametrize("result,expected_class", [(True, 'banner-with-tick'), (False, "banner-dangerous")])
+@pytest.mark.parametrize("passed_validation,message,expected_class", [
+    (True, 'Your PDF passed the layout check', 'banner-with-tick'),
+    (False, 'content-otside-printable-area', "banner-dangerous")
+])
 def test_letter_validation_preview_calls_template_preview_when_data_correct_and_displays_correct_message(
-    mocker, platform_admin_client, result, expected_class
+    mocker, platform_admin_client, passed_validation, message, expected_class
 ):
     endpoint = '{}/precompiled/validate?include_preview=true'.format(current_app.config['TEMPLATE_PREVIEW_API_HOST'])
     mocker.patch('app.main.views.platform_admin.antivirus_client.scan', return_value=True)
@@ -759,7 +762,7 @@ def test_letter_validation_preview_calls_template_preview_when_data_correct_and_
         rmock.request(
             "POST",
             endpoint,
-            json={"pages": [], "message": "bazinga!", "result": result},
+            json={"pages": [], "message": message, "result": passed_validation},
             status_code=200
         )
         with open('tests/test_pdf_files/multi_page_pdf.pdf', 'rb') as file:
@@ -773,7 +776,10 @@ def test_letter_validation_preview_calls_template_preview_when_data_correct_and_
         assert rmock.request_history[0].url == endpoint
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.find('div', class_=expected_class).text.strip() == "bazinga!"
+    if passed_validation:
+        assert page.find('div', class_=expected_class).text.strip() == message
+    else:
+        assert page.find('div', class_=expected_class).find('h1', {"data-error-type": message})
 
 
 def test_letter_validation_preview_doesnt_call_template_preview_when_no_file(mocker, platform_admin_client):

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -750,7 +750,7 @@ def test_letter_validation_preview_renders_correctly(mocker, platform_admin_clie
 
 @pytest.mark.parametrize("passed_validation,message,expected_class", [
     (True, 'Your PDF passed the layout check', 'banner-with-tick'),
-    (False, 'content-otside-printable-area', "banner-dangerous")
+    (False, 'content-outside-printable-area', "banner-dangerous")
 ])
 def test_letter_validation_preview_calls_template_preview_when_data_correct_and_displays_correct_message(
     mocker, platform_admin_client, passed_validation, message, expected_class

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2778,8 +2778,7 @@ def test_check_messages_does_not_allow_to_send_letter_longer_than_10_pages(
         upload_id=fake_uuid,
         _test_page_title=False,
     )
-
-    assert page.select('#letter-too-long')
+    assert page.find('h1', {"data-error-type": "Trying to send a letter that's too long"})
 
     assert len(page.select('.letter img')) == 10  # if letter longer than 10 pages, only 10 first pages are displayed
     assert not page.select('[type=submit]')
@@ -3149,7 +3148,7 @@ def test_send_one_off_letter_errors_if_letter_longer_than_10_pages(
         _test_page_title=False,
     )
 
-    assert page.select('#letter-too-long')
+    assert page.find('h1', {"data-error-type": "Trying to send a letter that's too long"})
     assert len(page.select('.letter img')) == 10
 
     assert not page.select('[type=submit]')

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2778,7 +2778,7 @@ def test_check_messages_does_not_allow_to_send_letter_longer_than_10_pages(
         upload_id=fake_uuid,
         _test_page_title=False,
     )
-    assert page.find('h1', {"data-error-type": "Trying to send a letter that's too long"})
+    assert page.find('h1', {"data-error-type": "letter-too-long"})
 
     assert len(page.select('.letter img')) == 10  # if letter longer than 10 pages, only 10 first pages are displayed
     assert not page.select('[type=submit]')
@@ -3148,7 +3148,7 @@ def test_send_one_off_letter_errors_if_letter_longer_than_10_pages(
         _test_page_title=False,
     )
 
-    assert page.find('h1', {"data-error-type": "Trying to send a letter that's too long"})
+    assert page.find('h1', {"data-error-type": "letter-too-long"})
     assert len(page.select('.letter img')) == 10
 
     assert not page.select('[type=submit]')

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -543,7 +543,7 @@ def test_view_letter_template_does_not_display_send_button_if_template_over_10_p
     )
 
     assert "Send" not in page.text
-    assert page.find('h1', {"data-error-type": "Trying to send a letter that's too long"})
+    assert page.find('h1', {"data-error-type": "letter-too-long"})
 
 
 def test_edit_letter_template_postage_page_displays_correctly(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -543,7 +543,7 @@ def test_view_letter_template_does_not_display_send_button_if_template_over_10_p
     )
 
     assert "Send" not in page.text
-    assert page.select('#letter-too-long')
+    assert page.find('h1', {"data-error-type": "Trying to send a letter that's too long"})
 
 
 def test_edit_letter_template_postage_page_displays_correctly(

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -249,11 +249,7 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request):
             message='content-outside-printable-area'
         )
 
-    assert page.find('div', class_='banner-dangerous').find('h1').text == 'We cannot print your letter'
-    assert page.find(
-        'div', class_='banner-dangerous').find('p').text == (
-        'The content appears outside the printable area on page 1 Files must meet our letter specification.'
-    )
+    assert page.find('div', class_='banner-dangerous').find('h1', {"data-error-type": 'content-outside-printable-area'})
     assert not page.find('button', {'type': 'submit'})
 
 


### PR DESCRIPTION
### This introduces dynamic validation failed messages when:
- user goes to notification page for a precompiled letter sent through API that failed valdiation
- admin / user visits an endpoint to check if pdf meets our validation conditions (I asked Pete and he said we want to keep this endpoint so I updated it in line with other endpoints)

### Other work:
- Refactor upload preview to use shared components
- Checking if overlay is needed for notification preview now happens in API, based on metadata, so I removed redundant code from admin

### Screenshots
#### Notification page:
<img width="1037" alt="Screenshot 2019-10-31 at 12 42 45" src="https://user-images.githubusercontent.com/20957548/67947684-19753780-fbdc-11e9-9fb2-aabf91298542.png">
<img width="1015" alt="Screenshot 2019-10-31 at 12 39 33" src="https://user-images.githubusercontent.com/20957548/67947685-1a0dce00-fbdc-11e9-9252-9fe4453e2eb2.png">
<img width="1019" alt="Screenshot 2019-10-31 at 12 39 18" src="https://user-images.githubusercontent.com/20957548/67947686-1a0dce00-fbdc-11e9-9bcf-ec141cc20e80.png">

#### Validation check:
##### for services:
<img width="1007" alt="Screenshot 2019-10-31 at 12 51 59" src="https://user-images.githubusercontent.com/20957548/67948298-5b52ad80-fbdd-11e9-9d02-1acab400579b.png">
<img width="1007" alt="Screenshot 2019-10-31 at 12 51 25" src="https://user-images.githubusercontent.com/20957548/67948299-5b52ad80-fbdd-11e9-86e2-898952c262cf.png">

##### for platform admins:
<img width="1013" alt="Screenshot 2019-10-31 at 12 52 23" src="https://user-images.githubusercontent.com/20957548/67948323-64dc1580-fbdd-11e9-9d83-dce67b9557e1.png">
