### PR TITLE
Update footer and get started

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -164,6 +164,10 @@
             "text": "System status"
           },
           {
+            "href": "https://www.gov.uk/performance/govuk-notify",
+            "text": "Performance data"
+          },
+          {
             "href": "https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC",
             "text": "Chat to us on Slack"
           }
@@ -188,10 +192,6 @@
           {
             "href": url_for("main.terms"),
             "text": "Terms of use"
-          },
-          {
-            "href": "https://www.gov.uk/performance/govuk-notify",
-            "text": "Performance"
           },
           {
             "href": "https://gds.blog.gov.uk/category/notify/",

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -24,9 +24,8 @@
             <li>central government departments</li>
             <li>local authorities</li>
             <li>state-funded schools</li>
-            <li>housing associations</li>
             <li>the NHS</li>
-            <li>companies owned by local or central government that deliver services on their behalf</li>
+            <li>companies running a service on behalf of a public sector organisation</li>
           </ul>
           <p>Notify is not currently available to charities.</p>
         </div>'''


### PR DESCRIPTION
This PR updates the _Get started_ page and the Notify footer.

**Get started page**
- update list of organisations that can use Notify to remove 'housing associations'
- update the wording of 'companies owned by local or central government...'

**Footer**
- move 'Performance' to the Support column and rename it, 'Performance data'