### PR TITLE
Change how the bash script is started.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: unset GUNICORN_CMD_ARGS; scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application
+web: unset GUNICORN_CMD_ARGS; exec scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py application


### PR DESCRIPTION
By adding `exec` to the entrypoint bash script for the application, we can trap an EXIT from the script and execute our custom `on_exit` method with checks if the application process is busy before terminating, waiting up to 10 seconds.

Written by:
@servingupaces
@tlwr