### PR TITLE
Restyle template statistics and received text messages

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -142,3 +142,47 @@
   }
 
 }
+
+.banner-dashboard {
+
+  $baseline-shift: -5px;
+
+  display: block;
+  position: relative;
+  padding: $gutter-two-thirds 0;
+  border-top: 1px solid $border-colour;
+  border-bottom: 1px solid $border-colour;
+  margin-bottom: $gutter;
+  text-decoration: none;
+
+  &:focus {
+    border-color: $focus-colour;
+    box-shadow: 0 3px 0 0 $focus-colour, 0 -3px 0 0 $focus-colour;
+    color: $text-colour;
+  }
+
+  &-count {
+    @include bold-36;
+    padding-right: 5px;
+  }
+
+  &-count-label {
+    @include bold-24;
+    text-decoration: underline;
+    position: relative;
+    top: $baseline-shift;
+  }
+
+  &-meta {
+    @include core-19;
+    position: absolute;
+    right: 0;
+    bottom: $gutter-two-thirds - $baseline-shift;
+    text-align: right;
+  }
+
+  & + .banner-dashboard {
+    margin-top: -$gutter;
+    border-top: none;
+  }
+}

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -151,7 +151,7 @@
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  padding: ($gutter-two-thirds - 1px) 0 ($gutter-two-thirds + 1px) 0;
+  padding: ($gutter-half - 1px) 0 ($gutter-half + 1px) 0;
   border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
   margin-bottom: $gutter;
@@ -181,6 +181,7 @@
     @include govuk-font(24, $weight: bold);
     text-decoration: underline;
     padding-right: govuk-spacing(6);
+    margin: 10px 0px 5px; // 10px includes 5px extra to counter the -5px margin-top on the count item
     flex: 2 1 auto;
   }
 

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -158,7 +158,8 @@
   text-decoration: none;
 
   &:focus {
-    border: none;
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid transparent;    
   }
 
   &-count,

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -168,7 +168,7 @@
 
   &-count {
     @include govuk-font(36, $weight: bold);
-    padding-right: 5px;
+    padding-right: 8px;
     position: relative;
     // remove the top of the extra line-height this introduces
     top: $baseline-shift;

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -145,10 +145,12 @@
 
 .banner-dashboard {
 
-  $baseline-shift: -5px;
+  $baseline-shift: 5px;
 
-  display: block;
-  position: relative;
+  display: block; // for browsers that don't support flexbox
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
   padding: $gutter-two-thirds 0;
   border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
@@ -156,29 +158,36 @@
   text-decoration: none;
 
   &:focus {
-    border-color: $focus-colour;
-    box-shadow: 0 3px 0 0 $focus-colour, 0 -3px 0 0 $focus-colour;
-    color: $text-colour;
+    border: none;
+  }
+
+  &-count,
+  &-meta {
+    float: left; // for browsers that don't support flexbox
   }
 
   &-count {
-    @include bold-36;
+    @include govuk-font(36, $weight: bold);
     padding-right: 5px;
+    position: relative;
+    // remove the top of the extra line-height this introduces
+    top: $baseline-shift;
+    margin-top: -$baseline-shift;
+    flex: 0 1 0.85ch;
   }
 
   &-count-label {
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
     text-decoration: underline;
-    position: relative;
-    top: $baseline-shift;
+    padding-right: govuk-spacing(6);
+    flex: 2 1 auto;
   }
 
   &-meta {
-    @include core-19;
-    position: absolute;
-    right: 0;
-    bottom: $gutter-two-thirds - $baseline-shift;
+    @include govuk-font(19);
+    float: right;
     text-align: right;
+    flex: initial;
   }
 
   & + .banner-dashboard {

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -151,7 +151,7 @@
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  padding: $gutter-two-thirds 0;
+  padding: ($gutter-two-thirds - 1px) 0 ($gutter-two-thirds + 1px) 0;
   border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
   margin-bottom: $gutter;

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -38,3 +38,9 @@
   @extend %show-more;
   margin-top: -10px;
 }
+
+.show-more-no-border {
+  @extend %show-more;
+  border-top: 1px solid transparent;
+  margin-top: -5px;
+}

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -4,7 +4,7 @@
   @include core-16;
   display: block;
   padding: 0 0;
-  margin: $gutter-half 0 $gutter 0;
+  margin: $gutter-half 0 $gutter-half 0;
   text-align: center;
   border-top: 1px solid $border-colour;
 

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -34,11 +34,6 @@
 
 }
 
-.show-more-empty {
-  @extend %show-more;
-  margin-top: -10px;
-}
-
 .show-more-no-border {
   @extend %show-more;
   border-top: 1px solid transparent;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -51,6 +51,65 @@
 
 }
 
+.template-statistics-table {
+
+  .table {
+    table-layout: fixed;
+  }
+
+  .table-field-heading {
+    font-size: 0;
+  }
+
+  .table-field-heading-first {
+    width: 52.5%;
+  }
+
+  .table-row {
+    th {
+      display: table-cell;
+      width: 52.5%;
+      font-weight: normal;
+
+      .hint,
+      p {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+
+  &-template-name {
+
+    @include bold-24;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 10px 0 32px 0;
+    margin: -10px 0 -32px 0;
+
+    &:focus {
+
+      color: $text-colour;
+
+      & + .template-statistics-table-hint {
+        color: $text-colour;
+      }
+
+    }
+
+  }
+
+  &-hint {
+    @include core-19;
+    color: $secondary-text-colour;
+    pointer-events: none;
+  }
+
+}
+
 .settings-table {
 
   table {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -57,8 +57,9 @@
     table-layout: fixed;
   }
 
-  .table-field-heading {
-    font-size: 0;
+  .table-heading {
+    @include core-19;
+    margin: 0 0 10px 0;
   }
 
   .table-field-heading-first {

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -1,15 +1,7 @@
 .dashboard {
 
-  table {
-    th {
-      @include core-19;
-      border-bottom: 0;
-    }
-
-    td {
-      @include core-19;
-      border: 0;
-    }
+  th {
+    font-weight: normal;
   }
 
   > .heading-medium:first-of-type {
@@ -34,15 +26,17 @@
   color: $text-colour;
   text-align: left;
 
-  span {
+  &-bar {
+    @include bold-27;
     box-sizing: border-box;
     display: inline-block;
     overflow: visible;
     background: $panel-colour;
     color: $black;
-    padding: 5px 5px 2px 5px;
-    text-indent: -2px;
-    margin: 3px 0 5px 0;
+    padding: 10px 6px 8px 0;
+    text-indent: 12px;
+    text-align: right;
+    margin: 2px 0 1px 0;
     transition: width 0.6s ease-in-out;
   }
 
@@ -82,19 +76,6 @@
 .failure-highlight {
   @include bold-19;
   color: $error-colour;
-}
-
-.template-usage-table {
-
-  border-top: 1px solid $border-colour;
-  border-bottom: 1px solid $border-colour;
-  margin-top: 10px;
-  margin-bottom: $gutter * 1.3333;
-
-  .table {
-    margin-bottom: 5px;
-  }
-
 }
 
 .align-with-message-body {

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -280,15 +280,8 @@ def get_dashboard_partials(service_id):
     all_statistics = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     template_statistics = aggregate_template_usage(all_statistics)
     stats = aggregate_notifications_stats(all_statistics)
-    column_width, max_notifiction_count = get_column_properties(3)
 
     dashboard_totals = get_dashboard_totals(stats),
-    highest_notification_count = max(
-        sum(
-            value[key] for key in {'requested', 'failed', 'delivered'}
-        )
-        for key, value in dashboard_totals[0].items()
-    )
     free_sms_allowance = billing_api_client.get_free_sms_fragment_limit_for_year(
         current_service.id,
         get_current_financial_year(),
@@ -312,10 +305,6 @@ def get_dashboard_partials(service_id):
             'views/dashboard/_totals.html',
             service_id=service_id,
             statistics=dashboard_totals[0],
-            column_width=column_width,
-            smaller_font_size=(
-                highest_notification_count > max_notifiction_count
-            ),
         ),
         'template-statistics': render_template(
             'views/dashboard/template-statistics.html',
@@ -330,7 +319,6 @@ def get_dashboard_partials(service_id):
         ),
         'usage': render_template(
             'views/dashboard/_usage.html',
-            column_width=column_width,
             **calculate_usage(yearly_usage, free_sms_allowance),
         ),
     }
@@ -505,10 +493,3 @@ def get_tuples_of_financial_years(
         )
         for year in range(start, end + 1)
     )
-
-
-def get_column_properties(number_of_columns):
-    return {
-        2: ('column-half', 999999999),
-        3: ('column-third', 99999),
-    }.get(number_of_columns)

--- a/app/templates/components/show-more.html
+++ b/app/templates/components/show-more.html
@@ -1,10 +1,6 @@
-{% macro show_more(url=None, label=None, with_border=True) %}
-  {% if url and label %}
-    <a
-      href="{{ url }}"
-      class="show-more{% if not with_border %}-no-border{% endif %}"
-    ><span>{{ label }}</span></a>
-  {% else %}
-    <span class="show-more-empty"></span>
-  {% endif %}
+{% macro show_more(url, label, with_border=True) %}
+  <a
+    href="{{ url }}"
+    class="show-more{% if not with_border %}-no-border{% endif %}"
+  ><span>{{ label }}</span></a>
 {% endmacro %}

--- a/app/templates/components/show-more.html
+++ b/app/templates/components/show-more.html
@@ -1,6 +1,9 @@
-{% macro show_more(url=None, label=None) %}
+{% macro show_more(url=None, label=None, with_border=True) %}
   {% if url and label %}
-    <a href="{{ url }}" class="show-more"><span>{{ label }}</span></a>
+    <a
+      href="{{ url }}"
+      class="show-more{% if not with_border %}-no-border{% endif %}"
+    ><span>{{ label }}</span></a>
   {% else %}
     <span class="show-more-empty"></span>
   {% endif %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -188,11 +188,8 @@
 ) %}
   {% call field(align='right') %}
     <span {% if id %}id="{{ id }}"{% endif %} class="spark-bar">
-      <span style="width: {{ count / max_count * 100 }}%">
-        {{ big_number(
-          count,
-          smallest=True
-        ) }}
+      <span class="spark-bar-bar" style="width: {{ count / max_count * 100 }}%">
+        {{ '{:,.0f}'.format(count) }}
       </span>
     </span>
   {% endcall %}

--- a/app/templates/views/dashboard/_inbox.html
+++ b/app/templates/views/dashboard/_inbox.html
@@ -3,7 +3,7 @@
 
 <div class="ajax-block">
   {% if inbound_sms_summary != None %}
-    <a id="total-received" class="banner-dashboard" href="{{ url_for('.inbox', service_id=current_service.id) }}">
+    <a id="total-received" class="govuk-link govuk-link--no-visited-state banner-dashboard" href="{{ url_for('.inbox', service_id=current_service.id) }}">
       <span class="banner-dashboard-count">
         {{ inbound_sms_summary.count|format_thousands }}
       </span>

--- a/app/templates/views/dashboard/_inbox.html
+++ b/app/templates/views/dashboard/_inbox.html
@@ -2,20 +2,18 @@
 
 <div class="ajax-block">
   {% if inbound_sms_summary != None %}
-    <div id="total-received" class="big-number-meta-wrapper">
-      {{
-        big_number_with_status(
-          inbound_sms_summary.count,
-          'text messages received',
-          link=url_for('.inbox', service_id=current_service.id),
-          show_failures=False
-        )
-      }}
-      <div class="big-number-meta">
-        {% if inbound_sms_summary.most_recent %}
+    <a id="total-received" class="banner-dashboard" href="{{ url_for('.inbox', service_id=current_service.id) }}">
+      <span class="banner-dashboard-count">
+        {{ inbound_sms_summary.count|format_thousands }}
+      </span>
+      <span class="banner-dashboard-count-label">
+        text messages received
+      </span>
+      {% if inbound_sms_summary.most_recent %}
+        <span class="banner-dashboard-meta">
           latest message {{ inbound_sms_summary.most_recent | format_delta }}
-        {% endif %}
-      </div>
-    </div>
+        </span>
+      {% endif %}
+    </a>
   {% endif %}
 </div>

--- a/app/templates/views/dashboard/_inbox.html
+++ b/app/templates/views/dashboard/_inbox.html
@@ -1,4 +1,5 @@
 {% from "components/big-number.html" import big_number, big_number_with_status %}
+{% from "components/message-count-label.html" import message_count_label %}
 
 <div class="ajax-block">
   {% if inbound_sms_summary != None %}
@@ -7,7 +8,7 @@
         {{ inbound_sms_summary.count|format_thousands }}
       </span>
       <span class="banner-dashboard-count-label">
-        text messages received
+        {{ message_count_label(inbound_sms_summary.count, 'sms', suffix='received') }}
       </span>
       {% if inbound_sms_summary.most_recent %}
         <span class="banner-dashboard-meta">

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -3,7 +3,7 @@
 
 <div class="ajax-block-container">
   <div class="grid-row">
-    <div id="total-email" class="{{column_width}}">
+    <div id="total-email" class="column-third">
       {{ big_number_with_status(
         statistics['email']['requested'],
         message_count_label(statistics['email']['requested'], 'email', suffix='sent'),
@@ -12,10 +12,10 @@
         statistics['email']['show_warning'],
         failure_link=url_for(".view_notifications", service_id=service_id, message_type='email', status='failed'),
         link=url_for(".view_notifications", service_id=service_id, message_type='email', status='sending,delivered,failed'),
-        smaller=smaller_font_size
+        smaller=True,
       ) }}
     </div>
-    <div id="total-sms" class="{{column_width}}">
+    <div id="total-sms" class="column-third">
       {{ big_number_with_status(
         statistics['sms']['requested'],
         message_count_label(statistics['sms']['requested'], 'sms', suffix='sent'),
@@ -24,10 +24,10 @@
         statistics['sms']['show_warning'],
         failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
         link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed'),
-        smaller=smaller_font_size
+        smaller=True,
       ) }}
     </div>
-    <div id="total-letters" class="{{column_width}}">
+    <div id="total-letters" class="column-third">
       {{ big_number_with_status(
         statistics['letter']['requested'],
         message_count_label(statistics['letter']['requested'], 'letter', suffix='sent'),
@@ -36,7 +36,7 @@
         statistics['letter']['show_warning'],
         failure_link=url_for(".view_notifications", service_id=service_id, message_type='letter', status='failed'),
         link=url_for(".view_notifications", service_id=service_id, message_type='letter', status=''),
-        smaller=smaller_font_size
+        smaller=True,
       ) }}
     </div>
   </div>

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -36,7 +36,6 @@
           ) }}
         {% endcall %}
       {% endcall %}
-      {{ show_more() }}
     </div>
   {% endif %}
 </div>

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,12 +1,12 @@
 {% from "components/big-number.html" import big_number %}
 
 <div class='grid-row ajax-block-container'>
-  <div class='{{ column_width }}'>
+  <div class='column-third'>
     <div class="keyline-block">
       {{ big_number("Unlimited", 'free email allowance', smaller=True) }}
     </div>
   </div>
-  <div class='{{ column_width }}'>
+  <div class='column-third'>
     <div class="keyline-block">
       {% if sms_chargeable %}
         {{ big_number(
@@ -20,7 +20,7 @@
       {% endif %}
     </div>
   </div>
-  <div class='{{ column_width }}'>
+  <div class='column-third'>
     <div class="keyline-block">
       {{ big_number(
         letter_cost,

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -28,7 +28,7 @@
           No messages sent
         </p>
       {% else %}
-        <div class='dashboard-table template-usage-table'>
+        <div class='template-statistics-table'>
           {% call(item, row_number) list_table(
             month.templates_used,
             caption=month.name,
@@ -41,8 +41,8 @@
             field_headings_visible=False
           ) %}
             {% call row_heading() %}
-              <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
-              <span class="file-list-hint">
+              <a class="template-statistics-table-template-name" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
+              <span class="template-statistics-table-hint">
                 {{ message_count_label(1, item.type, suffix='template')|capitalize }}
               </span>
             {% endcall %}

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -6,7 +6,7 @@
 
 <div class="ajax-block-container">
   {% if template_statistics|length > 1 %}
-    <div class='dashboard-table'>
+    <div class='template-statistics-table'>
       {% call(item, row_number) list_table(
         template_statistics,
         caption="Templates used",
@@ -21,24 +21,26 @@
 
         {% call row_heading() %}
           {% if item.is_precompiled_letter %}
-          <span class="file-list-filename">
+          <span class="template-statistics-table-template-name">
           Provided as PDF
           </span>
-          <span class="file-list-hint">
+          <span class="template-statistics-table-hint">
             Letter
           </span>
           {% else %}
-          <a class="file-list-filename" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
-          <span class="file-list-hint">
+          <a class="template-statistics-table-template-name" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
+          <span class="template-statistics-table-hint">
             {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
           </span>
           {% endif %}
         {% endcall %}
+
         {{ spark_bar_field(item.count, most_used_template_count, id=item.template_id) }}
       {% endcall %}
       {{ show_more(
         url_for('.template_usage', service_id=current_service.id),
-        'See templates used by month'
+        'See templates used by month',
+        with_border=False
       ) }}
     </div>
   {% endif %}

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -9,14 +9,14 @@
     <div class='template-statistics-table'>
       {% call(item, row_number) list_table(
         template_statistics,
-        caption="Templates used",
-        caption_visible=False,
+        caption="By template",
+        caption_visible=True,
         empty_message='',
         field_headings=[
           'Template',
           'Messages sent'
         ],
-        field_headings_visible=True
+        field_headings_visible=False
       ) %}
 
         {% call row_heading() %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -222,11 +222,11 @@ def test_inbound_messages_shows_count_of_messages_when_there_are_messages(
         'main.service_dashboard',
         service_id=SERVICE_ONE_ID,
     )
-
+    banner = page.select_one('a.banner-dashboard')
     assert normalize_spaces(
-        page.select('.big-number-meta-wrapper')[0].text
-    ) == '99 text messages received latest message just now'
-    assert page.select('.big-number-meta-wrapper a')[0]['href'] == url_for(
+        banner.text
+    ) == '9,999 text messages received latest message just now'
+    assert banner['href'] == url_for(
         'main.inbox', service_id=SERVICE_ONE_ID
     )
 
@@ -248,9 +248,9 @@ def test_inbound_messages_shows_count_of_messages_when_there_are_no_messages(
         'main.service_dashboard',
         service_id=SERVICE_ONE_ID,
     )
-
-    assert normalize_spaces(page.select('.big-number-meta-wrapper')[0].text) == '0 text messages received'
-    assert page.select('.big-number-meta-wrapper a')[0]['href'] == url_for(
+    banner = page.select_one('a.banner-dashboard')
+    assert normalize_spaces(banner.text) == '0 text messages received'
+    assert banner['href'] == url_for(
         'main.inbox', service_id=SERVICE_ONE_ID
     )
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -553,7 +553,7 @@ def test_should_not_show_recent_templates_on_dashboard_if_only_one_template_used
     expected_count = stats[0]['count']
     assert expected_count == 50
     assert normalize_spaces(
-        page.select_one('#total-sms .big-number').text
+        page.select_one('#total-sms .big-number-smaller').text
     ) == (
         '{} text messages sent'.format(expected_count)
     )
@@ -713,14 +713,13 @@ def test_should_show_upcoming_jobs_on_dashboard(
     ['email', 'sms'],
     ['email', 'sms', 'letter'],
 ))
-@pytest.mark.parametrize('totals, big_number_class', [
+@pytest.mark.parametrize('totals', [
     (
         {
             'email': {'requested': 0, 'delivered': 0, 'failed': 0},
             'sms': {'requested': 99999, 'delivered': 0, 'failed': 0},
             'letter': {'requested': 99999, 'delivered': 0, 'failed': 0}
         },
-        '.big-number',
     ),
     (
         {
@@ -728,7 +727,6 @@ def test_should_show_upcoming_jobs_on_dashboard(
             'sms': {'requested': 0, 'delivered': 0, 'failed': 0},
             'letter': {'requested': 100000, 'delivered': 0, 'failed': 0},
         },
-        '.big-number-smaller',
     ),
 ])
 def test_correct_font_size_for_big_numbers(
@@ -743,7 +741,6 @@ def test_correct_font_size_for_big_numbers(
     service_one,
     permissions,
     totals,
-    big_number_class,
 ):
 
     service_one['permissions'] = permissions
@@ -758,11 +755,12 @@ def test_correct_font_size_for_big_numbers(
         service_id=service_one['id'],
     )
 
-    assert len(page.select_one('[data-key=totals]').select('.column-third')) == 3
-    assert len(page.select_one('[data-key=usage]').select('.column-third')) == 3
-
-    assert len(
-        page.select('.big-number-with-status {}'.format(big_number_class))
+    assert (
+        len(page.select_one('[data-key=totals]').select('.column-third'))
+    ) == (
+        len(page.select_one('[data-key=usage]').select('.column-third'))
+    ) == (
+        len(page.select('.big-number-with-status .big-number-smaller'))
     ) == 3
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1959,7 +1959,7 @@ def mock_get_inbound_sms_summary(mocker):
         service_id,
     ):
         return {
-            'count': 99,
+            'count': 9999,
             'most_recent': datetime.utcnow().isoformat()
         }
 


### PR DESCRIPTION
We want to add more things to the dashboard, but we can’t reuse the ‘received text messages’ banner because it has too much visual weight.

So we need to add a new style of banner with less visual weight, and restyle the template statistics section of the dashboard so it still feels visually coherent.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/74338463-24726300-4d9a-11ea-907c-2c087af4351c.png) | ![image](https://user-images.githubusercontent.com/355079/74337720-c2652e00-4d98-11ea-8b88-788b803e8d3a.png)