### PR TITLE
Remove things from readme that are no longer relevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![Requirements Status](https://requires.io/github/alphagov/notifications-admin/requirements.svg?branch=master)](https://requires.io/github/alphagov/notifications-admin/requirements/?branch=master)
-[![Coverage Status](https://coveralls.io/repos/alphagov/notifications-admin/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/notifications-admin?branch=master)
-
-
 # notifications-admin
 
 GOV.UK Notify admin application.


### PR DESCRIPTION
The requirements link has been broken for ages
We no longer use coveralls