### PR TITLE
Update navigation menus

### DIFF
--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -23,18 +23,6 @@ def features_nav():
             "link": "main.roadmap",
         },
         {
-            "name": "Get started",
-            "link": "main.get_started",
-        },
-        {
-            "name": "Trial mode",
-            "link": "main.trial_mode_new",
-        },
-        {
-            "name": "Message status",
-            "link": "main.message_status",
-        },
-        {
             "name": "Security",
             "link": "main.security",
         },
@@ -54,5 +42,25 @@ def pricing_nav():
         {
             "name": "How to pay",
             "link": "main.how_to_pay",
+        },
+    ]
+
+def using_notify_nav():
+    return [
+        {
+            "name": "Get started",
+            "link": "main.get_started",
+        },
+        {
+            "name": "Documentation",
+            "link": "main.documentation",
+        },
+        {
+            "name": "Trial mode",
+            "link": "main.trial_mode_new",
+        },
+        {
+            "name": "Message status",
+            "link": "main.message_status",
         },
     ]

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -23,6 +23,10 @@ def features_nav():
             "link": "main.roadmap",
         },
         {
+            "name": "Get started",
+            "link": "main.get_started",
+        },
+        {
             "name": "Trial mode",
             "link": "main.trial_mode_new",
         },

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -52,15 +52,15 @@ def using_notify_nav():
             "link": "main.get_started",
         },
         {
-            "name": "Documentation",
-            "link": "main.documentation",
-        },
-        {
             "name": "Trial mode",
             "link": "main.trial_mode_new",
         },
         {
             "name": "Message status",
             "link": "main.message_status",
+        },
+        {
+            "name": "Documentation",
+            "link": "main.documentation",
         },
     ]

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -75,6 +75,7 @@
           <ul>
             <li><a href="{{ url_for("main.features") }}">Features</a></li>
             <li><a href="{{ url_for("main.roadmap") }}">Roadmap</a></li>
+            <li><a href="{{ url_for("main.get_started") }}">Get started</a></li>
             <li><a href="{{ url_for("main.trial_mode_new") }}">Trial mode</a></li>
             <li><a href="{{ url_for("main.message_status") }}">Message status</a></li>
             <li><a href="{{ url_for("main.security") }}">Security</a></li>

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -64,22 +64,19 @@
       <div class="grid-row">
         <div class="column-one-quarter">
           <ul>
-            <li><a href="{{ url_for('main.support') }}">Support</a></li>
+            <li><a href="{{ url_for('main.support') }}">24-hour online support</a></li>
             <li><a href="https://status.notifications.service.gov.uk">System status</a></li>
-            <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
-            <li><a href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">Slack channel</a></li>
-            <li><a href="https://gds.blog.gov.uk/category/notify/">Blog</a></li>
+            <li><a href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">Chat to us on Slack</a></li>
           </ul>
         </div>
         <div class="column-one-quarter">
           <ul>
             <li><a href="{{ url_for("main.features") }}">Features</a></li>
             <li><a href="{{ url_for("main.roadmap") }}">Roadmap</a></li>
-            <li><a href="{{ url_for("main.get_started") }}">Get started</a></li>
-            <li><a href="{{ url_for("main.trial_mode_new") }}">Trial mode</a></li>
-            <li><a href="{{ url_for("main.message_status") }}">Message status</a></li>
             <li><a href="{{ url_for("main.security") }}">Security</a></li>
             <li><a href="{{ url_for("main.terms") }}">Terms of use</a></li>
+            <li><a href="https://www.gov.uk/performance/govuk-notify">Performance</a></li>
+            <li><a href="https://gds.blog.gov.uk/category/notify/">Blog</a></li>
           </ul>
         </div>
         <div class="column-one-quarter">
@@ -90,7 +87,10 @@
         </div>
         <div class="column-one-quarter">
           <ul>
-            <li><a href="{{ url_for("main.documentation") }}">Documentation</a></li>
+            <li><a href="{{ url_for("main.get_started") }}">Get started</a></li>
+            <li><a href="{{ url_for("main.documentation") }}">API documentation</a></li>
+            <li><a href="{{ url_for("main.trial_mode_new") }}">Trial mode</a></li>
+            <li><a href="{{ url_for("main.message_status") }}">Message status</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
This PR:

- adds the new `Get started` page to our navigation menus
- reorders the footer links into 4 distinct groups:
  - Support
  - About Notify
  - Pricing and payment
  - Using Notify
- updates the `Features` navigation menu
- adds a new `Using Notify` navigation menu