### PR TITLE
Do not allow to upload SVG logos with embedded raster images in them

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -42,6 +42,7 @@ from app.main.validators import (
     LettersNumbersAndFullStopsOnly,
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
+    NoEmbeddedImagesInSVG,
     OnlySMSCharacters,
     ValidEmail,
     ValidGovEmail,
@@ -1133,7 +1134,8 @@ class SVGFileUpload(StripWhitespaceForm):
         'Upload an SVG logo',
         validators=[
             FileAllowed(['svg'], 'SVG Images only!'),
-            DataRequired(message="You need to upload a file to submit")
+            DataRequired(message="You need to upload a file to submit"),
+            NoEmbeddedImagesInSVG()
         ]
     )
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -80,6 +80,16 @@ class NoCommasInPlaceHolders:
             raise ValidationError(self.message)
 
 
+class NoEmbeddedImagesInSVG:
+
+    def __init__(self, message='This SVG has an embedded raster image in it and will not render well'):
+        self.message = message
+
+    def __call__(self, form, field):
+        if '<image' in field.data.stream.read().decode("utf-8"):
+            raise ValidationError(self.message)
+
+
 class OnlySMSCharacters:
     def __call__(self, form, field):
         non_sms_characters = sorted(list(SanitiseSMS.get_non_compatible_characters(field.data)))


### PR DESCRIPTION
Those are for example png or jpg images. They do not render properly.

Story ticket: https://www.pivotaltracker.com/story/show/171597971