### PR TITLE
Handle precompiled letters in returned letters list

### DIFF
--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -28,7 +28,7 @@
       field_headings_visible=False
   ) %}
     {% call field() %}
-      <span class="file-list-filename file-list-filename-unlinked">{{ item.template_name or item.uploaded_letter_file_name }}</span>
+      <span class="file-list-filename file-list-filename-unlinked">{{ item.template_name or item.uploaded_letter_file_name or 'Provided as PDF' }}</span>
       <span class="file-list-hint">
         {% if item.client_reference %}
           Reference {{ item.client_reference }}

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -67,7 +67,7 @@ def test_returned_letters_page(
             'template_version': None,
             'original_file_name': original_file_name,
             'job_row_number': None,
-            'uploaded_letter_file_name': 'test_letter.pdf',
+            'uploaded_letter_file_name': uploaded_letter_file_name,
         }
         for client_reference, template_name, original_file_name, uploaded_letter_file_name in (
             ('ABC123', 'Example template', None, None),
@@ -90,8 +90,8 @@ def test_returned_letters_page(
         'Example template Reference ABC123 Originally sent 24 December 2019',
         'Example template Sent from Example spreadsheet.xlsx Originally sent 24 December 2019',
         'Example template No reference provided Originally sent 24 December 2019',
-        'test_letter.pdf Reference DEF456 Originally sent 24 December 2019',
-        'test_letter.pdf No reference provided Originally sent 24 December 2019',
+        'Example precompiled.pdf Reference DEF456 Originally sent 24 December 2019',
+        'Example one-off.pdf No reference provided Originally sent 24 December 2019',
     ] == [
         normalize_spaces(row.text) for row in page.select('tr')
     ]

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -75,6 +75,7 @@ def test_returned_letters_page(
             (None, 'Example template', None, None),
             ('DEF456', None, None, 'Example precompiled.pdf'),
             (None, None, None, 'Example one-off.pdf'),
+            ('XYZ999', None, None, None),
         )
     ]
     mocker.patch('app.service_api_client.get_returned_letters', return_value=data)
@@ -92,6 +93,7 @@ def test_returned_letters_page(
         'Example template No reference provided Originally sent 24 December 2019',
         'Example precompiled.pdf Reference DEF456 Originally sent 24 December 2019',
         'Example one-off.pdf No reference provided Originally sent 24 December 2019',
+        'Provided as PDF Reference XYZ999 Originally sent 24 December 2019',
     ] == [
         normalize_spaces(row.text) for row in page.select('tr')
     ]


### PR DESCRIPTION
Precompiled letters sent via the API don’t have:
- a template
- a filename

Which means in the list of returned letters we just show ‘None’. This commit changes this to ‘Provided as PDF’, which is how we talk about precompiled letters elsewhere (for example in the template statistics on the dashboard).