### PR TITLE
functional tests email reply to flakiness

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -72,6 +72,8 @@ class Config(object):
     ACTIVITY_STATS_LIMIT_DAYS = 7
     TEST_MESSAGE_FILENAME = 'Report'
 
+    REPLY_TO_EMAIL_ADDRESS_VALIDATION_TIMEOUT = 45
+
     NOTIFY_ENVIRONMENT = 'development'
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-local'
     MOU_BUCKET_NAME = 'local-mou'
@@ -146,6 +148,9 @@ class Preview(Config):
     CHECK_PROXY_HEADER = False
     ASSET_DOMAIN = 'static.notify.works'
     ASSET_PATH = 'https://static.notify.works/'
+
+    # On preview, extend the validation timeout to allow more leniency when running functional tests
+    REPLY_TO_EMAIL_ADDRESS_VALIDATION_TIMEOUT = 120
 
 
 class Staging(Config):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -478,7 +478,8 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
     created_at_no_tz = notification["created_at"][:-6]
     seconds_since_sending = (datetime.utcnow() - datetime.strptime(created_at_no_tz, '%Y-%m-%dT%H:%M:%S.%f')).seconds
     if notification["status"] in FAILURE_STATUSES or (
-        notification["status"] in SENDING_STATUSES and seconds_since_sending > 45
+        notification["status"] in SENDING_STATUSES and
+        seconds_since_sending > current_app.config['REPLY_TO_EMAIL_ADDRESS_VALIDATION_TIMEOUT']
     ):
         verification_status = "failure"
         form.email_address.data = notification['to']

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -6,12 +6,11 @@ from app.cloudfoundry_config import extract_cloudfoundry_config
 
 
 @pytest.fixture
-def cloudfoundry_environ(monkeypatch):
-    monkeypatch.setenv('VCAP_APPLICATION', '{"space_name":"🚀🌌"}')
+def cloudfoundry_environ(os_environ):
+    os.environ['VCAP_APPLICATION'] = '{"space_name":"🚀🌌"}'
 
 
-@pytest.mark.usefixtures('os_environ', 'cloudfoundry_environ')
-def test_extract_cloudfoundry_config_populates_other_vars():
+def test_extract_cloudfoundry_config_populates_other_vars(cloudfoundry_environ):
     extract_cloudfoundry_config()
 
     assert os.environ['NOTIFY_ENVIRONMENT'] == '🚀🌌'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2827,9 +2827,10 @@ def os_environ():
     """
     # for use whenever you expect code to edit environment variables
     old_env = os.environ.copy()
-    os.environ = {}
+    os.environ.clear()
     yield
-    os.environ = old_env
+    for k, v in old_env.items():
+        os.environ[k] = v
 
 
 @pytest.fixture


### PR DESCRIPTION
### dont reassign os.environ

os.environ is an `environ` object, not a dict. by only interacting with it through builtin functions we can ensure it remains properly accessible to third party libraries which might interact with it in different ways.

See https://github.com/alphagov/notifications-api/commit/d2441466 for more detail

### increase reply to address validation timeout on preview

Celery/SQS underperforms in low-traffic environments. Tasks will sit on celery queues for several seconds before getting picked up if they're the only thing on the queue. This is observable in our test environments like preview and staging, but we've got enough load on production that this isn't an issue.

When we validate reply to email addresses, we expect a delivery receipt to have been processed within 45 seconds of the button being pressed. On preview, we often observe times over that, possibly due to the several queues involved in sending an email and processing its receipt. So, to ensure that functional tests can pass (when we don't really care how fast things are, just that the flow doesn't break), bump this timeout up to 120 seconds on preview. The functional tests were waiting for 120 seconds for the reply to address to be validated anyway.