### PR TITLE
ensure highlighting div size always matches the relevant textarea

### DIFF
--- a/app/assets/javascripts/enhancedTextbox.js
+++ b/app/assets/javascripts/enhancedTextbox.js
@@ -27,6 +27,8 @@
         `))
         .on("input", this.update);
 
+      $(window).on("resize", this.resize);
+
       visibleTextbox = this.$textbox.clone().appendTo("body").css({
         position: 'absolute',
         visibility: 'hidden',
@@ -47,7 +49,7 @@
 
     this.resize = () => {
 
-      this.$background.width(this.$textbox.outerWidth());
+      this.$background.width(this.$textbox.width());
 
       this.$textbox.height(
         Math.max(

--- a/tests/javascripts/enhancedTextbox.test.js
+++ b/tests/javascripts/enhancedTextbox.test.js
@@ -107,8 +107,7 @@ describe('Enhanced textbox', () => {
 
         backgroundEl = textarea.nextElementSibling;
 
-        // element has box-sizing: border-box so width includes padding and border
-        expect(backgroundEl.style.width).toEqual('582px');
+        expect(backgroundEl.style.width).toEqual('576px');
         expect(backgroundEl.style.borderWidth).toEqual('1px');
 
       });
@@ -117,8 +116,7 @@ describe('Enhanced textbox', () => {
 
         backgroundEl = input.nextElementSibling;
 
-        // element has box-sizing: border-box so width includes padding and border
-        expect(backgroundEl.style.width).toEqual('582px');
+        expect(backgroundEl.style.width).toEqual('576px');
         expect(backgroundEl.style.borderWidth).toEqual('1px');
 
       });
@@ -147,7 +145,7 @@ describe('Enhanced textbox', () => {
       test("If the textbox is an <textarea>", () => {
 
         backgroundEl = textarea.nextElementSibling;
-        expect(backgroundEl.style.width).toEqual('582px');
+        expect(backgroundEl.style.width).toEqual('576px');
 
       });
 
@@ -256,7 +254,7 @@ describe('Enhanced textbox', () => {
   describe("When the content of the textbox is updated", () => {
 
     // doesn't apply to inputs as they have a fixed height
-    test("If new input changes the textarea's dimensions, the size of the element below should still match", () => {
+    test("If new input changes the textarea's height, the height of the element below should still match", () => {
 
       // set 10 lines of content
       textarea.textContent = `
@@ -286,6 +284,23 @@ describe('Enhanced textbox', () => {
       helpers.triggerEvent(textarea, 'input');
 
       expect(window.getComputedStyle(textarea).height).toEqual("248px");
+
+    });
+
+    test("If a resize changes the textarea's width, the width of the element below should still match", () => {
+      // start module
+      window.GOVUK.modules.start();
+
+      backgroundEl = textarea.nextElementSibling;
+
+      expect(window.getComputedStyle(textarea).width).toEqual("576px");
+      expect(window.getComputedStyle(backgroundEl).width).toEqual("576px");
+
+      textarea.style.width = "500px"
+      helpers.triggerEvent(window, 'resize');
+
+      expect(window.getComputedStyle(textarea).width).toEqual("500px");
+      expect(window.getComputedStyle(backgroundEl).width).toEqual("500px");
 
     });
 


### PR DESCRIPTION
todo: fix tests

| before | after
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5020841/75998289-7d946900-5ef8-11ea-8718-9b6ca33f0406.png) | ![image](https://user-images.githubusercontent.com/5020841/75998323-88e79480-5ef8-11ea-9b9a-db1cbacac9d0.png) |
