### PR TITLE
Make models for individual jobs and collections of jobs

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -20,12 +20,11 @@ from app import (
     current_service,
     format_date_numeric,
     format_datetime_numeric,
-    job_api_client,
     service_api_client,
     template_statistics_client,
 )
 from app.main import main
-from app.statistics_utils import add_rate_to_job, get_formatted_percentage
+from app.statistics_utils import get_formatted_percentage
 from app.utils import (
     DELIVERED_STATUSES,
     FAILURE_STATUSES,
@@ -281,14 +280,6 @@ def get_dashboard_partials(service_id):
     all_statistics = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     template_statistics = aggregate_template_usage(all_statistics)
 
-    scheduled_jobs, immediate_jobs = [], []
-    if job_api_client.has_jobs(service_id):
-        scheduled_jobs = job_api_client.get_scheduled_jobs(service_id)
-        immediate_jobs = [
-            add_rate_to_job(job)
-            for job in job_api_client.get_immediate_jobs(service_id)
-        ]
-
     stats = aggregate_notifications_stats(all_statistics)
     column_width, max_notifiction_count = get_column_properties(3)
 
@@ -310,7 +301,6 @@ def get_dashboard_partials(service_id):
     return {
         'upcoming': render_template(
             'views/dashboard/_upcoming.html',
-            scheduled_jobs=scheduled_jobs
         ),
         'inbox': render_template(
             'views/dashboard/_inbox.html',
@@ -337,9 +327,8 @@ def get_dashboard_partials(service_id):
         ),
         'jobs': render_template(
             'views/dashboard/_jobs.html',
-            jobs=immediate_jobs
+            jobs=current_service.immediate_jobs,
         ),
-        'has_jobs': bool(immediate_jobs),
         'usage': render_template(
             'views/dashboard/_usage.html',
             column_width=column_width,

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-
 from flask import (
     Response,
     abort,
@@ -15,11 +13,6 @@ from flask import (
 )
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
-from notifications_utils.letter_timings import (
-    CANCELLABLE_JOB_LETTER_STATUSES,
-    get_letter_timings,
-    letter_can_be_cancelled,
-)
 from notifications_utils.template import Template, WithSubjectTemplate
 
 from app import (
@@ -32,6 +25,7 @@ from app import (
 )
 from app.main import main
 from app.main.forms import SearchNotificationsForm
+from app.models.job import Job
 from app.statistics_utils import add_rate_to_job
 from app.utils import (
     generate_next_dict,
@@ -84,61 +78,45 @@ def view_jobs(service_id):
 @main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>")
 @user_has_permissions()
 def view_job(service_id, job_id):
-    job = job_api_client.get_job(service_id, job_id)['data']
-    if job['job_status'] == 'cancelled':
+    job = Job.from_id(job_id, service_id=current_service.id)
+    if job.cancelled:
         abort(404)
 
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)
 
-    total_notifications = job.get('notification_count', 0)
-    processed_notifications = job.get('notifications_delivered', 0) + job.get('notifications_failed', 0)
-
-    template = service_api_client.get_service_template(
-        service_id=service_id,
-        template_id=job['template'],
-        version=job['template_version']
-    )['data']
+    total_notifications = job.notification_count
+    processed_notifications = job.notifications_processed
 
     just_sent_message = 'Your {} been sent. Printing starts {} at 5:30pm.'.format(
-        'letter has' if job['notification_count'] == 1 else 'letters have',
+        'letter has' if job.notification_count == 1 else 'letters have',
         printing_today_or_tomorrow()
     )
-    partials = get_job_partials(job, template)
-    can_cancel_letter_job = partials["can_letter_job_be_cancelled"]
 
     return render_template(
         'views/jobs/job.html',
         finished=(total_notifications == processed_notifications),
-        uploaded_file_name=job['original_file_name'],
-        template_id=job['template'],
-        job_id=job_id,
+        job=job,
         status=request.args.get('status', ''),
         updates_url=url_for(
             ".view_job_updates",
             service_id=service_id,
-            job_id=job['id'],
+            job_id=job.id,
             status=request.args.get('status', ''),
         ),
-        partials=partials,
+        partials=get_job_partials(job),
         just_sent=bool(
             request.args.get('just_sent') == 'yes'
-            and template['template_type'] == 'letter'
+            and job.template_type == 'letter'
         ),
         just_sent_message=just_sent_message,
-        can_cancel_letter_job=can_cancel_letter_job,
     )
 
 
 @main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>.csv")
 @user_has_permissions('view_activity')
 def view_job_csv(service_id, job_id):
-    job = job_api_client.get_job(service_id, job_id)['data']
-    template = service_api_client.get_service_template(
-        service_id=service_id,
-        template_id=job['template'],
-        version=job['template_version']
-    )['data']
+    job = Job.from_id(job_id, service_id=service_id)
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)
 
@@ -151,14 +129,14 @@ def view_job_csv(service_id, job_id):
                 page=request.args.get('page', 1),
                 page_size=5000,
                 format_for_csv=True,
-                template_type=template['template_type'],
+                template_type=job.template_type,
             )
         ),
         mimetype='text/csv',
         headers={
             'Content-Disposition': 'inline; filename="{} - {}.csv"'.format(
-                template['name'],
-                format_datetime_short(job['created_at'])
+                job.template['name'],
+                format_datetime_short(job.created_at)
             )
         }
     )
@@ -167,7 +145,7 @@ def view_job_csv(service_id, job_id):
 @main.route("/services/<uuid:service_id>/jobs/<uuid:job_id>", methods=['POST'])
 @user_has_permissions('send_messages')
 def cancel_job(service_id, job_id):
-    job_api_client.cancel_job(service_id, job_id)
+    Job.from_id(job_id, service_id=service_id).cancel()
     return redirect(url_for('main.service_dashboard', service_id=service_id))
 
 
@@ -175,20 +153,18 @@ def cancel_job(service_id, job_id):
 @user_has_permissions()
 def cancel_letter_job(service_id, job_id):
     if request.method == 'POST':
-        job = job_api_client.get_job(service_id, job_id)['data']
-        notification_count = notification_api_client.get_notification_count_for_job_id(
-            service_id=service_id, job_id=job_id
-        )
-        if job['job_status'] != 'finished' or notification_count < job['notification_count']:
+        job = Job.from_id(job_id, service_id=service_id)
+
+        if job.status != 'finished' or job.notifications_created < job.notification_count:
             flash("We are still processing these letters, please try again in a minute.", 'try again')
             return view_job(service_id, job_id)
         try:
-            number_of_letters = job_api_client.cancel_letter_job(current_service.id, job_id)
+            number_of_letters = job.cancel()
         except HTTPError as e:
             flash(e.message, 'dangerous')
             return redirect(url_for('main.view_job', service_id=service_id, job_id=job_id))
         flash("Cancelled {} letters from {}".format(
-            format_thousands(number_of_letters), job['original_file_name']
+            format_thousands(number_of_letters), job.original_file_name
         ), 'default_with_tick')
         return redirect(url_for('main.service_dashboard', service_id=service_id))
 
@@ -200,16 +176,9 @@ def cancel_letter_job(service_id, job_id):
 @user_has_permissions()
 def view_job_updates(service_id, job_id):
 
-    job = job_api_client.get_job(service_id, job_id)['data']
+    job = Job.from_id(job_id, service_id=service_id)
 
-    return jsonify(**get_job_partials(
-        job,
-        service_api_client.get_service_template(
-            service_id=current_service.id,
-            template_id=job['template'],
-            version=job['template_version']
-        )['data'],
-    ))
+    return jsonify(**get_job_partials(job))
 
 
 @main.route('/services/<uuid:service_id>/notifications', methods=['GET', 'POST'])
@@ -386,61 +355,46 @@ def get_status_filters(service, message_type, statistics):
 
 
 def _get_job_counts(job):
-    sending = 0 if job['job_status'] == 'scheduled' else (
-        job.get('notification_count', 0) -
-        job.get('notifications_delivered', 0) -
-        job.get('notifications_failed', 0)
-    )
     return [
         (
             label,
             query_param,
             url_for(
                 ".view_job",
-                service_id=job['service'],
-                job_id=job['id'],
+                service_id=job.service,
+                job_id=job.id,
                 status=query_param,
             ),
             count
         ) for label, query_param, count in [
             [
                 'total', '',
-                job.get('notification_count', 0)
+                job.notification_count
             ],
             [
                 'sending', 'sending',
-                sending
+                job.notifications_sending
             ],
             [
                 'delivered', 'delivered',
-                job.get('notifications_delivered', 0)
+                job.notifications_delivered
             ],
             [
                 'failed', 'failed',
-                job.get('notifications_failed', 0)
+                job.notifications_failed
             ]
         ]
     ]
 
 
-def get_job_partials(job, template):
+def get_job_partials(job):
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)
-    notifications = notification_api_client.get_notifications_for_service(
-        job['service'], job['id'], status=filter_args['status']
-    )
-
-    if template['template_type'] == 'letter':
-        # there might be no notifications if the job has only just been created and the tasks haven't run yet
-        if notifications['notifications']:
-            postage = notifications['notifications'][0]['postage']
-        else:
-            postage = template['postage']
-
+    notifications = job.get_notifications(status=filter_args['status'])
+    if job.template_type == 'letter':
         counts = render_template(
             'partials/jobs/count-letters.html',
-            total=job.get('notification_count', 0),
-            delivery_estimate=get_letter_timings(job['created_at'], postage=postage).earliest_delivery,
+            job=job,
         )
     else:
         counts = render_template(
@@ -448,22 +402,11 @@ def get_job_partials(job, template):
             counts=_get_job_counts(job),
             status=filter_args['status'],
             notifications_deleted=(
-                job['job_status'] == 'finished' and not notifications['notifications']
+                job.status == 'finished' and not notifications['notifications']
             ),
         )
-    service_data_retention_days = current_service.get_days_of_retention(template['template_type'])
-    can_letter_job_be_cancelled = False
-    if template["template_type"] == "letter":
-        not_cancellable = [
-            n for n in notifications["notifications"] if n["status"] not in CANCELLABLE_JOB_LETTER_STATUSES
-        ]
-        job_created = job["created_at"][:-6]
-        if not letter_can_be_cancelled(
-            "created", datetime.strptime(job_created, '%Y-%m-%dT%H:%M:%S.%f')
-        ) or len(not_cancellable) != 0:
-            can_letter_job_be_cancelled = False
-        else:
-            can_letter_job_be_cancelled = True
+    service_data_retention_days = current_service.get_days_of_retention(job.template_type)
+
     return {
         'counts': counts,
         'notifications': render_template(
@@ -472,26 +415,21 @@ def get_job_partials(job, template):
                 add_preview_of_content_to_notifications(notifications['notifications'])
             ),
             more_than_one_page=bool(notifications.get('links', {}).get('next')),
-            percentage_complete=(job['notifications_requested'] / job['notification_count'] * 100),
             download_link=url_for(
                 '.view_job_csv',
                 service_id=current_service.id,
-                job_id=job['id'],
+                job_id=job.id,
                 status=request.args.get('status')
             ),
-            time_left=get_time_left(job['created_at'], service_data_retention_days=service_data_retention_days),
+            time_left=get_time_left(job.created_at, service_data_retention_days=service_data_retention_days),
             job=job,
-            template=template,
-            template_version=job['template_version'],
             service_data_retention_days=service_data_retention_days,
         ),
         'status': render_template(
             'partials/jobs/status.html',
             job=job,
-            template_type=template["template_type"],
-            letter_print_day=get_letter_printing_statement("created", job["created_at"])
+            letter_print_day=get_letter_printing_statement("created", job.created_at)
         ),
-        'can_letter_job_be_cancelled': can_letter_job_be_cancelled,
     }
 
 

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -77,9 +77,6 @@ def view_job(service_id, job_id):
     filter_args = parse_filter_args(request.args)
     filter_args['status'] = set_status_filters(filter_args)
 
-    total_notifications = job.notification_count
-    processed_notifications = job.notifications_processed
-
     just_sent_message = 'Your {} been sent. Printing starts {} at 5:30pm.'.format(
         'letter has' if job.notification_count == 1 else 'letters have',
         printing_today_or_tomorrow()
@@ -87,7 +84,6 @@ def view_job(service_id, job_id):
 
     return render_template(
         'views/jobs/job.html',
-        finished=(total_notifications == processed_notifications),
         job=job,
         status=request.args.get('status', ''),
         updates_url=url_for(

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,0 +1,159 @@
+from datetime import datetime
+
+from notifications_utils.letter_timings import (
+    CANCELLABLE_JOB_LETTER_STATUSES,
+    get_letter_timings,
+    letter_can_be_cancelled,
+)
+from werkzeug.utils import cached_property
+
+from app.models import JSONModel
+from app.notify_client.job_api_client import job_api_client
+from app.notify_client.notification_api_client import notification_api_client
+from app.notify_client.service_api_client import service_api_client
+from app.utils import set_status_filters
+
+
+class Job(JSONModel):
+
+    ALLOWED_PROPERTIES = {
+        'id',
+        'service',
+        'template',
+        'template_version',
+        'original_file_name',
+        'created_at',
+        'notification_count',
+        'notifications_sent',
+        'notifications_requested',
+        'job_status',
+        'statistics',
+        'created_by',
+        'scheduled_for',
+    }
+
+    @classmethod
+    def from_id(cls, job_id, service_id):
+        return cls(job_api_client.get_job(service_id, job_id)['data'])
+
+    @property
+    def status(self):
+        return self.job_status
+
+    @property
+    def cancelled(self):
+        return self.status == 'cancelled'
+
+    @property
+    def scheduled(self):
+        return self.status == 'scheduled'
+
+    @property
+    def notification_count(self):
+        return self._dict.get('notification_count', 0)
+
+    @property
+    def notifications_delivered(self):
+        return self._dict.get('notifications_delivered', 0)
+
+    @property
+    def notifications_failed(self):
+        return self._dict.get('notifications_failed', 0)
+
+    @property
+    def notifications_processed(self):
+        return self.notifications_delivered + self.notifications_failed
+
+    @property
+    def notifications_sending(self):
+        if self.scheduled:
+            return 0
+        return (
+            self.notification_count -
+            self.notifications_delivered -
+            self.notifications_failed
+        )
+
+    @property
+    def notifications_created(self):
+        return notification_api_client.get_notification_count_for_job_id(
+            service_id=self.service, job_id=self.id
+        )
+
+    @property
+    def still_processing(self):
+        return (
+            self.status != 'finished' or
+            self.notifications_created < self.notification_count
+        )
+
+    @property
+    def template_id(self):
+        return self._dict['template']
+
+    @cached_property
+    def template(self):
+        return service_api_client.get_service_template(
+            service_id=self.service,
+            template_id=self.template_id,
+            version=self.template_version,
+        )['data']
+
+    @property
+    def template_type(self):
+        return self.template['template_type']
+
+    @property
+    def percentage_complete(self):
+        return self.notifications_requested / self.notification_count * 100
+
+    @property
+    def letter_job_can_be_cancelled(self):
+
+        if self.template['template_type'] != 'letter':
+            return False
+
+        if any(self.uncancellable_notifications):
+            return False
+
+        if not letter_can_be_cancelled(
+            'created', datetime.strptime(self.created_at[:-6], '%Y-%m-%dT%H:%M:%S.%f')
+        ):
+            return False
+
+        return True
+
+    @cached_property
+    def all_notifications(self):
+        return self.get_notifications(set_status_filters({}))['notifications']
+
+    @property
+    def uncancellable_notifications(self):
+        return (
+            n for n in self.all_notifications
+            if n['status'] not in CANCELLABLE_JOB_LETTER_STATUSES
+        )
+
+    @cached_property
+    def postage(self):
+        # There might be no notifications if the job has only just been
+        # created and the tasks haven't run yet
+        try:
+            return self.all_notifications[0]['postage']
+        except IndexError:
+            return self.template['postage']
+
+    @property
+    def letter_timings(self):
+        return get_letter_timings(self.created_at, postage=self.postage)
+
+    def get_notifications(self, status):
+        return notification_api_client.get_notifications_for_service(
+            self.service, self.id, status=status,
+        )
+
+    def cancel(self):
+        if self.template_type == 'letter':
+            return job_api_client.cancel_letter_job(self.service, self.id)
+        else:
+            return job_api_client.cancel_job(self.service, self.id)

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from datetime import datetime
 
 from notifications_utils.letter_timings import (
@@ -46,33 +45,28 @@ class Job(JSONModel):
     def scheduled(self):
         return self.status == 'scheduled'
 
-    @cached_property
-    def statistics(self):
-        results = defaultdict(int)
-        for outcome in self._dict['statistics']:
-            if outcome['status'] in [
-                'failed', 'technical-failure', 'temporary-failure',
-                'permanent-failure', 'cancelled'
-            ]:
-                results['failed'] += outcome['count']
-            if outcome['status'] in ['sending', 'pending', 'created']:
-                results['sending'] += outcome['count']
-            if outcome['status'] in ['delivered', 'sent']:
-                results['delivered'] += outcome['count']
-            results['requested'] += outcome['count']
-        return results
-
     @property
     def notifications_delivered(self):
-        return self.statistics['delivered']
+        return sum(
+            outcome['count'] for outcome in self._dict['statistics']
+            if outcome['status'] in {'delivered', 'sent'}
+        )
 
     @property
     def notifications_failed(self):
-        return self.statistics['failed']
+        return sum(
+            outcome['count'] for outcome in self._dict['statistics']
+            if outcome['status'] in {
+                'failed', 'technical-failure', 'temporary-failure',
+                'permanent-failure', 'cancelled',
+            }
+        )
 
     @property
     def notifications_requested(self):
-        return self.statistics['requested']
+        return sum(
+            outcome['count'] for outcome in self._dict['statistics']
+        )
 
     @property
     def notifications_sent(self):

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -71,10 +71,6 @@ class Job(JSONModel):
         return self.notifications_delivered + self.notifications_failed
 
     @property
-    def notifications_processed(self):
-        return self.notifications_delivered + self.notifications_failed
-
-    @property
     def notifications_sending(self):
         if self.scheduled:
             return 0
@@ -94,7 +90,7 @@ class Job(JSONModel):
 
     @cached_property
     def finished_processing(self):
-        return self.notification_count == self.notifications_processed
+        return self.notification_count == self.notifications_sent
 
     @property
     def template_id(self):

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -45,28 +45,26 @@ class Job(JSONModel):
     def scheduled(self):
         return self.status == 'scheduled'
 
-    @property
-    def notifications_delivered(self):
+    def _aggregate_statistics(self, *statuses):
         return sum(
             outcome['count'] for outcome in self._dict['statistics']
-            if outcome['status'] in {'delivered', 'sent'}
+            if not statuses or outcome['status'] in statuses
         )
 
     @property
+    def notifications_delivered(self):
+        return self._aggregate_statistics('delivered', 'sent')
+
+    @property
     def notifications_failed(self):
-        return sum(
-            outcome['count'] for outcome in self._dict['statistics']
-            if outcome['status'] in {
-                'failed', 'technical-failure', 'temporary-failure',
-                'permanent-failure', 'cancelled',
-            }
+        return self._aggregate_statistics(
+            'failed', 'technical-failure', 'temporary-failure',
+            'permanent-failure', 'cancelled',
         )
 
     @property
     def notifications_requested(self):
-        return sum(
-            outcome['count'] for outcome in self._dict['statistics']
-        )
+        return self._aggregate_statistics()
 
     @property
     def notifications_sent(self):

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -83,9 +83,12 @@ class Job(JSONModel):
     @property
     def still_processing(self):
         return (
-            self.status != 'finished' or
-            self.notifications_created < self.notification_count
+            self.status != 'finished' or self.percentage_complete < 100
         )
+
+    @cached_property
+    def finished_processing(self):
+        return self.notification_count == self.notifications_processed
 
     @property
     def template_id(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -5,6 +5,12 @@ from notifications_utils.take import Take
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel
+from app.models.job import (
+    ImmediateJobs,
+    PaginatedJobs,
+    PaginatedUploads,
+    ScheduledJobs,
+)
 from app.models.organisation import Organisation
 from app.models.user import InvitedUsers, User, Users
 from app.notify_client.api_key_api_client import api_key_api_client
@@ -103,9 +109,27 @@ class Service(JSONModel):
     def has_permission(self, permission):
         return permission in self.permissions
 
+    def get_page_of_jobs(self, page):
+        return PaginatedJobs(self.id, page=page)
+
+    def get_page_of_uploads(self, page):
+        return PaginatedUploads(self.id, page=page)
+
     @cached_property
     def has_jobs(self):
         return job_api_client.has_jobs(self.id)
+
+    @cached_property
+    def immediate_jobs(self):
+        if not self.has_jobs:
+            return []
+        return ImmediateJobs(self.id)
+
+    @cached_property
+    def scheduled_jobs(self):
+        if not self.has_jobs:
+            return []
+        return ScheduledJobs(self.id)
 
     @cached_property
     def invited_users(self):

--- a/app/statistics_utils.py
+++ b/app/statistics_utils.py
@@ -78,19 +78,3 @@ def statistics_by_state(statistics):
             'failed': statistics['emails_failed']
         }
     }
-
-
-def get_failure_rate_for_job(job):
-    if not job.get('notifications_delivered'):
-        return 1 if job.get('notifications_failed') else 0
-    return (
-        job.get('notifications_failed', 0) /
-        (job.get('notifications_failed', 0) + job.get('notifications_delivered', 0))
-    )
-
-
-def add_rate_to_job(job):
-    return dict(
-        failure_rate=(get_failure_rate_for_job(job)) * 100,
-        **job
-    )

--- a/app/templates/partials/jobs/count-letters.html
+++ b/app/templates/partials/jobs/count-letters.html
@@ -5,8 +5,8 @@
   <div class="column-half">
     <div class="keyline-block">
       {{ big_number(
-        total,
-        message_count_label(total, 'letter', suffix='')|capitalize,
+        job.notification_count,
+        message_count_label(job.notification_count, 'letter', suffix='')|capitalize,
         smaller=True
       )}}
     </div>
@@ -14,7 +14,7 @@
   <div class="column-half">
     <div class="keyline-block">
       {{ big_number(
-        delivery_estimate|string|format_date_short,
+        job.letter_timings.earliest_delivery|string|format_date_short,
         'Estimated delivery date',
         smaller=True
       )}}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -28,7 +28,7 @@
       {% if template.template_type == 'letter' %}
         <div class="keyline-block bottom-gutter-1-2">
       {% endif %}
-        {% if job.percentage_complete < 100 and job.job_status != 'finished' %}
+        {% if job.still_processing %}
           <p class="{% if job.template.template_type != 'letter' %}bottom-gutter{% endif %} hint">
             Report is {{ "{:.0f}%".format(job.percentage_complete * 0.99) }} complete…
           </p>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -3,11 +3,11 @@
 {% from "components/form.html" import form_wrapper %}
 
 <div class="ajax-block-container" aria-labelledby='pill-selected-item'>
-  {% if job.job_status == 'scheduled' %}
+  {% if job.scheduled %}
 
     <p>
       Sending
-      <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=template.id, version=template_version) }}">{{ template.name }}</a>
+      <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=job.template.id, version=job.template_version) }}">{{ job.template.name }}</a>
       {{ job.scheduled_for|format_datetime_relative }}
     </p>
     <div class="page-footer">
@@ -28,12 +28,12 @@
       {% if template.template_type == 'letter' %}
         <div class="keyline-block bottom-gutter-1-2">
       {% endif %}
-        {% if percentage_complete < 100 and job.job_status != 'finished' %}
-          <p class="{% if template.template_type != 'letter' %}bottom-gutter{% endif %} hint">
-            Report is {{ "{:.0f}%".format(percentage_complete * 0.99) }} complete…
+        {% if job.percentage_complete < 100 and job.job_status != 'finished' %}
+          <p class="{% if job.template.template_type != 'letter' %}bottom-gutter{% endif %} hint">
+            Report is {{ "{:.0f}%".format(job.percentage_complete * 0.99) }} complete…
           </p>
         {% elif notifications %}
-          <p class="{% if template.template_type != 'letter' %}bottom-gutter{% endif %}">
+          <p class="{% if job.template.template_type != 'letter' %}bottom-gutter{% endif %}">
             <a href="{{ download_link }}" download class="heading-small">Download this report</a>
             &emsp;
             <span id="time-left">{{ time_left }}</span>

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -3,7 +3,7 @@
     {% if job.scheduled_for %}
       {% if job.processing_started %}
         Sent by {{ job.created_by.name }} on {{ job.processing_started|format_datetime_short }}
-        {% if template_type == "letter" %}
+        {% if job.template.template_type == "letter" %}
           <p id="printing-info">
             {{ letter_print_day }}
           </p>
@@ -13,7 +13,7 @@
       {% endif %}
     {% else %}
       Sent by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
-      {% if template_type == "letter" %}
+      {% if job.template.template_type == "letter" %}
         <p id="printing-info">
           {{ letter_print_day }}
         </p>

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -26,22 +26,22 @@
         {% endif %}
         <span class="file-list-hint">
           Sent {{
-            (item.scheduled_for if item.scheduled_for else item.created_at)|format_datetime_relative
+            (item.scheduled_for or item.created_at)|format_datetime_relative
           }}
         </span>
       </div>
     {% endcall %}
     {% call field() %}
       {{ big_number(
-        item.get('notification_count', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0),
+        item.notifications_sending,
         smallest=True
       ) }}
     {% endcall %}
     {% call field() %}
-      {{ big_number(item.get('notifications_delivered', 0), smallest=True) }}
+      {{ big_number(item.notifications_delivered, smallest=True) }}
     {% endcall %}
-    {% call field(status='error' if item.get('failure_rate', 0) > 3 else '') %}
-      {{ big_number(item.get('notifications_failed', 0), smallest=True) }}
+    {% call field(status='error' if item.high_failure_rate else '') %}
+      {{ big_number(item.notifications_failed, smallest=True) }}
     {% endcall %}
   {% endcall %}
 </div>

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -3,7 +3,7 @@
 {% from "components/show-more.html" import show_more %}
 
 <div class="ajax-block-container">
-  {% if scheduled_jobs %}
+  {% if current_service.scheduled_jobs %}
     <div class='dashboard-table'>
       {% if not hide_heading %}
         <h2 class="heading-medium heading-upcoming-jobs">
@@ -11,7 +11,7 @@
         </h2>
       {% endif %}
       {% call(item, row_number) list_table(
-        scheduled_jobs,
+        current_service.scheduled_jobs,
         caption="In the next few days",
         caption_visible=False,
         empty_message='Nothing to see here',

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -35,7 +35,7 @@
 
     {{ ajax_block(partials, updates_url, 'template-statistics', interval=5) }}
 
-    {% if partials['has_jobs'] %}
+    {% if current_service.immediate_jobs %}
       {{ ajax_block(partials, updates_url, 'jobs', interval=5) }}
       {{ show_more(
         url_for('.view_jobs', service_id=current_service.id),

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -16,10 +16,10 @@
     {% if just_sent %}
       {{ banner(just_sent_message, type='default', with_tick=True) }}
     {% else %}
-      {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
+      {{ ajax_block(partials, updates_url, 'status', finished=job.processing_finished) }}
     {% endif %}
-    {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
-    {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
+    {{ ajax_block(partials, updates_url, 'counts', finished=job.processing_finished) }}
+    {{ ajax_block(partials, updates_url, 'notifications', finished=job.processing_finished) }}
 
     {% if job.letter_job_can_be_cancelled %}
       <div class="js-stick-at-bottom-when-scrolling">

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -4,13 +4,13 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block service_page_title %}
-  {{ uploaded_file_name }}
+  {{ job.original_file_name }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
     <h1 class="heading-large">
-      {{ uploaded_file_name }}
+      {{ job.original_file_name }}
     </h1>
 
     {% if just_sent %}
@@ -21,11 +21,11 @@
     {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
 
-    {% if can_cancel_letter_job %}
+    {% if job.letter_job_can_be_cancelled %}
       <div class="js-stick-at-bottom-when-scrolling">
         <div class="page-footer">
           <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job_id) }}">Cancel sending these letters</a>
+              <a href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
           </span>
     {% else %}
       <div>&nbsp;</div>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -380,7 +380,12 @@ def job_json(
         'notifications_sent': notifications_sent,
         'notifications_requested': notifications_requested,
         'job_status': job_status,
-        'statistics': [],
+        'statistics': [
+            {
+                'status': 'blah',
+                'count': notifications_requested,
+            }
+        ],
         'created_by': created_by_json(
             created_by['id'],
             created_by['name'],

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1366,7 +1366,8 @@ def test_should_show_all_jobs_with_valid_statuses(
     mock_get_service_templates_when_no_templates_exist,
     mock_get_jobs,
     mock_get_usage,
-    mock_get_inbound_sms_summary
+    mock_get_inbound_sms_summary,
+    mock_get_free_sms_fragment_limit,
 ):
     logged_in_client.get(url_for('main.service_dashboard', service_id=SERVICE_ONE_ID))
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -518,7 +518,7 @@ def test_should_cancel_job(
     mock_get_service_template,
     mocker,
 ):
-    mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_job')
+    mock_cancel = mocker.patch('app.job_api_client.cancel_job')
     client_request.post(
         'main.cancel_job',
         service_id=SERVICE_ONE_ID,
@@ -687,7 +687,7 @@ def test_dont_cancel_letter_job_when_to_early_to_cancel(
         'app.notification_api_client.get_notification_count_for_job_id', return_value=number_of_processed_notifications
     )
 
-    mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_letter_job')
+    mock_cancel = mocker.patch('app.job_api_client.cancel_letter_job')
     page = client_request.post(
         'main.cancel_letter_job',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -514,6 +514,8 @@ def test_should_show_scheduled_job(
 def test_should_cancel_job(
     client_request,
     fake_uuid,
+    mock_get_job,
+    mock_get_service_template,
     mocker,
 ):
     mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_job')
@@ -549,6 +551,7 @@ def test_should_not_show_cancelled_job(
 def test_should_cancel_letter_job(
     client_request,
     mocker,
+    mock_get_service_letter_template,
     active_user_with_permissions
 ):
     job_id = str(uuid.uuid4())
@@ -564,7 +567,7 @@ def test_should_cancel_letter_job(
     mocker.patch('app.job_api_client.get_job', side_effect=[{"data": job}])
     mocker.patch('app.notification_api_client.get_notifications_for_service', return_value=notifications_json)
     mocker.patch('app.notification_api_client.get_notification_count_for_job_id', return_value=5)
-    mock_cancel = mocker.patch('app.main.jobs.job_api_client.cancel_letter_job', return_value=5)
+    mock_cancel = mocker.patch('app.job_api_client.cancel_letter_job', return_value=5)
     client_request.post(
         'main.cancel_letter_job',
         service_id=SERVICE_ONE_ID,
@@ -602,7 +605,7 @@ def test_should_not_show_cancel_link_for_letter_job_if_too_late(
     mocker.patch('app.job_api_client.get_job', side_effect=[{"data": job}])
     mocker.patch(
         'app.notification_api_client.get_notifications_for_service',
-        side_effect=[notifications_json]
+        return_value=notifications_json
     )
 
     page = client_request.get(
@@ -639,7 +642,7 @@ def test_should_show_cancel_link_for_letter_job(
     mocker.patch('app.job_api_client.get_job', side_effect=[{"data": job}])
     mocker.patch(
         'app.notification_api_client.get_notifications_for_service',
-        side_effect=[notifications_json]
+        return_value=notifications_json,
     )
 
     page = client_request.get(

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY
 
 import pytest
 
+from app.models.job import Job, PaginatedJobs
 from app.notify_client.job_api_client import JobApiClient
 
 
@@ -113,16 +114,15 @@ def test_client_parses_job_stats(mocker):
 
     expected_url = '/service/{}/job/{}'.format(service_id, job_id)
 
-    client = JobApiClient()
     mock_get = mocker.patch('app.notify_client.job_api_client.JobApiClient.get', return_value=expected_data)
 
-    result = client.get_job(service_id, job_id)
+    result = Job.from_id(job_id, service_id=service_id)
 
     mock_get.assert_called_once_with(url=expected_url, params={})
-    assert result['data']['notifications_requested'] == 80
-    assert result['data']['notifications_sent'] == 50
-    assert result['data']['notification_count'] == 80
-    assert result['data']['notifications_failed'] == 40
+    assert result.notifications_requested == 80
+    assert result.notifications_sent == 50
+    assert result.notification_count == 80
+    assert result.notifications_failed == 40
 
 
 def test_client_parses_empty_job_stats(mocker):
@@ -149,16 +149,15 @@ def test_client_parses_empty_job_stats(mocker):
 
     expected_url = '/service/{}/job/{}'.format(service_id, job_id)
 
-    client = JobApiClient()
     mock_get = mocker.patch('app.notify_client.job_api_client.JobApiClient.get', return_value=expected_data)
 
-    result = client.get_job(service_id, job_id)
+    result = Job.from_id(job_id, service_id=service_id)
 
     mock_get.assert_called_once_with(url=expected_url, params={})
-    assert result['data']['notifications_requested'] == 0
-    assert result['data']['notifications_sent'] == 0
-    assert result['data']['notification_count'] == 80
-    assert result['data']['notifications_failed'] == 0
+    assert result.notifications_requested == 0
+    assert result.notifications_sent == 0
+    assert result.notification_count == 80
+    assert result.notifications_failed == 0
 
 
 def test_client_parses_job_stats_for_service(mocker):
@@ -221,22 +220,21 @@ def test_client_parses_job_stats_for_service(mocker):
 
     expected_url = '/service/{}/job'.format(service_id)
 
-    client = JobApiClient()
     mock_get = mocker.patch('app.notify_client.job_api_client.JobApiClient.get', return_value=expected_data)
 
-    result = client.get_jobs(service_id)
+    result = PaginatedJobs(service_id)
 
-    mock_get.assert_called_once_with(url=expected_url, params={'page': 1})
-    assert result['data'][0]['id'] == job_1_id
-    assert result['data'][0]['notifications_requested'] == 80
-    assert result['data'][0]['notifications_sent'] == 50
-    assert result['data'][0]['notification_count'] == 80
-    assert result['data'][0]['notifications_failed'] == 40
-    assert result['data'][1]['id'] == job_2_id
-    assert result['data'][1]['notifications_requested'] == 40
-    assert result['data'][1]['notifications_sent'] == 25
-    assert result['data'][1]['notification_count'] == 40
-    assert result['data'][1]['notifications_failed'] == 20
+    mock_get.assert_called_once_with(url=expected_url, params={'page': 1, 'statuses': ANY})
+    assert result[0].id == job_1_id
+    assert result[0].notifications_requested == 80
+    assert result[0].notifications_sent == 50
+    assert result[0].notification_count == 80
+    assert result[0].notifications_failed == 40
+    assert result[1].id == job_2_id
+    assert result[1].notifications_requested == 40
+    assert result[1].notifications_sent == 25
+    assert result[1].notification_count == 40
+    assert result[1].notifications_failed == 20
 
 
 def test_client_parses_empty_job_stats_for_service(mocker):
@@ -281,22 +279,21 @@ def test_client_parses_empty_job_stats_for_service(mocker):
 
     expected_url = '/service/{}/job'.format(service_id)
 
-    client = JobApiClient()
     mock_get = mocker.patch('app.notify_client.job_api_client.JobApiClient.get', return_value=expected_data)
 
-    result = client.get_jobs(service_id)
+    result = PaginatedJobs(service_id)
 
-    mock_get.assert_called_once_with(url=expected_url, params={'page': 1})
-    assert result['data'][0]['id'] == job_1_id
-    assert result['data'][0]['notifications_requested'] == 0
-    assert result['data'][0]['notifications_sent'] == 0
-    assert result['data'][0]['notification_count'] == 80
-    assert result['data'][0]['notifications_failed'] == 0
-    assert result['data'][1]['id'] == job_2_id
-    assert result['data'][1]['notifications_requested'] == 0
-    assert result['data'][1]['notifications_sent'] == 0
-    assert result['data'][1]['notification_count'] == 40
-    assert result['data'][1]['notifications_failed'] == 0
+    mock_get.assert_called_once_with(url=expected_url, params={'page': 1, 'statuses': ANY})
+    assert result[0].id == job_1_id
+    assert result[0].notifications_requested == 0
+    assert result[0].notifications_sent == 0
+    assert result[0].notification_count == 80
+    assert result[0].notifications_failed == 0
+    assert result[1].id == job_2_id
+    assert result[1].notifications_requested == 0
+    assert result[1].notifications_sent == 0
+    assert result[1].notification_count == 40
+    assert result[1].notifications_failed == 0
 
 
 def test_cancel_job(mocker):

--- a/tests/app/test_statistics_utils.py
+++ b/tests/app/test_statistics_utils.py
@@ -128,25 +128,25 @@ def test_service_statistics_by_state():
     (1, 4, 20)
 ])
 def test_add_rate_to_job_calculates_rate(failed, delivered, expected_failure_rate):
-    resp = Job(
-        {
-            'notifications_failed': failed,
-            'notifications_delivered': delivered,
-            'id': 'foo'
-        }
-    )
+    resp = Job({
+        'statistics': [
+            {'status': 'failed', 'count': failed},
+            {'status': 'delivered', 'count': delivered},
+        ],
+        'id': 'foo',
+    })
 
     assert resp.failure_rate == expected_failure_rate
 
 
 def test_add_rate_to_job_preserves_initial_fields():
-    resp = Job(
-        {
-            'notifications_failed': 0,
-            'notifications_delivered': 0,
-            'id': 'foo'
-        }
-    )
+    resp = Job({
+        'statistics': [
+            {'status': 'failed', 'count': 0},
+            {'status': 'delivered', 'count': 0},
+        ],
+        'id': 'foo',
+    })
 
     assert resp.notifications_failed == resp.notifications_delivered == resp.failure_rate == 0
     assert resp.id == 'foo'

--- a/tests/app/test_statistics_utils.py
+++ b/tests/app/test_statistics_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
+from app.models.job import Job
 from app.statistics_utils import (
-    add_rate_to_job,
     add_rates_to,
     statistics_by_state,
     sum_of_statistics,
@@ -128,7 +128,7 @@ def test_service_statistics_by_state():
     (1, 4, 20)
 ])
 def test_add_rate_to_job_calculates_rate(failed, delivered, expected_failure_rate):
-    resp = add_rate_to_job(
+    resp = Job(
         {
             'notifications_failed': failed,
             'notifications_delivered': delivered,
@@ -136,11 +136,11 @@ def test_add_rate_to_job_calculates_rate(failed, delivered, expected_failure_rat
         }
     )
 
-    assert resp['failure_rate'] == expected_failure_rate
+    assert resp.failure_rate == expected_failure_rate
 
 
 def test_add_rate_to_job_preserves_initial_fields():
-    resp = add_rate_to_job(
+    resp = Job(
         {
             'notifications_failed': 0,
             'notifications_delivered': 0,
@@ -148,4 +148,5 @@ def test_add_rate_to_job_preserves_initial_fields():
         }
     )
 
-    assert set(resp.keys()) == {'notifications_failed', 'notifications_delivered', 'id', 'failure_rate'}
+    assert resp.notifications_failed == resp.notifications_delivered == resp.failure_rate == 0
+    assert resp.id == 'foo'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1732,12 +1732,16 @@ def mock_get_uploads(mocker, api_user_active):
                     'notification_count': 10,
                     'created_at': '2016-01-01 11:09:00.061258',
                     'statistics': [{'count': 8, 'status': 'delivered'}, {'count': 2, 'status': 'temporary-failure'}],
+                    'scheduled_for': None,
+                    'job_status': 'finished',
                     'upload_type': 'job'},
                    {'id': 'job_id_1',
                     'original_file_name': 'some.csv',
                     'notification_count': 1,
                     'created_at': '2016-01-01 11:09:00.061258',
                     'statistics': [{'count': 1, 'status': 'delivered'}],
+                    'scheduled_for': None,
+                    'job_status': 'finished',
                     'upload_type': 'letter'}
                    ]
         return {
@@ -1747,8 +1751,8 @@ def mock_get_uploads(mocker, api_user_active):
                 'next': 'services/{}/uploads?page={}'.format(service_id, page + 1)
             }
         }
-
-    return mocker.patch('app.job_api_client.get_uploads', side_effect=_get_uploads)
+    # Why is mocking on the model needed?
+    return mocker.patch('app.models.job.PaginatedUploads.client', side_effect=_get_uploads)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
This follows the pattern of what we’ve done with services, users and events.

It gives us a better interface to the data we get back from the API than dealing with the raw JSON directly.

Now is a good time to do this because we’re going to be making a bunch of changes to the jobs pages, and those changes will be easier to code and understand with a sensible model behind them.

***

There are lots of changes here, but very few that change the tests. So assuming the existing tests are good the changes should at least work…