### PR TITLE
Update the letter validation messages.

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -24,6 +24,7 @@ $govuk-assets-path: "/static/";
 @import 'components/footer/_footer';
 @import 'components/back-link/_back-link';
 @import 'components/details/_details';
+@import 'components/warning-text/_warning-text';
 
 @import "utilities/all";
 @import "overrides/all";

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -72,6 +72,7 @@ def view_notification(service_id, notification_id):
         except PdfReadError:
             return render_template(
                 'views/notifications/invalid_precompiled_letter.html',
+                message={"title": "There’s a problem with your letter", "detail": "Notify cannot read this PDF."},
                 created_at=notification['created_at']
             )
     else:

--- a/app/templates/views/notifications/invalid_precompiled_letter.html
+++ b/app/templates/views/notifications/invalid_precompiled_letter.html
@@ -1,17 +1,16 @@
 {% extends "withnav_template.html" %}
 
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
 {% block service_page_title %}
-  Letter
+  Letter validation failed
 {% endblock %}
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">Letter</h1>
-
-    <p>
+  {{ govukBackLink({ "href": back_link }) }}
+  {% include "partials/check/letter-validation-failed-banner.html" %}
+  <p>
       Provided as PDF on {{ created_at|format_datetime_short }}
-    </p>
-    <p class="notification-status-cancelled">
-      Validation failed – Notify cannot read this PDF file
-    </p>
+  </p>
 {% endblock %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -4,17 +4,23 @@
 {% from "components/message-count-label.html" import message_count_label %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-
+{% from "components/warning-text/macro.njk" import govukWarningText %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
 {% block service_page_title %}
   {{ message_count_label(1, template.template_type, suffix='') | capitalize }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
-    {{ page_header(
-      message_count_label(1, template.template_type, suffix='') | capitalize,
-      back_link=back_link
-    ) }}
+    {% if notification_status == 'validation-failed' %}
+      {{ govukBackLink({ "href": back_link }) }}
+      {% include "partials/check/letter-validation-failed-banner.html" %}
+    {% else %}
+      {{ page_header(
+        message_count_label(1, template.template_type, suffix='') | capitalize,
+        back_link=back_link
+      ) }}
+    {% endif %}
     <p>
       {% if is_precompiled_letter %}
         Provided as PDF
@@ -38,14 +44,13 @@
     </p>
 
     {% if template.template_type == 'letter' %}
-      {% if notification_status in ('permanent-failure', 'cancelled') %}
-        <p class="notification-status-cancelled">
-          Cancelled {{ updated_at|format_datetime_short }}
-        </p>
+      {% if notification_status in ('cancelled') %}
+        {{ govukWarningText({
+          "text": "Cancelled " + updated_at|format_datetime_short,
+          "iconFallbackText": "Warning"
+        }) }}
       {% elif notification_status == 'validation-failed' %}
-        <p class="notification-status-cancelled">
-          Validation failed. {{ message.detail | safe }}
-        </p>
+
       {% elif notification_status == 'technical-failure' %}
         <p class="notification-status-cancelled">
           Technical failure – Notify will resend once the team have

--- a/app/utils.py
+++ b/app/utils.py
@@ -566,14 +566,14 @@ def get_letter_printing_statement(status, created_at):
 
 LETTER_VALIDATION_MESSAGES = {
     'letter-not-a4-portrait-oriented': {
-        'title': 'We cannot print your letter',
-        'detail': 'Your letter is not A4 portrait size on {invalid_pages} <br>'
+        'title': 'Your letter is not A4 portrait size',
+        'detail': 'You need to change the size or orientation of {invalid_pages} <br>'
                   'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
                   'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     },
     'content-outside-printable-area': {
-        'title': 'We cannot print your letter',
-        'detail': 'The content appears outside the printable area on {invalid_pages}.<br>'
+        'title': 'Your content is outside the printable area',
+        'detail': 'You need to edit {invalid_pages}.<br>'
                   'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
                   'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     },
@@ -587,7 +587,14 @@ LETTER_VALIDATION_MESSAGES = {
     'unable-to-read-the-file': {
         'title': 'There’s a problem with your file',
         'detail': 'Notify cannot read this PDF.<br>Save a new copy of your file and try again.'
+    },
+    'address-is-empty': {
+        'title': 'The address block is empty',
+        'detail': 'You need to add a recipient address.<br>'
+                  'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
+                  'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     }
+
 }
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -567,7 +567,7 @@ def get_letter_printing_statement(status, created_at):
 LETTER_VALIDATION_MESSAGES = {
     'letter-not-a4-portrait-oriented': {
         'title': 'Your letter is not A4 portrait size',
-        'detail': 'You need to change the size or orientation of {invalid_pages} <br>'
+        'detail': 'You need to change the size or orientation of {invalid_pages}. <br>'
                   'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
                   'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,8 @@ const copy = {
         'header',
         'footer',
         'back-link',
-        'details'
+        'details',
+        'warning-text'
       ];
       let done = 0;
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -414,14 +414,15 @@ def test_get_letter_validation_error_for_unknown_error():
 
 
 @pytest.mark.parametrize('error_message, expected_title, expected_content', [
-    ('letter-not-a4-portrait-oriented', 'We cannot print your letter', 'A4 portrait size on page 2'),
-    ('content-outside-printable-area', 'We cannot print your letter', 'outside the printable area on page 2'),
+    ('letter-not-a4-portrait-oriented', 'Your letter is not A4 portrait size',
+     'You need to change the size or orientation of page 2'),
+    ('content-outside-printable-area', 'Your content is outside the printable area', 'You need to edit page 2'),
     ('letter-too-long', 'Your letter is too long', 'letter is 13 pages long.')
 ])
 def test_get_letter_validation_error_for_known_errors(
-    error_message,
-    expected_title,
-    expected_content,
+        error_message,
+        expected_title,
+        expected_content,
 ):
     error = get_letter_validation_error(error_message, invalid_pages=[2], page_count=13)
 


### PR DESCRIPTION
# What
This PR updates the way the validation errors are displayed for precompiled letters sent in via the API. They now use "partials/check/letter-validation-failed-banner.html", which is the same banner that is displayed when an uploaded letter failed validation.
Also added a new error message for missing address blocks.
There is an outstanding question about what the page title should be, the standard is to match the H1 on the page with the page title, this PR has changed the H1 from `Letter` to the first line of the error message. We'd like to take some time to answer this question, therefore, leaving the page titles as is for now. 

## Before
![Screenshot 2020-01-09 at 10 27 39](https://user-images.githubusercontent.com/4282990/72145199-ed232780-3391-11ea-8f10-13b59418d3a7.png)

# After
### Letter outside content area
![Screenshot 2020-01-10 at 10 10 02](https://user-images.githubusercontent.com/4282990/72145102-a9c8b900-3391-11ea-8530-dbf0b9705153.png)

### Letter that is missing EOF tag
![Screenshot 2020-01-10 at 10 05 22](https://user-images.githubusercontent.com/4282990/72145107-acc3a980-3391-11ea-996b-19a7c3b77622.png)

### Cancelled letters now show message using "govuk-warning-text"
![Screenshot 2020-01-10 at 10 04 13](https://user-images.githubusercontent.com/4282990/72145171-daa8ee00-3391-11ea-8da6-73bb01e4a3c2.png)
 
### Added a new error message for a letter that is missing an address block.
![Screenshot 2020-01-10 at 10 14 56](https://user-images.githubusercontent.com/4282990/72145274-12b03100-3392-11ea-81d0-d3f0bb017f61.png)

Pair: becca&karl