### PR TITLE
Update request to go live content

### DIFF
--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -71,7 +71,7 @@
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Start sending messages</h2>
     {% if not current_user.is_authenticated or not current_service %}
-    <p>When you’re ready to send messages to people outside your team, go to your Settings page and request to go live. We’ll approve your request within one working day.</p>
+    <p>When you’re ready to send messages to people outside your team, go to the Settings page and request to go live. We’ll approve your request within one working day.</p>
     {% else %}
     <p>You should <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
     {% endif %}

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -63,9 +63,8 @@
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Set up an API integration (optional)</h2>
-    <p>Share our <a href="{{ url_for('main.documentation') }}">documentation</a> with your developers to help them set up an API integration.</p>
-
-    <p>You only need to do this if you’re using the API to send messages automatically, rather than signing in to Notify.</p>
+    <p>You can use the Notify API to send messages automatically.</p>
+    <p>Our <a href="{{ url_for('main.documentation') }}">documentation</a> explains how to integrate the API with a web application or back office system.</p>
   </li>
 
   <li class="get-started-list__item">

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -71,7 +71,7 @@
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Start sending messages</h2>
     {% if not current_user.is_authenticated or not current_service %}
-    <p>You should request to go live when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
+    <p>When you’re ready to send messages to people outside your team, go to your Settings page and request to go live. We’ll approve your request within one working day.</p>
     {% else %}
     <p>You should <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
     {% endif %}


### PR DESCRIPTION
This PR updates step 6 of the [get started](https://www.notifications.service.gov.uk/features/get-started) page for users who are not signed in to Notify, to make it clearer how to request to go live.

**Before**
![Screen Shot 2019-11-20 at 14 24 53](https://user-images.githubusercontent.com/28294225/69246996-97a47880-0ba1-11ea-874d-a60c0e051cd1.png)

**After**
![Screen Shot 2019-11-20 at 14 20 25](https://user-images.githubusercontent.com/28294225/69246914-7b084080-0ba1-11ea-9750-d1c1567c45ef.png)
