### PR TITLE
Fix off-by-one dates on provider history

### DIFF
--- a/app/templates/views/providers/edit-sms-provider-ratio.html
+++ b/app/templates/views/providers/edit-sms-provider-ratio.html
@@ -51,7 +51,7 @@
   {% for day, versions in versions %}
     <h2 class="heading-small top-gutter">
       {% if day %}
-        {{ day|format_date_human|title }}
+        {{ versions[0]['updated_at']|format_date_human|title }}
       {% else %}
         Start
       {% endif %}

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -6,6 +6,7 @@ from unittest.mock import call
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
+from freezegun import freeze_time
 
 import app
 from app.main.views.providers import add_monthly_traffic
@@ -409,6 +410,7 @@ def test_should_show_provider_version_history(
     assert second_row[4].text.strip() == "True"
 
 
+@freeze_time('2022-2-22 15:00')
 def test_should_show_version_history_for_first_two_sms_providers(
     client_request,
     platform_admin_user,
@@ -473,8 +475,8 @@ def test_should_show_version_history_for_first_two_sms_providers(
         for heading in page.select('main h2')
     ] == [
         'Now',
-        '21 February 2022',
-        '31 December',
+        'Today',
+        '1 January 2020',
     ]
 
     assert [


### PR DESCRIPTION
We chunk history entries by their YYYY-MM-DD date representation to display them day-by-day.

However trying to convert a YYYY-MM-DD string into a timestamp is unpredictable, and was causing our dates to be one day out (probably because of midnight/daylight savings/general datetime horrors).

This commit changes the code to do the same thing as the history page, which is look at the `updated_at` field on the first entry to get a datetime object and from that the formatted date we show in the headings on the page.