### PR TITLE
Update error page content

### DIFF
--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Bad Request – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Bad request{% endblock %}
 {% block maincolumn_content %}
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Bad Request{% endblock %}
+{% block per_page_title %}Bad Request – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,9 +1,9 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Unauthorized{% endblock %}
+{% block per_page_title %}You are not authorised to see this page – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-    <h1>401</h1>
-    <p>You are not authorized to see this page.</p>
+    <h1>You are not authorised to see this page</h1>
+      <p><a href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
   </div>
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}You are not authorised to see this page – GOV.UK Notify{% endblock %}
+{% block per_page_title %}You are not authorised to see this page{% endblock %}
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,13 +1,13 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}403{% endblock %}
+{% block per_page_title %}You are not allowed to see this page – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          403
+          You are not allowed to see this page
         </h1>
         <p>
-          You do not have permission to view this page.
+          To check your permissions, speak to a member of your team who can manage settings, team and usage.
         </p>
       </div>
     </div>

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}You are not allowed to see this page – GOV.UK Notify{% endblock %}
+{% block per_page_title %}You are not allowed to see this page{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -13,7 +13,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p>
-          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
+          If the web address is correct or you selected a link or button, <a href="{{ url_for('main.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,13 +1,19 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Page could not be found{% endblock %}
+{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          Page could not be found
+          Page not found
         </h1>
         <p>
-          Check you’ve entered the correct web address.
+          If you typed the web address, check it is correct.
+        </p>
+        <p>
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p>
+          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,13 +1,19 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Page not found{% endblock %}
+{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          Page could not be found
+          Page not found
         </h1>
         <p>
-          Check you’ve entered the correct web address.
+          If you typed the web address, check it is correct.
+        </p>
+        <p>
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p>
+          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -13,7 +13,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p>
-          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
+          If the web address is correct or you selected a link or button, <a href="{{ url_for('main.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}File too big{% endblock %}
+{% block per_page_title %}File too big – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}File too big – GOV.UK Notify{% endblock %}
+{% block per_page_title %}File too big{% endblock %}
 {% block maincolumn_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Sorry, there’s a problem with the service – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,12 +1,20 @@
 {% extends "withoutnav_template.html" %}
-{% block per_page_title %}Server error{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service – GOV.UK Notify{% endblock %}
 {% block maincolumn_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        Sorry, we’re experiencing technical difficulties
+        Sorry, there’s a problem with GOV.UK Notify
       </h1>
-      <p>Try again later.</p>
+      <p>
+        Try again later.
+      </p>
+      <p>
+        You can check our <a href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
+      </p>
+      <p>
+        To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -10,6 +10,7 @@ def test_bad_url_returns_page_not_found(client):
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string.strip() == 'Page not found'
+    assert page.title.string.strip() == 'Page not found – GOV.UK Notify'
 
 
 def test_load_service_before_request_handles_404(client_request, mocker):
@@ -38,6 +39,7 @@ def test_malformed_token_returns_page_not_found(logged_in_client, url):
     assert page.h1.string.strip() == 'Page not found'
     flash_banner = page.find('div', class_='banner-dangerous').string.strip()
     assert flash_banner == "There’s something wrong with the link you’ve used."
+    assert page.title.string.strip() == 'Page not found – GOV.UK Notify'
 
 
 def test_csrf_returns_400(logged_in_client, mocker):
@@ -50,6 +52,7 @@ def test_csrf_returns_400(logged_in_client, mocker):
     assert response.status_code == 400
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string.strip() == 'Something went wrong, please go back and try again.'
+    assert page.title.string.strip() == 'Bad request – GOV.UK Notify'
 
 
 def test_csrf_redirects_to_sign_in_page_if_not_signed_in(client, mocker):
@@ -68,3 +71,4 @@ def test_405_returns_something_went_wrong_page(client, mocker):
     assert response.status_code == 405
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string.strip() == 'Something went wrong, please go back and try again.'
+    assert page.title.string.strip() == 'Bad request – GOV.UK Notify'

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -9,7 +9,7 @@ def test_bad_url_returns_page_not_found(client):
     response = client.get('/bad_url')
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.h1.string.strip() == 'Page could not be found'
+    assert page.h1.string.strip() == 'Page not found'
 
 
 def test_load_service_before_request_handles_404(client_request, mocker):
@@ -35,7 +35,7 @@ def test_malformed_token_returns_page_not_found(logged_in_client, url):
 
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.h1.string.strip() == 'Page could not be found'
+    assert page.h1.string.strip() == 'Page not found'
     flash_banner = page.find('div', class_='banner-dangerous').string.strip()
     assert flash_banner == "There’s something wrong with the link you’ve used."
 

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -247,8 +247,8 @@ def test_choose_account_should_not_show_back_to_service_link_if_service_archived
     )),
     (service_two, 403, (
         # Page has no ‘back to’ link
-        '403 '
-        'You do not have permission to view this page.'
+        'You are not allowed to see this page '
+        'To check your permissions, speak to a member of your team who can manage settings, team and usage.'
     )),
 ))
 def test_should_not_show_back_to_service_if_user_doesnt_belong_to_service(

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -415,7 +415,7 @@ def test_signed_in_existing_user_cannot_use_anothers_invite(
         _follow_redirects=True,
         _expected_status=403,
     )
-    assert page.h1.string.strip() == '403'
+    assert page.h1.string.strip() == 'You are not allowed to see this page'
     flash_banners = page.find_all('div', class_='banner-dangerous')
     assert len(flash_banners) == 1
     banner_contents = flash_banners[0].text.strip()


### PR DESCRIPTION
This PR updates the content for Notify's 400, 401, 403, 404, 410, 413 and 500 error pages.

The new content:
- follows the Design system pattern for page titles
- uses English language descriptions instead of error codes in the h1
- adds useful instructions (where possible) so users know what to do next

I've tried to simplify the language around these errors, using Plain English where possible. The Design system says we should not use "vague, unhelpful words" like maintenance, improvements and technical difficulties.