### PR TITLE
Do extra code style checks with flake8-bugbear

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1087,9 +1087,9 @@ class ServiceUpdateEmailBranding(StripWhitespaceForm):
         ]
     )
 
-    def validate_name(form, name):
+    def validate_name(self, name):
         op = request.form.get('operation')
-        if op == 'email-branding-details' and not form.name.data:
+        if op == 'email-branding-details' and not self.name.data:
             raise ValidationError('This field is required')
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -55,12 +55,12 @@ class ModelList(ABC, Sequence):
 
     @property
     @abstractmethod
-    def client():
+    def client(self):
         pass
 
     @property
     @abstractmethod
-    def model():
+    def model(self):
         pass
 
     def __init__(self, *args):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -14,5 +14,5 @@ gunicorn.SERVER_SOFTWARE = 'None'
 
 def worker_abort(worker):
     worker.log.info("worker received ABORT")
-    for threadId, stack in sys._current_frames().items():
+    for stack in sys._current_frames().values():
         worker.log.error(''.join(traceback.format_stack(stack)))

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -9,6 +9,7 @@ coveralls==1.8.1
 beautifulsoup4==4.7.1
 freezegun==0.3.12
 flake8==3.7.7
+flake8-bugbear==19.8.0
 flake8-print==3.1.0
 requests-mock==1.6.0
 # used for creating manifest file locally

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,5 @@ include_trailing_comma=True
 
 [flake8]
 # W504 line break after binary operator
-extend_ignore=W504
+extend_ignore=B003, B306, W504
+select=B901, B902, B903

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,16 +50,7 @@ def user_json(
     email_address='test@gov.uk',
     mobile_number='+447700900986',
     password_changed_at=None,
-    permissions={generate_uuid(): [
-        'view_activity',
-        'send_texts',
-        'send_emails',
-        'send_letters',
-        'manage_users',
-        'manage_templates',
-        'manage_settings',
-        'manage_api_keys']
-    },
+    permissions=None,
     auth_type='sms_auth',
     failed_login_count=0,
     logged_in_at=None,
@@ -67,10 +58,21 @@ def user_json(
     max_failed_login_count=3,
     platform_admin=False,
     current_session_id='1234',
-    organisations=[],
+    organisations=None,
     services=None
 
 ):
+    if not permissions:
+        permissions = {generate_uuid(): [
+            'view_activity',
+            'send_texts',
+            'send_emails',
+            'send_letters',
+            'manage_users',
+            'manage_templates',
+            'manage_settings',
+            'manage_api_keys',
+        ]}
     return {
         'id': id_,
         'name': name,
@@ -85,7 +87,7 @@ def user_json(
         'max_failed_login_count': max_failed_login_count,
         'platform_admin': platform_admin,
         'current_session_id': current_session_id,
-        'organisations': organisations,
+        'organisations': organisations or [],
         'services': list(permissions.keys()) if services is None else services
     }
 
@@ -97,7 +99,7 @@ def invited_user(
     email_address='testinviteduser@gov.uk',
     permissions=None,
     status='pending',
-    created_at=datetime.utcnow(),
+    created_at=None,
     auth_type='sms_auth',
     organisation=None
 ):
@@ -106,7 +108,7 @@ def invited_user(
         'from_user': from_user,
         'email_address': email_address,
         'status': status,
-        'created_at': created_at,
+        'created_at': created_at or datetime.utcnow(),
         'auth_type': auth_type,
     }
     if service:
@@ -330,14 +332,14 @@ def org_invite_json(id_, invited_by, org_id, email_address, created_at, status):
 TEST_USER_EMAIL = 'test@user.gov.uk'
 
 
-def create_test_api_user(state, permissions={}):
+def create_test_api_user(state, permissions=None):
     user_data = {'id': 1,
                  'name': 'Test User',
                  'password': 'somepassword',
                  'email_address': TEST_USER_EMAIL,
                  'mobile_number': '+441234123412',
                  'state': state,
-                 'permissions': permissions
+                 'permissions': permissions or {}
                  }
     return user_data
 

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -25,13 +25,13 @@ def _test_permissions(
     usr,
     permissions,
     will_succeed,
-    kwargs={}
+    kwargs=None,
 ):
     request.view_args.update({'service_id': 'foo'})
     if usr:
         client.login(usr)
 
-    decorator = user_has_permissions(*permissions, **kwargs)
+    decorator = user_has_permissions(*permissions, **(kwargs or {}))
     decorated_index = decorator(index)
 
     if will_succeed:
@@ -462,7 +462,7 @@ def test_routes_have_permissions_decorators():
             'app/main/views/{}.py::{}\n'
         ).format(file, function)
 
-    for endpoint, decorators in get_routes_and_decorators():
+    for _endpoint, decorators in get_routes_and_decorators():
 
         assert 'login_required' not in decorators, (
             '@login_required found\n'

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -36,7 +36,7 @@ def test_should_show_api_page(
     assert page.h1.string.strip() == 'API integration'
     rows = page.find_all('details')
     assert len(rows) == 5
-    for index, row in enumerate(rows):
+    for row in rows:
         assert row.find('h3').string.strip() == '07123456789'
 
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -26,7 +26,7 @@ def test_should_render_two_factor_page(
     assert page.select_one('main p').text.strip() == (
         'We’ve sent you a text message with a security code.'
     )
-    assert page.select_one('label').text.strip(
+    assert page.select_one('label').text.strip() == (
         'Text message code'
     )
     assert page.select_one('input')['type'] == 'tel'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2549,7 +2549,7 @@ def mock_send_already_registered_email(mocker):
     return mocker.patch('app.user_api_client.send_already_registered_email')
 
 
-def create_email_brandings(number_of_brandings, non_standard_values={}, shuffle=False):
+def create_email_brandings(number_of_brandings, non_standard_values=None, shuffle=False):
     brandings = [
         {
             'id': str(idx),
@@ -2560,7 +2560,7 @@ def create_email_brandings(number_of_brandings, non_standard_values={}, shuffle=
             'brand_type': 'org',
         } for idx in range(1, number_of_brandings + 1)]
 
-    for idx, row in enumerate(non_standard_values):
+    for idx, row in enumerate(non_standard_values or {}):
         brandings[row['idx']].update(non_standard_values[idx])
 
     if shuffle:
@@ -2636,7 +2636,7 @@ def mock_no_email_branding(mocker):
     )
 
 
-def create_email_branding(id, non_standard_values={}):
+def create_email_branding(id, non_standard_values=None):
     branding = {
         'logo': 'example.png',
         'name': 'Organisation name',
@@ -2646,7 +2646,7 @@ def create_email_branding(id, non_standard_values={}):
         'brand_type': 'org',
     }
 
-    if bool(non_standard_values):
+    if non_standard_values:
         branding.update(non_standard_values)
 
     return {'email_branding': branding}
@@ -2871,9 +2871,11 @@ def client_request(
             with logged_in_client.session_transaction() as session:
                 yield session
 
+        @staticmethod
         def login(user, service=service_one):
             logged_in_client.login(user, mocker, service)
 
+        @staticmethod
         def logout():
             logged_in_client.logout(None)
 


### PR DESCRIPTION
Flake8 Bugbear checks for some extra things that aren’t code style errors, but are likely to introduce bugs or unexpected behaviour. A good example is having mutable default function arguments, which get shared between every call to the function and therefore mutating a value
in one place can unexpectedly cause it to change in another.

This commit enables all the extra warnings provided by Flake8 Bugbear, except for the line length one (because we already lint for that separately).

It disables:
- _B003: Assigning to os.environ_ because I don’t really understand this
- _B306: BaseException.message is removed in Python 3_ because I think our exceptions have a custom structure that means the `.message` attribute is still present