### PR TITLE
Show who the recipient is even in trial mode

### DIFF
--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -30,20 +30,23 @@
       {{ template|string }}
     </div>
 
-    {% if status == 'valid' and current_service.live %}
+    {% if status == 'valid' %}
     <div class="js-stick-at-bottom-when-scrolling">
       <p class="top-gutter-0 bottom-gutter-1-2 send-recipient" title="{{ recipient }}">
         Recipient: {{ recipient }}
       </p>
 
-      <form method="post" enctype="multipart/form-data" action="{{url_for(
-          'main.send_uploaded_letter',
-          service_id=current_service.id,
-        )}}" class='page-footer'>
-          {{ radios(form.postage, hide_legend=true, inline=True) }}
-          {{ form.file_id(value=file_id) }}
-          {{ page_footer("Send 1 letter") }}
-      </form>
+      {% if current_service.live %}
+        <form method="post" enctype="multipart/form-data" action="{{url_for(
+            'main.send_uploaded_letter',
+            service_id=current_service.id,
+          )}}" class='page-footer'>
+            {{ radios(form.postage, hide_legend=true, inline=True) }}
+            {{ form.file_id(value=file_id) }}
+            {{ page_footer("Send 1 letter") }}
+        </form>
+      {% endif %}
+
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -366,7 +366,7 @@ def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_m
 ):
     mocker.patch('app.main.views.uploads.service_api_client')
     mocker.patch('app.main.views.uploads.get_letter_metadata', return_value={
-        'filename': 'my_letter.pdf', 'page_count': '1', 'status': 'valid'})
+        'filename': 'my_letter.pdf', 'page_count': '1', 'status': 'valid', 'recipient': 'The Queen'})
 
     # client_request uses service_one, which is in trial mode
     page = client_request.get(
@@ -382,6 +382,12 @@ def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_m
 
     assert normalize_spaces(page.find('h1').text) == 'You cannot send this letter'
     assert page.find('div', class_='letter-sent')
+    assert normalize_spaces(
+        page.select_one('.js-stick-at-bottom-when-scrolling p').text
+    ) == (
+        'Recipient: The Queen'
+    )
+    assert not page.find('form')
     assert not page.find('button', {'type': 'submit'})
 
 


### PR DESCRIPTION
Trial mode should let you preview the letter the same as live mode, except for being able to actually end the letter.

Showing the recipient helps people understand how the feature works.

***

![image](https://user-images.githubusercontent.com/355079/69722771-d42b2380-110f-11ea-8f48-dbe54ee31231.png)
