### PR TITLE
Bump utils to 36.3.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,5 +23,5 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.3.0#egg=notifications-utils==36.3.0
+git+https://github.com/alphagov/notifications-utils.git@36.3.1#egg=notifications-utils==36.3.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,14 +25,14 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.3.0#egg=notifications-utils==36.3.0
+git+https://github.com/alphagov/notifications-utils.git@36.3.1#egg=notifications-utils==36.3.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.3.0-alpha#egg=govuk-frontend-jinja==0.3.0-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.16.292
+awscli==1.16.298
 bleach==3.1.0
 boto3==1.9.221
-botocore==1.13.28
+botocore==1.13.34
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
Brings in this fix: https://github.com/alphagov/notifications-utils/pull/679

Question, am I right in thinking that I also need to do this for the API?