### PR TITLE
Add letter specification guidance

### DIFF
--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -37,8 +37,8 @@
   <p>To help you set up your letter, you can download:</p>
 
   <ul class="list list-bullet">
-    <li>our <a href="{{ url_for('.letter_spec') }}">letter specification document</a></li>
-    <li>a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Microsoft Word document template</a></li>
+    <li>our <a href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
+    <li>a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Microsoft Word document template (.docx)</a></li>
   </ul>
 
 

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -21,7 +21,7 @@
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>
 
-  <h2 class="heading-medium">Letter specification</h2>
+  <h2 class="heading-medium" id="letter-specification">Letter specification</h2>
 
   <p>Your file must be:</p>
 

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -21,8 +21,25 @@
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>
 
-  <p>Use the <a href="{{ url_for('.letter_spec') }}">letter specification document</a> to help you set up your letter.<p>
+  <h2 class="heading-medium">Letter specification</h2>
 
+  <p>Your file must be:</p>
+
+  <ul class="list list-bullet">
+    <li>a PDF</li>
+    <li>A4 portrait size (210 × 297 mm)</li>
+    <li>10 pages or less</li>
+    <li>smaller than 2MB</li>
+  </ul>
+  
+  <p>The content of your letter must appear inside the printable area.</p>
+  
+  <p>To help you set up your letter, you can download:</p>
+
+  <ul class="list list-bullet">
+    <li>our <a href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
+    <li>a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Microsoft Word document template (.docx)</a></li>
+  </ul>
 
 
 {% endblock %}

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -37,8 +37,8 @@
   <p>To help you set up your letter, you can download:</p>
 
   <ul class="list list-bullet">
-    <li>our <a href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
-    <li>a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Microsoft Word document template (.docx)</a></li>
+    <li>our <a href="{{ url_for('.letter_spec') }}">letter specification document</a></li>
+    <li>a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Microsoft Word document template</a></li>
   </ul>
 
 

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -33,7 +33,7 @@
     )}}
   </p>
   <p>You can upload a single letter as a PDF.</p>
-  <p>Your file must meet our <a href="{{ url_for('.upload_a_letter') }}">letter specification</a>.</p>
+  <p>Your file must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification</a>.</p>
 
   </div>
 </div>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -33,8 +33,7 @@
     )}}
   </p>
   <p>You can upload a single letter as a PDF.</p>
-  <p>Your file must meet our <a href="{{ url_for('.letter_spec') }}">letter specification</a>.</p>
-  <p>To help you set up your letter you can download a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Word document template</a>.</p>
+  <p>Your file must meet our <a href="{{ url_for('.upload_a_letter') }}">letter specification</a>.</p>
 
   </div>
 </div>

--- a/app/utils.py
+++ b/app/utils.py
@@ -650,8 +650,7 @@ def get_letter_validation_error(validation_message, invalid_pages=None, page_cou
             invalid_pages=invalid_pages,
             invalid_pages_are_or_is=invalid_pages_are_or_is,
             page_count=page_count,
-            letter_spec=url_for('.letter_spec')
-            letter_spec_guidance=url_for('.letter_spec_guidance'),
+            letter_spec_guidance=url_for('.upload_a_letter')
         ),
         'summary': LETTER_VALIDATION_MESSAGES[validation_message]['summary'].format(
             invalid_pages=invalid_pages,

--- a/app/utils.py
+++ b/app/utils.py
@@ -571,7 +571,7 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'Your letter is not A4 portrait size',
         'detail': (
             'You need to change the size or orientation of {invalid_pages}. <br>'
-            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{letter_spec_guidance}" target="_blank">letter specification</a>.'
         ),
         'summary': (
             'Validation failed because {invalid_pages} {invalid_pages_are_or_is} not A4 portrait size.<br>'
@@ -582,7 +582,7 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'Your content is outside the printable area',
         'detail': (
             'You need to edit {invalid_pages}.<br>'
-            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{letter_spec_guidance}" target="_blank">letter specification</a>.'
         ),
         'summary': (
             'Validation failed because content is outside the printable area on {invalid_pages}.<br>'
@@ -618,7 +618,7 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'The address block is empty',
         'detail': (
             'You need to add a recipient address.<br>'
-            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{letter_spec_guidance}" target="_blank">letter specification</a>.'
         ),
         'summary': (
             'Validation failed because the address block is empty.<br>'

--- a/app/utils.py
+++ b/app/utils.py
@@ -650,7 +650,8 @@ def get_letter_validation_error(validation_message, invalid_pages=None, page_cou
             invalid_pages=invalid_pages,
             invalid_pages_are_or_is=invalid_pages_are_or_is,
             page_count=page_count,
-            letter_spec=url_for('.letter_spec'),
+            letter_spec=url_for('.letter_spec')
+            letter_spec_guidance=url_for('.letter_spec_guidance'),
         ),
         'summary': LETTER_VALIDATION_MESSAGES[validation_message]['summary'].format(
             invalid_pages=invalid_pages,

--- a/app/utils.py
+++ b/app/utils.py
@@ -571,22 +571,22 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'Your letter is not A4 portrait size',
         'detail': (
             'You need to change the size or orientation of {invalid_pages}. <br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
         ),
         'summary': (
             'Validation failed because {invalid_pages} {invalid_pages_are_or_is} not A4 portrait size.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
         ),
     },
     'content-outside-printable-area': {
         'title': 'Your content is outside the printable area',
         'detail': (
             'You need to edit {invalid_pages}.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
         ),
         'summary': (
             'Validation failed because content is outside the printable area on {invalid_pages}.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
         ),
     },
     'letter-too-long': {
@@ -618,11 +618,11 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'The address block is empty',
         'detail': (
             'You need to add a recipient address.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
         ),
         'summary': (
             'Validation failed because the address block is empty.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
         ),
     }
 }

--- a/app/utils.py
+++ b/app/utils.py
@@ -575,7 +575,7 @@ LETTER_VALIDATION_MESSAGES = {
         ),
         'summary': (
             'Validation failed because {invalid_pages} {invalid_pages_are_or_is} not A4 portrait size.<br>'
-            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
         ),
     },
     'content-outside-printable-area': {
@@ -586,7 +586,7 @@ LETTER_VALIDATION_MESSAGES = {
         ),
         'summary': (
             'Validation failed because content is outside the printable area on {invalid_pages}.<br>'
-            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
         ),
     },
     'letter-too-long': {
@@ -622,7 +622,7 @@ LETTER_VALIDATION_MESSAGES = {
         ),
         'summary': (
             'Validation failed because the address block is empty.<br>'
-            'Files must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}" target="_blank">letter specification</a>.'
+            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
         ),
     }
 }

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -499,7 +499,7 @@ def test_get_letter_validation_error_for_known_errors(
 
     assert detail.text == expected_content
     if detail.select_one('a'):
-        assert detail.select_one('a')['href'] == url_for('.letter_spec')
+        assert detail.select_one('a')['href'] == url_for('.upload_a_letter')
         assert detail.select_one('a')['target'] == '_blank'
 
     assert summary.text == expected_summary


### PR DESCRIPTION
This PR adds letter specification information to the _Upload a letter_ guidance page.

We're making these updates so that we can user test the content and downloadable documents. If they're successful we'll keep them.