### PR TITLE
Update Zendesk tags to reflect new taxonomy

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1065,7 +1065,7 @@ def branding_request(service_id):
             ticket_type=zendesk_client.TYPE_QUESTION,
             user_email=current_user.email_address,
             user_name=current_user.name,
-            tags=['notify_action_add_branding'],
+            tags=['notify_action', 'notify_branding'],
         )
 
         flash((

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -625,7 +625,6 @@ class Service(JSONModel):
             return
 
         for test, tag in (
-            (True, ''),
             (not self.volumes, '_volumes'),
             (not self.go_live_checklist_completed, '_checklist'),
             (not self.organisation.agreement_signed, '_mou'),

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -615,8 +615,9 @@ class Service(JSONModel):
 
     def _get_request_to_go_live_tags(self):
 
-        BASE = 'notify_request_to_go_live'
+        BASE = 'notify_go_live'
 
+        yield 'notify_action'
         yield BASE
 
         if self.go_live_checklist_completed and self.organisation.agreement_signed:

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1457,7 +1457,6 @@ def test_should_redirect_after_request_to_go_live(
         tags=[
             'notify_action',
             'notify_go_live',
-            'notify_go_live_incomplete',
         ] + extra_tags + [
             'notify_go_live_incomplete_checklist',
             'notify_go_live_incomplete_mou',
@@ -1631,7 +1630,6 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             [
                 'notify_action',
                 'notify_go_live',
-                'notify_go_live_incomplete',
                 'notify_go_live_incomplete_checklist',
                 'notify_go_live_incomplete_email_reply_to',
             ],
@@ -1667,7 +1665,6 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             [
                 'notify_action',
                 'notify_go_live',
-                'notify_go_live_incomplete',
                 'notify_go_live_incomplete_checklist',
                 'notify_go_live_incomplete_sms_sender',
             ],
@@ -1686,7 +1683,6 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             [
                 'notify_action',
                 'notify_go_live',
-                'notify_go_live_incomplete',
                 'notify_go_live_incomplete_checklist',
                 'notify_go_live_incomplete_team_member',
             ],
@@ -1705,7 +1701,6 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             [
                 'notify_action',
                 'notify_go_live',
-                'notify_go_live_incomplete',
                 'notify_go_live_incomplete_checklist',
                 'notify_go_live_incomplete_template_content',
             ],
@@ -1724,7 +1719,6 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             [
                 'notify_action',
                 'notify_go_live',
-                'notify_go_live_incomplete',
                 'notify_go_live_incomplete_volumes',
                 'notify_go_live_incomplete_checklist',
                 'notify_go_live_incomplete_mou',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1398,7 +1398,7 @@ def test_non_gov_users_cant_request_to_go_live(
             'Text messages in next year: \n'
             'Letters in next year: \n'
         ),
-        ['notify_request_to_go_live_incomplete_volumes']
+        ['notify_go_live_incomplete_volumes']
     ),
     (
         (('email', 1234), ('sms', 0), ('letter', 999)),
@@ -1455,12 +1455,13 @@ def test_should_redirect_after_request_to_go_live(
         user_name=active_user_with_permissions['name'],
         user_email=active_user_with_permissions['email_address'],
         tags=[
-            'notify_request_to_go_live',
-            'notify_request_to_go_live_incomplete',
+            'notify_action',
+            'notify_go_live',
+            'notify_go_live_incomplete',
         ] + extra_tags + [
-            'notify_request_to_go_live_incomplete_checklist',
-            'notify_request_to_go_live_incomplete_mou',
-            'notify_request_to_go_live_incomplete_team_member',
+            'notify_go_live_incomplete_checklist',
+            'notify_go_live_incomplete_mou',
+            'notify_go_live_incomplete_team_member',
         ],
     )
     assert mock_post.call_args[1]['message'] == (
@@ -1611,8 +1612,9 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'Yes',
             True,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_complete',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_complete',
             ],
         ),
         (  # Needs to set reply to address
@@ -1627,10 +1629,11 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'No',
             True,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_incomplete',
-                'notify_request_to_go_live_incomplete_checklist',
-                'notify_request_to_go_live_incomplete_email_reply_to',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_incomplete',
+                'notify_go_live_incomplete_checklist',
+                'notify_go_live_incomplete_email_reply_to',
             ],
         ),
         (  # Just sending SMS
@@ -1645,8 +1648,9 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'Yes',
             True,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_complete',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_complete',
             ],
         ),
         (  # Needs to change SMS sender
@@ -1661,10 +1665,11 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'No',
             True,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_incomplete',
-                'notify_request_to_go_live_incomplete_checklist',
-                'notify_request_to_go_live_incomplete_sms_sender',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_incomplete',
+                'notify_go_live_incomplete_checklist',
+                'notify_go_live_incomplete_sms_sender',
             ],
         ),
         (  # Needs team members
@@ -1679,10 +1684,11 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'No',
             True,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_incomplete',
-                'notify_request_to_go_live_incomplete_checklist',
-                'notify_request_to_go_live_incomplete_team_member',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_incomplete',
+                'notify_go_live_incomplete_checklist',
+                'notify_go_live_incomplete_team_member',
             ],
         ),
         (  # Needs templates
@@ -1697,10 +1703,11 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'No',
             True,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_incomplete',
-                'notify_request_to_go_live_incomplete_checklist',
-                'notify_request_to_go_live_incomplete_template_content',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_incomplete',
+                'notify_go_live_incomplete_checklist',
+                'notify_go_live_incomplete_template_content',
             ],
         ),
         (  # Not done anything yet
@@ -1715,13 +1722,14 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
             'No',
             False,
             [
-                'notify_request_to_go_live',
-                'notify_request_to_go_live_incomplete',
-                'notify_request_to_go_live_incomplete_volumes',
-                'notify_request_to_go_live_incomplete_checklist',
-                'notify_request_to_go_live_incomplete_mou',
-                'notify_request_to_go_live_incomplete_team_member',
-                'notify_request_to_go_live_incomplete_template_content',
+                'notify_action',
+                'notify_go_live',
+                'notify_go_live_incomplete',
+                'notify_go_live_incomplete_volumes',
+                'notify_go_live_incomplete_checklist',
+                'notify_go_live_incomplete_mou',
+                'notify_go_live_incomplete_team_member',
+                'notify_go_live_incomplete_template_content',
             ],
         ),
     ),
@@ -4648,7 +4656,7 @@ def test_submit_email_branding_request(
         ticket_type='question',
         user_email='test@user.gov.uk',
         user_name='Test User',
-        tags=['notify_action_add_branding'],
+        tags=['notify_action', 'notify_branding'],
     )
     assert normalize_spaces(page.select_one('.banner-default').text) == (
         'Thanks for your branding request. We’ll get back to you '


### PR DESCRIPTION
Requests to go live and email branding requests come through to Zendesk with tags attached automatically.

With the revised taxonomy some of these tags need to be updated, as summarised in this spreadsheet.

In addition, `notify_action` tag has to be added in each of those cases.

Old|New
---|---
`notify_request_to_go_live_complete`|`notify_go_live_complete`
`notify_request_to_go_live_incomplete`|`notify_go_live_incomplete`
`notify_action_add_branding`|`notify_branding`
`notify_request_to_go_live_incomplete_mou`|`notify_go_live_incomplete_mou`
`notify_request_to_go_live`|`notify_go_live`

– https://docs.google.com/spreadsheets/d/1o5ATsFsVK8Qpj7x8QvxX-SfEuBZ75028GEySVcdBFYU/edit#gid=0
– https://www.pivotaltracker.com/story/show/169842970