### PR TITLE
Fix links to current service pages from guidance

### DIFF
--- a/app/templates/components/current-service-link.html
+++ b/app/templates/components/current-service-link.html
@@ -1,7 +1,0 @@
-{% macro current_service_link(endpoint, link_text) %}
-  {% if current_service %}
-    <a class="govuk-link" href="{{ url_for(endpoint, service_id=current_service.id) }}">{{ link_text }}</a>
-  {% else %}
-    <b class="govuk-!-font-weight-bold">{{ link_text|capitalize }}</b>
-  {% endif %}
-{% endmacro %}

--- a/app/templates/components/service-link.html
+++ b/app/templates/components/service-link.html
@@ -1,6 +1,6 @@
 {% macro service_link(service, endpoint, link_text) %}
   {% if service %}
-    <a class="govuk-link" href="{{ url_for(endpoint, service_id=service.id) }}">{{ link_text }}</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(endpoint, service_id=service.id) }}">{{ link_text }}</a>
   {% else %}
     <b class="govuk-!-font-weight-bold">{{ link_text|capitalize }}</b>
   {% endif %}

--- a/app/templates/components/service-link.html
+++ b/app/templates/components/service-link.html
@@ -1,0 +1,7 @@
+{% macro service_link(service, endpoint, link_text) %}
+  {% if service %}
+    <a class="govuk-link" href="{{ url_for(endpoint, service_id=service.id) }}">{{ link_text }}</a>
+  {% else %}
+    <b class="govuk-!-font-weight-bold">{{ link_text|capitalize }}</b>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -1,5 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/current-service-link.html" import current_service_link %}
+{% from "components/service-link.html" import service_link %}
 
 {% block per_page_title %}
   Branding and customisation
@@ -25,7 +25,7 @@
   <p>To change your email branding:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Email branding</b> row.</li>
   </ol>
 
@@ -36,7 +36,7 @@
   <p>To add a reply-to email address:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Reply-to email addresses</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Add reply-to address</b>.</li>
   </ol>
@@ -48,7 +48,7 @@
   <p>To change the text message sender from the default of ‘GOVUK’:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Manage</b> on the <b class="govuk-!-font-weight-bold">Text message senders</b> row.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> or <b class="govuk-!-font-weight-bold">Add text message sender</b>.</li>
 </ol>
@@ -60,7 +60,7 @@
   <p>To add a logo to your letters:</p>
 
   <ol class="list list-number">
-    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the {{ current_service_link('main.service_settings', 'settings') }} page.</li>
+    <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Change</b> on the <b class="govuk-!-font-weight-bold">Letter branding</b> row.</li>
   </ol>
 

--- a/app/templates/views/guidance/create-and-send-messages.html
+++ b/app/templates/views/guidance/create-and-send-messages.html
@@ -1,5 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/current-service-link.html" import current_service_link %}
+{% from "components/service-link.html" import service_link %}
 
 {% block per_page_title %}
   Send messages
@@ -15,7 +15,7 @@
 
   <p>To send a batch of messages at once:</p>
   <ol class="list list-number">
-    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page and choose an existing template.</li>
+    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page and choose an existing template.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Send</b>.</li>
     <li>If you’re sending emails, select <b class="govuk-!-font-weight-bold">Upload a list of email addresses</b>. If you’re sending text messages, select <b class="govuk-!-font-weight-bold">Upload a list of phone numbers</b>. If you’re sending letters, select <b class="govuk-!-font-weight-bold">Upload a list of addresses</b>.</li>
 

--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -1,5 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/current-service-link.html" import current_service_link %}
+{% from "components/service-link.html" import service_link %}
 
 {% block per_page_title %}
   Edit and format messages
@@ -22,7 +22,7 @@
   <p>You can see a list of formatting instructions on the edit template page:</p>
 
   <ol class="list list-number">
-    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page.</li>
+    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
   </ol>
 
@@ -61,7 +61,7 @@
   <p>To add a placeholder to the template:</p>
 
   <ol class="list list-number">
-    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page.</li>
+    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Add a placeholder using double brackets. For example: Hello ((first&nbsp;name)), your reference is ((ref&nbsp;number)).</li>
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>
@@ -81,7 +81,7 @@
   <p>To add optional content to your emails and text messages:</p>
 
   <ol class="list list-number">
-    <li>Go to the {{ current_service_link('main.choose_template', 'templates') }} page.</li>
+    <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
     <li>Use double brackets and ?? to define optional content. For example, if you only want to show something to people who are under 18: ((under18??Please get your application signed by a parent or guardian.))</li>
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -1,5 +1,5 @@
 {% extends "content_template.html" %}
-{% from "components/current-service-link.html" import current_service_link %}
+{% from "components/service-link.html" import service_link %}
 
 {% block per_page_title %}
   Upload a letter
@@ -14,7 +14,7 @@
   <p>To upload and send a letter from a PDF file:</p>
 
   <ol class="list list-number">
-    <li>Go to the {{ current_service_link('main.uploads', 'uploads') }} page.</li>
+    <li>Go to the {{ service_link(current_service, 'main.uploads', 'uploads') }} page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Upload a letter</b>.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 from app.main.forms import FieldWithNoneOption
-from tests.conftest import normalize_spaces, sample_uuid
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces, sample_uuid
 
 
 def test_non_logged_in_user_can_see_homepage(
@@ -107,6 +107,34 @@ def test_static_pages(
         session['service_id'] = None
         session['user_id'] = None
     request()
+
+
+def test_guidance_pages_link_to_service_pages_when_signed_in(
+    client_request,
+):
+    request = partial(client_request.get, 'main.edit_and_format_messages')
+    selector = '.list-number li a'
+
+    # Check the page loads when user is signed in
+    page = request()
+    assert page.select_one(selector)['href'] == url_for(
+        'main.choose_template',
+        service_id=SERVICE_ONE_ID,
+    )
+
+    # Check it still works when they don’t have a recent service
+    with client_request.session_transaction() as session:
+        session['service_id'] = None
+    page = request()
+    assert not page.select_one(selector)
+
+    # Check it still works when they sign out
+    client_request.logout()
+    with client_request.session_transaction() as session:
+        session['service_id'] = None
+        session['user_id'] = None
+    page = request()
+    assert not page.select_one(selector)
 
 
 @pytest.mark.parametrize('view, expected_view', [


### PR DESCRIPTION
This wasn’t working because:
- macros don’t have access to `current_service` from within their scope
- there were no tests for this behaviour