### PR TITLE
Be stricter about the format of URL parameters 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -83,6 +83,10 @@ from app.notify_client.template_statistics_api_client import (
     template_statistics_client,
 )
 from app.notify_client.user_api_client import user_api_client
+from app.url_converters import (
+    LetterFileExtensionConverter,
+    TemplateTypeConverter,
+)
 from app.utils import format_thousands, get_logo_cdn_domain, id_safe
 
 login_manager = LoginManager()
@@ -229,6 +233,8 @@ def init_app(application):
         }
 
     application.url_map.converters['uuid'].to_python = lambda self, value: value
+    application.url_map.converters['template_type'] = TemplateTypeConverter
+    application.url_map.converters['letter_file_extension'] = LetterFileExtensionConverter
 
 
 def convert_to_boolean(value):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -228,6 +228,8 @@ def init_app(application):
             'asset_url': asset_fingerprinter.get_url
         }
 
+    application.url_map.converters['uuid'].to_python = lambda self, value: value
+
 
 def convert_to_boolean(value):
     if isinstance(value, string_types):

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -32,7 +32,7 @@ from app.utils import email_safe, user_has_permissions
 dummy_bearer_token = 'bearer_token_set'
 
 
-@main.route("/services/<service_id>/api")
+@main.route("/services/<uuid:service_id>/api")
 @user_has_permissions('manage_api_keys')
 def api_integration(service_id):
     callbacks_link = (
@@ -46,13 +46,13 @@ def api_integration(service_id):
     )
 
 
-@main.route("/services/<service_id>/api/documentation")
+@main.route("/services/<uuid:service_id>/api/documentation")
 @user_has_permissions('manage_api_keys')
 def api_documentation(service_id):
     return redirect(url_for('.documentation'), code=301)
 
 
-@main.route("/services/<service_id>/api/whitelist", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/api/whitelist", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
 def whitelist(service_id):
     form = Whitelist()
@@ -71,7 +71,7 @@ def whitelist(service_id):
     )
 
 
-@main.route("/services/<service_id>/api/keys")
+@main.route("/services/<uuid:service_id>/api/keys")
 @user_has_permissions('manage_api_keys')
 def api_keys(service_id):
     return render_template(
@@ -79,7 +79,7 @@ def api_keys(service_id):
     )
 
 
-@main.route("/services/<service_id>/api/keys/create", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/api/keys/create", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys', restrict_admin_usage=True)
 def create_api_key(service_id):
     form = CreateKeyForm(current_service.api_keys)
@@ -119,7 +119,7 @@ def create_api_key(service_id):
     )
 
 
-@main.route("/services/<service_id>/api/keys/revoke/<key_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/api/keys/revoke/<uuid:key_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
 def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
@@ -161,7 +161,7 @@ def check_token_against_dummy_bearer(token):
         return ''
 
 
-@main.route("/services/<service_id>/api/callbacks", methods=['GET'])
+@main.route("/services/<uuid:service_id>/api/callbacks", methods=['GET'])
 @user_has_permissions('manage_api_keys')
 def api_callbacks(service_id):
     if not current_service.has_permission('inbound_sms'):
@@ -185,7 +185,7 @@ def get_delivery_status_callback_details():
         )
 
 
-@main.route("/services/<service_id>/api/callbacks/delivery-status-callback", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/api/callbacks/delivery-status-callback", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
 def delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
@@ -247,7 +247,7 @@ def get_received_text_messages_callback():
         )
 
 
-@main.route("/services/<service_id>/api/callbacks/received-text-messages-callback", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/api/callbacks/received-text-messages-callback", methods=['GET', 'POST'])
 @user_has_permissions('manage_api_keys')
 def received_text_messages_callback(service_id):
     if not current_service.has_permission('inbound_sms'):

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -11,7 +11,7 @@ from app.models.template_list import TemplateList
 from app.utils import user_has_permissions
 
 
-@main.route("/services/<service_id>/conversation/<notification_id>")
+@main.route("/services/<uuid:service_id>/conversation/<uuid:notification_id>")
 @user_has_permissions('view_activity')
 def conversation(service_id, notification_id):
 
@@ -26,7 +26,7 @@ def conversation(service_id, notification_id):
     )
 
 
-@main.route("/services/<service_id>/conversation/<notification_id>.json")
+@main.route("/services/<uuid:service_id>/conversation/<uuid:notification_id>.json")
 @user_has_permissions('view_activity')
 def conversation_updates(service_id, notification_id):
 
@@ -36,8 +36,8 @@ def conversation_updates(service_id, notification_id):
     ))
 
 
-@main.route("/services/<service_id>/conversation/<notification_id>/reply-with")
-@main.route("/services/<service_id>/conversation/<notification_id>/reply-with/from-folder/<uuid:from_folder>")
+@main.route("/services/<uuid:service_id>/conversation/<uuid:notification_id>/reply-with")
+@main.route("/services/<uuid:service_id>/conversation/<uuid:notification_id>/reply-with/from-folder/<uuid:from_folder>")
 @user_has_permissions('send_messages')
 def conversation_reply(
     service_id,
@@ -59,7 +59,7 @@ def conversation_reply(
     )
 
 
-@main.route("/services/<service_id>/conversation/<notification_id>/reply-with/<template_id>")
+@main.route("/services/<uuid:service_id>/conversation/<uuid:notification_id>/reply-with/<uuid:template_id>")
 @user_has_permissions('send_messages')
 def conversation_reply_with_template(
     service_id,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -38,13 +38,13 @@ from app.utils import (
 )
 
 
-@main.route("/services/<service_id>/dashboard")
+@main.route("/services/<uuid:service_id>/dashboard")
 @user_has_permissions('view_activity', 'send_messages')
 def old_service_dashboard(service_id):
     return redirect(url_for('.service_dashboard', service_id=service_id))
 
 
-@main.route("/services/<service_id>")
+@main.route("/services/<uuid:service_id>")
 @user_has_permissions()
 def service_dashboard(service_id):
 
@@ -62,20 +62,20 @@ def service_dashboard(service_id):
     )
 
 
-@main.route("/services/<service_id>/dashboard.json")
+@main.route("/services/<uuid:service_id>/dashboard.json")
 @user_has_permissions('view_activity')
 def service_dashboard_updates(service_id):
     return jsonify(**get_dashboard_partials(service_id))
 
 
-@main.route("/services/<service_id>/template-activity")
+@main.route("/services/<uuid:service_id>/template-activity")
 @user_has_permissions('view_activity')
 def template_history(service_id):
 
     return redirect(url_for('main.template_usage', service_id=service_id), code=301)
 
 
-@main.route("/services/<service_id>/template-usage")
+@main.route("/services/<uuid:service_id>/template-usage")
 @user_has_permissions('view_activity')
 def template_usage(service_id):
 
@@ -124,7 +124,7 @@ def template_usage(service_id):
     )
 
 
-@main.route("/services/<service_id>/usage")
+@main.route("/services/<uuid:service_id>/usage")
 @user_has_permissions('manage_service', allow_org_user=True)
 def usage(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
@@ -151,7 +151,7 @@ def usage(service_id):
     )
 
 
-@main.route("/services/<service_id>/monthly")
+@main.route("/services/<uuid:service_id>/monthly")
 @user_has_permissions('view_activity')
 def monthly(service_id):
     year, current_financial_year = requested_and_current_financial_year(request)
@@ -169,7 +169,7 @@ def monthly(service_id):
     )
 
 
-@main.route("/services/<service_id>/inbox")
+@main.route("/services/<uuid:service_id>/inbox")
 @user_has_permissions('view_activity')
 def inbox(service_id):
 
@@ -180,14 +180,14 @@ def inbox(service_id):
     )
 
 
-@main.route("/services/<service_id>/inbox.json")
+@main.route("/services/<uuid:service_id>/inbox.json")
 @user_has_permissions('view_activity')
 def inbox_updates(service_id):
 
     return jsonify(get_inbox_partials(service_id))
 
 
-@main.route("/services/<service_id>/inbox.csv")
+@main.route("/services/<uuid:service_id>/inbox.csv")
 @user_has_permissions('view_activity')
 def inbox_download(service_id):
     return Response(

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -26,8 +26,8 @@ def email_branding():
     )
 
 
-@main.route("/email-branding/<branding_id>/edit", methods=['GET', 'POST'])
-@main.route("/email-branding/<branding_id>/edit/<logo>", methods=['GET', 'POST'])
+@main.route("/email-branding/<uuid:branding_id>/edit", methods=['GET', 'POST'])
+@main.route("/email-branding/<uuid:branding_id>/edit/<logo>", methods=['GET', 'POST'])
 @user_is_platform_admin
 def update_email_branding(branding_id, logo=None):
     email_branding = email_branding_client.get_email_branding(branding_id)['email_branding']

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -23,7 +23,7 @@ def find_users_by_email():
     )
 
 
-@main.route("/users/<user_id>", methods=['GET'])
+@main.route("/users/<uuid:user_id>", methods=['GET'])
 @user_is_platform_admin
 def user_information(user_id):
     return render_template(

--- a/app/main/views/history.py
+++ b/app/main/views/history.py
@@ -9,7 +9,7 @@ from app.models.event import APIKeyEvent, APIKeyEvents, ServiceEvents
 from app.utils import user_has_permissions
 
 
-@main.route("/services/<service_id>/history")
+@main.route("/services/<uuid:service_id>/history")
 @user_has_permissions('manage_service')
 def history(service_id):
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -213,7 +213,7 @@ def view_job_updates(service_id, job_id):
 
 
 @main.route('/services/<uuid:service_id>/notifications', methods=['GET', 'POST'])
-@main.route('/services/<uuid:service_id>/notifications/<message_type>', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/notifications/<template_type:message_type>', methods=['GET', 'POST'])
 @user_has_permissions()
 def view_notifications(service_id, message_type=None):
     return render_template(
@@ -237,7 +237,7 @@ def view_notifications(service_id, message_type=None):
 
 
 @main.route('/services/<uuid:service_id>/notifications.json', methods=['GET', 'POST'])
-@main.route('/services/<uuid:service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/notifications/<template_type:message_type>.json', methods=['GET', 'POST'])
 @user_has_permissions()
 def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(
@@ -245,15 +245,14 @@ def get_notifications_as_json(service_id, message_type=None):
     ))
 
 
-@main.route('/services/<uuid:service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
+@main.route('/services/<uuid:service_id>/notifications.csv', endpoint="view_notifications_csv")
+@main.route('/services/<uuid:service_id>/notifications/<template_type:message_type>.csv', endpoint="view_notifications_csv")
 @user_has_permissions()
 def get_notifications(service_id, message_type, status_override=None):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()
     if page is None:
         abort(404, "Invalid page argument ({}).".format(request.args.get('page')))
-    if message_type not in ['email', 'sms', 'letter', None]:
-        abort(404)
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)
     service_data_retention_days = None

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -47,7 +47,7 @@ from app.utils import (
 )
 
 
-@main.route("/services/<service_id>/jobs")
+@main.route("/services/<uuid:service_id>/jobs")
 @user_has_permissions()
 def view_jobs(service_id):
     page = int(request.args.get('page', 1))
@@ -81,7 +81,7 @@ def view_jobs(service_id):
     )
 
 
-@main.route("/services/<service_id>/jobs/<job_id>")
+@main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>")
 @user_has_permissions()
 def view_job(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
@@ -130,7 +130,7 @@ def view_job(service_id, job_id):
     )
 
 
-@main.route("/services/<service_id>/jobs/<job_id>.csv")
+@main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>.csv")
 @user_has_permissions('view_activity')
 def view_job_csv(service_id, job_id):
     job = job_api_client.get_job(service_id, job_id)['data']
@@ -164,14 +164,14 @@ def view_job_csv(service_id, job_id):
     )
 
 
-@main.route("/services/<service_id>/jobs/<job_id>", methods=['POST'])
+@main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>", methods=['POST'])
 @user_has_permissions('send_messages')
 def cancel_job(service_id, job_id):
     job_api_client.cancel_job(service_id, job_id)
     return redirect(url_for('main.service_dashboard', service_id=service_id))
 
 
-@main.route("/services/<service_id>/jobs/<uuid:job_id>/cancel", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>/cancel", methods=['GET', 'POST'])
 @user_has_permissions()
 def cancel_letter_job(service_id, job_id):
     if request.method == 'POST':
@@ -196,7 +196,7 @@ def cancel_letter_job(service_id, job_id):
     return view_job(service_id, job_id)
 
 
-@main.route("/services/<service_id>/jobs/<job_id>.json")
+@main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>.json")
 @user_has_permissions()
 def view_job_updates(service_id, job_id):
 
@@ -212,8 +212,8 @@ def view_job_updates(service_id, job_id):
     ))
 
 
-@main.route('/services/<service_id>/notifications', methods=['GET', 'POST'])
-@main.route('/services/<service_id>/notifications/<message_type>', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/notifications', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/notifications/<message_type>', methods=['GET', 'POST'])
 @user_has_permissions()
 def view_notifications(service_id, message_type=None):
     return render_template(
@@ -236,8 +236,8 @@ def view_notifications(service_id, message_type=None):
     )
 
 
-@main.route('/services/<service_id>/notifications.json', methods=['GET', 'POST'])
-@main.route('/services/<service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/notifications.json', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/notifications/<message_type>.json', methods=['GET', 'POST'])
 @user_has_permissions()
 def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(
@@ -245,7 +245,7 @@ def get_notifications_as_json(service_id, message_type=None):
     ))
 
 
-@main.route('/services/<service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
+@main.route('/services/<uuid:service_id>/notifications/<message_type>.csv', endpoint="view_notifications_csv")
 @user_has_permissions()
 def get_notifications(service_id, message_type, status_override=None):
     # TODO get the api to return count of pages as well.

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -44,8 +44,8 @@ def letter_branding():
     )
 
 
-@main.route("/letter-branding/<branding_id>/edit", methods=['GET', 'POST'])
-@main.route("/letter-branding/<branding_id>/edit/<path:logo>", methods=['GET', 'POST'])
+@main.route("/letter-branding/<uuid:branding_id>/edit", methods=['GET', 'POST'])
+@main.route("/letter-branding/<uuid:branding_id>/edit/<path:logo>", methods=['GET', 'POST'])
 @user_is_platform_admin
 def update_letter_branding(branding_id, logo=None):
     letter_branding = letter_branding_client.get_letter_branding(branding_id)

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -29,7 +29,7 @@ from app.models.user import InvitedUser, User
 from app.utils import is_gov_user, redact_mobile_number, user_has_permissions
 
 
-@main.route("/services/<service_id>/users")
+@main.route("/services/<uuid:service_id>/users")
 @user_has_permissions(allow_org_user=True)
 def manage_users(service_id):
     return render_template(
@@ -42,7 +42,7 @@ def manage_users(service_id):
     )
 
 
-@main.route("/services/<service_id>/users/invite", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/invite", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def invite_user(service_id):
 
@@ -78,7 +78,7 @@ def invite_user(service_id):
     )
 
 
-@main.route("/services/<service_id>/users/<user_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/<uuid:user_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def edit_user_permissions(service_id, user_id):
     service_has_email_auth = current_service.has_permission('email_auth')
@@ -118,7 +118,7 @@ def edit_user_permissions(service_id, user_id):
     )
 
 
-@main.route("/services/<service_id>/users/<user_id>/delete", methods=['POST'])
+@main.route("/services/<uuid:service_id>/users/<uuid:user_id>/delete", methods=['POST'])
 @user_has_permissions('manage_service')
 def remove_user_from_service(service_id, user_id):
     try:
@@ -139,7 +139,7 @@ def remove_user_from_service(service_id, user_id):
     ))
 
 
-@main.route("/services/<service_id>/users/<uuid:user_id>/edit-email", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/<uuid:user_id>/edit-email", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
@@ -166,7 +166,7 @@ def edit_user_email(service_id, user_id):
     )
 
 
-@main.route("/services/<service_id>/users/<uuid:user_id>/edit-email/confirm", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/<uuid:user_id>/edit-email/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def confirm_edit_user_email(service_id, user_id):
     user = current_service.get_team_member(user_id)
@@ -200,7 +200,7 @@ def confirm_edit_user_email(service_id, user_id):
     )
 
 
-@main.route("/services/<service_id>/users/<uuid:user_id>/edit-mobile-number", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/<uuid:user_id>/edit-mobile-number", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def edit_user_mobile_number(service_id, user_id):
     user = current_service.get_team_member(user_id)
@@ -224,7 +224,7 @@ def edit_user_mobile_number(service_id, user_id):
     )
 
 
-@main.route("/services/<service_id>/users/<uuid:user_id>/edit-mobile-number/confirm", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/<uuid:user_id>/edit-mobile-number/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def confirm_edit_user_mobile_number(service_id, user_id):
     user = current_service.get_team_member(user_id)
@@ -259,7 +259,7 @@ def confirm_edit_user_mobile_number(service_id, user_id):
     )
 
 
-@main.route("/services/<service_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
+@main.route("/services/<uuid:service_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
 @user_has_permissions('manage_service')
 def cancel_invited_user(service_id, invited_user_id):
     current_service.cancel_invite(invited_user_id)

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from dateutil import parser
 from flask import (
     Response,
-    abort,
     flash,
     jsonify,
     redirect,
@@ -180,15 +179,11 @@ def get_preview_error_image():
         return file.read()
 
 
-@main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>.<filetype>")
+@main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>.<letter_file_extension:filetype>")
 @user_has_permissions('view_activity')
 def view_letter_notification_as_preview(
     service_id, notification_id, filetype, with_metadata=False
 ):
-
-    if filetype not in ('pdf', 'png'):
-        abort(404)
-
     try:
         preview = notification_api_client.get_notification_letter_preview(
             service_id,

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -48,7 +48,7 @@ from app.utils import (
 )
 
 
-@main.route("/services/<service_id>/notification/<uuid:notification_id>")
+@main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>")
 @user_has_permissions('view_activity', 'send_messages')
 def view_notification(service_id, notification_id):
     notification = notification_api_client.get_notification(service_id, str(notification_id))
@@ -162,7 +162,7 @@ def view_notification(service_id, notification_id):
     )
 
 
-@main.route("/services/<service_id>/notification/<uuid:notification_id>/cancel", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>/cancel", methods=['GET', 'POST'])
 @user_has_permissions('view_activity', 'send_messages')
 def cancel_letter(service_id, notification_id):
 
@@ -180,7 +180,7 @@ def get_preview_error_image():
         return file.read()
 
 
-@main.route("/services/<service_id>/notification/<uuid:notification_id>.<filetype>")
+@main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>.<filetype>")
 @user_has_permissions('view_activity')
 def view_letter_notification_as_preview(
     service_id, notification_id, filetype, with_metadata=False
@@ -207,7 +207,7 @@ def view_letter_notification_as_preview(
     return display_file
 
 
-@main.route("/services/<service_id>/notification/<notification_id>.json")
+@main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>.json")
 @user_has_permissions('view_activity', 'send_messages')
 def view_notification_updates(service_id, notification_id):
     return jsonify(**get_single_notification_partials(
@@ -241,7 +241,7 @@ def get_all_personalisation_from_notification(notification):
     return notification['personalisation']
 
 
-@main.route("/services/<service_id>/download-notifications.csv")
+@main.route("/services/<uuid:service_id>/download-notifications.csv")
 @user_has_permissions('view_activity')
 def download_notifications_csv(service_id):
     filter_args = parse_filter_args(request.args)

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -122,7 +122,7 @@ def add_organisation_from_nhs_local_service(service_id):
     )
 
 
-@main.route("/organisations/<org_id>", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>", methods=['GET'])
 @user_has_permissions()
 def organisation_dashboard(org_id):
     return render_template(
@@ -130,7 +130,7 @@ def organisation_dashboard(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/trial-services", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>/trial-services", methods=['GET'])
 @user_is_platform_admin
 def organisation_trial_mode_services(org_id):
     return render_template(
@@ -139,7 +139,7 @@ def organisation_trial_mode_services(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/users", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>/users", methods=['GET'])
 @user_has_permissions()
 def manage_org_users(org_id):
     return render_template(
@@ -150,7 +150,7 @@ def manage_org_users(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/users/invite", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/users/invite", methods=['GET', 'POST'])
 @user_has_permissions()
 def invite_org_user(org_id):
     form = InviteOrgUserForm(
@@ -173,7 +173,7 @@ def invite_org_user(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/users/<user_id>", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/users/<uuid:user_id>", methods=['GET', 'POST'])
 @user_has_permissions()
 def edit_user_org_permissions(org_id, user_id):
     return render_template(
@@ -182,7 +182,7 @@ def edit_user_org_permissions(org_id, user_id):
     )
 
 
-@main.route("/organisations/<org_id>/users/<user_id>/delete", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/users/<uuid:user_id>/delete", methods=['GET', 'POST'])
 @user_has_permissions()
 def remove_user_from_organisation(org_id, user_id):
     user = User.from_id(user_id)
@@ -211,7 +211,7 @@ def remove_user_from_organisation(org_id, user_id):
     )
 
 
-@main.route("/organisations/<org_id>/cancel-invited-user/<invited_user_id>", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
 @user_has_permissions()
 def cancel_invited_org_user(org_id, invited_user_id):
     org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
@@ -219,7 +219,7 @@ def cancel_invited_org_user(org_id, invited_user_id):
     return redirect(url_for('main.manage_org_users', org_id=org_id))
 
 
-@main.route("/organisations/<org_id>/settings/", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>/settings/", methods=['GET'])
 @user_is_platform_admin
 def organisation_settings(org_id):
     return render_template(
@@ -227,7 +227,7 @@ def organisation_settings(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/edit-name", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-name", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_name(org_id):
     form = RenameOrganisationForm()
@@ -249,7 +249,7 @@ def edit_organisation_name(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/edit-type", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-type", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_type(org_id):
 
@@ -270,7 +270,7 @@ def edit_organisation_type(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/edit-crown-status", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-crown-status", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_crown_status(org_id):
 
@@ -299,7 +299,7 @@ def edit_organisation_crown_status(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/edit-agreement", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-agreement", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_agreement(org_id):
 
@@ -328,7 +328,7 @@ def edit_organisation_agreement(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/set-email-branding", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/set-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_email_branding(org_id):
 
@@ -353,7 +353,7 @@ def edit_organisation_email_branding(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/preview-email-branding", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/preview-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def organisation_preview_email_branding(org_id):
 
@@ -375,7 +375,7 @@ def organisation_preview_email_branding(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/set-letter-branding", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/set-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_letter_branding(org_id):
     letter_branding = letter_branding_client.get_all_letter_branding()
@@ -399,7 +399,7 @@ def edit_organisation_letter_branding(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/preview-letter-branding", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/preview-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def organisation_preview_letter_branding(org_id):
     branding_style = request.args.get('branding_style')
@@ -420,7 +420,7 @@ def organisation_preview_letter_branding(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/edit-organisation-domains", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-organisation-domains", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_domains(org_id):
 
@@ -444,7 +444,7 @@ def edit_organisation_domains(org_id):
     )
 
 
-@main.route("/organisations/<org_id>/settings/edit-name/confirm", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-name/confirm", methods=['GET', 'POST'])
 @user_has_permissions()
 def confirm_edit_organisation_name(org_id):
     # Validate password for form
@@ -476,7 +476,7 @@ def confirm_edit_organisation_name(org_id):
         form=form)
 
 
-@main.route("/organisations/<org_id>/settings/edit-go-live-notes", methods=['GET', 'POST'])
+@main.route("/organisations/<uuid:org_id>/settings/edit-go-live-notes", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_organisation_go_live_notes(org_id):
 

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -392,7 +392,7 @@ def platform_admin_letter_validation_preview():
     return letter_validation_preview(from_platform_admin=True)
 
 
-@main.route("/services/<service_id>/letter-validation-preview", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/letter-validation-preview", methods=["GET", "POST"])
 @user_has_permissions()
 def service_letter_validation_preview(service_id):
     return letter_validation_preview(from_platform_admin=False)

--- a/app/main/views/providers.py
+++ b/app/main/views/providers.py
@@ -38,7 +38,7 @@ def add_monthly_traffic(domestic_sms_providers):
         provider['monthly_traffic'] = round(percentage)
 
 
-@main.route("/provider/<provider_id>/edit", methods=['GET', 'POST'])
+@main.route("/provider/<uuid:provider_id>/edit", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_provider(provider_id):
     provider = provider_client.get_provider_by_id(provider_id)['provider_details']
@@ -51,7 +51,7 @@ def edit_provider(provider_id):
     return render_template('views/providers/edit-provider.html', form=form, provider=provider)
 
 
-@main.route("/provider/<provider_id>")
+@main.route("/provider/<uuid:provider_id>")
 @user_is_platform_admin
 def view_provider(provider_id):
     versions = provider_client.get_provider_versions(provider_id)

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -100,7 +100,7 @@ def get_example_letter_address(key):
     }.get(key, '')
 
 
-@main.route("/services/<service_id>/send/<template_id>/csv", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/send/<uuid:template_id>/csv", methods=['GET', 'POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_messages(service_id, template_id):
     # if there's lots of data in the session, lets log it for debugging purposes
@@ -183,7 +183,7 @@ def send_messages(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/send/<template_id>.csv", methods=['GET'])
+@main.route("/services/<uuid:service_id>/send/<uuid:template_id>.csv", methods=['GET'])
 @user_has_permissions('send_messages', 'manage_templates')
 def get_example_csv(service_id, template_id):
     template = get_template(
@@ -198,7 +198,7 @@ def get_example_csv(service_id, template_id):
     }
 
 
-@main.route("/services/<service_id>/send/<template_id>/set-sender", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/send/<uuid:template_id>/set-sender", methods=['GET', 'POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def set_sender(service_id, template_id):
     session['sender_id'] = None
@@ -285,8 +285,8 @@ def get_sender_details(service_id, template_type):
     return api_call(service_id)
 
 
-@main.route("/services/<service_id>/send/<template_id>/test", endpoint='send_test')
-@main.route("/services/<service_id>/send/<template_id>/one-off", endpoint='send_one_off')
+@main.route("/services/<uuid:service_id>/send/<uuid:template_id>/test", endpoint='send_test')
+@main.route("/services/<uuid:service_id>/send/<uuid:template_id>/one-off", endpoint='send_one_off')
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_test(service_id, template_id):
     session['recipient'] = None
@@ -328,12 +328,12 @@ def get_notification_check_endpoint(service_id, template):
 
 
 @main.route(
-    "/services/<service_id>/send/<template_id>/test/step-<int:step_index>",
+    "/services/<uuid:service_id>/send/<uuid:template_id>/test/step-<int:step_index>",
     methods=['GET', 'POST'],
     endpoint='send_test_step',
 )
 @main.route(
-    "/services/<service_id>/send/<template_id>/one-off/step-<int:step_index>",
+    "/services/<uuid:service_id>/send/<uuid:template_id>/one-off/step-<int:step_index>",
     methods=['GET', 'POST'],
     endpoint='send_one_off_step',
 )
@@ -465,7 +465,7 @@ def send_test_step(service_id, template_id, step_index):
     )
 
 
-@main.route("/services/<service_id>/send/<template_id>/test.<filetype>", methods=['GET'])
+@main.route("/services/<uuid:service_id>/send/<uuid:template_id>/test.<filetype>", methods=['GET'])
 @user_has_permissions('send_messages')
 def send_test_preview(service_id, template_id, filetype):
 
@@ -600,8 +600,8 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
     )
 
 
-@main.route("/services/<service_id>/<uuid:template_id>/check/<upload_id>", methods=['GET'])
-@main.route("/services/<service_id>/<uuid:template_id>/check/<upload_id>/row-<int:row_index>", methods=['GET'])
+@main.route("/services/<uuid:service_id>/<uuid:template_id>/check/<uuid:upload_id>", methods=['GET'])
+@main.route("/services/<uuid:service_id>/<uuid:template_id>/check/<uuid:upload_id>/row-<int:row_index>", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_messages(service_id, template_id, upload_id, row_index=2):
 
@@ -647,11 +647,11 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
 
 
 @main.route(
-    "/services/<service_id>/<uuid:template_id>/check/<upload_id>.<filetype>",
+    "/services/<uuid:service_id>/<uuid:template_id>/check/<uuid:upload_id>.<filetype>",
     methods=['GET'],
 )
 @main.route(
-    "/services/<service_id>/<uuid:template_id>/check/<upload_id>/row-<int:row_index>.<filetype>",
+    "/services/<uuid:service_id>/<uuid:template_id>/check/<uuid:upload_id>/row-<int:row_index>.<filetype>",
     methods=['GET'],
 )
 @user_has_permissions('send_messages')
@@ -670,7 +670,7 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
 
 
 @main.route(
-    "/services/<service_id>/<uuid:template_id>/check.<filetype>",
+    "/services/<uuid:service_id>/<uuid:template_id>/check.<filetype>",
     methods=['GET'],
 )
 @user_has_permissions('send_messages')
@@ -688,7 +688,7 @@ def check_notification_preview(service_id, template_id, filetype):
     return TemplatePreview.from_utils_template(template, filetype, page=page)
 
 
-@main.route("/services/<service_id>/start-job/<upload_id>", methods=['POST'])
+@main.route("/services/<uuid:service_id>/start-job/<uuid:upload_id>", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def start_job(service_id, upload_id):
 
@@ -711,7 +711,7 @@ def start_job(service_id, upload_id):
     )
 
 
-@main.route("/services/<service_id>/end-tour/<example_template_id>")
+@main.route("/services/<uuid:service_id>/end-tour/<uuid:example_template_id>")
 @user_has_permissions('manage_templates')
 def go_to_dashboard_after_tour(service_id, example_template_id):
 
@@ -840,7 +840,7 @@ def get_back_link(service_id, template, step_index):
         )
 
 
-@main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
+@main.route("/services/<uuid:service_id>/template/<uuid:template_id>/notification/check", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_notification(service_id, template_id):
     return render_template(
@@ -917,7 +917,7 @@ def get_template_error_dict(exception):
     }
 
 
-@main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['POST'])
+@main.route("/services/<uuid:service_id>/template/<uuid:template_id>/notification/check", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_notification(service_id, template_id):
     if {'recipient', 'placeholders'} - set(session.keys()):

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -630,7 +630,7 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
 
     metadata_kwargs = {
         'notification_count': data['count_of_recipients'],
-        'template_id': str(template_id),
+        'template_id': template_id,
         'valid': True,
         'original_file_name': unicode_truncate(
             data['original_file_name'],

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -71,7 +71,7 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
 ])
 
 
-@main.route("/services/<service_id>/service-settings")
+@main.route("/services/<uuid:service_id>/service-settings")
 @user_has_permissions('manage_service', 'manage_api_keys')
 def service_settings(service_id):
     return render_template(
@@ -80,7 +80,7 @@ def service_settings(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/name", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/name", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_name_change(service_id):
     form = RenameServiceForm()
@@ -108,7 +108,7 @@ def service_name_change(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_name_change_confirm(service_id):
     # Validate password for form
@@ -140,7 +140,7 @@ def service_name_change_confirm(service_id):
         form=form)
 
 
-@main.route("/services/<service_id>/service-settings/request-to-go-live/estimate-usage", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/request-to-go-live/estimate-usage", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def estimate_usage(service_id):
 
@@ -172,7 +172,7 @@ def estimate_usage(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/request-to-go-live", methods=['GET'])
 @user_has_permissions('manage_service')
 def request_to_go_live(service_id):
     return render_template(
@@ -180,7 +180,7 @@ def request_to_go_live(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/request-to-go-live", methods=['POST'])
+@main.route("/services/<uuid:service_id>/service-settings/request-to-go-live", methods=['POST'])
 @user_has_permissions('manage_service')
 @user_is_gov_user
 def submit_request_to_go_live(service_id):
@@ -228,7 +228,7 @@ def submit_request_to_go_live(service_id):
     return redirect(url_for('.service_settings', service_id=service_id))
 
 
-@main.route("/services/<service_id>/service-settings/switch-live", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/service-settings/switch-live", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_switch_live(service_id):
     form = ServiceOnOffSettingForm(
@@ -247,7 +247,7 @@ def service_switch_live(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/switch-count-as-live", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/service-settings/switch-count-as-live", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_switch_count_as_live(service_id):
 
@@ -269,7 +269,7 @@ def service_switch_count_as_live(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/permissions/<permission>", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/service-settings/permissions/<permission>", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_set_permission(service_id, permission):
     if permission not in PLATFORM_ADMIN_SERVICE_PERMISSIONS:
@@ -293,7 +293,7 @@ def service_set_permission(service_id, permission):
     )
 
 
-@main.route("/services/<service_id>/service-settings/can-upload-document", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/can-upload-document", methods=['GET', 'POST'])
 @user_is_platform_admin
 def service_switch_can_upload_document(service_id):
     if current_service.contact_link:
@@ -313,7 +313,7 @@ def service_switch_can_upload_document(service_id):
     return render_template('views/service-settings/contact_link.html', form=form)
 
 
-@main.route("/services/<service_id>/service-settings/archive", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/archive", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def archive_service(service_id):
     if not current_service.active and (
@@ -335,7 +335,7 @@ def archive_service(service_id):
         return service_settings(service_id)
 
 
-@main.route("/services/<service_id>/service-settings/suspend", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/service-settings/suspend", methods=["GET", "POST"])
 @user_has_permissions('manage_service')
 def suspend_service(service_id):
     if request.method == 'POST':
@@ -347,7 +347,7 @@ def suspend_service(service_id):
         return service_settings(service_id)
 
 
-@main.route("/services/<service_id>/service-settings/resume", methods=["GET", "POST"])
+@main.route("/services/<uuid:service_id>/service-settings/resume", methods=["GET", "POST"])
 @user_has_permissions('manage_service')
 def resume_service(service_id):
     if request.method == 'POST':
@@ -358,7 +358,7 @@ def resume_service(service_id):
         return service_settings(service_id)
 
 
-@main.route("/services/<service_id>/service-settings/contact-link", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/contact-link", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_set_contact_link(service_id):
     form = ServiceContactDetailsForm()
@@ -382,19 +382,19 @@ def service_set_contact_link(service_id):
     return render_template('views/service-settings/contact_link.html', form=form)
 
 
-@main.route("/services/<service_id>/service-settings/set-reply-to-email", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/set-reply-to-email", methods=['GET'])
 @user_has_permissions('manage_service')
 def service_set_reply_to_email(service_id):
     return redirect(url_for('.service_email_reply_to', service_id=service_id))
 
 
-@main.route("/services/<service_id>/service-settings/email-reply-to", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/email-reply-to", methods=['GET'])
 @user_has_permissions('manage_service', 'manage_api_keys')
 def service_email_reply_to(service_id):
     return render_template('views/service-settings/email_reply_to.html')
 
 
-@main.route("/services/<service_id>/service-settings/email-reply-to/add", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/email-reply-to/add", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_add_email_reply_to(service_id):
     form = ServiceReplyToEmailForm()
@@ -425,7 +425,7 @@ def service_add_email_reply_to(service_id):
         first_email_address=first_email_address)
 
 
-@main.route("/services/<service_id>/service-settings/email-reply-to/<notification_id>/verify", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/email-reply-to/<uuid:notification_id>/verify", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_verify_reply_to_address(service_id, notification_id):
     replace = request.args.get('replace', False)
@@ -441,7 +441,7 @@ def service_verify_reply_to_address(service_id, notification_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/email-reply-to/<notification_id>/verify.json")
+@main.route("/services/<uuid:service_id>/service-settings/email-reply-to/<uuid:notification_id>/verify.json")
 @user_has_permissions('manage_service')
 def service_verify_reply_to_address_updates(service_id, notification_id):
     return jsonify(**get_service_verify_reply_to_address_partials(service_id, notification_id))
@@ -498,12 +498,12 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
 
 
 @main.route(
-    "/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/edit",
+    "/services/<uuid:service_id>/service-settings/email-reply-to/<uuid:reply_to_email_id>/edit",
     methods=['GET', 'POST'],
     endpoint="service_edit_email_reply_to"
 )
 @main.route(
-    "/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/delete",
+    "/services/<uuid:service_id>/service-settings/email-reply-to/<uuid:reply_to_email_id>/delete",
     methods=['GET'],
     endpoint="service_confirm_delete_email_reply_to"
 )
@@ -551,7 +551,10 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/email-reply-to/<reply_to_email_id>/delete", methods=['POST'])
+@main.route(
+    "/services/<uuid:service_id>/service-settings/email-reply-to/<uuid:reply_to_email_id>/delete",
+    methods=['POST']
+)
 @user_has_permissions('manage_service')
 def service_delete_email_reply_to(service_id, reply_to_email_id):
     service_api_client.delete_reply_to_email_address(
@@ -561,7 +564,7 @@ def service_delete_email_reply_to(service_id, reply_to_email_id):
     return redirect(url_for('.service_email_reply_to', service_id=service_id))
 
 
-@main.route("/services/<service_id>/service-settings/set-inbound-number", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-inbound-number", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_set_inbound_number(service_id):
     available_inbound_numbers = inbound_number_client.get_available_inbound_sms_numbers()
@@ -590,7 +593,7 @@ def service_set_inbound_number(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/sms-prefix", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/sms-prefix", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_set_sms_prefix(service_id):
 
@@ -612,7 +615,7 @@ def service_set_sms_prefix(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-international-sms", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-international-sms", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_set_international_sms(service_id):
     form = InternationalSMSForm(
@@ -632,7 +635,7 @@ def service_set_international_sms(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-inbound-sms", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/set-inbound-sms", methods=['GET'])
 @user_has_permissions('manage_service')
 def service_set_inbound_sms(service_id):
     return render_template(
@@ -640,7 +643,7 @@ def service_set_inbound_sms(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-letters", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/set-letters", methods=['GET'])
 @user_has_permissions('manage_service')
 def service_set_letters(service_id):
     return redirect(
@@ -653,7 +656,7 @@ def service_set_letters(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-<channel>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-<channel>", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_set_channel(service_id, channel):
 
@@ -680,7 +683,7 @@ def service_set_channel(service_id, channel):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-auth-type", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/set-auth-type", methods=['GET'])
 @user_has_permissions('manage_service')
 def service_set_auth_type(service_id):
     return render_template(
@@ -688,7 +691,7 @@ def service_set_auth_type(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/letter-contacts", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/letter-contacts", methods=['GET'])
 @user_has_permissions('manage_service', 'manage_api_keys')
 def service_letter_contact_details(service_id):
     letter_contact_details = service_api_client.get_letter_contacts(service_id)
@@ -697,7 +700,7 @@ def service_letter_contact_details(service_id):
         letter_contact_details=letter_contact_details)
 
 
-@main.route("/services/<service_id>/service-settings/letter-contact/add", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/letter-contact/add", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_add_letter_contact(service_id):
     form = ServiceLetterContactBlockForm()
@@ -732,12 +735,12 @@ def service_add_letter_contact(service_id):
 
 
 @main.route(
-    "/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/edit",
+    "/services/<uuid:service_id>/service-settings/letter-contact/<uuid:letter_contact_id>/edit",
     methods=['GET', 'POST'],
     endpoint="service_edit_letter_contact",
 )
 @main.route(
-    "/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/delete",
+    "/services/<uuid:service_id>/service-settings/letter-contact/<uuid:letter_contact_id>/delete",
     methods=['GET'],
     endpoint="service_confirm_delete_letter_contact",
 )
@@ -765,7 +768,7 @@ def service_edit_letter_contact(service_id, letter_contact_id):
         letter_contact_id=letter_contact_block['id'])
 
 
-@main.route("/services/<service_id>/service-settings/letter-contact/make-blank-default")
+@main.route("/services/<uuid:service_id>/service-settings/letter-contact/make-blank-default")
 @user_has_permissions('manage_service')
 def service_make_blank_default_letter_contact(service_id):
     current_service.remove_default_letter_contact_block()
@@ -773,7 +776,7 @@ def service_make_blank_default_letter_contact(service_id):
 
 
 @main.route(
-    "/services/<service_id>/service-settings/letter-contact/<letter_contact_id>/delete",
+    "/services/<uuid:service_id>/service-settings/letter-contact/<uuid:letter_contact_id>/delete",
     methods=['POST'],
 )
 @user_has_permissions('manage_service')
@@ -785,7 +788,7 @@ def service_delete_letter_contact(service_id, letter_contact_id):
     return redirect(url_for('.service_letter_contact_details', service_id=current_service.id))
 
 
-@main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
+@main.route("/services/<uuid:service_id>/service-settings/sms-sender", methods=['GET'])
 @user_has_permissions('manage_service', 'manage_api_keys')
 def service_sms_senders(service_id):
     return render_template(
@@ -793,7 +796,7 @@ def service_sms_senders(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
@@ -812,12 +815,12 @@ def service_add_sms_sender(service_id):
 
 
 @main.route(
-    "/services/<service_id>/service-settings/sms-sender/<sms_sender_id>/edit",
+    "/services/<uuid:service_id>/service-settings/sms-sender/<uuid:sms_sender_id>/edit",
     methods=['GET', 'POST'],
     endpoint="service_edit_sms_sender"
 )
 @main.route(
-    "/services/<service_id>/service-settings/sms-sender/<sms_sender_id>/delete",
+    "/services/<uuid:service_id>/service-settings/sms-sender/<uuid:sms_sender_id>/delete",
     methods=['GET'],
     endpoint="service_confirm_delete_sms_sender"
 )
@@ -852,7 +855,7 @@ def service_edit_sms_sender(service_id, sms_sender_id):
 
 
 @main.route(
-    "/services/<service_id>/service-settings/sms-sender/<sms_sender_id>/delete",
+    "/services/<uuid:service_id>/service-settings/sms-sender/<uuid:sms_sender_id>/delete",
     methods=['POST'],
 )
 @user_has_permissions('manage_service')
@@ -864,7 +867,7 @@ def service_delete_sms_sender(service_id, sms_sender_id):
     return redirect(url_for('.service_sms_senders', service_id=service_id))
 
 
-@main.route("/services/<service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-letter-contact-block", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_set_letter_contact_block(service_id):
 
@@ -887,7 +890,7 @@ def service_set_letter_contact_block(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-free-sms-allowance", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-free-sms-allowance", methods=['GET', 'POST'])
 @user_is_platform_admin
 def set_free_sms_allowance(service_id):
 
@@ -904,7 +907,7 @@ def set_free_sms_allowance(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-email-branding", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def service_set_email_branding(service_id):
     email_branding = email_branding_client.get_all_email_branding()
@@ -928,7 +931,7 @@ def service_set_email_branding(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/preview-email-branding", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/preview-email-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def service_preview_email_branding(service_id):
     branding_style = request.args.get('branding_style', None)
@@ -949,7 +952,7 @@ def service_preview_email_branding(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/set-letter-branding", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/set-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def service_set_letter_branding(service_id):
     letter_branding = letter_branding_client.get_all_letter_branding()
@@ -973,7 +976,7 @@ def service_set_letter_branding(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/preview-letter-branding", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/preview-letter-branding", methods=['GET', 'POST'])
 @user_is_platform_admin
 def service_preview_letter_branding(service_id):
     branding_style = request.args.get('branding_style')
@@ -994,7 +997,7 @@ def service_preview_letter_branding(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/request-letter-branding", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/request-letter-branding", methods=['GET', 'POST'])
 @user_has_permissions('manage_service', 'manage_templates')
 def request_letter_branding(service_id):
     return render_template(
@@ -1003,7 +1006,7 @@ def request_letter_branding(service_id):
     )
 
 
-@main.route("/services/<service_id>/service-settings/link-service-to-organisation", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/service-settings/link-service-to-organisation", methods=['GET', 'POST'])
 @user_is_platform_admin
 def link_service_to_organisation(service_id):
 
@@ -1031,7 +1034,7 @@ def link_service_to_organisation(service_id):
     )
 
 
-@main.route("/services/<service_id>/branding-request/email", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/branding-request/email", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def branding_request(service_id):
 
@@ -1077,7 +1080,7 @@ def branding_request(service_id):
     )
 
 
-@main.route("/services/<service_id>/data-retention", methods=['GET'])
+@main.route("/services/<uuid:service_id>/data-retention", methods=['GET'])
 @user_is_platform_admin
 def data_retention(service_id):
     return render_template(
@@ -1085,7 +1088,7 @@ def data_retention(service_id):
     )
 
 
-@main.route("/services/<service_id>/data-retention/add", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/data-retention/add", methods=['GET', 'POST'])
 @user_is_platform_admin
 def add_data_retention(service_id):
     form = ServiceDataRetentionForm()
@@ -1100,7 +1103,7 @@ def add_data_retention(service_id):
     )
 
 
-@main.route("/services/<service_id>/data-retention/<data_retention_id>/edit", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/data-retention/<uuid:data_retention_id>/edit", methods=['GET', 'POST'])
 @user_is_platform_admin
 def edit_data_retention(service_id, data_retention_id):
     data_retention_item = current_service.get_data_retention_item(data_retention_id)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -369,7 +369,7 @@ def copy_template(service_id, template_id):
 
     current_user.belongs_to_service_or_403(from_service)
 
-    template = service_api_client.get_service_template(from_service, str(template_id))['data']
+    template = service_api_client.get_service_template(from_service, template_id)['data']
 
     template_folder = template_folder_api_client.get_template_folder(from_service, template['folder'])
     if not current_user.has_template_folder_permission(template_folder):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -47,7 +47,7 @@ form_objects = {
 }
 
 
-@main.route("/services/<service_id>/templates/<uuid:template_id>")
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>")
 @user_has_permissions()
 def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
@@ -84,7 +84,7 @@ def view_template(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/start-tour/<uuid:template_id>")
+@main.route("/services/<uuid:service_id>/start-tour/<uuid:template_id>")
 @user_has_permissions('view_activity')
 def start_tour(service_id, template_id):
 
@@ -104,10 +104,10 @@ def start_tour(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/templates", methods=['GET', 'POST'])
-@main.route("/services/<service_id>/templates/folders/<template_folder_id>", methods=['GET', 'POST'])
-@main.route("/services/<service_id>/templates/<template_type>", methods=['GET', 'POST'])
-@main.route("/services/<service_id>/templates/<template_type>/folders/<template_folder_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/<template_type>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/<template_type>/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])
 @user_has_permissions()
 def choose_template(service_id, template_type='all', template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
@@ -215,7 +215,7 @@ def get_template_nav_items(template_folder_id):
     ]
 
 
-@main.route("/services/<service_id>/templates/<template_id>.<filetype>")
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>.<filetype>")
 @user_has_permissions()
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ('pdf', 'png'):
@@ -267,7 +267,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
     ))
 
 
-@main.route("/services/<service_id>/templates/<template_id>/version/<int:version>")
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>")
 @user_has_permissions()
 def view_template_version(service_id, template_id, version):
     return render_template(
@@ -276,7 +276,7 @@ def view_template_version(service_id, template_id, version):
     )
 
 
-@main.route("/services/<service_id>/templates/<template_id>/version/<int:version>.<filetype>")
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>.<filetype>")
 @user_has_permissions()
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = current_service.get_template(template_id, version=version)
@@ -313,7 +313,6 @@ def _add_template_by_type(template_type, template_folder_id):
             service_id=current_service.id,
             notification_type=template_type,
             return_to='add_new_template',
-            template_id='0'
         ))
     else:
         return redirect(url_for(
@@ -324,10 +323,10 @@ def _add_template_by_type(template_type, template_folder_id):
         ))
 
 
-@main.route("/services/<service_id>/templates/copy")
-@main.route("/services/<service_id>/templates/copy/from-folder/<uuid:from_folder>")
-@main.route("/services/<service_id>/templates/copy/from-service/<uuid:from_service>")
-@main.route("/services/<service_id>/templates/copy/from-service/<uuid:from_service>/from-folder/<uuid:from_folder>")
+@main.route("/services/<uuid:service_id>/templates/copy")
+@main.route("/services/<uuid:service_id>/templates/copy/from-folder/<uuid:from_folder>")
+@main.route("/services/<uuid:service_id>/templates/copy/from-service/<uuid:from_service>")
+@main.route("/services/<uuid:service_id>/templates/copy/from-service/<uuid:from_service>/from-folder/<uuid:from_folder>")
 @user_has_permissions('manage_templates')
 def choose_template_to_copy(
     service_id,
@@ -362,7 +361,7 @@ def choose_template_to_copy(
         )
 
 
-@main.route("/services/<service_id>/templates/copy/<uuid:template_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/copy/<uuid:template_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def copy_template(service_id, template_id):
     from_service = request.args.get('from_service')
@@ -405,9 +404,16 @@ def _get_template_copy_name(template, existing_templates):
     return '{} (copy)'.format(template['name'])
 
 
-@main.route("/services/<service_id>/templates/action-blocked/<notification_type>/<return_to>/<template_id>")
+@main.route((
+    '/services/<uuid:service_id>/templates/action-blocked/'
+    '<notification_type>'
+))
+@main.route((
+    '/services/<uuid:service_id>/templates/action-blocked/'
+    '<notification_type>/<return_to>/<uuid:template_id>'
+))
 @user_has_permissions('manage_templates')
-def action_blocked(service_id, notification_type, return_to, template_id):
+def action_blocked(service_id, notification_type, return_to='add_new_template', template_id=None):
     if notification_type == 'sms':
         notification_type = 'text messages'
     elif notification_type == 'email':
@@ -418,11 +424,11 @@ def action_blocked(service_id, notification_type, return_to, template_id):
         service_id=service_id,
         notification_type=notification_type,
         return_to=return_to,
-        template_id=template_id
+        template_id=template_id,
     )
 
 
-@main.route("/services/<service_id>/templates/folders/<template_folder_id>/manage", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/manage", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def manage_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
@@ -456,7 +462,7 @@ def manage_template_folder(service_id, template_folder_id):
     )
 
 
-@main.route("/services/<service_id>/templates/folders/<template_folder_id>/delete", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/delete", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def delete_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
@@ -498,9 +504,14 @@ def delete_template_folder(service_id, template_folder_id):
         return manage_template_folder(service_id, template_folder_id)
 
 
-@main.route("/services/<service_id>/templates/add-<template_type>", methods=['GET', 'POST'])
-@main.route("/services/<service_id>/templates/folders/<template_folder_id>/add-<template_type>",
-            methods=['GET', 'POST'])
+@main.route(
+    "/services/<uuid:service_id>/templates/add-<template_type>",
+    methods=['GET', 'POST'],
+)
+@main.route(
+    "/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/add-<template_type>",
+    methods=['GET', 'POST'],
+)
 @user_has_permissions('manage_templates')
 def add_service_template(service_id, template_type, template_folder_id=None):
 
@@ -544,7 +555,6 @@ def add_service_template(service_id, template_type, template_folder_id=None):
             notification_type=template_type,
             template_folder_id=template_folder_id,
             return_to='templates',
-            template_id='0'
         ))
     else:
         return render_template(
@@ -561,7 +571,7 @@ def abort_403_if_not_admin_user():
         abort(403)
 
 
-@main.route("/services/<service_id>/templates/<template_id>/edit", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/edit", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def edit_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
@@ -643,7 +653,7 @@ def edit_service_template(service_id, template_id):
         )
 
 
-@main.route("/services/<service_id>/templates/<template_id>/delete", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/delete", methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def delete_service_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
@@ -691,7 +701,7 @@ def delete_service_template(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/templates/<template_id>/redact", methods=['GET'])
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/redact", methods=['GET'])
 @user_has_permissions('manage_templates')
 def confirm_redact_template(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
@@ -714,7 +724,7 @@ def confirm_redact_template(service_id, template_id):
     )
 
 
-@main.route("/services/<service_id>/templates/<template_id>/redact", methods=['POST'])
+@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/redact", methods=['POST'])
 @user_has_permissions('manage_templates')
 def redact_template(service_id, template_id):
 
@@ -732,7 +742,7 @@ def redact_template(service_id, template_id):
     ))
 
 
-@main.route('/services/<service_id>/templates/<template_id>/versions')
+@main.route('/services/<uuid:service_id>/templates/<uuid:template_id>/versions')
 @user_has_permissions('view_activity')
 def view_template_versions(service_id, template_id):
     return render_template(
@@ -754,7 +764,7 @@ def view_template_versions(service_id, template_id):
     )
 
 
-@main.route('/services/<service_id>/templates/<template_id>/set-template-sender', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/templates/<uuid:template_id>/set-template-sender', methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def set_template_sender(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
@@ -784,7 +794,7 @@ def set_template_sender(service_id, template_id):
     )
 
 
-@main.route('/services/<service_id>/templates/<template_id>/edit-postage', methods=['GET', 'POST'])
+@main.route('/services/<uuid:service_id>/templates/<uuid:template_id>/edit-postage', methods=['GET', 'POST'])
 @user_has_permissions('manage_templates')
 def edit_template_postage(service_id, template_id):
     template = current_service.get_template_with_user_permission_or_403(template_id, current_user)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from functools import partial
 from string import ascii_uppercase
 
 from dateutil.parser import parse
@@ -406,25 +407,32 @@ def _get_template_copy_name(template, existing_templates):
 
 @main.route((
     '/services/<uuid:service_id>/templates/action-blocked/'
-    '<template_type:notification_type>'
+    '<template_type:notification_type>/<return_to>'
 ))
 @main.route((
     '/services/<uuid:service_id>/templates/action-blocked/'
     '<template_type:notification_type>/<return_to>/<uuid:template_id>'
 ))
 @user_has_permissions('manage_templates')
-def action_blocked(service_id, notification_type, return_to='add_new_template', template_id=None):
-    if notification_type == 'sms':
-        notification_type = 'text messages'
-    elif notification_type == 'email':
-        notification_type = 'emails'
+def action_blocked(service_id, notification_type, return_to, template_id=None):
+
+    back_link = {
+        'add_new_template': partial(
+            url_for, '.choose_template', service_id=current_service.id
+        ),
+        'templates': partial(
+            url_for, '.choose_template', service_id=current_service.id
+        ),
+        'view_template': partial(
+            url_for, '.view_template', service_id=current_service.id, template_id=template_id
+        ),
+    }.get(return_to)
 
     return render_template(
         'views/templates/action_blocked.html',
         service_id=service_id,
         notification_type=notification_type,
-        return_to=return_to,
-        template_id=template_id,
+        back_link=back_link(),
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -106,8 +106,8 @@ def start_tour(service_id, template_id):
 
 @main.route("/services/<uuid:service_id>/templates", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])
-@main.route("/services/<uuid:service_id>/templates/<template_type>", methods=['GET', 'POST'])
-@main.route("/services/<uuid:service_id>/templates/<template_type>/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/<template_type:template_type>", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates/<template_type:template_type>/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])
 @user_has_permissions()
 def choose_template(service_id, template_type='all', template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
@@ -406,11 +406,11 @@ def _get_template_copy_name(template, existing_templates):
 
 @main.route((
     '/services/<uuid:service_id>/templates/action-blocked/'
-    '<notification_type>'
+    '<template_type:notification_type>'
 ))
 @main.route((
     '/services/<uuid:service_id>/templates/action-blocked/'
-    '<notification_type>/<return_to>/<uuid:template_id>'
+    '<template_type:notification_type>/<return_to>/<uuid:template_id>'
 ))
 @user_has_permissions('manage_templates')
 def action_blocked(service_id, notification_type, return_to='add_new_template', template_id=None):
@@ -505,18 +505,16 @@ def delete_template_folder(service_id, template_folder_id):
 
 
 @main.route(
-    "/services/<uuid:service_id>/templates/add-<template_type>",
+    "/services/<uuid:service_id>/templates/add-<template_type:template_type>",
     methods=['GET', 'POST'],
 )
 @main.route(
-    "/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/add-<template_type>",
+    "/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>/add-<template_type:template_type>",
     methods=['GET', 'POST'],
 )
 @user_has_permissions('manage_templates')
 def add_service_template(service_id, template_type, template_folder_id=None):
 
-    if template_type not in ['sms', 'email', 'letter']:
-        abort(404)
     if not current_service.has_permission('letter') and template_type == 'letter':
         abort(403)
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -36,13 +36,13 @@ from app.utils import (
 MAX_FILE_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MB
 
 
-@main.route("/services/<service_id>/uploads")
+@main.route("/services/<uuid:service_id>/uploads")
 @user_has_permissions()
 def uploads(service_id):
     return view_jobs(service_id)
 
 
-@main.route("/services/<service_id>/upload-letter", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/upload-letter", methods=['GET', 'POST'])
 @user_has_permissions('send_messages')
 def upload_letter(service_id):
     form = PDFUploadForm()
@@ -138,7 +138,7 @@ def _get_error_from_upload_form(form_errors):
     return error
 
 
-@main.route("/services/<service_id>/preview-letter/<file_id>")
+@main.route("/services/<uuid:service_id>/preview-letter/<uuid:file_id>")
 @user_has_permissions('send_messages')
 def uploaded_letter_preview(service_id, file_id):
     metadata = get_letter_metadata(service_id, file_id)
@@ -183,7 +183,7 @@ def uploaded_letter_preview(service_id, file_id):
     )
 
 
-@main.route("/services/<service_id>/preview-letter-image/<file_id>")
+@main.route("/services/<uuid:service_id>/preview-letter-image/<uuid:file_id>")
 @user_has_permissions('send_messages')
 def view_letter_upload_as_preview(service_id, file_id):
     pdf_file, metadata = get_letter_pdf_and_metadata(service_id, file_id)
@@ -196,7 +196,7 @@ def view_letter_upload_as_preview(service_id, file_id):
         return TemplatePreview.from_valid_pdf_file(pdf_file, page)
 
 
-@main.route("/services/<service_id>/upload-letter/send", methods=['POST'])
+@main.route("/services/<uuid:service_id>/upload-letter/send", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_uploaded_letter(service_id):
     if not (current_service.has_permission('letter') and current_service.has_permission('upload_letters')):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -194,7 +194,7 @@ class Organisation(JSONModel):
 
     def associate_service(self, service_id):
         organisations_client.update_service_organisation(
-            str(service_id),
+            service_id,
             self.id
         )
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -176,7 +176,7 @@ class Service(JSONModel):
         ]
 
     def get_template(self, template_id, version=None):
-        return service_api_client.get_service_template(self.id, str(template_id), version)['data']
+        return service_api_client.get_service_template(self.id, template_id, version)['data']
 
     def get_template_folder_with_user_permission_or_403(self, folder_id, user):
         template_folder = self.get_template_folder(folder_id)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -234,7 +234,7 @@ class User(JSONModel, UserMixin):
         ]
 
     def belongs_to_service(self, service_id):
-        return str(service_id) in self.service_ids
+        return service_id in self.service_ids
 
     def belongs_to_service_or_403(self, service_id):
         if not self.belongs_to_service(service_id):

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -20,7 +20,7 @@ class InviteApiClient(NotifyAdminAPIClient):
                       auth_type,
                       folder_permissions):
         data = {
-            'service': str(service_id),
+            'service': service_id,
             'email_address': email_address,
             'from_user': invite_from_id,
             'permissions': ','.join(sorted(translate_permissions_from_admin_roles_to_db(permissions))),

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -2,6 +2,7 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/message-count-label.html" import message_count_label %}
 
 {% block service_page_title %}
   {{ notification_type.capitalize() }} are disabled
@@ -11,26 +12,15 @@
 
   <div class="grid-row">
     <div class="column-five-sixths">
-      {% set
-        back_link_dict = {
-          'add_new_template': '.choose_template',
-          'templates': '.choose_template',
-          'view_template': '.view_template'
-        }
-      %}
       {{ page_header(
         '{} are disabled'.format(notification_type.capitalize()),
-        back_link=url_for(
-          back_link_dict[return_to],
-          service_id=current_service.id,
-          template_id=template_id
-        )
+        back_link=back_link,
       ) }}
       <p>
-        Sending {{ notification_type }} has been disabled for your service.
+        Sending {{ message_count_label(999, notification_type, suffix='') -}} has been disabled for your service.
       </p>
       <p>
-        If you need to send {{ notification_type }}
+        If you need to send {{ message_count_label(999, notification_type, suffix='') }}
         <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
       </p>
 

--- a/app/url_converters.py
+++ b/app/url_converters.py
@@ -1,0 +1,11 @@
+from werkzeug.routing import BaseConverter
+
+
+class TemplateTypeConverter(BaseConverter):
+
+    regex = '(?:email|sms|letter)'
+
+
+class LetterFileExtensionConverter(BaseConverter):
+
+    regex = '(?:pdf|png)'

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -1,8 +1,9 @@
 import ast
 import inspect
+import re
 
 import pytest
-from flask import request
+from flask import current_app, request
 from werkzeug.exceptions import Forbidden, Unauthorized
 
 from app.main.views.index import index
@@ -481,3 +482,12 @@ def test_routes_have_permissions_decorators():
                 'Use @user_is_platform_admin only\n'
                 'app/main/views/{}.py::{}\n'
             ).format(file, function)
+
+
+def test_routes_require_uuids(client_request):
+    for rule in current_app.url_map.iter_rules():
+        for param in re.findall('<([^>]*)>', rule.rule):
+            if '_id' in param and not param.startswith('uuid:'):
+                pytest.fail((
+                    'Should be <uuid:{}> in {}'
+                ).format(param, rule.rule))

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -493,7 +493,7 @@ def test_should_cancel_letter_job(
     mocker,
     active_user_with_permissions
 ):
-    job_id = uuid.uuid4()
+    job_id = str(uuid.uuid4())
     job = job_json(
         SERVICE_ONE_ID,
         active_user_with_permissions,

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -51,9 +51,10 @@ def test_letter_branding_page_shows_full_branding_list(
 def test_update_letter_branding_shows_the_current_letter_brand(
     platform_admin_client,
     mock_get_letter_branding_by_id,
+    fake_uuid,
 ):
     response = platform_admin_client.get(
-        url_for('.update_letter_branding', branding_id='abc')
+        url_for('.update_letter_branding', branding_id=fake_uuid)
     )
 
     assert response.status_code == 200
@@ -81,7 +82,7 @@ def test_update_letter_branding_with_new_valid_file(
     mock_delete_temp_files = mocker.patch('app.main.views.letter_branding.delete_letter_temp_file')
 
     response = platform_admin_client.post(
-        url_for('.update_letter_branding', branding_id='abc'),
+        url_for('.update_letter_branding', branding_id=fake_uuid),
         data={'file': (BytesIO(''.encode('utf-8')), filename)},
         follow_redirects=True
     )
@@ -97,10 +98,11 @@ def test_update_letter_branding_with_new_valid_file(
 
 def test_update_letter_branding_when_uploading_invalid_file(
     platform_admin_client,
-    mock_get_letter_branding_by_id
+    mock_get_letter_branding_by_id,
+    fake_uuid,
 ):
     response = platform_admin_client.post(
-        url_for('.update_letter_branding', branding_id='abc'),
+        url_for('.update_letter_branding', branding_id=fake_uuid),
         data={'file': (BytesIO(''.encode('utf-8')), 'test.png')},
         follow_redirects=True
     )
@@ -127,7 +129,7 @@ def test_update_letter_branding_deletes_any_temp_files_when_uploading_a_file(
     mock_delete_temp_files = mocker.patch('app.main.views.letter_branding.delete_letter_temp_file')
 
     response = platform_admin_client.post(
-        url_for('.update_letter_branding', branding_id='abc', logo=temp_logo),
+        url_for('.update_letter_branding', branding_id=fake_uuid, logo=temp_logo),
         data={'file': (BytesIO(''.encode('utf-8')), 'new_uploaded_file.svg')},
         follow_redirects=True
     )
@@ -223,7 +225,7 @@ def test_update_letter_branding_shows_database_errors_on_name_field(
     ))
 
     response = platform_admin_client.post(
-        url_for('.update_letter_branding', branding_id='abc'),
+        url_for('.update_letter_branding', branding_id=fake_uuid),
         data={
             'name': 'my brand',
             'operation': 'branding-details'

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -260,11 +260,12 @@ def test_should_show_edit_provider_form(
     client,
     platform_admin_user,
     mocker,
+    fake_uuid,
 ):
     mocker.patch('app.provider_client.get_provider_by_id', return_value=copy.deepcopy(stub_provider))
 
     client.login(platform_admin_user, mocker)
-    response = client.get(url_for('main.edit_provider', provider_id='12345'))
+    response = client.get(url_for('main.edit_provider', provider_id=fake_uuid))
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -34,7 +34,6 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     active_caseworking_user,
     active_user_with_permissions,
-    fake_uuid,
     mock_get_international_service,
     mock_get_live_service,
     mock_get_service,
@@ -358,6 +357,7 @@ def test_shows_error_if_parsing_exception(
     mock_get_service_template,
     exception,
     expected_error_message,
+    fake_uuid,
 ):
 
     def _raise_exception_or_partial_exception(file_content, filename):

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2786,7 +2786,7 @@ def test_inbound_sms_sender_is_not_deleteable(
     page = client_request.get(
         '.service_edit_sms_sender',
         service_id=SERVICE_ONE_ID,
-        sms_sender_id='1234',
+        sms_sender_id=fake_uuid,
     )
 
     back_link = page.select_one('.govuk-back-link')
@@ -2810,19 +2810,19 @@ def test_delete_sms_sender(
     client_request.post(
         '.service_delete_sms_sender',
         service_id=SERVICE_ONE_ID,
-        sms_sender_id='1234',
+        sms_sender_id=fake_uuid,
         _expected_redirect=url_for(
             'main.service_sms_senders',
             service_id=SERVICE_ONE_ID,
             _external=True,
         )
     )
-    mock_delete.assert_called_once_with(service_id=SERVICE_ONE_ID, sms_sender_id='1234')
+    mock_delete.assert_called_once_with(service_id=SERVICE_ONE_ID, sms_sender_id=fake_uuid)
 
 
-@pytest.mark.parametrize('fixture, hide_textbox, fixture_sender_id', [
-    (get_inbound_number_sms_sender, True, '1234'),
-    (get_default_sms_sender, False, '1234'),
+@pytest.mark.parametrize('fixture, hide_textbox', [
+    (get_inbound_number_sms_sender, True),
+    (get_default_sms_sender, False),
 ])
 def test_inbound_sms_sender_is_not_editable(
     client_request,
@@ -2830,7 +2830,6 @@ def test_inbound_sms_sender_is_not_editable(
     fake_uuid,
     fixture,
     hide_textbox,
-    fixture_sender_id,
     mocker
 ):
     fixture(mocker)
@@ -2838,7 +2837,7 @@ def test_inbound_sms_sender_is_not_editable(
     page = client_request.get(
         '.service_edit_sms_sender',
         service_id=SERVICE_ONE_ID,
-        sms_sender_id=fixture_sender_id,
+        sms_sender_id=fake_uuid,
     )
 
     assert bool(page.find('input', attrs={'name': "sms_sender"})) != hide_textbox

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1260,6 +1260,7 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
     endpoint,
     data,
     expected_error,
+    fake_uuid,
 ):
     service_one['permissions'] = []
     page = client_request.post(
@@ -1273,7 +1274,6 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
     assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.choose_template',
         service_id=SERVICE_ONE_ID,
-        template_id='0',
     )
 
 
@@ -1299,7 +1299,6 @@ def test_should_not_allow_creation_of_a_template_without_correct_permission(
     assert page.select(".govuk-back-link")[0]['href'] == url_for(
         '.choose_template',
         service_id=service_one['id'],
-        template_id='0',
     )
 
 

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -50,8 +50,14 @@ def test_get_upload_letter(client_request):
     assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Choose file'
 
 
-def test_post_upload_letter_redirects_for_valid_file(mocker, active_user_with_permissions, service_one, client_request):
-    mocker.patch('uuid.uuid4', return_value='fake-uuid')
+def test_post_upload_letter_redirects_for_valid_file(
+    mocker,
+    active_user_with_permissions,
+    service_one,
+    client_request,
+    fake_uuid,
+):
+    mocker.patch('uuid.uuid4', return_value=fake_uuid)
     antivirus_mock = mocker.patch('app.main.views.uploads.antivirus_client.scan', return_value=True)
     mocker.patch(
         'app.main.views.uploads.sanitise_letter',
@@ -76,7 +82,7 @@ def test_post_upload_letter_redirects_for_valid_file(mocker, active_user_with_pe
 
     mock_s3.assert_called_once_with(
         b'The sanitised content',
-        file_location='service-{}/fake-uuid.pdf'.format(SERVICE_ONE_ID),
+        file_location='service-{}/{}.pdf'.format(SERVICE_ONE_ID, fake_uuid),
         status='valid',
         page_count=1,
         filename='tests/test_pdf_files/one_page_pdf.pdf'
@@ -85,7 +91,7 @@ def test_post_upload_letter_redirects_for_valid_file(mocker, active_user_with_pe
     assert page.find('h1').text == 'tests/test_pdf_files/one_page_pdf.pdf'
     assert not page.find(id='validation-error-message')
 
-    assert page.find('input', {'type': 'hidden', 'name': 'file_id', 'value': 'fake-uuid'})
+    assert page.find('input', {'type': 'hidden', 'name': 'file_id', 'value': fake_uuid})
     assert page.find('button', {'type': 'submit'}).text == 'Send 1 letter'
 
 
@@ -94,6 +100,7 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(
     active_user_with_permissions,
     service_one,
     client_request,
+    fake_uuid,
 ):
     letter_template = {'template_type': 'letter',
                        'reply_to_text': '',
@@ -101,7 +108,7 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(
                        'subject': 'hi',
                        'content': 'my letter'}
 
-    mocker.patch('uuid.uuid4', return_value='fake-uuid')
+    mocker.patch('uuid.uuid4', return_value=fake_uuid)
     mocker.patch('app.main.views.uploads.antivirus_client.scan', return_value=True)
     mocker.patch(
         'app.main.views.uploads.sanitise_letter',
@@ -137,7 +144,7 @@ def test_post_upload_letter_shows_letter_preview_for_valid_file(
         assert img['src'] == url_for(
             '.view_letter_upload_as_preview',
             service_id=SERVICE_ONE_ID,
-            file_id='fake-uuid',
+            file_id=fake_uuid,
             page=page_no)
 
 
@@ -211,8 +218,8 @@ def test_post_choose_upload_file_when_file_is_malformed(mocker, client_request):
     assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
 
 
-def test_post_upload_letter_with_invalid_file(mocker, client_request):
-    mocker.patch('uuid.uuid4', return_value='fake-uuid')
+def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid):
+    mocker.patch('uuid.uuid4', return_value=fake_uuid)
     mocker.patch('app.main.views.uploads.antivirus_client.scan', return_value=True)
     mock_s3 = mocker.patch('app.main.views.uploads.upload_letter_to_s3')
 
@@ -241,7 +248,7 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request):
 
         mock_s3.assert_called_once_with(
             file_contents,
-            file_location='service-{}/fake-uuid.pdf'.format(SERVICE_ONE_ID),
+            file_location='service-{}/{}.pdf'.format(SERVICE_ONE_ID, fake_uuid),
             status='invalid',
             page_count=1,
             filename='tests/test_pdf_files/one_page_pdf.pdf',
@@ -253,14 +260,14 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request):
     assert not page.find('button', {'type': 'submit'})
 
 
-def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client_request):
+def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client_request, fake_uuid):
     letter_template = {'template_type': 'letter',
                        'reply_to_text': '',
                        'postage': 'first',
                        'subject': 'hi',
                        'content': 'my letter'}
 
-    mocker.patch('uuid.uuid4', return_value='fake-uuid')
+    mocker.patch('uuid.uuid4', return_value=fake_uuid)
     mocker.patch('app.main.views.uploads.antivirus_client.scan', return_value=True)
     mocker.patch('app.main.views.uploads.upload_letter_to_s3')
     mock_sanitise_response = Mock()
@@ -287,13 +294,17 @@ def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client
     assert letter_images[0]['src'] == url_for(
         '.view_letter_upload_as_preview',
         service_id=SERVICE_ONE_ID,
-        file_id='fake-uuid',
+        file_id=fake_uuid,
         page=1
     )
 
 
-def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unknown_error(mocker, client_request):
-    mocker.patch('uuid.uuid4', return_value='fake-uuid')
+def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unknown_error(
+    mocker,
+    client_request,
+    fake_uuid,
+):
+    mocker.patch('uuid.uuid4', return_value=fake_uuid)
     mocker.patch('app.main.views.uploads.antivirus_client.scan', return_value=True)
     mock_s3 = mocker.patch('app.main.views.uploads.upload_letter_to_s3')
 
@@ -311,7 +322,13 @@ def test_post_upload_letter_does_not_upload_to_s3_if_template_preview_raises_unk
     assert not mock_s3.called
 
 
-def test_uploaded_letter_preview(mocker, active_user_with_permissions, service_one, client_request):
+def test_uploaded_letter_preview(
+    mocker,
+    active_user_with_permissions,
+    service_one,
+    client_request,
+    fake_uuid,
+):
     mocker.patch('app.main.views.uploads.service_api_client')
     mocker.patch('app.main.views.uploads.get_letter_metadata', return_value={
         'filename': 'my_letter.pdf', 'page_count': '1', 'status': 'valid'})
@@ -322,7 +339,7 @@ def test_uploaded_letter_preview(mocker, active_user_with_permissions, service_o
     page = client_request.get(
         'main.uploaded_letter_preview',
         service_id=SERVICE_ONE_ID,
-        file_id='fake-uuid',
+        file_id=fake_uuid,
         original_filename='my_letter.pdf',
         page_count=1,
         status='valid',
@@ -333,7 +350,11 @@ def test_uploaded_letter_preview(mocker, active_user_with_permissions, service_o
     assert page.find('div', class_='letter-sent')
 
 
-def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_mode(mocker, client_request):
+def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_mode(
+    mocker,
+    client_request,
+    fake_uuid,
+):
     mocker.patch('app.main.views.uploads.service_api_client')
     mocker.patch('app.main.views.uploads.get_letter_metadata', return_value={
         'filename': 'my_letter.pdf', 'page_count': '1', 'status': 'valid'})
@@ -342,7 +363,7 @@ def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_m
     page = client_request.get(
         'main.uploaded_letter_preview',
         service_id=SERVICE_ONE_ID,
-        file_id='fake-uuid',
+        file_id=fake_uuid,
         original_filename='my_letter.pdf',
         page_count=1,
         status='valid',
@@ -359,6 +380,7 @@ def test_uploaded_letter_preview_image_shows_overlay_when_content_outside_printa
     mocker,
     logged_in_client,
     mock_get_service,
+    fake_uuid,
 ):
     mocker.patch(
         'app.main.views.uploads.get_letter_pdf_and_metadata',
@@ -369,7 +391,7 @@ def test_uploaded_letter_preview_image_shows_overlay_when_content_outside_printa
         return_value=make_response('page.html', 200))
 
     logged_in_client.get(
-        url_for('main.view_letter_upload_as_preview', file_id='fake-uuid', service_id=SERVICE_ONE_ID, page=1)
+        url_for('main.view_letter_upload_as_preview', file_id=fake_uuid, service_id=SERVICE_ONE_ID, page=1)
     )
 
     template_preview_mock.assert_called_once_with('pdf_file', '1')
@@ -387,6 +409,7 @@ def test_uploaded_letter_preview_image_does_not_show_overlay_if_no_content_outsi
     logged_in_client,
     mock_get_service,
     metadata,
+    fake_uuid,
 ):
     mocker.patch(
         'app.main.views.uploads.get_letter_pdf_and_metadata',
@@ -397,7 +420,7 @@ def test_uploaded_letter_preview_image_does_not_show_overlay_if_no_content_outsi
         return_value=make_response('page.html', 200))
 
     logged_in_client.get(
-        url_for('main.view_letter_upload_as_preview', file_id='fake-uuid', service_id=SERVICE_ONE_ID, page=1)
+        url_for('main.view_letter_upload_as_preview', file_id=fake_uuid, service_id=SERVICE_ONE_ID, page=1)
     )
 
     template_preview_mock.assert_called_once_with('pdf_file', '1')


### PR DESCRIPTION
Before, these would need view-layer code or the result of an API call in order to respond with a 404:
```
/services/foo/templates
```
```
/services/1234/templates/fax
```

Now Flask will 404 them straight away because it knows that `service_id` should always be a UUID (not `foo` or `1234`) and `template_type` should always be `email`, `sms`, or `letter` (not `fax`).

***

This is what the tests look like if you miss marking an ID as being a UUID:

![image](https://user-images.githubusercontent.com/355079/68137522-0ab1bc00-ff1f-11e9-9580-056251eadcd7.png)
