### PR TITLE
Say ‘recently’ not ‘yet’ because jobs aren’t forever

### DIFF
--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -19,7 +19,7 @@
       {% endif %}
       {% if not jobs and not show_scheduled_jobs %}
         <p class="govuk-body">
-          You have not uploaded any files yet.
+          You have not uploaded any files recently.
         </p>
         {% if current_service.has_permission('upload_letters') %}
           <p class="govuk-body">

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -39,11 +39,11 @@ def test_no_upload_letters_button_without_permission(
 
 @pytest.mark.parametrize('extra_permissions, expected_empty_message', (
     (['letter'], (
-        'You have not uploaded any files yet. '
+        'You have not uploaded any files recently. '
         'To upload a list of contact details, first choose a template.'
     )),
     (['letter', 'upload_letters'], (
-        'You have not uploaded any files yet. '
+        'You have not uploaded any files recently. '
         'Upload a letter and Notify will print, pack and post it for you. '
         'To upload a list of contact details, first choose a template.'
     )),


### PR DESCRIPTION
We’re going to change the jobs page so that it only shows jobs within the last n days (your data retention)<sup>1</sup>.

This will match how long uploaded letters stick around for.

Therefore it’s not accurate to say ‘yet’, because that implies all-time. Since the data retention for different channels could be different it’s hard and maybe unhelpful to give an exact time period. ‘Recently’ is content we used here before, but then changed.

1. https://www.pivotaltracker.com/story/show/171623239