### PR TITLE
Make create account button more buttony

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -31,7 +31,7 @@
             Try GOV.UK Notify now if you work in central government, a&nbsp;local authority, or the NHS.
           </p>
           <div class="button-container">
-            <a class="button button-start" href='{{ url_for('.register' )}}'>
+            <a class="button button-start" role="button" draggable="false" href='{{ url_for('.register' )}}'>
               Create an account
             </a>
             or <a href="{{ url_for('.sign_in' )}}">sign in</a> if you’ve used

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -21,6 +21,10 @@ def test_non_logged_in_user_can_see_homepage(
         'Send emails, text messages and letters to your users'
     )
 
+    assert page.select_one('a[role=button][draggable=false]')['href'] == url_for(
+        'main.register'
+    )
+
     assert page.select_one('meta[name=description]')['content'].strip() == (
         'GOV.UK Notify lets you send emails, text messages and letters '
         'to your users. Try it now if you work in central government, a '


### PR DESCRIPTION
`role=button` for users of voice control software 

`draggable=false` as per https://github.com/alphagov/govuk-frontend/pull/1020