### PR TITLE
Rename `client` property on `ModelLists`

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -55,7 +55,7 @@ class ModelList(ABC, Sequence):
 
     @property
     @abstractmethod
-    def client(self):
+    def client_method(self):
         pass
 
     @property
@@ -64,7 +64,7 @@ class ModelList(ABC, Sequence):
         pass
 
     def __init__(self, *args):
-        self.items = self.client(*args)
+        self.items = self.client_method(*args)
 
     def __getitem__(self, index):
         return self.model(self.items[index])

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -157,12 +157,12 @@ class APIKeyEvent(Event):
 class APIKeyEvents(ModelList):
 
     model = APIKeyEvent
-    client = service_api_client.get_service_api_key_history
+    client_method = service_api_client.get_service_api_key_history
 
 
 class ServiceEvents(ModelList):
 
-    client = service_api_client.get_service_service_history
+    client_method = service_api_client.get_service_service_history
 
     @property
     def model(self):
@@ -187,5 +187,5 @@ class ServiceEvents(ModelList):
 
     def __init__(self, service_id):
         self.items = [
-            event for event in self.splat(self.client(service_id)) if event.relevant
+            event for event in self.splat(self.client_method(service_id)) if event.relevant
         ]

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -179,28 +179,28 @@ class Job(JSONModel):
 
 
 class ImmediateJobs(ModelList):
-    client = job_api_client.get_immediate_jobs
+    client_method = job_api_client.get_immediate_jobs
     model = Job
 
 
 class ScheduledJobs(ImmediateJobs):
-    client = job_api_client.get_scheduled_jobs
+    client_method = job_api_client.get_scheduled_jobs
 
 
 class PaginatedJobs(ImmediateJobs):
 
-    client = job_api_client.get_page_of_jobs
+    client_method = job_api_client.get_page_of_jobs
 
     def __init__(self, service_id, page=None):
         try:
             self.current_page = int(page)
         except TypeError:
             self.current_page = 1
-        response = self.client(service_id, page=self.current_page)
+        response = self.client_method(service_id, page=self.current_page)
         self.items = response['data']
         self.prev_page = response.get('links', {}).get('prev', None)
         self.next_page = response.get('links', {}).get('next', None)
 
 
 class PaginatedUploads(PaginatedJobs):
-    client = job_api_client.get_uploads
+    client_method = job_api_client.get_uploads

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -200,5 +200,5 @@ class Organisation(JSONModel):
 
 
 class Organisations(ModelList):
-    client = organisations_client.get_organisations
+    client_method = organisations_client.get_organisations
     model = Organisation

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -607,9 +607,6 @@ class Users(ModelList):
     client_method = user_api_client.get_users_for_service
     model = User
 
-    def __init__(self, service_id):
-        self.items = self.client(service_id)
-
     def get_name_from_id(self, id):
         for user in self:
             if user.id == id:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -604,7 +604,7 @@ class AnonymousUser(AnonymousUserMixin):
 
 class Users(ModelList):
 
-    client = user_api_client.get_users_for_service
+    client_method = user_api_client.get_users_for_service
     model = User
 
     def __init__(self, service_id):
@@ -618,21 +618,21 @@ class Users(ModelList):
 
 
 class OrganisationUsers(Users):
-    client = user_api_client.get_users_for_organisation
+    client_method = user_api_client.get_users_for_organisation
 
 
 class InvitedUsers(Users):
 
-    client = invite_api_client.get_invites_for_service
+    client_method = invite_api_client.get_invites_for_service
     model = InvitedUser
 
     def __init__(self, service_id):
         self.items = [
-            user for user in self.client(service_id)
+            user for user in self.client_method(service_id)
             if user['status'] != 'accepted'
         ]
 
 
 class OrganisationInvitedUsers(InvitedUsers):
-    client = org_invite_api_client.get_invites_for_organisation
+    client_method = org_invite_api_client.get_invites_for_organisation
     model = InvitedOrgUser

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -541,7 +541,7 @@ def validate_route_permission(mocker,
     mocker.patch('app.user_api_client.get_user', return_value=usr)
     mocker.patch('app.user_api_client.get_user_by_email', return_value=usr)
     mocker.patch('app.service_api_client.get_service', return_value={'data': service})
-    mocker.patch('app.models.user.Users.client', return_value=[usr])
+    mocker.patch('app.models.user.Users.client_method', return_value=[usr])
     mocker.patch('app.job_api_client.has_jobs', return_value=False)
     with app_.test_request_context():
         with app_.test_client() as client:

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -27,7 +27,7 @@ def test_organisation_page_shows_all_organisations(
     ]
 
     get_organisations = mocker.patch(
-        'app.models.organisation.Organisations.client', return_value=orgs
+        'app.models.organisation.Organisations.client_method', return_value=orgs
     )
     response = platform_admin_client.get(
         url_for('.organisations')
@@ -232,7 +232,7 @@ def test_nhs_local_can_create_own_organisations(
 ):
     mocker.patch('app.organisations_client.get_service_organisation', return_value=organisation)
     mocker.patch(
-        'app.models.organisation.Organisations.client',
+        'app.models.organisation.Organisations.client_method',
         return_value=[
             organisation_json('t1', 'Trust 1', organisation_type='nhs_local'),
             organisation_json('t2', 'Trust 2', organisation_type='nhs_local'),
@@ -366,7 +366,7 @@ def test_nhs_local_assigns_to_selected_organisation(
 ):
     mocker.patch('app.organisations_client.get_service_organisation', return_value=None)
     mocker.patch(
-        'app.models.organisation.Organisations.client',
+        'app.models.organisation.Organisations.client_method',
         return_value=[
             organisation_json(ORGANISATION_ID, 'Trust 1', organisation_type='nhs_local'),
         ],

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -180,7 +180,7 @@ def test_existing_user_of_service_get_redirected_to_signin(
 ):
     sample_invite['email_address'] = api_user_active['email_address']
     mocker.patch('app.invite_api_client.check_token', return_value=sample_invite)
-    mocker.patch('app.models.user.Users.client', return_value=[api_user_active])
+    mocker.patch('app.models.user.Users.client_method', return_value=[api_user_active])
 
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'), follow_redirects=True)
     assert response.status_code == 200
@@ -432,7 +432,7 @@ def test_accept_invite_does_not_treat_email_addresses_as_case_sensitive(
     # the email address of api_user_active is 'test@user.gov.uk'
     sample_invite['email_address'] = 'TEST@user.gov.uk'
     mocker.patch('app.invite_api_client.check_token', return_value=sample_invite)
-    mocker.patch('app.models.user.Users.client', return_value=[api_user_active])
+    mocker.patch('app.models.user.Users.client_method', return_value=[api_user_active])
 
     client_request.get(
         'main.accept_invite',

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -135,7 +135,7 @@ def test_should_show_overview_page(
     other_user['id'] = 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz'
 
     mocker.patch('app.user_api_client.get_user', return_value=current_user)
-    mock_get_users = mocker.patch('app.models.user.Users.client', return_value=[
+    mock_get_users = mocker.patch('app.models.user.Users.client_method', return_value=[
         current_user,
         other_user,
     ])
@@ -166,7 +166,7 @@ def test_should_show_caseworker_on_overview_page(
     other_user['email_address'] = 'zzzzzzz@example.gov.uk'
 
     mocker.patch('app.user_api_client.get_user', return_value=current_user)
-    mocker.patch('app.models.user.Users.client', return_value=[
+    mocker.patch('app.models.user.Users.client_method', return_value=[
         current_user,
         other_user,
     ])
@@ -699,8 +699,8 @@ def test_invite_user(
     sample_invite['email_address'] = 'test@example.gov.uk'
 
     assert is_gov_user(email_address) == gov_user
-    mocker.patch('app.models.user.InvitedUsers.client', return_value=[sample_invite])
-    mocker.patch('app.models.user.Users.client', return_value=[active_user_with_permissions])
+    mocker.patch('app.models.user.InvitedUsers.client_method', return_value=[sample_invite])
+    mocker.patch('app.models.user.Users.client_method', return_value=[active_user_with_permissions])
     mocker.patch('app.invite_api_client.create_invite', return_value=sample_invite)
     page = client_request.post(
         'main.invite_user',
@@ -753,8 +753,8 @@ def test_invite_user_with_email_auth_service(
     sample_invite['email_address'] = 'test@example.gov.uk'
 
     assert is_gov_user(email_address) is gov_user
-    mocker.patch('app.models.user.InvitedUsers.client', return_value=[sample_invite])
-    mocker.patch('app.models.user.Users.client', return_value=[active_user_with_permissions])
+    mocker.patch('app.models.user.InvitedUsers.client_method', return_value=[sample_invite])
+    mocker.patch('app.models.user.Users.client_method', return_value=[active_user_with_permissions])
     mocker.patch('app.invite_api_client.create_invite', return_value=sample_invite)
 
     page = client_request.post(
@@ -855,8 +855,8 @@ def test_manage_users_shows_invited_user(
     expected_text,
 ):
     sample_invite['status'] = invite_status
-    mocker.patch('app.models.user.InvitedUsers.client', return_value=[sample_invite])
-    mocker.patch('app.models.user.Users.client', return_value=[active_user_with_permissions])
+    mocker.patch('app.models.user.InvitedUsers.client_method', return_value=[sample_invite])
+    mocker.patch('app.models.user.Users.client_method', return_value=[active_user_with_permissions])
 
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
     assert page.h1.string.strip() == 'Team members'
@@ -873,8 +873,8 @@ def test_manage_users_does_not_show_accepted_invite(
     invited_user_id = uuid.uuid4()
     sample_invite['id'] = invited_user_id
     sample_invite['status'] = 'accepted'
-    mocker.patch('app.models.user.InvitedUsers.client', return_value=[sample_invite])
-    mocker.patch('app.models.user.Users.client', return_value=[active_user_with_permissions])
+    mocker.patch('app.models.user.InvitedUsers.client_method', return_value=[sample_invite])
+    mocker.patch('app.models.user.Users.client_method', return_value=[active_user_with_permissions])
 
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
 
@@ -1018,7 +1018,7 @@ def test_can_invite_user_as_platform_admin(
     mock_get_template_folders,
     mocker,
 ):
-    mocker.patch('app.models.user.Users.client', return_value=[active_user_with_permissions])
+    mocker.patch('app.models.user.Users.client_method', return_value=[active_user_with_permissions])
 
     page = client_request.get(
         'main.manage_users',
@@ -1252,7 +1252,7 @@ def test_confirm_edit_user_email_changes_user_email(
     # We want active_user_with_permissions (the current user) to update the email address for api_user_active
     # By default both users would have the same id, so we change the id of api_user_active
     api_user_active['id'] = str(uuid.uuid4())
-    mocker.patch('app.models.user.Users.client', return_value=[api_user_active, active_user_with_permissions])
+    mocker.patch('app.models.user.Users.client_method', return_value=[api_user_active, active_user_with_permissions])
     # get_user gets called twice - first to check if current user can see the page, then to see if the team member
     # whose email address we're changing belongs to the service
     mocker.patch('app.user_api_client.get_user',
@@ -1468,7 +1468,7 @@ def test_confirm_edit_user_mobile_number_changes_user_mobile_number(
     # By default both users would have the same id, so we change the id of api_user_active
     api_user_active['id'] = str(uuid.uuid4())
 
-    mocker.patch('app.models.user.Users.client', return_value=[api_user_active, active_user_with_permissions])
+    mocker.patch('app.models.user.Users.client_method', return_value=[api_user_active, active_user_with_permissions])
     # get_user gets called twice - first to check if current user can see the page, then to see if the team member
     # whose mobile number we're changing belongs to the service
     mocker.patch('app.user_api_client.get_user',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -763,7 +763,7 @@ def test_should_check_for_sending_things_right(
         }.get(template_type)
     active_user_with_permissions,
     mock_get_users = mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=(
             [active_user_with_permissions] * count_of_users_with_manage_service +
             [active_user_no_settings_permission]
@@ -783,7 +783,7 @@ def test_should_check_for_sending_things_right(
     invite_two['permissions'] = 'view_activity'
 
     mock_get_invites = mocker.patch(
-        'app.models.user.InvitedUsers.client',
+        'app.models.user.InvitedUsers.client_method',
         return_value=(
             ([invite_one] * count_of_invites_with_manage_service) +
             [invite_two]

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -480,7 +480,7 @@ def test_get_manage_folder_page(
         _folder('folder_two', folder_id, None, [active_user_with_permissions['id']]),
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions],
     )
     page = client_request.get(
@@ -514,7 +514,7 @@ def test_get_manage_folder_viewing_permissions_for_users(
         _folder('folder_two', folder_id, None, [active_user_with_permissions['id'], team_member_2['id']]),
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions, team_member, team_member_2],
     )
 
@@ -566,7 +566,7 @@ def test_get_manage_folder_viewing_permissions_for_users_not_visible_when_no_man
         ]},
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions, team_member, team_member_2],
     )
 
@@ -600,7 +600,7 @@ def test_get_manage_folder_viewing_permissions_for_users_not_visible_for_service
         ]},
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions],
     )
 
@@ -712,7 +712,7 @@ def test_rename_folder(client_request, active_user_with_permissions, service_one
         _folder('folder_two', folder_id, None, [active_user_with_permissions['id']])
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions],
     )
 
@@ -745,7 +745,7 @@ def test_manage_folder_users(
         _folder('folder_two', folder_id, None, [active_user_with_permissions['id'], team_member['id']])
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions, team_member],
     )
 
@@ -788,7 +788,7 @@ def test_manage_folder_users_doesnt_change_permissions_current_user_cannot_manag
         ]}
     ]
     mocker.patch(
-        'app.models.user.Users.client',
+        'app.models.user.Users.client_method',
         return_value=[active_user_with_permissions, team_member],
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1752,7 +1752,7 @@ def mock_get_uploads(mocker, api_user_active):
             }
         }
     # Why is mocking on the model needed?
-    return mocker.patch('app.models.job.PaginatedUploads.client', side_effect=_get_uploads)
+    return mocker.patch('app.models.job.PaginatedUploads.client_method', side_effect=_get_uploads)
 
 
 @pytest.fixture(scope='function')
@@ -2013,7 +2013,7 @@ def mock_get_users_by_service(mocker):
 
     # You shouldn’t be calling the user API client directly, so it’s the
     # instance on the model that’s mocked here
-    return mocker.patch('app.models.user.Users.client', side_effect=_get_users_for_service)
+    return mocker.patch('app.models.user.Users.client_method', side_effect=_get_users_for_service)
 
 
 @pytest.fixture(scope='function')
@@ -2082,7 +2082,7 @@ def mock_get_invites_for_service(mocker, service_one, sample_invite):
             data.append(invite)
         return data
 
-    return mocker.patch('app.models.user.InvitedUsers.client', side_effect=_get_invites)
+    return mocker.patch('app.models.user.InvitedUsers.client_method', side_effect=_get_invites)
 
 
 @pytest.fixture(scope='function')
@@ -2101,7 +2101,7 @@ def mock_get_invites_without_manage_permission(mocker, service_one, sample_invit
             status='pending',
         )]
 
-    return mocker.patch('app.models.user.InvitedUsers.client', side_effect=_get_invites)
+    return mocker.patch('app.models.user.InvitedUsers.client_method', side_effect=_get_invites)
 
 
 @pytest.fixture(scope='function')
@@ -2922,7 +2922,7 @@ def mock_get_organisations(mocker):
         ]
 
     mocker.patch(
-        'app.models.organisation.Organisations.client',
+        'app.models.organisation.Organisations.client_method',
         side_effect=_get_organisations,
     )
 
@@ -3037,7 +3037,7 @@ def mock_get_users_for_organisation(mocker):
         ]
 
     return mocker.patch(
-        'app.models.user.OrganisationUsers.client',
+        'app.models.user.OrganisationUsers.client_method',
         side_effect=_get_users_for_organisation
     )
 
@@ -3050,7 +3050,7 @@ def mock_get_invited_users_for_organisation(mocker, sample_org_invite):
         ]
 
     return mocker.patch(
-        'app.models.user.OrganisationInvitedUsers.client',
+        'app.models.user.OrganisationInvitedUsers.client_method',
         side_effect=_get_invited_invited_users_for_organisation
     )
 


### PR DESCRIPTION
The property doesn’t represent the whole client, but just one method on it. So this commit renames the property to better describe what it is designed to store.