### PR TITLE
Update Using Notify pages, features and guidance

### DIFF
--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -25,7 +25,7 @@
   <h3 class="heading-small" id="postage">Choose your postage</h3>
   <p>Notify can send letters by first or second class post.</p>
   <p>First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched.</p>
-  <p>Letters are printed at 5.30pm and dispatched the next working day (Monday to Friday). Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
+  <p>Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday). Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
 
   <h3 class="heading-small" id="branding">Branding</h3>
   <p>Add your organisation’s logo to your letter templates.</p>

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -35,7 +35,7 @@
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Create an account</h2>
     {% if not current_user.is_authenticated %}
-      <p><a href="{{ url_for('.register') }}">Create an account</a> for free and add your first Notify service. When you add a new service, it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+      <p><a href="{{ url_for('.register') }}">Create an account</a> for free and add your first Notify service. When you add a new service it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
     {% else %}
       <p>Create an account for free and add your first Notify service. When you add a new service, it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
     {% endif %}
@@ -70,7 +70,7 @@
     {% else %}
     <p>You should <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
     {% endif %}
-    <p>Check <a href="{{ url_for('main.how_to_pay') }}">how to pay</a> if you’re planning to send letters or exceed the <a href="{{ url_for('.pricing') }}">free text message allowance</a>.</p>
+    <p>Check <a href="{{ url_for('main.how_to_pay') }}">how to pay</a> if you’re planning to send letters or exceed the <a href="{{ url_for('.pricing', _anchor='text-messages') }}">free text message allowance</a>.</p>
   </li>
 
 </ol>

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -23,10 +23,10 @@
       caption_visible=False
     ) %}
       {% for message_length, charge in [
-        ('Sending', 'Notify has sent the message to the provider. The provider will try to deliver the message to the recipient. Notify is waiting for delivery information.'),
+        ('Sending', 'Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. Notify is waiting for delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
         ('Email address does not exist', 'The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.'),
-        ('Inbox not accepting messages right now', 'The provider could not deliver the message after trying for 72 hours. This can happen when the recipient’s inbox is full. You can try to send the message again.'),
+        ('Inbox not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again.'),
         ('Technical failure', 'Your message was not sent because there was a problem between Notify and the provider. You’ll have to try sending your messages again.'),
       ] %}
         {% call row() %}
@@ -41,7 +41,7 @@
   <p>If an email is marked as spam, Notify receives a ‘complaint’ from the email provider. We’ll contact you if we receive a complaint about any of your emails. When this happens you should remove the recipient’s email address from your list.</p>
 
   <h3 id="open-rates" class="heading-small">Open rates and click-throughs</h3>
-  <p>Notify cannot tell you if your users open an email or click on the links you send them. We do not track open rates and click-throughs because there are privacy issues. Tracking emails without asking permission from users could breach General Data Protection Regulations (GDPR).</p>
+  <p>Notify cannot tell you if your users open an email or click on the links in an email. We do not track open rates and click-throughs because there are privacy issues. Tracking emails without asking permission from users could breach General Data Protection Regulations (GDPR).</p>
 
   <h2 id="sms-statuses" class="heading-medium">Text messages</h2>
   <div class="bottom-gutter-3-2">
@@ -52,11 +52,11 @@
       caption_visible=False
     ) %}
       {% for message_length, charge in [
-        ('Sending', 'Notify has sent the message to the provider. The provider will try to deliver the message to the recipient. Notify is waiting for delivery information.'),
+        ('Sending', 'Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. Notify is waiting for delivery information.'),
         ('Sent internationally', 'The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
         ('Phone number does not exist', 'The provider could not deliver the message because the phone number was wrong. You should remove these phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist.'),
-        ('Phone not accepting messages right now', 'The provider could not deliver the message after trying for 72 hours. This can happen when the recipient’s phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
+        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
         ('Technical failure', 'Your message was not sent because there was a problem between Notify and the provider. You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.'),
       ] %}
         {% call row() %}
@@ -77,7 +77,7 @@
     ) %}
       {% for message_length, charge in [
         ('Sent', 'Notify has sent the letter to the provider to be printed.'),
-        ('Printed', 'The provider has printed the letter. Letters are printed at 5.30pm and dispatched the next working day.'), 
+        ('Printed', 'The provider has printed the letter. Letters are printed at 5:30pm and dispatched the next working day.'), 
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
         ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
       ] %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -27,10 +27,10 @@
 
   <p>When you add a new service it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
 
-  <h2 class="heading-medium">Emails</h2>
+  <h2 class="heading-medium" id="emails">Emails</h2>
   <p>It’s free to send emails through Notify.</p>
 
-  <h2 class="heading-medium">Text messages</h2>
+  <h2 class="heading-medium" id="text-messages">Text messages</h2>
   <p>Every service you add has an annual allowance of free text messages.</p>
   <p>If your organisation has more than one service on Notify, they each have a separate allowance.</p>
   <p>The allowance is:</p>
@@ -41,7 +41,7 @@
   <p>It costs 1.58 pence (plus VAT) for each text message you send after you've used your free allowance.</p>
   <p>See <a href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
-  <h3 class="heading-small">Long text messages</h3>
+  <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
   <p>If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message:</p>
   <div class="bottom-gutter-3-2">
     {% call mapping_table(
@@ -63,7 +63,7 @@
       {% endfor %}
     {% endcall %}
   </div>
-  <h3 class="heading-small">Accents and accented characters</h3>
+  <h3 class="heading-small" id="accents">Accents and accented characters</h3>
   <p>Some languages, such as Welsh, use accented characters.</p>
   <p>Text messages containing the following accented characters are charged at the normal rate: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>
   <p>Using other accented characters can increase the cost of sending text messages.<p>
@@ -152,7 +152,7 @@
     {% endcall %}
   </div>
 
-  <h3 class="heading-small">Sending text messages to international numbers</h3>
+  <h3 class="heading-small" id="international-numbers">Sending text messages to international numbers</h3>
   <p>It might cost more to send text messages to international numbers than UK ones, depending on the country.</p>
   <details>
     <summary>International text message rates</summary>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -29,15 +29,17 @@
     <li>Select <b class="govuk-!-font-weight-bold">Request to go live</b>.</li>
   </ol>
     {% endif %}
- 
-  <p>Before you request to go live, you must:</p>
-  <ul class="list list-bullet">
-    <li>accept our data sharing and financial agreement</li>
-    <li>accept our terms of use</li>
-    <li>set up your service so you’re ready to send and receive messages</li>
-  </ul>
-  <p>
+ <p>
     When we receive your request we’ll get back to you within one working day.
   </p>
+  <h2 class="heading-medium" id="before-you-resquest-to-go-live">Before you request to go live</h2>
+  <p>You must:</p>
+  <ul class="list list-bullet">
+    <li>add examples of the messages you want to send</li>
+    <li>update your settings so you’re ready to send and receive messages</li>
+    <li>accept our data sharing and financial agreement</li>
+    <li>accept our terms of use</li>
+  </ul>
+  
 
 {% endblock %}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -32,7 +32,7 @@
  <p>
     When we receive your request we’ll get back to you within one working day.
   </p>
-  <h2 class="heading-medium" id="before-you-resquest-to-go-live">Before you request to go live</h2>
+  <h2 class="heading-medium" id="before-you-request-to-go-live">Before you request to go live</h2>
   <p>You must:</p>
   <ul class="list list-bullet">
     <li>add examples of the messages you want to send</li>


### PR DESCRIPTION
This PR updates the content on the following Using Notify, guidance and features pages:

- `using-notify/trial-mode` – make the information about trial mode restrictions, request to go live process, and things you need to do beforehand clearer (see screenshots below)
- `using-notify/delivery-status` – make the status descriptions consistent with our API documentation
- `using-notify/get-started` – fix an anchor link
- `/pricing` – add anchor IDs to headings
- `using-notify/get-started`,  `using-notify/delivery-status` and `features/letters` – fix style inconsistencies 

# Trial mode page before
![trial-mode-old](https://user-images.githubusercontent.com/28294225/74433651-bb055980-4e58-11ea-8666-5ab796b5c8aa.png)

# Trial mode page after
![trial-mode-updates](https://user-images.githubusercontent.com/28294225/74433667-c193d100-4e58-11ea-9bce-556d107e7837.png)
