### PR TITLE
Use normal paragraphs for empty templates page

### DIFF
--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -22,7 +22,7 @@
       {{ page_title }}
     </h1>
     {% if current_user.has_permissions('manage_templates') %}
-       <p class="bottom-gutter top-gutter">
+       <p class="govuk-body">
          You need a template before you can send
          {% if 'letter' in current_service.permissions %}
            emails, text messages or letters
@@ -31,7 +31,7 @@
          {%- endif %}.
        </p>
     {% else %}
-      <p class="top-gutter">
+      <p class="govuk-body">
         You need to ask your service manager to add templates before you can send
         {% if 'letter' in current_service.permissions %}
           emails, text messages or letters


### PR DESCRIPTION
We don’t need the extra spacing, and it’s inconsistent with the uploads page.