### PR TITLE
Swap order of usage and team members in navigation when organisation users are looking at a service

### DIFF
--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -3,10 +3,10 @@
 {% else %}
 <nav class="navigation">
   <ul>
-  {% if current_user.has_permissions('view_activity') %}
-    <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}" {{ main_navigation.is_selected('dashboard') }}>Dashboard</a></li>
-  {% endif %}
   {% if current_user.has_permissions() %}
+    {% if current_user.has_permissions('view_activity') %}
+      <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}" {{ main_navigation.is_selected('dashboard') }}>Dashboard</a></li>
+    {% endif %}
     <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ main_navigation.is_selected('templates') }}>Templates</a></li>
     {% if current_user.has_permissions('view_activity') %}
       {% if current_service.can_upload_letters %}
@@ -18,16 +18,19 @@
         <li><a href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploads') }}>Uploads</a></li>
       {% endif %}
     {% endif %}
-  {% endif %}
     <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
-  {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
+    {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
+      <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
+    {% endif %}
+    {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
+      <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}" {{ main_navigation.is_selected('settings') }}>Settings</a></li>
+    {% endif %}
+    {% if current_user.has_permissions('manage_api_keys') %}
+      <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
+    {% endif %}
+  {% elif current_user.has_permissions(allow_org_user=True) %}
+    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
-  {% endif %}
-  {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-    <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}" {{ main_navigation.is_selected('settings') }}>Settings</a></li>
-  {% endif %}
-  {% if current_user.has_permissions('manage_api_keys') %}
-    <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -29,8 +29,8 @@
       <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
-    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
     <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
+    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -373,8 +373,8 @@ def test_service_navigation_for_org_user(
     assert [
         item.text.strip() for item in page.select('nav.navigation a')
     ] == [
-        'Team members',
         'Usage',
+        'Team members',
     ]
 
 

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -378,7 +378,28 @@ def test_service_navigation_for_org_user(
     ]
 
 
-def test_org_user_who_is_also_service_user_can_still_see_usage_page(
+@pytest.mark.parametrize('user_organisations, expected_menu_items, expected_status', [
+    (
+        [],
+        (
+            'Templates',
+            'Sent messages',
+            'Team members',
+        ),
+        403,
+    ),
+    (
+        [ORGANISATION_ID],
+        (
+            'Templates',
+            'Sent messages',
+            'Team members',
+            'Usage',
+        ),
+        200,
+    ),
+])
+def test_service_user_without_manage_service_permission_can_see_usage_page_when_org_user(
     client_request,
     mocker,
     active_caseworking_user,
@@ -390,9 +411,14 @@ def test_org_user_who_is_also_service_user_can_still_see_usage_page(
     mock_get_invites_for_service,
     mock_get_users_by_service,
     mock_get_service_organisation,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    user_organisations,
+    expected_status,
+    expected_menu_items,
 ):
     active_caseworking_user['services'] = [SERVICE_ONE_ID]
-    active_caseworking_user['organisations'] = [ORGANISATION_ID]
+    active_caseworking_user['organisations'] = user_organisations
     service = service_json(
         id_=SERVICE_ONE_ID,
         organisation_id=ORGANISATION_ID,
@@ -402,19 +428,19 @@ def test_org_user_who_is_also_service_user_can_still_see_usage_page(
         return_value={'data': service}
     )
     client_request.login(active_caseworking_user, service=service)
-
     page = client_request.get(
-        'main.usage',
+        'main.choose_template',
         service_id=SERVICE_ONE_ID,
     )
-    assert [
+    assert tuple(
         item.text.strip() for item in page.select('nav.navigation a')
-    ] == [
-        'Templates',
-        'Sent messages',
-        'Team members',
-        'Usage',
-    ]
+    ) == expected_menu_items
+
+    client_request.get(
+        'main.usage',
+        service_id=SERVICE_ONE_ID,
+        _expected_status=expected_status,
+    )
 
 
 def get_name_of_decorator_from_ast_node(node):

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -378,6 +378,45 @@ def test_service_navigation_for_org_user(
     ]
 
 
+def test_org_users_can_always_see_usage_page(
+    client_request,
+    mocker,
+    active_caseworking_user,
+    mock_has_no_jobs,
+    mock_get_usage,
+    mock_get_billable_units,
+    mock_get_free_sms_fragment_limit,
+    mock_get_service,
+    mock_get_invites_for_service,
+    mock_get_users_by_service,
+    mock_get_service_organisation,
+):
+    active_caseworking_user['services'] = [SERVICE_ONE_ID]
+    active_caseworking_user['organisations'] = [ORGANISATION_ID]
+    service = service_json(
+        id_=SERVICE_ONE_ID,
+        organisation_id=ORGANISATION_ID,
+    )
+    mocker.patch(
+        'app.service_api_client.get_service',
+        return_value={'data': service}
+    )
+    client_request.login(active_caseworking_user, service=service)
+
+    page = client_request.get(
+        'main.usage',
+        service_id=SERVICE_ONE_ID,
+    )
+    assert [
+        item.text.strip() for item in page.select('nav.navigation a')
+    ] == [
+        'Templates',
+        'Sent messages',
+        'Team members',
+        'Usage',
+    ]
+
+
 def get_name_of_decorator_from_ast_node(node):
     if isinstance(node, ast.Name):
         return str(node.id)

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -378,7 +378,7 @@ def test_service_navigation_for_org_user(
     ]
 
 
-def test_org_users_can_always_see_usage_page(
+def test_org_user_who_is_also_service_user_can_still_see_usage_page(
     client_request,
     mocker,
     active_caseworking_user,


### PR DESCRIPTION
▩ | Organisation | Service 
---|---|---
Before | ![image](https://user-images.githubusercontent.com/355079/73650694-a667db00-467a-11ea-8770-ca62c749a0e0.png) |  ![image](https://user-images.githubusercontent.com/355079/73650722-b54e8d80-467a-11ea-8ba5-19aecd42affa.png)
After | ![image](https://user-images.githubusercontent.com/355079/73650694-a667db00-467a-11ea-8770-ca62c749a0e0.png) | ![image](https://user-images.githubusercontent.com/355079/73650751-c9928a80-467a-11ea-8e11-d31c86904dc1.png)

Organisation users, when looking at the page for their org, see:
> Usage
> Team members

When they click into a service it switches to:
> Team members
> Usage

This is jarring. It should stay consistent. I think it that _Usage_ then _Team members_ is the natural way of ordering the navigation at the organisation level, so let’s follow that through to the service level.

This does mean that if someone is a member of both an organisation and a service that the nav will jump (because it’ll switch to the existing, service-level order of _Team members_ then _Usage_) but it’s going to jump anyway because you get all the extra navigation items when you’re a member of a service.