### PR TITLE
Add a command to fix import order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ upload-static:
 test: ## Run tests
 	./scripts/run_tests.sh
 
+.PHONY: fix-imports
+fix-imports:
+	isort -rc ./app ./tests
+
 .PHONY: freeze-requirements
 freeze-requirements:
 	rm -rf venv-freeze


### PR DESCRIPTION
We check import order as part of our automated tests. But fixing them
means:
- manually editing them and rechecking
- remembering the parameters to `isort`
- looking up the `isort` command from the last time you ran it

Putting it in the Makefile should make life a bit easier.