### PR TITLE
Update Get started page

### DIFF
--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -62,7 +62,7 @@
   </li>
 
   <li class="get-started-list__item">
-    <h2 class="get-started-list__heading">API integration (optional)</h2>
+    <h2 class="get-started-list__heading">Set up an API integration (optional)</h2>
     <p>Share our <a href="{{ url_for('main.documentation') }}">documentation</a> with your developers to help them set up an API integration.</p>
 
     <p>You only need to do this if you’re using the API to send messages automatically, rather than signing in to Notify.</p>
@@ -70,7 +70,7 @@
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Start sending messages</h2>
-    {% if not current_user.is_authenticated %}
+    {% if not current_user.is_authenticated or not current_service %}
     <p>You should request to go live when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
     {% else %}
     <p>You should <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>


### PR DESCRIPTION
This PR:

- fixes the if statement so we only show the `Request to go live` link if the user has is signed in *and* has a current service selected
- updates the step 5 heading to make the language active