### PR TITLE
Put day of week on estimated letter delivery page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -334,6 +334,10 @@ def format_date_human(date):
     return get_human_day(date)
 
 
+def format_day_of_week(date):
+    return utc_string_to_aware_gmt_datetime(date).strftime('%A')
+
+
 def _format_datetime_short(datetime):
     return datetime.strftime('%d %B').lstrip('0')
 
@@ -743,6 +747,7 @@ def add_template_filters(application):
         format_date_normal,
         format_date_short,
         format_datetime_relative,
+        format_day_of_week,
         format_delta,
         format_notification_status,
         format_notification_type,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -291,7 +291,7 @@ def format_time_24h(date):
     return utc_string_to_aware_gmt_datetime(date).strftime('%H:%M')
 
 
-def get_human_day(time):
+def get_human_day(time, date_prefix=''):
 
     #  Add 1 minute to transform 00:00 into ‘midnight today’ instead of ‘midnight tomorrow’
     date = (utc_string_to_aware_gmt_datetime(time) - timedelta(minutes=1)).date()
@@ -304,8 +304,15 @@ def get_human_day(time):
     if date == (now - timedelta(days=1)).date():
         return 'yesterday'
     if date.strftime('%Y') != now.strftime('%Y'):
-        return '{} {}'.format(_format_datetime_short(date), date.strftime('%Y'))
-    return _format_datetime_short(date)
+        return '{} {} {}'.format(
+            date_prefix,
+            _format_datetime_short(date),
+            date.strftime('%Y'),
+        ).strip()
+    return '{} {}'.format(
+        date_prefix,
+        _format_datetime_short(date),
+    ).strip()
 
 
 def format_time(date):
@@ -332,6 +339,13 @@ def format_date_short(date):
 
 def format_date_human(date):
     return get_human_day(date)
+
+
+def format_datetime_human(date, date_prefix=''):
+    return '{} at {}'.format(
+        get_human_day(date, date_prefix='on'),
+        format_time(date),
+    )
 
 
 def format_day_of_week(date):
@@ -746,6 +760,7 @@ def add_template_filters(application):
         format_date_human,
         format_date_normal,
         format_date_short,
+        format_datetime_human,
         format_datetime_relative,
         format_day_of_week,
         format_delta,

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -34,7 +34,7 @@
       {% elif created_by %}
         by {{ created_by.name }}
       {% endif %}
-      on {{ created_at|format_datetime_short }}
+      {{ created_at|format_datetime_human }}
     </p>
 
     {% if template.template_type == 'letter' %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -67,7 +67,7 @@
             {{ letter_print_day }}
           </p>
           <p>
-            Estimated delivery date: {{ estimated_letter_delivery_date|string|format_date_short }}
+            Estimated delivery date: {{ estimated_letter_delivery_date|format_day_of_week }} {{ estimated_letter_delivery_date|format_date_short }}
           </p>
         {% endif %}
       {% endif %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -17,7 +17,11 @@
     ) }}
     <p>
       {% if is_precompiled_letter %}
-        Provided as PDF
+        {% if created_by %}
+          Uploaded
+        {% else %}
+          Provided as PDF
+        {% endif %}
       {% else %}
         {% if help %}
           ‘{{ template.name }}’

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -152,22 +152,43 @@ def test_notification_status_shows_expected_back_link(
         assert back_link is None
 
 
-@freeze_time("2012-01-01 01:01")
+@pytest.mark.parametrize('time_of_viewing_page, expected_message', (
+    ('2012-01-01 01:01', (
+        "‘sample template’ was sent by Test User today at 1:01am"
+    )),
+    ('2012-01-02 01:01', (
+        "‘sample template’ was sent by Test User yesterday at 1:01am"
+    )),
+    ('2012-01-03 01:01', (
+        "‘sample template’ was sent by Test User on 1 January at 1:01am"
+    )),
+    ('2013-01-03 01:01', (
+        "‘sample template’ was sent by Test User on 1 January 2012 at 1:01am"
+    )),
+))
 def test_notification_page_doesnt_link_to_template_in_tour(
+    mocker,
     client_request,
     fake_uuid,
     mock_get_notification,
+    time_of_viewing_page,
+    expected_message,
 ):
 
-    page = client_request.get(
-        'main.view_notification',
-        service_id=SERVICE_ONE_ID,
-        notification_id=fake_uuid,
-        help=3,
-    )
+    with freeze_time('2012-01-01 01:01'):
+        notification = create_notification()
+        mocker.patch('app.notification_api_client.get_notification', return_value=notification)
+
+    with freeze_time(time_of_viewing_page):
+        page = client_request.get(
+            'main.view_notification',
+            service_id=SERVICE_ONE_ID,
+            notification_id=fake_uuid,
+            help=3,
+        )
 
     assert normalize_spaces(page.select('main p:nth-of-type(1)')[0].text) == (
-        "‘sample template’ was sent by Test User on 1 January at 1:01am"
+        expected_message
     )
     assert len(page.select('main p:nth-of-type(1) a')) == 0
 
@@ -196,7 +217,7 @@ def test_notification_page_shows_page_for_letter_notification(
     )
 
     assert normalize_spaces(page.select('main p:nth-of-type(1)')[0].text) == (
-        "‘sample template’ was sent by Test User on 1 January at 1:01am"
+        "‘sample template’ was sent by Test User today at 1:01am"
     )
     assert normalize_spaces(page.select('main p:nth-of-type(2)')[0].text) == (
         'Printing starts today at 5:30pm'
@@ -230,13 +251,13 @@ def test_notification_page_shows_page_for_letter_notification(
 @pytest.mark.parametrize('is_precompiled_letter, expected_p1, expected_p2, expected_postage', (
     (
         True,
-        'Provided as PDF on 1 January at 1:01am',
+        'Provided as PDF today at 1:01am',
         'This letter passed our checks, but we will not print it because you used a test key.',
         'Postage: second class'
     ),
     (
         False,
-        '‘sample template’ was sent on 1 January at 1:01am',
+        '‘sample template’ was sent today at 1:01am',
         'We will not print this letter because you used a test key.',
         'Postage: second class',
     ),
@@ -377,7 +398,7 @@ def test_notification_page_shows_cancelled_or_failed_letter(
     )
 
     assert normalize_spaces(page.select('main p')[0].text) == (
-        "‘sample template’ was sent by Test User on 1 January at 1:01am"
+        "‘sample template’ was sent by Test User today at 1:01am"
     )
     assert normalize_spaces(page.select('main p')[1].text) == (
         expected_message

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -202,7 +202,7 @@ def test_notification_page_shows_page_for_letter_notification(
         'Printing starts today at 5:30pm'
     )
     assert normalize_spaces(page.select('main p:nth-of-type(3)')[0].text) == (
-        'Estimated delivery date: 6 January'
+        'Estimated delivery date: Wednesday 6 January'
     )
     assert len(page.select('.letter-postage')) == 1
     assert normalize_spaces(page.select_one('.letter-postage').text) == (
@@ -473,7 +473,9 @@ def test_notification_page_shows_page_for_first_class_letter_notification(
     )
 
     assert normalize_spaces(page.select('main p:nth-of-type(2)')[0].text) == 'Printing starts tomorrow at 5:30pm'
-    assert normalize_spaces(page.select('main p:nth-of-type(3)')[0].text) == 'Estimated delivery date: 5 January'
+    assert normalize_spaces(page.select('main p:nth-of-type(3)')[0].text) == (
+        'Estimated delivery date: Tuesday 5 January'
+    )
     assert normalize_spaces(page.select_one('.letter-postage').text) == (
         'Postage: first class'
     )


### PR DESCRIPTION
This helps people understand how delivery dates fit into the week, because if sending a letter spans the weekend it will take a bit longer.

![image](https://user-images.githubusercontent.com/355079/74656174-88739d80-5185-11ea-9c91-813fcc725222.png)
