### PR TITLE
More fixes for move to govuk frontend

### DIFF
--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -1,3 +1,5 @@
+@import 'settings/typography-font-families';
+
 // needed for IE10 desktop snap mode: http://menacingcloud.com/?c=cssViewportOrMetaTag
 @-ms-viewport {
   width: device-width;
@@ -87,4 +89,11 @@ select:focus,
 button:focus {
   outline: 3px solid $focus-colour;
   outline-offset: 0;
+}
+
+// To be removed when all buttons follow the GOV.UK Frontend conventions
+// - https://design-system.service.gov.uk/components/button/
+
+button {
+  font-family: $govuk-font-family-nta;
 }

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -11,14 +11,6 @@
 
 }
 
-// The GOV.UK Frontend header component wraps content that is `position: relative`
-// This changes its z-index position, putting it above the `<main>` section
-// We need the `<main>` section to be above it, like the default order, to hide the theme colour
-// bar on full-width pages
-.govuk-main-wrapper {
-  position: relative;
-}
-
 // Additional padding-bottom override, following the GOV.UK Frontend spacing scale:
 // https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale
 .govuk-\!-padding-bottom-12 {

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -2,6 +2,11 @@
 
   &-intro {
 
+    // The GOV.UK Frontend header component wraps content that is `position: relative`
+    // This changes its z-index position, putting it above the `<main>` section in the stacking order
+    // We need the `<main>` section to be above it, like the default order, so when we apply the
+    // negative margin-top it overlaps the theme bar at the bottom of the header
+    position: relative;
     margin: -10px 0 $gutter * 1.5 0;
     padding: 0 0 $gutter * 2 0;
     background: $govuk-blue;

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -145,6 +145,7 @@
   {% endif %}
 
   {{ notify_footer({
+    "classes": "js-footer",
     "navigation": [
       {
         "columns": 1,


### PR DESCRIPTION
Fixes for the following issues:
1. sticky JS broken on send email page
2. buttons don't have the New Transport font

## 1. sticky JS broken on send email page

This was caused by the lack of a `js-footer` class on the global footer and by the main content area being set to `position: relative`.

The first meant the JavaScript couldn't find the element it uses as the furthest point a sticky element should travel.

The second meant when sticky elements were set to `position: absolute`, they were positioned relative to the main content area, not the page. The position calculated is relative to the page so was wrong.

## 2. buttons don't have the New Transport font

Some styles, applying to all `button` elements, weren't moved across from the GOVUK Template CSS when it was removed.