### PR TITLE
Fix incorrect assertion for letter job CSV link

### DIFF
--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -329,7 +329,11 @@ def test_should_show_letter_job(
     assert normalize_spaces(page.select('.keyline-block')[1].text) == (
         '6 January Estimated delivery date'
     )
-    assert page.select('[download=download]') == []
+    assert page.select_one('a[download]')['href'] == url_for(
+        'main.view_job_csv',
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+    )
     assert page.select('.hint') == []
 
     get_notifications.assert_called_with(


### PR DESCRIPTION
The statement `page.select('[download=download]')` was returning an empty list because the link on the page has an empty `download` attribute, rather than it being set to the string `download`.

This pull request:
- updates the assertion to find the element on the page
- makes the test more specific by checking where the link goes to, not  just its existance or lack thereof