### PR TITLE
Stop removing GA cookies

### DIFF
--- a/app/assets/javascripts/consent.js
+++ b/app/assets/javascripts/consent.js
@@ -1,8 +1,8 @@
 (function (window) {
   "use strict";
 
-  function hasConsentFor (cookieCategory) {
-    const consentCookie = window.GOVUK.getConsentCookie();
+  function hasConsentFor (cookieCategory, consentCookie) {
+    if (consentCookie === undefined) { consentCookie = window.GOVUK.getConsentCookie(); }
 
     if (consentCookie === null) { return false; }
 

--- a/app/assets/javascripts/cookieMessage.js
+++ b/app/assets/javascripts/cookieMessage.js
@@ -4,14 +4,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   function CookieBanner () { }
 
-  CookieBanner.clearOldCookies = function () {
-    // clear any cookies set by the previous version
-    var oldCookies = ['seen_cookie_message', '_ga', '_gid'];
+  CookieBanner.clearOldCookies = function (consent) {
+    var gaCookies = ['_ga', '_gid'];
 
-    for (var i = 0; i < oldCookies.length; i++) {
-      if (window.GOVUK.cookie(oldCookies[i])) {
-        var cookieString = oldCookies[i] + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/';
-        document.cookie = cookieString;
+    // clear old cookie set by our previous JS, set on the www domain
+    if (window.GOVUK.cookie('seen_cookie_message')) {
+      document.cookie = 'seen_cookie_message=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/';
+    }
+
+    if (consent === null) {
+      for (var i = 0; i < gaCookies.length; i++) {
+        if (window.GOVUK.cookie(gaCookies[i])) {
+          // GA cookies are set on the base domain so need the www stripping
+          var cookieString = gaCookies[i] + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/';
+          document.cookie = cookieString;
+        }
       }
     }
   };

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,8 +1,9 @@
 window.GOVUK.Frontend.initAll();
 
-window.GOVUK.Modules.CookieBanner.clearOldCookies();
+var consentData = window.GOVUK.getConsentCookie();
+window.GOVUK.Modules.CookieBanner.clearOldCookies(consentData);
 
-if (window.GOVUK.hasConsentFor('analytics')) {
+if (window.GOVUK.hasConsentFor('analytics', consentData)) {
   window.GOVUK.initAnalytics();
 }
 

--- a/tests/javascripts/cookieMessage.test.js
+++ b/tests/javascripts/cookieMessage.test.js
@@ -98,17 +98,43 @@ describe("Cookie message", () => {
     This works through CSS, based on the presence of the `js-enabled` class on the <body> so is not tested here.
   */
 
-  test("If the cookies set by the old banner still exist, they can be cleared with the `clearOldCookies` method", () => {
+  describe("The `clearOldCookies` method", () => {
 
-    helpers.setCookie('seen_cookie_message', 'true', { 'days': 365 });
-    helpers.setCookie('_ga', 'GA1.1.123.123', { 'days': 365 });
-    helpers.setCookie('_gid', 'GA1.1.456.456', { 'days': 1 });
+    test("Will clear the seen_cookie_message cookie if it still exists", () => {
 
-    window.GOVUK.Modules.CookieBanner.clearOldCookies();
+      // seen_cookie_message was set on the www domain, which setCookie defaults to
+      helpers.setCookie('seen_cookie_message', 'true', { 'days': 365 });
 
-    expect(window.GOVUK.cookie('seen_cookie_message')).toBeNull();
-    expect(window.GOVUK.cookie('_ga')).toBeNull();
-    expect(window.GOVUK.cookie('_gid')).toBeNull();
+      window.GOVUK.Modules.CookieBanner.clearOldCookies({ "analytics": false });
+
+      expect(window.GOVUK.cookie('seen_cookie_message')).toBeNull();
+
+    });
+
+    test("Will clear any existing Google Analytics cookies if consent is not set", () => {
+
+      // GA cookies are set on the root domain
+      helpers.setCookie('_ga', 'GA1.1.123.123', { 'days': 365, 'domain': '.notifications.service.gov.uk' });
+      helpers.setCookie('_gid', 'GA1.1.456.456', { 'days': 1, 'domain': '.notifications.service.gov.uk' });
+
+      window.GOVUK.Modules.CookieBanner.clearOldCookies(null);
+
+      expect(window.GOVUK.cookie('_ga')).toBeNull();
+      expect(window.GOVUK.cookie('_gid')).toBeNull();
+
+    });
+
+    test("Will leave any existing Google Analytics cookies if consent is set", () => {
+
+      helpers.setCookie('_ga', 'GA1.1.123.123', { 'days': 365 });
+      helpers.setCookie('_gid', 'GA1.1.456.456', { 'days': 1 });
+
+      window.GOVUK.Modules.CookieBanner.clearOldCookies({ "analytics": true });
+
+      expect(window.GOVUK.cookie('_ga')).not.toBeNull();
+      expect(window.GOVUK.cookie('_gid')).not.toBeNull();
+
+    });
 
   });
 

--- a/tests/javascripts/jest.config.js
+++ b/tests/javascripts/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  setupFiles: ['./support/setup.js']
+  setupFiles: ['./support/setup.js'],
+  testURL: 'https://www.notifications.service.gov.uk'
 }

--- a/tests/javascripts/support/helpers/cookies.js
+++ b/tests/javascripts/support/helpers/cookies.js
@@ -1,15 +1,18 @@
 // Helper for deleting a cookie
-function deleteCookie (cookieName) {
-
-  document.cookie = cookieName + '=; path=/; expires=' + (new Date());
-
+function deleteCookie (cookieName, options) {
+  if (typeof options === 'undefined') {
+    options = {};
+  }
+  if (!options.domain) { options.domain = window.location.hostname; }
+  document.cookie = cookieName + '=; path=/; domain=' + options.domain + '; expires=' + (new Date());
 };
 
 function setCookie (name, value, options) {
   if (typeof options === 'undefined') {
     options = {};
   }
-  var cookieString = name + '=' + value + '; path=/;domain=' + window.location.hostname;
+  if (!options.domain) { options.domain = window.location.hostname; }
+  var cookieString = name + '=' + value + '; path=/; domain=' + options.domain;
   if (options.days) {
     var date = new Date();
     date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));


### PR DESCRIPTION
The original pull request for the new cookies work included code to remove any cookies set by previous implementations. This removed cookies set by Google Analytics (GA), even if this was as a result of users choosing to accept analytics.

This changes that code so it only removes those cookies if consent for analytics (whether accepted or rejected) is not set. In other words, if there is no consent cookie, it assumes the GA cookies were set by the previous implementation.