### PR TITLE
Fix exception in track-error js module that broke our re-upload button

### DIFF
--- a/app/assets/javascripts/errorTracking.js
+++ b/app/assets/javascripts/errorTracking.js
@@ -5,7 +5,7 @@
 
     this.start = function(component) {
 
-      if (!ga) return;
+      if (!('ga' in window)) return;
 
       ga(
         'send',


### PR DESCRIPTION
Basically since we disabled google analytics, and we run `track-error` module in strict js, it caused an exception. Luckily it's a one-line fix (but it took us a while to find what's actually wrong)

Thanks @tombye for help with this 💖 