### PR TITLE
Account for missing scheduled for field

### DIFF
--- a/app/models/job.py
+++ b/app/models/job.py
@@ -26,7 +26,6 @@ class Job(JSONModel):
         'notification_count',
         'job_status',
         'created_by',
-        'scheduled_for',
     }
 
     @classmethod
@@ -44,6 +43,10 @@ class Job(JSONModel):
     @property
     def scheduled(self):
         return self.status == 'scheduled'
+
+    @property
+    def scheduled_for(self):
+        return self._dict.get('scheduled_for')
 
     def _aggregate_statistics(self, *statuses):
         return sum(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1732,7 +1732,6 @@ def mock_get_uploads(mocker, api_user_active):
                     'notification_count': 10,
                     'created_at': '2016-01-01 11:09:00.061258',
                     'statistics': [{'count': 8, 'status': 'delivered'}, {'count': 2, 'status': 'temporary-failure'}],
-                    'scheduled_for': None,
                     'job_status': 'finished',
                     'upload_type': 'job'},
                    {'id': 'job_id_1',
@@ -1740,7 +1739,6 @@ def mock_get_uploads(mocker, api_user_active):
                     'notification_count': 1,
                     'created_at': '2016-01-01 11:09:00.061258',
                     'statistics': [{'count': 1, 'status': 'delivered'}],
-                    'scheduled_for': None,
                     'job_status': 'finished',
                     'upload_type': 'letter'}
                    ]


### PR DESCRIPTION
Jobs have a `scheduled_for` field. Single letter uploads don’t.

At the moment we treat both of them as `Job`s. So the `Job` model needs to account for when the `scheduled_for` field is missing.