### PR TITLE
Split gitignore and cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -68,7 +68,6 @@ cache/
 node_modules
 bower_components
 npm-debug.log
-app/templates/vendor
 
 environment.sh
 .envrc

--- a/.cfignore
+++ b/.cfignore
@@ -1,3 +1,5 @@
+# This file is a copy of .gitignore except for file/folders created by the build
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,78 @@
-.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+venv/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache
+coverage.xml
+test_results.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+.idea/
+.DS_Store
+.vscode
+
+# Frontend dependencies and compiled assets
+app/assets/stylesheets/govuk_template/.sass-cache/
+.sass-cache/
+cache/
+node_modules
+bower_components
+npm-debug.log
+app/templates/vendor
+
+environment.sh
+.envrc
+
+# CloudFoundry
+.cf
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 .installed.cfg
 *.egg
 venv/
+app/version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -62,6 +63,7 @@ target/
 .vscode
 
 # Frontend dependencies and compiled assets
+app/static
 app/assets/stylesheets/govuk_template/.sass-cache/
 .sass-cache/
 cache/

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ var/
 .installed.cfg
 *.egg
 venv/
-app/version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -63,14 +62,12 @@ target/
 .vscode
 
 # Frontend dependencies and compiled assets
-app/static
 app/assets/stylesheets/govuk_template/.sass-cache/
 .sass-cache/
 cache/
 node_modules
 bower_components
 npm-debug.log
-app/templates/vendor
 
 environment.sh
 .envrc
@@ -78,3 +75,8 @@ environment.sh
 # CloudFoundry
 .cf
 package-lock.json
+
+# Files/folders created by build so not present in .cfignore
+app/version.py
+app/static
+app/templates/vendor

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,0 @@
-/version.py
-/static

--- a/deploy-exclude.lst
+++ b/deploy-exclude.lst
@@ -9,3 +9,4 @@ target/*
 venv/*
 .envrc
 .cf/*
+.pytest_cache/*


### PR DESCRIPTION
`.cfignore` was just a symlink to `.gitignore`.

If we wanted to ignore anything from the repo but not the build (for example, artefacts of the build), it had to be added to `app/.gitignore`.

This flattens this by just copying the contents of `.gitignore` into `.cfignore`, as a starting point and then adding the entries in `app/.gitignore` to `.gitignore` so they're:
- ignored by Git
- included by CloudFront

Note: this work came out of https://github.com/alphagov/notifications-admin/pull/3212 causing the app to fail due to `app/templates/vendor` not being part of what was deployed.