### PR TITLE
Upgrade Pytest to version 5.3.2

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,10 +1,10 @@
 -r requirements.txt
 isort==4.3.21
-pytest==3.10.1  # pyup: <4.0.0
+pytest==5.3.2
 pytest-env==0.6.2
 pytest-cov==2.8.1
 pytest-mock==1.11.2
-pytest-xdist==1.27.0 # pyup: <1.28.0
+pytest-xdist==1.31.0
 beautifulsoup4==4.8.1
 freezegun==0.3.12
 flake8==3.7.9

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -37,5 +37,5 @@ npm test
 display_result $? 3 "Javascript tests have"
 
 ## Code coverage
-py.test -n auto --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict -p no:warnings
+py.test -n auto --maxfail=10 --cov=app --cov-report=term-missing tests/ --strict -p no:warnings
 display_result $? 4 "Code coverage"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -150,6 +150,8 @@ def service_json(
         users = []
     if permissions is None:
         permissions = ['email', 'sms']
+    if service_callback_api is None:
+        service_callback_api = []
     if inbound_api is None:
         inbound_api = []
     return {

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -11,10 +11,7 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     mock_get_empty_service_callback_api,
     mock_get_empty_service_inbound_api,
-    mock_get_live_service,
     mock_get_notifications,
-    mock_get_service,
-    mock_get_service_with_letters,
     mock_get_valid_service_callback_api,
     mock_get_valid_service_inbound_api,
     normalize_spaces,
@@ -210,8 +207,8 @@ def test_should_show_api_keys_page(
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 
 
-@pytest.mark.parametrize('service_mock, expected_options', [
-    (mock_get_service, [
+@pytest.mark.parametrize('restricted, can_send_letters, expected_options', [
+    (True, False, [
         (
             'Live – sends to anyone '
             'Not available because your service is in trial mode'
@@ -219,12 +216,12 @@ def test_should_show_api_keys_page(
         'Team and whitelist – limits who you can send to',
         'Test – pretends to send messages',
     ]),
-    (mock_get_live_service, [
+    (False, False, [
         'Live – sends to anyone',
         'Team and whitelist – limits who you can send to',
         'Test – pretends to send messages',
     ]),
-    (mock_get_service_with_letters, [
+    (False, True, [
         'Live – sends to anyone',
         (
             'Team and whitelist – limits who you can send to '
@@ -238,10 +235,16 @@ def test_should_show_create_api_key_page(
     mocker,
     api_user_active,
     mock_get_api_keys,
-    service_mock,
+    restricted,
+    can_send_letters,
     expected_options,
+    service_one,
 ):
-    service_mock(mocker, api_user_active)
+    service_one['restricted'] = restricted
+    if can_send_letters:
+        service_one['permissions'].append('letter')
+
+    mocker.patch('app.service_api_client.get_service', return_value={'data': service_one})
 
     page = client_request.get('main.create_api_key', service_id=SERVICE_ONE_ID)
 

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -8,7 +8,7 @@ from flask import url_for
 from tests import sample_uuid, validate_route_permission
 from tests.conftest import (
     SERVICE_ONE_ID,
-    mock_get_notifications,
+    create_notifications,
     normalize_spaces,
 )
 
@@ -73,13 +73,13 @@ def test_should_show_api_page_with_no_notifications(
 ])
 def test_letter_notifications_should_have_link_to_view_letter(
     client_request,
-    api_user_active,
     mock_has_permissions,
     mocker,
     template_type,
     link_text,
 ):
-    mock_get_notifications(mocker, api_user_active, diff_template_type=template_type)
+    notifications = create_notifications(template_type=template_type)
+    mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications)
     page = client_request.get(
         'main.api_integration',
         service_id=SERVICE_ONE_ID,
@@ -93,13 +93,13 @@ def test_letter_notifications_should_have_link_to_view_letter(
 ])
 def test_should_not_have_link_to_view_letter_for_precompiled_letters_in_virus_states(
     client_request,
-    api_user_active,
     fake_uuid,
     mock_has_permissions,
     mocker,
     status
 ):
-    mock_get_notifications(mocker, api_user_active, noti_status=status)
+    notifications = create_notifications(status=status)
+    mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications)
 
     page = client_request.get(
         'main.api_integration',
@@ -115,14 +115,14 @@ def test_should_not_have_link_to_view_letter_for_precompiled_letters_in_virus_st
 ])
 def test_letter_notifications_should_show_client_reference(
     client_request,
-    api_user_active,
     fake_uuid,
     mock_has_permissions,
     mocker,
     client_reference,
     shows_ref
 ):
-    mock_get_notifications(mocker, api_user_active, client_reference=client_reference)
+    notifications = create_notifications(client_reference=client_reference)
+    mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications)
 
     page = client_request.get(
         'main.api_integration',

--- a/tests/app/main/views/test_conversation.py
+++ b/tests/app/main/views/test_conversation.py
@@ -11,7 +11,7 @@ from app.main.views.conversation import get_user_number
 from tests.conftest import (
     SERVICE_ONE_ID,
     _template,
-    mock_get_notifications,
+    create_notifications,
     normalize_spaces,
 )
 
@@ -76,7 +76,6 @@ def test_get_user_phone_number_raises_if_both_api_requests_fail(mocker):
 def test_view_conversation(
     client_request,
     mocker,
-    api_user_active,
     mock_get_inbound_sms_by_id_with_no_messages,
     mock_get_notification,
     fake_uuid,
@@ -84,14 +83,12 @@ def test_view_conversation(
     expected_outbound_content,
     mock_get_inbound_sms
 ):
-
-    mock = mock_get_notifications(
-        mocker,
-        api_user_active,
-        template_content='Hello ((name))',
+    notifications = create_notifications(
+        content='Hello ((name))',
         personalisation={'name': 'Jo'},
         redact_personalisation=outbound_redacted,
     )
+    mock = mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications)
 
     page = client_request.get(
         'main.conversation',

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -7,7 +7,7 @@ from flask import url_for
 from notifications_python_client.errors import HTTPError
 
 from app.s3_client.s3_logo_client import EMAIL_LOGO_LOCATION_STRUCTURE, TEMP_TAG
-from tests.conftest import mock_get_email_branding, normalize_spaces
+from tests.conftest import create_email_branding, normalize_spaces
 
 
 def test_email_branding_page_shows_full_branding_list(
@@ -231,7 +231,7 @@ def test_deletes_previous_temp_logo_after_uploading_logo(
     fake_uuid
 ):
     if has_data:
-        mock_get_email_branding(mocker, fake_uuid)
+        mocker.patch('app.email_branding_client.get_email_branding', return_value=create_email_branding(fake_uuid))
 
     with platform_admin_client.session_transaction() as session:
         user_id = session["user_id"]

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -11,7 +11,7 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     create_active_caseworking_user,
     create_active_user_with_permissions,
-    mock_get_notifications,
+    create_notifications,
     mock_get_service_letter_template,
     normalize_spaces,
 )
@@ -360,11 +360,13 @@ def test_should_show_letter_job(
     mock_get_job,
     mock_get_service_data_retention,
     fake_uuid,
-    active_user_with_permissions,
     mocker,
 ):
-
-    get_notifications = mock_get_notifications(mocker, active_user_with_permissions, diff_template_type='letter')
+    notifications = create_notifications(template_type='letter', subject='template subject')
+    get_notifications = mocker.patch(
+        'app.notification_api_client.get_notifications_for_service',
+        return_value=notifications,
+    )
 
     page = client_request.get(
         'main.view_job',
@@ -742,15 +744,10 @@ def test_should_show_letter_job_with_first_class_if_notifications_are_first_clas
     mock_get_job,
     mock_get_service_data_retention,
     fake_uuid,
-    active_user_with_permissions,
     mocker,
 ):
-    mock_get_notifications(
-        mocker,
-        active_user_with_permissions,
-        diff_template_type='letter',
-        postage='first'
-    )
+    notifications = create_notifications(template_type='letter', postage='first')
+    mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications)
 
     page = client_request.get(
         'main.view_job',

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -12,7 +12,7 @@ from tests.conftest import (
     create_active_caseworking_user,
     create_active_user_with_permissions,
     create_notifications,
-    mock_get_service_letter_template,
+    create_template,
     normalize_spaces,
 )
 
@@ -768,8 +768,10 @@ def test_should_show_letter_job_with_first_class_if_no_notifications(
     mock_get_service_data_retention,
     mocker
 ):
-
-    mock_get_service_letter_template(mocker, postage="first")
+    mocker.patch(
+        'app.service_api_client.get_service_template',
+        return_value={'data': create_template(template_type='letter', postage='first')}
+    )
 
     page = client_request.get(
         'main.view_job',

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -45,8 +45,6 @@ from tests.conftest import (
     multiple_sms_senders,
     multiple_sms_senders_no_inbound,
     multiple_sms_senders_with_diff_default,
-    no_reply_to_email_addresses,
-    no_sms_senders,
     normalize_spaces,
 )
 
@@ -204,26 +202,12 @@ def test_sender_session_is_present_after_selected(
         assert session['sender_id'] == '1234'
 
 
-@pytest.mark.parametrize('template_mock, sender_data', [
-    (
-        mock_get_service_email_template,
-        no_reply_to_email_addresses,
-    ),
-    (
-        mock_get_service_template,
-        no_sms_senders
-    )
-])
-def test_set_sender_redirects_if_no_sender_data(
+def test_set_sender_redirects_if_no_reply_to_email_addresses(
     client_request,
-    service_one,
     fake_uuid,
-    template_mock,
-    sender_data,
-    mocker
+    mock_get_service_email_template,
+    no_reply_to_email_addresses,
 ):
-    template_mock(mocker)
-    sender_data(mocker)
     client_request.get(
         '.set_sender',
         service_id=SERVICE_ONE_ID,
@@ -231,7 +215,27 @@ def test_set_sender_redirects_if_no_sender_data(
         _expected_status=302,
         _expected_url=url_for(
             '.send_one_off',
-            service_id=service_one['id'],
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _external=True,
+        )
+    )
+
+
+def test_set_sender_redirects_if_no_sms_senders(
+    client_request,
+    fake_uuid,
+    mock_get_service_template,
+    no_sms_senders,
+):
+    client_request.get(
+        '.set_sender',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _expected_status=302,
+        _expected_url=url_for(
+            '.send_one_off',
+            service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             _external=True,
         )

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -551,8 +551,8 @@ def test_edit_letter_template_postage_page_displays_correctly(
     service_one,
     fake_uuid,
     mocker,
+    mock_get_service_letter_template,
 ):
-    mock_get_service_letter_template(mocker)
     page = client_request.get(
         'main.edit_template_postage',
         service_id=SERVICE_ONE_ID,
@@ -586,12 +586,12 @@ def test_edit_letter_templates_postage_updates_postage(
     client_request,
     service_one,
     mocker,
-    fake_uuid
+    fake_uuid,
+    mock_get_service_letter_template,
 ):
     mock_update_template_postage = mocker.patch(
         'app.main.views.templates.service_api_client.update_service_template_postage'
     )
-    mock_get_service_letter_template(mocker)
 
     client_request.post(
         'main.edit_template_postage',

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -29,9 +29,7 @@ from tests.conftest import (
     create_active_caseworking_user,
     create_active_user_view_permissions,
     create_letter_contact_block,
-    mock_get_service_email_template,
-    mock_get_service_letter_template,
-    mock_get_service_template,
+    create_template,
     normalize_spaces,
 )
 
@@ -495,7 +493,11 @@ def test_view_letter_template_displays_postage(
 ):
     mocker.patch('app.main.views.templates.get_page_count_for_letter', return_value=1)
     client_request.login(active_user_with_permissions)
-    mock_get_service_letter_template(mocker, postage=template_postage)
+    mocker.patch(
+        'app.service_api_client.get_service_template',
+        return_value={'data': create_template(template_type='letter', postage=template_postage)}
+    )
+
     page = client_request.get(
         'main.view_template',
         service_id=SERVICE_ONE_ID,
@@ -534,7 +536,11 @@ def test_view_letter_template_does_not_display_send_button_if_template_over_10_p
 ):
     mocker.patch('app.main.views.templates.get_page_count_for_letter', return_value=11)
     client_request.login(active_user_with_permissions)
-    mock_get_service_letter_template(mocker, postage="second")
+    mocker.patch(
+        'app.service_api_client.get_service_template',
+        return_value={'data': create_template(template_type='letter', postage='second')}
+    )
+
     page = client_request.get(
         'main.view_template',
         service_id=SERVICE_ONE_ID,
@@ -1300,10 +1306,10 @@ def test_should_not_allow_creation_of_a_template_without_correct_permission(
     )
 
 
-@pytest.mark.parametrize('fixture,  expected_status_code', [
-    (mock_get_service_email_template, 200),
-    (mock_get_service_template, 200),
-    (mock_get_service_letter_template, 302),
+@pytest.mark.parametrize('template_type,  expected_status_code', [
+    ('email', 200),
+    ('sms', 200),
+    ('letter', 302),
 ])
 def test_should_redirect_to_one_off_if_template_type_is_letter(
     client_request,
@@ -1311,10 +1317,13 @@ def test_should_redirect_to_one_off_if_template_type_is_letter(
     multiple_sms_senders,
     fake_uuid,
     mocker,
-    fixture,
+    template_type,
     expected_status_code
 ):
-    fixture(mocker)
+    mocker.patch(
+        'app.service_api_client.get_service_template',
+        return_value={'data': create_template(template_type=template_type)}
+    )
     client_request.get(
         '.set_sender',
         service_id=SERVICE_ONE_ID,
@@ -1506,11 +1515,14 @@ def test_should_show_interstitial_when_making_breaking_change(
     old_content,
     expected_paragraphs,
 ):
-    mock_get_service_email_template(
-        mocker,
+    email_template = create_template(
+        template_id=fake_uuid,
+        template_type='email',
         subject="Your ((thing)) is due soon",
-        content=old_content,
+        content=old_content
     )
+    mocker.patch('app.service_api_client.get_service_template', return_value={'data': email_template})
+
     data = {
         'id': fake_uuid,
         'name': "new name",
@@ -2048,18 +2060,17 @@ def test_should_show_template_as_first_page_of_tour(
     )
 
 
-@pytest.mark.parametrize('template_mock', [
-    mock_get_service_email_template,
-    mock_get_service_letter_template,
-])
+@pytest.mark.parametrize('template_type', ['email', 'letter'])
 def test_cant_see_email_template_in_tour(
     client_request,
     fake_uuid,
     mocker,
-    template_mock,
+    template_type,
 ):
-
-    template_mock(mocker)
+    mocker.patch(
+        'app.service_api_client.get_service_template',
+        return_value={'data': create_template(template_type=template_type)}
+    )
 
     client_request.get(
         'main.start_tour',
@@ -2124,8 +2135,8 @@ def test_should_show_hint_once_template_redacted(
     mock_get_template_folders,
     fake_uuid,
 ):
-
-    mock_get_service_email_template(mocker, redact_personalisation=True)
+    template = create_template(template_type='email', content='hi ((name))', redact_personalisation=True)
+    mocker.patch('app.service_api_client.get_service_template', return_value={'data': template})
 
     page = client_request.get(
         'main.view_template',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -866,11 +866,20 @@ def mock_get_service_email_template(mocker, content=None, subject=None, redact_p
 
 @pytest.fixture(scope='function')
 def mock_get_service_email_template_without_placeholders(mocker):
-    return mock_get_service_email_template(
-        mocker,
-        content="Your vehicle tax expires soon",
-        subject="Your thing is due soon",
-    )
+    def _get(service_id, template_id, version=None):
+        template = template_json(
+            service_id,
+            template_id,
+            "Two week reminder",
+            "email",
+            "Your vehicle tax expires soon",
+            "Your thing is due soon",
+            redact_personalisation=False,
+        )
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template', side_effect=_get)
 
 
 @pytest.fixture(scope='function')
@@ -3965,4 +3974,26 @@ def create_notifications(
         status=status,
         created_by_name='Firstname Lastname',
         postage=postage
+    )
+
+
+def create_template(
+    service_id=SERVICE_ONE_ID,
+    template_id=None,
+    template_type='sms',
+    name='sample template',
+    content='Template content',
+    subject='Template subject',
+    redact_personalisation=False,
+    postage=None
+):
+    return template_json(
+        service_id=service_id,
+        id_=template_id or str(generate_uuid()),
+        name=name,
+        type_=template_type,
+        content=content,
+        subject=subject,
+        redact_personalisation=redact_personalisation,
+        postage=postage,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1687,8 +1687,7 @@ def mock_get_api_keys(mocker, fake_uuid):
 
 
 @pytest.fixture(scope='function')
-# Second argument added so can be used interchangeably with `mock_get_api_keys`
-def mock_get_no_api_keys(mocker, _=None):
+def mock_get_no_api_keys(mocker):
     def _get_keys(service_id):
         keys = {'apiKeys': []}
         return keys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3930,3 +3930,39 @@ def create_notification(
     if key_type:
         noti['key_type'] = key_type
     return noti
+
+
+def create_notifications(
+    service_id=SERVICE_ONE_ID,
+    template_type='sms',
+    rows=5,
+    status=None,
+    subject='subject',
+    content='content',
+    client_reference=None,
+    personalisation=None,
+    redact_personalisation=False,
+    is_precompiled_letter=False,
+    postage=None,
+):
+    template = template_json(
+        service_id,
+        id_=str(generate_uuid()),
+        type_=template_type,
+        subject=subject,
+        content=content,
+        redact_personalisation=redact_personalisation,
+        is_precompiled_letter=is_precompiled_letter
+    )
+
+    return notification_json(
+        service_id,
+        template=template,
+        rows=rows,
+        personalisation=personalisation,
+        template_type=template_type,
+        client_reference=client_reference,
+        status=status,
+        created_by_name='Firstname Lastname',
+        postage=postage
+    )


### PR DESCRIPTION
The work to make some tests Pytest 5 compatible was started in https://github.com/alphagov/notifications-admin/pull/3229 and https://github.com/alphagov/notifications-admin/pull/3231. This finishes making the remaining tests compatible with Pytest 5, and bumps the version of Pytest from `3.10.1` to `5.3.2`.

There were 2 main reasons why the current tests weren't compatible: 
- Some were calling fixtures as if they were functions - fixed by creating a couple of helper functions in `conftest.py` which can be called with different arguments instead
- Others were using fixtures as arguments to `parametrize` - fixed by either removing the parameterization (in a few very simple tests), or by re-writing the tests to not do this (in most cases)

`conftest.py` still needs to be tidied up and refactored a bit, for example we can remove most of the arguments to the fixtures now, but will do this in a separate PR.