### PR TITLE
Update notifications-utils library

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,5 +24,5 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.1#egg=notifications-utils==36.6.1
+git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,14 +26,14 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.1#egg=notifications-utils==36.6.1
+git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.6
+awscli==1.18.13
 bleach==3.1.1
 boto3==1.10.38
-botocore==1.15.6
+botocore==1.15.13
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
The SMS character count validation has been updated to exclude the service name when validating the message.
The upload CSV was the only place we were doing this.

Still to come: update the API to use the same method from the SMSTemplate class to check the message lenghth.