### PR TITLE
Fix test that fails 1 in 60 times

### DIFF
--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -552,8 +552,11 @@ def test_should_not_show_recent_templates_on_dashboard_if_only_one_template_used
     # count appears as total, but not per template
     expected_count = stats[0]['count']
     assert expected_count == 50
-    assert main.count(str(expected_count)) == 1
-    assert '50 text messages sent' in normalize_spaces(main)
+    assert normalize_spaces(
+        page.select_one('#total-sms .big-number').text
+    ) == (
+        '{} text messages sent'.format(expected_count)
+    )
 
 
 @freeze_time("2016-07-01 12:00")  # 4 months into 2016 financial year


### PR DESCRIPTION
This test looks for how many times the string `50` appears in the text of the `<main>` element of the page. The `<main>` element also contains some times, for example 1:23pm.

This means that when the time reaches 1:50pm, 2:50pm, etc the number of times the string `50` appears in the page changes. Which causes the test assertions to fail.

This commit changes the test to be much more specific about where it’s looking for the string. This tends to be how we write assertions now (it’s only in the very early days that we though asserting for text anywhere in the page was the best way to do things).