### PR TITLE
Update Delivery status page introduction

### DIFF
--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -9,9 +9,10 @@
 
   <h1 class="heading-large">Delivery status</h1>
 
-  <p>Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered. This page describes the statuses you’ll see when you’re signed in to Notify.</p>
+  <p>Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered.</p>
   <p>For <a href="{{ url_for("main.security") }}">security</a>, this information is only available for 7 days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
-  <p>If you're using the Notify API, read our <a href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p>
+  <p>This page describes the statuses you’ll see when you’re signed in to Notify.</p>
+  <p>If you’re using the Notify API, read our <a href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p>
 
   <h2 id="email-statuses" class="heading-medium">Emails</h2>
   <div class="bottom-gutter-3-2">


### PR DESCRIPTION
This PR updates introductory content on the Delivery status page to:

* make the information easier to understand
* fix smart quotes

# Before
![Screenshot 2020-02-12 at 12 36 54](https://user-images.githubusercontent.com/28294225/74335573-6ac4c380-4d94-11ea-87b4-e57d35d0e16a.png)

# After
![Screenshot 2020-02-12 at 12 33 39](https://user-images.githubusercontent.com/28294225/74335391-073a9600-4d94-11ea-8d24-f6bae9289deb.png)
