### PR TITLE
Fix spacing of address on uploaded letter preview

### DIFF
--- a/app/assets/stylesheets/views/send.scss
+++ b/app/assets/stylesheets/views/send.scss
@@ -5,3 +5,9 @@
   }
 
 }
+
+.send-recipient {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -32,7 +32,7 @@
 
     {% if status == 'valid' and current_service.live %}
     <div class="js-stick-at-bottom-when-scrolling">
-      <p class="top-gutter-0 bottom-gutter-1-2">
+      <p class="top-gutter-0 bottom-gutter-1-2 send-recipient" title="{{ recipient }}">
         Recipient: {{ recipient }}
       </p>
 

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -32,7 +32,7 @@
 
     {% if status == 'valid' and current_service.live %}
     <div class="js-stick-at-bottom-when-scrolling">
-      <p>
+      <p class="top-gutter-0 bottom-gutter-1-2">
         Recipient: {{ recipient }}
       </p>
 


### PR DESCRIPTION
Just looks a bit more even/balanced with a bit less space above and below than a normal paragraph.

Doing this using modifier classes so it will be easy to migrate to the design system.

# Before

![image](https://user-images.githubusercontent.com/355079/69642800-3c1f3280-105a-11ea-86af-5e18e0ea2ce7.png)

# After 

<img width="798" alt="Screenshot 2019-11-26 at 14 36 34" src="https://user-images.githubusercontent.com/355079/69642825-42151380-105a-11ea-866d-9803dc0d74ff.png">
