### PR TITLE
Set cookie on document host by removing domain

### DIFF
--- a/app/assets/javascripts/cookieMessage.js
+++ b/app/assets/javascripts/cookieMessage.js
@@ -9,7 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // clear old cookie set by our previous JS, set on the www domain
     if (window.GOVUK.cookie('seen_cookie_message')) {
-      document.cookie = 'seen_cookie_message=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/';
+      document.cookie = 'seen_cookie_message=;expires=' + new Date() + ';path=/';
     }
 
     if (consent === null) {


### PR DESCRIPTION
Fixes an issue with the code that deletes the `seen_cookie_message` cookie.

I assumed that, when setting it be be expired, having the `domain` attribute as the hostname (ie. `www.notifications.service.gov.uk`) would match the original, which was set to that exact string.

In practice, on non-local environments, browsers prefixed it with a `.` which meant it didn't match and didn't overwrite the original. I assume this is to allow subdomains(?)

This removes the `domain` attribute from the cookie string which results in it being set against the domain without the `.` prefix.