### PR TITLE
Added a new error message when the letter is missing an address block.

### DIFF
--- a/app/templates/views/notifications/invalid_precompiled_letter.html
+++ b/app/templates/views/notifications/invalid_precompiled_letter.html
@@ -12,6 +12,6 @@
       Provided as PDF on {{ created_at|format_datetime_short }}
     </p>
     <p class="notification-status-cancelled">
-      Validation failed – Notify cannot read this PDF file
+      Validation failed – There’s a problem with your letter. <br>Notify cannot read this PDF.
     </p>
 {% endblock %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -44,7 +44,7 @@
         </p>
       {% elif notification_status == 'validation-failed' %}
         <p class="notification-status-cancelled">
-          Validation failed. {{ message.detail | safe }}
+          Validation failed – {{ message.title | safe }}. {{ message.detail | safe }}
         </p>
       {% elif notification_status == 'technical-failure' %}
         <p class="notification-status-cancelled">

--- a/app/utils.py
+++ b/app/utils.py
@@ -566,14 +566,14 @@ def get_letter_printing_statement(status, created_at):
 
 LETTER_VALIDATION_MESSAGES = {
     'letter-not-a4-portrait-oriented': {
-        'title': 'We cannot print your letter',
-        'detail': 'Your letter is not A4 portrait size on {invalid_pages} <br>'
+        'title': 'Your letter is not A4 portrait size',
+        'detail': 'You need to change the size or orientation of {invalid_pages}. <br>'
                   'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
                   'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     },
     'content-outside-printable-area': {
-        'title': 'We cannot print your letter',
-        'detail': 'The content appears outside the printable area on {invalid_pages}.<br>'
+        'title': 'Your content is outside the printable area',
+        'detail': 'You need to edit {invalid_pages}.<br>'
                   'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
                   'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     },
@@ -587,6 +587,12 @@ LETTER_VALIDATION_MESSAGES = {
     'unable-to-read-the-file': {
         'title': 'There’s a problem with your file',
         'detail': 'Notify cannot read this PDF.<br>Save a new copy of your file and try again.'
+    },
+    'address-is-empty': {
+        'title': 'The address block is empty',
+        'detail': 'You need to add a recipient address.<br>'
+                  'Files must meet our <a href="https://docs.notifications.service.gov.uk/documentation/images/'
+                  'notify-pdf-letter-spec-v2.4.pdf" target="_blank">letter specification</a>.'
     }
 }
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -414,14 +414,21 @@ def test_get_letter_validation_error_for_unknown_error():
 
 
 @pytest.mark.parametrize('error_message, expected_title, expected_content', [
-    ('letter-not-a4-portrait-oriented', 'We cannot print your letter', 'A4 portrait size on page 2'),
-    ('content-outside-printable-area', 'We cannot print your letter', 'outside the printable area on page 2'),
-    ('letter-too-long', 'Your letter is too long', 'letter is 13 pages long.')
+    ('letter-not-a4-portrait-oriented', 'Your letter is not A4 portrait size',
+     'You need to change the size or orientation of page 2. <br>Files must meet our '
+     '<a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf" '
+     'target="_blank">letter specification</a>.'),
+    ('content-outside-printable-area', 'Your content is outside the printable area',
+     'You need to edit page 2.<br>Files must meet our '
+     '<a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf" '
+     'target="_blank">letter specification</a>.'),
+    ('letter-too-long', 'Your letter is too long',
+     'Letters must be 10 pages or less. <br>Your letter is 13 pages long.')
 ])
 def test_get_letter_validation_error_for_known_errors(
-    error_message,
-    expected_title,
-    expected_content,
+        error_message,
+        expected_title,
+        expected_content,
 ):
     error = get_letter_validation_error(error_message, invalid_pages=[2], page_count=13)
 


### PR DESCRIPTION
Before deploying a change to template-preview to return a validation error for letters that are missing the address block, we need to add the new erorr message to admin.

Some content changes have been made to other messages.
The format of the message has changed.

Here is an example of the new error message. 

![Screenshot 2020-01-10 at 14 42 49](https://user-images.githubusercontent.com/4282990/72161379-ed361e00-33b7-11ea-9e34-fe9520d43704.png)
