### PR TITLE
Remove links to templates and permissions

### DIFF
--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -43,17 +43,17 @@
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Write some messages</h2>
-    <p>Add <a href="{{ url_for('main.features', _anchor='templates') }}">message templates</a> with examples of the content you plan to send. You can use our <a href="{{ url_for('main.guidance_index') }}">guidance</a> to help you.</p>
+    <p>Add message templates with examples of the content you plan to send. You can use our <a href="{{ url_for('main.guidance_index') }}">guidance</a> to help you.</p>
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Set up your service</h2>
     {% if not current_user.is_authenticated or not current_service %}
     <p>Review your settings to add message branding, reply-to addresses and sender information.</p>
-    <p>Add team members and check their <a href="{{ url_for('main.features', _anchor='permissions') }}">permissions</a>.</p>
+    <p>Add team members and check their permissions.</p>
     {% else %}
     <p>Review your <a href="{{ url_for('.service_settings', service_id=current_service.id) }}">settings</a> to add message branding, reply-to addresses and sender information.</p>
-    <p>Add <a href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a> and check their <a href="{{ url_for('main.features', _anchor='permissions') }}">permissions</a>.</p>
+    <p>Add <a href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a> and check their permissions.</p>
     {% endif %}
   </li>
 


### PR DESCRIPTION
This PR removes the following links to features content from the [Get started](https://www.notifications.service.gov.uk/using-notify/get-started) page:

- [Message templates](https://www.notifications.service.gov.uk/features#templates) from step 3
- [Permissions](https://www.notifications.service.gov.uk/features#permissions) from step 4

## Reason
For Notify users who are signed in, these links are not as useful as the other links to relevant guidance or service pages.

The 2 links are most useful for potential Notify users without an account. However, they're probably not essential, because step 1 already links to the [Features](https://www.notifications.service.gov.uk/features) page.

We could display the links when users are signed out, and hide them when they sign in, but this feels like a confusing behaviour.

We should probably remove them from both states for consistency.