### PR TITLE
Revert "Remove pip-accel"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 SHELL := /bin/bash
 DATE = $(shell date +%Y-%m-%dT%H:%M:%S)
 
+PIP_ACCEL_CACHE ?= ${CURDIR}/cache/pip-accel
 APP_VERSION_FILE = app/version.py
 
 GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")
@@ -30,6 +31,13 @@ NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 .PHONY: help
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: venv
+venv: venv/bin/activate ## Create virtualenv if it does not exist
+
+venv/bin/activate:
+	test -d venv || virtualenv venv -p python3
+	. venv/bin/activate && pip install pip-accel
 
 .PHONY: check-env-vars
 check-env-vars: ## Check mandatory environment variables
@@ -61,11 +69,12 @@ production: ## Set environment to production
 	@true
 
 .PHONY: dependencies
-dependencies: ## Install build dependencies
+dependencies: venv ## Install build dependencies
 	npm set progress=false
 	npm install
 	npm rebuild node-sass
-	pip install -r requirements_for_test.txt
+	mkdir -p ${PIP_ACCEL_CACHE}
+	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel install -r requirements_for_test.txt
 
 .PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
@@ -74,7 +83,7 @@ generate-version-file: ## Generates the app version file
 .PHONY: build
 build: dependencies generate-version-file ## Build project
 	npm run build
-	pip install -r requirements.txt
+	. venv/bin/activate && PIP_ACCEL_CACHE=${PIP_ACCEL_CACHE} pip-accel install -r requirements.txt
 
 .PHONY: build-paas-artifact
 build-paas-artifact: ## Build the deploy artifact for PaaS
@@ -93,7 +102,7 @@ upload-static:
 	aws s3 cp --region eu-west-1 --recursive --cache-control max-age=315360000,immutable ./app/static s3://${DNS_NAME}-static
 
 .PHONY: test
-test: ## Run tests
+test: venv ## Run tests
 	./scripts/run_tests.sh
 
 .PHONY: freeze-requirements
@@ -115,14 +124,20 @@ test-requirements:
 	         echo "Run 'make freeze-requirements' to update."; exit 1; } \
 || { echo "requirements.txt is up to date"; exit 0; }
 
+.PHONY: coverage
+coverage: venv ## Create coverage report
+	. venv/bin/activate && coveralls
+
 .PHONY: prepare-docker-build-image
 prepare-docker-build-image: ## Prepare the Docker builder image
+	mkdir -p ${PIP_ACCEL_CACHE}
 	make -C docker build
 
 define run_docker_container
 	@docker run -i${DOCKER_TTY} --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-${1}" \
 		-v "`pwd`:/var/project" \
+		-v "${PIP_ACCEL_CACHE}:/var/project/cache/pip-accel" \
 		-e UID=$(shell id -u) \
 		-e GID=$(shell id -g) \
 		-e GIT_COMMIT=${GIT_COMMIT} \
@@ -133,6 +148,7 @@ define run_docker_container
 		-e https_proxy="${HTTPS_PROXY}" \
 		-e HTTPS_PROXY="${HTTPS_PROXY}" \
 		-e NO_PROXY="${NO_PROXY}" \
+		-e COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN} \
 		-e CIRCLECI=1 \
 		-e CI_NAME=${CI_NAME} \
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
@@ -156,13 +172,18 @@ build-with-docker: prepare-docker-build-image ## Build inside a Docker container
 test-with-docker: prepare-docker-build-image ## Run tests inside a Docker container
 	$(call run_docker_container,test,gosu hostuser make test)
 
+# FIXME: CIRCLECI=1 is an ugly hack because the coveralls-python library sends the PR link only this way
+.PHONY: coverage-with-docker
+coverage-with-docker: prepare-docker-build-image ## Generates coverage report inside a Docker container
+	$(call run_docker_container,coverage,gosu hostuser make coverage)
+
 .PHONY: clean-docker-containers
 clean-docker-containers: ## Clean up any remaining docker containers
 	docker rm -f $(shell docker ps -q -f "name=${DOCKER_CONTAINER_PREFIX}") 2> /dev/null || true
 
 .PHONY: clean
 clean:
-	rm -rf node_modules cache target
+	rm -rf node_modules cache target venv .coverage
 
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -5,6 +5,7 @@ pytest-env==0.6.2
 pytest-cov==2.8.1
 pytest-mock==1.11.2
 pytest-xdist==1.27.0 # pyup: <1.28.0
+coveralls==1.8.2
 beautifulsoup4==4.8.1
 freezegun==0.3.12
 flake8==3.7.9


### PR DESCRIPTION
Reverts alphagov/notifications-admin#3228

I think the removal of venv is now meaning that docker trys to install the pip dependancies to jenkins local version of python and breaks things.

Just going to revert this as it's gives me time to think about how to fix this without any time pressure.

May end up not remerging until we move this to concourse as would likely solve these problems anyway.