### PR TITLE
Only show the breaking change page to teams who use the API

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -603,7 +603,12 @@ def edit_service_template(service_id, template_id):
 
         new_template = get_template(new_template_data, current_service)
         template_change = get_template(template, current_service).compare_to(new_template)
-        if template_change.placeholders_added and not request.form.get('confirm'):
+
+        if (
+            template_change.placeholders_added and
+            not request.form.get('confirm') and
+            current_service.api_keys
+        ):
             example_column_headings = (
                 first_column_headings[new_template.template_type] + list(new_template.placeholders)
             )

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -609,20 +609,11 @@ def edit_service_template(service_id, template_id):
             not request.form.get('confirm') and
             current_service.api_keys
         ):
-            example_column_headings = (
-                first_column_headings[new_template.template_type] + list(new_template.placeholders)
-            )
             return render_template(
                 'views/templates/breaking-change.html',
                 template_change=template_change,
                 new_template=new_template,
-                column_headings=list(ascii_uppercase[:len(example_column_headings)]),
-                example_rows=[
-                    example_column_headings,
-                    get_example_csv_rows(new_template),
-                    get_example_csv_rows(new_template)
-                ],
-                form=form
+                form=form,
             )
         try:
             service_api_client.update_service_template(

--- a/app/templates/components/list.html
+++ b/app/templates/components/list.html
@@ -5,3 +5,11 @@
     separator=' '
   ) }}
 {%- endmacro %}
+
+{% macro list_of_code_snippets(variables) %}
+  {{ variables | formatted_list(
+    before_each="<code>",
+    after_each='</code>',
+    separator=' '
+  ) }}
+{%- endmacro %}

--- a/app/templates/components/list.html
+++ b/app/templates/components/list.html
@@ -10,6 +10,6 @@
   {{ variables | formatted_list(
     before_each="<code>",
     after_each='</code>',
-    separator=' '
+    separator=', '
   ) }}
 {%- endmacro %}

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -16,20 +16,19 @@
     back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id)
   ) }}
 
-  <div class="bottom-gutter">
-    {% if template_change.placeholders_removed %}
-      <p>
-        You removed {{ list_of_placeholders(template_change.placeholders_removed) }}
-      </p>
-    {% endif %}
-    {% if template_change.placeholders_added %}
-      <p>
-        You added {{ list_of_placeholders(template_change.placeholders_added) }}
-      </p>
-    {% endif %}
-  </div>
-
-  <p class="top-gutter">Developers, you’ll need to update your API calls</p>
+  {% if template_change.placeholders_removed %}
+    <p>
+      You removed {{ list_of_placeholders(template_change.placeholders_removed) }}
+    </p>
+  {% endif %}
+  {% if template_change.placeholders_added %}
+    <p>
+      You added {{ list_of_placeholders(template_change.placeholders_added) }}
+    </p>
+  {% endif %}
+  <p>
+    Developers, you’ll need to update your API calls.
+  </p>
 
   {% call form_wrapper() %}
     <input type="hidden" name="name" value="{{ new_template.name }}" />

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -2,7 +2,6 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
 {% from "components/list.html" import list_of_placeholders %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -30,6 +29,8 @@
     {% endif %}
   </div>
 
+  <p class="top-gutter">Developers, you’ll need to update your API calls</p>
+
   {% call form_wrapper() %}
     <input type="hidden" name="name" value="{{ new_template.name }}" />
     <input type="hidden" name="subject" value="{{ new_template._subject or '' }}" />
@@ -39,31 +40,5 @@
     <input type="hidden" name="confirm" value="true" />
     {{ page_footer('Save changes to template') }}
   {% endcall %}
-
-  <p>
-    When you send messages using this template you’ll need
-    {{ column_headings|length }}
-    column{{ 's' if column_headings|length > 1 else '' }} of data:
-  </p>
-
-  <div class="spreadsheet fullscreen-content" data-module="fullscreen-table"">
-    {% call(item, row_number) list_table(
-      example_rows,
-      caption="Example",
-      caption_visible=False,
-      field_headings=[''] + column_headings
-    ) %}
-      {% if 1 == row_number %}
-        {{ index_field('') }}
-      {% else %}
-        {{ index_field(row_number - 1) }}
-      {% endif %}
-      {% for column in item %}
-        {{ text_field(column) }}
-      {% endfor %}
-    {% endcall %}
-  </div>
-
-  <p class="top-gutter">Developers, you’ll need to update your API calls</p>
 
 {% endblock %}

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -2,7 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/list.html" import list_of_placeholders %}
+{% from "components/list.html" import list_of_placeholders, list_of_code_snippets %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -15,20 +15,21 @@
     'Confirm changes',
     back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id)
   ) }}
-
-  {% if template_change.placeholders_removed %}
-    <p>
-      You removed {{ list_of_placeholders(template_change.placeholders_removed) }}
-    </p>
-  {% endif %}
-  {% if template_change.placeholders_added %}
-    <p>
-      You added {{ list_of_placeholders(template_change.placeholders_added) }}
-    </p>
-  {% endif %}
-  <p>
-    Developers, you’ll need to update your API calls.
-  </p>
+  <div class="grid-row">
+    <div class="column-five-sixths">
+      {% if template_change.placeholders_removed %}
+        <p>
+          You removed {{ list_of_placeholders(template_change.placeholders_removed) }}
+        </p>
+      {% endif %}
+      <p>
+        You added {{ list_of_placeholders(template_change.placeholders_added) }}
+      </p>
+      <p>
+        Before you send any messages, make sure your API calls include {{ list_of_code_snippets(template_change.placeholders_added) }}.
+      </p>
+    </div>
+  </div>
 
   {% call form_wrapper() %}
     <input type="hidden" name="name" value="{{ new_template.name }}" />

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,5 +23,5 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.1.2#egg=notifications-utils==36.1.2
+git+https://github.com/alphagov/notifications-utils.git@36.2.1#egg=notifications-utils==36.2.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,14 +25,14 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.1.2#egg=notifications-utils==36.1.2
+git+https://github.com/alphagov/notifications-utils.git@36.2.1#egg=notifications-utils==36.2.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.283
+awscli==1.16.292
 bleach==3.1.0
 boto3==1.9.221
-botocore==1.13.19
+botocore==1.13.28
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
@@ -49,7 +49,7 @@ jdcal==1.4.1
 Jinja2==2.10.3
 jmespath==0.9.4
 lml==0.0.9
-lxml==4.4.1
+lxml==4.4.2
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1487,11 +1487,11 @@ def test_should_403_when_create_template_with_process_type_of_priority_for_non_p
     ),
     (
         "hello ((name))",
-        "hello ((full name))",
+        "hello ((first name)) ((middle name)) ((last name))",
         [
             'You removed ((name))',
-            'You added ((full name))',
-            'Before you send any messages, make sure your API calls include full name.',
+            'You added ((first name)) ((middle name)) and ((last name))',
+            'Before you send any messages, make sure your API calls include first name, middle name and last name.',
         ]
     ),
 ])

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1328,6 +1328,7 @@ def test_should_redirect_to_one_off_if_template_type_is_letter(
 def test_should_redirect_when_saving_a_template(
     client_request,
     mock_get_service_template,
+    mock_get_api_keys,
     mock_update_service_template,
     fake_uuid,
 ):
@@ -1499,6 +1500,7 @@ def test_should_show_interstitial_when_making_breaking_change(
     client_request,
     mock_update_service_template,
     mock_get_user_by_email,
+    mock_get_api_keys,
     fake_uuid,
     mocker,
     template_mock,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1483,7 +1483,6 @@ def test_should_403_when_create_template_with_process_type_of_priority_for_non_p
         [
             'You removed ((date))',
             'You added ((name))',
-            'When you send messages using this template you’ll need 3 columns of data:',
         ]
     ),
     (
@@ -1492,7 +1491,6 @@ def test_should_403_when_create_template_with_process_type_of_priority_for_non_p
         [
             'You removed ((date))',
             'You added ((name))',
-            'When you send messages using this template you’ll need 9 columns of data:',
         ]
     ),
 ])


### PR DESCRIPTION
We introduced the ‘breaking change’ page in #631 partly to help teach people about the relationship between the placeholders in their template and the data they were providing. Data can be provided either by API or by uploading a spreadsheet. The users who we struggled to communicate this relationship to were the ones using the upload a spreadsheet feature.

We made two changes to the context of this feature:

1. Around the same time (in #613) we introduced the interactive tour, which ultimately proved to be the thing that helped people understand the relationship between the data they were providing and the placeholders in the template.

2. We introduced a way for people to send one-off messages without using the API or uploading a spreadsheet in #1293. So for this page to say that you’ll need to update a spreadsheet or change an API call if you change the placeholders in your template is no longer accurate.

Therefore I think it makes sense to only show this page to teams who are using the API to send messages. The best proxy we have for that is to look at whether they’ve created any API keys.

***

Since we’re only showing this page to team who are using the API we don’t have to worry about explaining what’s going on in terms of the spreadsheet any more. So this pull request also removes the example spreadsheet.

This makes the page simpler and more focused.

# Before 

Shown to everyone:

![image](https://user-images.githubusercontent.com/355079/68843669-6e2aaf00-06c0-11ea-9a35-141edcb05326.png)

# After 

Only shown to teams using the API:

![image](https://user-images.githubusercontent.com/355079/68843629-581cee80-06c0-11ea-9d21-1f6bb8808a55.png)
