### PR TITLE
Add usage stats to organisation page.

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -125,8 +125,10 @@ def add_organisation_from_nhs_local_service(service_id):
 @main.route("/organisations/<uuid:org_id>", methods=['GET'])
 @user_has_permissions()
 def organisation_dashboard(org_id):
+    services = current_organisation.services_and_usage()
     return render_template(
         'views/organisations/organisation/index.html',
+        services=services
     )
 
 

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -5,6 +5,7 @@ from app.models import JSONModel, ModelList
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
+from app.utils import get_current_financial_year
 
 
 class Organisation(JSONModel):
@@ -197,6 +198,9 @@ class Organisation(JSONModel):
             service_id,
             self.id
         )
+
+    def services_and_usage(self):
+        return organisations_client.get_services_and_usage(self.id, get_current_financial_year())
 
 
 class Organisations(ModelList):

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -87,5 +87,11 @@ class OrganisationsClient(NotifyAdminAPIClient):
             params={"org_id": org_id, "name": name}
         )["result"]
 
+    def get_services_and_usage(self, org_id, year):
+        return self.get(
+            url=f"/organisations/{org_id}/services-with-usage",
+            params={"year": str(year)}
+        )
+
 
 organisations_client = OrganisationsClient()

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -9,11 +9,17 @@
   <h1 class="heading-medium">
     Usage
   </h1>
+
   <ul>
-  {% for service in current_org.live_services %}
+  {% for service in services['services'] %}
     <li class="browse-list-item">
-      <a href="{{ url_for('main.usage', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
+      <a href="{{ url_for('main.usage', service_id=service.service_id) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service.service_name  }}</a>
     </li>
+    <div class="grid-row">
+      <div class="column-one-third">{{ service.emails_sent|format_thousands }} emails sent</div>
+      <div class="column-one-third">{{ "£{:,.2f}".format(service.sms_cost) }} spent on text messages</div>
+      <div class="column-one-third">{{ "£{:,.2f}".format(service.letter_cost) }} spent on letters</div>
+    </div>
   {% endfor %}
   </ul>
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -143,12 +143,15 @@ def test_a_page_should_nave_selected_header_navigation_item(
 def test_a_page_should_nave_selected_org_navigation_item(
     client_request,
     mock_get_organisation,
-    mock_get_organisation_services,
     mock_get_users_for_organisation,
     mock_get_invited_users_for_organisation,
     endpoint,
     selected_nav_item,
+    mocker
 ):
+    mocker.patch(
+        'app.organisations_client.get_services_and_usage', return_value=[]
+    )
     page = client_request.get(endpoint, org_id=ORGANISATION_ID)
     selected_nav_items = page.select('.navigation a.selected')
     assert len(selected_nav_items) == 1


### PR DESCRIPTION
This PR adds usage data on the organisation dashboard pages. 

There is a real risk that this page will not be performant. Because we need to calculate and update ft_billing table for each service in an organisation, some organisations have 115 live services or more. This is the first iteration for the page to test the performance, as such there the formatting to the page is not yet complete. 

The API must be deployed first.
- [ ] https://github.com/alphagov/notifications-api/pull/2723