### PR TITLE
cleanup

### DIFF
--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -189,7 +189,7 @@
 
   <h2 class="heading-large">API key</h2>
 
-  {{ api_key('d30512af92e1386d63b90e5973b49a10') }}
+  {{ api_key('00000000-0000-0000-0000-000000000000') }}
 
 
   <h2 class="heading-large">Formatted list</h2>

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -13,9 +13,9 @@ pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8
 pyexcel-ods3==0.5.3
 pytz==2019.3
-gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
+gunicorn==20.0.4
 eventlet==0.25.1
-notifications-python-client==5.5.0
+notifications-python-client==5.5.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8
 pyexcel-ods3==0.5.3
 pytz==2019.3
-gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
+gunicorn==20.0.4
 eventlet==0.25.1
-notifications-python-client==5.5.0
+notifications-python-client==5.5.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
@@ -46,10 +46,10 @@ future==0.18.2
 greenlet==0.4.15
 idna==2.8
 jdcal==1.4.1
-Jinja2==2.11.0
+Jinja2==2.11.1
 jmespath==0.9.4
 lml==0.0.9
-lxml==4.4.2
+lxml==4.5.0
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
@@ -63,7 +63,7 @@ PyPDF2==1.26.0
 python-dateutil==2.8.1
 python-json-logger==0.1.11
 PyYAML==5.2
-redis==3.3.11
+redis==3.4.1
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.3.2

--- a/tests/javascripts/apiKey.test.js
+++ b/tests/javascripts/apiKey.test.js
@@ -17,7 +17,7 @@ describe('API key', () => {
 
   beforeEach(() => {
 
-    apiKey = 'admin-service-6658542f-0cad-491f-bec8-ab8457700ead-53c0c274-8e83-48f1-8448-598657bb39af';
+    apiKey = '00000000-0000-0000-0000-000000000000';
     thing = 'API key';
 
     // mock sticky JS


### PR DESCRIPTION
make things that aren't api keys not look like actual keys. Our pentester thought they might have been live keys.

also bump gunicorn (sec vuln) and python client