### PR TITLE
Update trial mode content

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -252,11 +252,11 @@
     {% if current_service.trial_mode %}
       <h2 class="heading-medium top-gutter-0">Your service is in trial mode</h2>
 
-      <p>A service in trial mode can only:</p>
+      <p>You can only:</p>
 
       <ul class='list list-bullet'>
         <li>send {{ current_service.message_limit }} text messages and emails per day</li>
-        <li>send messages to you and other people in your team</li>
+        <li>send messages to yourself and other people in your team</li>
         <li>create letter templates, but not send them</li>
       </ul>
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -252,16 +252,18 @@
     {% if current_service.trial_mode %}
       <h2 class="heading-medium top-gutter-0">Your service is in trial mode</h2>
 
+      <p>A service in trial mode can only:</p>
+
       <ul class='list list-bullet'>
-        <li>you can only send messages to yourself</li>
-        <li>you can add people to your team, then you can send messages to them too</li>
-        <li>you can only send {{ current_service.message_limit }} messages per day</li>
+        <li>send {{ current_service.message_limit }} text messages and emails per day</li>
+        <li>send messages to you and other people in your team</li>
+        <li>create letter templates, but not send them</li>
       </ul>
 
       <p>
         {% if current_user.has_permissions('manage_service') %}
-          To remove these restrictions, you can send us a
-          <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+          To remove these restrictions, you can 
+          <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">send us a request to go live</a>.
         {% else %}
           Your service manager can ask to have these restrictions removed.
         {% endif %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -262,8 +262,8 @@
 
       <p>
         {% if current_user.has_permissions('manage_service') %}
-          To remove these restrictions, you can 
-          <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">send us a request to go live</a>.
+          To remove these restrictions, you can send us a
+          <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
         {% else %}
           Your service manager can ask to have these restrictions removed.
         {% endif %}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -16,16 +16,13 @@
      <li>create letter templates, but not send them</li>
    </ul>
 
+  <p>
     {% if current_service and current_service.trial_mode %}
-     <p>To remove these restrictions, you can <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.</p>
+     To remove these restrictions, you can <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
     {% else %}
-      <p>To remove these restrictions:</p>
-      <ol class="list list-number">
-        <li><a href="{{ url_for('main.sign_in') }}">Sign in</a>.</li>
-        <li>Go to the Settings page.</li>
-        <li>In the Your service is in trial mode section, select request to go live.</li>
-      </ol>
+     To remove these restrictions, go to the Settings page and request to go live.
     {% endif %}
+  </p>
 
   <p>Before you can request to go live, you must:</p>
   <ul class="list list-bullet">

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -9,10 +9,10 @@
   <h1 class="heading-large">Trial mode</h1>
 
   <p>When you set up a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
-  <p>A service in trial mode can only:</p>
+  <p>While your service in trial mode you can only:</p>
     <ul class="list list-bullet">
      <li>send 50 text messages and emails per day</li>
-      <li>send messages to you and other people in your team</li>
+      <li>send messages to yourself and other people in your team</li>
      <li>create letter templates, but not send them</li>
    </ul>
 

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -17,14 +17,15 @@
    </ul>
 
   <p>
+    To remove these restrictions, you can 
     {% if current_service and current_service.trial_mode %}
-     To remove these restrictions, you can <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+     <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
     {% else %}
-     To remove these restrictions, go to the Settings page and request to go live.
+     go to the Settings page and request to go live.
     {% endif %}
   </p>
 
-  <p>Before you can request to go live, you must:</p>
+  <p>Before you request to go live, you must:</p>
   <ul class="list list-bullet">
     <li>accept our data sharing and financial agreement</li>
     <li>accept our terms of use</li>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -17,9 +17,9 @@
    </ul>
 
   <p>
-    To remove these restrictions, you can 
+    To remove these restrictions, 
     {% if current_service and current_service.trial_mode %}
-     <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+     you can <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
     {% else %}
      go to the Settings page and request to go live.
     {% endif %}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -9,7 +9,7 @@
   <h1 class="heading-large">Trial mode</h1>
 
   <p>When you set up a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
-  <p>While your service in trial mode you can only:</p>
+  <p>While your service is in trial mode you can only:</p>
     <ul class="list list-bullet">
      <li>send 50 text messages and emails per day</li>
       <li>send messages to yourself and other people in your team</li>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -8,7 +8,7 @@
 
   <h1 class="heading-large">Trial mode</h1>
 
-  <p>When you set up a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
+  <p>When you add a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
   <p>While your service is in trial mode you can only:</p>
     <ul class="list list-bullet">
      <li>send 50 text messages and emails per day</li>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -16,14 +16,16 @@
      <li>create letter templates, but not send them</li>
    </ul>
 
-  <p>
-    To remove these restrictions, you can
     {% if current_service and current_service.trial_mode %}
-      <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">send us a request to go live</a>.
+     <p>To remove these restrictions, you can <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.</p>
     {% else %}
-      send us a request to go live.
+      <p>To remove these restrictions:</p>
+      <ol class="list list-number">
+        <li><a href="{{ url_for('main.sign_in') }}">Sign in</a>.</li>
+        <li>Go to the Settings page.</li>
+        <li>In the Your service is in trial mode section, select request to go live.</li>
+      </ol>
     {% endif %}
-  </p>
 
   <p>Before you can request to go live, you must:</p>
   <ul class="list list-bullet">

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -435,7 +435,7 @@ def test_show_restricted_service(
     assert normalize_spaces(request_to_live.text) == expected_text
 
     if expected_link:
-        assert request_to_live_link.text.strip() == 'send us a request to go live'
+        assert request_to_live_link.text.strip() == 'request to go live'
         assert request_to_live_link['href'] == url_for('main.request_to_go_live', service_id=SERVICE_ONE_ID)
     else:
         assert not request_to_live_link

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -430,13 +430,12 @@ def test_show_restricted_service(
     assert page.find('h1').text == 'Settings'
     assert page.find_all('h2')[0].text == 'Your service is in trial mode'
 
-    request_to_live = page.select_one('main p')
+    request_to_live = page.select('main p')[1]
     request_to_live_link = request_to_live.select_one('a')
-
     assert normalize_spaces(request_to_live.text) == expected_text
 
     if expected_link:
-        assert request_to_live_link.text.strip() == 'request to go live'
+        assert request_to_live_link.text.strip() == 'send us a request to go live'
         assert request_to_live_link['href'] == url_for('main.request_to_go_live', service_id=SERVICE_ONE_ID)
     else:
         assert not request_to_live_link


### PR DESCRIPTION
The content changes in this PR:

- improve the lead-in line and bullets on the [Trial mode](https://www.notifications.service.gov.uk/features/trial-mode) page
- add a lead-in line for the bullet points to the *Settings* page – conforming to the [style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bullet-points-steps)
- add information about letters to the *Settings* page
- make it clear how to request to go live
- make the information on the 2 pages consistent