### PR TITLE
don't set cookies on letter preview pngs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -61,7 +61,10 @@ class Config(object):
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_NAME = 'notify_admin_session'
     SESSION_COOKIE_SECURE = True
-    SESSION_REFRESH_EACH_REQUEST = True
+    # don't send back the cookie if it hasn't been modified by the request. this means that the expiry time won't be
+    # updated unless the session is changed - but it's generally refreshed by `save_service_or_org_after_request`
+    # every time anyway, except for specific endpoints (png/pdfs generally) where we've disabled that handler.
+    SESSION_REFRESH_EACH_REQUEST = False
     SHOW_STYLEGUIDE = True
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,6 +1,7 @@
 from flask import Blueprint
 
 main = Blueprint('main', __name__)
+no_cookie = Blueprint('no_cookie', __name__)
 
 from app.main.views import (  # noqa isort:skip
     add_service,

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -200,7 +200,7 @@ def letter_template():
         filename = 'no-branding'
 
     template = {'subject': '', 'content': ''}
-    image_url = url_for('main.letter_branding_preview_image', filename=filename)
+    image_url = url_for('no_cookie.letter_branding_preview_image', filename=filename)
 
     template_image = str(LetterImageTemplate(
         template,

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -34,7 +34,7 @@ from app import (
     notification_api_client,
     service_api_client,
 )
-from app.main import main
+from app.main import main, no_cookie
 from app.main.forms import (
     ChooseTimeForm,
     CsvUploadForm,
@@ -135,7 +135,7 @@ def send_messages(service_id, template_id):
         current_service,
         show_recipient=True,
         letter_preview_url=url_for(
-            '.view_letter_template_preview',
+            'no_cookie.view_letter_template_preview',
             service_id=service_id,
             template_id=template_id,
             filetype='png',
@@ -364,7 +364,7 @@ def send_test_step(service_id, template_id, step_index):
         current_service,
         show_recipient=True,
         letter_preview_url=url_for(
-            '.send_test_preview',
+            'no_cookie.send_test_preview',
             service_id=service_id,
             template_id=template_id,
             filetype='png',
@@ -465,7 +465,7 @@ def send_test_step(service_id, template_id, step_index):
     )
 
 
-@main.route("/services/<uuid:service_id>/send/<uuid:template_id>/test.<filetype>", methods=['GET'])
+@no_cookie.route("/services/<uuid:service_id>/send/<uuid:template_id>/test.<filetype>", methods=['GET'])
 @user_has_permissions('send_messages')
 def send_test_preview(service_id, template_id, filetype):
 
@@ -478,7 +478,7 @@ def send_test_preview(service_id, template_id, filetype):
         db_template,
         current_service,
         letter_preview_url=url_for(
-            '.send_test_preview',
+            'no_cookie.send_test_preview',
             service_id=service_id,
             template_id=template_id,
             filetype='png',
@@ -502,7 +502,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         # errors when we try and unpack in the check_messages route.
         # Rasing a werkzeug.routing redirect means that doesn't happen.
         raise PermanentRedirect(url_for(
-            '.send_messages',
+            'main.send_messages',
             service_id=service_id,
             template_id=template_id
         ))
@@ -529,7 +529,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         current_service,
         show_recipient=True,
         letter_preview_url=url_for(
-            '.check_messages_preview',
+            'no_cookie.check_messages_preview',
             service_id=service_id,
             template_id=template_id,
             upload_id=upload_id,
@@ -556,10 +556,10 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
 
     if request.args.get('from_test'):
         # only happens if generating a letter preview test
-        back_link = url_for('.send_test', service_id=service_id, template_id=template.id)
+        back_link = url_for('main.send_test', service_id=service_id, template_id=template.id)
         choose_time_form = None
     else:
-        back_link = url_for('.send_messages', service_id=service_id, template_id=template.id)
+        back_link = url_for('main.send_messages', service_id=service_id, template_id=template.id)
         choose_time_form = ChooseTimeForm()
 
     if preview_row < 2:
@@ -650,11 +650,11 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
     return render_template('views/check/ok.html', **data)
 
 
-@main.route(
+@no_cookie.route(
     "/services/<uuid:service_id>/<uuid:template_id>/check/<uuid:upload_id>.<filetype>",
     methods=['GET'],
 )
-@main.route(
+@no_cookie.route(
     "/services/<uuid:service_id>/<uuid:template_id>/check/<uuid:upload_id>/row-<int:row_index>.<filetype>",
     methods=['GET'],
 )
@@ -673,7 +673,7 @@ def check_messages_preview(service_id, template_id, upload_id, filetype, row_ind
     return TemplatePreview.from_utils_template(template, filetype, page=page)
 
 
-@main.route(
+@no_cookie.route(
     "/services/<uuid:service_id>/<uuid:template_id>/check.<filetype>",
     methods=['GET'],
 )
@@ -868,7 +868,7 @@ def _check_notification(service_id, template_id, exception=None):
         email_reply_to=email_reply_to,
         sms_sender=sms_sender,
         letter_preview_url=url_for(
-            '.check_notification_preview',
+            'no_cookie.check_notification_preview',
             service_id=service_id,
             template_id=template_id,
             filetype='png',

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -16,7 +16,7 @@ from app import (
     template_folder_api_client,
     template_statistics_client,
 )
-from app.main import main
+from app.main import main, no_cookie
 from app.main.forms import (
     EmailTemplateForm,
     LetterTemplateForm,
@@ -67,7 +67,7 @@ def view_template(service_id, template_id):
             template,
             current_service,
             letter_preview_url=url_for(
-                '.view_letter_template_preview',
+                'no_cookie.view_letter_template_preview',
                 service_id=service_id,
                 template_id=template_id,
                 filetype='png',
@@ -219,7 +219,7 @@ def get_template_nav_items(template_folder_id):
     ]
 
 
-@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>.<filetype>")
+@no_cookie.route("/services/<uuid:service_id>/templates/<uuid:template_id>.<filetype>")
 @user_has_permissions()
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ('pdf', 'png'):
@@ -230,7 +230,7 @@ def view_letter_template_preview(service_id, template_id, filetype):
     return TemplatePreview.from_database_object(db_template, filetype, page=request.args.get('page'))
 
 
-@main.route("/templates/letter-preview-image/<filename>")
+@no_cookie.route("/templates/letter-preview-image/<filename>")
 @user_is_platform_admin
 def letter_branding_preview_image(filename):
     template = {
@@ -262,7 +262,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
         current_service.get_template(template_id, version=version),
         current_service,
         letter_preview_url=url_for(
-            '.view_template_version_preview',
+            'no_cookie.view_template_version_preview',
             service_id=service_id,
             template_id=template_id,
             version=version,
@@ -280,7 +280,7 @@ def view_template_version(service_id, template_id, version):
     )
 
 
-@main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>.<filetype>")
+@no_cookie.route("/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>.<filetype>")
 @user_has_permissions()
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = current_service.get_template(template_id, version=version)
@@ -697,7 +697,7 @@ def delete_service_template(service_id, template_id):
             template,
             current_service,
             letter_preview_url=url_for(
-                '.view_letter_template_preview',
+                'no_cookie.view_letter_template_preview',
                 service_id=service_id,
                 template_id=template['id'],
                 filetype='png',
@@ -719,7 +719,7 @@ def confirm_redact_template(service_id, template_id):
             template,
             current_service,
             letter_preview_url=url_for(
-                '.view_letter_template_preview',
+                'no_cookie.view_letter_template_preview',
                 service_id=service_id,
                 template_id=template_id,
                 filetype='png',
@@ -759,7 +759,7 @@ def view_template_versions(service_id, template_id):
                 template,
                 current_service,
                 letter_preview_url=url_for(
-                    '.view_template_version_preview',
+                    'no_cookie.view_template_version_preview',
                     service_id=service_id,
                     template_id=template_id,
                     version=template['version'],

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -12,7 +12,8 @@ class Navigation:
     def __init__(self):
         self.mapping = {
             navigation: {
-                'main.{}'.format(endpoint) for endpoint in endpoints
+                # if not specified, assume endpoints are all in the `main` blueprint.
+                self._get_endpoint_with_blueprint(endpoint) for endpoint in endpoints
             } for navigation, endpoints in self.mapping.items()
         }
 
@@ -26,13 +27,17 @@ class Navigation:
     @property
     def endpoints_without_navigation(self):
         return tuple(
-            'main.{}'.format(endpoint) for endpoint in self.exclude
+            self._get_endpoint_with_blueprint(endpoint) for endpoint in self.exclude
         ) + ('static', 'status.show_status')
 
     def is_selected(self, navigation_item):
         if request.endpoint in self.mapping[navigation_item]:
             return self.selected_attribute
         return ''
+
+    @staticmethod
+    def _get_endpoint_with_blueprint(endpoint):
+        return endpoint if '.' in endpoint else 'main.{}'.format(endpoint)
 
 
 class HeaderNavigation(Navigation):
@@ -141,9 +146,9 @@ class HeaderNavigation(Navigation):
         'check_and_resend_text_code',
         'check_and_resend_verification_code',
         'check_messages',
-        'check_messages_preview',
+        'no_cookie.check_messages_preview',
         'check_notification',
-        'check_notification_preview',
+        'no_cookie.check_notification_preview',
         'choose_account',
         'choose_service',
         'choose_template',
@@ -201,7 +206,7 @@ class HeaderNavigation(Navigation):
         'information_security',
         'invite_org_user',
         'invite_user',
-        'letter_branding_preview_image',
+        'no_cookie.letter_branding_preview_image',
         'letter_template',
         'link_service_to_organisation',
         'manage_org_users',
@@ -243,7 +248,7 @@ class HeaderNavigation(Navigation):
         'send_one_off',
         'send_one_off_step',
         'send_test',
-        'send_test_preview',
+        'no_cookie.send_test_preview',
         'send_test_step',
         'send_uploaded_letter',
         'service_add_email_reply_to',
@@ -313,7 +318,7 @@ class HeaderNavigation(Navigation):
         'view_job_updates',
         'view_jobs',
         'view_letter_notification_as_preview',
-        'view_letter_template_preview',
+        'no_cookie.view_letter_template_preview',
         'view_letter_upload_as_preview',
         'view_notification',
         'view_notification_updates',
@@ -321,7 +326,7 @@ class HeaderNavigation(Navigation):
         'view_notifications_csv',
         'view_template',
         'view_template_version',
-        'view_template_version_preview',
+        'no_cookie.view_template_version_preview',
         'view_template_versions',
         'whitelist',
     }
@@ -363,7 +368,7 @@ class MainNavigation(Navigation):
             'send_one_off',
             'send_one_off_step',
             'send_test',
-            'send_test_preview',
+            'no_cookie.send_test_preview',
             'send_test_step',
             'set_sender',
             'set_template_sender',
@@ -465,8 +470,8 @@ class MainNavigation(Navigation):
         'cancel_letter_job',
         'check_and_resend_text_code',
         'check_and_resend_verification_code',
-        'check_messages_preview',
-        'check_notification_preview',
+        'no_cookie.check_messages_preview',
+        'no_cookie.check_notification_preview',
         'choose_account',
         'choose_service',
         'clear_cache',
@@ -520,7 +525,7 @@ class MainNavigation(Navigation):
         'integration_testing',
         'invite_org_user',
         'letter_branding',
-        'letter_branding_preview_image',
+        'no_cookie.letter_branding_preview_image',
         'live_services',
         'live_services_csv',
         'letter_template',
@@ -611,13 +616,13 @@ class MainNavigation(Navigation):
         'view_job_csv',
         'view_job_updates',
         'view_letter_notification_as_preview',
-        'view_letter_template_preview',
+        'no_cookie.view_letter_template_preview',
         'view_letter_upload_as_preview',
         'view_notification_updates',
         'view_notifications_csv',
         'view_provider',
         'view_providers',
-        'view_template_version_preview',
+        'no_cookie.view_template_version_preview',
     }
 
 
@@ -671,9 +676,9 @@ class CaseworkNavigation(Navigation):
         'check_and_resend_text_code',
         'check_and_resend_verification_code',
         'check_messages',
-        'check_messages_preview',
+        'no_cookie.check_messages_preview',
         'check_notification',
-        'check_notification_preview',
+        'no_cookie.check_notification_preview',
         'choose_account',
         'choose_service',
         'choose_template_to_copy',
@@ -747,7 +752,7 @@ class CaseworkNavigation(Navigation):
         'integration_testing',
         'invite_org_user',
         'invite_user',
-        'letter_branding_preview_image',
+        'no_cookie.letter_branding_preview_image',
         'letter_branding',
         'letter_template',
         'link_service_to_organisation',
@@ -799,7 +804,7 @@ class CaseworkNavigation(Navigation):
         'security',
         'send_messages',
         'send_notification',
-        'send_test_preview',
+        'no_cookie.send_test_preview',
         'send_uploaded_letter',
         'service_add_email_reply_to',
         'service_add_letter_contact',
@@ -892,7 +897,7 @@ class CaseworkNavigation(Navigation):
         'view_job_csv',
         'view_job_updates',
         'view_letter_notification_as_preview',
-        'view_letter_template_preview',
+        'no_cookie.view_letter_template_preview',
         'view_letter_upload_as_preview',
         'view_notification_updates',
         'view_notifications_csv',
@@ -900,7 +905,7 @@ class CaseworkNavigation(Navigation):
         'view_providers',
         'view_template',
         'view_template_version',
-        'view_template_version_preview',
+        'no_cookie.view_template_version_preview',
         'view_template_versions',
         'whitelist',
     }
@@ -966,9 +971,9 @@ class OrgNavigation(Navigation):
         'check_and_resend_text_code',
         'check_and_resend_verification_code',
         'check_messages',
-        'check_messages_preview',
+        'no_cookie.check_messages_preview',
         'check_notification',
-        'check_notification_preview',
+        'no_cookie.check_notification_preview',
         'choose_account',
         'choose_service',
         'choose_template',
@@ -1030,7 +1035,7 @@ class OrgNavigation(Navigation):
         'integration_testing',
         'invite_user',
         'letter_branding',
-        'letter_branding_preview_image',
+        'no_cookie.letter_branding_preview_image',
         'letter_template',
         'link_service_to_organisation',
         'live_services',
@@ -1077,7 +1082,7 @@ class OrgNavigation(Navigation):
         'send_one_off',
         'send_one_off_step',
         'send_test',
-        'send_test_preview',
+        'no_cookie.send_test_preview',
         'send_test_step',
         'send_uploaded_letter',
         'service_add_email_reply_to',
@@ -1176,7 +1181,7 @@ class OrgNavigation(Navigation):
         'view_job_updates',
         'view_jobs',
         'view_letter_notification_as_preview',
-        'view_letter_template_preview',
+        'no_cookie.view_letter_template_preview',
         'view_letter_upload_as_preview',
         'view_notification',
         'view_notification_updates',
@@ -1186,7 +1191,7 @@ class OrgNavigation(Navigation):
         'view_providers',
         'view_template',
         'view_template_version',
-        'view_template_version_preview',
+        'no_cookie.view_template_version_preview',
         'view_template_versions',
         'whitelist',
     }

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -47,7 +47,7 @@
       {% if (template.template_type != 'letter' or not request.args.from_test) and not letter_too_long %}
       <button type="submit" class="button">Send {{ count_of_recipients|format_thousands }} {{ message_count_label(count_of_recipients, template.template_type, suffix='') }}</button>
       {% else %}
-        <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_id=template.id, upload_id=upload_id, filetype='pdf') }}" download class="button">Download as a PDF</a>
+        <a href="{{ url_for('no_cookie.check_messages_preview', service_id=current_service.id, template_id=template.id, upload_id=upload_id, filetype='pdf') }}" download class="button">Download as a PDF</a>
       {% endif %}
     </form>
   </div>

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -79,7 +79,7 @@
         <button type="submit" class="button">Send 1 {{ message_count_label(1, template.template_type, suffix='') }}</button>
       {% endif %}
       {% if template.template_type == 'letter' %}
-        <a href="{{ url_for('main.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
+        <a href="{{ url_for('no_cookie.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
       {% endif %}
     </form>
   </div>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -226,7 +226,7 @@ def test_letter_template_preview_links_to_the_correct_image(
     image_link = page.find('img')['src']
 
     assert image_link == url_for(
-        'main.letter_branding_preview_image',
+        'no_cookie.letter_branding_preview_image',
         filename=filename,
         page=1
     )

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -775,7 +775,7 @@ def test_upload_valid_csv_only_sets_meta_if_filename_known(
     )
 
     client_request.get(
-        'main.check_messages_preview',
+        'no_cookie.check_messages_preview',
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         upload_id=fake_uuid,
@@ -1992,7 +1992,7 @@ def test_send_test_works_as_letter_preview(
         session['placeholders'] = {'address_line_1': 'Jo Lastname'}
     response = platform_admin_client.get(
         url_for(
-            'main.send_test_preview',
+            'no_cookie.send_test_preview',
             service_id=service_id,
             template_id=template_id,
             filetype=filetype
@@ -2384,7 +2384,7 @@ def test_should_show_preview_letter_message(
 
     response = platform_admin_client.get(
         url_for(
-            'main.check_messages_preview',
+            'no_cookie.check_messages_preview',
             service_id=service_id,
             template_id=fake_uuid,
             upload_id=fake_uuid,
@@ -2412,7 +2412,7 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
 ):
     resp = logged_in_client.get(
         url_for(
-            'main.check_messages_preview',
+            'no_cookie.check_messages_preview',
             service_id=service_one['id'],
             template_id=fake_uuid,
             upload_id=fake_uuid,
@@ -3130,7 +3130,7 @@ def test_one_off_letters_have_download_link(
     assert len(page.select('.letter img')) == 5
 
     assert page.select_one('a[download]')['href'] == url_for(
-        'main.check_notification_preview',
+        'no_cookie.check_notification_preview',
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         filetype='pdf',

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -773,8 +773,8 @@ def test_should_show_page_template_with_priority_select_if_platform_admin(
 
 @pytest.mark.parametrize('filetype', ['pdf', 'png'])
 @pytest.mark.parametrize('view, extra_view_args', [
-    ('.view_letter_template_preview', {}),
-    ('.view_template_version_preview', {'version': 1}),
+    ('no_cookie.view_letter_template_preview', {}),
+    ('no_cookie.view_template_version_preview', {'version': 1}),
 ])
 def test_should_show_preview_letter_templates(
     view,
@@ -817,7 +817,7 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
 ):
     resp = logged_in_client.get(
         url_for(
-            '.view_letter_template_preview',
+            'no_cookie.view_letter_template_preview',
             service_id=service_one['id'],
             template_id=fake_uuid,
             filetype='blah'
@@ -842,7 +842,7 @@ def test_letter_branding_preview_image(
         return_value='foo'
     )
     resp = platform_admin_client.get(
-        url_for('.letter_branding_preview_image', filename=original_filename)
+        url_for('no_cookie.letter_branding_preview_image', filename=original_filename)
     )
 
     mocked_preview.assert_called_with(ANY, new_filename)


### PR DESCRIPTION
we have a hunch that some session related issues that we've seen over the last few weeks might be related to weird race conditions where cookies set by subresources (image previews of letters on the send flow) arrive just as the img request is cancelled because the user has clicked on a button to navigate to a new page, but still manage to set the cookie? We're not entirely sure what's going on, but we've got a hunch that not setting cookies on image fetches sounds sensible. Images are always loaded as a subresource (ie: through a `src` tag in an html element), so they should never need to change the cookies, so this seems sensible. We've done this by creating a new blueprint that doesn't set session.permanent, and doesn't call `save_serivce_or_org_after_request` either.  cookies are sent back to the browser if: `sesion.modified or (session.permanent and 'REFRESH_EVERY_REQUEST')` (where the latter is a config setting).

Turning off REFRESH_EVERY_REQUEST (which is True by default) means that we will only update the sesion if it's been modified. In practice, literally every request is modified in the after_request handler `save_service_or_org_after_request`. This is accidentally convenient, as it guarantees that we'll still send back the cookie normally even though refresh_every_request is disabled. Sending back the cookie updates the expiry time (20 hours), so we need to keep doing this to preserve existing session timeout behaviour.