### PR TITLE
Fix navigation around uploads and jobs

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -90,10 +90,7 @@ def view_job(service_id, job_id):
             status=request.args.get('status', ''),
         ),
         partials=get_job_partials(job),
-        just_sent=bool(
-            request.args.get('just_sent') == 'yes'
-            and job.template_type == 'letter'
-        ),
+        just_sent=request.args.get('just_sent') == 'yes',
         just_sent_message=just_sent_message,
     )
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -355,8 +355,6 @@ class MainNavigation(Navigation):
             'returned_letters',
             'service_dashboard',
             'template_usage',
-            'view_job',
-            'view_jobs',
             'view_notification',
             'view_notifications',
         },
@@ -390,6 +388,8 @@ class MainNavigation(Navigation):
             'upload_letter',
             'uploaded_letter_preview',
             'uploads',
+            'view_job',
+            'view_jobs',
         },
         'team-members': {
             'confirm_edit_user_email',

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -2,6 +2,7 @@
 {% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
 
 {% block service_page_title %}
   {{ job.original_file_name }}
@@ -9,11 +10,12 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ job.original_file_name }}
-    </h1>
+    {{ page_header(
+      job.original_file_name,
+      back_link=None if just_sent else url_for('main.uploads', service_id=current_service.id)
+    ) }}
 
-    {% if just_sent %}
+    {% if just_sent and job.template_type == 'letter' %}
       {{ banner(just_sent_message, type='default', with_tick=True) }}
     {% else %}
       {{ ajax_block(partials, updates_url, 'status', finished=job.processing_finished) }}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -199,6 +199,9 @@ def test_should_show_page_for_one_job(
     )
 
     assert page.h1.text.strip() == 'thisisatest.csv'
+    assert page.select_one('.govuk-back-link')['href'] == url_for(
+        'main.uploads', service_id=SERVICE_ONE_ID,
+    )
     assert ' '.join(page.find('tbody').find('tr').text.split()) == (
         '07123456789 template content Delivered 1 January at 11:10am'
     )
@@ -477,6 +480,7 @@ def test_should_show_letter_job_with_banner_after_sending_before_1730(
     assert normalize_spaces(page.select('.banner-default-with-tick')[0].text) == (
         'Your letter has been sent. Printing starts today at 5:30pm.'
     )
+    assert not page.select_one('.govuk-back-link')
 
 
 @freeze_time("2016-01-01 11:09:00")
@@ -538,6 +542,7 @@ def test_should_show_scheduled_job(
         'main.view_job',
         service_id=SERVICE_ONE_ID,
         job_id=fake_uuid,
+        just_sent='yes',
     )
 
     assert normalize_spaces(page.select('main p')[1].text) == (
@@ -550,6 +555,7 @@ def test_should_show_scheduled_job(
         version=1,
     )
     assert page.select_one('main button[type=submit]').text.strip() == 'Cancel sending'
+    assert not page.select_one('.govuk-back-link')
 
 
 def test_should_cancel_job(


### PR DESCRIPTION
The uploads and jobs page should start showing in the _Uploads_ menu on the left hand side.

If you’ve navigated to a job from the uploads page (ie you haven’t got to that page because you’ve just sent the job) then you should see a link back to the uploads page.