### PR TITLE
Reverse sort scheduled jobs

### DIFF
--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -70,7 +70,8 @@ class JobApiClient(NotifyAdminAPIClient):
                 service_id,
                 statuses=[self.SCHEDULED_JOB_STATUS]
             )['data'],
-            key=lambda job: job['scheduled_for']
+            key=lambda job: job['scheduled_for'],
+            reverse=True,
         )
 
     @cache.set('has_jobs-{service_id}')

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -14,8 +14,9 @@ class JobApiClient(NotifyAdminAPIClient):
         'ready to send',
         'sent to dvla'
     }
-
-    NON_SCHEDULED_JOB_STATUSES = JOB_STATUSES - {'scheduled', 'cancelled'}
+    SCHEDULED_JOB_STATUS = 'scheduled'
+    CANCELLED_JOB_STATUS = 'cancelled'
+    NON_SCHEDULED_JOB_STATUSES = JOB_STATUSES - {SCHEDULED_JOB_STATUS, CANCELLED_JOB_STATUS}
 
     def get_job(self, service_id, job_id):
         params = {}
@@ -65,7 +66,10 @@ class JobApiClient(NotifyAdminAPIClient):
 
     def get_scheduled_jobs(self, service_id):
         return sorted(
-            self.get_jobs(service_id, statuses=['scheduled'])['data'],
+            self.get_jobs(
+                service_id,
+                statuses=[self.SCHEDULED_JOB_STATUS]
+            )['data'],
             key=lambda job: job['scheduled_for']
         )
 

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -20,7 +20,7 @@
       </span>
       <span class="banner-dashboard-meta">
         sending starts
-        {{ current_service.scheduled_jobs[0].scheduled_for|format_datetime_relative }}
+        {{ current_service.scheduled_jobs[-1].scheduled_for|format_datetime_relative }}
       </span>
     </a>
   {% endif %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -45,12 +45,12 @@ from tests.conftest import (
             'File Messages to be sent'
         ),
         (
-            'send_me_later.csv '
-            'Sending 1 January 2016 at 11:09am 1'
-        ),
-        (
             'even_later.csv '
             'Sending 1 January 2016 at 11:09pm 1'
+        ),
+        (
+            'send_me_later.csv '
+            'Sending 1 January 2016 at 11:09am 1'
         ),
         (
             'File Status'

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -668,13 +668,13 @@ def test_uploads_page_shows_scheduled_jobs(
             'File Status'
         ),
         (
-            'send_me_later.csv '
-            'Sending 1 January 2016 at 11:09am '
+            'even_later.csv '
+            'Sending 1 January 2016 at 11:09pm '
             '1 text message waiting to send'
         ),
         (
-            'even_later.csv '
-            'Sending 1 January 2016 at 11:09pm '
+            'send_me_later.csv '
+            'Sending 1 January 2016 at 11:09am '
             '1 text message waiting to send'
         ),
     ]


### PR DESCRIPTION
Now that scheduled jobs are mixed in with regular jobs it looks weird for the sort order to be different. This makes the sort order consistently go from furthest in the future to furthest in the past.

The old sort order made sense when scheduled jobs were displayed separately on the dashboard.