### PR TITLE
Make pill items match their heights

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -25,7 +25,9 @@
 
   a,
   &-selected-item {
-    display: block;
+    display: flex; // float causes display: block in browsers without flexbox
+    flex-direction: column;
+    justify-content: center;
     float: left;
     box-sizing: border-box;
     width: 100%;

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -14,6 +14,13 @@
       See: https://www.w3.org/TR/css-flexbox-1/#flex-containers
     */
     float: left;
+    /*
+      Setting this as a flex container means the contents (1 item)
+      will fill the vertical space due to `align-items` defaulting
+      to `stretch`.
+      See: https://css-tricks.com/snippets/css/a-guide-to-flexbox/#prop-align-items
+    */
+    display: flex;
   }
 
   a,


### PR DESCRIPTION
Makes items in the pill nav all the same height by exploiting some flexbox rules.

Flex items fill their vertical space by default, assuming the flex-direction is 'row', due to the container's [align-items](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#prop-align-items) property defaulting to `stretch`.

The only reason this doesn't fix the height for the pill nav is that the `<li>`s which now become flex items are just wrappers for the pill items. By making each `<li>` a flex container itself, the pill items in them become flex items too, and again fill their container's height.

The label text for each pill is vertically centered by turning each pill item into (another) flex container, this time with a flex-direction of `column`. Centering the alignment of their flex item (the label text), by setting `justify-content: center` means it sits in the middle of the item.

This won't effect the styles already in place setting the styling for browsers that don't support flexbox.

Checked (and works) in:
- latest Firefox and Chrome
- non-chromium Edge (18)
- IE11
- Safari on Mac

## Examples

This is only really visible on smaller screens so my examples are in mobile viewports.

### Before
![pill_nav_before](https://user-images.githubusercontent.com/87140/73960319-92360f00-4902-11ea-82aa-05d9749265d6.png)

### After
![pill_on_mobile_after](https://user-images.githubusercontent.com/87140/74052331-91b87980-49d1-11ea-8cf2-da21bde77b3a.png)
