### PR TITLE
Summarise scheduled jobs on the dashboard

### DIFF
--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -4,38 +4,24 @@
 
 <div class="ajax-block-container">
   {% if current_service.scheduled_jobs %}
-    <div class='dashboard-table'>
-      {% if not hide_heading %}
-        <h2 class="heading-medium heading-upcoming-jobs">
-          In the next few days
-        </h2>
-      {% endif %}
-      {% call(item, row_number) list_table(
-        current_service.scheduled_jobs,
-        caption="In the next few days",
-        caption_visible=False,
-        empty_message='Nothing to see here',
-        field_headings=[
-          'File',
-          'Messages to be sent'
-        ],
-        field_headings_visible=True
-      ) %}
-        {% call row_heading() %}
-          <div class="file-list">
-            <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
-            <span class="file-list-hint">
-              Sending {{ item.scheduled_for|format_datetime_relative }}
-            </span>
-          </div>
-        {% endcall %}
-        {% call field() %}
-          {{ big_number(
-            item.notification_count,
-            smallest=True
-          ) }}
-        {% endcall %}
-      {% endcall %}
-    </div>
+    <h2 class="heading-medium heading-upcoming-jobs">
+      In the next few days
+    </h2>
+    <a class="govuk-link govuk-link--no-visited-state banner-dashboard" href="{{ url_for('.uploads', service_id=current_service.id) }}">
+      <span class="banner-dashboard-count">
+        {{ current_service.scheduled_jobs|length }}
+      </span>
+      <span class="banner-dashboard-count-label">
+        {% if current_service.scheduled_jobs|length == 1 %}
+          file waiting to send
+        {% else %}
+          files waiting to send
+        {% endif %}
+      </span>
+      <span class="banner-dashboard-meta">
+        sending starts
+        {{ current_service.scheduled_jobs[0].scheduled_for|format_datetime_relative }}
+      </span>
+    </a>
   {% endif %}
 </div>

--- a/app/templates/views/jobs/_scheduled.html
+++ b/app/templates/views/jobs/_scheduled.html
@@ -1,0 +1,34 @@
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/big-number.html" import big_number %}
+{% from "components/show-more.html" import show_more %}
+
+{% if current_service.scheduled_jobs %}
+  <div class='dashboard-table'>
+    {% call(item, row_number) list_table(
+      current_service.scheduled_jobs,
+      caption="In the next few days",
+      caption_visible=False,
+      empty_message='Nothing to see here',
+      field_headings=[
+        'File',
+        'Messages to be sent'
+      ],
+      field_headings_visible=True
+    ) %}
+      {% call row_heading() %}
+        <div class="file-list">
+          <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+          <span class="file-list-hint">
+            Sending {{ item.scheduled_for|format_datetime_relative }}
+          </span>
+        </div>
+      {% endcall %}
+      {% call field() %}
+        {{ big_number(
+          item.notification_count,
+          smallest=True
+        ) }}
+      {% endcall %}
+    {% endcall %}
+  </div>
+{% endif %}

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -11,7 +11,7 @@
     <div class="dashboard">
       {% if show_scheduled_jobs %}
         {% with hide_heading = True %}
-          {% include 'views/dashboard/_upcoming.html' %}
+          {% include 'views/jobs/_scheduled.html' %}
         {% endwith %}
       {% endif %}
       {% if jobs %}


### PR DESCRIPTION
Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/74930805-44c3a280-53d6-11ea-933d-b8527cc0f2eb.png) | ![image](https://user-images.githubusercontent.com/355079/74930741-26f63d80-53d6-11ea-83a7-5901ea95f0c2.png)

***

Scheduled jobs push everything else on the dashboard down, which makes them very prominent. This is exacerbated by people scheduling more jobs simultaneously than we expected when we originally designed the feature.

We also want to remove all jobs from the dashboard, in favour of putting them on the uploads page.

So this commit replaces them with one of our new dashboard banners (used for received text messages in returned letters) which summarises:
- how many scheduled jobs you have
- when the first one is going out (i.e. how long you have to stop it, if  you need to)

***

Shouldn’t be merged until:
- [x] #3306