### PR TITLE
More Pytest 5 fixes

### DIFF
--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -3,7 +3,7 @@ from flask import session, url_for
 
 from app.utils import is_gov_user
 from tests import organisation_json
-from tests.conftest import mock_get_organisation_by_domain, normalize_spaces
+from tests.conftest import normalize_spaces
 
 
 def test_non_gov_user_cannot_see_add_service_button(
@@ -66,7 +66,10 @@ def test_get_should_not_render_radios_if_org_type_known(
     client_request,
     mocker,
 ):
-    mock_get_organisation_by_domain(mocker, organisation_type='central')
+    mocker.patch(
+        'app.organisations_client.get_organisation_by_domain',
+        return_value=organisation_json(organisation_type='central'),
+    )
     page = client_request.get('main.add_service')
     assert page.select_one('h1').text.strip() == 'About your service'
     assert page.select_one('input[name=name]')['value'] == ''
@@ -113,7 +116,10 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
 ):
     api_user_active['email_address'] = email_address
     client_request.login(api_user_active)
-    mock_get_organisation_by_domain(mocker, organisation_type=inherited)
+    mocker.patch(
+        'app.organisations_client.get_organisation_by_domain',
+        return_value=organisation_json(organisation_type=inherited),
+    )
     client_request.post(
         'main.add_service',
         _data={

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -7,11 +7,7 @@ from flask import url_for
 from freezegun import freeze_time
 
 from tests import organisation_json
-from tests.conftest import (
-    SERVICE_ONE_ID,
-    mock_get_service_organisation,
-    normalize_spaces,
-)
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 class _MockS3Object():
@@ -94,11 +90,12 @@ def test_show_agreement_page(
     crown,
     expected_links,
 ):
-    mock_get_service_organisation(
-        mocker,
+    org = organisation_json(
         crown=crown,
-        agreement_signed=agreement_signed,
+        agreement_signed=agreement_signed
     )
+    mocker.patch('app.organisations_client.get_service_organisation', return_value=org)
+
     page = client_request.get('main.service_agreement', service_id=SERVICE_ONE_ID)
     links = page.select('main .column-five-sixths a')
     assert len(links) == len(expected_links)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -33,7 +33,6 @@ from tests.conftest import (
     create_platform_admin_user,
     create_reply_to_email_address,
     create_sms_sender,
-    mock_get_service_organisation,
     normalize_spaces,
 )
 
@@ -1095,11 +1094,10 @@ def test_should_check_for_mou_on_request_to_go_live(
             return_value=None,
         )
 
-    mock_get_service_organisation(
-        mocker,
-        agreement_signed=agreement_signed,
+    mocker.patch(
+        'app.organisations_client.get_service_organisation',
+        return_value=organisation_json(agreement_signed=agreement_signed)
     )
-
     page = client_request.get(
         'main.request_to_go_live', service_id=SERVICE_ONE_ID
     )
@@ -1452,11 +1450,11 @@ def test_should_redirect_after_request_to_go_live(
     formatted_displayed_volumes,
     extra_tags,
 ):
-    mock_get_service_organisation(
-        mocker,
-        name=None,
-        agreement_signed=None,
+    mocker.patch(
+        'app.organisations_client.get_service_organisation',
+        return_value=organisation_json(name=None, agreement_signed=None)
     )
+
     for channel, volume in volumes:
         mocker.patch(
             'app.models.service.Service.volume_{}'.format(channel),
@@ -1767,9 +1765,9 @@ def test_ready_to_go_live(
     agreement_signed,
     expected_tags,
 ):
-    mock_get_service_organisation(
-        mocker,
-        agreement_signed=agreement_signed,
+    mocker.patch(
+        'app.organisations_client.get_service_organisation',
+        return_value=organisation_json(agreement_signed=agreement_signed)
     )
 
     for prop in {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,21 +252,6 @@ def get_default_letter_contact_block(mocker):
 
 
 @pytest.fixture(scope='function')
-def get_non_default_letter_contact_block(mocker):
-    def _get(service_id, letter_contact_id):
-        return {
-            'id': '1234',
-            'service_id': service_id,
-            'contact_block': '1 Example Street',
-            'is_default': False,
-            'created_at': datetime.utcnow(),
-            'updated_at': None
-        }
-
-    return mocker.patch('app.service_api_client.get_letter_contact', side_effect=_get)
-
-
-@pytest.fixture(scope='function')
 def mock_add_letter_contact(mocker):
     def _add_letter_contact(service_id, contact_block, is_default=False):
         return {'data': {
@@ -435,22 +420,6 @@ def get_non_default_sms_sender(mocker):
             'is_default': False,
             'created_at': datetime.utcnow(),
             'inbound_number_id': None,
-            'updated_at': None
-        }
-
-    return mocker.patch('app.service_api_client.get_sms_sender', side_effect=_get)
-
-
-@pytest.fixture(scope='function')
-def get_inbound_number_sms_sender(mocker):
-    def _get(service_id, sms_sender_id):
-        return {
-            'id': '1234',
-            'service_id': service_id,
-            'sms_sender': 'GOVUK',
-            'is_default': False,
-            'created_at': datetime.utcnow(),
-            'inbound_number_id': '1234',
             'updated_at': None
         }
 
@@ -3585,22 +3554,22 @@ def create_api_user_active(with_unique_id=False):
 
 
 def create_active_user_empty_permissions(with_unique_id=False):
-    user_data = {'id': str(uuid4()) if with_unique_id else sample_uuid(),
-                 'name': 'Test User With Empty Permissions',
-                 'password': 'somepassword',
-                 'password_changed_at': str(datetime.utcnow()),
-                 'email_address': 'test@user.gov.uk',
-                 'mobile_number': '07700 900763',
-                 'state': 'active',
-                 'failed_login_count': 0,
-                 'permissions': {},
-                 'platform_admin': False,
-                 'auth_type': 'sms_auth',
-                 'organisations': [],
-                 'services': [SERVICE_ONE_ID],
-                 'current_session_id': None,
-                 }
-    return user_data
+    return {
+        'id': str(uuid4()) if with_unique_id else sample_uuid(),
+        'name': 'Test User With Empty Permissions',
+        'password': 'somepassword',
+        'password_changed_at': str(datetime.utcnow()),
+        'email_address': 'test@user.gov.uk',
+        'mobile_number': '07700 900763',
+        'state': 'active',
+        'failed_login_count': 0,
+        'permissions': {},
+        'platform_admin': False,
+        'auth_type': 'sms_auth',
+        'organisations': [],
+        'services': [SERVICE_ONE_ID],
+        'current_session_id': None,
+    }
 
 
 def create_active_user_with_permissions(with_unique_id=False):
@@ -3764,3 +3733,143 @@ def create_platform_admin_user(with_unique_id=False):
         'current_session_id': None,
         'logged_in_at': None,
     }
+
+
+def create_reply_to_email_address(
+    id_='1234',
+    service_id='abcd',
+    email_address='test@example.com',
+    is_default=True,
+    created_at=None,
+    updated_at=None
+):
+    return {
+        'id': id_,
+        'service_id': service_id,
+        'email_address': email_address,
+        'is_default': is_default,
+        'created_at': created_at,
+        'updated_at': updated_at
+    }
+
+
+def create_multiple_email_reply_to_addresses(service_id='abcd'):
+    return [
+        {
+            'id': '1234',
+            'service_id': service_id,
+            'email_address': 'test@example.com',
+            'is_default': True,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }, {
+            'id': '5678',
+            'service_id': service_id,
+            'email_address': 'test2@example.com',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }, {
+            'id': '9457',
+            'service_id': service_id,
+            'email_address': 'test3@example.com',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }
+    ]
+
+
+def create_sms_sender(
+    id_='1234',
+    service_id='abcd',
+    sms_sender='GOVUK',
+    is_default=True,
+    created_at=None,
+    inbound_number_id=None,
+    updated_at=None
+):
+    return {
+        'id': id_,
+        'service_id': service_id,
+        'sms_sender': sms_sender,
+        'is_default': is_default,
+        'created_at': created_at,
+        'inbound_number_id': inbound_number_id,
+        'updated_at': updated_at
+    }
+
+
+def create_multiple_sms_senders(service_id='abcd'):
+    return [
+        {
+            'id': '1234',
+            'service_id': service_id,
+            'sms_sender': 'Example',
+            'is_default': True,
+            'created_at': datetime.utcnow(),
+            'inbound_number_id': '1234',
+            'updated_at': None
+        }, {
+            'id': '5678',
+            'service_id': service_id,
+            'sms_sender': 'Example 2',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'inbound_number_id': None,
+            'updated_at': None
+        }, {
+            'id': '9457',
+            'service_id': service_id,
+            'sms_sender': 'Example 3',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'inbound_number_id': None,
+            'updated_at': None
+        }
+    ]
+
+
+def create_letter_contact_block(
+    id_='1234',
+    service_id='abcd',
+    contact_block='1 Example Street',
+    is_default=True,
+    created_at=None,
+    updated_at=None,
+):
+    return {
+        'id': id_,
+        'service_id': service_id,
+        'contact_block': contact_block,
+        'is_default': is_default,
+        'created_at': created_at,
+        'updated_at': updated_at
+    }
+
+
+def create_multiple_letter_contact_blocks(service_id='abcd'):
+    return [
+        {
+            'id': '1234',
+            'service_id': service_id,
+            'contact_block': '1 Example Street',
+            'is_default': True,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }, {
+            'id': '5678',
+            'service_id': service_id,
+            'contact_block': '2 Example Street',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }, {
+            'id': '9457',
+            'service_id': service_id,
+            'contact_block': '3 Example Street',
+            'is_default': False,
+            'created_at': datetime.utcnow(),
+            'updated_at': None
+        }
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3873,3 +3873,46 @@ def create_multiple_letter_contact_blocks(service_id='abcd'):
             'updated_at': None
         }
     ]
+
+
+def create_notification(
+    notifification_id=None,
+    service_id='abcd',
+    notification_status='delivered',
+    redact_personalisation=False,
+    template_type=None,
+    template_name='sample template',
+    is_precompiled_letter=False,
+    key_type=None,
+    postage=None,
+    sent_one_off=True,
+):
+    noti = notification_json(
+        service_id,
+        rows=1,
+        status=notification_status,
+        template_type=template_type,
+        postage=postage
+    )['notifications'][0]
+
+    noti['id'] = notifification_id or sample_uuid()
+    if sent_one_off:
+        noti['created_by'] = {
+            'id': sample_uuid(),
+            'name': 'Test User',
+            'email_address': 'test@user.gov.uk'
+        }
+    noti['personalisation'] = {'name': 'Jo'}
+    noti['template'] = template_json(
+        service_id,
+        '5407f4db-51c7-4150-8758-35412d42186a',
+        content='hello ((name))',
+        subject='blah',
+        redact_personalisation=redact_personalisation,
+        type_=template_type,
+        is_precompiled_letter=is_precompiled_letter,
+        name=template_name
+    )
+    if key_type:
+        noti['key_type'] = key_type
+    return noti


### PR DESCRIPTION
Following on from https://github.com/alphagov/notifications-admin/pull/3229, this PR stops calling more fixtures as if they were functions.

Once we have upgraded to Pytest 5, `conftest.py` can be tidied up and refactored.

Total errors and failures before: `365`
Total errors and failures after: `133`