### PR TITLE
Reorder the methods called in sign out

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -154,10 +154,10 @@ class User(JSONModel, UserMixin):
         return True
 
     def sign_out(self):
-        # Update the db so the server also knows the user is logged out.
         session.clear()
+        # Update the db so the server also knows the user is logged out.
+        self.update(current_session_id=None)
         logout_user()
-        return self.update(current_session_id=None)
 
     @property
     def sms_auth(self):


### PR DESCRIPTION
We found another scenario where signing out of the db can cause a 500.
If the user archives their trial mode service, current_service.active = false, then signs out, the current user was being signed out client side first, meaning current_user is now an Anonymous user, next the call to the API is made to log out user on db, all calls to NotifyApiClient `check_inactive_service`, which is only authorised if user is platform_admin, but an AnonymousUser does not have that attribute, so a 500 is raise.
Seemed a bit cleaner to change the User.signout method to rather than the `check_inactive_service` method for current_user.is_authenticated.

Recreate bug on master: sign in, archive a trial mode service, sign out -> 500