### PR TITLE
Guidance simplify numbered lists

### DIFF
--- a/app/templates/components/current-service-link.html
+++ b/app/templates/components/current-service-link.html
@@ -1,0 +1,7 @@
+{% macro current_service_link(endpoint, link_text) %}
+  {% if current_service %}
+    <a class="govuk-link" href="{{ url_for(endpoint, service_id=current_service.id) }}">{{ link_text }}</a>
+  {% else %}
+    <b class="govuk-!-font-weight-bold">{{ link_text|capitalize }}</b>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
+{% from "components/current-service-link.html" import current_service_link %}
 
 {% block per_page_title %}
   Branding and customisation
@@ -9,59 +8,59 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Branding and customisation</h1>
-  
+
   <p>This page explains how to:</p>
-  
+
   <ul class="list list-bullet">
     <li><a href="#email-branding">change your email branding</a></li>
     <li><a href="#reply-to-address">add a reply-to email address</a></li>
     <li><a href="#text-message-sender">change the text message sender</a></li>
     <li><a href="#letter-branding">change your letter branding</a></li>
   </ul>
-  
+
   <h2 class="heading-medium" id="email-branding">Change your email branding</h2>
 
   <p>The default branding for email templates is the GOV.UK logo.</p>
-  
+
   <p>To change your email branding:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Email branding</b> row.</li>
   </ol>
 
   <h2 class="heading-medium" id="reply-to-address">Add a reply-to email address</h2>
-  
+
   <p>You can choose the email address that your users reply to. You must add at least one reply-to address for your service before you can <a href="{{ url_for('main.trial_mode_new') }}">request to go live</a>.</p>
 
   <p>To add a reply-to email address:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Reply-to email addresses</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Add reply-to address</b>.</li>
   </ol>
-  
+
   <h2 class="heading-medium" id="text-message-sender">Change the text message sender</h2>
-  
+
   <p>The text message sender tells your users who the message is from.</p>
 
   <p>To change the text message sender from the default of ‘GOVUK’:</p>
-  
+
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Text message senders</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> or <b class="govuk-!-font-weight-bold">Add text message sender</b>.</li>
 </ol>
 
   <h2 class="heading-medium" id="letter-branding">Change your letter branding</h2>
-  
+
   <p>Letter templates do not have default branding.</p>
-    
+
   <p>To add a logo to your letters:</p>
-  
+
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Letter branding</b> row.</li>
   </ol>
 

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -26,7 +26,7 @@
   <p>To change your email branding:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Email branding</b> row.</li>
   </ol>
 
@@ -37,7 +37,7 @@
   <p>To add a reply-to email address:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Reply-to email addresses</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Add reply-to address</b>.</li>
   </ol>
@@ -49,7 +49,7 @@
   <p>To change the text message sender from the default of ‘GOVUK’:</p>
   
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Text message senders</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> or <b class="govuk-!-font-weight-bold">Add text message sender</b>.</li>
 </ol>
@@ -61,7 +61,7 @@
   <p>To add a logo to your letters:</p>
   
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('main.service_settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Letter branding</b> row.</li>
   </ol>
 

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -26,9 +26,8 @@
   <p>To change your email branding:</p>
 
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Settings</b> page.</li>
-    <li>In the <b class="govuk-!-font-weight-bold">Email settings</b> section, select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Email branding</b> row.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Email branding</b> row.</li>
   </ol>
 
   <h2 class="heading-medium" id="reply-to-address">Add a reply-to email address</h2>
@@ -38,9 +37,8 @@
   <p>To add a reply-to email address:</p>
 
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Settings</b> page.</li>
-    <li>In the <b class="govuk-!-font-weight-bold">Email settings</b> section, select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Reply-to email addresses</b> row.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Reply-to email addresses</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Add reply-to address</b>.</li>
   </ol>
   
@@ -51,9 +49,8 @@
   <p>To change the text message sender from the default of ‘GOVUK’:</p>
   
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Settings</b> page.</li>
-    <li>In the <b class="govuk-!-font-weight-bold">Text message settings</b> section, select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Text message senders</b> row.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Text message senders</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> or <b class="govuk-!-font-weight-bold">Add text message sender</b>.</li>
 </ol>
 
@@ -64,9 +61,8 @@
   <p>To add a logo to your letters:</p>
   
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Settings</b> page.</li>
-    <li>In the <b class="govuk-!-font-weight-bold">Letter settings</b> section, select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Letter branding</b> row.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.settings', service_id=current_service.id) }}">Settings</a></b> page.</li>
+    <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Letter branding</b> row.</li>
   </ol>
 
 {% endblock %}

--- a/app/templates/views/guidance/create-and-send-messages.html
+++ b/app/templates/views/guidance/create-and-send-messages.html
@@ -16,8 +16,7 @@
 
   <p>To send a batch of messages at once:</p>
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Templates</b> page and choose an existing template.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page and choose an existing template.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Send</b>.</li>
     <li>If you’re sending emails, select <b class="govuk-!-font-weight-bold">Upload a list of email addresses</b>. If you’re sending text messages, select <b class="govuk-!-font-weight-bold">Upload a list of phone numbers</b>. If you’re sending letters, select <b class="govuk-!-font-weight-bold">Upload a list of addresses</b>.</li>
   

--- a/app/templates/views/guidance/create-and-send-messages.html
+++ b/app/templates/views/guidance/create-and-send-messages.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
+{% from "components/current-service-link.html" import current_service_link %}
 
 {% block per_page_title %}
   Send messages
@@ -9,15 +8,15 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Send messages</h1>
-  
+
   <p><a href="{{ url_for('main.register') }}">Create an account</a> to see a short tutorial explaining how to create and send messages.</p>
-  
+
   <h2 class="heading-medium" id="bulk-sending">Bulk sending</h2>
 
   <p>To send a batch of messages at once:</p>
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page and choose an existing template.</li>
+    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page and choose an existing template.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Send</b>.</li>
     <li>If you’re sending emails, select <b class="govuk-!-font-weight-bold">Upload a list of email addresses</b>. If you’re sending text messages, select <b class="govuk-!-font-weight-bold">Upload a list of phone numbers</b>. If you’re sending letters, select <b class="govuk-!-font-weight-bold">Upload a list of addresses</b>.</li>
-  
+
   {% endblock %}

--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
+{% from "components/current-service-link.html" import current_service_link %}
 
 {% block per_page_title %}
   Edit and format messages
@@ -23,7 +22,7 @@
   <p>You can see a list of formatting instructions on the edit template page:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page.</li>
+    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
   </ol>
 
@@ -62,7 +61,7 @@
   <p>To add a placeholder to the template:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page.</li>
+    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Add a placeholder using double brackets. For example: Hello ((first&nbsp;name)), your reference is ((ref&nbsp;number)).</li>
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>
@@ -82,7 +81,7 @@
   <p>To add optional content to your emails and text messages:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page.</li>
+    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Use double brackets and ?? to define optional content. For example, if you only want to show something to people who are under 18: ((under18??Please get your application signed by a parent or guardian.))</li>
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>

--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -23,8 +23,7 @@
   <p>You can see a list of formatting instructions on the edit template page:</p>
 
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Templates</b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
   </ol>
 
@@ -63,8 +62,7 @@
   <p>To add a placeholder to the template:</p>
 
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Templates</b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Add a placeholder using double brackets. For example: Hello ((first&nbsp;name)), your reference is ((ref&nbsp;number)).</li>
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>
@@ -84,8 +82,7 @@
   <p>To add optional content to your emails and text messages:</p>
 
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Templates</b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.templates', service_id=current_service.id) }}">Templates</a></b> page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Use double brackets and ?? to define optional content. For example, if you only want to show something to people who are under 18: ((under18??Please get your application signed by a parent or guardian.))</li>
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>

--- a/app/templates/views/guidance/send-files-by-email.html
+++ b/app/templates/views/guidance/send-files-by-email.html
@@ -1,6 +1,4 @@
 {% extends "content_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
   Send files by email
@@ -9,10 +7,9 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Send files by email</h1>
-  
+
   <p><a href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
 
   <p>Then follow the instructions to send a file by email in our <a href="{{ url_for('.documentation') }}">API documentation</a>.</p>
-  
+
 {% endblock %}
-  

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -15,8 +15,7 @@
   <p>To upload and send a letter from a PDF file:</p>
   
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
-    <li>Go to the <b class="govuk-!-font-weight-bold">Uploads</b> page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.uploads', service_id=current_service.id) }}">Uploads</a></b> page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Upload a letter</b>.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>
@@ -34,11 +33,11 @@
   
   <p>The content of your letter must appear inside the printable area.</p>
   
-  <p>To help you set up your letter, you can download:</p>
+  <p>To help you set up your letter, you can download our:</p>
 
   <ul class="list list-bullet">
-    <li>our <a href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
-    <li>a <a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">Microsoft Word document template (.docx)</a></li>
+    <li><a href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
+    <li><a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">print margin checker for Microsoft Word (.docx)</a></li>
   </ul>
 
 

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
+{% from "components/current-service-link.html" import current_service_link %}
 
 {% block per_page_title %}
   Upload a letter
@@ -9,13 +8,13 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Upload a letter</h1>
-  
+
   <p>You can upload and send your own letters instead of creating a reusable letter template.</p>
-  
+
   <p>To upload and send a letter from a PDF file:</p>
-  
+
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold"><a href="{{ url_for('.uploads', service_id=current_service.id) }}">Uploads</a></b> page.</li>
+    <li>Go to the {{ current_service_link('main.uploads', 'uploads') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Upload a letter</b>.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>
@@ -30,9 +29,9 @@
     <li>10 pages or less</li>
     <li>smaller than 2MB</li>
   </ul>
-  
+
   <p>The content of your letter must appear inside the printable area.</p>
-  
+
   <p>To help you set up your letter, you can download our:</p>
 
   <ul class="list list-bullet">


### PR DESCRIPTION
This PR simplifies the numbered lists of instructions in our guidance pages by:

- removing the instruction to `Sign in to Notify`
- linking directly to the page users need to visit