### PR TITLE
Turn on compatibility mode for GOVUK Frontend

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -2,6 +2,13 @@
 // Included to allow us to only include the components we need
 // All imports come from node_modules/govuk-frontend
 
+// turn on compatibility mode for all legacy frameworks
+// https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/compatibility.md#turn-on-compatibility-mode
+// to be removed when these frameworks are removed.
+$govuk-compatibility-govukfrontendtoolkit: true;
+$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govukelements: true;
+
 // set asset URL root to match that of application
 $govuk-assets-path: "/static/";
 


### PR DESCRIPTION
Automatically fixes a load of known issues that arise when you use GOVUK Frontend at the same time as GOVUK Frontend Toolkit, GOVUK Template and GOVUK Elements.

We use all of them so this should be turned on. Suggested by @36degrees from the Design System team.

See the [docs explaining compatibility mode](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/compatibility.md#turn-on-compatibility-mode) for more detail.