### PR TITLE
Increase the number of tests that are Pytest 5 compliant

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -55,15 +55,14 @@ def user_json(
     failed_login_count=0,
     logged_in_at=None,
     state='active',
-    max_failed_login_count=3,
     platform_admin=False,
     current_session_id='1234',
     organisations=None,
     services=None
 
 ):
-    if not permissions:
-        permissions = {generate_uuid(): [
+    if permissions is None:
+        permissions = {str(generate_uuid()): [
             'view_activity',
             'send_texts',
             'send_emails',
@@ -73,6 +72,10 @@ def user_json(
             'manage_settings',
             'manage_api_keys',
         ]}
+
+    if services is None:
+        services = [str(service_id) for service_id in permissions.keys()]
+
     return {
         'id': id_,
         'name': name,
@@ -84,11 +87,10 @@ def user_json(
         'failed_login_count': failed_login_count,
         'logged_in_at': logged_in_at or datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f'),
         'state': state,
-        'max_failed_login_count': max_failed_login_count,
         'platform_admin': platform_admin,
         'current_session_id': current_session_id,
         'organisations': organisations or [],
-        'services': list(permissions.keys()) if services is None else services
+        'services': services
     }
 
 

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -10,9 +10,9 @@ from tests.conftest import (
     ORGANISATION_ID,
     SERVICE_ONE_ID,
     SERVICE_TWO_ID,
-    active_user_with_permissions,
+    create_active_user_with_permissions,
+    create_platform_admin_user,
     normalize_spaces,
-    platform_admin_user,
 )
 
 
@@ -548,10 +548,10 @@ def test_organisation_settings_for_platform_admin(
 ))
 @pytest.mark.parametrize('user', (
     pytest.param(
-        platform_admin_user,
+        create_platform_admin_user(),
     ),
     pytest.param(
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         marks=pytest.mark.xfail
     ),
 ))
@@ -565,7 +565,7 @@ def test_view_organisation_settings(
     expected_selected,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     page = client_request.get(endpoint, org_id=organisation_one['id'])
 
@@ -633,10 +633,10 @@ def test_view_organisation_settings(
 ))
 @pytest.mark.parametrize('user', (
     pytest.param(
-        platform_admin_user,
+        create_platform_admin_user(),
     ),
     pytest.param(
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         marks=pytest.mark.xfail
     ),
 ))
@@ -653,7 +653,7 @@ def test_update_organisation_settings(
     user,
 ):
     mocker.patch('app.organisations_client.get_organisation_services', return_value=[])
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     client_request.post(
         endpoint,
@@ -704,10 +704,10 @@ def test_update_organisation_sector_sends_service_id_data_to_api_client(
 
 @pytest.mark.parametrize('user', (
     pytest.param(
-        platform_admin_user,
+        create_platform_admin_user(),
     ),
     pytest.param(
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         marks=pytest.mark.xfail
     ),
 ))
@@ -717,7 +717,7 @@ def test_view_organisation_domains(
     fake_uuid,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     mocker.patch(
         'app.organisations_client.get_organisation',
@@ -785,10 +785,10 @@ def test_view_organisation_domains(
 ))
 @pytest.mark.parametrize('user', (
     pytest.param(
-        platform_admin_user,
+        create_platform_admin_user(),
     ),
     pytest.param(
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         marks=pytest.mark.xfail
     ),
 ))
@@ -802,7 +802,7 @@ def test_update_organisation_domains(
     expected_persisted,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     client_request.post(
         'main.edit_organisation_domains',

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -9,8 +9,8 @@ import app
 from tests.conftest import (
     SERVICE_ONE_ID,
     USER_ONE_ID,
-    active_caseworking_user,
-    active_user_with_permissions,
+    create_active_caseworking_user,
+    create_active_user_with_permissions,
     normalize_spaces,
 )
 
@@ -126,8 +126,8 @@ def test_invite_goes_in_session(
 
 
 @pytest.mark.parametrize('user, landing_page_title', [
-    (active_user_with_permissions, 'Dashboard'),
-    (active_caseworking_user, 'Templates'),
+    (create_active_user_with_permissions(), 'Dashboard'),
+    (create_active_caseworking_user(), 'Templates'),
 ])
 def test_accepting_invite_removes_invite_from_session(
     client_request,
@@ -153,7 +153,6 @@ def test_accepting_invite_removes_invite_from_session(
     user,
     landing_page_title,
 ):
-    user = user(fake_uuid)
     sample_invite['email_address'] = user['email_address']
 
     mocker.patch('app.invite_api_client.check_token', return_value=sample_invite)

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -11,10 +11,8 @@ from tests.conftest import (
     USER_ONE_ID,
     active_caseworking_user,
     active_user_with_permissions,
+    normalize_spaces,
 )
-from tests.conftest import mock_check_invite_token as mock_check_token_invite
-from tests.conftest import normalize_spaces
-from tests.conftest import sample_invite as create_sample_invite
 
 
 def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
@@ -296,13 +294,12 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(
 
 def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation(
     client,
-    service_one,
-    mocker,
     mock_get_user,
     mock_get_service,
+    sample_invite,
+    mock_check_invite_token,
 ):
-    cancelled_invitation = create_sample_invite(mocker, service_one, status='cancelled')
-    mock_check_token_invite(mocker, cancelled_invitation)
+    sample_invite['status'] = 'cancelled'
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
 
     app.invite_api_client.check_token.assert_called_with('thisisnotarealtoken')

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -11,9 +11,9 @@ from app.main.views.jobs import get_status_filters, get_time_left
 from app.models.service import Service
 from tests.conftest import (
     SERVICE_ONE_ID,
-    active_caseworking_user,
-    active_user_view_permissions,
-    active_user_with_permissions,
+    create_active_caseworking_user,
+    create_active_user_view_permissions,
+    create_active_user_with_permissions,
     mock_get_api_keys,
     mock_get_no_api_keys,
     mock_get_notifications,
@@ -24,21 +24,21 @@ from tests.conftest import (
 @pytest.mark.parametrize(
     "user,extra_args,expected_update_endpoint,expected_limit_days,page_title", [
         (
-            active_user_view_permissions,
+            create_active_user_view_permissions(),
             {'message_type': 'email'},
             '/email.json',
             7,
             'Emails',
         ),
         (
-            active_user_view_permissions,
+            create_active_user_view_permissions(),
             {'message_type': 'sms'},
             '/sms.json',
             7,
             'Text messages',
         ),
         (
-            active_caseworking_user,
+            create_active_caseworking_user(),
             {},
             '.json',
             None,
@@ -109,9 +109,8 @@ def test_can_show_notifications(
     to_argument,
     expected_to_argument,
     mocker,
-    fake_uuid,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
     if expected_to_argument:
         page = client_request.post(
             'main.view_notifications',
@@ -191,7 +190,7 @@ def test_can_show_notifications_if_data_retention_not_available(
 
 @pytest.mark.parametrize('user, query_parameters, expected_download_link', [
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         {},
         partial(
             url_for,
@@ -200,7 +199,7 @@ def test_can_show_notifications_if_data_retention_not_available(
         ),
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         {'status': 'failed'},
         partial(
             url_for,
@@ -209,7 +208,7 @@ def test_can_show_notifications_if_data_retention_not_available(
         ),
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         {'message_type': 'sms'},
         partial(
             url_for,
@@ -218,7 +217,7 @@ def test_can_show_notifications_if_data_retention_not_available(
         ),
     ),
     (
-        active_user_view_permissions,
+        create_active_user_view_permissions(),
         {},
         partial(
             url_for,
@@ -226,14 +225,13 @@ def test_can_show_notifications_if_data_retention_not_available(
         ),
     ),
     (
-        active_caseworking_user,
+        create_active_caseworking_user(),
         {},
         lambda service_id: None,
     ),
 ])
 def test_link_to_download_notifications(
     client_request,
-    fake_uuid,
     mock_get_notifications,
     mock_get_service_statistics,
     mock_get_service_data_retention,
@@ -243,7 +241,7 @@ def test_link_to_download_notifications(
     query_parameters,
     expected_download_link,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
     page = client_request.get(
         'main.view_notifications',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -25,8 +25,8 @@ from tests import (
 from tests.conftest import (
     ORGANISATION_ID,
     SERVICE_ONE_ID,
-    active_caseworking_user,
-    active_user_view_permissions,
+    create_active_caseworking_user,
+    create_active_user_view_permissions,
     mock_get_inbound_sms_summary,
     mock_get_inbound_sms_summary_with_no_messages,
     normalize_spaces,
@@ -101,16 +101,15 @@ stub_template_stats = [
 
 
 @pytest.mark.parametrize('user', (
-    active_user_view_permissions,
-    active_caseworking_user,
+    create_active_user_view_permissions(),
+    create_active_caseworking_user(),
 ))
 def test_redirect_from_old_dashboard(
     logged_in_client,
     user,
     mocker,
-    fake_uuid,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     expected_location = 'http://localhost/services/{}'.format(SERVICE_ONE_ID)
 
     response = logged_in_client.get('/services/{}/dashboard'.format(SERVICE_ONE_ID))

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -7,11 +7,7 @@ from flask import url_for
 from notifications_python_client.errors import HTTPError
 
 from app.s3_client.s3_logo_client import EMAIL_LOGO_LOCATION_STRUCTURE, TEMP_TAG
-from tests.conftest import (
-    mock_get_email_branding,
-    normalize_spaces,
-    platform_admin_user,
-)
+from tests.conftest import mock_get_email_branding, normalize_spaces
 
 
 def test_email_branding_page_shows_full_branding_list(
@@ -124,8 +120,8 @@ def test_create_new_email_branding_without_logo(
 def test_create_email_branding_requires_a_name_when_submitting_logo_details(
     client_request,
     mocker,
-    fake_uuid,
     mock_create_email_branding,
+    platform_admin_user,
 ):
     mocker.patch('app.main.views.email_branding.persist_logo')
     mocker.patch('app.main.views.email_branding.delete_email_temp_files_created_by')
@@ -137,7 +133,7 @@ def test_create_email_branding_requires_a_name_when_submitting_logo_details(
         'name': '',
         'brand_type': 'org',
     }
-    client_request.login(platform_admin_user(fake_uuid))
+    client_request.login(platform_admin_user)
     page = client_request.post(
         '.create_email_branding',
         content_type='multipart/form-data',
@@ -152,7 +148,7 @@ def test_create_email_branding_requires_a_name_when_submitting_logo_details(
 def test_create_email_branding_does_not_require_a_name_when_uploading_a_file(
     client_request,
     mocker,
-    fake_uuid,
+    platform_admin_user,
 ):
     mocker.patch('app.main.views.email_branding.upload_email_logo', return_value='temp_filename')
     data = {
@@ -162,7 +158,7 @@ def test_create_email_branding_does_not_require_a_name_when_uploading_a_file(
         'name': '',
         'brand_type': 'org',
     }
-    client_request.login(platform_admin_user(fake_uuid))
+    client_request.login(platform_admin_user)
     page = client_request.post(
         '.create_email_branding',
         content_type='multipart/form-data',

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -3,7 +3,7 @@ from flask import Response, url_for
 from notifications_python_client.errors import HTTPError
 
 import app
-from tests.conftest import api_user_active as create_active_user
+from tests import user_json
 
 
 def test_should_render_forgot_password(client):
@@ -23,7 +23,7 @@ def test_should_redirect_to_password_reset_sent_for_valid_email(
     email_address,
     mocker,
 ):
-    sample_user = create_active_user(fake_uuid, email_address=email_address)
+    sample_user = user_json(email_address=email_address)
     mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
     response = client.post(
         url_for('.forgot_password'),

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -9,8 +9,8 @@ from app.main.views.jobs import get_time_left
 from tests import job_json, notification_json, sample_uuid
 from tests.conftest import (
     SERVICE_ONE_ID,
-    active_caseworking_user,
-    active_user_with_permissions,
+    create_active_caseworking_user,
+    create_active_user_with_permissions,
     mock_get_notifications,
     mock_get_service_letter_template,
     normalize_spaces,
@@ -18,7 +18,7 @@ from tests.conftest import (
 
 
 @pytest.mark.parametrize('user, expected_rows', [
-    (active_user_with_permissions, (
+    (create_active_user_with_permissions(), (
         (
             'File Sending Delivered Failed'
         ),
@@ -39,7 +39,7 @@ from tests.conftest import (
             'Sent today at 12:12pm 1 0 0'
         ),
     )),
-    (active_caseworking_user, (
+    (create_active_caseworking_user(), (
         (
             'File Messages to be sent'
         ),
@@ -78,11 +78,10 @@ def test_jobs_page_shows_scheduled_jobs_if_user_doesnt_have_dashboard(
     service_one,
     active_user_with_permissions,
     mock_get_jobs,
-    fake_uuid,
     user,
     expected_rows,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
     page = client_request.get('main.view_jobs', service_id=service_one['id'])
 
     for index, row in enumerate(expected_rows):
@@ -90,17 +89,16 @@ def test_jobs_page_shows_scheduled_jobs_if_user_doesnt_have_dashboard(
 
 
 @pytest.mark.parametrize('user', [
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ])
 def test_get_jobs_shows_page_links(
     client_request,
     active_user_with_permissions,
     mock_get_jobs,
     user,
-    fake_uuid,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
     page = client_request.get('main.view_jobs', service_id=SERVICE_ONE_ID)
 
     assert 'Next page' in page.find('li', {'class': 'next-page'}).text
@@ -108,8 +106,8 @@ def test_get_jobs_shows_page_links(
 
 
 @pytest.mark.parametrize('user', [
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ])
 @freeze_time("2012-12-12 12:12")
 def test_jobs_page_doesnt_show_scheduled_on_page_2(
@@ -117,10 +115,9 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
     service_one,
     active_user_with_permissions,
     mock_get_jobs,
-    fake_uuid,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
     page = client_request.get('main.view_jobs', service_id=service_one['id'], page=2)
 
     for index, row in enumerate((
@@ -148,8 +145,8 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
 
 
 @pytest.mark.parametrize('user', [
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ])
 @pytest.mark.parametrize(
     "status_argument, expected_api_call", [
@@ -182,7 +179,6 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_show_page_for_one_job(
     client_request,
-    active_user_with_permissions,
     mock_get_service_template,
     mock_get_job,
     mocker,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -11,8 +11,8 @@ from PyPDF2.utils import PdfReadError
 
 from tests.conftest import (
     SERVICE_ONE_ID,
-    active_caseworking_user,
-    active_user_with_permissions,
+    create_active_caseworking_user,
+    create_active_user_with_permissions,
     mock_get_notification,
     normalize_spaces,
 )
@@ -33,8 +33,8 @@ from tests.conftest import (
     ('test', 'permanent-failure', 'Phone number does not exist (test)'),
 ])
 @pytest.mark.parametrize('user', [
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ])
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_notification_status_page_shows_details(
@@ -49,7 +49,7 @@ def test_notification_status_page_shows_details(
     expected_status,
 ):
 
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
 
     _mock_get_notification = mock_get_notification(
         mocker,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -32,8 +32,8 @@ from tests import (
 )
 from tests.conftest import (
     SERVICE_ONE_ID,
-    active_caseworking_user,
-    active_user_with_permissions,
+    create_active_caseworking_user,
+    create_active_user_with_permissions,
     mock_get_international_service,
     mock_get_live_service,
     mock_get_service,
@@ -954,8 +954,8 @@ def test_404_for_previewing_a_row_out_of_range(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 def test_send_test_doesnt_show_file_contents(
     client_request,
@@ -969,7 +969,7 @@ def test_send_test_doesnt_show_file_contents(
     fake_uuid,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     mocker.patch('app.main.views.send.s3download', return_value="""
         phone number
         07700 900 986
@@ -990,43 +990,43 @@ def test_send_test_doesnt_show_file_contents(
 
 @pytest.mark.parametrize('user, endpoint, template_mock, expected_recipient', [
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         'main.send_test_step',
         mock_get_service_template_with_placeholders,
         '07700 900762'
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         'main.send_test_step',
         mock_get_service_email_template,
         'test@user.gov.uk'
     ),
     (
-        active_caseworking_user,
+        create_active_caseworking_user(),
         'main.send_test_step',
         mock_get_service_email_template,
         'caseworker@example.gov.uk'
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         'main.send_test_step',
         mock_get_service_letter_template,
         None
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         'main.send_one_off_step',
         mock_get_service_template,
         None
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         'main.send_one_off_step',
         mock_get_service_email_template,
         None
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         'main.send_one_off_step',
         mock_get_service_letter_template,
         None
@@ -1044,7 +1044,7 @@ def test_send_test_step_redirects_if_session_not_setup(
     expected_recipient,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     template_mock(mocker)
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
@@ -1090,8 +1090,8 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 @pytest.mark.parametrize('template_mock, partial_url, expected_h1, tour_shown', [
     (
@@ -1155,7 +1155,7 @@ def test_send_one_off_or_test_has_correct_page_titles(
     tour_shown,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     template_mock(mocker)
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
@@ -1230,24 +1230,24 @@ def test_send_one_off_or_test_shows_placeholders_in_correct_order(
 
 @pytest.mark.parametrize('user, template_mock, expected_link_text, expected_link_url', [
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         mock_get_service_template,
         'Use my phone number',
         partial(url_for, 'main.send_test')
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         mock_get_service_email_template,
         'Use my email address',
         partial(url_for, 'main.send_test')
     ),
     (
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         mock_get_service_letter_template,
         None, None
     ),
     (
-        active_caseworking_user,
+        create_active_caseworking_user(),
         mock_get_service_template,
         None, None
     ),
@@ -1264,7 +1264,7 @@ def test_send_one_off_has_skip_link(
     expected_link_url,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     template_mock(mocker)
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
 
@@ -1316,8 +1316,8 @@ def test_send_one_off_has_sticky_header_for_email_and_letter(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(
     client_request,
@@ -1328,7 +1328,6 @@ def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(
     mocker,
     user,
 ):
-    user = user(fake_uuid)
     user['mobile_number'] = None
     client_request.login(user)
     page = client_request.get(
@@ -1343,8 +1342,8 @@ def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(
 
 
 @pytest.mark.parametrize('user, link_index', (
-    (active_user_with_permissions, 2),
-    (active_caseworking_user, 1),
+    (create_active_user_with_permissions(), 2),
+    (create_active_caseworking_user(), 1),
 ))
 def test_send_one_off_offers_link_to_upload(
     client_request,
@@ -1354,7 +1353,7 @@ def test_send_one_off_offers_link_to_upload(
     user,
     link_index,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     page = client_request.get(
         'main.send_one_off',
@@ -1377,8 +1376,8 @@ def test_send_one_off_offers_link_to_upload(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 def test_link_to_upload_not_offered_in_tour(
     client_request,
@@ -1386,7 +1385,7 @@ def test_link_to_upload_not_offered_in_tour(
     mock_get_service_template,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     page = client_request.get(
         'main.send_test',
@@ -1403,8 +1402,8 @@ def test_link_to_upload_not_offered_in_tour(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 @pytest.mark.parametrize('endpoint, step_index', (
     ('main.send_one_off_step', 1),
@@ -1419,7 +1418,7 @@ def test_link_to_upload_not_offered_when_entering_personalisation(
     endpoint,
     step_index,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     with client_request.session_transaction() as session:
         session['recipient'] = '07900900900'
@@ -1441,8 +1440,8 @@ def test_link_to_upload_not_offered_when_entering_personalisation(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 @pytest.mark.parametrize('endpoint, expected_redirect, placeholders', [
     (
@@ -1466,7 +1465,7 @@ def test_send_test_redirects_to_end_if_step_out_of_bounds(
     mocker,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     with client_request.session_transaction() as session:
         session['placeholders'] = placeholders
@@ -1487,8 +1486,8 @@ def test_send_test_redirects_to_end_if_step_out_of_bounds(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 @pytest.mark.parametrize('endpoint, expected_redirect', [
     ('main.send_test_step', 'main.send_test'),
@@ -1508,7 +1507,7 @@ def test_send_test_redirects_to_start_if_you_skip_steps(
     expected_redirect,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
 
     with platform_admin_client.session_transaction() as session:
         session['send_test_letter_page_count'] = 1
@@ -1530,8 +1529,8 @@ def test_send_test_redirects_to_start_if_you_skip_steps(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 @pytest.mark.parametrize('endpoint, expected_redirect', [
     ('main.send_test_step', 'main.send_test'),
@@ -1551,7 +1550,7 @@ def test_send_test_redirects_to_start_if_index_out_of_bounds_and_some_placeholde
     mocker,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     with client_request.session_transaction() as session:
         session['placeholders'] = {'name': 'foo'}
 
@@ -1571,8 +1570,8 @@ def test_send_test_redirects_to_start_if_index_out_of_bounds_and_some_placeholde
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 @pytest.mark.parametrize('endpoint, expected_redirect', [
     ('main.send_test', 'main.send_test_step'),
@@ -1587,7 +1586,7 @@ def test_send_test_sms_message_redirects_with_help_argument(
     expected_redirect,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
     template = {'data': {'template_type': 'sms', 'folder': None}}
     mocker.patch('app.service_api_client.get_service_template', return_value=template)
 
@@ -1609,8 +1608,8 @@ def test_send_test_sms_message_redirects_with_help_argument(
 
 
 @pytest.mark.parametrize('user', (
-    active_user_with_permissions,
-    active_caseworking_user,
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
 ))
 def test_send_test_email_message_without_placeholders_redirects_to_check_page(
     client_request,
@@ -1624,7 +1623,7 @@ def test_send_test_email_message_without_placeholders_redirects_to_check_page(
     fake_uuid,
     user,
 ):
-    mocker.patch('app.user_api_client.get_user', return_value=user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=user)
 
     with client_request.session_transaction() as session:
         session['recipient'] = 'foo@bar.com'

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -762,6 +762,7 @@ def test_should_check_for_sending_things_right(
     count_of_email_templates,
     reply_to_email_addresses,
     expected_reply_to_checklist_item,
+    active_user_with_permissions,
 ):
     def _templates_by_type(template_type):
         return {
@@ -772,7 +773,7 @@ def test_should_check_for_sending_things_right(
     mock_get_users = mocker.patch(
         'app.models.user.Users.client',
         return_value=(
-            [active_user_with_permissions(fake_uuid)] * count_of_users_with_manage_service +
+            [active_user_with_permissions] * count_of_users_with_manage_service +
             [active_user_no_settings_permission(fake_uuid)]
         )
     )

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -10,9 +10,9 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     TEMPLATE_ONE_ID,
     _template,
-    active_caseworking_user,
-    active_user_view_permissions,
-    active_user_with_permissions,
+    create_active_caseworking_user,
+    create_active_user_view_permissions,
+    create_active_user_with_permissions,
     normalize_spaces,
 )
 
@@ -507,8 +507,9 @@ def test_get_manage_folder_viewing_permissions_for_users(
     mocker
 ):
     folder_id = str(uuid.uuid4())
-    team_member = active_user_view_permissions(str(uuid.uuid4()))
-    team_member_2 = active_user_view_permissions(str(uuid.uuid4()))
+    team_member = create_active_user_view_permissions(with_unique_id=True)
+    team_member_2 = create_active_user_view_permissions(with_unique_id=True)
+
     mock_get_template_folders.return_value = [
         _folder('folder_two', folder_id, None, [active_user_with_permissions['id'], team_member_2['id']]),
     ]
@@ -556,8 +557,8 @@ def test_get_manage_folder_viewing_permissions_for_users_not_visible_when_no_man
         'view_activity',
     ]
     folder_id = str(uuid.uuid4())
-    team_member = active_user_view_permissions(str(uuid.uuid4()))
-    team_member_2 = active_user_view_permissions(str(uuid.uuid4()))
+    team_member = create_active_user_view_permissions(with_unique_id=True)
+    team_member_2 = create_active_user_view_permissions(with_unique_id=True)
     service_one["permissions"] += ["edit_folder_permissions"]
     mock_get_template_folders.return_value = [
         {'id': folder_id, 'name': 'folder_two', 'parent_id': None, 'users_with_permission': [
@@ -737,7 +738,7 @@ def test_rename_folder(client_request, active_user_with_permissions, service_one
 def test_manage_folder_users(
     client_request, active_user_with_permissions, service_one, mock_get_template_folders, mocker
 ):
-    team_member = active_user_view_permissions(str(uuid.uuid4()))
+    team_member = create_active_user_view_permissions(with_unique_id=True)
     mock_update = mocker.patch('app.template_folder_api_client.update_template_folder')
     folder_id = str(uuid.uuid4())
     mock_get_template_folders.return_value = [
@@ -778,7 +779,7 @@ def test_manage_folder_users_doesnt_change_permissions_current_user_cannot_manag
         'manage_api_keys',
         'view_activity',
     ]
-    team_member = active_user_view_permissions(str(uuid.uuid4()))
+    team_member = create_active_user_view_permissions(with_unique_id=True)
     mock_update = mocker.patch('app.template_folder_api_client.update_template_folder')
     folder_id = str(uuid.uuid4())
     mock_get_template_folders.return_value = [
@@ -907,14 +908,14 @@ def test_delete_folder(client_request, service_one, mock_get_template_folders, m
 
 @pytest.mark.parametrize('user', [
     pytest.param(
-        active_user_with_permissions
+        create_active_user_with_permissions()
     ),
     pytest.param(
-        active_user_view_permissions,
+        create_active_user_view_permissions(),
         marks=pytest.mark.xfail(raises=AssertionError)
     ),
     pytest.param(
-        active_caseworking_user,
+        create_active_caseworking_user(),
         marks=pytest.mark.xfail(raises=AssertionError)
     ),
 ])
@@ -925,10 +926,9 @@ def test_should_show_checkboxes_for_selecting_templates(
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
-    fake_uuid,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     page = client_request.get(
         'main.choose_template',
@@ -947,10 +947,10 @@ def test_should_show_checkboxes_for_selecting_templates(
 
 
 @pytest.mark.parametrize('user', [
-    active_user_view_permissions,
-    active_caseworking_user,
+    create_active_user_view_permissions(),
+    create_active_caseworking_user(),
     pytest.param(
-        active_user_with_permissions,
+        create_active_user_with_permissions(),
         marks=pytest.mark.xfail(raises=AssertionError),
     ),
 ])
@@ -961,10 +961,9 @@ def test_should_not_show_radios_and_buttons_for_move_destination_if_incorrect_pe
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
-    fake_uuid,
     user,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     page = client_request.get(
         'main.choose_template',
@@ -1086,8 +1085,8 @@ def test_should_be_able_to_move_to_existing_folder(
 
 
 @pytest.mark.parametrize('user, expected_status, expected_called', [
-    (active_user_view_permissions, 403, False),
-    (active_user_with_permissions, 302, True),
+    (create_active_user_view_permissions(), 403, False),
+    (create_active_user_with_permissions(), 302, True),
 ])
 def test_should_not_be_able_to_move_to_existing_folder_if_dont_have_permission(
     client_request,
@@ -1100,7 +1099,7 @@ def test_should_not_be_able_to_move_to_existing_folder_if_dont_have_permission(
     expected_status,
     expected_called,
 ):
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
     FOLDER_TWO_ID = str(uuid.uuid4())
     mock_get_template_folders.return_value = [
         _folder('folder_one', PARENT_FOLDER_ID, None),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -9,6 +9,7 @@ from notifications_python_client.errors import HTTPError
 
 from app.main.views.templates import get_human_readable_delta
 from tests import (
+    sample_uuid,
     single_notification_json,
     template_json,
     validate_route_permission,
@@ -25,9 +26,8 @@ from tests.conftest import (
     SERVICE_TWO_ID,
     TEMPLATE_ONE_ID,
     ElementNotFound,
-    active_caseworking_user,
-    active_user_view_permissions,
-    fake_uuid,
+    create_active_caseworking_user,
+    create_active_user_view_permissions,
     mock_get_service_email_template,
     mock_get_service_letter_template,
     mock_get_service_template,
@@ -90,7 +90,7 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
     'user, expected_page_title, extra_args, expected_nav_links, expected_templates',
     [
         (
-            active_user_view_permissions,
+            create_active_user_view_permissions(),
             'Templates',
             {},
             ['Email', 'Text message', 'Letter'],
@@ -104,28 +104,28 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
             ]
         ),
         (
-            active_user_view_permissions,
+            create_active_user_view_permissions(),
             'Templates',
             {'template_type': 'sms'},
             ['All', 'Email', 'Letter'],
             ['sms_template_one', 'sms_template_two'],
         ),
         (
-            active_user_view_permissions,
+            create_active_user_view_permissions(),
             'Templates',
             {'template_type': 'email'},
             ['All', 'Text message', 'Letter'],
             ['email_template_one', 'email_template_two'],
         ),
         (
-            active_user_view_permissions,
+            create_active_user_view_permissions(),
             'Templates',
             {'template_type': 'letter'},
             ['All', 'Email', 'Text message'],
             ['letter_template_one', 'letter_template_two'],
         ),
         (
-            active_caseworking_user,
+            create_active_caseworking_user(),
             'Templates',
             {},
             ['Email', 'Text message', 'Letter'],
@@ -139,7 +139,7 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
             ],
         ),
         (
-            active_caseworking_user,
+            create_active_caseworking_user(),
             'Templates',
             {'template_type': 'email'},
             ['All', 'Text message', 'Letter'],
@@ -157,12 +157,11 @@ def test_should_show_page_for_choosing_a_template(
     expected_templates,
     service_one,
     mocker,
-    fake_uuid,
     user,
     expected_page_title,
 ):
     service_one['permissions'].append('letter')
-    client_request.login(user(fake_uuid))
+    client_request.login(user)
 
     page = client_request.get(
         'main.choose_template',
@@ -358,9 +357,10 @@ def test_caseworker_redirected_to_one_off(
     mock_get_service_template,
     mocker,
     fake_uuid,
+    active_caseworking_user,
 ):
 
-    mocker.patch('app.user_api_client.get_user', return_value=active_caseworking_user(fake_uuid))
+    mocker.patch('app.user_api_client.get_user', return_value=active_caseworking_user)
 
     client_request.get(
         'main.view_template',
@@ -717,10 +717,10 @@ def test_should_show_sms_template_with_downgraded_unicode_characters(
 
 @pytest.mark.parametrize('mock_contact_block, expected_partial_url', (
     (no_letter_contact_blocks, partial(
-        url_for, 'main.service_add_letter_contact', from_template=fake_uuid(),
+        url_for, 'main.service_add_letter_contact', from_template=sample_uuid(),
     )),
     (single_letter_contact_block, partial(
-        url_for, 'main.set_template_sender', template_id=fake_uuid(),
+        url_for, 'main.set_template_sender', template_id=sample_uuid(),
     )),
 ))
 def test_should_let_letter_contact_block_be_changed_for_the_template(

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -5,8 +5,7 @@ import pytest
 from flask import url_for
 from notifications_utils.url_safe_token import generate_token
 
-from tests.conftest import api_user_active as create_user
-from tests.conftest import url_for_endpoint_with_token
+from tests.conftest import create_api_user_active, url_for_endpoint_with_token
 
 
 def test_should_show_overview_page(
@@ -200,11 +199,10 @@ def test_should_redirect_after_mobile_number_confirm(
     mocker,
     mock_update_user_attribute,
     mock_check_verify_code,
-    fake_uuid,
     phone_number_to_register_with,
 ):
-    user_before = create_user(fake_uuid)
-    user_after = create_user(fake_uuid)
+    user_before = create_api_user_active(with_unique_id=True)
+    user_after = create_api_user_active(with_unique_id=True)
     user_before['current_session_id'] = str(uuid.UUID(int=1))
     user_after['current_session_id'] = str(uuid.UUID(int=2))
 

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import date
 from unittest.mock import patch
 
@@ -9,7 +8,11 @@ from app.models.service import Service
 from app.notify_client import NotifyAdminAPIClient
 from app.notify_client.notification_api_client import notification_api_client
 from tests import service_json
-from tests.conftest import api_user_active, platform_admin_user, set_config
+from tests.conftest import (
+    create_api_user_active,
+    create_platform_admin_user,
+    set_config,
+)
 
 
 @pytest.mark.parametrize('method', [
@@ -18,8 +21,8 @@ from tests.conftest import api_user_active, platform_admin_user, set_config
     'delete'
 ])
 @pytest.mark.parametrize('user', [
-    api_user_active(str(uuid.uuid4())),
-    platform_admin_user(str(uuid.uuid4()))
+    create_api_user_active(),
+    create_platform_admin_user(),
 ], ids=['api_user', 'platform_admin'])
 @pytest.mark.parametrize('service', [
     service_json(active=True),

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -5,7 +5,7 @@ import pytest
 
 from app import invite_api_client, service_api_client, user_api_client
 from tests import sample_uuid
-from tests.conftest import SERVICE_ONE_ID, api_user_pending
+from tests.conftest import SERVICE_ONE_ID
 
 user_id = sample_uuid()
 
@@ -193,7 +193,7 @@ def test_returns_value_from_cache(
     (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, user_id, [], []], {}),
     (user_api_client, 'add_user_to_organisation', [sample_uuid(), user_id], {}),
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),
-    (user_api_client, 'activate_user', [api_user_pending(sample_uuid())['id']], {}),
+    (user_api_client, 'activate_user', [user_id], {}),
     (user_api_client, 'archive_user', [user_id], {}),
     (service_api_client, 'remove_user_from_service', [SERVICE_ONE_ID, user_id], {}),
     (service_api_client, 'create_service', ['', '', 0, False, user_id, sample_uuid()], {}),

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -8,12 +8,7 @@ from app.navigation import (
     MainNavigation,
     OrgNavigation,
 )
-from tests.conftest import (
-    ORGANISATION_ID,
-    SERVICE_ONE_ID,
-    active_caseworking_user,
-    normalize_spaces,
-)
+from tests.conftest import ORGANISATION_ID, SERVICE_ONE_ID, normalize_spaces
 
 
 def flask_app():
@@ -181,14 +176,14 @@ def test_navigation_urls(
 def test_caseworkers_get_caseworking_navigation(
     client_request,
     mocker,
-    fake_uuid,
     mock_get_template_folders,
     mock_get_service_templates,
     mock_has_no_jobs,
+    active_caseworking_user,
 ):
     mocker.patch(
         'app.user_api_client.get_user',
-        return_value=active_caseworking_user(fake_uuid)
+        return_value=active_caseworking_user
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('header + .govuk-width-container nav').text) == (
@@ -199,14 +194,14 @@ def test_caseworkers_get_caseworking_navigation(
 def test_caseworkers_see_jobs_nav_if_jobs_exist(
     client_request,
     mocker,
-    fake_uuid,
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_jobs,
+    active_caseworking_user,
 ):
     mocker.patch(
         'app.user_api_client.get_user',
-        return_value=active_caseworking_user(fake_uuid)
+        return_value=active_caseworking_user
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('header + .govuk-width-container nav').text) == (

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -1,5 +1,7 @@
 import pytest
+from flask import Flask
 
+from app import create_app
 from app.navigation import (
     CaseworkNavigation,
     HeaderNavigation,
@@ -10,12 +12,22 @@ from tests.conftest import (
     ORGANISATION_ID,
     SERVICE_ONE_ID,
     active_caseworking_user,
-    app_,
     normalize_spaces,
 )
 
+
+def flask_app():
+    app = Flask('app')
+    create_app(app)
+
+    ctx = app.app_context()
+    ctx.push()
+
+    yield app
+
+
 all_endpoints = [
-    rule.endpoint for rule in next(app_(None)).url_map.iter_rules()
+    rule.endpoint for rule in next(flask_app()).url_map.iter_rules()
 ]
 
 navigation_instances = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3562,3 +3562,205 @@ def mock_get_service_history(mocker):
         ],
         'events': [],
     })
+
+
+def create_api_user_active(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User',
+        'password': 'somepassword',
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'password_changed_at': str(datetime.utcnow()),
+        'services': [],
+        'organisations': [],
+        'current_session_id': None,
+        'logged_in_at': None,
+    }
+
+
+def create_active_user_empty_permissions(with_unique_id=False):
+    user_data = {'id': str(uuid4()) if with_unique_id else sample_uuid(),
+                 'name': 'Test User With Empty Permissions',
+                 'password': 'somepassword',
+                 'password_changed_at': str(datetime.utcnow()),
+                 'email_address': 'test@user.gov.uk',
+                 'mobile_number': '07700 900763',
+                 'state': 'active',
+                 'failed_login_count': 0,
+                 'permissions': {},
+                 'platform_admin': False,
+                 'auth_type': 'sms_auth',
+                 'organisations': [],
+                 'services': [SERVICE_ONE_ID],
+                 'current_session_id': None,
+                 }
+    return user_data
+
+
+def create_active_user_with_permissions(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: ['send_texts',
+                                         'send_emails',
+                                         'send_letters',
+                                         'manage_users',
+                                         'manage_templates',
+                                         'manage_settings',
+                                         'manage_api_keys',
+                                         'view_activity']},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'organisations': [ORGANISATION_ID],
+        'services': [SERVICE_ONE_ID],
+        'current_session_id': None,
+                 }
+
+
+def create_active_user_view_permissions(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: ['view_activity']},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'organisations': [],
+        'services': [SERVICE_ONE_ID],
+        'current_session_id': None,
+    }
+
+
+def create_active_caseworking_user(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'caseworker@example.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'send_texts',
+            'send_emails',
+            'send_letters',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'organisations': [],
+        'services': [SERVICE_ONE_ID],
+        'current_session_id': None,
+    }
+
+
+def create_active_user_no_api_key_permission(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'manage_templates',
+            'manage_settings',
+            'view_activity',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'organisations': [],
+        'current_session_id': None,
+        'services': [SERVICE_ONE_ID],
+    }
+
+
+def create_active_user_no_settings_permission(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'manage_templates',
+            'manage_api_keys',
+            'view_activity',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'current_session_id': None,
+        'services': [SERVICE_ONE_ID],
+        'organisations': [],
+    }
+
+
+def create_active_user_manage_template_permissions(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User With Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: [
+            'manage_templates',
+            'view_activity',
+        ]},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'organisations': [],
+        'services': [SERVICE_ONE_ID],
+        'current_session_id': None,
+    }
+
+
+def create_platform_admin_user(with_unique_id=False):
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Platform admin user',
+        'password': 'somepassword',
+        'email_address': 'platform@admin.gov.uk',
+        'mobile_number': '07700 900762',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {SERVICE_ONE_ID: ['send_texts',
+                                         'send_emails',
+                                         'send_letters',
+                                         'manage_users',
+                                         'manage_templates',
+                                         'manage_settings',
+                                         'manage_api_keys',
+                                         'view_activity']},
+        'platform_admin': True,
+        'auth_type': 'sms_auth',
+        'password_changed_at': str(datetime.utcnow()),
+        'services': [],
+        'organisations': [],
+        'current_session_id': None,
+        'logged_in_at': None,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -703,15 +703,12 @@ USER_ONE_ID = "7b395b52-c6c1-469c-9d61-54166461c1ab"
 
 
 @pytest.fixture(scope='function')
-def mock_get_services(mocker, fake_uuid, user=None):
-    if user is None:
-        user = active_user_with_permissions(fake_uuid)
-
+def mock_get_services(mocker, active_user_with_permissions):
     def _get_services(params_dict=None):
         service_one = service_json(
-            SERVICE_ONE_ID, "service_one", [user['id']], 1000, True, False)
+            SERVICE_ONE_ID, "service_one", [active_user_with_permissions['id']], 1000, True, False)
         service_two = service_json(
-            SERVICE_TWO_ID, "service_two", [user['id']], 1000, True, False)
+            SERVICE_TWO_ID, "service_two", [active_user_with_permissions['id']], 1000, True, False)
         return {'data': [service_one, service_two]}
 
     return mocker.patch(
@@ -719,10 +716,7 @@ def mock_get_services(mocker, fake_uuid, user=None):
 
 
 @pytest.fixture(scope='function')
-def mock_get_services_with_no_services(mocker, fake_uuid, user=None):
-    if user is None:
-        user = active_user_with_permissions(fake_uuid)
-
+def mock_get_services_with_no_services(mocker):
     def _get_services(params_dict=None):
         return {'data': []}
 
@@ -731,13 +725,10 @@ def mock_get_services_with_no_services(mocker, fake_uuid, user=None):
 
 
 @pytest.fixture(scope='function')
-def mock_get_services_with_one_service(mocker, fake_uuid, user=None):
-    if user is None:
-        user = api_user_active(fake_uuid)
-
+def mock_get_services_with_one_service(mocker, api_user_active):
     def _get_services(params_dict=None):
         return {'data': [service_json(
-            SERVICE_ONE_ID, "service_one", [user['id']], 1000, True, True
+            SERVICE_ONE_ID, "service_one", [api_user_active['id']], 1000, True, True
         )]}
 
     return mocker.patch(
@@ -797,15 +788,12 @@ def mock_get_deleted_template(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_get_template_version(mocker, fake_uuid, user=None):
-    if user is None:
-        user = api_user_active(fake_uuid)
-
+def mock_get_template_version(mocker, api_user_active):
     def _get(service_id, template_id, version):
         template_version = template_version_json(
             service_id,
             template_id,
-            user,
+            api_user_active,
             version=version
         )
         return {'data': template_version}
@@ -817,15 +805,12 @@ def mock_get_template_version(mocker, fake_uuid, user=None):
 
 
 @pytest.fixture(scope='function')
-def mock_get_template_versions(mocker, fake_uuid, user=None):
-    if user is None:
-        user = api_user_active(fake_uuid)
-
+def mock_get_template_versions(mocker, api_user_active):
     def _get(service_id, template_id):
         template_version = template_version_json(
             service_id,
             template_id,
-            user,
+            api_user_active,
             version=1
         )
         return {'data': [template_version]}
@@ -1146,11 +1131,11 @@ def platform_admin_user(fake_uuid):
 
 
 @pytest.fixture(scope='function')
-def api_user_active(fake_uuid, email_address='test@user.gov.uk'):
+def api_user_active(fake_uuid):
     user_data = {'id': fake_uuid,
                  'name': 'Test User',
                  'password': 'somepassword',
-                 'email_address': email_address,
+                 'email_address': 'test@user.gov.uk',
                  'mobile_number': '07700 900762',
                  'state': 'active',
                  'failed_login_count': 0,
@@ -1520,39 +1505,22 @@ def mock_register_user(mocker, api_user_pending):
 
 
 @pytest.fixture(scope='function')
-def mock_get_non_govuser(mocker, user=None):
-    if user is None:
-        user = api_user_active(sample_uuid(), email_address='someuser@notonwhitelist.com')
+def mock_get_non_govuser(mocker, api_user_active):
+    api_user_active['email_address'] = 'someuser@notonwhitelist.com'
 
     def _get_user(id_):
-        user['id'] = id_
-        return user
+        api_user_active['id'] = id_
+        return api_user_active
 
     return mocker.patch(
         'app.user_api_client.get_user', side_effect=_get_user)
 
 
 @pytest.fixture(scope='function')
-def mock_get_user(mocker, user=None):
-    if user is None:
-        user = api_user_active(sample_uuid())
-
+def mock_get_user(mocker, api_user_active):
     def _get_user(id_):
-        user['id'] = id_
-        return user
-
-    return mocker.patch(
-        'app.user_api_client.get_user', side_effect=_get_user)
-
-
-@pytest.fixture(scope='function')
-def mock_get_organisation_user(mocker, user=None):
-    if user is None:
-        user = api_user_active(sample_uuid())
-
-    def _get_user(id_):
-        user['id'] = id_
-        return user
+        api_user_active['id'] = id_
+        return api_user_active
 
     return mocker.patch(
         'app.user_api_client.get_user', side_effect=_get_user)
@@ -1560,7 +1528,12 @@ def mock_get_organisation_user(mocker, user=None):
 
 @pytest.fixture(scope='function')
 def mock_get_locked_user(mocker, api_user_locked):
-    return mock_get_user(mocker, user=api_user_locked)
+    def _get_user(id_):
+        api_user_locked['id'] = id_
+        return api_user_locked
+
+    return mocker.patch(
+        'app.user_api_client.get_user', side_effect=_get_user)
 
 
 @pytest.fixture(scope='function')
@@ -1576,32 +1549,23 @@ def mock_get_user_pending(mocker, api_user_pending):
 
 
 @pytest.fixture(scope='function')
-def mock_get_user_by_email(mocker, user=None):
-    if user is None:
-        user = api_user_active(sample_uuid())
-
+def mock_get_user_by_email(mocker, api_user_active):
     def _get_user(email_address):
-        user['email_address'] = email_address
-        return user
+        api_user_active['email_address'] = email_address
+        return api_user_active
 
     return mocker.patch('app.user_api_client.get_user_by_email', side_effect=_get_user)
 
 
 @pytest.fixture(scope='function')
-def mock_get_unknown_user_by_email(mocker, user=None):
-    if user is None:
-        user = api_user_active(USER_ONE_ID)
+def mock_get_unknown_user_by_email(mocker, api_user_active):
+    api_user_active['id'] = USER_ONE_ID
 
     def _get_user(email_address):
-        user['email_address'] = email_address
-        return user
+        api_user_active['email_address'] = email_address
+        return api_user_active
 
     return mocker.patch('app.user_api_client.get_user_by_email', side_effect=_get_user)
-
-
-@pytest.fixture(scope='function')
-def mock_get_locked_user_by_email(mocker, api_user_locked):
-    return mock_get_user_by_email(mocker, user=api_user_locked)
 
 
 @pytest.fixture(scope='function')
@@ -2882,7 +2846,7 @@ def platform_admin_client(
     service_one,
     mock_login,
 ):
-    mock_get_user(mocker, user=platform_admin_user)
+    mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     client.login(platform_admin_user, mocker, service_one)
     yield client
 
@@ -3291,7 +3255,7 @@ def _get_organisation_services(organisation_id):
     return [
         service_json('12345', 'service one'),
         service_json('67890', 'service two'),
-        service_json(SERVICE_ONE_ID, 'service one', [api_user_active(fake_uuid())['id']])
+        service_json(SERVICE_ONE_ID, 'service one', [sample_uuid()])
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ class ElementNotFound(Exception):
 
 
 @pytest.fixture(scope='session')
-def app_(request):
+def app_():
     app = Flask('app')
     create_app(app)
 


### PR DESCRIPTION
This PR mostly deals with getting the tests related to users Pytest 5 compliant, but also fixes a few other test files.

We were using user fixtures in a lot of parameterized tests, but this is no longer allowed in Pytest 5. To avoid having to split up the parametrized tests (which would make the test files a lot longer and slightly more difficult to read) this PR creates functions which return various types of user json so that we can use these as the test parameters instead.

Total errors and failures before: `1649`
Total errors and failures after: `365`