### PR TITLE
Don’t assume a job’s status will be present

### DIFF
--- a/app/models/job.py
+++ b/app/models/job.py
@@ -34,7 +34,7 @@ class Job(JSONModel):
 
     @property
     def status(self):
-        return self.job_status
+        return self._dict.get('job_status')
 
     @property
     def cancelled(self):

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -24,7 +24,6 @@ class Job(JSONModel):
         'original_file_name',
         'created_at',
         'notification_count',
-        'job_status',
         'created_by',
     }
 

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -47,7 +47,7 @@
         notifications,
         caption=uploaded_file_name,
         caption_visible=False,
-        empty_message='These messages have been deleted because they were sent more than {} days ago'.format(service_data_retention_days) if job.job_status == 'finished' else 'No messages to show yet…',
+        empty_message='These messages have been deleted because they were sent more than {} days ago'.format(service_data_retention_days) if job.status == 'finished' else 'No messages to show yet…',
         field_headings=[
           'Recipient',
           'Status'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1732,14 +1732,12 @@ def mock_get_uploads(mocker, api_user_active):
                     'notification_count': 10,
                     'created_at': '2016-01-01 11:09:00.061258',
                     'statistics': [{'count': 8, 'status': 'delivered'}, {'count': 2, 'status': 'temporary-failure'}],
-                    'job_status': 'finished',
                     'upload_type': 'job'},
                    {'id': 'job_id_1',
                     'original_file_name': 'some.csv',
                     'notification_count': 1,
                     'created_at': '2016-01-01 11:09:00.061258',
                     'statistics': [{'count': 1, 'status': 'delivered'}],
-                    'job_status': 'finished',
                     'upload_type': 'letter'}
                    ]
         return {


### PR DESCRIPTION
The API response for jobs includes a field called `job_status`. The API response for uploads doesn’t.

The `Job` model handles uploads and jobs, so it needs to account for the possibility of the field not being there.