### PR TITLE
handle invalid upload errors correctly

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -629,13 +629,15 @@ LETTER_VALIDATION_MESSAGES = {
 
 
 def get_letter_validation_error(validation_message, invalid_pages=None, page_count=None):
+    if not invalid_pages:
+        invalid_pages = []
     if validation_message not in LETTER_VALIDATION_MESSAGES:
         return {'title': 'Validation failed'}
 
     invalid_pages_are_or_is = 'is' if len(invalid_pages) == 1 else 'are'
 
     invalid_pages = unescaped_formatted_list(
-        invalid_pages or [],
+        invalid_pages,
         before_each='',
         after_each='',
         prefix='page',

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -458,7 +458,7 @@ def test_get_letter_validation_error_for_unknown_error():
     ),
     (
         'letter-too-long',
-        [2],
+        None,
         'Your letter is too long',
         (
             'Letters must be 10 pages or less. '
@@ -471,7 +471,7 @@ def test_get_letter_validation_error_for_unknown_error():
     ),
     (
         'unable-to-read-the-file',
-        [2],
+        None,
         'There’s a problem with your file',
         (
             'Notify cannot read this PDF.'


### PR DESCRIPTION
previously it assumed that invalid_pages would always exist, however it might be `None` if the error isn't on a specific page. Errors on specific pages include a page not being A4 or content being outside the boundary. Errors not on specific pages include the file not being a pdf, or containing too many pages

![image](https://user-images.githubusercontent.com/5020841/73186370-7fa82280-4117-11ea-9b88-b5b06945425f.png)
