### PR TITLE
Ensure that the session is logged out server side, not just client side.

### DIFF
--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -1,5 +1,5 @@
-from flask import redirect, session, url_for
-from flask_login import current_user, logout_user
+from flask import redirect, url_for
+from flask_login import current_user
 
 from app.main import main
 
@@ -7,6 +7,4 @@ from app.main import main
 @main.route('/sign-out', methods=(['GET']))
 def sign_out():
     current_user.sign_out()
-    session.clear()
-    logout_user()
     return redirect(url_for('main.index'))

--- a/app/main/views/sign_out.py
+++ b/app/main/views/sign_out.py
@@ -1,11 +1,12 @@
 from flask import redirect, session, url_for
-from flask_login import logout_user
+from flask_login import current_user, logout_user
 
 from app.main import main
 
 
 @main.route('/sign-out', methods=(['GET']))
 def sign_out():
+    current_user.sign_out()
     session.clear()
     logout_user()
     return redirect(url_for('main.index'))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -127,8 +127,7 @@ class User(JSONModel, UserMixin):
         )
 
     def logged_in_elsewhere(self):
-        # if the current user (ie: db object) has no session, they've never logged in before
-        return self.current_session_id is not None and session.get('current_session_id') != self.current_session_id
+        return session.get('current_session_id') != self.current_session_id
 
     def activate(self):
         if self.state == 'pending':
@@ -153,6 +152,10 @@ class User(JSONModel, UserMixin):
             user_api_client.send_verify_code(self.id, 'sms', self.mobile_number)
 
         return True
+
+    def sign_out(self):
+        # Update the db so the server also knows the user is logged out.
+        return self.update(current_session_id=None)
 
     @property
     def sms_auth(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,5 +1,5 @@
 from flask import abort, current_app, request, session
-from flask_login import AnonymousUserMixin, UserMixin, login_user
+from flask_login import AnonymousUserMixin, UserMixin, login_user, logout_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 from werkzeug.utils import cached_property
@@ -155,6 +155,8 @@ class User(JSONModel, UserMixin):
 
     def sign_out(self):
         # Update the db so the server also knows the user is logged out.
+        session.clear()
+        logout_user()
         return self.update(current_session_id=None)
 
     @property

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -10,7 +10,8 @@ ALLOWED_ATTRIBUTES = {
     'email_address',
     'mobile_number',
     'auth_type',
-    'updated_by'
+    'updated_by',
+    'current_session_id'
 }
 
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -61,6 +61,7 @@ def test_doesnt_redirect_to_sign_in_if_no_session_info(
 
 @pytest.mark.parametrize('db_sess_id, cookie_sess_id', [
     (None, None),
+    (None, uuid.UUID(int=1)),  # BAD - cookie doesn't match db
     (uuid.UUID(int=1), None),  # BAD - has used other browsers before but this is a brand new browser with no cookie
     (uuid.UUID(int=1), uuid.UUID(int=2)),  # BAD - this person has just signed in on a different browser
 ])

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -60,8 +60,7 @@ def test_doesnt_redirect_to_sign_in_if_no_session_info(
 
 
 @pytest.mark.parametrize('db_sess_id, cookie_sess_id', [
-    pytest.param(None, None, marks=pytest.mark.xfail),  # OK - not used notify since browser signout was implemented
-
+    (None, None),
     (uuid.UUID(int=1), None),  # BAD - has used other browsers before but this is a brand new browser with no cookie
     (uuid.UUID(int=1), uuid.UUID(int=2)),  # BAD - this person has just signed in on a different browser
 ])

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -4,9 +4,9 @@ from tests.conftest import SERVICE_ONE_ID
 
 
 def test_render_sign_out_redirects_to_sign_in(
-    client
+    logged_in_client
 ):
-    response = client.get(
+    response = logged_in_client.get(
         url_for('main.sign_out'))
     assert response.status_code == 302
     assert response.location == url_for(


### PR DESCRIPTION
Anytime a user clicks "sign out" we should be signing them out server side as well. This can be accomplished by setting the Users.current_session_id = null.
I found that the method User.logged_in_elsewhere doesn't need to check if the current_session_id is None. The current_session_ids in the cookie and db (redis or postgres) then the user should be forced to log in again.