### PR TITLE
Update upload a letter content

### DIFF
--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -7,7 +7,7 @@
     caption="Recent files uploaded",
     caption_visible=False,
     empty_message=(
-      'Upload a letter and Notify will print, pack and post it for you.' if current_service.can_upload_letters else 'You have not uploaded any files yet'
+      'You have not yet uploaded any files yet.'
     ),
     field_headings=[
       'File',

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -7,7 +7,7 @@
     caption="Recent files uploaded",
     caption_visible=False,
     empty_message=(
-      'You have not yet uploaded any files yet.'
+      'Upload a letter and Notify will print, pack and post it for you.' if current_service.can_upload_letters else 'You have not uploaded any files yet'
     ),
     field_headings=[
       'File',

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -9,7 +9,8 @@
 
   <h1 class="heading-large">Upload a letter</h1>
 
-  <p>You can upload and send your own letters instead of creating a reusable letter template.</p>
+  <p>Upload a one-off letter as a PDF and we’ll print, pack and post it for you.</p>
+  <p>You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
 
   <p>To upload and send a letter from a PDF file:</p>
 
@@ -19,7 +20,9 @@
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>
 
-  <h2 class="heading-medium" id="letter-specification">Letter specification</h2>
+  <h2 class="heading-medium" id="letter-specification">Your file must meet our letter specification</h2>
+
+  <p>The content of your letter must appear inside the printable area.</p>
 
   <p>Your file must be:</p>
 
@@ -30,14 +33,6 @@
     <li>smaller than 2MB</li>
   </ul>
 
-  <p>The content of your letter must appear inside the printable area.</p>
-
-  <p>To help you set up your letter, you can download our:</p>
-
-  <ul class="list list-bullet">
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">print margin checker for Microsoft Word (.docx)</a></li>
-  </ul>
-
+  <p>To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a>.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -1,5 +1,6 @@
 {% extends "content_template.html" %}
 {% from "components/service-link.html" import service_link %}
+>>>>>>> Update content so it matches 3302
 
 {% block per_page_title %}
   Upload a letter

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
 {% from "components/service-link.html" import service_link %}
->>>>>>> Update content so it matches 3302
 
 {% block per_page_title %}
   Upload a letter

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -4,7 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 
 {% block service_page_title %}
-  Upload a one-off letter
+  Upload a letter
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -19,7 +19,7 @@
       {% endcall %}
     {% else %}
       {{ page_header(
-        'Upload a one-off letter',
+        'Upload a letter',
         back_link=url_for('main.uploads', service_id=current_service.id)
     ) }}
     <p>Upload a single letter as a PDF and we’ll print, pack and post it for you.</p>
@@ -35,9 +35,20 @@
     )}}
   </p>
 
-  <h2 class="heading-medium">Your file must meet our letter specification TBC</h2>
-  <p>You can upload a single letter as a PDF.</p>
-  <p>Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification</a>.</p>
+  <h2 class="heading-medium">Your file must meet our letter specification</h2>
+
+  <p>The content of your letter must appear inside the printable area.</p>
+
+  <p>Your file must be:</p>
+
+    <ul class="list list-bullet">
+      <li>a PDF</li>
+      <li>A4 portrait size (210 × 297 mm)</li>
+      <li>10 pages or less</li>
+      <li>smaller than 2MB</li>
+    </ul>
+
+  <p>To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification document (PDF)</a>.</p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -22,6 +22,7 @@
         'Upload a letter',
         back_link=url_for('main.uploads', service_id=current_service.id)
     ) }}
+      <p>If a reusable letter template does not meet your needs, you can upload and send a one-off letter instead.</p>
     {% endif %}
 
   <p>
@@ -32,9 +33,10 @@
       show_errors=False
     )}}
   </p>
+
+  <h2 class="heading-medium">Your file must meet our letter specification TBC</h2>
   <p>You can upload a single letter as a PDF.</p>
   <p>Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification</a>.</p>
-
   </div>
 </div>
 {% endblock %}

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -48,7 +48,7 @@
       <li>smaller than 2MB</li>
     </ul>
 
-  <p>To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification document (PDF)</a>.</p>
+  <p>To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a>.</p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -22,7 +22,8 @@
         'Upload a letter',
         back_link=url_for('main.uploads', service_id=current_service.id)
     ) }}
-      <p>If a reusable letter template does not meet your needs, you can upload and send a one-off letter instead.</p>
+    <p>Upload a single letter as a PDF and we'll print, pack and post it for you.</p>
+    <p>You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
     {% endif %}
 
   <p>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -4,7 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 
 {% block service_page_title %}
-  Upload a letter
+  Upload a one-off letter
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -19,10 +19,10 @@
       {% endcall %}
     {% else %}
       {{ page_header(
-        'Upload a letter',
+        'Upload a one-off letter',
         back_link=url_for('main.uploads', service_id=current_service.id)
     ) }}
-    <p>Upload a single letter as a PDF and we'll print, pack and post it for you.</p>
+    <p>Upload a single letter as a PDF and we’ll print, pack and post it for you.</p>
     <p>You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
     {% endif %}
 


### PR DESCRIPTION
Research shows users:

* are confused about when they would need to upload a letter
* expect an uploaded letter to behave in the same way as a letter template – with placeholders that can be filled
* miss important information about the layout specifications of their letter

This PR updates the _Guidance_ and _Upload a letter_ pages to:

* do a better job of explaining the feature
* provide context, guidance and important information at the right point in the journey
