### PR TITLE
Tidy up command that runs unit tests

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,7 +2,6 @@
 isort==4.3.21
 pytest==5.3.2
 pytest-env==0.6.2
-pytest-cov==2.8.1
 pytest-mock==1.11.2
 pytest-xdist==1.31.0
 beautifulsoup4==4.8.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -36,6 +36,5 @@ display_result $? 2 "Import order check"
 npm test
 display_result $? 3 "Javascript tests have"
 
-## Code coverage
-py.test -n auto --maxfail=10 --cov=app --cov-report=term-missing tests/ --strict -p no:warnings
-display_result $? 4 "Code coverage"
+py.test -n auto --maxfail=10 tests/ --strict
+display_result $? 4 "Unit tests have"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -36,5 +36,5 @@ display_result $? 2 "Import order check"
 npm test
 display_result $? 3 "Javascript tests have"
 
-py.test -n auto --maxfail=10 tests/ --strict
+py.test -n auto --maxfail=10 tests/
 display_result $? 4 "Unit tests have"


### PR DESCRIPTION
# Remove code coverage report

We don’t use it any more as of #3228

# Remove `--strict` argument to pytest

We set it in pytest.ini anyway.