### PR TITLE
Make analytics send the same title for all pages

### DIFF
--- a/app/assets/javascripts/analytics/analytics.js
+++ b/app/assets/javascripts/analytics/analytics.js
@@ -15,6 +15,7 @@
     window.ga('set', 'anonymizeIp', config.anonymizeIp);
     window.ga('set', 'allowAdFeatures', config.allowAdFeatures);
     window.ga('set', 'transport', config.transport);
+    window.ga('set', 'title', 'GOV.UK Notify');
 
   };
 

--- a/tests/javascripts/analytics/analytics.test.js
+++ b/tests/javascripts/analytics/analytics.test.js
@@ -52,6 +52,7 @@ describe("Analytics", () => {
       expect(setUpArguments[1]).toEqual(['set', 'anonymizeIp', true]);
       expect(setUpArguments[2]).toEqual(['set', 'allowAdFeatures', false]);
       expect(setUpArguments[3]).toEqual(['set', 'transport', 'beacon']);
+      expect(setUpArguments[4]).toEqual(['set', 'title', 'GOV.UK Notify']);
 
     });
 

--- a/tests/javascripts/analytics/init.test.js
+++ b/tests/javascripts/analytics/init.test.js
@@ -111,10 +111,10 @@ describe("Analytics init", () => {
 
     test("A pageview will be registered", () => {
 
-      expect(window.ga.mock.calls.length).toEqual(5);
+      expect(window.ga.mock.calls.length).toEqual(6);
 
-      // The first 4 calls configure the analytics tracker. All subsequent calls send data
-      expect(window.ga.mock.calls[4]).toEqual(['send', 'pageview', '/privacy']);
+      // The first 5 calls configure the analytics tracker. All subsequent calls send data
+      expect(window.ga.mock.calls[5]).toEqual(['send', 'pageview', '/privacy']);
 
     });
 

--- a/tests/javascripts/cookieSettings.test.js
+++ b/tests/javascripts/cookieSettings.test.js
@@ -231,8 +231,8 @@ describe("Cookie settings", () => {
         expect(window.GOVUK.initAnalytics).toHaveBeenCalled();
 
         expect(window.ga).toHaveBeenCalled();
-        // the first 4 calls are configuration
-        expect(window.ga.mock.calls[4]).toEqual(['send', 'pageview', '/privacy']);
+        // the first 5 calls are configuration
+        expect(window.ga.mock.calls[5]).toEqual(['send', 'pageview', '/privacy']);
 
       });
 


### PR DESCRIPTION
We don't need the data and this will stop any personal info' being sent.

https://www.pivotaltracker.com/n/projects/1443052/stories/171378392

## How do I test this?

Use Chrome and install the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna/related) to see the data sent to Google Analytics.

We track pageviews and validation errors (see https://www.notifications.service.gov.uk/cookies) so it's worth checking both.