### PR TITLE
Show scheduled jobs on page one of the uploads page

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -51,19 +51,16 @@ def view_jobs(service_id):
     if jobs.next_page:
         next_page = generate_next_dict('main.view_jobs', service_id, jobs.current_page)
 
-    scheduled_jobs = ''
-    if not current_user.has_permissions('view_activity') and jobs.current_page == 1:
-        scheduled_jobs = render_template(
-            'views/dashboard/_upcoming.html',
-            hide_heading=True,
-        )
-
     return render_template(
         'views/jobs/jobs.html',
         jobs=jobs,
         prev_page=prev_page,
         next_page=next_page,
-        scheduled_jobs=scheduled_jobs,
+        show_scheduled_jobs=(
+            jobs.current_page == 1
+            and not current_user.has_permissions('view_activity')
+            and current_service.scheduled_jobs
+        ),
     )
 
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -52,12 +52,19 @@ def uploads(service_id):
     if uploads.prev_page:
         next_page = generate_next_dict('main.uploads', service_id, uploads.current_page)
 
+    scheduled_jobs = ''
+    if uploads.current_page == 1:
+        scheduled_jobs = render_template(
+            'views/dashboard/_upcoming.html',
+            hide_heading=True,
+        )
+
     return render_template(
         'views/jobs/jobs.html',
         jobs=uploads,
         prev_page=prev_page,
         next_page=next_page,
-        scheduled_jobs='',
+        scheduled_jobs=scheduled_jobs,
     )
 
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -52,19 +52,14 @@ def uploads(service_id):
     if uploads.prev_page:
         next_page = generate_next_dict('main.uploads', service_id, uploads.current_page)
 
-    scheduled_jobs = ''
-    if uploads.current_page == 1:
-        scheduled_jobs = render_template(
-            'views/dashboard/_upcoming.html',
-            hide_heading=True,
-        )
-
     return render_template(
         'views/jobs/jobs.html',
         jobs=uploads,
         prev_page=prev_page,
         next_page=next_page,
-        scheduled_jobs=scheduled_jobs,
+        show_scheduled_jobs=(
+            uploads.current_page == 1 and current_service.scheduled_jobs
+        ),
     )
 
 

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -7,7 +7,7 @@
     caption="Recent files uploaded",
     caption_visible=False,
     empty_message=(
-      'Upload a letter and Notify will print, pack and post it for you.' if current_service.can_upload_letters else 'You have not uploaded any files recently'
+      'Upload a letter and Notify will print, pack and post it for you.' if current_service.can_upload_letters else 'You have not uploaded any files yet'
     ),
     field_headings=[
       'File',

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -9,8 +9,19 @@
 {% block maincolumn_content %}
     <h1 class="heading-large">Uploads</h1>
     <div class="dashboard">
-      {{ scheduled_jobs|safe }}
-      {% if jobs or not current_service.scheduled_jobs %}
+      {% if show_scheduled_jobs %}
+        {% with hide_heading = True %}
+          {% include 'views/dashboard/_upcoming.html' %}
+        {% endwith %}
+      {% endif %}
+      {% if jobs %}
+        {% include 'views/dashboard/_jobs.html' %}
+      {% endif %}
+      {% if not jobs and not show_scheduled_jobs %}
+        {#
+          `_jobs.html` will show the ‘You have no jobs’ message when
+          passed an empty list of jobs
+        #}
         {% include 'views/dashboard/_jobs.html' %}
       {% endif %}
       {{ previous_next_navigation(prev_page, next_page) }}

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -10,7 +10,9 @@
     <h1 class="heading-large">Uploads</h1>
     <div class="dashboard">
       {{ scheduled_jobs|safe }}
-      {% include 'views/dashboard/_jobs.html' %}
+      {% if jobs or not current_service.scheduled_jobs %}
+        {% include 'views/dashboard/_jobs.html' %}
+      {% endif %}
       {{ previous_next_navigation(prev_page, next_page) }}
       {% if current_service.can_upload_letters and current_user.has_permissions('send_messages') %}
         <div class="js-stick-at-bottom-when-scrolling">

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -632,11 +632,10 @@ def test_format_recipient(original_address, expected_address):
 def test_uploads_page_shows_scheduled_jobs(
     mocker,
     client_request,
-    mock_get_uploads,
+    mock_get_no_uploads,
     mock_get_jobs,
     user,
 ):
-    mocker.patch('app.models.job.PaginatedUploads.client_method', return_value={'data': []})
     client_request.login(user)
     page = client_request.get('main.uploads', service_id=SERVICE_ONE_ID)
 

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -4,11 +4,16 @@ from unittest.mock import Mock
 
 import pytest
 from flask import make_response, url_for
+from freezegun import freeze_time
 from requests import RequestException
 
 from app.main.views.uploads import format_recipient
 from app.utils import normalize_spaces
-from tests.conftest import SERVICE_ONE_ID
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    create_active_caseworking_user,
+    create_active_user_with_permissions,
+)
 
 
 @pytest.mark.parametrize('extra_permissions', (
@@ -24,6 +29,7 @@ def test_no_upload_letters_button_without_permission(
     client_request,
     service_one,
     mock_get_uploads,
+    mock_get_jobs,
     extra_permissions,
 ):
     service_one['permissions'] += extra_permissions
@@ -31,11 +37,38 @@ def test_no_upload_letters_button_without_permission(
     assert not page.find('a', text=re.compile('Upload a letter'))
 
 
+@pytest.mark.parametrize('extra_permissions, expected_empty_message', (
+    (['letter'], (
+        'You have not uploaded any files yet'
+    )),
+    (['letter', 'upload_letters'], (
+        'Upload a letter and Notify will print, pack and post it for you.'
+    )),
+))
+def test_get_upload_hub_with_no_uploads(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_no_uploads,
+    extra_permissions,
+    expected_empty_message,
+):
+    mocker.patch('app.job_api_client.get_jobs', return_value={'data': []})
+    service_one['permissions'] += extra_permissions
+    page = client_request.get('main.uploads', service_id=SERVICE_ONE_ID)
+    assert normalize_spaces(
+        page.select_one('.table-empty-message').text
+    ) == expected_empty_message
+    assert not page.select('.file-list-filename')
+
+
 def test_get_upload_hub_page(
+    mocker,
     client_request,
     service_one,
     mock_get_uploads,
 ):
+    mocker.patch('app.job_api_client.get_jobs', return_value={'data': []})
     service_one['permissions'] += ['letter', 'upload_letters']
     page = client_request.get('main.uploads', service_id=SERVICE_ONE_ID)
     assert page.find('h1').text == 'Uploads'
@@ -589,3 +622,37 @@ def test_send_uploaded_letter_when_metadata_states_pdf_is_invalid(mocker, servic
 ])
 def test_format_recipient(original_address, expected_address):
     assert format_recipient(urllib.parse.quote(original_address)) == expected_address
+
+
+@pytest.mark.parametrize('user', (
+    create_active_caseworking_user(),
+    create_active_user_with_permissions(),
+))
+@freeze_time("2012-12-12 12:12")
+def test_uploads_page_shows_scheduled_jobs(
+    mocker,
+    client_request,
+    mock_get_uploads,
+    mock_get_jobs,
+    user,
+):
+    mocker.patch('app.models.job.PaginatedUploads.client_method', return_value={'data': []})
+    client_request.login(user)
+    page = client_request.get('main.uploads', service_id=SERVICE_ONE_ID)
+
+    assert [
+        normalize_spaces(row.text) for row in page.select('tr')
+    ] == [
+        (
+            'File Messages to be sent'
+        ),
+        (
+            'send_me_later.csv '
+            'Sending 1 January 2016 at 11:09am 1'
+        ),
+        (
+            'even_later.csv '
+            'Sending 1 January 2016 at 11:09pm 1'
+        ),
+    ]
+    assert not page.select('.table-empty-message')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1779,6 +1779,16 @@ def mock_get_uploads(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_get_no_uploads(mocker, api_user_active):
+    mocker.patch(
+        'app.models.job.PaginatedUploads.client_method',
+        return_value={
+            'data': [],
+        }
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_notifications(
     mocker,
     api_user_active,


### PR DESCRIPTION
Since we’re going to summarise scheduled jobs on the dashboard instead of listing them they need to be listed here instead (which is where we’ll link to from the dashboard).

This is the same thing we do with the jobs page for caseworking users who don’t have the dashboard. 

Design of this will probably evolve as we work out how to style single letter uploads and letter jobs, but that’s OK for now because no-one has the uploads page at the moment.

***

![image](https://user-images.githubusercontent.com/355079/74665201-1f952100-5197-11ea-9077-de30fe2d43a5.png)
