### PR TITLE
bump python version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.x
+python-3.6.x


### PR DESCRIPTION
we all run 3.6 locally, we test against 3.6 both locally and on concourse, and the latest version of openpyxl (required by pyexcel-xlsx) doesn't support 3.5 anymore