### PR TITLE
Update purchase order content

### DIFF
--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -39,7 +39,7 @@
     </h2>
 
     <p>
-      If your organisation’s estimated spend is more than £500 per year (before <abbr title="Value Added Tax">VAT</abbr>), you need to send us a purchase order (PO).
+      If your organisation’s estimated spend is more than £500 per quarter (before <abbr title="Value Added Tax">VAT</abbr>), you need to send us a purchase order (PO).
     </p>
 
     <p>


### PR DESCRIPTION
This PR corrects the information about estimated spend.

Organisations should raise a PO if their estimated spend is £500+ per **quarter**, not per year.