### PR TITLE
Convert all links to govuk frontend 2nd attempt

### DIFF
--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -75,7 +75,7 @@
               Try again later.
             </p>
             <p class="govuk-body">
-              You can check our <a href="https://status.notifications.service.gov.uk/">system status</a> page to see if there are any known issues.<br/>To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
+              You can check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk/">system status</a> page to see if there are any known issues.<br/>To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
           </div>
         </div>
       </main>

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -114,7 +114,7 @@
     this.makeButton = (text, opts) => {
       let $btn = $('<a href=""></a>')
                     .html(text)
-                    .addClass('js-cancel')
+                    .addClass('govuk-link govuk-link--no-visited-state js-cancel')
                     // isn't set if cancelSelector is undefined
                     .data('target', opts.cancelSelector || undefined)
                     .attr('tabindex', '0')

--- a/app/assets/stylesheets/_grids.scss
+++ b/app/assets/stylesheets/_grids.scss
@@ -120,19 +120,3 @@
 .align-with-big-number-hint {
   margin-top: $gutter / 0.6;
 }
-
-.global-cookie-message {
-  p {
-    @extend %site-width-container;
-  }
-}
-
-.footer-nav {
-  @include copy-16;
-  margin-bottom: $gutter-two-thirds;
-
-  a {
-    display: inline-block;
-    margin-right: $gutter-half;
-  }
-}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -1,10 +1,4 @@
 // Extra CSS overlaying elements
-a {
-  &:visited {
-    color: $link-colour;
-  }
-}
-
 .form-control-1-1 {
   width: 100%;
 }

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -55,19 +55,6 @@
     outline: 3px solid $yellow;
   }
 
-  a {
-
-    &:link,
-    &:visited {
-      color: $error-colour;
-    }
-
-    &:hover {
-      color: $mellow-red;
-    }
-
-  }
-
   .list {
     margin-bottom: 0;
   }
@@ -108,7 +95,7 @@
 
   a {
 
-    @include bold-19;
+    font-weight: bold;
     display: block;
     padding: 0 ;
     margin: 0 0 $gutter 0;
@@ -118,16 +105,16 @@
       color: $white;
     }
 
-    &:hover,
+    &:focus,
     &:active {
-      background-color: $link-hover-colour;
-      outline: 10px solid $link-hover-colour;
+      color: $govuk-focus-text-colour;
+      outline: 10px solid $yellow;
     }
 
-    &:active,
-    &:focus {
-      background-color: $yellow;
-      outline: 10px solid $yellow;
+    &:hover {
+      color: $white;
+      background-color: $link-hover-colour;
+      outline: 10px solid $link-hover-colour;
     }
 
   }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -130,7 +130,6 @@
       &:active,
       &:focus {
         color: $black;
-        border-bottom: 1px solid $black;
       }
 
     }

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -16,22 +16,16 @@
     margin-bottom: $gutter-half;
   }
 
-  &-link {
-    @include bold-24;
+  &-link-destructive {
+    color: $error-colour;
 
-    &-destructive {
-      @include bold-24;
+    &:visited,
+    &:link {
       color: $error-colour;
+    }
 
-      &:visited,
-      &:link {
-        @include bold-24;
-        color: $error-colour;
-      }
-
-      &:hover {
-        color: $mellow-red;
-      }
+    &:hover {
+      color: $mellow-red;
     }
   }
 

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -16,19 +16,6 @@
     margin-bottom: $gutter-half;
   }
 
-  &-link-destructive {
-    color: $error-colour;
-
-    &:visited,
-    &:link {
-      color: $error-colour;
-    }
-
-    &:hover {
-      color: $mellow-red;
-    }
-  }
-
   &-hint {
     @include core-19;
     margin: 5px 0 10px 0;

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -16,6 +16,10 @@
     margin-bottom: $gutter-half;
   }
 
+  &-link {
+    @include govuk-font(24, $weight: bold);
+  }
+
   &-hint {
     @include core-19;
     margin: 5px 0 10px 0;

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -43,7 +43,7 @@
       line-height: 35px;
 
       a {
-        @include bold-19;
+        font-weight: bold;
       }
 
     }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -34,15 +34,8 @@
       margin-bottom: -$gutter;
       padding-bottom: $gutter;
 
-      &:hover {
-        color: $link-hover-colour;
-
-        .message-name-separator {
-          &:before {
-            border-color: $link-hover-colour;
-          }
-        }
-
+      &:hover .message-name-separator:before {
+        border-color: $link-hover-colour;
       }
 
       &:focus {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -1,41 +1,59 @@
 .navigation {
 
+  @include govuk-font($size: 19);
   padding: 0 $gutter 0 0;
 
   $padding-top: 14px;
   $padding-bottom: 11px;
 
+  &-service-name,
+  &-organisation-link {
+    display: inline-block;
+    overflow: hidden;
+    // aligning to the baseline with overflow: hidden adds to the parent's height
+    // aligning to the top doesn't
+    // see: https://stackoverflow.com/questions/23529369/why-does-x-overflowhidden-cause-extra-space-below#answer-51088033
+    vertical-align: top;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &-service-switch,
+  &-service-back-to,
+  &-organisation-link {
+
+    &:link,
+    &:visited {
+      text-decoration: none;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+  }
+
   &-service {
 
+    @include govuk-font($size: 19);
     border-bottom: 1px solid $border-colour;
     margin: 0 0 10px;
     position: relative;
-    font-size: 0;
 
     &-name {
-      @include bold-19;
+
       padding: $padding-top 0 $padding-bottom 0;
-      display: inline-block;
       max-width: 50%;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+
     }
 
     &-switch {
 
-      @include core-19;
-      text-decoration: none;
       text-align: right;
       position: absolute;
       top: 0;
       right: 0;
       padding: $padding-top 0 $padding-bottom $gutter-half;
-
-      &:hover {
-        color: $link-hover-colour;
-        text-decoration: underline;
-      }
 
       &:focus {
         outline: none;
@@ -43,22 +61,14 @@
         border-left: 10px solid $yellow;
         border-right: 3px solid $yellow;
         right: -3px;
-        color: $text-colour;
       }
 
     }
 
     &-back-to {
 
-      @include core-19;
       padding: $padding-top $gutter-half $padding-bottom 0;
       display: inline-block;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-        color: $link-hover-colour;
-      }
 
     }
 
@@ -66,14 +76,7 @@
 
   &-organisation-link {
 
-    @include core-19;
-    display: inline-block;
     max-width: 25%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-weight: normal;
-    text-decoration: none;
     padding: $padding-top 20px $padding-bottom 0;
     margin-right: 7px;
     box-sizing: border-box;
@@ -97,13 +100,8 @@
       border-color: $secondary-text-colour;
     }
 
-    &:hover {
-      color: $link-hover-colour;
-      text-decoration: underline;
-    }
-
+    // hack to make the focus style fit in the navigation bar
     &:focus {
-      color: $text-colour;
       outline: none;
       box-shadow: 0 1px 0 0 $focus-colour, -3px 0 0 0 $focus-colour, -3px 1px 0 0 $focus-colour;
     }
@@ -111,7 +109,6 @@
   }
 
   li {
-    @include core-19;
     margin: 0;
     list-style-type: none;
   }
@@ -129,12 +126,7 @@
     }
 
     &:hover {
-      color: $link-hover-colour;
       text-decoration: underline;
-    }
-
-    &:focus {
-      color: $text-colour;
     }
 
     &.selected {

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -8,26 +8,9 @@
     line-height: 40px;
     padding: 1px 0 0 15px;
 
-    a {
-
-      &:visited,
-      &:link {
-        color: $error-colour;
-        display: inline-block;
-        vertical-align: center;
-      }
-
-      &:hover,
-      &:active {
-        color: $mellow-red;
-      }
-
-    }
-
   }
 
   &-delete-link-without-button {
-    @include core-19;
     padding: 0;
     display: inline-block;
   }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -212,15 +212,6 @@
       color: $error-colour;
       font-weight: bold;
 
-      a {
-
-        &:link,
-        &:visited {
-          color: $error-colour;
-        }
-
-      }
-
       .status-hint {
         display: block;
         font-weight: normal;
@@ -356,22 +347,12 @@
       background: transparent;
     }
 
-    &:hover {
-      color: $link-hover-colour;
-    }
-
-    &:active,
-    &:focus {
-
-      color: $black;
-
-      &:before {
-        border-color: $yellow;
-        border-style: solid;
-        border-width: 15px 3px 15px 15px;
-        right: -3px;
-      }
-
+    &:active:before,
+    &:focus:before {
+      border-color: $yellow;
+      border-style: solid;
+      border-width: 15px 3px 15px 15px;
+      right: -3px;
     }
 
   }

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -31,13 +31,8 @@ $indicator-colour: $black;
       padding-right: 20%;
       position: relative;
 
-      &:hover {
-        color: $link-hover-colour;
-      }
-
       &:focus {
         outline: none;
-        color: $black;
         box-shadow: -3px 0 0 0 $focus-colour, 3px 0 0 0 $focus-colour;
         border-color: transparent;
         top: -1px;

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -61,22 +61,12 @@
           background: transparent;
         }
 
-        &:hover {
-          color: $link-hover-colour;
-        }
-
-        &:active,
-        &:focus {
-
-          color: $black;
-
-          &:before {
-            border-color: $yellow;
-            border-style: solid;
-            border-width: 15px 3px 15px 15px;
-            right: -3px;
-          }
-
+        &:active:before,
+        &:focus:before {
+          border-color: $yellow;
+          border-style: solid;
+          border-width: 15px 3px 15px 15px;
+          right: -3px;
         }
 
       }

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -54,10 +54,6 @@ $is-ie: false !default;
       padding: $gutter-half;
       text-decoration: none;
 
-      &:visited {
-        color: $link-colour;
-      }
-
       &:hover,
       &:active {
         background-color: $canvas-colour;

--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -41,34 +41,6 @@ input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-// To be removed when all links follow the GOV.UK Frontend conventions:
-// https://design-system.service.gov.uk/styles/typography/#links
-a {
-  /* Give a strong clear visual idea as to what is currently in focus */
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
-
-  &:link {
-    color: $link-colour;
-  }
-
-  &:visited {
-    color: $link-visited-colour;
-  }
-
-  &:hover {
-    color: $link-hover-colour;
-  }
-
-  &:active {
-    color: $link-active-colour;
-  }
-
-  &:focus {
-    background-color: $focus-colour;
-    outline: 3px solid $focus-colour;
-  }
-}
-
 // Each selector, and then the whole block when only one remains, to be removed when the
 // element comes from the corresponding GOV.UK Frontend component:
 // - https://design-system.service.gov.uk/components/text-input/

--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -5,6 +5,16 @@
   width: device-width;
 }
 
+// To be removed when all text uses the GOV.UK Frontend New Transport font styles.
+// At present, some text gets these styles due to being in a GOV.UK Frontend component
+// or a link.
+// This ensures all text will have these styles applied, until it can be moved to use
+// the GOV.UK Frontend font styles.
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 b,
 strong {
   font-weight: 600;

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -8,3 +8,30 @@
   }
 }
 
+// Extends govuk-link to create a class of link that causes a destructive action
+// Based on styles of link in:
+// https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/helpers/_links.scss
+//
+// Note: all destructive actions must have a confirmation step these links navigate to
+@mixin govuk-link-style-destructive-no-visited-state {
+  &:link,
+  &:visited {
+    color: $govuk-error-colour;
+  }
+
+  &:hover {
+    color: govuk-tint($govuk-error-colour, 25%);
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable against the focus colour
+  // Activated links are usually focused so this applies to them as well
+  &:active,
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}
+
+.govuk-link--destructive {
+  @include govuk-link-style-destructive-no-visited-state;
+}

--- a/app/assets/stylesheets/local/_typography.scss
+++ b/app/assets/stylesheets/local/_typography.scss
@@ -1,0 +1,62 @@
+@import 'settings/all';
+@import 'helpers/all';
+
+@mixin destructive-link-style-default {
+  &:link {
+    color: $govuk-error-colour;
+  }
+
+  &:visited {
+    color: $govuk-link-visited-colour;
+  }
+
+  &:hover {
+    color: govuk-tint( $govuk-error-colour, 25% );
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}
+
+@mixin destructive-link-style-no-visited-state {
+  &:link {
+    color: $govuk-error-colour;
+  }
+
+  &:visited {
+    color: $govuk-error-colour;
+  }
+
+  &:hover {
+    color: govuk-tint( $govuk-error-colour, 25% );
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}
+
+// mimics styles for govuk-link:
+// https://github.com/alphagov/govuk-frontend/blob/063cd8e2470b62b824c6e50ca66342ac7a95d2d8/package/core/_links.scss#L7
+.destructive-link {
+  @include govuk-link-common;
+  @include destructive-link-style-default;
+  @include govuk-link-print-friendly;
+}
+
+.destructive-link--no-visited-state {
+  @include destructive-link-style-no-visited-state;
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -36,6 +36,7 @@ $path: '/static/images/';
 @import './govuk-frontend/all';
 
 // Specific to this application
+@import 'local/typography';
 @import 'grids';
 @import 'components/cookie-message';
 @import 'components/site-footer';

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -6,18 +6,14 @@
 
   &.error {
 
-    color: $error-colour;
+    color: $govuk-error-colour;
     font-weight: bold;
-
-    a {
-      color: $error-colour;
-    }
 
   }
 
   &-cancelled {
     @include bold-19;
-    color: $error-colour;
+    color: $govuk-error-colour;
   }
 
 }

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -46,7 +46,8 @@ class ValidGovEmail:
         message = (
             'Enter a government email address.'
             ' If you think you should have access'
-            ' <a href="{}">contact us</a>').format(url_for('main.support'))
+            ' <a class="govuk-link govuk-link--no-visited-state" href="{}">contact us</a>'
+        ).format(url_for('main.support'))
         if not is_gov_user(field.data.lower()):
             raise ValidationError(message)
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -7,7 +7,7 @@ class Navigation:
 
     mapping = {}
     exclude = {}
-    selected_attribute = "class=selected"
+    selected_class = "selected"
 
     def __init__(self):
         self.mapping = {
@@ -32,7 +32,7 @@ class Navigation:
 
     def is_selected(self, navigation_item):
         if request.endpoint in self.mapping[navigation_item]:
-            return self.selected_attribute
+            return " " + self.selected_class
         return ''
 
     @staticmethod
@@ -41,8 +41,6 @@ class Navigation:
 
 
 class HeaderNavigation(Navigation):
-
-    selected_attribute = "class=active"
 
     mapping = {
         'support': {

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -1,6 +1,6 @@
 {% macro big_number(number, label, link=None, currency='', smaller=False, smallest=False) %}
   {% if link %}
-    <a class="big-number-link" href="{{ link }}">
+    <a class="govuk-link govuk-link--no-visited-state big-number-link" href="{{ link }}">
   {% endif %}
   <div class="big-number{% if smaller %}-smaller{% endif %}{% if smallest %}-smallest{% endif %}">
     <div class="big-number-number">
@@ -42,7 +42,7 @@
       <div class="big-number-status{% if danger_zone %}-failing{% endif %}">
         {% if failures %}
           {% if failure_link %}
-            <a href="{{ failure_link }}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ failure_link }}">
               {{ "{:,}".format(failures) }}
               failed – {{ failure_percentage }}%
             </a>

--- a/app/templates/components/browse-list.html
+++ b/app/templates/components/browse-list.html
@@ -5,7 +5,7 @@
         {% for item in items %}
           {% if item.title and item.link %}
             <li class="browse-list-item">
-              <a href="{{ item.link }}" class="browse-list-link{% if item.destructive %}-destructive{% endif %}">{{ item.title }}</a>
+              <a href="{{ item.link }}" class="govuk-link govuk-link--no-visited-state browse-list-link{% if item.destructive %}-destructive{% endif %}">{{ item.title }}</a>
               {% if item.hint %}
                 <div class="browse-list-hint">
                   {{ item.hint }}

--- a/app/templates/components/browse-list.html
+++ b/app/templates/components/browse-list.html
@@ -5,7 +5,7 @@
         {% for item in items %}
           {% if item.title and item.link %}
             <li class="browse-list-item">
-              <a href="{{ item.link }}" class="govuk-link govuk-link--no-visited-state{% if item.destructive %} browse-list-link-destructive{% endif %}">{{ item.title }}</a>
+              <a href="{{ item.link }}" class="govuk-link govuk-link--{% if item.destructive %}--destructive{% else %}--no-visited-state{% endif %}">{{ item.title }}</a>
               {% if item.hint %}
                 <div class="browse-list-hint">
                   {{ item.hint }}

--- a/app/templates/components/browse-list.html
+++ b/app/templates/components/browse-list.html
@@ -5,7 +5,7 @@
         {% for item in items %}
           {% if item.title and item.link %}
             <li class="browse-list-item">
-              <a href="{{ item.link }}" class="govuk-link govuk-link--no-visited-state browse-list-link{% if item.destructive %}-destructive{% endif %}">{{ item.title }}</a>
+              <a href="{{ item.link }}" class="govuk-link govuk-link--no-visited-state{% if item.destructive %} browse-list-link-destructive{% endif %}">{{ item.title }}</a>
               {% if item.hint %}
                 <div class="browse-list-hint">
                   {{ item.hint }}

--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -32,7 +32,7 @@
     </label>
     {% if alternate_link and alternate_link_text %}
       <span class="file-upload-alternate-link">
-        or <a href="{{ alternate_link }}">{{ alternate_link_text }}</a>
+        or <a class="govuk-link govuk-link--no-visited-state" href="{{ alternate_link }}">{{ alternate_link_text }}</a>
       </span>
     {% endif %}
     <label class="file-upload-filename" for="{{ field.name }}"></label>

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -17,12 +17,12 @@
       {% else %}
         {% if folder.id %}
           {% if current_user.has_template_folder_permission(folder) %}
-            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
+            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
           {% else %}
             <span class="folder-heading-folder">{{ folder.name }}</span>
           {% endif %}
         {% else %}
-          <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="{% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
+          <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
         {% endif %}
         {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
       {% endif %}
@@ -40,7 +40,7 @@
   {% if folder_path %}
     <h2 class="heading-medium folder-heading">
       {% if folder_path|length == 1 %}
-        <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id) }}">Services</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_template_to_copy', service_id=current_service_id) }}">Services</a>
         {{ folder_path_separator() }}
       {% endif %}
       {% for folder in folder_path %}
@@ -51,15 +51,15 @@
         {% else %}
           {% if folder.id %}
             {% if current_user.has_template_folder_permission(folder) %}
-              <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="folder-heading-folder">{{ folder.name }}</a>
+              <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">{{ folder.name }}</a>
              {% else %}
               <span class="folder-heading-folder">{{ folder.name }}</span>
             {% endif %}
             {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% elif folder.parent_id == None %}
-            <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="folder-heading-folder">{{ from_service.name }}</a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+            <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">{{ from_service.name }}</a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% else %}
-            <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id) }}">{{ from_service.name }}</a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id) }}">{{ from_service.name }}</a> {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
           {% endif %}
         {% endif %}
       {% endfor %}

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -26,7 +26,7 @@
     {% endif %}
     {% if delete_link %}
       <span class="page-footer-delete-link {% if not button_text %}page-footer-delete-link-without-button{% endif %}">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ delete_link }}">{{ delete_link_text }}</a>
+        <a class="govuk-link govuk-link--destructive" href="{{ delete_link }}">{{ delete_link_text }}</a>
       </span>
     {% endif %}
     {% if secondary_link and secondary_link_text %}

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -26,11 +26,11 @@
     {% endif %}
     {% if delete_link %}
       <span class="page-footer-delete-link {% if not button_text %}page-footer-delete-link-without-button{% endif %}">
-        <a href="{{ delete_link }}">{{ delete_link_text }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ delete_link }}">{{ delete_link_text }}</a>
       </span>
     {% endif %}
     {% if secondary_link and secondary_link_text %}
-      <a class="page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
+      <a class="govuk-link govuk-link--no-visited-state page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
     {% endif %}
   </div>
 {% endmacro %}

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -13,7 +13,7 @@
           <div class='pill-selected-item{% if not show_count %} pill-centered-item{% endif %}' tabindex='0'>
       {% else %}
         <li aria-selected='false' role='tab'>
-          <a href="{{ link }}">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">
       {% endif %}
         {% if show_count %}
             {{ big_number(count, **big_number_args) }}

--- a/app/templates/components/previous-next-navigation.html
+++ b/app/templates/components/previous-next-navigation.html
@@ -4,7 +4,7 @@
       <ul class="group">
         {% if previous_page %}
           <li class="previous-page">
-            <a href="{{previous_page['url']}}" rel="previous" >
+            <a class="govuk-link govuk-link--no-visited-state" href="{{previous_page['url']}}" rel="previous" >
               <span class="pagination-part-title">
                 <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
                   <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
@@ -17,7 +17,7 @@
         {% endif %}
         {% if next_page %}
           <li class="next-page">
-            <a href="{{next_page['url']}}" rel="next">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{next_page['url']}}" rel="next">
               <span class="pagination-part-title">
                 {{next_page['title']}}
                 <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">

--- a/app/templates/components/show-more.html
+++ b/app/templates/components/show-more.html
@@ -1,6 +1,6 @@
 {% macro show_more(url, label, with_border=True) %}
   <a
     href="{{ url }}"
-    class="show-more{% if not with_border %}-no-border{% endif %}"
+    class="govuk-link govuk-link--no-visited-state show-more{% if not with_border %}-no-border{% endif %}"
   ><span>{{ label }}</span></a>
 {% endmacro %}

--- a/app/templates/components/status-box.html
+++ b/app/templates/components/status-box.html
@@ -2,7 +2,7 @@
   <div class="big-number-with-status">
     <div class="big-number-status{% if failing %}-failing{% endif %}">
       {% if url %}
-        <a href="{{ url }}">{{ number }} {{ label }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url }}">{{ number }} {{ label }}</a>
       {% else %}
         {{ number }} {{ label }}
       {% endif %}

--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -4,7 +4,7 @@
       itemscope
       itemtype="http://schema.org/ListItem"
   >
-    <a href="{{ url_for(item['link']) }}" itemprop="item">
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(item['link']) }}" itemprop="item">
       <span itemprop="name">{{item['name']}}</span>
     </a>
   </li>

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -149,13 +149,14 @@
   {% if not notification %}
     {% call field(align='right') %}{% endcall %}
   {% else %}
+    {% set status = notification.status|format_notification_status_as_field_status(notification.notification_type) %}
     {% call field(
-      status=notification.status|format_notification_status_as_field_status(notification.notification_type),
+      status=status,
       align='right'
     ) %}
       {% if displayed_on_single_line %}<span class="align-with-message-body">{% endif %}
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
+        <a class="govuk-link govuk-link--{% if status == 'error' %}destructive{% else %}no-visited-state{% endif %}" href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
       {% endif %}
       {{ notification.status|format_notification_status(notification.template.template_type) }}
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -117,14 +117,14 @@
 
 {% macro link_field(text, link) -%}
   {% call field() %}
-    <a href="{{ link }}">{{ text }}</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">{{ text }}</a>
   {% endcall %}
 {%- endmacro %}
 
 {% macro edit_field(text, link, permissions=[]) -%}
   {% call field(align='right') %}
     {% if not permissions or current_user.has_permissions(*permissions) %}
-      <a href="{{ link }}">{{ text }}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">{{ text }}</a>
     {% endif %}
   {% endcall %}
 {%- endmacro %}
@@ -155,7 +155,7 @@
     ) %}
       {% if displayed_on_single_line %}<span class="align-with-message-body">{% endif %}
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
-        <a href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
       {% endif %}
       {{ notification.status|format_notification_status(notification.template.template_type) }}
       {% if notification.status|format_notification_status_as_url(notification.notification_type) %}

--- a/app/templates/components/task-list.html
+++ b/app/templates/components/task-list.html
@@ -1,6 +1,6 @@
 {% macro task_list_item(completed, label, link) %}
   <li class="task-list-item">
-    <span aria-describedby="{{ label|id_safe }}"><a href="{{ link }}">{{ label }}</a></span>
+    <span aria-describedby="{{ label|id_safe }}"><a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">{{ label }}</a></span>
     {% if completed %}
       <strong class="task-list-indicator-completed" id="{{ label|id_safe }}">Completed</strong>
     {% else %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -58,7 +58,7 @@
     {% endif %}
     {% if help_link and help_link_text %}
       <p class="textbox-help-link">
-        <a href='{{ help_link }}'>{{ help_link_text }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href='{{ help_link }}'>{{ help_link_text }}</a>
       </p>
     {% endif %}
   </div>

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -4,6 +4,6 @@
   <div class="grid-row">
     <div class="column-two-thirds">
     <h1>You’re not authorised to see this page</h1>
-      <p><a href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
+      <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
   </div>
 {% endblock %}

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -13,7 +13,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p>
-          If the web address is correct or you selected a link or button, <a href="{{ url_for('main.support') }}">contact us</a>.
+          If the web address is correct or you selected a link or button, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -13,7 +13,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p>
-          If the web address is correct or you selected a link or button, <a href="{{ url_for('main.support') }}">contact us</a>.
+          If the web address is correct or you selected a link or button, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -12,7 +12,7 @@
               Files must be smaller than 5 MB.
             </p>
             <p>
-              <a href="javascript: history.go(-1)">Go back and try again.</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="javascript: history.go(-1)">Go back and try again.</a>
             </p>
           </div>
         </div>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -10,10 +10,10 @@
         Try again later.
       </p>
       <p>
-        You can check our <a href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
+        You can check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
       </p>
       <p>
-        To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
+        To report a problem, email <a class="govuk-link govuk-link--no-visited-state" href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
       </p>
     </div>
   </div>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -5,32 +5,32 @@
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_user.has_permissions('view_activity') %}
-      <li><a href="{{ url_for('.service_dashboard', service_id=current_service.id) }}" {{ main_navigation.is_selected('dashboard') }}>Dashboard</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}" {{ main_navigation.is_selected('dashboard') }}>Dashboard</a></li>
     {% endif %}
-    <li><a href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ main_navigation.is_selected('templates') }}>Templates</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ main_navigation.is_selected('templates') }}>Templates</a></li>
     {% if current_user.has_permissions('view_activity') %}
       {% if current_service.can_upload_letters %}
-        <li><a href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ main_navigation.is_selected('uploads') }}>Uploads</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ main_navigation.is_selected('uploads') }}>Uploads</a></li>
       {% endif %}
     {% else %}
-      <li><a href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>
       {% if current_service.has_jobs or current_service.can_upload_letters %}
-        <li><a href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploads') }}>Uploads</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploads') }}>Uploads</a></li>
       {% endif %}
     {% endif %}
-    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
     {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
-      <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-      <li><a href="{{ url_for('.service_settings', service_id=current_service.id) }}" {{ main_navigation.is_selected('settings') }}>Settings</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_settings', service_id=current_service.id) }}" {{ main_navigation.is_selected('settings') }}>Settings</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys') %}
-      <li><a href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
-    <li><a href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
-    <li><a href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -5,32 +5,32 @@
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_user.has_permissions('view_activity') %}
-      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}" {{ main_navigation.is_selected('dashboard') }}>Dashboard</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_template', service_id=current_service.id) }}" {{ main_navigation.is_selected('templates') }}>Templates</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
     {% if current_user.has_permissions('view_activity') %}
       {% if current_service.can_upload_letters %}
-        <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ main_navigation.is_selected('uploads') }}>Uploads</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
       {% endif %}
     {% else %}
-      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}" {{ casework_navigation.is_selected('sent-messages') }}>Sent messages</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
       {% if current_service.has_jobs or current_service.can_upload_letters %}
-        <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.uploads', service_id=current_service.id) }}" {{ casework_navigation.is_selected('uploads') }}>Uploads</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
       {% endif %}
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
-      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_settings', service_id=current_service.id) }}" {{ main_navigation.is_selected('settings') }}>Settings</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys') %}
-      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.api_integration', service_id=current_service.id) }}" {{ main_navigation.is_selected('api-integration') }}>API integration</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.usage', service_id=current_service.id) }}" {{ main_navigation.is_selected('usage') }}>Usage</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}" {{ main_navigation.is_selected('team-members') }}>Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -1,10 +1,10 @@
 <nav class="navigation">
   <ul>
-  	<li><a href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}" {{ org_navigation.is_selected('dashboard') }}>Usage</a></li>
-    <li><a href="{{ url_for('.manage_org_users', org_id=current_org.id) }}" {{ org_navigation.is_selected('team-members') }}>Team members</a></li>
+  	<li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}" {{ org_navigation.is_selected('dashboard') }}>Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}" {{ org_navigation.is_selected('team-members') }}>Team members</a></li>
     {% if current_user.platform_admin %}
-    <li><a href="{{ url_for('.organisation_settings', org_id=current_org.id) }}" {{ org_navigation.is_selected('settings') }}>Settings</a></li>
-    <li><a href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}" {{ org_navigation.is_selected('trial-services') }}>Trial mode services</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}" {{ org_navigation.is_selected('settings') }}>Settings</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}" {{ org_navigation.is_selected('trial-services') }}>Trial mode services</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -1,10 +1,10 @@
 <nav class="navigation">
   <ul>
-  	<li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}" {{ org_navigation.is_selected('dashboard') }}>Usage</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}" {{ org_navigation.is_selected('team-members') }}>Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('dashboard') }}" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
     {% if current_user.platform_admin %}
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}" {{ org_navigation.is_selected('settings') }}>Settings</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}" {{ org_navigation.is_selected('trial-services') }}>Trial mode services</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('settings') }}" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}">Settings</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('trial-services') }}" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}">Trial mode services</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -8,12 +8,12 @@
   <div class="govuk-width-container">
     <div class="navigation-service">
       {% if current_user.platform_admin %}
-        <a href="{{ url_for('.organisations') }}" class="navigation-organisation-link">All organisations</a>
+        <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state navigation-organisation-link">All organisations</a>
       {% endif %}
       <div class="navigation-service-name">
         {{ current_org.name }}
       </div>
-      <a href="{{ url_for('main.choose_account') }}" class="navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
     <div class="grid-row govuk-!-padding-bottom-12">
       <div class="column-one-quarter">

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -10,7 +10,7 @@
       {% if current_user.platform_admin %}
         <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state navigation-organisation-link">All organisations</a>
       {% endif %}
-      <div class="navigation-service-name">
+      <div class="navigation-service-name govuk-!-font-weight-bold">
         {{ current_org.name }}
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>

--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -7,6 +7,6 @@
   {%- endif %}
 </h1>
 <p>
-  In <a href="{{ url_for('.trial_mode_new') }}">trial mode</a> you can only
+  In <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new') }}">trial mode</a> you can only
   send to yourself and members of your team
 </p>

--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -8,7 +8,7 @@
 <p>
   You can only send {{ current_service.message_limit }} messages per day
   {%- if current_service.trial_mode %}
-    in <a href="{{ url_for('.trial_mode_new')}}">trial mode</a>
+    in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new')}}">trial mode</a>
   {%- endif -%}
   .
 </p>

--- a/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
+++ b/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
@@ -3,6 +3,6 @@
   {{ 'this letter' if count_of_recipients == 1 else 'these letters' }}
 </h1>
 <p>
-  In <a href="{{ url_for('.trial_mode_new') }}">trial mode</a> you
+  In <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new') }}">trial mode</a> you
   can only preview how your letters will look
 </p>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -7,7 +7,7 @@
 
     <p>
       Sending
-      <a href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=job.template.id, version=job.template_version) }}">{{ job.template.name }}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=job.template.id, version=job.template_version) }}">{{ job.template.name }}</a>
       {{ job.scheduled_for|format_datetime_relative }}
     </p>
     <div class="page-footer">
@@ -34,7 +34,7 @@
           </p>
         {% elif notifications %}
           <p class="{% if job.template.template_type != 'letter' %}bottom-gutter{% endif %}">
-            <a href="{{ download_link }}" download class="heading-small">Download this report</a>
+            <a href="{{ download_link }}" download class="govuk-link govuk-link--no-visited-state heading-small">Download this report</a>
             &emsp;
             <span id="time-left">{{ time_left }}</span>
           </p>
@@ -55,7 +55,7 @@
         field_headings_visible=False
       ) %}
         {% call row_heading() %}
-          <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id, from_job=job.id) }}">{{ item.to }}</a>
+          <a class="govuk-link govuk-link--no-visited-state file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id, from_job=job.id) }}">{{ item.to }}</a>
           <p class="file-list-hint">
             {{ item.preview_of_content }}
           </p>

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -1,12 +1,14 @@
 <div class="ajax-block-container">
-  <p class="notification-status {{ notification.status|format_notification_status_as_field_status(notification.notification_type) }}">
-    {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
+  {% set field_status = notification.status|format_notification_status_as_field_status(notification.notification_type) %}
+  {% set status_url = notification.status|format_notification_status_as_url(notification.notification_type) %}
+  <p class="notification-status {{ field_status }}">
+    {% if status_url %}
+      <a class="govuk-link govuk-link--destructive" href="{{ status_url }}">
     {% endif %}
     {{ notification.status|format_notification_status(
       notification.template.template_type
     ) }}
-    {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
+    {% if status_url %}
       </a>
     {% endif %}
     {% if sent_with_test_key %}

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -1,7 +1,7 @@
 <div class="ajax-block-container">
   <p class="notification-status {{ notification.status|format_notification_status_as_field_status(notification.notification_type) }}">
     {% if notification.status|format_notification_status_as_url(notification.notification_type) %}
-      <a href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ notification.status|format_notification_status_as_url(notification.notification_type) }}">
     {% endif %}
     {{ notification.status|format_notification_status(
       notification.template.template_type

--- a/app/templates/partials/templates/guidance-character-count.html
+++ b/app/templates/partials/templates/guidance-character-count.html
@@ -4,5 +4,5 @@
   cost more.
 </p>
 <p>
-  See <a href="{{ url_for('.pricing') }}">pricing</a> for details.
+  See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a> for details.
 </p>

--- a/app/templates/partials/templates/guidance-postage.html
+++ b/app/templates/partials/templates/guidance-postage.html
@@ -11,5 +11,5 @@
   Royal Mail delivers from Monday to Saturday, excluding bank holidays.
 </p>
 <p>
-  See a list of <a href="{{ url_for('.pricing') + '#letters'}}">postage prices</a>.
+  See a list of <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') + '#letters'}}">postage prices</a>.
 </p>

--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -9,4 +9,4 @@
     Download your document at: ((link_to_document))
   </p>
 </div>
-  Next, use the API to upload your document. Follow the instructions to send a document by email in the <a href="{{ url_for('main.documentation') }}">API documentation</a>.
+  Next, use the API to upload your document. Follow the instructions to send a document by email in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a>.

--- a/app/templates/partials/tour.html
+++ b/app/templates/partials/tour.html
@@ -31,7 +31,7 @@
           Notify delivers the message
         </p>
         {% if help == '3' %}
-          <a href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
             Now go to your dashboard
           </a>
         {% endif %}

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -19,7 +19,7 @@
         {% if item.status in ('pending-virus-check', 'virus-scan-failed') %}
           <span class="file-list-filename loading-indicator">Checking</span>
         {% else %}
-          <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to.splitlines()[0].lstrip().rstrip(' ,') if item.to else '' }}</a>
+          <a class="govuk-link govuk-link--no-visited-state file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.to.splitlines()[0].lstrip().rstrip(' ,') if item.to else '' }}</a>
         {% endif %}
         <p class="file-list-hint">
           {{ item.preview_of_content }}

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -15,7 +15,7 @@
     </h1>
 
     <p>
-      <a href="{{ download_link }}">Download the agreement</a>{% if owner %} for {{ owner }}{% endif %}.
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ download_link }}">Download the agreement</a>{% if owner %} for {{ owner }}{% endif %}.
     </p>
     <p>
       The agreement contains commercially sensitive information. Do not share it outside your organisation.

--- a/app/templates/views/agreement/service-agreement-choose.html
+++ b/app/templates/views/agreement/service-agreement-choose.html
@@ -28,7 +28,7 @@
       There are different agreements for crown and non-crown organisations.
     </p>
     <p>
-      <a href="{{ url_for('main.support') }}">Contact us</a> to tell us
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact us</a> to tell us
       whether or not you work for a crown organisation. If you’re not sure
       we’ll help you work it out.
     </p>

--- a/app/templates/views/agreement/service-agreement-signed.html
+++ b/app/templates/views/agreement/service-agreement-signed.html
@@ -19,7 +19,7 @@
       {{ current_service.organisation.name }} has already accepted the GOV.UK
       Notify data sharing and financial agreement.
     </p>
-    <p>For more information, you can <a href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">download a copy of the agreement</a>.
+    <p>For more information, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">download a copy of the agreement</a>.
     </p>
     <p>
       The agreement is confidential and should not be shared outside your organisation.

--- a/app/templates/views/agreement/service-agreement.html
+++ b/app/templates/views/agreement/service-agreement.html
@@ -26,7 +26,7 @@
       Once accepted, the agreement covers all Notify services from {{ current_service.organisation.name }}.
     </p>
     <p>
-      <a href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">Download a copy of the data sharing and financial agreement</a>.
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">Download a copy of the data sharing and financial agreement</a>.
     </p>
     <p>
       The agreement is confidential and should not be shared outside your organisation.

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -19,7 +19,7 @@
 
       <p>
         When you send an email or text message, we can tell you if Notify was able to deliver it.
-        Read the Callbacks section of our <a href="{{ url_for('main.documentation') }}">API documentation</a> for more information.
+        Read the Callbacks section of our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a> for more information.
       </p>
 
       {% call form_wrapper() %}

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -17,7 +17,7 @@
     <div class="column-five-sixths">
       <p>
         When you receive a text message in Notify, we can forward it to your system.
-        Check the <a href="{{ url_for('.callbacks') }}"> callback documentation </a> for more information.
+        Check the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.callbacks') }}"> callback documentation </a> for more information.
       </p>
 
       {% call form_wrapper() %}

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -16,13 +16,13 @@
 
   <nav class="grid-row bottom-gutter-1-2">
     <div class="column-one-third">
-      <a class="pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
+      <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
     </div>
     <div class="column-one-third">
-      <a class="pill-separate-item" href="{{ url_for('.whitelist', service_id=current_service.id) }}">Whitelist</a>
+      <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.whitelist', service_id=current_service.id) }}">Whitelist</a>
     </div>
     <div class="column-one-third">
-      <a class="pill-separate-item" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">Callbacks</a>
+      <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">Callbacks</a>
     </div>
   </nav>
 
@@ -33,7 +33,7 @@
       </h2>
     </div>
     <div class="column-half align-with-heading-copy-right">
-      <a href="{{ url_for('.api_integration', service_id=current_service.id) }}">Refresh</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.api_integration', service_id=current_service.id) }}">Refresh</a>
     </div>
   </div>
   <div class="api-notifications">
@@ -77,7 +77,7 @@
               {% endif %}
             {% endfor %}
             {% if notification.status not in ('pending-virus-check', 'virus-scan-failed') %}
-              <a class="api-notifications-item__view" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=notification.id) }}">View {{ message_count_label(1, notification.template.template_type, suffix='') }}</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=notification.id) }}">View {{ message_count_label(1, notification.template.template_type, suffix='') }}</a>
             {% endif %}
           </dl>
         </div>

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -46,7 +46,7 @@
         {% endcall %}
       {% else %}
         {% call field(align='right', status='error') %}
-          <a href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>Revoke</a>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>Revoke</a>
         {% endcall %}
       {% endif %}
     {% endcall %}

--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -22,12 +22,12 @@
       <ul>
         {% if form.email_addresses.errors %}
           <li>
-            <a href="#{{ form.email_addresses.name }}">Enter valid email addresses</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="#{{ form.email_addresses.name }}">Enter valid email addresses</a>
           </li>
         {% endif %}
         {% if form.phone_numbers.errors %}
           <li>
-            <a href="#{{ form.phone_numbers.name }}">Enter valid phone numbers</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="#{{ form.phone_numbers.name }}">Enter valid phone numbers</a>
           </li>
         {% endif %}
       </ul>
@@ -41,7 +41,7 @@
 
   <p>
     You and members of
-    <a href="{{ url_for('main.manage_users', service_id=current_service.id) }}">your team</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.manage_users', service_id=current_service.id) }}">your team</a>
     are included in the whitelist automatically.
   </p>
 

--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -22,12 +22,12 @@
       <ul>
         {% if form.email_addresses.errors %}
           <li>
-            <a class="govuk-link govuk-link--no-visited-state" href="#{{ form.email_addresses.name }}">Enter valid email addresses</a>
+            <a class="govuk-link govuk-link--destructive" href="#{{ form.email_addresses.name }}">Enter valid email addresses</a>
           </li>
         {% endif %}
         {% if form.phone_numbers.errors %}
           <li>
-            <a class="govuk-link govuk-link--no-visited-state" href="#{{ form.phone_numbers.name }}">Enter valid phone numbers</a>
+            <a class="govuk-link govuk-link--destructive" href="#{{ form.phone_numbers.name }}">Enter valid phone numbers</a>
           </li>
         {% endif %}
       </ul>

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -9,7 +9,7 @@
 {% set file_contents_header_id = 'file-preview' %}
 {% macro skip_to_file_contents() %}
   <p class="govuk-visually-hidden">
-    <a href="#{{ file_contents_header_id }}">Skip to file contents</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
   </p>
 {% endmacro %}
 
@@ -150,7 +150,7 @@
         ) }}
       {% endif %}
     </div>
-    <a href="#content" class="back-to-top-link">Back to top</a>
+    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
   {% if not request.args.from_test %}
@@ -176,7 +176,7 @@
               (not errors or recipients.more_rows_than_can_send) and
               displayed_index != preview_row
             ) %}
-              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=displayed_index, original_file_name=original_file_name) }}">{{ displayed_index }}</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=displayed_index, original_file_name=original_file_name) }}">{{ displayed_index }}</a>
             {% else %}
               {{ displayed_index }}
             {% endif %}

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -9,7 +9,7 @@
 {% set file_contents_header_id = 'file-preview' %}
 {% macro skip_to_file_contents() %}
   <p class="govuk-visually-hidden">
-    <a href="#{{ file_contents_header_id }}">Skip to file contents</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
   </p>
 {% endmacro %}
 
@@ -76,7 +76,7 @@
             {% if (item.index + 2) == preview_row %}
               {{ item.index + 2 }}
             {% else %}
-              <a href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=(item.index + 2), original_file_name=original_file_name) }}">{{ item.index + 2 }}</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=(item.index + 2), original_file_name=original_file_name) }}">{{ item.index + 2 }}</a>
             {% endif %}
           </span>
         {% endcall %}

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -9,7 +9,7 @@
 {% set file_contents_header_id = 'file-preview' %}
 {% macro skip_to_file_contents() %}
   <p class="govuk-visually-hidden">
-    <a href="#{{ file_contents_header_id }}">Skip to file contents</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
   </p>
 {% endmacro %}
 
@@ -55,7 +55,7 @@
         button_text='Upload your file again'
       ) }}
     </div>
-    <a href="#content" class="back-to-top-link">Back to top</a>
+    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
   <div class="fullscreen-content" data-module="fullscreen-table">

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -21,7 +21,7 @@
   {% endif %}
   {% for org in organisations %}
     <li class="browse-list-item">
-      <a href="{{ url_for('.organisation_dashboard', org_id=org.id) }}" class="browse-list-link">{{ org.name }}</a>
+      <a href="{{ url_for('.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ org.name }}</a>
       <p class="browse-list-hint">
         {{ org.count_of_live_services }}
         live service{% if org.count_of_live_services != 1 %}s{% endif %}
@@ -30,7 +30,7 @@
   {% endfor %}
   {% for service in services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.name }}</a>
     </li>
   {% endfor %}
   {% if show_heading %}
@@ -64,7 +64,7 @@
         </div>
         <ul class="column-three-quarters">
           <li class="browse-list-item">
-            <a href="{{ url_for('.organisations') }}" class="browse-list-link">All organisations</a>
+            <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state browse-list-link">All organisations</a>
             <p class="browse-list-hint">
               {{ org_count|format_thousands }} organisations, {{ live_service_count|format_thousands }} live services
             </p>

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -21,7 +21,7 @@
   {% endif %}
   {% for org in organisations %}
     <li class="browse-list-item">
-      <a href="{{ url_for('.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ org.name }}</a>
+      <a href="{{ url_for('.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state">{{ org.name }}</a>
       <p class="browse-list-hint">
         {{ org.count_of_live_services }}
         live service{% if org.count_of_live_services != 1 %}s{% endif %}
@@ -30,7 +30,7 @@
   {% endfor %}
   {% for service in services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.name }}</a>
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state">{{ service.name }}</a>
     </li>
   {% endfor %}
   {% if show_heading %}
@@ -64,7 +64,7 @@
         </div>
         <ul class="column-three-quarters">
           <li class="browse-list-item">
-            <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state browse-list-link">All organisations</a>
+            <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state">All organisations</a>
             <p class="browse-list-hint">
               {{ org_count|format_thousands }} organisations, {{ live_service_count|format_thousands }} live services
             </p>

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -24,7 +24,7 @@
 
     {% if current_user.has_permissions('send_messages') %}
       <p class="sms-message-reply-link">
-        <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id) }}">Send a text message to this phone number</a>
       </p>
     {% endif %}
 

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -5,7 +5,7 @@
 <div class="ajax-block-container">
   {% if messages %}
     <p class="bottom-gutter-2-3 top-gutter-1-2">
-      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="heading-small">Download these messages</a>
+      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download these messages</a>
     </p>
   {% endif %}
   {% call(item, row_number) list_table(
@@ -21,7 +21,7 @@
   ) %}
     {% call field() %}
       <a
-        class="file-list-filename"
+        class="govuk-link govuk-link--no-visited-state file-list-filename"
         href="{{ url_for('.conversation', service_id=current_service.id, notification_id=item.id) }}#n{{ item.id }}"
       >
         {{ item.user_number | format_phone_number_human_readable }}

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -20,9 +20,9 @@
     {% call row_heading() %}
       <div class="file-list">
         {% if item.upload_type == 'letter' %}
-          <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.original_file_name }}</a>
+          <a class="file-list-filename govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id) }}">{{ item.original_file_name }}</a>
         {% else %}
-          <a class="file-list-filename" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
+          <a class="file-list-filename govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_job', service_id=current_service.id, job_id=item.id) }}">{{ item.original_file_name }}</a>
         {% endif %}
         <span class="file-list-hint">
           Sent {{

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -41,7 +41,7 @@
             field_headings_visible=False
           ) %}
             {% call row_heading() %}
-              <a class="template-statistics-table-template-name" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
+              <a class="govuk-link govuk-link--no-visited-state template-statistics-table-template-name" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}">{{ item.name }}</a>
               <span class="template-statistics-table-hint">
                 {{ message_count_label(1, item.type, suffix='template')|capitalize }}
               </span>

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -28,7 +28,7 @@
             Letter
           </span>
           {% else %}
-          <a class="template-statistics-table-template-name" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
+          <a class="govuk-link govuk-link--no-visited-state template-statistics-table-template-name" href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.template_id) }}">{{ item.template_name }}</a>
           <span class="template-statistics-table-hint">
             {{ message_count_label(1, item.template_type, suffix='template')|capitalize }}
           </span>

--- a/app/templates/views/dashboard/write-first-messages.html
+++ b/app/templates/views/dashboard/write-first-messages.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">Get started</h2>
 
 <nav>
-  <a class="pill-separate-item" href="{{ url_for('.choose_template', service_id=current_service.id) }}">
+  <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.choose_template', service_id=current_service.id) }}">
     {% if 'letter' in current_service.permissions %}
       Write an email, text message or letter
     {% else %}

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -19,12 +19,12 @@
       ('python', 'Python'),
       ('ruby', 'Ruby'),
     ] %}
-      <li><a href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
     <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
   <h2 class="heading-medium">Integrate directly with the API</h2>
     <p>If you cannot use the client libraries, you can integrate directly with the API instead.</p>
-<p>Read the <a href="https://docs.notifications.service.gov.uk/rest-api.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
+<p>Read the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/rest-api.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
 
 {% endblock %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -25,11 +25,17 @@
   ) }}
 
   <p>
-    {{ user.email_address }}&emsp;<a href="{{ url_for('.edit_user_email', service_id=current_service.id, user_id=user.id)}}">Change</a>
+    {{ user.email_address }}&emsp;
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_email', service_id=current_service.id, user_id=user.id)}}">
+    Change<span class="govuk-visually-hidden"> email address</span>
+    </a>
   </p>
   {% if mobile_number %}
     <p id="user_mobile_number">
-      {{ mobile_number }}&emsp;<a href="{{ url_for('.edit_user_mobile_number', service_id=current_service.id, user_id=user.id)}}">Change</a>
+      {{ mobile_number }}&emsp;
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_mobile_number', service_id=current_service.id, user_id=user.id)}}">
+      Change<span class="govuk-visually-hidden"> mobile number</span>
+      </a>
     </p>
   {% endif %}
   <div class="grid-row">

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -15,7 +15,7 @@
     {% for brand in email_brandings %}
       <div class="email-brand">
         <div class="message-name">
-          <a href="{{ url_for('.update_email_branding', branding_id=brand.id) }}">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_email_branding', branding_id=brand.id) }}">
             {{ brand.name or 'Unnamed' }}
           </a>
         </div>

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -11,7 +11,7 @@
   <div class="column-two-thirds">
     <h1 class="heading-large">The link has expired</h1>
 
-    <p><a href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>
+    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>
 
   </div>
 </div>

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -12,13 +12,13 @@
 <p>If you work for central government, a local authority or the NHS, you can use GOV.UK Notify to keep your users updated.</p>
 <p>Notify makes it easy to create, customise and send:</p>
 <ul class="list list-bullet">
-  <li><a href="{{ url_for('main.features_email') }}">emails</a></li>
-  <li><a href="{{ url_for('main.features_sms') }}">text messages</a></li>
-  <li><a href="{{ url_for('main.features_letters') }}">letters</a></li>
+  <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_email') }}">emails</a></li>
+  <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_sms') }}">text messages</a></li>
+  <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_letters') }}">letters</a></li>
 </ul>
 <p>You do not need any technical knowledge to use Notify.</p>
 {% if not current_user.is_authenticated %}
-  <p><a href="{{ url_for('main.register') }}">Create an account</a> for free and try it yourself.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> for free and try it yourself.</p>
 {% endif %}
 
 <h2 class="heading-medium" id="templates">Reusable message templates</h2>
@@ -34,11 +34,11 @@
 
 <h2 class="heading-medium" id="api">API integration</h2>
 <p>You can integrate the Notify API with your web application or back-office system to send messages automatically.</p>
-<p>Read our <a href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
+<p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
 <h2 class="heading-medium" id="reporting">Reporting</h2>
 <p>Notify’s real-time dashboard lets you see the number of messages sent. You can also check the current status of any message to see when it was delivered.</p>
-<p>Read more about the <a href="{{ url_for('main.message_status') }}">delivery status</a> of your messages.</p>
+<p>Read more about the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.message_status') }}">delivery status</a> of your messages.</p>
 
 <h2 class="heading-medium" id="permissions">Permissions</h2>
 <p>Control which members of your team can see, create, edit and send messages.</p>
@@ -58,7 +58,7 @@
 
 <p>We send messages through several different providers. If one provider fails, Notify switches to another so that your messages are not affected.</p>
 
-<p>Visit GOV.UK Performance to <a href="https://www.gov.uk/performance/govuk-notify">see how Notify is performing</a>.</p>
+<p>Visit GOV.UK Performance to <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/performance/govuk-notify">see how Notify is performing</a>.</p>
 
 <h2 class="heading-medium" id="security">Security</h2>
 <p>Notify protects and manages data to meet the needs of government services.</p>
@@ -68,10 +68,10 @@
 
 <h3 class="heading-small">Two-factor authentication</h3>
 <p>Notify uses two-factor authentication (2FA) to keep your account secure. When you sign in, we’ll send a unique one-time code to your phone and ask you to enter it before we let you use your account.</p>
-<p>Read more about <a href="{{ url_for('main.security') }}">security</a>.
+<p>Read more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.security') }}">security</a>.
 
 <h2 class="heading-medium" id="support">Support</h2>
 <p>Notify provides 24-hour online support. If you have an emergency outside office hours, we’ll reply within 30 minutes.</p>
-<p>Find out more about <a href="{{ url_for('.support') }}">support</a>.</p>
+<p>Find out more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">support</a>.</p>
 
 {% endblock %}

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -27,7 +27,7 @@
 
 <h2 class="heading-medium" id="personalised-messages">Personalised content</h2>
 <p>Notify makes it easy to send personalised messages from a single template.</p>
-<p>See <a href="{{ url_for('.edit_and_format_messages', _anchor='personalised-content') }}">how to personalise your content</a>.</p>
+<p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages', _anchor='personalised-content') }}">how to personalise your content</a>.</p>
 
 <h2 class="heading-medium" id="bulk-sending">Bulk sending</h2>
 <p>To send a batch of messages at once, upload a list of contact details to Notify. If you’re sending emails and text messages, you can also schedule the date and time you want them to be sent.</p>

--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -10,7 +10,7 @@
   <h1 class="heading heading-large">Emails</h1>
   <p>Send an unlimited number of emails for free with GOV.UK Notify.</p>
   {% if not current_user.is_authenticated %}
-    <p><a href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
+    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
   {% endif %}
 
   <h2 class="heading heading-medium">Features</h2>
@@ -20,7 +20,7 @@
     <li>personalise the content of your emails</li>
     <li>send and schedule bulk messages</li>
   </ul>
-  <p>You can also <a href="{{ url_for('.documentation') }}">integrate with our API</a> to send emails automatically.</p>
+  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send emails automatically.</p>
 
   <h3 class="heading heading-small" id="branding">Email branding</h3>
   <p>Add your organisation’s logo and brand colour to email templates.</p>
@@ -35,8 +35,8 @@
     <!--<li>you can track when the recipient downloads your document</li>-->
     <li>email attachments are often marked as spam</li>
   </ul>
-  <p><a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> if you want to send files by email.</p>
-  <p>Read our <a href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> if you want to send files by email.</p>
+  <p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h3 class="heading heading-small" id="reply-to">Add a reply-to address</h3>
   <p>Notify lets you choose the email address that users reply to.</p>
@@ -45,6 +45,6 @@
 
   <h2 class="heading heading-medium">Pricing</h2>
   <p>It’s free to send emails through Notify.</p>
-  <p><a href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -24,7 +24,7 @@
 
   <h3 class="heading heading-small" id="branding">Email branding</h3>
   <p>Add your organisation’s logo and brand colour to email templates.</p>
-  <p>See <a href="{{ url_for('.branding_and_customisation', _anchor='email-branding') }}">how to change your email branding</a>.</p>
+  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='email-branding') }}">how to change your email branding</a>.</p>
 
   <h3 class="heading heading-small" id="send-files">Send files by email</h3>
   <p>Notify offers a safe and reliable way to send files by email.</p>
@@ -41,7 +41,7 @@
   <h3 class="heading heading-small" id="reply-to">Add a reply-to address</h3>
   <p>Notify lets you choose the email address that users reply to.</p>
   <p>Emails with a reply-to address seem more trustworthy and are less likely to be labelled as spam.</p>
-  <p>See <a href="{{ url_for('.branding_and_customisation', _anchor='reply-to-address') }}">how to add a reply-to address</a>.</p>
+  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='reply-to-address') }}">how to add a reply-to address</a>.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>
   <p>It’s free to send emails through Notify.</p>

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -10,7 +10,7 @@
   <h1 class="heading heading-large">Letters</h1>
   <p>GOV.UK Notify will print, pack and post your letters for you.</p>
   {% if not current_user.is_authenticated %}
-    <p><a href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
+    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
   {% endif %}
 
   <h2 class="heading heading-medium">Features</h2>
@@ -20,7 +20,7 @@
     <li>personalise the content of your letter</li>
     <li>send bulk mail</li>
   </ul>
-  <p>You can also <a href="{{ url_for('.documentation') }}">integrate with our API</a> to send letters automatically.</p>
+  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send letters automatically.</p>
 
   <h3 class="heading-small" id="postage">Choose your postage</h3>
   <p>Notify can send letters by first or second class post.</p>
@@ -33,7 +33,7 @@
 
   <h3 class="heading heading-small" id="upload-letters">Upload your own letters</h3>
   <p>You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>
-  <p>Read our <a href="{{ url_for('.documentation') }}">documentation</a>.</p>
+  <p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>
   <p>It costs between 30p and 76p (plus VAT) to send a letter. Prices include:</p>
@@ -44,6 +44,6 @@
      <li>first or second class postage</li>
   </ul>
   <p>Letters can be up to 10 pages long (5 double-sided sheets of paper).</p>
-  <p><a href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -29,7 +29,7 @@
 
   <h3 class="heading-small" id="branding">Branding</h3>
   <p>Add your organisation’s logo to your letter templates.</p>
-  <p>See <a href="{{ url_for('.branding_and_customisation', _anchor='letter-branding') }}">how to change your letter branding</a>.</p>
+  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='letter-branding') }}">how to change your letter branding</a>.</p>
 
   <h3 class="heading heading-small" id="upload-letters">Upload your own letters</h3>
   <p>You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -10,7 +10,7 @@
   <h1 class="heading heading-large">Text messages</h1>
   <p>Send thousands of free text messages to UK and international numbers with GOV.UK Notify.</p>
   {% if not current_user.is_authenticated %}
-  <p><a href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
   {% endif %}
 
   <h2 class="heading heading-medium">Features</h2>
@@ -19,12 +19,12 @@
     <li>create reusable text message templates</li>
     <li>personalise the content of your texts</li>
     <li>send and schedule bulk messages</li></ul>
-  <p>You can also <a href="{{ url_for('.documentation') }}">integrate with our API</a> to send text messages automatically.<p>
+  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send text messages automatically.<p>
 
   <h3 class="heading heading-small" id="receive">Receive text messages</h3>
   <p>Let people send messages to your service or reply to your texts.</p>
   <p>You can see and reply to the messages you receive when you sign in to Notify. If you’re using our API, you can set up your own automated processes to manage replies.</p>
-  <p><a href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> to request a unique number for text message replies.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> to request a unique number for text message replies.</p>
 
   <h3 class="heading heading-small" id="sender">Show people who your texts are from</h3>
   <p>When you send a text message with Notify, the sender name tells people who it's from.</p>
@@ -36,6 +36,6 @@
     <ul class="list list-bullet">
       <li>250,000 free text messages for central government services</li>
       <li>25,000 free text messages for other public sector services</li></ul>
-    <p><a href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -28,7 +28,7 @@
 
   <h3 class="heading heading-small" id="sender">Show people who your texts are from</h3>
   <p>When you send a text message with Notify, the sender name tells people who it's from.</p>
-  <p>See <a href="{{ url_for('.branding_and_customisation', _anchor='text-message-sender') }}">how to change the text message sender</a>.</p>
+  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='text-message-sender') }}">how to change the text message sender</a>.</p>
 
   <h2 class="heading heading-medium">Pricing<h2>
     <p>Each service you add has a free annual allowance. After that it costs 1.58 pence (plus VAT) to send a text to a UK number.</p>

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -43,7 +43,7 @@
     <ul>
     {% for service in services_found %}
       <li class="browse-list-item">
-        <a href="{{url_for('.service_dashboard', service_id=service.id)}}" class="browse-list-link">{{ service.name }}</a>
+        <a href="{{url_for('.service_dashboard', service_id=service.id)}}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.name }}</a>
       </li>
       <hr>
     {% endfor %}

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -43,7 +43,7 @@
     <ul>
     {% for service in services_found %}
       <li class="browse-list-item">
-        <a href="{{url_for('.service_dashboard', service_id=service.id)}}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.name }}</a>
+        <a href="{{url_for('.service_dashboard', service_id=service.id)}}" class="govuk-link govuk-link--no-visited-state">{{ service.name }}</a>
       </li>
       <hr>
     {% endfor %}

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -43,7 +43,7 @@
     <ul>
     {% for user in users_found %}
       <li class="browse-list-item">
-        <a href="{{url_for('.user_information', user_id=user.id)}}" class="browse-list-link">{{ user.email_address }}</a>
+        <a href="{{url_for('.user_information', user_id=user.id)}}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ user.email_address }}</a>
         <p class="browse-list-hint">{{ user.name }}</p>
       </li>
       <hr>

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -62,7 +62,7 @@
       {% endif %}
       {% if user.state == 'active' %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.archive_user', user_id=user.id) }}">
+          <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.archive_user', user_id=user.id) }}">
             Archive user
           </a>
         </span>

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -19,7 +19,7 @@
           <ul>
           {% for service in user.live_services %}
             <li class="browse-list-item">
-              <a class="browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
+              <a class="govuk-link govuk-link--no-visited-state browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
             </li>
           {% endfor %}
           </ul>
@@ -35,7 +35,7 @@
           <ul>
           {% for service in user.trial_mode_services %}
             <li class="browse-list-item">
-              <a class="browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
+              <a class="govuk-link govuk-link--no-visited-state browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
             </li>
           {% endfor %}
           </ul>
@@ -62,7 +62,7 @@
       {% endif %}
       {% if user.state == 'active' %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a href="{{ url_for('main.archive_user', user_id=user.id) }}">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.archive_user', user_id=user.id) }}">
             Archive user
           </a>
         </span>

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -14,7 +14,7 @@
 <ol class="get-started-list">
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Check if GOV.UK Notify is right for you</h2>
-    <p>Read about our <a href="{{ url_for('main.features') }}">features</a>, <a href="{{ url_for('.pricing') }}">pricing</a> and <a href="{{ url_for('main.roadmap') }}">roadmap</a>.</p>
+    <p>Read about our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features') }}">features</a>, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a> and <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.roadmap') }}">roadmap</a>.</p>
     {{ govukDetails({
       "summaryText": "Organisations that can use Notify",
       "html": '''
@@ -35,15 +35,15 @@
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Create an account</h2>
     {% if not current_user.is_authenticated %}
-      <p><a href="{{ url_for('.register') }}">Create an account</a> for free and add your first Notify service. When you add a new service it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+      <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.register') }}">Create an account</a> for free and add your first Notify service. When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
     {% else %}
-      <p>Create an account for free and add your first Notify service. When you add a new service, it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+      <p>Create an account for free and add your first Notify service. When you add a new service, it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
     {% endif %}
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Write some messages</h2>
-    <p>Add message templates with examples of the content you plan to send. You can use our <a href="{{ url_for('main.guidance_index') }}">guidance</a> to help you.</p>
+    <p>Add message templates with examples of the content you plan to send. You can use our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_index') }}">guidance</a> to help you.</p>
   </li>
 
   <li class="get-started-list__item">
@@ -52,15 +52,15 @@
     <p>Review your settings to add message branding, reply-to addresses and sender information.</p>
     <p>Add team members and check their permissions.</p>
     {% else %}
-    <p>Review your <a href="{{ url_for('.service_settings', service_id=current_service.id) }}">settings</a> to add message branding, reply-to addresses and sender information.</p>
-    <p>Add <a href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a> and check their permissions.</p>
+    <p>Review your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_settings', service_id=current_service.id) }}">settings</a> to add message branding, reply-to addresses and sender information.</p>
+    <p>Add <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a> and check their permissions.</p>
     {% endif %}
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Set up an API integration (optional)</h2>
     <p>You can use the Notify API to send messages automatically.</p>
-    <p>Our <a href="{{ url_for('main.documentation') }}">documentation</a> explains how to integrate the API with a web application or back office system.</p>
+    <p>Our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation</a> explains how to integrate the API with a web application or back office system.</p>
   </li>
 
   <li class="get-started-list__item">
@@ -68,9 +68,9 @@
     {% if not current_user.is_authenticated or not current_service %}
     <p>When you’re ready to send messages to people outside your team, go to the <b class="govuk-!-font-weight-bold">Settings</b> page and select <b class="govuk-!-font-weight-bold">Request to go live</b>. We’ll approve your request within one working day.</p>
     {% else %}
-    <p>You should <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
+    <p>You should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
     {% endif %}
-    <p>Check <a href="{{ url_for('main.how_to_pay') }}">how to pay</a> if you’re planning to send letters or exceed the <a href="{{ url_for('.pricing', _anchor='text-messages') }}">free text message allowance</a>.</p>
+    <p>Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a> if you’re planning to send letters or exceed the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing', _anchor='text-messages') }}">free text message allowance</a>.</p>
   </li>
 
 </ol>

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -12,10 +12,10 @@
   <p>This page explains how to:</p>
 
   <ul class="list list-bullet">
-    <li><a href="#email-branding">change your email branding</a></li>
-    <li><a href="#reply-to-address">add a reply-to email address</a></li>
-    <li><a href="#text-message-sender">change the text message sender</a></li>
-    <li><a href="#letter-branding">change your letter branding</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#email-branding">change your email branding</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#reply-to-address">add a reply-to email address</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#text-message-sender">change the text message sender</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#letter-branding">change your letter branding</a></li>
   </ul>
 
   <h2 class="heading-medium" id="email-branding">Change your email branding</h2>
@@ -31,7 +31,7 @@
 
   <h2 class="heading-medium" id="reply-to-address">Add a reply-to email address</h2>
 
-  <p>You can choose the email address that your users reply to. You must add at least one reply-to address for your service before you can <a href="{{ url_for('main.trial_mode_new') }}">request to go live</a>.</p>
+  <p>You can choose the email address that your users reply to. You must add at least one reply-to address for your service before you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">request to go live</a>.</p>
 
   <p>To add a reply-to email address:</p>
 

--- a/app/templates/views/guidance/create-and-send-messages.html
+++ b/app/templates/views/guidance/create-and-send-messages.html
@@ -9,7 +9,7 @@
 
   <h1 class="heading-large">Send messages</h1>
 
-  <p><a href="{{ url_for('main.register') }}">Create an account</a> to see a short tutorial explaining how to create and send messages.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> to see a short tutorial explaining how to create and send messages.</p>
 
   <h2 class="heading-medium" id="bulk-sending">Bulk sending</h2>
 

--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -11,10 +11,10 @@
 
   <p>This page explains how to:</p>
   <ul class="list list-bullet">
-    <li><a href="#formatting">format your content</a></li>
-    <li><a href="#links">add links</a></li>
-    <li><a href="#personalised-content">personalise your content</a></li>
-    <li><a href="#optional-content">add optional content</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#formatting">format your content</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#links">add links</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#personalised-content">personalise your content</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="#optional-content">add optional content</a></li>
   </ul>
 
   <h2 class="heading-medium" id="formatting">Format your content</h2>
@@ -30,7 +30,7 @@
   <ul class="list list-bullet">
     <li>headings</li>
     <li>bullets</li>
-    <li><a href="https://design-system.service.gov.uk/components/inset-text/">inset text</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://design-system.service.gov.uk/components/inset-text/">inset text</a></li>
     <li>horizontal rules</li>
   </ul>
 

--- a/app/templates/views/guidance/index.html
+++ b/app/templates/views/guidance/index.html
@@ -15,9 +15,9 @@
   <p>It explains how to:</p>
 
   <ul class="list list-bullet">
-    <li><a href="{{ url_for('.edit_and_format_messages') }}">edit and format messages</a></li>
-    <li><a href="{{ url_for('.branding_and_customisation') }}">add branding and customisation</a></li>
-    <li><a href="{{ url_for('.send_files_by_email') }}">send files by email</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages') }}">edit and format messages</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation') }}">add branding and customisation</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.send_files_by_email') }}">send files by email</a></li>
   </ul>
 
   <h2 class="heading-medium">More information</h2>
@@ -25,10 +25,10 @@
   <p>The GOV.UK Service Manual has advice on:</p>
 
   <ul class="list list-bullet">
-    <li><a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">planning and writing text messages and emails</a></li>
-    <li><a href="https://www.gov.uk/service-manual/design/writing-effective-letters">writing effective letters</a></li>
-    <li><a href="https://www.gov.uk/service-manual/technology/how-to-email-your-users">sending emails from your service domain</a></li>
-    <li><a href="https://www.gov.uk/service-manual/technology/sending-text-messages-securely">sending text messages securely</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">planning and writing text messages and emails</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/writing-effective-letters">writing effective letters</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/technology/how-to-email-your-users">sending emails from your service domain</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/technology/sending-text-messages-securely">sending text messages securely</a></li>
   </ul>
 
 {% endblock %}

--- a/app/templates/views/guidance/send-files-by-email.html
+++ b/app/templates/views/guidance/send-files-by-email.html
@@ -8,8 +8,8 @@
 
   <h1 class="heading-large">Send files by email</h1>
 
-  <p><a href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
 
-  <p>Then follow the instructions to send a file by email in our <a href="{{ url_for('.documentation') }}">API documentation</a>.</p>
+  <p>Then follow the instructions to send a file by email in our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a>.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -35,8 +35,8 @@
   <p>To help you set up your letter, you can download our:</p>
 
   <ul class="list list-bullet">
-    <li><a href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
-    <li><a href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">print margin checker for Microsoft Word (.docx)</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-word-template-v1.0.docx">print margin checker for Microsoft Word (.docx)</a></li>
   </ul>
 
 

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -58,7 +58,7 @@ Inbound Numbers
               {% endif %}
               </th>
               <th style="font-weight:normal;">
-                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="browse-list-link">{{ value.service.name }}</a>
+                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ value.service.name }}</a>
               </th>
           </tr>
           {% endfor %}

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -58,7 +58,7 @@ Inbound Numbers
               {% endif %}
               </th>
               <th style="font-weight:normal;">
-                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ value.service.name }}</a>
+                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state">{{ value.service.name }}</a>
               </th>
           </tr>
           {% endfor %}

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -46,8 +46,8 @@ Inbound Numbers
 
           {% for value in inbound_num_list.data: %}
           <tr>
-              <th style="font-weight:normal;">{{value.number}}</th>
-              <th style="font-weight:normal;">
+              <td>{{value.number}}</td>
+              <td>
 
               {% if value.active %}
                 Active
@@ -56,10 +56,10 @@ Inbound Numbers
               {% else %}
                 Inactive
               {% endif %}
-              </th>
-              <th style="font-weight:normal;">
-                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state">{{ value.service.name }}</a>
-              </th>
+              </td>
+              <td>
+                  <a href="{{ url_for('main.service_dashboard', service_id=value.service.id) }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-24 govuk-!-font-weight-bold">{{ value.service.name }}</a>
+              </td>
           </tr>
           {% endfor %}
           </tbody>

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -14,7 +14,7 @@
     <p>This information has moved.</p>
 
     <p>
-      Refer to the <a href="{{ url_for('main.documentation') }}">documentation
+      Refer to the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation
       for the client library you are using.
     </p>
 

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -25,7 +25,7 @@
       <div class="js-stick-at-bottom-when-scrolling">
         <div class="page-footer">
           <span class="page-footer-delete-link page-footer-delete-link-without-button">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
+            <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
           </span>
     {% else %}
       <div>&nbsp;</div>

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -25,7 +25,7 @@
       <div class="js-stick-at-bottom-when-scrolling">
         <div class="page-footer">
           <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
           </span>
     {% else %}
       <div>&nbsp;</div>

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -15,7 +15,7 @@
     {% for brand in letter_brandings %}
       <div class="letter-brand">
         <div class="message-name">
-          <a href="{{ url_for('.update_letter_branding', branding_id=brand.id) }}">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_letter_branding', branding_id=brand.id) }}">
             {{ brand.name }}
           </a>
         </div>

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -73,9 +73,9 @@
           {% if current_user.has_permissions('manage_service') %}
             <li class="tick-cross-list-edit-link">
               {% if user.status == 'pending' %}
-                <a href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
               {% elif user.state == 'active' and current_user.id != user.id %}
-                <a href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details</a>
               {% endif %}
             </li>
           {% endif %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -10,9 +10,9 @@
   <h1 class="heading-large">Delivery status</h1>
 
   <p>Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered.</p>
-  <p>For <a href="{{ url_for("main.security") }}">security</a>, this information is only available for 7 days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
+  <p>For <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("main.security") }}">security</a>, this information is only available for 7 days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
   <p>This page describes the statuses you’ll see when you’re signed in to Notify.</p>
-  <p>If you’re using the Notify API, read our <a href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p>
+  <p>If you’re using the Notify API, read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p>
 
   <h2 id="email-statuses" class="heading-medium">Emails</h2>
   <div class="bottom-gutter-3-2">

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -72,7 +72,7 @@
 
   {% if current_user.has_permissions('view_activity') %}
     <p class="bottom-gutter">
-      <a href="{{ download_link }}" download="download" class="heading-small">Download this report</a>
+      <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
       &emsp;
       Data available for {{ partials.service_data_retention_days }} days
     </p>

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -81,7 +81,7 @@
         {{ govukButton({ "text": button_text }) }}
       {% endif %}
       {% if template.template_type == 'letter' %}
-        <a href="{{ url_for('no_cookie.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
+        <a href="{{ url_for('no_cookie.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
       {% endif %}
     </form>
   </div>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -86,7 +86,7 @@
         <div class="page-footer">
           {% if show_cancel_button %}
             <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.cancel_letter', service_id=current_service.id, notification_id=notification_id) }}">Cancel sending this letter</a>
+              <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.cancel_letter', service_id=current_service.id, notification_id=notification_id) }}">Cancel sending this letter</a>
             </span>
           {% else %}
             <div>&nbsp;</div>

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -26,7 +26,7 @@
         {% if help %}
           ‘{{ template.name }}’
         {% else %}
-          <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">‘{{ template.name }}’</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_template', service_id=current_service.id, template_id=template.id) }}">‘{{ template.name }}’</a>
         {% endif %}
         was sent
       {% endif %}
@@ -34,7 +34,7 @@
         {% set destination =
           {'letter': 'an address', 'email': 'an email address', 'sms': 'a phone number'} %}
         to {{ destination[template.template_type] }} from
-        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id) }}">{{ job.original_file_name }}</a>
       {% elif created_by %}
         by {{ created_by.name }}
       {% endif %}
@@ -86,12 +86,12 @@
         <div class="page-footer">
           {% if show_cancel_button %}
             <span class="page-footer-delete-link page-footer-delete-link-without-button">
-              <a href="{{ url_for('main.cancel_letter', service_id=current_service.id, notification_id=notification_id) }}">Cancel sending this letter</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.cancel_letter', service_id=current_service.id, notification_id=notification_id) }}">Cancel sending this letter</a>
             </span>
           {% else %}
             <div>&nbsp;</div>
           {% endif %}
-          <a class="page-footer-right-aligned-link-without-button" href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download>Download as a PDF</a>
+          <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" href="{{ url_for('main.view_letter_notification_as_preview', service_id=current_service.id, notification_id=notification_id, filetype='pdf') }}" download>Download as a PDF</a>
         </div>
       </div>
     {% elif template.template_type == 'email' %}
@@ -104,7 +104,7 @@
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}
       <p>
-        <a href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
       </p>
     {% endif %}
 

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -12,8 +12,8 @@
 {% block main %}
   <div class="govuk-width-container">
     <div class="navigation-service">
-      <a href="{{ url_for('.organisations') }}" class="navigation-service-back-to">All organisations</a>
-      <a href="{{ url_for('main.choose_account') }}" class="navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state navigation-service-back-to">All organisations</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
 
     <div class="grid-row">

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -14,7 +14,7 @@
       <div class="navigation-service-name">
         &nbsp;
       </div>
-      <a href="{{ url_for('main.choose_account') }}" class="navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
 
     <div class="grid-row top-gutter-2-3">
@@ -31,7 +31,7 @@
           <ul>
             {% for org in organisations %}
               <li class="browse-list-item">
-                <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="browse-list-link">{{ org.name }}</a>
+                <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ org.name }}</a>
                 <p class="browse-list-hint">
                   {{ org.count_of_live_services }}
                   live service{% if org.count_of_live_services != 1 %}s{% endif %}

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -11,7 +11,7 @@
 {% block maincolumn_content %}
 
     <div class="navigation-service">
-      <div class="navigation-service-name">
+      <div class="navigation-service-name govuk-!-font-weight-bold">
         &nbsp;
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>

--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -31,7 +31,7 @@
           <ul>
             {% for org in organisations %}
               <li class="browse-list-item">
-                <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ org.name }}</a>
+                <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state">{{ org.name }}</a>
                 <p class="browse-list-hint">
                   {{ org.count_of_live_services }}
                   live service{% if org.count_of_live_services != 1 %}s{% endif %}

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -12,7 +12,7 @@
   <ul>
   {% for service in current_org.live_services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('main.usage', service_id=service.id) }}" class="browse-list-link">{{ service['name'] }}</a>
+      <a href="{{ url_for('main.usage', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
     </li>
   {% endfor %}
   </ul>

--- a/app/templates/views/organisations/organisation/trial-mode-services.html
+++ b/app/templates/views/organisations/organisation/trial-mode-services.html
@@ -14,7 +14,7 @@
   <ul>
   {% for service in current_org.trial_services %}
     <li class="browse-list-item">
-      <a href="{{ url_for('main.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service['name'] }}</a>
+      <a href="{{ url_for('main.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
     </li>
   {% endfor %}
   </ul>

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -44,7 +44,7 @@
         <ul class="tick-cross-list">
           <li class="tick-cross-list-edit-link">
             {% if user.status == 'pending' %}
-              <a href="{{ url_for('.cancel_invited_org_user', org_id=current_org.id, invited_user_id=user.id)}}">Cancel invitation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.cancel_invited_org_user', org_id=current_org.id, invited_user_id=user.id)}}">Cancel invitation</a>
             {% endif %}
           </li>
         </ul>

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -27,7 +27,7 @@
           ('Clear cache', url_for('main.clear_cache')),
         ] %}
           <li>
-            <a href="{{ url }}">
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url }}">
               {{ link_text }}
             </a>
           </li>

--- a/app/templates/views/platform-admin/reports.html
+++ b/app/templates/views/platform-admin/reports.html
@@ -11,17 +11,17 @@
   </h1>
 
 <p>
-  <a target="_blank" href="{{ url_for('main.live_services_csv') }}">Download live services csv report</a>
+  <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ url_for('main.live_services_csv') }}">Download live services csv report</a>
 </p>
 
 <p>
-  <a target="_blank" href="{{ url_for('main.performance_platform_xlsx') }}">Download performance platform report (.xlsx)</a>
+  <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ url_for('main.performance_platform_xlsx') }}">Download performance platform report (.xlsx)</a>
 <p>
 
 <p>
-  <a href="{{ url_for('main.notifications_sent_by_service') }}">Monthly notification statuses for live services</a>
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.notifications_sent_by_service') }}">Monthly notification statuses for live services</a>
 <p>
 <p>
-  <a href="{{ url_for('main.usage_for_all_services') }}">Usage for all services</a>
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.usage_for_all_services') }}">Usage for all services</a>
 </p>
 {% endblock %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -49,7 +49,7 @@
 
         {% call row() %}
           {% call field(border=False) %}
-            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="browse-list-link">{{ service['name'] }}</a>
+            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
           {% endcall %}
 
           {{ stats_fields('email', service['stats']) }}

--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -18,7 +18,7 @@
     </p>
 
     <ul class="list list-bullet">
-      <li>exceed the <a href="{{ url_for('.pricing') }}">free text message allowance</a></li>
+      <li>exceed the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">free text message allowance</a></li>
       <li>send letters</li>
     </ul>
 
@@ -51,7 +51,7 @@
     </p>
 
     <p>
-       <a href="{{ support_link }}">Contact us</a> if you need help raising a purchase order.
+       <a class="govuk-link govuk-link--no-visited-state" href="{{ support_link }}">Contact us</a> if you need help raising a purchase order.
     </p>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -20,13 +20,13 @@
 
   <p>
     {% if not current_user.is_authenticated %}
-      <a href="{{ url_for('main.register') }}">Create an account</a> then add as many different services as you need to.</p>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many different services as you need to.</p>
     {% else %}
       You can add as many different services as you need to.
     {% endif %}
   </p>
 
-  <p>When you add a new service it will start in <a href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+  <p>When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
 
   <h2 class="heading-medium" id="emails">Emails</h2>
   <p>It’s free to send emails through Notify.</p>
@@ -40,7 +40,7 @@
     <li>25,000 free text messages for other public sector services</li>
   </ul>
   <p>It costs 1.58 pence (plus VAT) for each text message you send after you've used your free allowance.</p>
-  <p>See <a href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
+  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
   <p>If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message:</p>

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -23,7 +23,7 @@
 
     <p>For the credentials used to access GOV.UK Notify, Cabinet Office is the data controller.</p>
 
-    <p>For more information see the Information Commissioner’s Office (ICO) <a href="https://ico.org.uk/esdwebpages/search">Data Protection Public Register</a>.
+    <p>For more information see the Information Commissioner’s Office (ICO) <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/esdwebpages/search">Data Protection Public Register</a>.
       The Cabinet Office registration number is: Z7414053</p>
 
     <h2 class="heading-medium">What data we collect from you</h2>
@@ -120,7 +120,7 @@
 
     <p>
     GDS Privacy Team<br>
-    <a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a>
     </p>
     
     <p>
@@ -129,18 +129,18 @@
     
     <p>
     Data Protection Officer<br>
-    <a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br>
+    <a class="govuk-link govuk-link--no-visited-state" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br>
     Data Protection Officer<br>
     Cabinet Office<br>
     70 Whitehall<br>
     London SW1A 2AS
     </p>
 
-    <p>If you have a complaint, you can also contact the <a href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
+    <p>If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
     
     <p>
     Information Commissioner’s Office<br>
-    <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
+    <a class="govuk-link govuk-link--no-visited-state" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
     0303 123 1113</br>
     Wycliffe House<br>
     Water Lane<br>

--- a/app/templates/views/providers/providers.html
+++ b/app/templates/views/providers/providers.html
@@ -12,7 +12,7 @@ Providers
 
   <h2 class="heading-medium">SMS</h2>
 
-  <a href="{{ url_for('main.edit_sms_provider_ratio') }}">Change priority</a>
+  <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.edit_sms_provider_ratio') }}">Change priority</a>
 
   {% call(item, row_number) list_table(
       domestic_sms_providers,

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -11,7 +11,7 @@
 
   <p>The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
   <p>Notify is in public beta. This means it’s fully operational and supported, but we’re still adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
-  <p>You can <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
+  <p>You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
   <h2 class="heading-medium">January to March 2020</h2>
   

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -51,7 +51,7 @@
     <li>your email address and password</li>
     <li>a text message code that Notify sends to your phone</li>
   </ul>
-  <p>If signing in with a text message is a problem for your team, <a href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
+  <p>If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
 
   <h2 class="heading-medium">Information risk management</h2>
   <p>Our approach to information risk management follows NCSC guidance. It assesses:</p>
@@ -65,8 +65,8 @@
   <h2 class="heading-medium">How we manage risks on Notify</h2>
   <p>Things we do to manage risks on Notify include:</p>
   <ul class="list list-bullet">
-    <li>formal risk assessments based on <a href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 2700:2011</a> and National Cyber Security Centre guidance</li>
-    <li><a href="https://www.cesg.gov.uk/articles/check-fundamental-principles">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
+    <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 2700:2011</a> and National Cyber Security Centre guidance</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.cesg.gov.uk/articles/check-fundamental-principles">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
     <li>residual risk statement preparation and active management of the risk treatment plan</li>
     <li>regular updates to the Privacy Impact Assessment</li>
     <li>security impact assessments</li>
@@ -77,8 +77,8 @@
   <p>Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
 
   <h2 class="heading-medium">Classifications and security vetting</h2>
-  <p>You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
-  <p>You must not use Notify to send ‘<a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/special-category-data/">special category data</a>’, as defined in the General Data Protection Regulation (GDPR).</p>
-  <p>The Notify team has Security Check (SC) level clearance from <a href="https://www.gov.uk/guidance/security-vetting-and-clearance">United Kingdom Security Vetting</a> (UKSV).</p>
+  <p>You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
+  <p>You must not use Notify to send ‘<a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/special-category-data/">special category data</a>’, as defined in the General Data Protection Regulation (GDPR).</p>
+  <p>The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/guidance/security-vetting-and-clearance">United Kingdom Security Vetting</a> (UKSV).</p>
 
 {% endblock %}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -31,13 +31,13 @@
       </div>
       {% if skip_link %}
         <div class="column-one-third">
-          <a href="{{ skip_link[1] }}" class="top-gutter-4-3">{{ skip_link[0] }}</a>
+          <a href="{{ skip_link[1] }}" class="govuk-link govuk-link--no-visited-state top-gutter-4-3">{{ skip_link[0] }}</a>
         </div>
       {% endif %}
     </div>
     {% if link_to_upload %}
       <p>
-        <a href="{{ url_for('.send_messages', service_id=current_service.id, template_id=template.id) }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.send_messages', service_id=current_service.id, template_id=template.id) }}">
           Upload a list of {{ recipient_count_label(999, template.template_type) }}
         </a>
       </p>

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -46,7 +46,7 @@
     {% endcall %}
   </div>
   <p class="table-show-more-link">
-    <a href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download>Download this example</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download>Download this example</a>
   </p>
 
   <h2 class="heading-medium">Your file will populate this template ({{ template.name }})</h2>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -263,7 +263,7 @@
       <p>
         {% if current_user.has_permissions('manage_service') %}
           To remove these restrictions, you can send us a
-          <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
         {% else %}
           Your service manager can ask to have these restrictions removed.
         {% endif %}
@@ -279,7 +279,7 @@
       </p>
       <p>
         Problems or comments?
-        <a href="{{ url_for('main.support') }}">Give feedback</a>.
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Give feedback</a>.
       </p>
 
     {% endif %}
@@ -318,7 +318,7 @@
             {{ text_field('Organisation')}}
             {% call field() %}
               {% if current_service.organisation_id %}
-                <a href="{{ url_for('main.organisation_dashboard', org_id=current_service.organisation_id) }}">
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.organisation_dashboard', org_id=current_service.organisation_id) }}">
                   {{ current_service.organisation.name }}
                 </a>
               {% else %}
@@ -375,13 +375,13 @@
     {% if current_service.active and (current_service.trial_mode or current_user.platform_admin) %}
       <p class="top-gutter-1-2">
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a href="{{ url_for('.archive_service', service_id=current_service.id) }}">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.archive_service', service_id=current_service.id) }}">
             Delete this service
           </a>
         </span>
         {% if current_user.platform_admin %}
           <span class="page-footer-delete-link">
-            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="page-footer-delete-link">
+            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="govuk-link govuk-link--no-visited-state page-footer-delete-link">
                 Suspend service
               </a>
           </span>
@@ -394,7 +394,7 @@
           Service suspended
         </div>
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a href="{{ url_for('.resume_service', service_id=current_service.id) }}">
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.resume_service', service_id=current_service.id) }}">
             Resume service
           </a>
         </span>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -375,13 +375,13 @@
     {% if current_service.active and (current_service.trial_mode or current_user.platform_admin) %}
       <p class="top-gutter-1-2">
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.archive_service', service_id=current_service.id) }}">
+          <a class="govuk-link govuk-link--destructive" href="{{ url_for('.archive_service', service_id=current_service.id) }}">
             Delete this service
           </a>
         </span>
         {% if current_user.platform_admin %}
           <span class="page-footer-delete-link">
-            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="govuk-link govuk-link--no-visited-state page-footer-delete-link">
+            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="govuk-link govuk-link--destructive page-footer-delete-link">
                 Suspend service
               </a>
           </span>
@@ -394,7 +394,7 @@
           Service suspended
         </div>
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.resume_service', service_id=current_service.id) }}">
+          <a class="govuk-link govuk-link--destructive" href="{{ url_for('.resume_service', service_id=current_service.id) }}">
             Resume service
           </a>
         </span>

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -15,7 +15,7 @@
     </p>
 
     <p class="js-hidden">
-      <a href="{{ url_for('main.service_verify_reply_to_address', service_id=service_id, notification_id=notification_id, is_default=is_default, replace=replace) }}">Refresh</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_verify_reply_to_address', service_id=service_id, notification_id=notification_id, is_default=is_default, replace=replace) }}">Refresh</a>
     </p>
   {% elif verification_status == "success" %}
     {{ banner("‘{}’ is ready to use".format(reply_to_email_address), type='default', with_tick=True) }}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -31,7 +31,7 @@
           </span>
         </h3>
         {% if current_user.has_permissions('manage_service') %}
-          <a class="user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
+          <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
         {% endif %}
         {% if current_service.count_email_reply_to_addresses > 1 %}
           {{ api_key(item.id, thing="ID") }}

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -22,7 +22,7 @@
         Blank
         {% if current_service.default_letter_contact_block %}
           {% if current_user.has_permissions('manage_service') %}
-            <a class="user-list-edit-link" href="{{ url_for('.service_make_blank_default_letter_contact', service_id =current_service.id) }}">Make default</a>
+            <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_make_blank_default_letter_contact', service_id =current_service.id) }}">Make default</a>
           {% endif %}
         {% else %}
           (default)
@@ -40,7 +40,7 @@
           {% endif %}
         </p>
         {% if current_user.has_permissions('manage_service') %}
-        <a class="user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
+        <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
         {% endif %}
         {% if letter_contact_details|length  > 1 %}
           {{ api_key(item.id, thing="ID") }}

--- a/app/templates/views/service-settings/preview-letter-branding.html
+++ b/app/templates/views/service-settings/preview-letter-branding.html
@@ -17,7 +17,7 @@
           {{ form.hidden_tag() }}
           <div class="page-footer">
             {{ govukButton({ "text": "Save", "classes": "govuk-!-margin-right-2" }) }}
-            <a class="page-footer-back-link" href="{{ url_for('main.service_settings', service_id=service_id) }}">Back to service settings</a>
+            <a class="govuk-link govuk-link--no-visited-state page-footer-back-link" href="{{ url_for('main.service_settings', service_id=service_id) }}">Back to service settings</a>
           </div>
         </div>
       {% endcall %}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -69,7 +69,7 @@
           When we receive your request we’ll get back to you within one working day.
         </p>
         <p class="bottom-gutter">
-          By requesting to go live you’re agreeing to our <a href="{{ url_for('.terms') }}">terms of use</a>.
+          By requesting to go live you’re agreeing to our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.terms') }}">terms of use</a>.
         </p>
         {% call form_wrapper() %}
           {{ page_footer('Request to go live') }}

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -24,7 +24,7 @@
           or an email link.
         </p>
         <p>
-          You can <a href="{{ url_for('.manage_users', service_id=current_service.id) }}">set the sign-in method for individual team members</a>.
+          You can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}">set the sign-in method for individual team members</a>.
         </p>
       {% else %}
         <p class="heading-small bottom-gutter-2-3">
@@ -34,7 +34,7 @@
           Your team members sign in with a text message code.
         </p>
         <p>
-          <a href="{{ url_for('.support') }}">Contact us</a> if signing in with a text message is a problem for your team.
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if signing in with a text message is a problem for your team.
         </p>
       {% endif %}
     </div>

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -23,17 +23,17 @@
           You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.
         </p>
         <p>
-          <a href="{{ url_for('.support') }}">Contact us</a> if you want to switch this feature off.
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to switch this feature off.
         </p>
         {% if current_user.has_permissions('manage_api_keys') %}
           <p>
             You can set up callbacks for received text messages on the
-            <a href="{{ url_for('.api_callbacks', service_id=current_service.id) }}">API integration page</a>.
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.api_callbacks', service_id=current_service.id) }}">API integration page</a>.
           </p>
         {% endif %}
       {% else %}
         <p>
-          <a href="{{ url_for('.support') }}">Contact us</a> if you want to be able to receive text messages from your users.
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to be able to receive text messages from your users.
         </p>
         <p>
           We’ll create a unique phone number for your service that they can reply to.

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -20,7 +20,7 @@
         Messages to international mobile numbers are charged at 1, 2, or
         3 times the cost of messages to UK mobile numbers.</p>
       <p>
-        See <a href="{{ url_for(".pricing") }}">pricing</a> for the list
+        See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing") }}">pricing</a> for the list
         of rates.
       </p>
       {% call form_wrapper() %}

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -20,7 +20,7 @@
         It costs between 30p and 76p to send a letter using Notify.
       </p>
       <p>
-        See <a href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for the list
+        See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for the list
         of rates.
       </p>
       {% call form_wrapper() %}

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -26,7 +26,7 @@
         after your free allowance.
       </p>
       <p>
-        See <a href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for more details.
+        See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for more details.
       </p>
       {% call form_wrapper() %}
         {{ radios(form.enabled) }}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -33,7 +33,7 @@
           {% endif %}
         </h3>
         {% if current_user.has_permissions('manage_service') %}
-          <a class="user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
+          <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
         {% endif %}
         {% if current_service.count_sms_senders > 1 %}
           {{ api_key(item.id, thing="ID") }}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -16,10 +16,10 @@
       <nav class="breadcrumbs breadcrumbs--inverse" aria-label="Breadcrumbs">
        <ol itemscope itemtype="http://schema.org/BreadcrumbList">
          <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-           <a class="govuk-link" href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
+           <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
          </li>
          <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-           <a class="govuk-link" href="#main" itemprop="item"><span itemprop="name">GOV.UK Notify</span></a>
+           <a class="govuk-link govuk-link--no-visited-state" href="#main" itemprop="item"><span itemprop="name">GOV.UK Notify</span></a>
          </li>
        </ol>
       </nav>
@@ -38,7 +38,7 @@
               "classes": "product-page-button button-container__button govuk-!-margin-right-3",
               "href": url_for('main.register' )
             }) }}
-            or <a class="govuk-link" href="{{ url_for('.sign_in' )}}">sign in</a> if you’ve used
+            or <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">sign in</a> if you’ve used
             it before
           </div>
         </div>
@@ -135,7 +135,7 @@
       </div>
       <p>
         See the
-        <a class="govuk-link" href="https://www.gov.uk/performance/govuk-notify/government-services">list of services and organisations</a>.
+        <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/performance/govuk-notify/government-services">list of services and organisations</a>.
       </p>
     </div>
   </div>
@@ -163,7 +163,7 @@
           <p class="align-with-big-number-hint">
             There’s no monthly charge, no setup fee and no&nbsp;procurement process.
           </p>
-          <p>Find out more about <a class="govuk-link" href="https://www.notifications.service.gov.uk/pricing">pricing</a>.
+          <p>Find out more about <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/pricing">pricing</a>.
           </p>
         </div>
       </div>
@@ -180,7 +180,7 @@
           and is supported 24 hours a day, 7 days a week.
         </p>
         <p>
-          <a class="govuk-link" href="{{ url_for('main.support') }}">Contact us</a> if you have a question or want
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact us</a> if you have a question or want
           to give feedback.
         </p>
       </div>

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -27,7 +27,7 @@
       <h1 class="heading-large">Sign in</h1>
       <p>
         If you do not have an account, you can
-        <a href="{{ url_for('.register') }}">create one now</a>.
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.register') }}">create one now</a>.
       </p>
     {% endif %}
 

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -16,11 +16,11 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">
-    <a href="http://www.notify.works/_styleguide" style="text-decoration: none;">www.notify.works/_styleguide</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="http://www.notify.works/_styleguide" style="text-decoration: none;">www.notify.works/_styleguide</a>
   </h1>
 
   <p>
-    <a href="https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/styleguide.html">View source</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/styleguide.html">View source</a>
   </p>
 
   <h2 class="heading-large">Banner</h2>
@@ -125,7 +125,7 @@
           {{ boolean_field(True) }}
           {{ boolean_field(False) }}
           {% call field(align='right') %}
-            <a href="#">Change</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="#">Change</a>
           {% endcall %}
         {% endcall %}
       {% endcall %}
@@ -173,7 +173,7 @@
         {% endcall %}
       {% endcall %}
       <p class="table-show-more-link">
-        <a href="#">Add a job now</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="#">Add a job now</a>
       </p>
     </div>
   </div>

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -15,7 +15,7 @@
       <div class="column-two-thirds">
         <p>
           First, check the
-          <a href="https://status.notifications.service.gov.uk">system status page</a>.
+          <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status page</a>.
           You do not need to contact us if
           the problem you’re having is listed on that page.
         </p>
@@ -33,11 +33,11 @@
         </p>
         <h2 class="heading-medium">Any other problems</h2>
         <p class="bottom-gutter-2">
-          <a href="{{ url_for('main.feedback', ticket_type='report-problem', severe='no') }}">Fill in this form</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.feedback', ticket_type='report-problem', severe='no') }}">Fill in this form</a>
           and we’ll get back to you by the next working day.
         </p>
         <p>
-          <a href="{{ url_for('.support') }}">Back to support</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Back to support</a>
         </p>
       </div>
     </div>

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -20,7 +20,7 @@
       {{ page_footer('Continue') }}
     {% endcall %}
 
-    <p>You can also <a href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">contact us on Slack</a>.</p>
+    <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">contact us on Slack</a>.</p>
     
     <h2 class="heading-medium">Office hours</h2>
     <p>Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>

--- a/app/templates/views/support/report-problem.html
+++ b/app/templates/views/support/report-problem.html
@@ -19,7 +19,7 @@
       <div class="column-two-thirds">
         <div class="panel panel-border-wide">
           <p>
-            Check our <a href="https://status.notifications.service.gov.uk">system status</a>
+            Check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a>
             page to see if there are any known issues with GOV.UK Notify.
           </p>
         </div>

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -23,7 +23,7 @@
         {% endif %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
             <div class="column-half">
-              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Send
               </a>
             </div>
@@ -31,14 +31,14 @@
         {% else %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
             <div class="column-half">
-              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Send
               </a>
             </div>
           {% endif %}
           {% if current_user.has_permissions('manage_templates') %}
             <div class="column-half">
-              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="pill-separate-item">
+              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Edit
               </a>
             </div>
@@ -51,14 +51,14 @@
 <div class="column-whole template-container">
   {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
     {% if not current_service.letter_branding_id %}
-      <a href="{{ url_for(".branding_request", service_id=current_service.id, branding_type="letter", from_template=template.id) }}" class="edit-template-link-letter-branding">Add logo</a>
+      <a href="{{ url_for(".branding_request", service_id=current_service.id, branding_type="letter", from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-branding">Add logo</a>
     {% endif %}
-    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-postage">Change</a>
-    <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-body">Edit</a>
+    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-postage">Change</a>
+    <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-body">Edit</a>
     {% if current_service.count_letter_contact_details %}
-      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
+      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit</a>
     {% else %}
-      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="edit-template-link-letter-contact">Edit</a>
+      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit</a>
     {% endif %}
   {% endif %}
   {{ template|string }}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -34,16 +34,16 @@
         {% endif %}
         <h2 class="message-name">
           {% for ancestor in item.ancestors %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="template-list-folder">
+            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {{- format_item_name(ancestor.name) -}}
             </a> <span class="message-name-separator"></span>
           {% endfor %}
           {% if item.is_folder %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="template-list-folder">
+            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% else %}
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" class="template-list-template">
+            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% endif %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -21,7 +21,7 @@
       </p>
       <p>
         If you need to send {{ message_count_label(999, notification_type, suffix='') }}
-        <a href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
       </p>
 
     </div>

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -42,16 +42,16 @@
         <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           <h2 class="message-name">
             {% for ancestor in item.ancestors %}
-                <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="template-list-folder">
+                <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 {{ ancestor.name }}
               </a> <span class="message-name-separator">/</span>
             {% endfor %}
             {% if item.is_folder %}
-              <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="template-list-folder">
+              <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% else %}
-              <a href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
+              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% endif %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -54,7 +54,7 @@
       </div>
       {% if current_user.has_permissions('manage_templates') and current_template_folder_id and user_has_template_folder_permission %}
         <div class="column-one-sixth">
-          <a href="{{ url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="folder-heading-manage-link">Manage</a>
+          <a href="{{ url_for('.manage_template_folder', service_id=current_service.id, template_folder_id=current_template_folder_id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-manage-link">Manage<span class="govuk-visually-hidden"> this folder</span></a>
         </div>
       {% endif %}
     </div>

--- a/app/templates/views/templates/choose_history.html
+++ b/app/templates/views/templates/choose_history.html
@@ -14,6 +14,6 @@
     {% endfor %}
   </div>
   <p>
-    <a href="{{ url_for(".choose_template", service_id=current_service.id) }}">Back to current templates</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".choose_template", service_id=current_service.id) }}">Back to current templates</a>
   </p>
 {% endblock %}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -25,23 +25,23 @@
             <h2 class="message-name">
               {% for ancestor in item.ancestors %}
                 {% if ancestor.is_service %}
-                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="template-list-folder">
+                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 {% else %}
-                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}" class="template-list-folder">
+                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 {% endif %}
                   {{ ancestor.name }}
                 </a> <span class="message-name-separator"></span>
               {% endfor %}
               {% if item.is_service %}
-                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}" class="template-list-folder">
+                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% elif item.is_folder %}
-                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}" class="template-list-folder">
+                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% else %}
-                <a href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% endif %}

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -23,7 +23,7 @@
           hide_legend=True
         ) }}
         {{ page_footer('Continue') }}
-        <a href="{{ url_for('.service_add_letter_contact', service_id=current_service.id, from_template=template_id) }}">Add new sender</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_add_letter_contact', service_id=current_service.id, from_template=template_id) }}">Add new sender</a>
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -60,21 +60,21 @@
       </h2>
 
       &emsp;
-      <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
       &emsp;
       <br/>
     {% endif %}
     {% if current_user.has_permissions('manage_templates') and user_has_template_permission %}
       {% if not template._template.archived %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
-          <a href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
         </span>
         &emsp;
       {% endif %}
       {% if template.template_type != 'letter' %}
         {% if not template._template.redact_personalisation %}
           <span class="page-footer-delete-link page-footer-delete-link-without-button">
-            <a href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
           </span>
         {% else %}
           <p class="hint">Personalisation is hidden after sending</p>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -67,14 +67,14 @@
     {% if current_user.has_permissions('manage_templates') and user_has_template_permission %}
       {% if not template._template.archived %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
+          <a class="govuk-link govuk-link--destructive" href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
         </span>
         &emsp;
       {% endif %}
       {% if template.template_type != 'letter' %}
         {% if not template._template.redact_personalisation %}
           <span class="page-footer-delete-link page-footer-delete-link-without-button">
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
+            <a class="govuk-link govuk-link--destructive" href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
           </span>
         {% else %}
           <p class="hint">Personalisation is hidden after sending</p>

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -20,9 +20,9 @@
     <li>tell us immediately if you have any security breaches</li>
     <li>keep your API keys secure</li>
     <li>get the right levels of consent (to send messages and to use data)</li>
-    <li>not send unsolicited messages, only ones related to a transaction or something the user has subscribed to be updated about (<a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">check the Service Manual</a> if you’re not sure)</li>
+    <li>not send unsolicited messages, only ones related to a transaction or something the user has subscribed to be updated about (<a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">check the Service Manual</a> if you’re not sure)</li>
     <li>
-      send messages that meet the GOV.UK Service Manual standards for <a href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
+      send messages that meet the GOV.UK Service Manual standards for <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
     <li>not send messages containing any personally or commercially sensitive information</li>
     <li>check that the data you add to Notify is accurate and complies with data protection legislation</li>
   </ul>
@@ -32,14 +32,14 @@
   <ul class="list list-bullet">
     <li>send all the messages you pass to us, as long as they meet our guidelines</li>
     <li>
-      show how Notify is performing (through our <a href="https://www.gov.uk/performance/govuk-notify">performance</a> and <a href="https://status.notifications.service.gov.uk/">status</a> pages)
+      show how Notify is performing (through our <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/performance/govuk-notify">performance</a> and <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk/">status</a> pages)
     </li>
-    <li>keep your data <a href="{{ url_for('.security') }}">secure</a></li>
+    <li>keep your data <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.security') }}">secure</a></li>
     <li>give you one month’s notice by email if we change our terms of use or delivery providers</li>
   </ul>
 
   <h2 class="heading-medium">Leaving Notify</h2>
-  <p>You can leave Notify at any time. Just <a href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> and we’ll close your account.</p>
+  <p>You can leave Notify at any time. Just <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> and we’ll close your account.</p>
   <p>When you leave Notify, all your data will be deleted.</p>
 
 {% endblock %}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -18,7 +18,7 @@
 
     {% if current_service and current_service.trial_mode %}
   <p>
-    To remove these restrictions, you can <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.</p>
+    To remove these restrictions, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.</p>
     {% else %}
   <p>
     To remove these restrictions:

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -24,7 +24,7 @@
     To remove these restrictions:
   </p>
   <ol class="list list-number">
-    <li><a href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in') }}">Sign in to Notify</a>.</li>
     <li>Go to the <b class="govuk-!-font-weight-bold">Settings</b> page.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Request to go live</b>.</li>
   </ol>

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -33,7 +33,7 @@
     )}}
   </p>
   <p>You can upload a single letter as a PDF.</p>
-  <p>Your file must meet our <a href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification</a>.</p>
+  <p>Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.upload_a_letter', _anchor='letter-specification') }}">letter specification</a>.</p>
 
   </div>
 </div>

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -24,7 +24,7 @@
             button_text='Upload your file again'
           ) }}
         </div>
-        <a href="#content" class="back-to-top-link">Back to top</a>
+        <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
       </div>
     </div>
   {% elif current_service.trial_mode %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -132,7 +132,7 @@
       <div class="column-two-thirds">
         <p class="align-with-heading-copy">
           What counts as 1 text message?<br />
-          See <a href="{{ url_for('.pricing') }}">pricing</a>.
+          See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a>.
         </p>
       </div>
     </div>

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -19,11 +19,11 @@
 
     <p>Find out more about:</p>
     <ul class="list list-bullet">
-      <li><a href="{{ url_for('main.trial_mode_new') }}">trial mode</a></li>
-      <li><a href="{{ url_for('main.message_status') }}">message status types</a></li>
-      <li><a href="{{ url_for('main.features_email') }}">email replies</a></li>
-      <li><a href="{{ url_for('main.features_sms') }}">text message replies</a></li>
-      <li><a href="{{ url_for('main.features_letters') }}">letters</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.message_status') }}">message status types</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_email') }}">email replies</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_sms') }}">text message replies</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_letters') }}">letters</a></li>
     </ul>
 
     <!-- <h2 id="trial-mode" class="heading-medium">Trial mode</h2>
@@ -38,7 +38,7 @@
     <p>
       To remove these restrictions, you can
       {% if current_service and current_service.trial_mode %}
-        <a href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">send us a request to go live</a>.
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">send us a request to go live</a>.
       {% else %}
         send us a request to go live.
       {% endif %}
@@ -56,7 +56,7 @@
 
     <p>Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered. You can use our API to check the status of your messages too.</p>
 
-    <p><a href="https://www.notifications.service.gov.uk/documentation">Read our documentation</a> for a detailed list of API message statuses.</p>
+    <p><a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/documentation">Read our documentation</a> for a detailed list of API message statuses.</p>
     <img
         src="{{ asset_url('images/message-sending-flow.svg') }}"
         alt="A picture of the sending flow of messages in Notify, showing the three states of Sending, Delivered, And Failed. Also shows the next

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -12,13 +12,13 @@
       {% if current_service.organisation_id %}
         {% if current_user.platform_admin or
           (current_user.belongs_to_organisation(current_service.organisation_id) and current_service.live) %}
-          <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation_id) }}" class="navigation-organisation-link">{{ current_service.organisation.name }}</a>
+          <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation_id) }}" class="govuk-link govuk-link--no-visited-state navigation-organisation-link">{{ current_service.organisation.name }}</a>
         {% endif %}
       {% endif %}
       <div class="navigation-service-name">
         {{ current_service.name }}
       </div>
-      <a href="{{ url_for('main.choose_account') }}" class="navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
     </div>
     <div class="grid-row govuk-!-padding-bottom-12">
       {% if help %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -15,7 +15,7 @@
           <a href="{{ url_for('.organisation_dashboard', org_id=current_service.organisation_id) }}" class="govuk-link govuk-link--no-visited-state navigation-organisation-link">{{ current_service.organisation.name }}</a>
         {% endif %}
       {% endif %}
-      <div class="navigation-service-name">
+      <div class="navigation-service-name govuk-!-font-weight-bold">
         {{ current_service.name }}
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -5,7 +5,7 @@
 {% block beforeContent %}
     {% if current_service and current_service.active and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}
     <div class="navigation-service">
-      <a href="{{ url_for('main.show_accounts_or_dashboard') }}" class="navigation-service-back-to">Back to {{ current_service.name }}</a>
+      <a href="{{ url_for('main.show_accounts_or_dashboard') }}" class="govuk-link govuk-link--no-visited-state navigation-service-back-to">Back to {{ current_service.name }}</a>
     </div>
     {% endif %}
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -571,22 +571,34 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'Your letter is not A4 portrait size',
         'detail': (
             'You need to change the size or orientation of {invalid_pages}. <br>'
-            'Files must meet our <a href="{letter_spec_guidance}" target="_blank">letter specification</a>.'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec_guidance}" target="_blank">'
+            'letter specification'
+            '</a>.'
         ),
         'summary': (
             'Validation failed because {invalid_pages} {invalid_pages_are_or_is} not A4 portrait size.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec}" target="_blank">'
+            'letter specification'
+            '</a>.'
         ),
     },
     'content-outside-printable-area': {
         'title': 'Your content is outside the printable area',
         'detail': (
             'You need to edit {invalid_pages}.<br>'
-            'Files must meet our <a href="{letter_spec_guidance}" target="_blank">letter specification</a>.'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec_guidance}" target="_blank">'
+            'letter specification'
+            '</a>.'
         ),
         'summary': (
             'Validation failed because content is outside the printable area on {invalid_pages}.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec}" target="_blank">'
+            'letter specification'
+            '</a>.'
         ),
     },
     'letter-too-long': {
@@ -618,11 +630,17 @@ LETTER_VALIDATION_MESSAGES = {
         'title': 'The address block is empty',
         'detail': (
             'You need to add a recipient address.<br>'
-            'Files must meet our <a href="{letter_spec_guidance}" target="_blank">letter specification</a>.'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec_guidance}" target="_blank">'
+            'letter specification'
+            '</a>.'
         ),
         'summary': (
             'Validation failed because the address block is empty.<br>'
-            'Files must meet our <a href="{letter_spec}" target="_blank">letter specification</a>.'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec}" target="_blank">'
+            'letter specification'
+            '</a>.'
         ),
     }
 }

--- a/app/utils.py
+++ b/app/utils.py
@@ -572,7 +572,7 @@ LETTER_VALIDATION_MESSAGES = {
         'detail': (
             'You need to change the size or orientation of {invalid_pages}. <br>'
             'Files must meet our '
-            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec_guidance}" target="_blank">'
+            '<a class="govuk-link govuk-link--destructive" href="{letter_spec_guidance}" target="_blank">'
             'letter specification'
             '</a>.'
         ),
@@ -589,7 +589,7 @@ LETTER_VALIDATION_MESSAGES = {
         'detail': (
             'You need to edit {invalid_pages}.<br>'
             'Files must meet our '
-            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec_guidance}" target="_blank">'
+            '<a class="govuk-link govuk-link--destructive" href="{letter_spec_guidance}" target="_blank">'
             'letter specification'
             '</a>.'
         ),
@@ -631,7 +631,7 @@ LETTER_VALIDATION_MESSAGES = {
         'detail': (
             'You need to add a recipient address.<br>'
             'Files must meet our '
-            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec_guidance}" target="_blank">'
+            '<a class="govuk-link govuk-link--destructive" href="{letter_spec_guidance}" target="_blank">'
             'letter specification'
             '</a>.'
         ),

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -43,7 +43,7 @@ def test_organisation_page_shows_all_organisations(
     expected_hints = ('0 live services', '1 live service', '2 live services')
 
     for index, org in enumerate(orgs):
-        assert page.select('a.browse-list-link')[index].text == org['name']
+        assert page.select('.browse-list-item a')[index].text == org['name']
         if not org['active']:
             assert page.select_one('.table-field-status-default,heading-medium').text == '- archived'
         assert normalize_spaces(page.select('.browse-list-hint')[index].text) == (

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -28,7 +28,7 @@ class _MockS3Object():
                 partial(url_for, 'main.request_to_go_live', service_id=SERVICE_ONE_ID),
             ),
             (
-                [],
+                ['govuk-link', 'govuk-link--no-visited-state'],
                 partial(url_for, 'main.service_download_agreement', service_id=SERVICE_ONE_ID),
             ),
         ]
@@ -41,7 +41,7 @@ class _MockS3Object():
                 partial(url_for, 'main.request_to_go_live', service_id=SERVICE_ONE_ID),
             ),
             (
-                [],
+                ['govuk-link', 'govuk-link--no-visited-state'],
                 partial(url_for, 'main.service_download_agreement', service_id=SERVICE_ONE_ID),
             ),
             (
@@ -58,7 +58,7 @@ class _MockS3Object():
                 partial(url_for, 'main.request_to_go_live', service_id=SERVICE_ONE_ID),
             ),
             (
-                [],
+                ['govuk-link', 'govuk-link--no-visited-state'],
                 partial(url_for, 'main.service_download_agreement', service_id=SERVICE_ONE_ID),
             ),
             (
@@ -75,7 +75,7 @@ class _MockS3Object():
                 partial(url_for, 'main.request_to_go_live', service_id=SERVICE_ONE_ID),
             ),
             (
-                [],
+                ['govuk-link', 'govuk-link--no-visited-state'],
                 partial(url_for, 'main.support'),
             ),
         ]

--- a/tests/app/main/views/test_find_services.py
+++ b/tests/app/main/views/test_find_services.py
@@ -25,7 +25,7 @@ def test_find_services_by_name_displays_services_found(
         _expected_status=200
     )
     get_services.assert_called_once_with(service_name="Test Service")
-    result = document.find('a', {'class': 'browse-list-link'})
+    result = document.select_one('.browse-list-item a')
     assert result.text.strip() == 'Test Service'
     assert result.attrs["href"] == "/services/1234"
 
@@ -42,7 +42,7 @@ def test_find_services_by_name_displays_multiple_services(
     )
     document = client_request.post('main.find_services_by_name', _data={"search": "Tadfield"}, _expected_status=200)
 
-    results = document.findAll('a', {'class': 'browse-list-link'})
+    results = document.select('.browse-list-item a')
     assert len(results) == 2
     assert sorted([result.text.strip() for result in results]) == ["Tadfield Air Base", "Tadfield Police"]
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -550,7 +550,7 @@ def test_cant_edit_user_folder_permissions_for_platform_admin_users(
         service_id=SERVICE_ONE_ID,
         user_id=platform_admin_user['id'],
     )
-    assert normalize_spaces(page.select('main p')[0].text) == 'platform@admin.gov.uk Change'
+    assert normalize_spaces(page.select('main p')[0].text) == 'platform@admin.gov.uk Change email address'
     assert normalize_spaces(page.select('main p')[2].text) == (
         'Platform admin users can access all template folders.'
     )

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -263,7 +263,7 @@ def test_non_gov_user_cannot_see_change_email_link(
 ):
     client_request.login(api_nongov_user_active)
     page = client_request.get('main.user_profile')
-    assert '<a href="/user-profile/email">' not in str(page)
+    assert '<a class="govuk-link govuk-link--no-visited-state" href="/user-profile/email">' not in str(page)
     assert page.select_one('h1').text.strip() == 'Your profile'
 
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -263,7 +263,7 @@ def test_non_gov_user_cannot_see_change_email_link(
 ):
     client_request.login(api_nongov_user_active)
     page = client_request.get('main.user_profile')
-    assert '<a class="govuk-link govuk-link--no-visited-state" href="/user-profile/email">' not in str(page)
+    assert not page.find('a', {'href': url_for('main.user_profile_email')})
     assert page.select_one('h1').text.strip() == 'Your profile'
 
 

--- a/tests/javascripts/cookieMessage.test.js
+++ b/tests/javascripts/cookieMessage.test.js
@@ -43,7 +43,7 @@ describe("Cookie message", () => {
       <div id="global-cookie-message" class="notify-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="">
         <div class="notify-cookie-banner__wrapper govuk-width-container govuk-!-padding-4">
           <h2 class="notify-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK Notify</h2>
-          <p class="notify-cookie-banner__message govuk-body">We use <a class="govuk-link" href="/cookies">small files called cookies</a> to make GOV.UK Notify work.</p>
+          <p class="notify-cookie-banner__message govuk-body">We use <a class="govuk-link govuk-link--no-visited-state" href="/cookies">small files called cookies</a> to make GOV.UK Notify work.</p>
           <div class="notify-cookie-banner__buttons notify-cookie-banner__no-js">
             <div class="notify-cookie-banner__button">
               <a href="/cookies" class="govuk-button notify-cookie-banner-button--inline" role="button" data-accept-cookies="true">Set cookie preferences</a>
@@ -64,7 +64,7 @@ describe("Cookie message", () => {
         </div>
         <div class="notify-cookie-banner__confirmation govuk-width-container" tabindex="-1">
           <p class="notify-cookie-banner__confirmation-message govuk-body">
-            You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.
+            You can <a class="govuk-link govuk-link--no-visited-state" href="/cookies">change your cookie settings</a> at any time.
           </p>
           <button class="notify-cookie-banner__hide-button" data-hide-cookie-banner="true">Hide</button>
         </div>

--- a/tests/javascripts/cookieSettings.test.js
+++ b/tests/javascripts/cookieSettings.test.js
@@ -34,7 +34,7 @@ describe("Cookie settings", () => {
     cookiesPageContent = `
       <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
         <h2 class="banner-title">Your cookie settings were saved</h2>
-        <a class="govuk_link cookie-settings__prev-page" href="#" data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
+        <a class="govuk_link govuk_link--no-visited-state cookie-settings__prev-page" href="#" data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
           Go back to the page you were looking at
         </a>
       </div>

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -484,7 +484,7 @@ describe('Live search', () => {
               </div>
             </div>
             <li class="tick-cross-list-edit-link">
-              <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/cancel-invited-user/21d6d54f-51e2-44ba-b48f-545d678c4c64">Cancel invitation</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/cancel-invited-user/21d6d54f-51e2-44ba-b48f-545d678c4c64">Cancel invitation</a>
             </li>
           </ul>
         </div>`);

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -697,7 +697,7 @@ describe("Stick to top/bottom of window when scrolling", () => {
               <p>This is a paragraph with a horizontal line underneath.</p>
               <hr>
               <p>This is a paragraph with a horizontal line above.</p>
-              <p>This paragraph has a link in it: <a href="https://www.gov.uk">https://www.gov.uk</a>.</p>
+              <p>This paragraph has a link in it: <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk">https://www.gov.uk</a>.</p>
             </div>
             <div class="page-footer js-stick-at-bottom-when-scrolling">
               <form method="post" action="">

--- a/tests/javascripts/support/helpers/html.js
+++ b/tests/javascripts/support/helpers/html.js
@@ -45,7 +45,7 @@ function templatesAndFoldersCheckboxes (hierarchy) {
           <label></label>
         </div>
         <h2 class="message-name">
-          <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/templates/all/folders/3d057d9a-51fc-45ea-8b63-0003206350a6" class="template-list-${node.type === 'folder' ? 'folder' : 'template'}">
+          <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/templates/all/folders/3d057d9a-51fc-45ea-8b63-0003206350a6" class="govuk-link govuk-link--no-visited-state template-list-${node.type === 'folder' ? 'folder' : 'template'}">
             <span class="live-search-relevant">${node.label}</span>
           </a>
         </h2>

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -55,7 +55,7 @@ describe('Update content', () => {
               </div>
             </li>
             <li aria-selected="false" role="tab">
-              <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=sending">
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=sending">
                 <div class="big-number-smaller">
                   <div class="big-number-number">0</div>
                 </div>
@@ -63,7 +63,7 @@ describe('Update content', () => {
               </a>
             </li>
             <li aria-selected="false" role="tab">
-              <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=delivered">
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=delivered">
                 <div class="big-number-smaller">
                   <div class="big-number-number">0</div>
                 </div>
@@ -71,7 +71,7 @@ describe('Update content', () => {
               </a>
             </li>
             <li aria-selected="false" role="tab">
-              <a href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=failed">
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=failed">
                 <div class="big-number-smaller">
                   <div class="big-number-number">0</div>
                 </div>


### PR DESCRIPTION
Second attempt at deploying [the Convert all links to GOVUK Frontend PR](https://github.com/alphagov/notifications-admin/pull/3303)

This contains exactly the same changes, just cherry-picked across.

The first attempt failed due to some locators no longer matching because of changes to the text or class names of a few elements.

The locators were fixed in these PRs:
- https://github.com/alphagov/notifications-functional-tests/pull/315
- https://github.com/alphagov/notifications-functional-tests/pull/317