### PR TITLE
Update Google Analytics tracker config

### DIFF
--- a/app/assets/javascripts/analytics/analytics.js
+++ b/app/assets/javascripts/analytics/analytics.js
@@ -6,10 +6,14 @@
   // Stripped-down wrapper for Google Analytics, based on:
   // https://github.com/alphagov/static/blob/master/doc/analytics.md
   const Analytics = function (config) {
-    window.ga('create', config.trackingId, config.cookieDomain, config.name, { 'cookieExpires': config.expires * 24 * 60 * 60 });
+    window.ga('create', {
+      'trackingId': config.trackingId,
+      'cookieDomain': config.cookieDomain,
+      'cookieExpires': config.expires * 24 * 60 * 60
+    });
 
     window.ga('set', 'anonymizeIp', config.anonymizeIp);
-    window.ga('set', 'displayFeaturesTask', config.displayFeaturesTask);
+    window.ga('set', 'allowAdFeatures', config.allowAdFeatures);
     window.ga('set', 'transport', config.transport);
 
   };

--- a/app/assets/javascripts/analytics/init.js
+++ b/app/assets/javascripts/analytics/init.js
@@ -24,9 +24,8 @@
         trackingId: trackingId,
         cookieDomain: 'auto',
         anonymizeIp: true,
-        displayFeaturesTask: null,
+        allowAdFeatures: false,
         transport: 'beacon',
-        name: 'GOVUK.analytics',
         expires: 365
       });
 

--- a/tests/javascripts/analytics/analytics.test.js
+++ b/tests/javascripts/analytics/analytics.test.js
@@ -29,9 +29,8 @@ describe("Analytics", () => {
       trackingId: 'UA-75215134-1',
       cookieDomain: 'auto',
       anonymizeIp: true,
-      displayFeaturesTask: null,
+      allowAdFeatures: false,
       transport: 'beacon',
-      name: 'GOVUK.analytics',
       expires: 365
     });
 
@@ -49,9 +48,9 @@ describe("Analytics", () => {
 
       setUpArguments = window.ga.mock.calls;
 
-      expect(setUpArguments[0]).toEqual(['create', 'UA-75215134-1', 'auto', 'GOVUK.analytics', { 'cookieExpires': 31536000 }]);
+      expect(setUpArguments[0]).toEqual(['create', { 'trackingId': 'UA-75215134-1', 'cookieDomain': 'auto', 'cookieExpires': 31536000 }]);
       expect(setUpArguments[1]).toEqual(['set', 'anonymizeIp', true]);
-      expect(setUpArguments[2]).toEqual(['set', 'displayFeaturesTask', null]);
+      expect(setUpArguments[2]).toEqual(['set', 'allowAdFeatures', false]);
       expect(setUpArguments[3]).toEqual(['set', 'transport', 'beacon']);
 
     });


### PR DESCRIPTION
The configuration used for our Google Analytics tracker was erroring when run in debug mode.

When using the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) here's the output before and after these changes:

## Before

<img width="720" alt="ga_debug_output_not_working" src="https://user-images.githubusercontent.com/87140/72893302-995cfa80-3d10-11ea-8ac9-449c178155ee.png">

## After

<img width="767" alt="ga_debug_output_working" src="https://user-images.githubusercontent.com/87140/72893310-9f52db80-3d10-11ea-94e7-99978a584381.png">
