### PR TITLE
Don’t show the postage when validation has failed

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -78,7 +78,10 @@ def view_notification(service_id, notification_id):
         page_count = get_page_count_for_letter(notification['template'], values=personalisation)
 
     if notification.get('postage'):
-        notification['template']['postage'] = notification['postage']
+        if notification["status"] == "validation-failed":
+            notification['template']['postage'] = None
+        else:
+            notification['template']['postage'] = notification['postage']
     template = get_template(
         notification['template'],
         current_service,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -405,6 +405,7 @@ def test_notification_page_shows_validation_failed_precompiled_letter(
     assert not page.select('p.notification-status')
 
     assert page.select_one('main img')['src'].endswith('.png?page=1')
+    assert not page.select('.letter-postage')
 
 
 @pytest.mark.parametrize('notification_status, expected_message', (


### PR DESCRIPTION
The postage covers up some of the letter, so it can hide the problem. It also implies that the letter has been put in an envelope, which will never happen if it fails validation.

This matches what we do for uploaded letters.