### PR TITLE
Show recipient when about to send uploaded letter

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -92,14 +92,18 @@ def upload_letter(service_id):
             else:
                 raise ex
         else:
+            response = response.json()
+            recipient = response['recipient_address']
             status = 'valid'
-            file_contents = base64.b64decode(response.json()['file'].encode())
+            file_contents = base64.b64decode(response['file'].encode())
+
             upload_letter_to_s3(
                 file_contents,
                 file_location=file_location,
                 status=status,
                 page_count=page_count,
-                filename=original_filename)
+                filename=original_filename,
+                recipient=recipient)
 
         return redirect(
             url_for(
@@ -147,6 +151,7 @@ def uploaded_letter_preview(service_id, file_id):
     status = metadata.get('status')
     error_shortcode = metadata.get('message')
     invalid_pages = metadata.get('invalid_pages')
+    recipient = metadata.get('recipient')
 
     if invalid_pages:
         invalid_pages = json.loads(invalid_pages)
@@ -180,6 +185,7 @@ def uploaded_letter_preview(service_id, file_id):
         message=error_message,
         error_code=error_shortcode,
         form=form,
+        recipient=recipient,
     )
 
 

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -3,13 +3,24 @@ import json
 from boto3 import resource
 from flask import current_app
 from notifications_utils.s3 import s3upload as utils_s3upload
+from notifications_utils.sanitise_text import SanitiseASCII
 
 
 def get_transient_letter_file_location(service_id, upload_id):
     return 'service-{}/{}.pdf'.format(service_id, upload_id)
 
 
-def upload_letter_to_s3(data, *, file_location, status, page_count, filename, message=None, invalid_pages=None):
+def upload_letter_to_s3(
+    data,
+    *,
+    file_location,
+    status,
+    page_count,
+    filename,
+    message=None,
+    invalid_pages=None,
+    recipient=None
+):
     metadata = {
         'status': status,
         'page_count': str(page_count),
@@ -19,6 +30,8 @@ def upload_letter_to_s3(data, *, file_location, status, page_count, filename, me
         metadata['message'] = message
     if invalid_pages:
         metadata['invalid_pages'] = json.dumps(invalid_pages)
+    if recipient:
+        metadata['recipient'] = format_recipient(recipient)
 
     utils_s3upload(
         filedata=data,
@@ -46,3 +59,20 @@ def get_letter_metadata(service_id, file_id):
     s3_object = s3.Object(current_app.config['TRANSIENT_UPLOADED_LETTERS'], file_location).get()
 
     return s3_object['Metadata']
+
+
+def format_recipient(address):
+    '''
+    To format the recipient we need to:
+    - remove new line characters
+    - remove whitespace around the lines
+    - join the address lines, separated by a comma
+    - convert the string to ASCII (S3 metadata must be stored as ASCII)
+    '''
+    stripped_address_lines_no_trailing_commas = [
+        line.lstrip().rstrip(' ,')
+        for line in address.splitlines() if line
+    ]
+    one_line_address = ', '.join(stripped_address_lines_no_trailing_commas)
+
+    return SanitiseASCII.encode(one_line_address)

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -32,6 +32,10 @@
 
     {% if status == 'valid' and current_service.live %}
     <div class="js-stick-at-bottom-when-scrolling">
+      <p>
+        Recipient: {{ recipient }}
+      </p>
+
       <form method="post" enctype="multipart/form-data" action="{{url_for(
           'main.send_uploaded_letter',
           service_id=current_service.id,


### PR DESCRIPTION
The recipient of the letter now displays at the bottom of the page when
previewing a valid letter. The template preview `/precompiled/sanitise`
endpoint returns the address, but we format it to display on a single
line with commas between each line. We also need to convert the
recipient address to ASCII so that it can be stored as S3 metadata.

[Pivotal story](https://www.pivotaltracker.com/story/show/167534041)

<img width="795" alt="Screenshot 2019-11-08 at 10 11 45" src="https://user-images.githubusercontent.com/12881990/68468613-4941c200-0210-11ea-9e4d-dbb8ac4a17b5.png">
