### PR TITLE
Delete template dialog

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -279,7 +279,6 @@ def aggregate_notifications_stats(template_statistics):
 def get_dashboard_partials(service_id):
     all_statistics = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     template_statistics = aggregate_template_usage(all_statistics)
-
     stats = aggregate_notifications_stats(all_statistics)
     column_width, max_notifiction_count = get_column_properties(3)
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -672,11 +672,11 @@ def delete_service_template(service_id, template_id):
         ))
 
     try:
-        last_used_notification = template_statistics_client.get_template_statistics_for_template(
+        last_used_notification = template_statistics_client.get_last_used_date_for_template(
             service_id, template['id']
         )
         message = 'This template has never been used.' if not last_used_notification else \
-            'This template was last used {}.'.format(format_delta(last_used_notification['created_at']))
+            'This template was last used {}.'.format(format_delta(last_used_notification))
 
     except HTTPError as e:
         if e.status_code == 404:

--- a/app/notify_client/template_statistics_api_client.py
+++ b/app/notify_client/template_statistics_api_client.py
@@ -19,11 +19,10 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
             url='/service/{}/notifications/templates_usage/monthly?year={}'.format(service_id, year)
         )['stats']
 
-    def get_template_statistics_for_template(self, service_id, template_id):
-
+    def get_last_used_date_for_template(self, service_id, template_id):
         return self.get(
-            url='/service/{}/template-statistics/{}'.format(service_id, template_id)
-        )['data']
+            url='/service/{}/template-statistics/last-used/{}'.format(service_id, template_id)
+        )['last_date_used']
 
 
 template_statistics_client = TemplateStatisticsApiClient()

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from functools import partial
 from unittest.mock import ANY, Mock
 
@@ -7,7 +6,6 @@ from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 
-from app.main.views.templates import get_human_readable_delta
 from tests import (
     sample_uuid,
     single_notification_json,
@@ -1730,7 +1728,7 @@ def test_should_show_delete_template_page_with_time_block_for_empty_notification
         )
     assert "Are you sure you want to delete ‘Two week reminder’?" in page.select('.banner-dangerous')[0].text
     assert normalize_spaces(page.select('.banner-dangerous p')[0].text) == (
-        'This template was last used more than seven days ago.'
+        'This template has never been used.'
     )
     assert normalize_spaces(page.select('.sms-message-wrapper')[0].text) == (
         'service one: Template <em>content</em> with & entity'
@@ -1918,21 +1916,6 @@ def test_route_invalid_permissions(
         ['view_activity'],
         api_user_active,
         service_one)
-
-
-@pytest.mark.parametrize('from_time, until_time, message', [
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 1, 12, 0, 59), 'under a minute'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 1, 12, 1), '1 minute'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 1, 12, 2, 35), '2 minutes'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 1, 12, 59), '59 minutes'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 1, 13, 0), '1 hour'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 1, 14, 0), '2 hours'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 2, 11, 59), '23 hours'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 2, 12, 0), '1 day'),
-    (datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 3, 14, 0), '2 days'),
-])
-def test_get_human_readable_delta(from_time, until_time, message):
-    assert get_human_readable_delta(from_time, until_time) == message
 
 
 def test_can_create_email_template_with_emoji(

--- a/tests/app/notify_client/test_template_statistics_client.py
+++ b/tests/app/notify_client/test_template_statistics_client.py
@@ -22,11 +22,11 @@ def test_template_statistics_client_calls_correct_api_endpoint_for_service(mocke
 def test_template_statistics_client_calls_correct_api_endpoint_for_template(mocker, api_user_active):
     some_service_id = uuid.uuid4()
     some_template_id = uuid.uuid4()
-    expected_url = '/service/{}/template-statistics/{}'.format(some_service_id, some_template_id)
+    expected_url = '/service/{}/template-statistics/last-used/{}'.format(some_service_id, some_template_id)
 
     client = TemplateStatisticsApiClient()
     mock_get = mocker.patch('app.notify_client.template_statistics_api_client.TemplateStatisticsApiClient.get')
 
-    client.get_template_statistics_for_template(some_service_id, some_template_id)
+    client.get_last_used_date_for_template(some_service_id, some_template_id)
 
     mock_get.assert_called_once_with(url=expected_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ from . import (
     organisation_json,
     sample_uuid,
     service_json,
-    single_notification_json,
     template_json,
     template_version_json,
     user_json,
@@ -2220,17 +2219,6 @@ def mock_get_monthly_notification_stats(mocker, service_one, fake_uuid):
         'app.service_api_client.get_monthly_notification_stats',
         side_effect=_stats
     )
-
-
-@pytest.fixture(scope='function')
-def mock_get_template_statistics_for_template(mocker, service_one):
-    def _get_stats(service_id, template_id):
-        template = template_json(service_id, template_id, "Test template", "sms", "Something very interesting")
-        notification = single_notification_json(service_id, template=template)
-        return notification
-
-    return mocker.patch(
-        'app.template_statistics_client.get_template_statistics_for_template', side_effect=_get_stats)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Change the content for the delete template confirmation dialog. …
ca930e6
As per https://www.pivotaltracker.com/story/show/170796514 we want to make the delete template confirmation dialog box more consistent and clear.
The API has been updated with a new endpoint that only returns the last-used date, this date is more accurate since it goes to the ft_notification_status table, if the notification table is empty.

- [x] depends on https://github.com/alphagov/notifications-api/pull/2708