### PR TITLE
Clean up more things to do with letter validation

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -5,8 +5,6 @@ from datetime import datetime
 
 from flask import abort, flash, redirect, render_template, request, url_for
 from notifications_python_client.errors import HTTPError
-from notifications_utils import LETTER_MAX_PAGE_COUNT
-from requests import RequestException
 
 from app import (
     billing_api_client,
@@ -17,12 +15,11 @@ from app import (
     platform_stats_api_client,
     service_api_client,
 )
-from app.extensions import antivirus_client, redis_client
+from app.extensions import redis_client
 from app.main import main
 from app.main.forms import (
     ClearCacheForm,
     DateFilterForm,
-    PDFUploadForm,
     RequiredDateFilterForm,
     ReturnedLettersForm,
 )
@@ -30,14 +27,11 @@ from app.statistics_utils import (
     get_formatted_percentage,
     get_formatted_percentage_two_dp,
 )
-from app.template_previews import validate_letter
 from app.utils import (
     Spreadsheet,
     generate_next_dict,
     generate_previous_dict,
-    get_letter_validation_error,
     get_page_from_request,
-    user_has_permissions,
     user_is_platform_admin,
 )
 

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -94,14 +94,6 @@ def get_page_count_for_letter(template, values=None):
     return page_count
 
 
-def validate_letter(pdf_file):
-    return requests.post(
-        '{}/precompiled/validate?include_preview=true'.format(current_app.config['TEMPLATE_PREVIEW_API_HOST']),
-        data=pdf_file,
-        headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
-    )
-
-
 def sanitise_letter(pdf_file):
     return requests.post(
         '{}/precompiled/sanitise'.format(current_app.config['TEMPLATE_PREVIEW_API_HOST']),


### PR DESCRIPTION
Missed these in https://github.com/alphagov/notifications-admin/pull/3201

***

Questions:
- why didn’t flake8 catch these unused imports?
- does anything else call `/precompiled/validate` on template preview or can we remove that too?