### PR TITLE
Remove govuk_template compatibility flag

### DIFF
--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -67,11 +67,6 @@ a {
     background-color: $focus-colour;
     outline: 3px solid $focus-colour;
   }
-
-  /* Make links slightly darker when focused to improve contrast. */
-  &:link:focus {
-    color: darken( $link-colour, 2.5%)
-  }
 }
 
 // Each selector, and then the whole block when only one remains, to be removed when the

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -6,7 +6,6 @@
 // https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/compatibility.md#turn-on-compatibility-mode
 // to be removed when these frameworks are removed.
 $govuk-compatibility-govukfrontendtoolkit: true;
-$govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 
 // set asset URL root to match that of application


### PR DESCRIPTION
Setting the `$govuk-compatibility-govuktemplate` flag (in https://github.com/alphagov/notifications-admin/pull/3243) turned off the New Transport font.

I'll add some reasons for why it did here when I know more.

For now, this unsets the flag and removes a piece of govuk_template CSS turning it on fixed, removing the need for it.