### PR TITLE
Prefer shorter URL

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -105,8 +105,8 @@ def start_tour(service_id, template_id):
     )
 
 
-@main.route("/services/<uuid:service_id>/templates", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/templates/all", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/templates", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/templates/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/templates/<template_type:template_type>", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/templates/all/folders/<uuid:template_folder_id>", methods=['GET', 'POST'])

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -148,6 +148,24 @@ def test_a_page_should_nave_selected_org_navigation_item(
     assert selected_nav_items[0].text.strip() == selected_nav_item
 
 
+def test_navigation_urls(
+    client_request,
+    mock_get_service_templates,
+    mock_get_template_folders,
+):
+    page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
+    assert [
+        a['href'] for a in page.select('.navigation a')
+    ] == [
+        '/services/{}'.format(SERVICE_ONE_ID),
+        '/services/{}/templates'.format(SERVICE_ONE_ID),
+        '/services/{}/users'.format(SERVICE_ONE_ID),
+        '/services/{}/usage'.format(SERVICE_ONE_ID),
+        '/services/{}/service-settings'.format(SERVICE_ONE_ID),
+        '/services/{}/api'.format(SERVICE_ONE_ID),
+    ]
+
+
 def test_caseworkers_get_caseworking_navigation(
     client_request,
     mocker,


### PR DESCRIPTION
Flask will pick the first route that matches. Decorators get applied from innermost to outermost.

So if the same endpoint is served at `/abc` and `/123` the one used when `url_for` is generating a URL is whichever decorator is lowest (in terms of line number).

It doesn’t functionally make a difference, but it’s causing the functional tests to fail at the moment. And shorter URLs are nicer, so I think it makes sense to change here, rather than change the tests.