### PR TITLE
Serve video from a domain that doesn’t set cookies

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -558,7 +558,7 @@ def useful_headers_after_request(response):
         "object-src 'self';"
         "font-src 'self' {asset_domain} data:;"
         "img-src 'self' {asset_domain} *.google-analytics.com *.notifications.service.gov.uk {logo_domain} data:;"
-        "frame-src 'self' www.youtube.com;".format(
+        "frame-src 'self' www.youtube-nocookie.com;".format(
             asset_domain=current_app.config['ASSET_DOMAIN'],
             logo_domain=get_logo_cdn_domain(),
         )

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -110,7 +110,7 @@
     </h2>
     <div class="responsive-embed responsive-embed--16by9 responsive-embed--bordered bottom-gutter-2">
       <div class="responsive-embed__wrapper">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/_90cv1YgQo4" frameborder="0" allowfullscreen></iframe>
+        <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/_90cv1YgQo4" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>
   </div>

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -21,7 +21,7 @@ def test_owasp_useful_headers_set(
         "font-src 'self' static.example.com data:;"
         "img-src "
         "'self' static.example.com *.google-analytics.com *.notifications.service.gov.uk static-logos.test.com data:;"
-        "frame-src 'self' www.youtube.com;"
+        "frame-src 'self' www.youtube-nocookie.com;"
     )
 
 
@@ -43,5 +43,5 @@ def test_headers_non_ascii_characters_are_replaced(
         "font-src 'self' static.example.com data:;"
         "img-src "
         "'self' static.example.com *.google-analytics.com *.notifications.service.gov.uk static-logos??.test.com data:;"
-        "frame-src 'self' www.youtube.com;"
+        "frame-src 'self' www.youtube-nocookie.com;"
     )


### PR DESCRIPTION
Then it’s one less cookie we have to get users to opt in to. We don’t derive any value from Youtube setting cookies.

`youtube-nocookie.com` is a domain provided by Google for this purpose.

***

https://www.pivotaltracker.com/n/projects/1443052/stories/170379929