### PR TITLE
Send asset path to Header component

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -125,7 +125,8 @@
     "homepageUrl": url_for('main.show_accounts_or_dashboard'),
     "productName": "Notify",
     "navigation": navigation,
-    "navigationClasses": "govuk-header__navigation--end"
+    "navigationClasses": "govuk-header__navigation--end",
+    "assetsPath": asset_path + "images"
   }) }}
 {% endblock %}
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -177,6 +177,15 @@ def test_css_is_served_from_correct_path(client_request):
         ][index])
 
 
+def test_resources_that_use_asset_path_variable_have_correct_path(client_request):
+
+    page = client_request.get('main.documentation')  # easy static page
+
+    logo_svg_fallback = page.select_one('.govuk-header__logotype-crown-fallback-image')
+
+    assert logo_svg_fallback['src'].startswith('https://static.example.com/images/govuk-logotype-crown.png')
+
+
 @pytest.mark.parametrize('extra_args, email_branding_retrieved', (
     (
         {},


### PR DESCRIPTION
The fallback image for the SVG GOV.UK logo has an incorrect path.

We were getting 404's for it from IE11, which seems to load it despite being able to render the SVG.

Sets the `assetsPath` option on the Header component. See [the docs](https://design-system.service.gov.uk/components/header/#https://design-system.service.gov.uk/components/header/) for details.