### PR TITLE
Only put the overlay on bad pages

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -241,11 +241,19 @@ def uploaded_letter_preview(service_id, file_id):
 @main.route("/services/<uuid:service_id>/preview-letter-image/<uuid:file_id>")
 @user_has_permissions('send_messages')
 def view_letter_upload_as_preview(service_id, file_id):
+
+    try:
+        page = int(request.args.get('page'))
+    except ValueError:
+        abort(400)
+
     pdf_file, metadata = get_letter_pdf_and_metadata(service_id, file_id)
+    invalid_pages = json.loads(metadata.get('invalid_pages', '[]'))
 
-    page = request.args.get('page')
-
-    if metadata.get('message') == 'content-outside-printable-area':
+    if (
+        metadata.get('message') == 'content-outside-printable-area' and
+        page in invalid_pages
+    ):
         return TemplatePreview.from_invalid_pdf_file(pdf_file, page)
     else:
         return TemplatePreview.from_valid_pdf_file(pdf_file, page)


### PR DESCRIPTION
This will make it easier to find errors in your file, because you won’t spent time looking for them on pages which are OK.

***

![invalid-p1](https://user-images.githubusercontent.com/355079/72278147-4fe32000-362b-11ea-886b-5323ee1744c3.gif)

***

Need to decide if it’s worth trying to do this for API letters as well (the code path is different).