### PR TITLE
Convert all layouts to GOV.UK Frontend style

### DIFF
--- a/app/assets/javascripts/previewPane.js
+++ b/app/assets/javascripts/previewPane.js
@@ -28,7 +28,7 @@
   }
 
   $paneWrapper.append($previewPane);
-  $form.find('.grid-row').eq(0).prepend($paneWrapper);
+  $form.find('.govuk-grid-row').eq(0).prepend($paneWrapper);
   $form.attr('action', location.pathname.replace(new RegExp(`set-${previewType}-branding$`), `preview-${previewType}-branding`));
   $form.find('button[type="submit"]').text('Save');
 

--- a/app/assets/javascripts/previewPane.js
+++ b/app/assets/javascripts/previewPane.js
@@ -10,7 +10,7 @@
 
   branding_style = branding_style.val();
 
-  const $paneWrapper = $('<div class="column-full"></div>');
+  const $paneWrapper = $('<div class="govuk-grid-column-full"></div>');
   const $form = $('form');
   const previewType = $form.data('previewType');
   const $previewPane = $(`<iframe src="/_${previewType}?${buildQueryString(['branding_style', branding_style])}" class="branding-preview"></iframe>`);

--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -1,29 +1,22 @@
-.column-whole {
-  @include grid-column(1/1);
+
+.govuk-grid-column-one-sixth {
+  @include govuk-grid-column(one-sixth, $class: false);
 }
 
-.column-three-quarters {
-  @include grid-column(3/4);
+.govuk-grid-column-five-sixths {
+  @include govuk-grid-column(five-sixths, $class: false);
 }
 
-.column-one-sixth {
-  @include grid-column(1/6);
+.govuk-grid-column-one-eighth {
+  @include govuk-grid-column(one-eighth, $class: false);
 }
 
-.column-five-sixths {
-  @include grid-column(5/6);
+.govuk-grid-column-five-eighths {
+  @include govuk-grid-column(five-eighths, $class: false);
 }
 
-.column-one-eighth {
-  @include grid-column(1/8);
-}
-
-.column-five-eighths {
-  @include grid-column(5/8);
-}
-
-.column-seven-eighths {
-  @include grid-column(7/8);
+.govuk-grid-column-seven-eighths {
+  @include govuk-grid-column(seven-eighths, $class: false);
 }
 
 %top-gutter,

--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -23,28 +23,28 @@
 .top-gutter {
   @extend %contain-floats;
   display: block;
-  margin-top: $gutter;
+  margin-top: govuk-spacing(6);
   clear: both;
 }
 
 .top-gutter-4-3 {
   @extend %top-gutter;
-  margin-top: $gutter * 4 / 3;
+  margin-top: govuk-spacing(7);
 }
 
 .top-gutter-1-2 {
   @extend %top-gutter;
-  margin-top: $gutter-half;
+  margin-top: govuk-spacing(3);
 }
 
 .top-gutter-1-3 {
   @extend %top-gutter;
-  margin-top: $gutter / 3;
+  margin-top: govuk-spacing(2);
 }
 
 .top-gutter-2-3 {
   @extend %top-gutter;
-  margin-top: $gutter * 2 / 3;
+  margin-top: govuk-spacing(4);
 }
 
 .top-gutter-0 {
@@ -54,41 +54,41 @@
 %bottom-gutter,
 .bottom-gutter {
   @extend %contain-floats;
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
   clear: both;
 }
 
 .bottom-gutter-2-3 {
   @extend %bottom-gutter;
-  margin-bottom: $gutter-two-thirds;
+  margin-bottom: govuk-spacing(4);
 }
 
 .bottom-gutter-1-2 {
   @extend %bottom-gutter;
-  margin-bottom: $gutter-half;
+  margin-bottom: govuk-spacing(3);
 }
 
 .bottom-gutter-1-3 {
   @extend %bottom-gutter;
-  margin-bottom: $gutter/3;
+  margin-bottom: govuk-spacing(2);
 }
 
 .bottom-gutter-3-2 {
   @extend %bottom-gutter;
-  margin-bottom: $gutter * 3/2;
+  margin-bottom: govuk-spacing(6) * 3/2;
 }
 
 .bottom-gutter-2 {
   @extend %bottom-gutter;
-  margin-bottom: $gutter * 2;
+  margin-bottom: govuk-spacing(9);
 }
 
 .left-gutter {
-  padding-left: $gutter;
+  padding-left: govuk-spacing(6);
 }
 
 .left-gutter-4-3 {
-  padding-left: $gutter * 4 / 3;
+  padding-left: govuk-spacing(7);
 }
 
 .align-with-heading {
@@ -111,5 +111,5 @@
 }
 
 .align-with-big-number-hint {
-  margin-top: $gutter / 0.6;
+  margin-top: govuk-spacing(8);
 }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -17,7 +17,7 @@
 
   .heading-large,
   > .heading-medium {
-    margin: $gutter-half 0 ($gutter / 3 * 2) 0;
+    margin: govuk-spacing(3) 0 govuk-spacing(4) 0;
     word-wrap: break-word;
 
     &.top-gutter-0 {
@@ -55,7 +55,7 @@ td {
 }
 
 .heading-medium {
-  margin-top: $gutter;
+  margin-top: govuk-spacing(6);
 }
 
 .form-label {
@@ -86,12 +86,12 @@ td {
 
 details summary {
   text-decoration: underline;
-  margin-bottom: $gutter-half;
+  margin-bottom: govuk-spacing(3);
 }
 
 .spreadsheet {
 
-  margin-bottom: -$gutter;
+  margin-bottom: -govuk-spacing(6);
 
   .table {
     margin-bottom: 0;
@@ -208,5 +208,5 @@ details .arrow {
 }
 
 .heading-upcoming-jobs {
-  margin-top: $gutter-half;
+  margin-top: govuk-spacing(3);
 }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -91,7 +91,7 @@ details summary {
 
 .spreadsheet {
 
-  margin-bottom: -govuk-spacing(6);
+  margin-bottom: -1 * govuk-spacing(6);
 
   .table {
     margin-bottom: 0;

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -187,10 +187,6 @@ details .arrow {
   margin-top: 5px;
 }
 
-#content.override-elements-content {
-  padding-bottom: 0;
-}
-
 .multiple-choice input:disabled+label {
   opacity: 1;
   color: $secondary-text-colour;

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -88,7 +88,7 @@
     }
 
     & + p {
-      margin-top: -govuk-spacing(3);
+      margin-top: -1 * govuk-spacing(3);
     }
 
   }
@@ -175,7 +175,7 @@
   }
 
   & + .banner-dashboard {
-    margin-top: -govuk-spacing(6);
+    margin-top: -1 * govuk-spacing(6);
     border-top: none;
   }
 }

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -5,8 +5,8 @@
   @include bold-19;
   color: $button-colour;
   display: block;
-  padding: $gutter-half;
-  margin: $gutter-half 0 $gutter 0;
+  padding: govuk-spacing(3);
+  margin: govuk-spacing(3) 0 govuk-spacing(6) 0;
   text-align: left;
   position: relative;
   clear: both;
@@ -28,11 +28,11 @@
 
 %banner-with-tick,
 .banner-with-tick {
-  padding: $gutter-half ($gutter + $gutter-half);
+  padding: govuk-spacing(3) (govuk-spacing(6) + govuk-spacing(3));
   background-image: file-url('tick.png');
   background-size: 19px;
   background-repeat: no-repeat;
-  background-position: $gutter-half $gutter-half;
+  background-position: govuk-spacing(3) govuk-spacing(3);
 
 }
 
@@ -68,7 +68,7 @@
   color: $white;
   margin-top: 10px;
   margin-bottom: 0;
-  padding: $gutter;
+  padding: govuk-spacing(6);
   height: 425px;
   overflow: hidden;
   box-shadow: inset 0 -1em 1.6em 0 rgba(0, 0, 0, 0.05);
@@ -81,14 +81,14 @@
   p {
 
     margin-top: 0;
-    margin-bottom: $gutter;
+    margin-bottom: govuk-spacing(6);
 
     &:last-child {
       margin-bottom: 0;
     }
 
     & + p {
-      margin-top: -$gutter-half;
+      margin-top: -govuk-spacing(3);
     }
 
   }
@@ -98,7 +98,7 @@
     font-weight: bold;
     display: block;
     padding: 0 ;
-    margin: 0 0 $gutter 0;
+    margin: 0 0 govuk-spacing(6) 0;
 
     &:link,
     &:visited {
@@ -133,15 +133,15 @@
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  padding: ($gutter-half - 1px) 0 ($gutter-half + 1px) 0;
+  padding: (govuk-spacing(3) - 1px) 0 (govuk-spacing(3) + 1px) 0;
   border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
   text-decoration: none;
 
   &:focus {
     border-top: 1px solid transparent;
-    border-bottom: 1px solid transparent;    
+    border-bottom: 1px solid transparent;
   }
 
   &-count,
@@ -175,7 +175,7 @@
   }
 
   & + .banner-dashboard {
-    margin-top: -$gutter;
+    margin-top: -govuk-spacing(6);
     border-top: none;
   }
 }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -18,7 +18,7 @@
 
 .big-number-dark {
   @extend %big-number;
-  padding: $gutter-half;
+  padding: govuk-spacing(3);
   position: relative;
   background: $black;
   color: $white;
@@ -52,11 +52,11 @@
 
   @extend %big-number;
   position: relative;
-  margin-bottom: $gutter-two-thirds;
+  margin-bottom: govuk-spacing(4);
 
   .big-number,
   .big-number-smaller {
-    padding: $gutter-half;
+    padding: govuk-spacing(3);
     position: relative;
     background: $black;
     color: $white;
@@ -146,12 +146,12 @@
 .big-number-meta-wrapper {
 
   position: relative;
-  margin: $gutter-half 0 $gutter 0;
+  margin: govuk-spacing(3) 0 govuk-spacing(6) 0;
   background: $govuk-blue;
 
   .big-number-meta {
 
-    padding: ($gutter / 3) $gutter-half;
+    padding: govuk-spacing(2) govuk-spacing(3);
     color: $white;
     pointer-events: none;
 

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -1,11 +1,11 @@
 .browse-list {
-  margin-bottom: $gutter-half;
+  margin-bottom: govuk-spacing(3);
 
   .browse-sub-list {
-    margin-top: $gutter-half;
-    margin-left: $gutter;
+    margin-top: govuk-spacing(3);
+    margin-left: govuk-spacing(6);
     @include media('desktop') {
-      margin-left: $gutter * 2;
+      margin-left: govuk-spacing(9);
     }
   }
 
@@ -13,7 +13,7 @@
   &-sub-item {
     @include bold-24;
     list-style: none;
-    margin-bottom: $gutter-half;
+    margin-bottom: govuk-spacing(3);
   }
 
   &-link {

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -3,7 +3,7 @@
   .selection-summary__text {
     @include core-19($tabular-numbers: true);
     padding: 5px 0 0 0;
-    margin-bottom: $gutter / 2;
+    margin-bottom: govuk-spacing(3);
 
     &:focus {
       outline: none;
@@ -66,7 +66,7 @@
 }
 
 .selection-content {
-  margin-bottom: ($gutter / 3) * 2;
+  margin-bottom: govuk-spacing(4);
 
   .checkboxes-nested {
     margin-bottom: 0;

--- a/app/assets/stylesheets/components/conditional-radios.scss
+++ b/app/assets/stylesheets/components/conditional-radios.scss
@@ -17,7 +17,7 @@ $top-spacing: govuk-spacing(5);
 
   &-panel {
     border-left: $border-thickness solid $border-colour;
-    margin: 0 0 (-govuk-spacing(3)) (govuk-spacing(3) + ($border-thickness / 2));
+    margin: 0 0 (-1 * govuk-spacing(3)) (govuk-spacing(3) + ($border-thickness / 2));
     padding: govuk-spacing(3) 0 0 (govuk-spacing(6) - ($border-thickness / 2));
     position: relative;
     top: -$top-spacing;

--- a/app/assets/stylesheets/components/conditional-radios.scss
+++ b/app/assets/stylesheets/components/conditional-radios.scss
@@ -1,5 +1,5 @@
 $border-thickness: 4px;
-$top-spacing: $gutter - 5px;
+$top-spacing: govuk-spacing(5);
 
 .multiple-choice {
 
@@ -17,8 +17,8 @@ $top-spacing: $gutter - 5px;
 
   &-panel {
     border-left: $border-thickness solid $border-colour;
-    margin: 0 0 (-$gutter-half) ($gutter-half + ($border-thickness / 2));
-    padding: $gutter-half 0 0 ($gutter - ($border-thickness / 2));
+    margin: 0 0 (-govuk-spacing(3)) (govuk-spacing(3) + ($border-thickness / 2));
+    padding: govuk-spacing(3) 0 0 (govuk-spacing(6) - ($border-thickness / 2));
     position: relative;
     top: -$top-spacing;
     z-index: 1;

--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -1,12 +1,12 @@
 $white-50-opaque: rgba($white, 0.5);
 $button-bottom-border-colour: rgba(0, 0, 0, 0.17);
-$email-message-gutter: $gutter * 2;
+$email-message-gutter: govuk-spacing(9);
 
 // sass-lint:disable no-important
 
 .email-message {
 
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
   border: 1px solid $border-colour;
 
   &-meta {
@@ -49,7 +49,7 @@ $email-message-gutter: $gutter * 2;
 
     width: 100%;
     box-sizing: border-box;
-    padding: $gutter-half $email-message-gutter 0 $email-message-gutter;
+    padding: govuk-spacing(3) $email-message-gutter 0 $email-message-gutter;
     margin: 0 0 0 0;
     clear: both;
     position: relative;

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -31,7 +31,7 @@
     &-filename {
       @include bold-19;
       display: inline-block;
-      padding-left: $gutter-half;
+      padding-left: govuk-spacing(3);
     }
 
     &-submit {

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -6,7 +6,7 @@
     z-index: 10;
     overflow-y: hidden;
     box-sizing: border-box;
-    margin: 0 0 $gutter 0;
+    margin: 0 0 govuk-spacing(6) 0;
     padding: 0 0 0 0;
     overflow: hidden;
     border-bottom: 1px solid $border-colour;

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -9,7 +9,7 @@ $iso-paper-ratio: 141.42135624%;
 .letter {
 
   padding: $iso-paper-ratio 0 0 0;
-  margin: 0 0 $gutter 0;
+  margin: 0 0 govuk-spacing(6) 0;
   position: relative;
   background: $panel-colour;
 

--- a/app/assets/stylesheets/components/live-search.scss
+++ b/app/assets/stylesheets/components/live-search.scss
@@ -14,7 +14,7 @@ input[type=search] {
   }
 
   .form-group {
-    margin-bottom: $gutter * 2 / 3;
+    margin-bottom: govuk-spacing(4);
   }
 
 }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   vertical-align: top;
   width: 20px;
-  height: $gutter;
+  height: govuk-spacing(6);
   position: relative;
 
   &:before {
@@ -31,8 +31,8 @@
     margin: 0;
 
     a {
-      margin-bottom: -$gutter;
-      padding-bottom: $gutter;
+      margin-bottom: -govuk-spacing(6);
+      padding-bottom: govuk-spacing(6);
 
       &:hover .message-name-separator:before {
         border-color: $link-hover-colour;
@@ -64,7 +64,7 @@
 
   &-type {
     color: $secondary-text-colour;
-    margin: 0 0 $gutter-two-thirds 0;
+    margin: 0 0 govuk-spacing(4) 0;
     pointer-events: none;
   }
 
@@ -72,7 +72,7 @@
 
 #template-list {
 
-  margin-top: $gutter;
+  margin-top: govuk-spacing(6);
 
   &.top-gutter-5px {
     margin-top: 5px;
@@ -87,7 +87,7 @@
     &-with-checkbox {
 
       position: relative;
-      padding-left: $gutter * 2;
+      padding-left: govuk-spacing(9);
 
       .multiple-choice {
         position: absolute;
@@ -148,22 +148,22 @@
 
   &-empty {
     color: $secondary-text-colour;
-    padding: $gutter-half 0 $gutter-one-third 0;
+    padding: govuk-spacing(3) 0 govuk-spacing(2) 0;
   }
 
   &-selected-counter {
     color: $secondary-text-colour;
-    margin: $gutter-half 0;
+    margin: govuk-spacing(3) 0;
 
     @include media(tablet) {
       position: absolute;
       right: 0;
-      top: $gutter - 1px;
+      top: govuk-spacing(6) - 1px;
       margin: 0;
     }
 
     .content-fixed & {
-      right: $gutter-half;
+      right: govuk-spacing(3);
     }
 
   }
@@ -173,7 +173,7 @@
 .folder-heading {
 
   .govuk-grid-row & {
-    margin: $gutter-half 0 20px 0;
+    margin: govuk-spacing(3) 0 20px 0;
     word-wrap: break-word;
   }
 
@@ -246,7 +246,7 @@
   &-manage-link {
     display: block;
     text-align: right;
-    padding: $gutter-two-thirds 0 0 0;
+    padding: govuk-spacing(4) 0 0 0;
     position: relative;
     top: -6px;
   }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -31,7 +31,7 @@
     margin: 0;
 
     a {
-      margin-bottom: -govuk-spacing(6);
+      margin-bottom: -1 * govuk-spacing(6);
       padding-bottom: govuk-spacing(6);
 
       &:hover .message-name-separator:before {

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -172,7 +172,7 @@
 
 .folder-heading {
 
-  .grid-row & {
+  .govuk-grid-row & {
     margin: $gutter-half 0 20px 0;
     word-wrap: break-word;
   }

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -1,7 +1,7 @@
 .navigation {
 
   @include govuk-font($size: 19);
-  padding: 0 $gutter 0 0;
+  padding: 0 govuk-spacing(6) 0 0;
 
   $padding-top: 14px;
   $padding-bottom: 11px;
@@ -53,7 +53,7 @@
       position: absolute;
       top: 0;
       right: 0;
-      padding: $padding-top 0 $padding-bottom $gutter-half;
+      padding: $padding-top 0 $padding-bottom govuk-spacing(3);
 
       &:focus {
         outline: none;
@@ -67,7 +67,7 @@
 
     &-back-to {
 
-      padding: $padding-top $gutter-half $padding-bottom 0;
+      padding: $padding-top govuk-spacing(3) $padding-bottom 0;
       display: inline-block;
 
     }
@@ -145,7 +145,7 @@
 // https://github.com/alphagov/product-page-example/blob/master/source/stylesheets/modules/_sub-navigation.scss
 .sub-navigation {
   @include media(tablet) {
-    margin-top: $gutter * 1.5;
+    margin-top: govuk-spacing(6) * 1.5;
   }
 
   ol,
@@ -160,7 +160,7 @@
 
     border-bottom: 1px $grey-3 solid;
     display: block;
-    padding: $gutter-one-third 0;
+    padding: govuk-spacing(2) 0;
 
     a:link {
       text-decoration: none;
@@ -172,7 +172,7 @@
     }
 
     ol ol & {
-      padding-left: $gutter;
+      padding-left: govuk-spacing(6);
     }
   }
 

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -17,7 +17,7 @@
 
   &-secondary-link {
     display: block;
-    margin-top: $gutter;
+    margin-top: govuk-spacing(6);
   }
 
   &-right-aligned-link {

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -88,7 +88,7 @@
 
     display: block;
     text-align: left;
-    padding: 10px $gutter-half;
+    padding: 10px govuk-spacing(3);
     text-align: center;
 
     &:link,

--- a/app/assets/stylesheets/components/preview-pane.scss
+++ b/app/assets/stylesheets/components/preview-pane.scss
@@ -3,7 +3,7 @@
   box-sizing: border-box;
   border: solid 1px $border-colour;
   min-height: 200px;
-  margin-bottom: $gutter
+  margin-bottom: govuk-spacing(6)
 }
 
 #logo-img {

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -4,7 +4,7 @@
   @include core-16;
   display: block;
   padding: 0 0;
-  margin: $gutter-half 0 $gutter-half 0;
+  margin: govuk-spacing(3) 0 govuk-spacing(3) 0;
   text-align: center;
   border-top: 1px solid $border-colour;
 

--- a/app/assets/stylesheets/components/site-footer.scss
+++ b/app/assets/stylesheets/components/site-footer.scss
@@ -3,8 +3,8 @@
     margin: 0 auto;
 
     &-wrapper {
-      margin-bottom: $gutter;
-      padding-bottom: $gutter * 2;
+      margin-bottom: govuk-spacing(6);
+      padding-bottom: govuk-spacing(9);
       border-bottom: 1px solid $grey-2;
     }
 

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -6,12 +6,12 @@ $tail-angle: 20deg;
   width: 100%;
   max-width: 464px;
   box-sizing: border-box;
-  padding: $gutter-half $gutter-half $gutter-half $gutter-half;
+  padding: govuk-spacing(3);
   background: $panel-colour;
   border: 1px solid $panel-colour;
   border-radius: 5px;
   white-space: normal;
-  margin: 0 0 $gutter 0;
+  margin: 0 0 govuk-spacing(6) 0;
   clear: both;
   word-wrap: break-word;
 
@@ -63,7 +63,7 @@ $tail-angle: 20deg;
 .sms-message-status {
   @include core-16;
   color: $secondary-text-colour;
-  margin: -20px $gutter-half 20px $gutter-half;
+  margin: -20px govuk-spacing(3) 20px govuk-spacing(3);
 }
 
 .sms-message-status-outbound {

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -7,7 +7,7 @@ $sticky-padding: govuk-spacing(4);
 .js-stick-at-bottom-when-scrolling {
 
   overflow: hidden;
-  margin-left: -govuk-spacing(3);
+  margin-left: -1 * govuk-spacing(3);
   padding: 10px 0 0 govuk-spacing(3);
   position: relative;
 

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -1,14 +1,14 @@
 // CSS adapted from
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/d9489a987086471fe30b4b925a81c12cd198c91d/docs/javascript.md#stick-at-top-when-scrolling
 
-$sticky-padding: $gutter * 2 / 3;
+$sticky-padding: govuk-spacing(4);
 
 .js-stick-at-top-when-scrolling,
 .js-stick-at-bottom-when-scrolling {
 
   overflow: hidden;
-  margin-left: -$gutter-half;
-  padding: 10px 0 0 $gutter-half;
+  margin-left: -govuk-spacing(3);
+  padding: 10px 0 0 govuk-spacing(3);
   position: relative;
 
   .form-group {
@@ -21,8 +21,8 @@ $sticky-padding: $gutter * 2 / 3;
 
   .back-to-top-link {
     position: absolute;
-    top: $gutter;
-    right: $gutter-half;
+    top: govuk-spacing(6);
+    right: govuk-spacing(3);
     opacity: 0;
     transition: opacity 0.1s ease-in-out;
   }
@@ -41,7 +41,7 @@ $sticky-padding: $gutter * 2 / 3;
 .js-stick-at-bottom-when-scrolling {
 
   transition: bottom 0.1s ease-out, box-shadow 1s ease-in-out;
-  padding: $sticky-padding 0 $sticky-padding $gutter-half;
+  padding: $sticky-padding 0 $sticky-padding govuk-spacing(3);
   margin-top: -$sticky-padding;
 
   & + .js-stick-at-bottom-when-scrolling {
@@ -68,7 +68,7 @@ $sticky-padding: $gutter * 2 / 3;
   position: fixed;
   background: $white;
   z-index: 100;
-  padding-right: $gutter-half;
+  padding-right: govuk-spacing(3);
   margin-top: 0;
 
   .back-to-top-link {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -1,11 +1,11 @@
 .table {
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
   width: 100%;
 }
 
 .table-heading {
   text-align: left;
-  margin: $gutter-half 0 $gutter-half 0;
+  margin: govuk-spacing(3) 0 govuk-spacing(3) 0;
 }
 
 .dashboard-table {
@@ -119,7 +119,7 @@
 
   table {
     table-layout: fixed;
-    margin-bottom: $gutter / 6;
+    margin-bottom: govuk-spacing(1);
   }
 
   th {
@@ -343,10 +343,10 @@
 
       position: absolute;
 
-      top: -$gutter-half;
+      top: -govuk-spacing(3);
       right: 0;
-      bottom: -$gutter-half + 4px;
-      left: -$gutter-half;
+      bottom: -govuk-spacing(3) + 4px;
+      left: -govuk-spacing(3);
 
       background: transparent;
     }
@@ -381,13 +381,13 @@ td.table-empty-message {
 
   @include core-16;
   color: $secondary-text-colour;
-  margin-bottom: $gutter * 1.3333;
+  margin-bottom: govuk-spacing(7);
   border-bottom: 1px solid $border-colour;
   padding: 35px 0 10px 0;
   text-align: center;
 
   .table + & {
-    margin-top: -$gutter;
+    margin-top: -govuk-spacing(6);
   }
 
 }
@@ -400,7 +400,7 @@ a.table-show-more-link {
   @include core-16;
   color: $secondary-text-colour;
   margin-top: 10px;
-  margin-bottom: $gutter * 1.3333;
+  margin-bottom: govuk-spacing(7);
   border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
   padding: 0.75em 0 0.5625em 0;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -343,10 +343,10 @@
 
       position: absolute;
 
-      top: -govuk-spacing(3);
+      top: -1 * govuk-spacing(3);
       right: 0;
-      bottom: -govuk-spacing(3) + 4px;
-      left: -govuk-spacing(3);
+      bottom: -1 * govuk-spacing(3) + 4px;
+      left: -1 * govuk-spacing(3);
 
       background: transparent;
     }
@@ -387,7 +387,7 @@ td.table-empty-message {
   text-align: center;
 
   .table + & {
-    margin-top: -govuk-spacing(6);
+    margin-top: -1 * govuk-spacing(6);
   }
 
 }

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -6,7 +6,7 @@ $indicator-colour: $black;
   padding: 3px 8px 1px 8px;
   position: absolute;
   right: 0;
-  top: $gutter - 2px;
+  top: govuk-spacing(6) - 2px;
   margin-top: -15px;
   border: 2px solid $indicator-colour;
   pointer-events: none;
@@ -18,7 +18,7 @@ $indicator-colour: $black;
 .task-list {
 
   border-top: 1px solid $border-colour;
-  margin: $gutter 0;
+  margin: govuk-spacing(6) 0;
 
   &-item {
 
@@ -27,7 +27,7 @@ $indicator-colour: $black;
     a {
       border-bottom: 1px solid $border-colour;
       display: block;
-      padding: $gutter-half 0;
+      padding: govuk-spacing(3) 0;
       padding-right: 20%;
       position: relative;
 
@@ -37,8 +37,8 @@ $indicator-colour: $black;
         border-color: transparent;
         top: -1px;
         margin-bottom: -2px;
-        padding-top: $gutter-half + 1px;
-        padding-bottom: $gutter-half + 1px;
+        padding-top: govuk-spacing(3) + 1px;
+        padding-bottom: govuk-spacing(3) + 1px;
       }
 
     }

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -36,7 +36,7 @@
     overflow-wrap: break-word;
     word-wrap: break-word;
     border: 2px solid transparent;
-    padding-bottom: $gutter-half;
+    padding-bottom: govuk-spacing(3);
     z-index: 10;
 
     .placeholder,

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -23,12 +23,10 @@
 
   &-list {
 
-    @extend %grid-row;
     position: relative;
 
     &-permissions {
 
-      @include grid-column(3/4);
       margin-top: 5px;
 
       li {

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -51,10 +51,10 @@
 
           position: absolute;
 
-          top: -govuk-spacing(3) - 1;
+          top: -1 * govuk-spacing(3) - 1;
           right: 0;
-          bottom: -govuk-spacing(3);
-          left: -govuk-spacing(3);
+          bottom: -1 * govuk-spacing(3);
+          left: -1 * govuk-spacing(3);
 
           background: transparent;
         }

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -51,10 +51,10 @@
 
           position: absolute;
 
-          top: -$gutter-half - 1;
+          top: -govuk-spacing(3) - 1;
           right: 0;
-          bottom: -$gutter-half;
-          left: -$gutter-half;
+          bottom: -govuk-spacing(3);
+          left: -govuk-spacing(3);
 
           background: transparent;
         }

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -32,11 +32,11 @@
   @include govuk-width-container;
   @include core-16($line-height: (25 / 16), $line-height-640: 1.75);
 
-  padding: $gutter-one-third 0;
+  padding: govuk-spacing(2) 0;
   list-style: none;
 
   @include media(tablet) {
-    margin-bottom: $gutter;
+    margin-bottom: govuk-spacing(6);
   }
 
   ol {
@@ -49,7 +49,7 @@
     display: inline-block;
 
     margin: 0;
-    padding: 0 $gutter-one-quarter 0 (11px + $gutter-one-quarter);
+    padding: 0 (govuk-spacing(6) / 4) 0 (11px + govuk-spacing(6) / 4);
 
     background-image: file-url('separator.png');
     background-repeat: no-repeat;

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -29,7 +29,7 @@
  */
 
 .breadcrumbs {
-  @extend %site-width-container;
+  @include govuk-width-container;
   @include core-16($line-height: (25 / 16), $line-height-640: 1.75);
 
   padding: $gutter-one-third 0;

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -32,8 +32,8 @@ $is-ie: false !default;
   display: block;
   margin-top: govuk-spacing(6);
   margin-bottom: govuk-spacing(6);
-  margin-left: -govuk-spacing(3);
-  margin-right: -govuk-spacing(3);
+  margin-left: -1 * govuk-spacing(3);
+  margin-right: -1 * govuk-spacing(3);
   overflow: hidden;
 
   ul {

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -30,10 +30,10 @@ $is-ie: false !default;
 
 .govuk-previous-and-next-navigation {
   display: block;
-  margin-top: $gutter;
-  margin-bottom: $gutter;
-  margin-left: -$gutter-half;
-  margin-right: -$gutter-half;
+  margin-top: govuk-spacing(6);
+  margin-bottom: govuk-spacing(6);
+  margin-left: -govuk-spacing(3);
+  margin-right: -govuk-spacing(3);
   overflow: hidden;
 
   ul {
@@ -52,7 +52,7 @@ $is-ie: false !default;
 
     a {
       display: block;
-      padding: $gutter-half;
+      padding: govuk-spacing(3);
       text-decoration: none;
 
       &:hover,

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -35,3 +35,16 @@
 .govuk-link--destructive {
   @include govuk-link-style-destructive-no-visited-state;
 }
+$govuk-grid-widths: (
+  one-eighth: 12.5%,
+  one-sixth: 16.6666%,
+  one-quarter: 25%,
+  one-third: 33.3333%,
+  one-half: 50%,
+  five-eighths: 62.5%,
+  two-thirds: 66.6666%,
+  three-quarters: 75%,
+  five-sixths: 83.3333%,
+  seven-eighths: 87.5%,
+  full: 100%
+);

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -27,7 +27,6 @@ $path: '/static/images/';
 @import 'elements/forms';
 @import 'elements/forms/form-multiple-choice';
 @import 'elements/forms/form-validation';
-@import 'elements/layout';
 @import 'elements/lists';
 @import 'elements/panels';
 @import 'elements/tables';

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -18,7 +18,7 @@
 
     &__heading {
       display: block;
-      margin-bottom: $gutter-half;
+      margin-bottom: govuk-spacing(3);
 
       &::before {
         top: -1.3em;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -5,14 +5,14 @@
   }
 
   > .heading-medium:first-of-type {
-    margin-top: $gutter-half;
+    margin-top: govuk-spacing(3);
   }
 
 }
 
 .keyline-block {
   border-top: 1px solid $border-colour;
-  padding-top: $gutter-half;
+  padding-top: govuk-spacing(3);
 }
 
 .spark-bar {
@@ -21,8 +21,8 @@
   box-sizing: border-box;
   display: block;
   width: 100%;
-  margin-bottom: $gutter-half;
-  height: $gutter-half;
+  margin-bottom: govuk-spacing(3);
+  height: govuk-spacing(3);
   color: $text-colour;
   text-align: left;
 
@@ -92,5 +92,5 @@
 
 .align-with-message-body {
   display: block;
-  margin-top: $gutter * 5 / 6;
+  margin-top: govuk-spacing(5);
 }

--- a/app/assets/stylesheets/views/get_started.scss
+++ b/app/assets/stylesheets/views/get_started.scss
@@ -5,8 +5,8 @@
   &__item {
 
     counter-increment: get-started-counter;
-    padding: 0 0 0 $gutter + 5px;
-    margin: ($gutter * 1.67) 0 0 0;
+    padding: 0 0 0 govuk-spacing(6) + 5px;
+    margin: govuk-spacing(8) 0 0 0;
     position: relative;
 
     &:before {
@@ -26,7 +26,7 @@
   &__heading {
     @include bold-24;
     display: inline-block;
-    margin: 5px 0 $gutter-half 0;
+    margin: 5px 0 govuk-spacing(3) 0;
   }
 
 }

--- a/app/assets/stylesheets/views/history.scss
+++ b/app/assets/stylesheets/views/history.scss
@@ -1,13 +1,13 @@
-$item-top-padding: $gutter-half;
+$item-top-padding: govuk-spacing(3);
 
 .history-list {
 
   @include core-19;
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 
   &-item {
 
-    padding: $item-top-padding 0 $gutter-half 0;
+    padding: $item-top-padding 0 govuk-spacing(3) 0;
     border-top: 1px solid $border-colour;
     position: relative;
 

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -2,7 +2,7 @@
 
   @include core-16;
   color: $secondary-text-colour;
-  margin-top: -$gutter-half;
+  margin-top: -govuk-spacing(3);
 
   &.error {
 

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -2,7 +2,7 @@
 
   @include core-16;
   color: $secondary-text-colour;
-  margin-top: -govuk-spacing(3);
+  margin-top: -1 * govuk-spacing(3);
 
   &.error {
 

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -18,7 +18,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
     &-wrapper {
 
-      @extend %site-width-container;
+      @include govuk-width-container;
 
       @include media(desktop) {
         background-image: file-url('product/proposition-illustration.png');
@@ -57,7 +57,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
   &-section {
 
-    @extend %site-width-container;
+    @include govuk-width-container;
     margin-bottom: $gutter-half;
 
     h2 {

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -11,8 +11,8 @@ $button-shadow-size: $govuk-border-width-form-element;
     // We need the `<main>` section to be above it, like the default order, so when we apply the
     // negative margin-top it overlaps the theme bar at the bottom of the header
     position: relative;
-    margin: -10px 0 $gutter * 1.5 0;
-    padding: 0 0 $gutter * 2 0;
+    margin: -10px 0 govuk-spacing(6) * 1.5 0;
+    padding: 0 0 govuk-spacing(9) 0;
     background: $product-page-blue;
     color: $white;
 
@@ -31,12 +31,12 @@ $button-shadow-size: $govuk-border-width-form-element;
 
     h1 {
       @include bold-48;
-      margin: 20px 0 $gutter 0;
+      margin: 20px 0 govuk-spacing(6) 0;
     }
 
     p {
       @include core-24;
-      margin: $gutter-half 0 $gutter;
+      margin: govuk-spacing(3) 0 govuk-spacing(6);
     }
 
     .govuk-link {
@@ -58,21 +58,21 @@ $button-shadow-size: $govuk-border-width-form-element;
   &-section {
 
     @include govuk-width-container;
-    margin-bottom: $gutter-half;
+    margin-bottom: govuk-spacing(3);
 
     h2 {
       @include bold-27;
-      margin: 0 0 $gutter;
+      margin: 0 0 govuk-spacing(6);
     }
 
     .with-keyline {
       border-top: 1px solid $border-colour;
-      padding: $gutter * 1.5 0 0 0;
+      padding: govuk-spacing(6) * 1.5 0 0 0;
     }
 
     img {
       width: 100%;
-      margin: 0 0 $gutter * 1.5 0;
+      margin: 0 0 govuk-spacing(6) * 1.5 0;
     }
 
   }

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -9,7 +9,7 @@
   position: absolute;
   background: $link-colour;
   color: $white;
-  padding: 10px $gutter-half;
+  padding: 10px govuk-spacing(3);
   z-index: 10000;
 
   &:link, &:visited {

--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -1,19 +1,19 @@
-$item-top-padding: $gutter-half;
+$item-top-padding: govuk-spacing(3);
 
 .user-list {
 
   @include core-19;
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 
   &-item {
 
-    padding: $item-top-padding 150px $gutter-half 0;
+    padding: $item-top-padding 150px govuk-spacing(3) 0;
     border-top: 1px solid $border-colour;
     position: relative;
 
     h3 {
 
-      padding-right: $gutter-half;
+      padding-right: govuk-spacing(3);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -8,7 +8,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
 
     {% if navigation_links %}
       <div class="column-one-quarter">

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -11,7 +11,7 @@
   <div class="govuk-grid-row">
 
     {% if navigation_links %}
-      <div class="column-one-quarter">
+      <div class="govuk-grid-column-one-quarter">
         {{ sub_navigation(navigation_links) }}
       </div>
       <div class="column-five-eighths">

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -16,7 +16,7 @@
       </div>
       <div class="column-five-eighths">
     {% else %}
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
     {% endif %}
 
     {% block content_column_content %}

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -14,7 +14,7 @@
       <div class="govuk-grid-column-one-quarter">
         {{ sub_navigation(navigation_links) }}
       </div>
-      <div class="column-five-eighths">
+      <div class="govuk-grid-column-five-eighths">
     {% else %}
       <div class="govuk-grid-column-two-thirds">
     {% endif %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}You’re not authorised to see this page{% endblock %}
 {% block maincolumn_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
     <h1>You’re not authorised to see this page</h1>
       <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -2,7 +2,7 @@
 {% block per_page_title %}You’re not authorised to see this page{% endblock %}
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
     <h1>You’re not authorised to see this page</h1>
       <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
   </div>

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}You’re not allowed to see this page{% endblock %}
 {% block maincolumn_content %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
           You’re not allowed to see this page

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -2,7 +2,7 @@
 {% block per_page_title %}You’re not allowed to see this page{% endblock %}
 {% block maincolumn_content %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="heading-large">
           You’re not allowed to see this page
         </h1>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
           Page not found

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -2,7 +2,7 @@
 {% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="heading-large">
           Page not found
         </h1>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
           Page not found

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -2,7 +2,7 @@
 {% block per_page_title %}Page not found{% endblock %}
 {% block maincolumn_content %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="heading-large">
           Page not found
         </h1>

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -1,12 +1,12 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}File too big{% endblock %}
 {% block maincolumn_content %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
           The file you uploaded was too big
         </h1>
-        <div class="grid-row">
+        <div class="govuk-grid-row">
           <div class="column-two-thirds">
             <p>
               Files must be smaller than 5 MB.

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -2,12 +2,12 @@
 {% block per_page_title %}File too big{% endblock %}
 {% block maincolumn_content %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="heading-large">
           The file you uploaded was too big
         </h1>
         <div class="govuk-grid-row">
-          <div class="column-two-thirds">
+          <div class="govuk-grid-column-two-thirds">
             <p>
               Files must be smaller than 5 MB.
             </p>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block maincolumn_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
         Sorry, there’s a problem with GOV.UK Notify

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -2,7 +2,7 @@
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="heading-large">
         Sorry, there’s a problem with GOV.UK Notify
       </h1>

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -19,7 +19,7 @@
       <div class="govuk-grid-column-one-quarter">
         {% include "org_nav.html" %}
       </div>
-      <div class="column-three-quarters">
+      <div class="govuk-grid-column-three-quarters">
         {% block beforeContent %}{% endblock %}
         <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main" >
           {% block content %}

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -15,7 +15,7 @@
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
-    <div class="grid-row govuk-!-padding-bottom-12">
+    <div class="govuk-grid-row govuk-!-padding-bottom-12">
       <div class="column-one-quarter">
         {% include "org_nav.html" %}
       </div>

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -16,7 +16,7 @@
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
     <div class="govuk-grid-row govuk-!-padding-bottom-12">
-      <div class="column-one-quarter">
+      <div class="govuk-grid-column-one-quarter">
         {% include "org_nav.html" %}
       </div>
       <div class="column-three-quarters">

--- a/app/templates/partials/count.html
+++ b/app/templates/partials/count.html
@@ -5,7 +5,7 @@
   {% if notifications_deleted %}
     <div class="govuk-grid-row bottom-gutter-1-2">
       {% for label, query_param, url, count in counts %}
-        <div class="column-one-quarter">
+        <div class="govuk-grid-column-one-quarter">
           {{ big_number(count, label, smaller=True) }}
         </div>
       {% endfor %}

--- a/app/templates/partials/count.html
+++ b/app/templates/partials/count.html
@@ -3,7 +3,7 @@
 
 <div class="ajax-block-container">
   {% if notifications_deleted %}
-    <div class="grid-row bottom-gutter-1-2">
+    <div class="govuk-grid-row bottom-gutter-1-2">
       {% for label, query_param, url, count in counts %}
         <div class="column-one-quarter">
           {{ big_number(count, label, smaller=True) }}

--- a/app/templates/partials/jobs/count-letters.html
+++ b/app/templates/partials/jobs/count-letters.html
@@ -1,7 +1,7 @@
 {% from 'components/big-number.html' import big_number %}
 {% from 'components/message-count-label.html' import message_count_label %}
 
-<div class="grid-row bottom-gutter-2-3">
+<div class="govuk-grid-row bottom-gutter-2-3">
   <div class="column-half">
     <div class="keyline-block">
       {{ big_number(

--- a/app/templates/partials/jobs/count-letters.html
+++ b/app/templates/partials/jobs/count-letters.html
@@ -2,7 +2,7 @@
 {% from 'components/message-count-label.html' import message_count_label %}
 
 <div class="govuk-grid-row bottom-gutter-2-3">
-  <div class="column-half">
+  <div class="govuk-grid-column-one-half">
     <div class="keyline-block">
       {{ big_number(
         job.notification_count,
@@ -11,7 +11,7 @@
       )}}
     </div>
   </div>
-  <div class="column-half">
+  <div class="govuk-grid-column-one-half">
     <div class="keyline-block">
       {{ big_number(
         job.letter_timings.earliest_delivery|string|format_date_short,

--- a/app/templates/partials/tour.html
+++ b/app/templates/partials/tour.html
@@ -3,30 +3,30 @@
 {% call banner_wrapper(type='tour') %}
     <p class="heading-medium">Try sending yourself this example</p>
     <div class="govuk-grid-row bottom-gutter {% if help != '1' %}greyed-out-step{% endif %}">
-      <div class="column-one-sixth">
+      <div class="govuk-grid-column-one-sixth">
         <p class="heading-large" style="float: left;">1.</p>
       </div>
-      <div class="column-five-sixths">
+      <div class="govuk-grid-column-five-sixths">
         <p>
           Every message is sent from a template
         </p>
       </div>
     </div>
     <div class="govuk-grid-row bottom-gutter {% if help != '2' %}greyed-out-step{% endif %}">
-      <div class="column-one-sixth">
+      <div class="govuk-grid-column-one-sixth">
         <p class="heading-large">2.</p>
       </div>
-      <div class="column-five-sixths">
+      <div class="govuk-grid-column-five-sixths">
         <p>
           The template pulls in the data you provide
         </p>
       </div>
     </div>
     <div class="govuk-grid-row bottom-gutter {% if help != '3' %}greyed-out-step{% endif %}">
-      <div class="column-one-sixth">
+      <div class="govuk-grid-column-one-sixth">
         <p class="heading-large">3.</p>
       </div>
-      <div class="column-five-sixths">
+      <div class="govuk-grid-column-five-sixths">
         <p>
           Notify delivers the message
         </p>

--- a/app/templates/partials/tour.html
+++ b/app/templates/partials/tour.html
@@ -2,7 +2,7 @@
 
 {% call banner_wrapper(type='tour') %}
     <p class="heading-medium">Try sending yourself this example</p>
-    <div class="grid-row bottom-gutter {% if help != '1' %}greyed-out-step{% endif %}">
+    <div class="govuk-grid-row bottom-gutter {% if help != '1' %}greyed-out-step{% endif %}">
       <div class="column-one-sixth">
         <p class="heading-large" style="float: left;">1.</p>
       </div>
@@ -12,7 +12,7 @@
         </p>
       </div>
     </div>
-    <div class="grid-row bottom-gutter {% if help != '2' %}greyed-out-step{% endif %}">
+    <div class="govuk-grid-row bottom-gutter {% if help != '2' %}greyed-out-step{% endif %}">
       <div class="column-one-sixth">
         <p class="heading-large">2.</p>
       </div>
@@ -22,7 +22,7 @@
         </p>
       </div>
     </div>
-    <div class="grid-row bottom-gutter {% if help != '3' %}greyed-out-step{% endif %}">
+    <div class="govuk-grid-row bottom-gutter {% if help != '3' %}greyed-out-step{% endif %}">
       <div class="column-one-sixth">
         <p class="heading-large">3.</p>
       </div>

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-<div class="govuk-govuk-grid-row">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     {{ page_header('About your service') }}

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-govuk-grid-row">
   <div class="column-two-thirds">
 
     {{ page_header('About your service') }}

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -12,7 +12,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
     {{ page_header('About your service') }}
 

--- a/app/templates/views/agreement/agreement-accept.html
+++ b/app/templates/views/agreement/agreement-accept.html
@@ -12,7 +12,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-five-sixths">
 
     {{ page_header(

--- a/app/templates/views/agreement/agreement-accept.html
+++ b/app/templates/views/agreement/agreement-accept.html
@@ -13,7 +13,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
 
     {{ page_header(
       'Accept our data sharing and financial agreement',

--- a/app/templates/views/agreement/agreement-confirm.html
+++ b/app/templates/views/agreement/agreement-confirm.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
 
     {{ page_header(
       'Confirm that you accept the agreement',

--- a/app/templates/views/agreement/agreement-confirm.html
+++ b/app/templates/views/agreement/agreement-confirm.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-five-sixths">
 
     {{ page_header(

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
 
     <h1 class="heading-large">

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
     <h1 class="heading-large">
       Download the GOV.UK Notify data sharing and financial agreement

--- a/app/templates/views/agreement/service-agreement-choose.html
+++ b/app/templates/views/agreement/service-agreement-choose.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-five-sixths">
 
     {{ page_header(

--- a/app/templates/views/agreement/service-agreement-choose.html
+++ b/app/templates/views/agreement/service-agreement-choose.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
 
     {{ page_header(
       'Accept the data sharing and financial agreement',

--- a/app/templates/views/agreement/service-agreement-signed.html
+++ b/app/templates/views/agreement/service-agreement-signed.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-five-sixths">
 
     {{ page_header(

--- a/app/templates/views/agreement/service-agreement-signed.html
+++ b/app/templates/views/agreement/service-agreement-signed.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
 
     {{ page_header(
       'Your organisation has already accepted the agreement',

--- a/app/templates/views/agreement/service-agreement.html
+++ b/app/templates/views/agreement/service-agreement.html
@@ -9,7 +9,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
 
     {{ page_header(
       'Accept our data sharing and financial agreement',

--- a/app/templates/views/agreement/service-agreement.html
+++ b/app/templates/views/agreement/service-agreement.html
@@ -8,7 +8,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-five-sixths">
 
     {{ page_header(

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
 
       {{ page_header(
         'Callbacks for delivery receipts',

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
 
       {{ page_header(

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -14,7 +14,7 @@
     back_link=url_for('.api_callbacks', service_id=current_service.id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       <p>
         When you receive a text message in Notify, we can forward it to your system.
         Check the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.callbacks') }}"> callback documentation </a> for more information.

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -13,7 +13,7 @@
     'Callbacks for received text messages',
     back_link=url_for('.api_callbacks', service_id=current_service.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       <p>
         When you receive a text message in Notify, we can forward it to your system.

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -14,7 +14,7 @@
     API integration
   </h1>
 
-  <nav class="grid-row bottom-gutter-1-2">
+  <nav class="govuk-grid-row bottom-gutter-1-2">
     <div class="column-one-third">
       <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
     </div>
@@ -26,7 +26,7 @@
     </div>
   </nav>
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-half">
       <h2 class="heading-small">
         Message log

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -15,13 +15,13 @@
   </h1>
 
   <nav class="govuk-grid-row bottom-gutter-1-2">
-    <div class="column-one-third">
+    <div class="govuk-grid-column-one-third">
       <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
     </div>
-    <div class="column-one-third">
+    <div class="govuk-grid-column-one-third">
       <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.whitelist', service_id=current_service.id) }}">Whitelist</a>
     </div>
-    <div class="column-one-third">
+    <div class="govuk-grid-column-one-third">
       <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">Callbacks</a>
     </div>
   </nav>

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -27,12 +27,12 @@
   </nav>
 
   <div class="govuk-grid-row">
-    <div class="column-half">
+    <div class="govuk-grid-column-one-half">
       <h2 class="heading-small">
         Message log
       </h2>
     </div>
-    <div class="column-half align-with-heading-copy-right">
+    <div class="govuk-grid-column-one-half align-with-heading-copy-right">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.api_integration', service_id=current_service.id) }}">Refresh</a>
     </div>
   </div>

--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -47,7 +47,7 @@
 
   {% call form_wrapper() %}
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
 
         {{ list_entry(

--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -48,7 +48,7 @@
   {% call form_wrapper() %}
 
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
 
         {{ list_entry(
           form.email_addresses,

--- a/app/templates/views/cancelled-invitation.html
+++ b/app/templates/views/cancelled-invitation.html
@@ -2,7 +2,7 @@
 {% block per_page_title %}Invitation has been cancelled{% endblock %}
 {% block maincolumn_content %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <h1 class="heading-large">
           The invitation you were sent has been cancelled
         </h1>

--- a/app/templates/views/cancelled-invitation.html
+++ b/app/templates/views/cancelled-invitation.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% block per_page_title %}Invitation has been cancelled{% endblock %}
 {% block maincolumn_content %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
           The invitation you were sent has been cancelled

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -14,7 +14,7 @@
           {{ heading }}
         </h2>
       </div>
-      <div class="column-three-quarters">
+      <div class="govuk-grid-column-three-quarters">
         <ul>
   {% else %}
     <ul>
@@ -62,7 +62,7 @@
             Platform admin
           </h2>
         </div>
-        <ul class="column-three-quarters">
+        <ul class="govuk-grid-column-three-quarters">
           <li class="browse-list-item">
             <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state">All organisations</a>
             <p class="browse-list-hint">
@@ -106,7 +106,7 @@
           <div class="govuk-grid-column-one-quarter">
             &nbsp;
           </div>
-          <div class="column-three-quarters">
+          <div class="govuk-grid-column-three-quarters">
       {% endif %}
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -8,7 +8,7 @@
   services=[]
 ) %}
   {% if show_heading %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-one-quarter">
         <h2>
           {{ heading }}
@@ -56,7 +56,7 @@
   <nav class="browse-list {% if current_user.has_access_to_live_and_trial_mode_services %}top-gutter-2-3{% endif %}">
 
     {% if current_user.platform_admin %}
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-one-quarter">
           <h2>
             Platform admin
@@ -102,7 +102,7 @@
   {% if can_add_service %}
     <div class="js-stick-at-bottom-when-scrolling">
       {% if current_user.has_access_to_live_and_trial_mode_services %}
-        <div class="grid-row">
+        <div class="govuk-grid-row">
           <div class="column-one-quarter">
             &nbsp;
           </div>

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -9,7 +9,7 @@
 ) %}
   {% if show_heading %}
     <div class="govuk-grid-row">
-      <div class="column-one-quarter">
+      <div class="govuk-grid-column-one-quarter">
         <h2>
           {{ heading }}
         </h2>
@@ -57,7 +57,7 @@
 
     {% if current_user.platform_admin %}
       <div class="govuk-grid-row">
-        <div class="column-one-quarter">
+        <div class="govuk-grid-column-one-quarter">
           <h2>
             Platform admin
           </h2>
@@ -103,7 +103,7 @@
     <div class="js-stick-at-bottom-when-scrolling">
       {% if current_user.has_access_to_live_and_trial_mode_services %}
         <div class="govuk-grid-row">
-          <div class="column-one-quarter">
+          <div class="govuk-grid-column-one-quarter">
             &nbsp;
           </div>
           <div class="column-three-quarters">

--- a/app/templates/views/conversations/messages.html
+++ b/app/templates/views/conversations/messages.html
@@ -1,6 +1,6 @@
 <div class="ajax-block-container">
   {% for message in conversation %}
-    <div class="grid-row sms-message-row" id="n{{ message.id }}" tabindex="0">
+    <div class="govuk-grid-row sms-message-row" id="n{{ message.id }}" tabindex="0">
       {% if message.inbound %}
         <div class="column-two-thirds sms-message-inbound">
           {{ message.content | string }}

--- a/app/templates/views/conversations/messages.html
+++ b/app/templates/views/conversations/messages.html
@@ -9,7 +9,7 @@
           </div>
         </div>
       {% else %}
-        <div class="column-one-third">
+        <div class="govuk-grid-column-one-third">
           &nbsp;
         </div>
         <div class="column-two-thirds">

--- a/app/templates/views/conversations/messages.html
+++ b/app/templates/views/conversations/messages.html
@@ -2,7 +2,7 @@
   {% for message in conversation %}
     <div class="govuk-grid-row sms-message-row" id="n{{ message.id }}" tabindex="0">
       {% if message.inbound %}
-        <div class="column-two-thirds sms-message-inbound">
+        <div class="govuk-grid-column-two-thirds sms-message-inbound">
           {{ message.content | string }}
           <div class="sms-message-status">
             {{ message.created_at | format_datetime_relative }}
@@ -12,7 +12,7 @@
         <div class="govuk-grid-column-one-third">
           &nbsp;
         </div>
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           {{ message.content | string }}
           {% if message.status == 'delivered' %}
             <div class="sms-message-status sms-message-status-outbound">

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
       <h2 class="banner-title">Your cookie settings were saved</h2>
       <a class="govuk_link cookie-settings__prev-page govuk-!-margin-top-1" href="#" data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
       <h2 class="banner-title">Your cookie settings were saved</h2>
@@ -89,7 +89,7 @@
         <tbody>
             <tr>
                 <td>
-                  _ga 
+                  _ga
                 </td>
                 <td width="50%">
                   Checks if you’ve visited Notify before. This helps us count how many people visit our site.

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -69,18 +69,18 @@
           {% endfor %}
         </p>
       {% else %}
-        <div class="grid-row">
-          <div class="column-one-third">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-third">
             {{ big_number(
               item.notifications_sending,
               smallest=True,
               label='sending',
             ) }}
           </div>
-          <div class="column-one-third">
+          <div class="govuk-grid-column-one-third">
         {{ big_number(item.notifications_delivered, smallest=True, label='delivered') }}
       </div>
-      <div class="column-one-third">
+      <div class="govuk-grid-column-one-third">
         {{ big_number(item.notifications_failed, smallest=True, label='failed') }}
       </div></div>
 

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -3,7 +3,7 @@
 
 <div class="ajax-block-container">
   <div class="govuk-grid-row">
-    <div id="total-email" class="column-third">
+    <div id="total-email" class="govuk-grid-column-one-third">
       {{ big_number_with_status(
         statistics['email']['requested'],
         message_count_label(statistics['email']['requested'], 'email', suffix='sent'),
@@ -15,7 +15,7 @@
         smaller=True,
       ) }}
     </div>
-    <div id="total-sms" class="column-third">
+    <div id="total-sms" class="govuk-grid-column-one-third">
       {{ big_number_with_status(
         statistics['sms']['requested'],
         message_count_label(statistics['sms']['requested'], 'sms', suffix='sent'),
@@ -27,7 +27,7 @@
         smaller=True,
       ) }}
     </div>
-    <div id="total-letters" class="column-third">
+    <div id="total-letters" class="govuk-grid-column-one-third">
       {{ big_number_with_status(
         statistics['letter']['requested'],
         message_count_label(statistics['letter']['requested'], 'letter', suffix='sent'),

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -2,7 +2,7 @@
 {% from "components/message-count-label.html" import message_count_label %}
 
 <div class="ajax-block-container">
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div id="total-email" class="column-third">
       {{ big_number_with_status(
         statistics['email']['requested'],

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,12 +1,12 @@
 {% from "components/big-number.html" import big_number %}
 
 <div class='govuk-grid-row ajax-block-container'>
-  <div class='column-third'>
+  <div class='govuk-grid-column-one-third'>
     <div class="keyline-block">
       {{ big_number("Unlimited", 'free email allowance', smaller=True) }}
     </div>
   </div>
-  <div class='column-third'>
+  <div class='govuk-grid-column-one-third'>
     <div class="keyline-block">
       {% if sms_chargeable %}
         {{ big_number(
@@ -20,7 +20,7 @@
       {% endif %}
     </div>
   </div>
-  <div class='column-third'>
+  <div class='govuk-grid-column-one-third'>
     <div class="keyline-block">
       {{ big_number(
         letter_cost,

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -1,6 +1,6 @@
 {% from "components/big-number.html" import big_number %}
 
-<div class='grid-row ajax-block-container'>
+<div class='govuk-grid-row ajax-block-container'>
   <div class='column-third'>
     <div class="keyline-block">
       {{ big_number("Unlimited", 'free email allowance', smaller=True) }}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -17,7 +17,7 @@
     ) }}
 
     {% call form_wrapper() %}
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -18,7 +18,7 @@
 
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
-        <div class="column-five-sixths">
+        <div class="govuk-grid-column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
@@ -29,7 +29,7 @@
             'Save'
           ) }}
         </div>
-        <aside class="column-whole">
+        <aside class="govuk-grid-column-full">
           {% include "partials/templates/guidance-formatting.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -17,7 +17,7 @@
     ) }}
 
     {% call form_wrapper() %}
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -18,7 +18,7 @@
 
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
-        <div class="column-five-sixths">
+        <div class="govuk-grid-column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
@@ -26,7 +26,7 @@
             'Save'
           ) }}
         </div>
-        <aside class="column-three-quarters">
+        <aside class="govuk-grid-column-three-quarters">
           {% include "partials/templates/guidance-formatting-letters.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
         </aside>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -18,10 +18,10 @@
 
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this') }}
         </div>
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=5) }}
           {% if current_user.platform_admin %}
             {{ radios(form.process_type) }}

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -17,7 +17,7 @@
     ) }}
 
     {% call form_wrapper() %}
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-two-thirds">
           {{ textbox(form.name, width='1-1', hint='Your recipients will not see this') }}
         </div>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -30,7 +30,7 @@
             'Save'
           ) }}
         </div>
-        <aside class="column-whole">
+        <aside class="govuk-grid-column-full">
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}
           {% include "partials/templates/guidance-links.html" %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -39,7 +39,7 @@
     </p>
   {% endif %}
   <div class="govuk-grid-row">
-    {% call form_wrapper(class="column-three-quarters") %}
+    {% call form_wrapper(class="govuk-grid-column-three-quarters") %}
 
       {% include 'views/manage-users/permissions.html' %}
 

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -38,7 +38,7 @@
       </a>
     </p>
   {% endif %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     {% call form_wrapper(class="column-three-quarters") %}
 
       {% include 'views/manage-users/permissions.html' %}

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -17,7 +17,7 @@
     back_link=url_for('.email_branding')
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% if logo %}
         <div id="logo-img">
           <img src="https://{{ cdn_url }}/{{ logo }}"/>

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -16,7 +16,7 @@
     '{} email branding'.format('Update' if email_branding else 'Add'),
     back_link=url_for('.email_branding')
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% if logo %}
         <div id="logo-img">

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">The link has expired</h1>
 

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">The link has expired</h1>
 
     <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Resend email link</h1>
 
     <p>Emails sometimes take a few minutes to arrive. If you do not receive an email link, Notify can send you a new one.</p>

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Resend email link</h1>
 

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -18,7 +18,7 @@
       action=url_for('.find_services_by_name'),
       class='govuk-grid-row'
   ) %}
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {{ textbox(
         form.search,
         width='1-1',

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -25,7 +25,7 @@
         label='Find services by name, or by partial name'
       ) }}
     </div>
-    <div class="column-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       {{ govukButton({
         "text": "Search",

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -16,7 +16,7 @@
 
   {% call form_wrapper(
       action=url_for('.find_services_by_name'),
-      class='grid-row'
+      class='govuk-grid-row'
   ) %}
     <div class="column-three-quarters">
       {{ textbox(

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -16,7 +16,7 @@
 
   {% call form_wrapper(
       action=url_for('.find_users_by_email'),
-      class='grid-row'
+      class='govuk-grid-row'
   ) %}
     <div class="column-three-quarters">
       {{ textbox(

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -18,7 +18,7 @@
       action=url_for('.find_users_by_email'),
       class='govuk-grid-row'
   ) %}
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {{ textbox(
         form.search,
         width='1-1',

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -25,7 +25,7 @@
         label='Find users by email, or by partial email'
       ) }}
     </div>
-    <div class="column-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       {{ govukButton({
         "text": "Search",

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -7,7 +7,7 @@
 
 {% block platform_admin_content %}
   <div class="govuk-grid-row bottom-gutter">
-    <div class="column-whole">
+    <div class="govuk-grid-column-full">
       <h1 class="heading-large">
         {{ user.name }}
       </h1>

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block platform_admin_content %}
-  <div class="grid-row bottom-gutter">
+  <div class="govuk-grid-row bottom-gutter">
     <div class="column-whole">
       <h1 class="heading-large">
         {{ user.name }}

--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -10,7 +10,7 @@ Create a new password
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Forgotten your password?</h1>
 
     <p>We’ll send you an email to create a new password.</p>

--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -9,7 +9,7 @@ Create a new password
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Forgotten your password?</h1>
 

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -21,7 +21,7 @@ Inbound Numbers
 {% block platform_admin_content %}
 
   <div class="govuk-grid-row bottom-gutter">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="heading-large">
         Inbound SMS
       </h1>

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -20,7 +20,7 @@ Inbound Numbers
 
 {% block platform_admin_content %}
 
-  <div class="grid-row bottom-gutter">
+  <div class="govuk-grid-row bottom-gutter">
     <div class="column-two-thirds">
       <h1 class="heading-large">
         Inbound SMS

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Integration testing</h1>
 
     <p>This information has moved.</p>

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Integration testing</h1>
 

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -15,7 +15,7 @@
     '{} letter branding'.format('Update' if is_update else 'Add'),
     back_link=url_for('main.letter_branding')
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% if logo %}
         <div id="logo-img">

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -16,7 +16,7 @@
     back_link=url_for('main.letter_branding')
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% if logo %}
         <div id="logo-img">
           <img src="https://{{ cdn_url }}/{{ logo }}"/>

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -38,8 +38,8 @@
             {% endif %}
           </span>
         </h3>
-        <ul class="tick-cross-list">
-          <div class="tick-cross-list-permissions">
+        <ul class="tick-cross-list govuk-grid-row">
+          <div class="tick-cross-list-permissions govuk-grid-column-three-quarters">
             {% for permission, label in permissions %}
               {{ tick_cross(
                 user.has_permission_for_service(current_service.id, permission),

--- a/app/templates/views/manage-users/confirm-edit-user-email.html
+++ b/app/templates/views/manage-users/confirm-edit-user-email.html
@@ -14,7 +14,7 @@
   url_for('.edit_user_email', service_id=service_id, user_id=user.id)
 ) }}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-whole">
   {% call form_wrapper() %}
     <p>New email address:</p>

--- a/app/templates/views/manage-users/confirm-edit-user-email.html
+++ b/app/templates/views/manage-users/confirm-edit-user-email.html
@@ -15,7 +15,7 @@
 ) }}
 
 <div class="govuk-grid-row">
-  <div class="column-whole">
+  <div class="govuk-grid-column-full">
   {% call form_wrapper() %}
     <p>New email address:</p>
     <div class="panel panel-border-wide bottom-gutter">

--- a/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
+++ b/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
@@ -15,7 +15,7 @@
 ) }}
 
 <div class="govuk-grid-row">
-  <div class="column-whole">
+  <div class="govuk-grid-column-full">
   {% call form_wrapper() %}
     <p>New mobile number:</p>
     <div class="panel panel-border-wide bottom-gutter">

--- a/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
+++ b/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
@@ -14,7 +14,7 @@
   back_link=url_for('.edit_user_mobile_number', service_id=service_id, user_id=user.id)
 ) }}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-whole">
   {% call form_wrapper() %}
     <p>New mobile number:</p>

--- a/app/templates/views/manage-users/edit-user-mobile.html
+++ b/app/templates/views/manage-users/edit-user-mobile.html
@@ -17,7 +17,7 @@
 
   <p id="user_name">This will change the mobile number for {{ user.name }}.</p>
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper(class="extra-tracking") %}
         {{ textbox(form.mobile_number) }}
         {{ page_footer('Save') }}

--- a/app/templates/views/manage-users/edit-user-mobile.html
+++ b/app/templates/views/manage-users/edit-user-mobile.html
@@ -16,7 +16,7 @@
   ) }}
 
   <p id="user_name">This will change the mobile number for {{ user.name }}.</p>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper(class="extra-tracking") %}
         {{ textbox(form.mobile_number) }}

--- a/app/templates/views/new-password.html
+++ b/app/templates/views/new-password.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     {% if user %}
       <h1 class="heading-large">
         Create a new password

--- a/app/templates/views/new-password.html
+++ b/app/templates/views/new-password.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     {% if user %}
       <h1 class="heading-large">

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -36,7 +36,7 @@
 
     {% call form_wrapper(
       action=url_for('.view_notifications', service_id=current_service.id, message_type=message_type),
-      class="grid-row"
+      class="govuk-grid-row"
     ) %}
       <div class="column-three-quarters {% if message_type == 'sms' %}extra-tracking{% endif %}">
         {{ textbox(

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -51,7 +51,7 @@
           )
         ) }}
       </div>
-      <div class="column-one-quarter">
+      <div class="govuk-grid-column-one-quarter">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         {{ govukButton({
           "text": "Search",

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -38,7 +38,7 @@
       action=url_for('.view_notifications', service_id=current_service.id, message_type=message_type),
       class="govuk-grid-row"
     ) %}
-      <div class="column-three-quarters {% if message_type == 'sms' %}extra-tracking{% endif %}">
+      <div class="govuk-grid-column-three-quarters {% if message_type == 'sms' %}extra-tracking{% endif %}">
         {{ textbox(
           search_form.to,
           width='1-1',

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -20,7 +20,7 @@
       <div class="govuk-grid-column-one-quarter">
         &nbsp;
       </div>
-      <div class="column-three-quarters">
+      <div class="govuk-grid-column-three-quarters">
         <main class="govuk-main-wrapper column-main govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main" >
           {% block beforeContent %}{% endblock %}
           {% block content %}

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -17,7 +17,7 @@
     </div>
 
     <div class="govuk-grid-row">
-      <div class="column-one-quarter">
+      <div class="govuk-grid-column-one-quarter">
         &nbsp;
       </div>
       <div class="column-three-quarters">

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -16,7 +16,7 @@
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-one-quarter">
         &nbsp;
       </div>

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -23,7 +23,7 @@
           All organisations
         </h1>
       </div>
-      <div class="column-three-quarters">
+      <div class="govuk-grid-column-three-quarters">
 
         {{ live_search(target_selector='.browse-list-item', show=True, form=search_form, label='Search by name') }}
 
@@ -51,7 +51,7 @@
         <div class="govuk-grid-column-one-quarter">
           &nbsp;
         </div>
-        <div class="column-three-quarters">
+        <div class="govuk-grid-column-three-quarters">
           {{ govukButton({
             "element": "a",
             "text": "New organisation",

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -18,7 +18,7 @@
     </div>
 
     <div class="govuk-grid-row top-gutter-2-3">
-      <div class="column-one-quarter">
+      <div class="govuk-grid-column-one-quarter">
         <h1>
           All organisations
         </h1>
@@ -48,7 +48,7 @@
     </div>
     <div class="js-stick-at-bottom-when-scrolling">
       <div class="govuk-grid-row">
-        <div class="column-one-quarter">
+        <div class="govuk-grid-column-one-quarter">
           &nbsp;
         </div>
         <div class="column-three-quarters">

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -17,7 +17,7 @@
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
 
-    <div class="grid-row top-gutter-2-3">
+    <div class="govuk-grid-row top-gutter-2-3">
       <div class="column-one-quarter">
         <h1>
           All organisations
@@ -47,7 +47,7 @@
       </div>
     </div>
     <div class="js-stick-at-bottom-when-scrolling">
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-one-quarter">
           &nbsp;
         </div>

--- a/app/templates/views/organisations/organisation/settings/edit-agreement.html
+++ b/app/templates/views/organisations/organisation/settings/edit-agreement.html
@@ -15,7 +15,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {% call form_wrapper() %}
         {{ radios(
           form.agreement_signed,

--- a/app/templates/views/organisations/organisation/settings/edit-agreement.html
+++ b/app/templates/views/organisations/organisation/settings/edit-agreement.html
@@ -14,7 +14,7 @@
     "Data sharing and financial agreement",
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {% call form_wrapper() %}
         {{ radios(

--- a/app/templates/views/organisations/organisation/settings/edit-crown-status.html
+++ b/app/templates/views/organisations/organisation/settings/edit-crown-status.html
@@ -15,7 +15,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {% call form_wrapper() %}
         {{ radios(form.crown_status) }}
         {{ page_footer('Save') }}

--- a/app/templates/views/organisations/organisation/settings/edit-crown-status.html
+++ b/app/templates/views/organisations/organisation/settings/edit-crown-status.html
@@ -14,7 +14,7 @@
     "Crown organisation",
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {% call form_wrapper() %}
         {{ radios(form.crown_status) }}

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -16,7 +16,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       <p>
         If a user’s email addresses ends with one of these domains then
         any services they create will be associated with this organisation.

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -15,7 +15,7 @@
     "Known email domains",
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       <p>
         If a user’s email addresses ends with one of these domains then

--- a/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
@@ -14,7 +14,7 @@
     "Edit request to go live notes",
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       <p>
         Text entered here will be displayed in the Zendesk ticket when a service

--- a/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
@@ -15,7 +15,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       <p>
         Text entered here will be displayed in the Zendesk ticket when a service
         belonging to this organisation requests to go live.

--- a/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
@@ -15,7 +15,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
 
     {% call form_wrapper() %}

--- a/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
 
     {% call form_wrapper() %}
       {{ textbox(form.password, autocomplete='current-password') }}

--- a/app/templates/views/organisations/organisation/settings/preview-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-email-branding.html
@@ -10,7 +10,7 @@
 
   <h1 class="heading-large">Preview email branding</h1>
   <div class="govuk-grid-row">
-    <div class="column-full">
+    <div class="govuk-grid-column-full">
       <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}
         <div class="form-group">

--- a/app/templates/views/organisations/organisation/settings/preview-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-email-branding.html
@@ -9,7 +9,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Preview email branding</h1>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-full">
       <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}

--- a/app/templates/views/organisations/organisation/settings/preview-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-letter-branding.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Preview letter branding</h1>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-full">
       <iframe src="{{ url_for('main.letter_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}

--- a/app/templates/views/organisations/organisation/settings/preview-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-letter-branding.html
@@ -9,7 +9,7 @@
 
   <h1 class="heading-large">Preview letter branding</h1>
   <div class="govuk-grid-row">
-    <div class="column-full">
+    <div class="govuk-grid-column-full">
       <iframe src="{{ url_for('main.letter_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}
         <div class="form-group">

--- a/app/templates/views/organisations/organisation/settings/set-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-email-branding.html
@@ -16,11 +16,11 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'email'}) %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full preview-pane">
       </div>
     </div>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search branding styles by name') }}
         {{ radios(form.branding_style) }}

--- a/app/templates/views/organisations/organisation/settings/set-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-email-branding.html
@@ -17,11 +17,11 @@
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'email'}) %}
     <div class="govuk-grid-row">
-      <div class="column-full preview-pane">
+      <div class="govuk-grid-column-full preview-pane">
       </div>
     </div>
     <div class="govuk-grid-row">
-      <div class="column-full">
+      <div class="govuk-grid-column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search branding styles by name') }}
         {{ radios(form.branding_style) }}
       </div>

--- a/app/templates/views/organisations/organisation/settings/set-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-letter-branding.html
@@ -16,11 +16,11 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'letter'}) %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full preview-pane">
       </div>
     </div>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search by name') }}
         {{ radios(form.branding_style, hide_legend=True) }}

--- a/app/templates/views/organisations/organisation/settings/set-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-letter-branding.html
@@ -17,11 +17,11 @@
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'letter'}) %}
     <div class="govuk-grid-row">
-      <div class="column-full preview-pane">
+      <div class="govuk-grid-column-full preview-pane">
       </div>
     </div>
     <div class="govuk-grid-row">
-      <div class="column-full">
+      <div class="govuk-grid-column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search by name') }}
         {{ radios(form.branding_style, hide_legend=True) }}
       </div>

--- a/app/templates/views/organisations/organisation/users/user/index.html
+++ b/app/templates/views/organisations/organisation/users/user/index.html
@@ -19,7 +19,7 @@
     {{ user.email_address }}
   </p>
 
-  {% call form_wrapper(class="column-three-quarters") %}
+  {% call form_wrapper(class="govuk-grid-column-three-quarters") %}
       {{ page_footer(
         'Save',
         delete_link=url_for('.remove_user_from_organisation', org_id=current_org.id, user_id=user.id) if user or None,

--- a/app/templates/views/password-reset-sent.html
+++ b/app/templates/views/password-reset-sent.html
@@ -6,7 +6,7 @@ Check your email
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Check your email</h1>
 

--- a/app/templates/views/password-reset-sent.html
+++ b/app/templates/views/password-reset-sent.html
@@ -7,7 +7,7 @@ Check your email
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Check your email</h1>
 
     <p>Click the link in the email to reset your password.</p>

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -34,7 +34,7 @@
         {% endfor %}
       </nav>
     </div>
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% block platform_admin_content %}{% endblock %}
     </div>
   </div>

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -5,7 +5,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-one-quarter">
       <p class="heading-medium">
         Platform admin

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -6,7 +6,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <p class="heading-medium">
         Platform admin
       </p>

--- a/app/templates/views/platform-admin/_global_stats.html
+++ b/app/templates/views/platform-admin/_global_stats.html
@@ -1,6 +1,6 @@
 {% from "components/big-number.html" import big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
-<div class="grid-row bottom-gutter">
+<div class="govuk-grid-row bottom-gutter">
   <div class="column-third">
     {{ big_number_with_status(
       global_stats.email.delivered + global_stats.email.failed,

--- a/app/templates/views/platform-admin/_global_stats.html
+++ b/app/templates/views/platform-admin/_global_stats.html
@@ -1,7 +1,7 @@
 {% from "components/big-number.html" import big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}
 <div class="govuk-grid-row bottom-gutter">
-  <div class="column-third">
+  <div class="govuk-grid-column-one-third">
     {{ big_number_with_status(
       global_stats.email.delivered + global_stats.email.failed,
       message_count_label(global_stats.email.delivered, 'email'),
@@ -11,7 +11,7 @@
       smaller=True
     ) }}
   </div>
-  <div class="column-third">
+  <div class="govuk-grid-column-one-third">
     {{ big_number_with_status(
       global_stats.sms.delivered + global_stats.sms.failed,
       message_count_label(global_stats.sms.delivered, 'sms'),
@@ -21,7 +21,7 @@
       smaller=True
     ) }}
   </div>
-  <div class="column-third">
+  <div class="govuk-grid-column-one-third">
     {{ big_number_with_status(
       global_stats.letter.requested,
       message_count_label(global_stats.letter.requested, 'letter'),

--- a/app/templates/views/platform-admin/index.html
+++ b/app/templates/views/platform-admin/index.html
@@ -32,7 +32,7 @@
     "open": form.errors | convert_to_boolean
   }) }}
 
-  <div class="grid-row bottom-gutter">
+  <div class="govuk-grid-row bottom-gutter">
     {% for noti_type in global_stats %}
       <div class="column-third">
         {{ big_number_simple(
@@ -53,7 +53,7 @@
     {% endfor %}
   </div>
 
-  <div class="grid-row bottom-gutter">
+  <div class="govuk-grid-row bottom-gutter">
     {% for noti_type in global_stats %}
       <div class="column-third">
         <div class="bordered-text-box">

--- a/app/templates/views/platform-admin/index.html
+++ b/app/templates/views/platform-admin/index.html
@@ -34,7 +34,7 @@
 
   <div class="govuk-grid-row bottom-gutter">
     {% for noti_type in global_stats %}
-      <div class="column-third">
+      <div class="govuk-grid-column-one-third">
         {{ big_number_simple(
             noti_type.black_box.number,
             message_count_label(noti_type.black_box.number, noti_type.black_box.notification_type)
@@ -55,7 +55,7 @@
 
   <div class="govuk-grid-row bottom-gutter">
     {% for noti_type in global_stats %}
-      <div class="column-third">
+      <div class="govuk-grid-column-one-third">
         <div class="bordered-text-box">
           <span class="big-number-number">{{ "{:,}".format(noti_type.test_data.number) }}</span>
           {{ noti_type.test_data.label }}

--- a/app/templates/views/platform-admin/returned-letters.html
+++ b/app/templates/views/platform-admin/returned-letters.html
@@ -9,7 +9,7 @@
 
 {% block platform_admin_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Submit returned letters</h1>
     {% call form_wrapper() %}

--- a/app/templates/views/platform-admin/returned-letters.html
+++ b/app/templates/views/platform-admin/returned-letters.html
@@ -10,7 +10,7 @@
 {% block platform_admin_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Submit returned letters</h1>
     {% call form_wrapper() %}
       {{ textbox(form.references, width='1-1', rows=8, autosize=True) }}

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -7,7 +7,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Privacy notice: how we use your data</h1>
 
     <p>Last update: 5 March 2019</p>

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -6,7 +6,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Privacy notice: how we use your data</h1>
 
@@ -16,7 +16,7 @@
 
     <p>GOV.UK Notify is a service that lets public service teams in the UK send emails, text messages, and letters
       to users of their service.</p>
-    
+
     <p>GOV.UK Notify is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.</p>
 
     <p>Organisations sending notifications using GOV.UK Notify are the data controller and Cabinet Office is the data processor. The data controller must tell you about what they are doing with your personal data.</p>
@@ -63,7 +63,7 @@
 
     <h2 class="heading-medium">Where your data is processed and stored</h2>
 
-    <p>We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s 
+    <p>We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s
       processed and when it’s stored.</p>
 
     <p>Your personal data will not be transferred outside of the European Economic Area (EEA) throughout the course of its
@@ -112,7 +112,7 @@
     <h2 class="heading-medium">Questions and complaints</h2>
 
     <p>Contact the GDS Privacy Team if you either:</p>
-    
+
     <ul class="list list-bullet">
       <li>have any questions about anything in this document</li>
       <li>think that your personal data has been misused or mishandled</li>
@@ -122,11 +122,11 @@
     GDS Privacy Team<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a>
     </p>
-    
+
     <p>
     You can also contact the Cabinet Office Data Protection Officer.
     </p>
-    
+
     <p>
     Data Protection Officer<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br>
@@ -137,7 +137,7 @@
     </p>
 
     <p>If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
-    
+
     <p>
     Information Commissioner’s Office<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>

--- a/app/templates/views/providers/edit-provider.html
+++ b/app/templates/views/providers/edit-provider.html
@@ -11,7 +11,7 @@ Provider - {{provider.display_name}}
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
 
         {{ page_header(
           provider.display_name,

--- a/app/templates/views/providers/edit-provider.html
+++ b/app/templates/views/providers/edit-provider.html
@@ -10,7 +10,7 @@ Provider - {{provider.display_name}}
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
     <div class="column-three-quarters">
 
         {{ page_header(

--- a/app/templates/views/providers/edit-sms-provider-ratio.html
+++ b/app/templates/views/providers/edit-sms-provider-ratio.html
@@ -21,7 +21,7 @@
     <div class="history-list-item">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">&nbsp;</div>
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           <div class="history-list-percentage-without-border">
             <div class="history-list-percentage-left-label">
               {{ primary_provider }}
@@ -70,7 +70,7 @@
                 </div>
               {% endif %}
             </div>
-            <div class="column-two-thirds">
+            <div class="govuk-grid-column-two-thirds">
               <div class="history-list-percentage">
                 <div class="history-list-percentage-left-label">
                   {{ primary_provider }}<br><br>

--- a/app/templates/views/providers/edit-sms-provider-ratio.html
+++ b/app/templates/views/providers/edit-sms-provider-ratio.html
@@ -19,7 +19,7 @@
   </h2>
   <div class="bottom-gutter">
     <div class="history-list-item">
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-one-third">&nbsp;</div>
         <div class="column-two-thirds">
           <div class="history-list-percentage-without-border">
@@ -59,7 +59,7 @@
     <ul class="bottom-gutter">
       {% for version in versions %}
         <li class="history-list-item">
-          <div class="grid-row">
+          <div class="govuk-grid-row">
             <div class="column-one-third">
               <div class="history-list-user">
                 {{ version.created_by.name or ('&nbsp;'|safe) }}

--- a/app/templates/views/providers/edit-sms-provider-ratio.html
+++ b/app/templates/views/providers/edit-sms-provider-ratio.html
@@ -20,7 +20,7 @@
   <div class="bottom-gutter">
     <div class="history-list-item">
       <div class="govuk-grid-row">
-        <div class="column-one-third">&nbsp;</div>
+        <div class="govuk-grid-column-one-third">&nbsp;</div>
         <div class="column-two-thirds">
           <div class="history-list-percentage-without-border">
             <div class="history-list-percentage-left-label">
@@ -60,7 +60,7 @@
       {% for version in versions %}
         <li class="history-list-item">
           <div class="govuk-grid-row">
-            <div class="column-one-third">
+            <div class="govuk-grid-column-one-third">
               <div class="history-list-user">
                 {{ version.created_by.name or ('&nbsp;'|safe) }}
               </div>

--- a/app/templates/views/providers/provider.html
+++ b/app/templates/views/providers/provider.html
@@ -10,7 +10,7 @@ Provider versions
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
     {{ page_header(
       provider_versions[0].display_name,

--- a/app/templates/views/providers/provider.html
+++ b/app/templates/views/providers/provider.html
@@ -9,7 +9,7 @@ Provider versions
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
 
     {{ page_header(

--- a/app/templates/views/re-validate-email-sent.html
+++ b/app/templates/views/re-validate-email-sent.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
     <p>For security, we need to check if you still have access to your email address.</p>
     <p>We’ve sent you a link to sign in to Notify. The link will open in a new browser window, so you can close this one.</p>

--- a/app/templates/views/re-validate-email-sent.html
+++ b/app/templates/views/re-validate-email-sent.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
     <p>For security, we need to check if you still have access to your email address.</p>

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -9,7 +9,7 @@ Create an account
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     <p>

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -10,7 +10,7 @@ Create an account
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     <p>
       Your account will be created with this email address:

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -10,7 +10,7 @@ Create an account
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     <p>Your account will be created with this email: {{invited_org_user.email_address}}</p>
     {% call form_wrapper() %}

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -9,7 +9,7 @@ Create an account
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     <p>Your account will be created with this email: {{invited_org_user.email_address}}</p>

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -10,7 +10,7 @@ Create an account
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.name, width='3-4') }}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -9,7 +9,7 @@ Create an account
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
     {% call form_wrapper(autocomplete=True) %}

--- a/app/templates/views/returned-letter-summary.html
+++ b/app/templates/views/returned-letter-summary.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 <div class="grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
     {{ page_header(
       'Returned letters',
       back_link=url_for('main.service_dashboard', service_id=current_service.id)

--- a/app/templates/views/returned-letter-summary.html
+++ b/app/templates/views/returned-letter-summary.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-five-sixths">
     {{ page_header(
       'Returned letters',

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -30,7 +30,7 @@
         ) }}
       </div>
       {% if skip_link %}
-        <div class="column-one-third">
+        <div class="govuk-grid-column-one-third">
           <a href="{{ skip_link[1] }}" class="govuk-link govuk-link--no-visited-state top-gutter-4-3">{{ skip_link[0] }}</a>
         </div>
       {% endif %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -21,7 +21,7 @@
     module="autofocus",
     data_kwargs={'force-focus': True}
   ) %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
         {{ textbox(
           form.placeholder_value,

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -22,7 +22,7 @@
     data_kwargs={'force-focus': True}
   ) %}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
+      <div class="govuk-grid-column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
         {{ textbox(
           form.placeholder_value,
           hint='Optional' if optional_placeholder else None,

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -15,7 +15,7 @@
     back_link=url_for('main.service_settings', service_id=current_service.id)
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
 
     {% call form_wrapper() %}

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
 
     {% call form_wrapper() %}
       {{ textbox(form.password, autocomplete='current-password') }}

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -15,7 +15,7 @@
         Data retention
       </h1>
     </div>
-   <div class="column-one-third">
+   <div class="govuk-grid-column-one-third">
     {{ govukButton({
       "element": "a",
       "text": "Add data retention",

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -25,7 +25,7 @@
   </div>
   </div>
   <div class="govuk-grid-row bottom-gutter">
-      <div class="column-full">
+      <div class="govuk-grid-column-full">
           By default data is kept for 7 days
       </div>
   </div>

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row bottom-gutter">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="heading-large">
         Data retention
       </h1>

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row bottom-gutter">
+  <div class="govuk-grid-row bottom-gutter">
     <div class="column-two-thirds">
       <h1 class="heading-large">
         Data retention
@@ -24,7 +24,7 @@
     }) }}
   </div>
   </div>
-  <div class="grid-row bottom-gutter">
+  <div class="govuk-grid-row bottom-gutter">
       <div class="column-full">
           By default data is kept for 7 days
       </div>

--- a/app/templates/views/service-settings/delete.html
+++ b/app/templates/views/service-settings/delete.html
@@ -10,7 +10,7 @@
 
 
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
 
       <h1 class="heading-large">Delete this service from GOV.UK Notify</h1>

--- a/app/templates/views/service-settings/delete.html
+++ b/app/templates/views/service-settings/delete.html
@@ -11,7 +11,7 @@
 
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
 
       <h1 class="heading-large">Delete this service from GOV.UK Notify</h1>
 

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -40,7 +40,7 @@
     {% endfor %}
   </div>
   <div class="govuk-grid-row">
-    <div class="column-whole">
+    <div class="govuk-grid-column-full">
       {% if current_user.has_permissions('manage_service') %}
         <div class="js-stick-at-bottom-when-scrolling">
           {{ govukButton({
@@ -51,7 +51,7 @@
         </div>
       {% endif %}
     </div>
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       <p>
         You need to add at least one reply-to address so recipients can reply to your messages.
       </p>

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -39,7 +39,7 @@
       </div>
     {% endfor %}
   </div>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-whole">
       {% if current_user.has_permissions('manage_service') %}
         <div class="js-stick-at-bottom-when-scrolling">

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -12,7 +12,7 @@
 
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
-    <div class="column-whole">
+    <div class="govuk-grid-column-full">
       {% if not form.at_least_one_volume_filled %}
         {% call banner_wrapper(type='dangerous') %}
           <h1 class='banner-title'>

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-whole">
       {% if not form.at_least_one_volume_filled %}
         {% call banner_wrapper(type='dangerous') %}

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -49,7 +49,7 @@
     {% endfor %}
   </div>
   {% if current_user.has_permissions('manage_service') %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-whole">
         <div class="js-stick-at-bottom-when-scrolling">
           {{ govukButton({

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -50,7 +50,7 @@
   </div>
   {% if current_user.has_permissions('manage_service') %}
     <div class="govuk-grid-row">
-      <div class="column-whole">
+      <div class="govuk-grid-column-full">
         <div class="js-stick-at-bottom-when-scrolling">
           {{ govukButton({
             "element": "a",

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -15,7 +15,7 @@
     'Add a new address',
     back_link=back_link
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-whole">
       {% call form_wrapper() %}
         {{ textbox(

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -16,7 +16,7 @@
     back_link=back_link
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-whole">
+    <div class="govuk-grid-column-full">
       {% call form_wrapper() %}
         {{ textbox(
             form.letter_contact_block,

--- a/app/templates/views/service-settings/preview-email-branding.html
+++ b/app/templates/views/service-settings/preview-email-branding.html
@@ -10,7 +10,7 @@
 
   <h1 class="heading-large">Preview email branding</h1>
   <div class="govuk-grid-row">
-    <div class="column-full">
+    <div class="govuk-grid-column-full">
       <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}
         <div class="form-group">

--- a/app/templates/views/service-settings/preview-email-branding.html
+++ b/app/templates/views/service-settings/preview-email-branding.html
@@ -9,7 +9,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Preview email branding</h1>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-full">
       <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}

--- a/app/templates/views/service-settings/preview-letter-branding.html
+++ b/app/templates/views/service-settings/preview-letter-branding.html
@@ -10,7 +10,7 @@
 
   <h1 class="heading-large">Preview letter branding</h1>
   <div class="govuk-grid-row">
-    <div class="column-full">
+    <div class="govuk-grid-column-full">
       <iframe src="{{ url_for('main.letter_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}
         <div class="form-group">

--- a/app/templates/views/service-settings/preview-letter-branding.html
+++ b/app/templates/views/service-settings/preview-letter-branding.html
@@ -9,7 +9,7 @@
 {% block platform_admin_content %}
 
   <h1 class="heading-large">Preview letter branding</h1>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-full">
       <iframe src="{{ url_for('main.letter_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
       {% call form_wrapper(action=action) %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
-    <div class="column-whole">
+    <div class="govuk-grid-column-full">
       {{ page_header(
         'Before you request to go live',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-whole">
       {{ page_header(
         'Before you request to go live',

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Send files by email',

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -12,7 +12,7 @@
 
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Send files by email',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Sign-in method',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Sign-in method',

--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -17,11 +17,11 @@
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'email'}) %}
     <div class="govuk-grid-row">
-      <div class="column-full preview-pane">
+      <div class="govuk-grid-column-full preview-pane">
       </div>
     </div>
     <div class="govuk-grid-row">
-      <div class="column-full">
+      <div class="govuk-grid-column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search branding styles by name') }}
         {{ radios(form.branding_style) }}
       </div>

--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -16,11 +16,11 @@
     back_link=url_for('.service_settings', service_id=current_service.id)
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'email'}) %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full preview-pane">
       </div>
     </div>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search branding styles by name') }}
         {{ radios(form.branding_style) }}

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Send emails',

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Send emails',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Receive text messages',

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Receive text messages',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Send international text messages',

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Send international text messages',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-letter-branding.html
+++ b/app/templates/views/service-settings/set-letter-branding.html
@@ -17,11 +17,11 @@
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'letter'}) %}
     <div class="govuk-grid-row">
-      <div class="column-full preview-pane">
+      <div class="govuk-grid-column-full preview-pane">
       </div>
     </div>
     <div class="govuk-grid-row">
-      <div class="column-full">
+      <div class="govuk-grid-column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search by name') }}
         {{ radios(form.branding_style, hide_legend=True) }}
       </div>

--- a/app/templates/views/service-settings/set-letter-branding.html
+++ b/app/templates/views/service-settings/set-letter-branding.html
@@ -16,11 +16,11 @@
     back_link=url_for('.service_settings', service_id=current_service.id)
   ) }}
   {% call form_wrapper(data_kwargs={'preview-type': 'letter'}) %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full preview-pane">
       </div>
     </div>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-full">
         {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search by name') }}
         {{ radios(form.branding_style, hide_legend=True) }}

--- a/app/templates/views/service-settings/set-letter-contact-block.html
+++ b/app/templates/views/service-settings/set-letter-contact-block.html
@@ -14,7 +14,7 @@
     'Letter contact details',
     back_link=None if request.args.get('from_template') else url_for('.service_settings', service_id=current_service.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     {% call form_wrapper(class="column-half") %}
       {{ textbox(
         form.letter_contact_block,

--- a/app/templates/views/service-settings/set-letter-contact-block.html
+++ b/app/templates/views/service-settings/set-letter-contact-block.html
@@ -15,7 +15,7 @@
     back_link=None if request.args.get('from_template') else url_for('.service_settings', service_id=current_service.id)
   ) }}
   <div class="govuk-grid-row">
-    {% call form_wrapper(class="column-half") %}
+    {% call form_wrapper(class="govuk-grid-column-one-half") %}
       {{ textbox(
         form.letter_contact_block,
         label='How should users contact your service?<br>This applies to all the letters you send.'|safe,

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Send letters',

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Send letters',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-service-setting.html
+++ b/app/templates/views/service-settings/set-service-setting.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         title,

--- a/app/templates/views/service-settings/set-service-setting.html
+++ b/app/templates/views/service-settings/set-service-setting.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         title,
         back_link=url_for('.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Send text messages',

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Send text messages',
         back_link=url_for('main.service_settings', service_id=current_service.id)

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -44,7 +44,7 @@
 
   {% if current_user.has_permissions('manage_service') %}
     <div class="govuk-grid-row bottom-gutter">
-      <div class="column-whole">
+      <div class="govuk-grid-column-full">
         {{ govukButton({
           "element": "a",
           "text": "Add text message sender",

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -43,7 +43,7 @@
   </div>
 
   {% if current_user.has_permissions('manage_service') %}
-    <div class="grid-row bottom-gutter">
+    <div class="govuk-grid-row bottom-gutter">
       <div class="column-whole">
         {{ govukButton({
           "element": "a",

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -23,7 +23,7 @@
          </li>
        </ol>
       </nav>
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-two-thirds">
           <h1>
             Send emails, text messages and letters to your users
@@ -47,7 +47,7 @@
   </div>
 
   <div class="product-page-section">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-half">
         <h2>
           Control your content
@@ -63,7 +63,7 @@
     </div>
   </div>
   <div class="product-page-section">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-half">
         <h2>
           See how your messages perform
@@ -85,7 +85,7 @@
     <h2 class="with-keyline">
       Send messages manually or automatically
     </h2>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-half">
         <p>
           Upload a spreadsheet of email&nbsp;addresses or
@@ -121,7 +121,7 @@
   <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2" id="whos-using-notify">
       <h2>Who’s using GOV.UK Notify</h2>
-      <div class="grid-row bottom-gutter">
+      <div class="govuk-grid-row bottom-gutter">
         <div class="column-half">
           <h3 class="govuk-visually-hidden">Services</h3>
           <div class="product-page-big-number">{{ counts.services|format_thousands }}</div>
@@ -142,7 +142,7 @@
   <div class="product-page-section">
     <div class="with-keyline bottom-gutter-2">
       <h2>Pricing</h2>
-      <div class="grid-row bottom-gutter">
+      <div class="govuk-grid-row bottom-gutter">
         <div class="column-half">
           <h3 class="govuk-visually-hidden">Emails</h3>
           <div class="product-page-big-number">Unlimited</div>
@@ -170,7 +170,7 @@
     </div>
   </div>
   <div class="product-page-section">
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-half">
         <h2 class="with-keyline">
           The team

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -24,7 +24,7 @@
        </ol>
       </nav>
       <div class="govuk-grid-row">
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
           <h1>
             Send emails, text messages and letters to your users
           </h1>

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -12,7 +12,7 @@
 {% block content %}
 
   <div class="product-page-intro">
-    <div class="product-page-intro-wrapper override-elements-content" id="content">
+    <div class="product-page-intro-wrapper">
       <nav class="breadcrumbs breadcrumbs--inverse" aria-label="Breadcrumbs">
        <ol itemscope itemtype="http://schema.org/BreadcrumbList">
          <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -48,7 +48,7 @@
 
   <div class="product-page-section">
     <div class="govuk-grid-row">
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <h2>
           Control your content
         </h2>
@@ -57,14 +57,14 @@
           text&nbsp;message or letter templates.
         </p>
       </div>
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <img src="{{ asset_url('images/product/01-templates.svg') }}" alt="">
       </div>
     </div>
   </div>
   <div class="product-page-section">
     <div class="govuk-grid-row">
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <h2>
           See how your messages perform
         </h2>
@@ -73,7 +73,7 @@
           find out which ones are not being delivered.
         </p>
       </div>
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <img
           src="{{ asset_url('images/product/02-reporting.svg') }}"
           alt="A screenshot of GOV.UK Notify showing counts of emails and text messages sent"
@@ -86,7 +86,7 @@
       Send messages manually or automatically
     </h2>
     <div class="govuk-grid-row">
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <p>
           Upload a spreadsheet of email&nbsp;addresses or
           phone&nbsp;numbers and Notify sends the messages.
@@ -96,7 +96,7 @@
           alt="A screenshot of a spreadsheet with columns for email address, name and colour"
         >
       </div>
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <p>
           Integrate the GOV.UK Notify API with your web&nbsp;application or
           back office system.
@@ -122,12 +122,12 @@
     <div class="with-keyline bottom-gutter-2" id="whos-using-notify">
       <h2>Who’s using GOV.UK Notify</h2>
       <div class="govuk-grid-row bottom-gutter">
-        <div class="column-half">
+        <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Services</h3>
           <div class="product-page-big-number">{{ counts.services|format_thousands }}</div>
           services
         </div>
-        <div class="column-half">
+        <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Organisations</h3>
           <div class="product-page-big-number">{{ counts.organisations|format_thousands }}</div>
           organisations
@@ -143,23 +143,23 @@
     <div class="with-keyline bottom-gutter-2">
       <h2>Pricing</h2>
       <div class="govuk-grid-row bottom-gutter">
-        <div class="column-half">
+        <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Emails</h3>
           <div class="product-page-big-number">Unlimited</div>
           free emails
         </div>
-        <div class="column-half">
+        <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Text messages</h3>
           <div class="product-page-big-number">Up to 250,000</div>
           free text messages a year,<br>
           then 1.58 pence per message
         </div>
-        <div class="column-half">
+        <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Letters</h3>
           <div class="product-page-big-number">35 pence</div>
           to print and post a one page letter
         </div>
-        <div class="column-half">
+        <div class="govuk-grid-column-one-half">
           <p class="align-with-big-number-hint">
             There’s no monthly charge, no setup fee and no&nbsp;procurement process.
           </p>
@@ -171,7 +171,7 @@
   </div>
   <div class="product-page-section">
     <div class="govuk-grid-row">
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <h2 class="with-keyline">
           The team
         </h2>
@@ -184,7 +184,7 @@
           to give feedback.
         </p>
       </div>
-      <div class="column-half">
+      <div class="govuk-grid-column-one-half">
         <img
           src="{{ asset_url('images/product/team.jpg') }}"
           alt="A photo of the GOV.UK Notify team gathered around a big screen. One team member is pointing at a graph on the screen."

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
 
     {% if again %}

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
     {% if again %}
       <h1 class="heading-large">You need to sign in again</h1>

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -43,10 +43,10 @@
   <p>Used to show some important statistics.</p>
 
   <div class="govuk-grid-row">
-    <div class="column-one-third">
+    <div class="govuk-grid-column-one-third">
       {{ big_number("567") }}
     </div>
-    <div class="column-one-third">
+    <div class="govuk-grid-column-one-third">
       {{ big_number("2", "Messages delivered") }}
     </div>
   </div>

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -25,7 +25,7 @@
 
   <h2 class="heading-large">Banner</h2>
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       <p>Used to show the status of a thing or action.</p>
 
       {{ banner("You sent 1,234 text messages", with_tick=True) }}
@@ -110,7 +110,7 @@
 
   <h2 class="heading-large">Tables</h2>
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       <p>
         Used for comparing rows of data.
       </p>

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -24,7 +24,7 @@
   </p>
 
   <h2 class="heading-large">Banner</h2>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       <p>Used to show the status of a thing or action.</p>
 
@@ -42,7 +42,7 @@
 
   <p>Used to show some important statistics.</p>
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-one-third">
       {{ big_number("567") }}
     </div>
@@ -109,7 +109,7 @@
   ) }}
 
   <h2 class="heading-large">Tables</h2>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       <p>
         Used for comparing rows of data.

--- a/app/templates/views/support/ask-question-give-feedback.html
+++ b/app/templates/views/support/ask-question-give-feedback.html
@@ -15,7 +15,7 @@
       back_link=url_for('.support')
     ) }}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         {% call form_wrapper() %}
             {{ textbox(form.feedback, width='1-1', hint='', rows=10, autosize=True) }}
             {% if not current_user.is_authenticated %}

--- a/app/templates/views/support/ask-question-give-feedback.html
+++ b/app/templates/views/support/ask-question-give-feedback.html
@@ -14,7 +14,7 @@
       'Ask a question or give feedback',
       back_link=url_for('.support')
     ) }}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         {% call form_wrapper() %}
             {{ textbox(form.feedback, width='1-1', hint='', rows=10, autosize=True) }}

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -11,7 +11,7 @@
     <h1 class="heading-large">
       Out of hours emergencies
     </h1>
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <p>
           First, check the

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -12,7 +12,7 @@
       Out of hours emergencies
     </h1>
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <p>
           First, check the
           <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status page</a>.

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
     <h1 class="heading-large">Support</h1>
     <p>We provide 24-hour online support for teams with a live service on GOV.UK Notify.</p>

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
 
     <h1 class="heading-large">Support</h1>
@@ -21,11 +21,11 @@
     {% endcall %}
 
     <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">contact us on Slack</a>.</p>
-    
+
     <h2 class="heading-medium">Office hours</h2>
     <p>Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>
     <p>When you report a problem in office hours, we’ll aim to read it within 30 minutes and reply within one working day.</p>
-    
+
     <h2 class="heading-medium">Out-of-hours</h2>
     <p>Outside office hours, response times depend on whether you’re reporting an emergency.</p>
     <p>If it’s an emergency, we’ll reply within 30 minutes and update you every hour until the problem’s fixed.</p>

--- a/app/templates/views/support/report-problem.html
+++ b/app/templates/views/support/report-problem.html
@@ -16,7 +16,7 @@
       back_link=url_for('.support')
     ) }}
     <div class="govuk-grid-row">
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <div class="panel panel-border-wide">
           <p>
             Check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a>

--- a/app/templates/views/support/report-problem.html
+++ b/app/templates/views/support/report-problem.html
@@ -15,7 +15,7 @@
       'Report a problem',
       back_link=url_for('.support')
     ) }}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-two-thirds">
         <div class="panel panel-border-wide">
           <p>

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       {{ page_header(
         'Report a problem',
         back_link=url_for('.support')

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-two-thirds">
       {{ page_header(
         'Report a problem',

--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -33,7 +33,7 @@
       {% for event in events %}
         <li class="history-list-item">
           <div class="govuk-grid-row">
-            <div class="column-one-third">
+            <div class="govuk-grid-column-one-third">
               <div class="history-list-user">
                 {{ user_getter(event.user_id) }}
               </div>

--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -41,7 +41,7 @@
                 {{ event.time|format_time }}
               </div>
             </div>
-            <div class="column-two-thirds">
+            <div class="govuk-grid-column-two-thirds">
               {{ event }}
             </div>
         </li>

--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -32,7 +32,7 @@
     <ul class="bottom-gutter">
       {% for event in events %}
         <li class="history-list-item">
-          <div class="grid-row">
+          <div class="govuk-grid-row">
             <div class="column-one-third">
               <div class="history-list-user">
                 {{ user_getter(event.user_id) }}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -14,7 +14,7 @@
     </p>
   {% else %}
     <div class="bottom-gutter-2-3">
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         {% if template.template_type == 'letter' %}
         {% if letter_too_long %}
           {% call banner_wrapper(type='dangerous') %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -22,7 +22,7 @@
           {% endcall %}
         {% endif %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
-            <div class="column-half">
+            <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Send
               </a>
@@ -30,14 +30,14 @@
           {% endif %}
         {% else %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
-            <div class="column-half">
+            <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Send
               </a>
             </div>
           {% endif %}
           {% if current_user.has_permissions('manage_templates') %}
-            <div class="column-half">
+            <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Edit
               </a>

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -1,7 +1,7 @@
 {% from 'components/message-count-label.html' import message_count_label %}
 {% from "components/banner.html" import banner_wrapper %}
 
-<div class="column-whole">
+<div class="govuk-grid-column-full">
   {% if template._template.archived %}
     <p class="hint">
       This template was deleted {{ template._template.updated_at|format_datetime_relative }}.
@@ -48,7 +48,7 @@
     </div>
   {% endif %}
 </div>
-<div class="column-whole template-container">
+<div class="govuk-grid-column-full template-container">
   {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
     {% if not current_service.letter_branding_id %}
       <a href="{{ url_for(".branding_request", service_id=current_service.id, branding_type="letter", from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-branding">Add logo</a>

--- a/app/templates/views/templates/_template_history.html
+++ b/app/templates/views/templates/_template_history.html
@@ -1,4 +1,4 @@
-<div class="column-whole">
+<div class="govuk-grid-column-full">
   <h2 class="message-name">{{ template.name }}</h2>
   <p class="hint">
     {% if template.get_raw('version', 1) > 1 %}
@@ -11,6 +11,6 @@
   </p>
 </div>
 
-<div class="column-whole">
+<div class="govuk-grid-column-full">
   {{ template|string }}
 </div>

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         '{} are disabled'.format(notification_type.capitalize()),
         back_link=back_link,

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         '{} are disabled'.format(notification_type.capitalize()),

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -15,7 +15,7 @@
     'Confirm changes',
     back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {% if template_change.placeholders_removed %}
         <p>

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -16,7 +16,7 @@
     back_link=url_for(".edit_service_template", service_id=current_service.id, template_id=new_template.id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {% if template_change.placeholders_removed %}
         <p>
           You removed {{ list_of_placeholders(template_change.placeholders_removed) }}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -35,7 +35,7 @@
 
   {% else %}
 
-    {{ live_search(target_selector='#template-list .column-whole', show=True, form=search_form) }}
+    {{ live_search(target_selector='#template-list .govuk-grid-column-full', show=True, form=search_form) }}
 
     <nav id="template-list">
       {% for item in templates_and_folders %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -44,7 +44,7 @@
   {% else %}
 
     <div class="govuk-grid-row">
-      <div class="{% if current_user.has_permissions('manage_templates') %} column-five-sixths {% else %} column-whole {% endif %}">
+      <div class="{% if current_user.has_permissions('manage_templates') %} govuk-grid-column-five-sixths {% else %} govuk-grid-column-full {% endif %}">
         {{ folder_path(
           folders=template_folder_path,
           service_id=current_service.id,
@@ -53,7 +53,7 @@
         ) }}
       </div>
       {% if current_user.has_permissions('manage_templates') and current_template_folder_id and user_has_template_folder_permission %}
-        <div class="column-one-sixth">
+        <div class="govuk-grid-column-one-sixth">
           <a href="{{ url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-manage-link">Manage<span class="govuk-visually-hidden"> this folder</span></a>
         </div>
       {% endif %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -43,7 +43,7 @@
 
   {% else %}
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="{% if current_user.has_permissions('manage_templates') %} column-five-sixths {% else %} column-whole {% endif %}">
         {{ folder_path(
           folders=template_folder_path,

--- a/app/templates/views/templates/choose_history.html
+++ b/app/templates/views/templates/choose_history.html
@@ -6,7 +6,7 @@
 
 {% block maincolumn_content %}
   <h1 class="heading-large">Previous versions</h1>
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     {% for template in versions %}
       {% with show_title=True %}
         {% include 'views/templates/_template_history.html' %}

--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -16,11 +16,11 @@
     ) }}
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
-        <div class="column-five-sixths">
+        <div class="govuk-grid-column-five-sixths">
           {{ radios(form.postage) }}
           {{ page_footer('Save') }}
         </div>
-        <aside class="column-three-quarters">
+        <aside class="govuk-grid-column-three-quarters">
           {% include "partials/templates/guidance-postage.html" %}
         </aside>
       </div>

--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -15,7 +15,7 @@
       back_link=url_for('.view_template', service_id=service_id, template_id=template_id)
     ) }}
     {% call form_wrapper() %}
-      <div class="grid-row">
+      <div class="govuk-grid-row">
         <div class="column-five-sixths">
           {{ radios(form.postage) }}
           {{ page_footer('Save') }}

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -12,7 +12,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row bottom-gutter-1-2">
-    <div class="column-whole">
+    <div class="govuk-grid-column-full">
       {{ folder_path(
         folders=template_folder_path,
         service_id=current_service.id,

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -11,7 +11,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row bottom-gutter-1-2">
+  <div class="govuk-grid-row bottom-gutter-1-2">
     <div class="column-whole">
       {{ folder_path(
         folders=template_folder_path,

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -15,7 +15,7 @@
     back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper() %}
         {{ radios(

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper() %}
         {{ radios(
           form.sender,

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -15,7 +15,7 @@
     back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
   ) }}
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper() %}
         {{ radios(
           form.sender,

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -14,7 +14,7 @@
     'Set letter contact block',
     back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
   ) }}
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper() %}
         {{ radios(

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -31,7 +31,7 @@
     </div>
   {% else %}
     <div class="govuk-grid-row">
-      <div class="column-whole">
+      <div class="govuk-grid-column-full">
         {{ folder_path(
           folders=current_service.get_template_path(template._template),
           service_id=current_service.id,

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -30,7 +30,7 @@
       {% endcall %}
     </div>
   {% else %}
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-whole">
         {{ folder_path(
           folders=current_service.get_template_path(template._template),
@@ -42,7 +42,7 @@
     </div>
   {% endif %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     {% include 'views/templates/_template.html' %}
   </div>
 

--- a/app/templates/views/templates/template_history.html
+++ b/app/templates/views/templates/template_history.html
@@ -11,7 +11,7 @@
 
   <h1 class="heading-large">{{ template.name }}</h1>
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     {% with show_title=False %}
       {% include 'views/templates/_template_history.html' %}
     {% endwith %}

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -9,7 +9,7 @@ Check your mobile number
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Check your mobile number</h1>
 

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -10,7 +10,7 @@ Check your mobile number
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Check your mobile number</h1>
 
     <p>Check your mobile phone number is correct and then resend the security code.</p>

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
     <p>We’ve emailed you a link to sign in to Notify.</p>
     <p>Clicking the link will open Notify in a new browser window, so you can close this one.</p>

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
     <p>We’ve emailed you a link to sign in to Notify.</p>

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Check your phone</h1>
 

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Check your phone</h1>
 
     <p>We’ve sent you a text message with a security code.</p>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -9,7 +9,7 @@
 
 {% block maincolumn_content %}
 <div class="govuk-grid-row">
-  <div class="column-five-sixths">
+  <div class="govuk-grid-column-five-sixths">
     {% if error %}
       {% call banner_wrapper(type='dangerous') %}
         <h1 class="banner-title">{{ error.title }}</h1>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-five-sixths">
     {% if error %}
       {% call banner_wrapper(type='dangerous') %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -18,14 +18,14 @@
     </div>
     <div id='pill-selected-item'>
       <div class='govuk-grid-row'>
-        <div class='column-one-third'>
+        <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
             {{ big_number(emails_sent, 'sent', smaller=True) }}
             {{ big_number("Unlimited", 'free allowance', smaller=True) }}
           </div>
         </div>
-        <div class='column-one-third'>
+        <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Text messages</h2>
           <div class="keyline-block">
             {{ big_number(sms_sent, 'sent', smaller=True) }}
@@ -40,7 +40,7 @@
             {% endif %}
           </div>
         </div>
-        <div class='column-one-third'>
+        <div class='govuk-grid-column-one-third'>
           <h2 class='heading-small'>Letters</h2>
           <div class="keyline-block">
             {{ big_number(letter_sent, 'sent', smaller=True) }}
@@ -49,12 +49,12 @@
       </div>
 
       <div class='govuk-grid-row'>
-        <div class='column-one-third'>
+        <div class='govuk-grid-column-one-third'>
           <div class="keyline-block">
             &nbsp;
           </div>
         </div>
-        <div class='column-one-third'>
+        <div class='govuk-grid-column-one-third'>
           <div class="keyline-block">
             {{ big_number(
               (sms_chargeable * sms_rate),
@@ -64,7 +64,7 @@
             ) }}
           </div>
         </div>
-        <div class='column-one-third'>
+        <div class='govuk-grid-column-one-third'>
           <div class="keyline-block">
             {{ big_number(
                 letter_cost,
@@ -124,7 +124,7 @@
     </div>
 
     <div class="govuk-grid-row">
-      <div class="column-one-third">
+      <div class="govuk-grid-column-one-third">
         <p class="align-with-heading-copy">
           Financial year ends 31&nbsp;March
         </p>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -17,7 +17,7 @@
       {{ pill(years, selected_year, big_number_args={'smallest': True}) }}
     </div>
     <div id='pill-selected-item'>
-      <div class='grid-row'>
+      <div class='govuk-grid-row'>
         <div class='column-one-third'>
           <h2 class='heading-small'>Emails</h2>
           <div class="keyline-block">
@@ -48,7 +48,7 @@
         </div>
       </div>
 
-      <div class='grid-row'>
+      <div class='govuk-grid-row'>
         <div class='column-one-third'>
           <div class="keyline-block">
             &nbsp;
@@ -123,7 +123,7 @@
       {% endif %}
     </div>
 
-    <div class="grid-row">
+    <div class="govuk-grid-row">
       <div class="column-one-third">
         <p class="align-with-heading-copy">
           Financial year ends 31&nbsp;March

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -129,7 +129,7 @@
           Financial year ends 31&nbsp;March
         </p>
       </div>
-      <div class="column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
         <p class="align-with-heading-copy">
           What counts as 1 text message?<br />
           See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a>.

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
 
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.password, autocomplete='current-password') }}

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -15,7 +15,7 @@
     back_link=back_link
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
 
     {% call form_wrapper(autocomplete=True) %}

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper(autocomplete=True) %}
         {{ textbox(form.old_password) }}
         {{ textbox(form.new_password) }}

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -15,7 +15,7 @@
     back_link=url_for('.user_profile')
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper(autocomplete=True) %}
         {{ textbox(form.old_password) }}

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -15,7 +15,7 @@
     back_link=url_for('.user_profile')
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       {% call form_wrapper() %}
         {{ textbox(form_field, safe_error_message=True) }}

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper() %}
         {{ textbox(form_field, safe_error_message=True) }}
         {{ page_footer('Save') }}

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -15,7 +15,7 @@
     back_link=url_for('.user_profile')
   ) }}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-three-quarters">
       <p>
         We’ve sent a security code to your new {{ thing }}.

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -16,7 +16,7 @@
   ) }}
 
   <div class="govuk-grid-row">
-    <div class="column-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       <p>
         We’ve sent a security code to your new {{ thing }}.
       </p>

--- a/app/templates/views/user-profile/disable-platform-admin-view.html
+++ b/app/templates/views/user-profile/disable-platform-admin-view.html
@@ -10,7 +10,7 @@
 
 {% block maincolumn_content %}
 
-  <div class="grid-row">
+  <div class="govuk-grid-row">
     <div class="column-five-sixths">
       {{ page_header(
         'Use platform admin view',

--- a/app/templates/views/user-profile/disable-platform-admin-view.html
+++ b/app/templates/views/user-profile/disable-platform-admin-view.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
-    <div class="column-five-sixths">
+    <div class="govuk-grid-column-five-sixths">
       {{ page_header(
         'Use platform admin view',
         back_link=url_for('.user_profile')

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-one-third">
     {{ sub_navigation(navigation_links) }}
   </div>

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-one-third">
+  <div class="govuk-grid-column-one-third">
     {{ sub_navigation(navigation_links) }}
   </div>
   <div class="column-two-thirds">

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-one-third">
     {{ sub_navigation(navigation_links) }}
   </div>
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
     <h1 class="heading-large">Using Notify</h1>
 

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -8,7 +8,7 @@
 {% block maincolumn_content %}
 
 <div class="govuk-grid-row">
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Resend security code</h1>
 
     <p>Text messages sometimes take a few minutes to arrive. If you do not receive a security code, Notify can send you a new one.</p>

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -7,7 +7,7 @@
 
 {% block maincolumn_content %}
 
-<div class="grid-row">
+<div class="govuk-grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">Resend security code</h1>
 

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -24,7 +24,7 @@
       {% if help %}
         <div class="govuk-grid-column-one-third">
       {% else %}
-        <div class="column-one-quarter">
+        <div class="govuk-grid-column-one-quarter">
       {% endif %}
           {% include "main_nav.html" %}
         </div>

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -29,7 +29,7 @@
           {% include "main_nav.html" %}
         </div>
       {% if help %}
-        <div class="column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
       {% else %}
         <div class="column-three-quarters">
       {% endif %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -31,7 +31,7 @@
       {% if help %}
         <div class="govuk-grid-column-two-thirds">
       {% else %}
-        <div class="column-three-quarters">
+        <div class="govuk-grid-column-three-quarters">
       {% endif %}
         {% block beforeContent %}{% endblock %}
         <main class="govuk-main-wrapper column-main {{ mainClasses }}" id="main-content" role="main">

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -22,7 +22,7 @@
     </div>
     <div class="govuk-grid-row govuk-!-padding-bottom-12">
       {% if help %}
-        <div class="column-one-third">
+        <div class="govuk-grid-column-one-third">
       {% else %}
         <div class="column-one-quarter">
       {% endif %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -20,7 +20,7 @@
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
-    <div class="grid-row govuk-!-padding-bottom-12">
+    <div class="govuk-grid-row govuk-!-padding-bottom-12">
       {% if help %}
         <div class="column-one-third">
       {% else %}

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -97,7 +97,7 @@ def test_show_agreement_page(
     mocker.patch('app.organisations_client.get_service_organisation', return_value=org)
 
     page = client_request.get('main.service_agreement', service_id=SERVICE_ONE_ID)
-    links = page.select('main .column-five-sixths a')
+    links = page.select('main .govuk-grid-column-five-sixths a')
     assert len(links) == len(expected_links)
     for index, link in enumerate(links):
         classes, url = expected_links[index]

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -895,9 +895,9 @@ def test_correct_font_size_for_big_numbers(
     )
 
     assert (
-        len(page.select_one('[data-key=totals]').select('.column-third'))
+        len(page.select_one('[data-key=totals]').select('.govuk-grid-column-one-third'))
     ) == (
-        len(page.select_one('[data-key=usage]').select('.column-third'))
+        len(page.select_one('[data-key=usage]').select('.govuk-grid-column-one-third'))
     ) == (
         len(page.select('.big-number-with-status .big-number-smaller'))
     ) == 3
@@ -996,7 +996,7 @@ def test_usage_page(
     mock_get_usage.assert_called_once_with(SERVICE_ONE_ID, 2011)
     mock_get_free_sms_fragment_limit.assert_called_with(SERVICE_ONE_ID, 2011)
 
-    cols = page.find_all('div', {'class': 'column-one-third'})
+    cols = page.find_all('div', {'class': 'govuk-grid-column-one-third'})
     nav = page.find('ul', {'class': 'pill', 'role': 'tablist'})
     nav_links = nav.find_all('a')
 
@@ -1038,7 +1038,7 @@ def test_usage_page_with_letters(
     mock_get_usage.assert_called_once_with(SERVICE_ONE_ID, 2011)
     mock_get_free_sms_fragment_limit.assert_called_with(SERVICE_ONE_ID, 2011)
 
-    cols = page.find_all('div', {'class': 'column-one-third'})
+    cols = page.find_all('div', {'class': 'govuk-grid-column-one-third'})
     nav = page.find('ul', {'class': 'pill', 'role': 'tablist'})
     nav_links = nav.find_all('a')
 

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -29,7 +29,7 @@ def test_email_branding_page_shows_full_branding_list(
         page.select_one('h1').text
     ) == "Email branding"
 
-    assert page.select('.column-three-quarters a')[-1]['href'] == url_for('main.create_email_branding')
+    assert page.select('.govuk-grid-column-three-quarters a')[-1]['href'] == url_for('main.create_email_branding')
 
     assert brand_names == [
         'org 1',

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -181,12 +181,12 @@ def test_old_integration_testing_page(
         'main.integration_testing',
         _expected_status=410,
     )
-    assert normalize_spaces(page.select_one('.grid-row').text) == (
+    assert normalize_spaces(page.select_one('.govuk-grid-row').text) == (
         'Integration testing '
         'This information has moved. '
         'Refer to the documentation for the client library you are using.'
     )
-    assert page.select_one('.grid-row a')['href'] == url_for(
+    assert page.select_one('.govuk-grid-row a')['href'] == url_for(
         'main.documentation'
     )
 

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -32,7 +32,7 @@ def test_letter_branding_page_shows_full_branding_list(
         page.select_one('h1').text
     ) == "Letter branding"
 
-    assert page.select('.column-three-quarters a')[-1]['href'] == url_for('main.create_letter_branding')
+    assert page.select('.govuk-grid-column-three-quarters a')[-1]['href'] == url_for('main.create_letter_branding')
 
     assert brand_names == [
         'HM Government',

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -663,18 +663,20 @@ def test_platform_admin_displays_stats_in_right_boxes_and_with_correct_styling(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     # Email permanent failure status box - number is correct
-    assert '3 permanent failures' in page.find_all('div', class_='column-third')[0].find(string=re.compile('permanent'))
+    assert '3 permanent failures' in page.find_all(
+        'div', class_='govuk-grid-column-one-third'
+    )[0].find(string=re.compile('permanent'))
     # Email complaints status box - link exists and number is correct
     assert page.find('a', string='15 complaints')
     # SMS total box - number is correct
     assert page.find_all('div', class_='big-number-number')[1].text.strip() == '168'
     # Test SMS box - number is correct
-    assert '5' in page.find_all('div', class_='column-third')[4].text
+    assert '5' in page.find_all('div', class_='govuk-grid-column-one-third')[4].text
     # SMS technical failure status box - number is correct and failure class is used
-    assert '1 technical failures' in page.find_all('div', class_='column-third')[1].find(
+    assert '1 technical failures' in page.find_all('div', class_='govuk-grid-column-one-third')[1].find(
         'div', class_='big-number-status-failing').text
     # Letter virus scan failure status box - number is correct and failure class is used
-    assert '1 virus scan failures' in page.find_all('div', class_='column-third')[2].find(
+    assert '1 virus scan failures' in page.find_all('div', class_='govuk-grid-column-one-third')[2].find(
         'div', class_='big-number-status-failing').text
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2189,7 +2189,7 @@ def test_add_sender_link_only_appears_on_services_with_no_senders(
         template_id=fake_uuid,
     )
 
-    assert page.select_one('.column-three-quarters form > a')['href'] == url_for(
+    assert page.select_one('.govuk-grid-column-three-quarters form > a')['href'] == url_for(
         'main.service_add_letter_contact',
         service_id=SERVICE_ONE_ID,
         from_template=fake_uuid,
@@ -2212,6 +2212,6 @@ def test_set_template_sender_escapes_letter_contact_block_names(
 
     # use decode_contents, which returns the raw html, rather than text, which sanitises it and makes
     # testing confusing
-    radio_text = page.select_one('.column-three-quarters label[for="sender-1"]').decode_contents()
+    radio_text = page.select_one('.govuk-grid-column-three-quarters label[for="sender-1"]').decode_contents()
     assert "&lt;script&gt;" in radio_text
     assert "<script>" not in radio_text

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -476,8 +476,8 @@ describe('Live search', () => {
               <span class="live-search-relevant">${user.label} (${user.email})</span> (invited)
             </span>
           </h3>
-          <ul class="tick-cross-list">
-            <div class="tick-cross-list-permissions">
+          <ul class="tick-cross-list govuk-grid-row">
+            <div class="tick-cross-list-permissions govuk-grid-column-three-quarters">
               ${getPermissionsHTML(user.permissions)}
               <div class="tick-cross-list-hint">
                   Can see 15 folders

--- a/tests/javascripts/previewPane.test.js
+++ b/tests/javascripts/previewPane.test.js
@@ -63,7 +63,7 @@ describe('Preview pane', () => {
       `<form method="post" action="${emailPageURL}" autocomplete="off" data-preview-type="email" novalidate>
         <div class="govuk-grid-row"></div>
         <div class="govuk-grid-row">
-          <div class="column-full">
+          <div class="govuk-grid-column-full">
             <div data-module="autofocus">
               <div class="live-search js-header" data-module="live-search" data-targets=".multiple-choice">
                 <div class="form-group">
@@ -81,7 +81,7 @@ describe('Preview pane', () => {
         </div>
       </form>`;
 
-    document.querySelector('.column-full').appendChild(helpers.getRadioGroup(brands));
+    document.querySelector('.govuk-grid-column-full').appendChild(helpers.getRadioGroup(brands));
     form = document.querySelector('form');
     radios = form.querySelector('fieldset');
 

--- a/tests/javascripts/previewPane.test.js
+++ b/tests/javascripts/previewPane.test.js
@@ -61,8 +61,8 @@ describe('Preview pane', () => {
     // set up DOM
     document.body.innerHTML =
       `<form method="post" action="${emailPageURL}" autocomplete="off" data-preview-type="email" novalidate>
-        <div class="grid-row"></div>
-        <div class="grid-row">
+        <div class="govuk-grid-row"></div>
+        <div class="govuk-grid-row">
           <div class="column-full">
             <div data-module="autofocus">
               <div class="live-search js-header" data-module="live-search" data-targets=".multiple-choice">

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -78,7 +78,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
 
       document.body.innerHTML = `
         <div class="govuk-grid-row">
-          <main class="column-three-quarters column-main">
+          <main class="govuk-grid-column-three-quarters column-main">
             <form method="post" autocomplete="off">
               <div class="govuk-grid-row js-stick-at-top-when-scrolling">
                 <div class="govuk-grid-column-two-thirds ">
@@ -669,7 +669,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
     beforeEach(() => {
 
       document.body.innerHTML = `
-        <main role="main" class="column-three-quarters column-main">
+        <main role="main" class="govuk-grid-column-three-quarters column-main">
           <a class="govuk-back-link" href="">Back</a>
           <h1 class="heading-large js-header">
             Preview of ‘Content email’

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -81,7 +81,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
           <main class="column-three-quarters column-main">
             <form method="post" autocomplete="off">
               <div class="govuk-grid-row js-stick-at-top-when-scrolling">
-                <div class="column-two-thirds ">
+                <div class="govuk-grid-column-two-thirds ">
                   <div class="form-group" data-module="">
                     <label class="form-label" for="placeholder_value">
                       name

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -77,10 +77,10 @@ describe("Stick to top/bottom of window when scrolling", () => {
     beforeEach(() => {
 
       document.body.innerHTML = `
-        <div class="grid-row">
+        <div class="govuk-grid-row">
           <main class="column-three-quarters column-main">
             <form method="post" autocomplete="off">
-              <div class="grid-row js-stick-at-top-when-scrolling">
+              <div class="govuk-grid-row js-stick-at-top-when-scrolling">
                 <div class="column-two-thirds ">
                   <div class="form-group" data-module="">
                     <label class="form-label" for="placeholder_value">
@@ -98,7 +98,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
         </div>
         <footer class="js-footer"></footer>`;
 
-      inputForm = document.querySelector('form > .grid-row');
+      inputForm = document.querySelector('form > .govuk-grid-row');
       formFooter = document.querySelector('.page-footer');
       footer = document.querySelector('.js-footer');
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169344149

This updates the grid and spacing to use the GOV.UK Frontend grid system instead of using both GOV.UK Elements and GOV.UK Frontend Toolkit. The guide here was followed to see which new classes to use https://design-system.service.gov.uk/get-started/updating-your-code/, with details in the individual commits.