### PR TITLE
upgrade flask_login to 0.5.0

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -139,6 +139,7 @@ class User(JSONModel, UserMixin):
 
     def login(self):
         login_user(self)
+        session['user_id'] = self.id
 
     def sign_in(self):
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ ago==0.0.93
 humanize==1.0.0
 Flask==1.1.1
 Flask-WTF==0.14.3
-Flask-Login==0.4.1
+Flask-Login==0.5.0
 
 blinker==1.4
 pyexcel==0.5.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ago==0.0.93
 humanize==1.0.0
 Flask==1.1.1
 Flask-WTF==0.14.3
-Flask-Login==0.4.1
+Flask-Login==0.5.0
 
 blinker==1.4
 pyexcel==0.5.15
@@ -30,10 +30,10 @@ git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.13
+awscli==1.18.15
 bleach==3.1.1
 boto3==1.10.38
-botocore==1.15.13
+botocore==1.15.15
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from flask import session as flask_session
 from flask import url_for
 from flask.testing import FlaskClient
 from flask_login import login_user
@@ -27,6 +28,9 @@ class TestClient(FlaskClient):
 
         with patch('app.events_api_client.create_event'):
             login_user(model_user)
+        with self.session_transaction() as test_session:
+            for key, value in flask_session.items():
+                test_session[key] = value
 
     def logout(self, user):
         self.get(url_for("main.sign_out"))

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -172,13 +172,13 @@ def test_api_documentation_page_should_redirect(
 
 def test_should_show_empty_api_keys_page(
     client,
-    api_user_pending,
+    api_user_active,
     mock_login,
     mock_get_no_api_keys,
     mock_get_service,
     mock_has_permissions,
 ):
-    client.login(api_user_pending)
+    client.login(api_user_active)
     service_id = str(uuid.uuid4())
     response = client.get(url_for('main.api_keys', service_id=service_id))
 


### PR DESCRIPTION
flask_login sets a bunch of variables in the session object. We only use one of them, `user_id`. We set that to the user id from the database, and refer to it all over the placye.

However, in flask_login 0.5.0 they prefix this with an underscore to prevent people accidentally overwriting it etc. So when a user logs in we need to make sure that we set user_id manually so we can still use it.

I've manually tested inviting a new user, and the send one off flow to make sure session stuff still behaves reasonably. It seems okay but if anyone can think of anything else to test that'd be appreciated