### PR TITLE
Guard against obscure bug in test setup

### DIFF
--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -516,3 +516,16 @@ def test_get_letter_validation_error_for_known_errors(
 @freeze_time('2020-02-14T12:00:00')
 def test_is_less_than_90_days_ago(date_from_db, expected_result):
     assert is_less_than_90_days_ago(date_from_db) == expected_result
+
+
+@pytest.mark.parametrize('method', ('get', 'post'))
+@freeze_time('2010-12-31 23:59:59')
+def test_freeze_time_before_2010_warning(client_request, method):
+    with pytest.raises(ValueError) as exception:
+        getattr(client_request, method)('main.index')
+    assert str(
+        exception.value
+    ) == (
+        'You can’t freeze time to before 2011 because it breaks the '
+        'session serializer'
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2688,6 +2688,14 @@ def client_request(
                 yield session
 
         @staticmethod
+        def check_current_time():
+            if datetime.utcnow().strftime('%Y') < '2011':
+                raise ValueError(
+                    'You can’t freeze time to before 2011 because it '
+                    'breaks the session serializer'
+                )
+
+        @staticmethod
         def login(user, service=service_one):
             logged_in_client.login(user, mocker, service)
 
@@ -2722,6 +2730,7 @@ def client_request(
             _test_page_title=True,
             **endpoint_kwargs
         ):
+            ClientRequest.check_current_time()
             resp = logged_in_client.get(
                 url,
                 follow_redirects=_follow_redirects,
@@ -2750,6 +2759,7 @@ def client_request(
             _expected_redirect=None,
             **endpoint_kwargs
         ):
+            ClientRequest.check_current_time()
             if _expected_status is None:
                 _expected_status = 200 if _follow_redirects else 302
             resp = logged_in_client.post(


### PR DESCRIPTION
If you try to freeze time to before 2011 you get the following obscure exception from somewhere within itsdangerous:

```
timestamp = base64_encode(int_to_bytes(self.get_timestamp()))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

num = -1

def int_to_bytes(num):
>       assert num >= 0
E       AssertionError
```

Something in there is baselining `timestamp` to `0` at the start of 2011. Which means that trying to freeze time to before then results in a negative timestamp.

This is a very non-obvious exception to see, so hopefully raising a specific exception instead will save others some time.