### PR TITLE
Cache returned letter summary in Redis

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -360,6 +360,9 @@ def platform_admin_returned_letters():
 
         try:
             letter_jobs_client.submit_returned_letters(references)
+            redis_client.delete_cache_keys_by_pattern(
+                'service-????????-????-????-????-????????????-returned-letters-summary'
+            )
         except HTTPError as error:
             if error.status_code == 400:
                 error_references = [

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -569,6 +569,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def get_service_data_retention(self, service_id):
         return self.get("/service/{}/data-retention".format(service_id))
 
+    @cache.set('service-{service_id}-returned-letters-summary')
     def get_returned_letter_summary(self, service_id):
         return self.get("service/{}/returned-letter-summary".format(service_id))
 

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -680,6 +680,7 @@ def test_platform_admin_displays_stats_in_right_boxes_and_with_correct_styling(
 
 def test_platform_admin_submit_returned_letters(mocker, platform_admin_client):
 
+    redis = mocker.patch('app.main.views.platform_admin.redis_client')
     mock_client = mocker.patch('app.letter_jobs_client.submit_returned_letters')
 
     response = platform_admin_client.post(
@@ -688,7 +689,9 @@ def test_platform_admin_submit_returned_letters(mocker, platform_admin_client):
     )
 
     mock_client.assert_called_once_with(['REF1', 'REF2'])
-
+    redis.delete_cache_keys_by_pattern.assert_called_once_with(
+        'service-????????-????-????-????-????????????-returned-letters-summary'
+    )
     assert response.status_code == 302
     assert response.location == url_for('main.platform_admin_returned_letters', _external=True)
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -316,6 +316,25 @@ def test_client_returns_count_of_service_templates(
             ],
             {'data_from': 'api'},
         ),
+        (
+            service_api_client.get_returned_letter_summary,
+            [SERVICE_ONE_ID],
+            [
+                call('service-{}-returned-letters-summary'.format(SERVICE_ONE_ID))
+            ],
+            None,
+            [
+                call('service/{}/returned-letter-summary'.format(SERVICE_ONE_ID))
+            ],
+            [
+                call(
+                    'service-{}-returned-letters-summary'.format(SERVICE_ONE_ID),
+                    '{"data_from": "api"}',
+                    ex=604800,
+                )
+            ],
+            {'data_from': 'api'},
+        ),
     ]
 )
 def test_returns_value_from_cache(


### PR DESCRIPTION
We’re going to start using the returned letters summary to show some info on the dashboard.

This means we will be accessing it more often than it changes. And we know exactly when it changes because it’s us manually submitting the references we get from DVLA.

This makes it a good candidate for being cached, and Redis is where we cache stuff that we’d otherwise go to the API for.