### PR TITLE
Convert checkboxes to GOVUK Frontend

### DIFF
--- a/app/assets/javascripts/collapsibleCheckboxes.js
+++ b/app/assets/javascripts/collapsibleCheckboxes.js
@@ -5,7 +5,7 @@
 
   function Summary (module) {
     this.module = module;
-    this.$el = module.$formGroup.find('.selection-summary');
+    this.$el = module.$formGroup.find('.selection-summary').first();
     this.fieldLabel = module.fieldLabel;
     this.total = module.total;
     this.addContent();
@@ -25,6 +25,7 @@
     if (this.fieldLabel === 'folder') { this.$text.addClass('selection-summary__text--folders'); }
 
     this.$el.append(this.$text);
+    this.module.$formGroup.find('.govuk-hint').remove();
   };
   Summary.prototype.update = function(selection) {
     let template;
@@ -86,12 +87,13 @@
       .focus();
   };
   CollapsibleCheckboxes.prototype.start = function(component) {
-    this.$formGroup = $(component);
-    this.$fieldset = this.$formGroup.find('fieldset');
+    this.$component = $(component);
+    this.$formGroup = this.$component.find('.govuk-form-group').first();
+    this.$fieldset = this.$formGroup.find('fieldset').first();
     this.$checkboxes = this.$fieldset.find('input[type=checkbox]');
-    this.fieldLabel = this.$formGroup.data('fieldLabel');
+    this.fieldLabel = this.$component.data('fieldLabel');
     this.total = this.$checkboxes.length;
-    this.legendText = this.$fieldset.find('legend').text().trim();
+    this.legendText = this.$fieldset.find('legend').first().text().trim();
     this.expanded = false;
 
     this.addHeadingHideLegend();
@@ -113,7 +115,7 @@
   };
   CollapsibleCheckboxes.prototype.getSelection = function() { return this.$checkboxes.filter(':checked').length; };
   CollapsibleCheckboxes.prototype.addHeadingHideLegend = function() {
-    const headingLevel = this.$formGroup.data('heading-level') || '2';
+    const headingLevel = this.$component.data('heading-level') || '2';
 
     this.$heading = $(`<h${headingLevel} class="heading-small">${this.legendText}</h${headingLevel}>`);
     this.$fieldset.before(this.$heading);

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -1,3 +1,7 @@
+// Taken from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/checkboxes/_checkboxes.scss
+$govuk-touch-target-size: 44px;
+$govuk-checkboxes-size: 40px;
+
 .selection-summary {
 
   .selection-summary__text {
@@ -63,6 +67,30 @@
 
   }
 
+}
+
+.govuk-form-group--nested {
+
+  $border-thickness: $govuk-touch-target-size - $govuk-checkboxes-size;
+  $border-indent: $govuk-touch-target-size / 2;
+
+  position: relative;
+
+  // To equalise the spacing between the line and the top/bottom of
+  // the radio
+  margin-top: govuk-spacing(1) + ($border-thickness / 2);
+  margin-bottom: govuk-spacing(1) * -1;
+  padding-left: govuk-spacing(2) + 2;
+
+  &:before {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: $border-indent * -1;
+    width: $border-thickness;
+    height: 100%;
+    background: $govuk-border-colour;
+  }
 }
 
 .selection-content {

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -78,18 +78,6 @@ $message-type-bottom-spacing: govuk-spacing(4);
 
   &-item {
 
-    &-with-checkbox {
-
-      position: relative;
-      padding-left: govuk-spacing(9);
-
-      .multiple-choice {
-        position: absolute;
-        left: 0;
-      }
-
-    }
-
     &-hidden-by-default {
       display: none;
     }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -24,6 +24,9 @@
   }
 }
 
+$message-text-left-spacing: 22px;
+$message-type-bottom-spacing: govuk-spacing(4);
+
 .message {
 
   &-name {
@@ -63,19 +66,10 @@
   }
 
   &-type {
-    color: $secondary-text-colour;
-    margin: 0 0 govuk-spacing(4) 0;
+    color: $govuk-secondary-text-colour;
+    margin: 0 0 $message-type-bottom-spacing 0;
+    padding-left: 0;
     pointer-events: none;
-  }
-
-}
-
-#template-list {
-
-  margin-top: govuk-spacing(6);
-
-  &.top-gutter-5px {
-    margin-top: 5px;
   }
 
 }
@@ -121,6 +115,22 @@
 
       }
 
+    }
+
+    &-hint,
+    &-label {
+      padding-left: $message-text-left-spacing;
+    }
+
+    &-label {
+      padding-top: 0px;
+      padding-bottom: 0px;
+    }
+
+    // Fix for GOVUK Frontend selector with high precendence
+    // https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/hint/_hint.scss
+    &-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl)+.template-list-item-hint {
+      margin-bottom: $message-type-bottom-spacing;
     }
 
   }

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -26,6 +26,7 @@ $govuk-assets-path: "/static/";
 @import 'components/button/_button';
 @import 'components/details/_details';
 @import 'components/radios/_radios';
+@import 'components/checkboxes/_checkboxes';
 
 @import "utilities/all";
 @import "overrides/all";

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -1,54 +1,7 @@
-{% from "components/select-input.html" import select_nested, select %}
 {% from "components/error-message/macro.njk" import govukErrorMessage -%}
 {% from "components/fieldset/macro.njk" import govukFieldset %}
 {% from "components/hint/macro.njk" import govukHint %}
 {% from "components/label/macro.njk" import govukLabel %}
-
-
-{% macro checkbox(
-  field,
-  hint=False,
-  width='2-3'
-) %}
-  <div class="multiple-choice">
-    {{ checkbox_input(field.id, field.name, field.data) }}
-    <label for="{{ field.id }}">
-      {{ field.label.text }}
-      {% if hint %}
-        <div class="hint">
-          {{ hint }}
-        </div>
-      {% endif %}
-    </label>
-  </div>
-{% endmacro %}
-
-
-{% macro checkboxes_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, collapsible_opts={}, legend_style="text") %}
-  {{ select_nested(field, child_map, hint, disable, option_hints, hide_legend, collapsible_opts, legend_style, input="checkbox") }}
-{% endmacro %}
-
-
-{% macro checkboxes(field, hint=None, disable=[], option_hints={}, hide_legend=False, collapsible_opts={}) %}
-  {{ select(field, hint, disable, option_hints, hide_legend, collapsible_opts, input="checkbox") }}
-{% endmacro %}
-
-
-{% macro checkbox_input(id, name, data=None, value="y") %}
-  <input
-    id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ value }}"
-    {% if data %}
-      checked
-    {% endif %}
-  >
-{% endmacro %}
-
-{% macro unlabelled_checkbox(id, name, data=None, value="y") %}
-  <div class="multiple-choice">
-    {{ checkbox_input(id, name, data, value) }}
-    <label></label>
-  </div>
-{% endmacro %}
 
 
 {#- Copied from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/checkboxes/template.njk

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -192,3 +192,14 @@
   {% endif %}
   </div>
 {% endmacro %}
+
+
+{% macro notifyCollapsibleCheckboxes(params, field_label) %}
+  <div class="selection-wrapper" data-module="collapsible-checkboxes" data-field-label="{{ field_label }}">
+    {#- Add live region as hint by assigning results of dict update to unused variable -#}
+    {% set _ = params.update({
+      "hint": { "html": "<div class=\"selection-summary\" role=\"region\" aria-live=\"polite\"></div>" }
+    }) %}
+    {{ notifyCheckboxes(params) }}
+  </div>
+{% endmacro %}

--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -1,4 +1,9 @@
 {% from "components/select-input.html" import select_nested, select %}
+{% from "components/error-message/macro.njk" import govukErrorMessage -%}
+{% from "components/fieldset/macro.njk" import govukFieldset %}
+{% from "components/hint/macro.njk" import govukHint %}
+{% from "components/label/macro.njk" import govukLabel %}
+
 
 {% macro checkbox(
   field,
@@ -42,5 +47,148 @@
   <div class="multiple-choice">
     {{ checkbox_input(id, name, data, value) }}
     <label></label>
+  </div>
+{% endmacro %}
+
+
+{#- Copied from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/checkboxes/template.njk
+    Changes:
+    - `classes` option added to `item` allow custom classes on the `.govuk-checkboxes__item` element
+    - `classes` option added to `item.hint` allow custom classes on the `.govuk-hint` element (added to GOVUK Frontend in v3.5.0 - remove when we update)
+    - `asList` option added the root `params` object to allow setting of the `.govuk-checkboxes` and `.govuk-checkboxes__item` element types
+    - Nunjucks-to-Jinja language problems fixed (see https://github.com/alphagov/govuk-frontend-jinja/blob/master/govuk_frontend_jinja/templates.py) -#}
+{% macro notifyCheckboxes(params) %}
+
+  {#- If an id 'prefix' is not passed, fall back to using the name attribute
+     instead. We need this for error messages and hints as well -#}
+  {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+
+  {#- a record of other elements that we need to associate with the input using
+     aria-describedby – for example hints or error messages -#}
+  {% set describedBy = params.describedBy if params.describedBy else "" %}
+  {% if params.fieldset.describedBy %}
+     {% set describedBy = params.fieldset.describedBy %}
+  {% endif %}
+
+  {#- set the types of element used for the checkboxes and their group based on
+     whether asList is set -#}
+  {% if params.asList %}
+    {% set groupElement = 'ul' %}
+    {% set groupItemElement = 'li' %}
+  {% else %}
+    {% set groupElement = 'div' %}
+    {% set groupItemElement = 'div' %}
+  {% endif %}
+
+  {% set isConditional = False %}
+
+  {#- fieldset is False by default -#}
+  {% set hasFieldset = True if params.fieldset else False %}
+
+  {#- Capture the HTML so we can optionally nest it in a fieldset -#}
+  {% set innerHtml %}
+  {% if params.hint %}
+    {% set hintId = idPrefix ~ '-hint' %}
+    {% set describedBy = describedBy ~ ' ' ~ hintId if describedBy else hintId %}
+    {{ govukHint({
+      "id": hintId,
+      "classes": params.hint.classes,
+      "attributes": params.hint.attributes,
+      "html": params.hint.html,
+      "text": params.hint.text
+    }) | indent(2) | trim }}
+  {% endif %}
+  {% if params.errorMessage %}
+    {% set errorId = idPrefix ~ '-error' %}
+    {% set describedBy = describedBy ~ ' ' ~ errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      "id": errorId,
+      "classes": params.errorMessage.classes,
+      "attributes": params.errorMessage.attributes,
+      "html": params.errorMessage.html,
+      "text": params.errorMessage.text,
+      "visuallyHiddenText": params.errorMessage.visuallyHiddenText
+    }) | indent(2) | trim }}
+  {% endif %}
+    <{{ groupElement }} class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
+      {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+      {%- if isConditional %} data-module="checkboxes"{% endif -%}>
+      {% for item in params['items'] %}
+      {% set id = item.id if item.id else idPrefix ~ "-" ~ loop.index %}
+      {% set name = item.name if item.name else params.name %}
+      {% set conditionalId = "conditional-" ~ id %}
+      {% set hasHint = True if item.hint.text or item.hint.html %}
+      {% set itemHintId = id ~ "-item-hint" if hasHint else "" %}
+      {% set itemDescribedBy = describedBy if not hasFieldset else "" %}
+      {% set itemDescribedBy = (itemDescribedBy ~ " " ~ itemHintId) | trim %}
+      <{{ groupItemElement }} class="govuk-checkboxes__item {%- if item.classes %} {{ item.classes }}{% endif %}">
+        <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
+        {{-" checked" if item.checked }}
+        {{-" disabled" if item.disabled }}
+        {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+        {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
+        {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+        {{ govukLabel({
+          "html": item.html,
+          "text": item.text,
+          "classes": 'govuk-checkboxes__label' ~ (' ' ~ item.label.classes if item.label.classes),
+          "attributes": item.label.attributes,
+          "for": id
+        }) | indent(6) | trim }}
+        {%- if hasHint %}
+        {{ govukHint({
+          "id": itemHintId,
+          "classes": 'govuk-checkboxes__hint' ~ (' ' ~ item.hint.classes if item.hint.classes),
+          "attributes": item.hint.attributes,
+          "html": item.hint.html,
+          "text": item.hint.text
+        }) | indent(6) | trim }}
+        {%- endif %}
+        {%- if params.asList and item.conditional %}
+        <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+          {{ item.conditional.html | safe }}
+        </div>
+        {%- endif %}
+        {%- if item.children %}
+          {{ notifyCheckboxes({
+            "describedBy": describedBy,
+            "idPrefix": params.idPrefix,
+            "name": params.name,
+            "formGroup": {
+              "classes": "govuk-form-group--nested"
+            },
+            "fieldset": {
+              "legend": {
+                "text": item.text,
+                "classes": "govuk-visually-hidden"
+              }
+            },
+            "asList": True,
+            "items": item.children
+          }) }}
+        {%- endif %}
+      </{{ groupItemElement }}>
+      {%- if not params.asList and item.conditional %}
+      <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+        {{ item.conditional.html | safe }}
+      </div>
+      {% endif %}
+    {% endfor %}
+    </{{ groupElement }}>
+  {% endset -%}
+
+  <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+  {% if params.fieldset %}
+    {% call govukFieldset({
+      "describedBy": describedBy,
+      "classes": params.fieldset.classes,
+      "attributes": params.fieldset.attributes,
+      "legend": params.fieldset.legend
+    }) %}
+    {{ innerHtml | trim | safe }}
+    {% endcall %}
+  {% else %}
+    {{ innerHtml | trim | safe }}
+  {% endif %}
   </div>
 {% endmacro %}

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -14,7 +14,20 @@
 </fieldset>
 
 {% if form.folder_permissions.all_template_folders %}
-  {{ checkboxes_nested(form.folder_permissions, form.folder_permissions.children(), hide_legend=True, collapsible_opts={ 'field': 'folder' }) }}
+  {% set option_to_children_map = form.folder_permissions.children() %}
+  {% set folder_permissions = get_tree_of_govuk_items_from_wtforms_option_fields(option_to_children_map[None], option_to_children_map) %}
+  {{ notifyCollapsibleCheckboxes({
+    "idPrefix": "folder_permissions",
+    "fieldset": {
+      "attributes": { "id": form.folder_permissions.id },
+      "legend": {
+        "text": "Folders this team member can see",
+        "classes": "govuk-fieldset__legend--s"
+      }
+    },
+    "asList": True,
+    "items": folder_permissions
+  }, 'folder') }}
 {% elif user and user.platform_admin %}
   <p class="bottom-gutter">
     Platform admin users can access all template folders.

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -1,21 +1,50 @@
-{% from "components/checkbox.html" import checkbox, checkboxes_nested %}
+{% from "components/checkbox.html" import notifyCollapsibleCheckboxes %}
 {% from "components/radios.html" import radio, radios, conditional_radio_panel %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
-<fieldset class="form-group">
-  <legend class="form-label heading-small">
-    Permissions
-  </legend>
-  <span class="hint">
-    All team members can see sent messages.
-  </span>
-  {% for field in form.permissions_fields %}
-    {{ checkbox(field) }}
+{% set items = [] %}
+{% for option in form.permissions_fields %}
+  {% set _ = items.append({
+    "name": option.name,
+    "text": option.label.text,
+    "value": 'y',
+    "checked": option.data
+  }) %}
+{% endfor %}
+{{ govukCheckboxes({
+  "idPrefix": "permissions",
+  "fieldset": {
+    "legend": {
+      "text": "Permissions",
+      "classes": "govuk-fieldset__legend--s"
+    }
+  },
+  "hint": {
+    "text": "All team members can see sent messages."
+  },
+  "items": items
+}) }}
+
+{% macro build_tree_from_fields(_items, _fields) %}
+  {% for _field in _fields %}
+    {% set _item = {
+      "name": _field.name,
+      "text": _field.label.text,
+      "value": _field.data,
+      "checked": _field.checked
+    } %}
+    {% if _field.data in form.folder_permissions.children() %}
+      {% set _ = _item.update({"children": []}) %}
+      {{ build_tree_from_fields(_item["children"], form.folder_permissions.children()[_field.data]) }}
+    {% endif %}
+    {% set _ = _items.append(_item) %}
   {% endfor %}
-</fieldset>
+{% endmacro %}
+
 
 {% if form.folder_permissions.all_template_folders %}
-  {% set option_to_children_map = form.folder_permissions.children() %}
-  {% set folder_permissions = get_tree_of_govuk_items_from_wtforms_option_fields(option_to_children_map[None], option_to_children_map) %}
+  {% set folder_permissions = [] %}
+  {% set _ =  build_tree_from_fields(folder_permissions, form.folder_permissions.children()[None]) %}
   {{ notifyCollapsibleCheckboxes({
     "idPrefix": "folder_permissions",
     "fieldset": {

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -2,15 +2,6 @@
 {% from "components/radios.html" import radio, radios, conditional_radio_panel %}
 {% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
-{% set items = [] %}
-{% for option in form.permissions_fields %}
-  {% set _ = items.append({
-    "name": option.name,
-    "text": option.label.text,
-    "value": 'y',
-    "checked": option.data
-  }) %}
-{% endfor %}
 {{ govukCheckboxes({
   "idPrefix": "permissions",
   "fieldset": {
@@ -22,29 +13,13 @@
   "hint": {
     "text": "All team members can see sent messages."
   },
-  "items": items
+  "asList": True,
+  "items": wtforms_boolean_fields_to_govuk_items(form.permissions_fields)
 }) }}
 
-{% macro build_tree_from_fields(_items, _fields) %}
-  {% for _field in _fields %}
-    {% set _item = {
-      "name": _field.name,
-      "text": _field.label.text,
-      "value": _field.data,
-      "checked": _field.checked
-    } %}
-    {% if _field.data in form.folder_permissions.children() %}
-      {% set _ = _item.update({"children": []}) %}
-      {{ build_tree_from_fields(_item["children"], form.folder_permissions.children()[_field.data]) }}
-    {% endif %}
-    {% set _ = _items.append(_item) %}
-  {% endfor %}
-{% endmacro %}
-
-
 {% if form.folder_permissions.all_template_folders %}
-  {% set folder_permissions = [] %}
-  {% set _ =  build_tree_from_fields(folder_permissions, form.folder_permissions.children()[None]) %}
+  {% set option_to_children_map = form.folder_permissions.children() %}
+  {% set folder_permissions = get_tree_of_govuk_items_from_wtforms_option_fields(option_to_children_map[None], option_to_children_map) %}
   {{ notifyCollapsibleCheckboxes({
     "idPrefix": "folder_permissions",
     "fieldset": {

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -1,6 +1,5 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block maincolumn_content %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -109,13 +109,7 @@
       {{ textbox(form.start_date, hint="Enter start date in format YYYY-MM-DD") }}
       {{ textbox(form.end_date, hint="Enter end date in format YYYY-MM-DD") }}
       {{ govukCheckboxes({
-        "items": [{
-          "name": form.include_from_test_key.name,
-          "id": form.include_from_test_key.id,
-          "text": form.include_from_test_key.label.text,
-          "value": "y",
-          "checked": form.include_from_test_key.data
-        }]
+        "items": wtforms_boolean_fields_to_govuk_items([form.include_from_test_key])
       }) }}
       {{ govukButton({ "text": "Filter" }) }}
     {% endcall %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -8,6 +8,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/details/macro.njk" import govukDetails %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% macro stats_fields(channel, data) -%}
 
@@ -108,8 +109,15 @@
     {% call form_wrapper(method="get") %}
       {{ textbox(form.start_date, hint="Enter start date in format YYYY-MM-DD") }}
       {{ textbox(form.end_date, hint="Enter end date in format YYYY-MM-DD") }}
-      {{ checkbox(form.include_from_test_key) }}
-      </br>
+      {{ govukCheckboxes({
+        "items": [{
+          "name": form.include_from_test_key.name,
+          "id": form.include_from_test_key.id,
+          "text": form.include_from_test_key.label.text,
+          "value": "y",
+          "checked": form.include_from_test_key.data
+        }]
+      }) }}
       {{ govukButton({ "text": "Filter" }) }}
     {% endcall %}
   {% endset %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -1,6 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/big-number.html" import big_number, big_number_with_status %}
 {% from "components/message-count-label.html" import message_count_label %}

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -4,6 +4,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 <div class="ajax-block-container">
   {% if verification_status == "pending" %}
@@ -55,9 +56,15 @@
         hint='This should be a shared inbox managed by your team, not your own email address'
       ) }}
       {% if not first_email_address and not existing_is_default %}
-        <div class="form-group">
-          {{ checkbox(form.is_default) }}
-        </div>
+        {{ govukCheckboxes({
+          "items": [{
+            "name": form.is_default.name,
+            "id": form.is_default.id,
+            "text": form.is_default.label.text,
+            "value": "y",
+            "checked": form.is_default.data
+          }]
+        }) }}
       {% endif %}
       {{ page_footer('Try again') }}
     {% endcall %}

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -1,6 +1,5 @@
 {% from "components/banner.html" import banner, banner_wrapper %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -56,13 +56,7 @@
       ) }}
       {% if not first_email_address and not existing_is_default %}
         {{ govukCheckboxes({
-          "items": [{
-            "name": form.is_default.name,
-            "id": form.is_default.id,
-            "text": form.is_default.label.text,
-            "value": "y",
-            "checked": form.is_default.data
-          }]
+          "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
         }) }}
       {% endif %}
       {{ page_footer('Try again') }}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -4,6 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block service_page_title %}
   Add reply-to email address
@@ -24,9 +25,15 @@
       safe_error_message=True
     ) }}
     {% if not first_email_address %}
-      <div class="form-group">
-        {{ checkbox(form.is_default) }}
-      </div>
+      {{ govukCheckboxes({
+        "items": [{
+          "name": form.is_default.name,
+          "id": form.is_default.id,
+          "text": form.is_default.label.text,
+          "value": "y",
+          "checked": form.is_default.data
+        }]
+      }) }}
     {% endif %}
     {{ page_footer('Add') }}
   {% endcall %}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -25,13 +25,7 @@
     ) }}
     {% if not first_email_address %}
       {{ govukCheckboxes({
-        "items": [{
-          "name": form.is_default.name,
-          "id": form.is_default.id,
-          "text": form.is_default.label.text,
-          "value": "y",
-          "checked": form.is_default.data
-        }]
+        "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
       }) }}
     {% endif %}
     {{ page_footer('Add') }}

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -30,13 +30,7 @@
       {{ page_footer('Save') }}
     {% else %}
       {{ govukCheckboxes({
-        "items": [{
-          "name": form.is_default.name,
-          "id": form.is_default.id,
-          "text": form.is_default.label.text,
-          "value": "y",
-          "checked": form.is_default.data
-        }]
+        "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
       }) }}
       {{ page_footer(
         'Save',

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -5,6 +5,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block service_page_title %}
  Change reply-to email address
@@ -29,9 +30,15 @@
       </p>
       {{ page_footer('Save') }}
     {% else %}
-      <div class="form-group">
-        {{ checkbox(form.is_default) }}
-      </div>
+      {{ govukCheckboxes({
+        "items": [{
+          "name": form.is_default.name,
+          "id": form.is_default.id,
+          "text": form.is_default.label.text,
+          "value": "y",
+          "checked": form.is_default.data
+        }]
+      }) }}
       {{ page_footer(
         'Save',
         delete_link=url_for('.service_confirm_delete_email_reply_to', service_id=current_service.id, reply_to_email_id=reply_to_email_address_id),

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -4,6 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block service_page_title %}
   Add a new address
@@ -27,9 +28,15 @@
             highlight_placeholders=True
           ) }}
         {% if not first_contact_block %}
-          <div class="form-group">
-            {{ checkbox(form.is_default) }}
-          </div>
+          {{ govukCheckboxes({
+            "items": [{
+              "name": form.is_default.name,
+              "id": form.is_default.id,
+              "text": form.is_default.label.text,
+              "value": "y",
+              "checked": form.is_default.data
+            }]
+          }) }}
         {% endif %}
         {{ page_footer('Add') }}
       {% endcall %}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -28,13 +28,7 @@
           ) }}
         {% if not first_contact_block %}
           {{ govukCheckboxes({
-            "items": [{
-              "name": form.is_default.name,
-              "id": form.is_default.id,
-              "text": form.is_default.label.text,
-              "value": "y",
-              "checked": form.is_default.data
-            }]
+            "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
           }) }}
         {% endif %}
         {{ page_footer('Add') }}

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -32,13 +32,7 @@
       </p>
     {% else %}
       {{ govukCheckboxes({
-        "items": [{
-          "name": form.is_default.name,
-          "id": form.is_default.id,
-          "text": form.is_default.label.text,
-          "value": "y",
-          "checked": form.is_default.data
-        }]
+        "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
       }) }}
     {% endif %}
 

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -4,6 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block service_page_title %}
   Change sender address
@@ -31,9 +32,15 @@
         This is currently your default address for {{ current_service.name }}.
       </p>
     {% else %}
-      <div class="form-group">
-        {{ checkbox(form.is_default) }}
-      </div>
+      {{ govukCheckboxes({
+        "items": [{
+          "name": form.is_default.name,
+          "id": form.is_default.id,
+          "text": form.is_default.label.text,
+          "value": "y",
+          "checked": form.is_default.data
+        }]
+      }) }}
     {% endif %}
 
     {{ page_footer(

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -4,6 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block service_page_title %}
   Add text message sender
@@ -23,9 +24,15 @@
       hint='Up to 11 characters, letters, numbers and spaces only'
     ) }}
     {% if not first_sms_sender %}
-      <div class="form-group">
-        {{ checkbox(form.is_default) }}
-      </div>
+      {{ govukCheckboxes({
+        "items": [{
+          "name": form.is_default.name,
+          "id": form.is_default.id,
+          "text": form.is_default.label.text,
+          "value": "y",
+          "checked": form.is_default.data
+        }]
+      }) }}
     {% endif %}
     {{ page_footer('Save') }}
   {% endcall %}

--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -24,13 +24,7 @@
     ) }}
     {% if not first_sms_sender %}
       {{ govukCheckboxes({
-        "items": [{
-          "name": form.is_default.name,
-          "id": form.is_default.id,
-          "text": form.is_default.label.text,
-          "value": "y",
-          "checked": form.is_default.data
-        }]
+        "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
       }) }}
     {% endif %}
     {{ page_footer('Save') }}

--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -5,6 +5,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block service_page_title %}
   Change text message sender
@@ -35,9 +36,15 @@
       </p>
       {{ page_footer('Save') }}
     {% else %}
-      <div class="form-group">
-        {{ checkbox(form.is_default) }}
-      </div>
+      {{ govukCheckboxes({
+        "items": [{
+          "name": form.is_default.name,
+          "id": form.is_default.id,
+          "text": form.is_default.label.text,
+          "value": "y",
+          "checked": form.is_default.data
+        }]
+      }) }}
       {% if inbound_number %}
         {{ page_footer('Save') }}
       {% else %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -36,13 +36,7 @@
       {{ page_footer('Save') }}
     {% else %}
       {{ govukCheckboxes({
-        "items": [{
-          "name": form.is_default.name,
-          "id": form.is_default.id,
-          "text": form.is_default.label.text,
-          "value": "y",
-          "checked": form.is_default.data
-        }]
+        "items": wtforms_boolean_fields_to_govuk_items([form.is_default])
       }) }}
       {% if inbound_number %}
         {{ page_footer('Save') }}

--- a/app/templates/views/support/report-problem.html
+++ b/app/templates/views/support/report-problem.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/page-header.html" import page_header %}

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -1,4 +1,4 @@
-{% from "components/checkbox.html" import unlabelled_checkbox %}
+{% from "components/checkbox.html" import notifyCheckboxes %}
 {% from "components/message-count-label.html" import folder_contents_count, message_count_label %}
 
 {% macro format_item_name(name) -%}
@@ -21,37 +21,74 @@
     {% endif %}
   </p>
 {% else %}
-  <nav id="template-list" class="{{ 'top-gutter-5px' if (not show_template_nav and not show_search_box) else '' }}">
+  <nav id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!margin-top-6' }}">
+    {% set template_name_content_items = [] %}
+    {% set checkbox_items = [] %}
+
     {% for item in template_list %}
-      <div class="template-list-item {% if current_user.has_permissions('manage_templates') %}template-list-item-with-checkbox{% endif %} {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
-        {% if current_user.has_permissions('manage_templates') %}
-          {{ unlabelled_checkbox(
-            id='templates-or-folder-{}'.format(item.id),
-            name='templates_and_folders',
-            data=templates_and_folders_form.is_selected(item.id),
-            value=item.id,
-          ) }}
+
+      {% set template_name_content %}
+        {% for ancestor in item.ancestors %}
+          <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+            {{- format_item_name(ancestor.name) -}}
+          </a> <span class="message-name-separator"></span>
+        {% endfor %}
+        {% if item.is_folder %}
+          <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+            <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
+          </a>
+        {% else %}
+          <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
+            <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
+          </a>
         {% endif %}
-        <h2 class="message-name">
-          {% for ancestor in item.ancestors %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-              {{- format_item_name(ancestor.name) -}}
-            </a> <span class="message-name-separator"></span>
-          {% endfor %}
-          {% if item.is_folder %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-              <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
-            </a>
-          {% else %}
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
-              <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
-            </a>
-          {% endif %}
-        </h2>
-        <p class="message-type">
-          {{ item.hint }}
-        </p>
-      </div>
+      {% endset %}
+
+      {% if current_user.has_permissions('manage_templates') %}
+        {% set checkbox_item = {
+          "id": 'templates-or-folder-{}'.format(item.id),
+          "name": 'templates_and_folders',
+          "html": template_name_content,
+          "data": templates_and_folders_form.is_selected(item.id),
+          "value": item.id,
+          "label": {
+            "classes": "template-list-item-label govuk-!-font-size-24 govuk-!-font-weight-bold"
+          },
+          "hint": {
+            "text": item.hint,
+            "classes": "template-list-item-hint"
+          },
+          "classes": "template-list-item {}".format(
+            "template-list-item-hidden-by-default" if item.ancestors else "template-list-item-without-ancestors")
+        } %}
+        {% set _ = checkbox_items.append(checkbox_item) %}
+      {% endif %}
+
+      {% set _ = template_name_content_items.append(template_name_content) %}
     {% endfor %}
+
+    {% if current_user.has_permissions('manage_templates') %}
+      {{ notifyCheckboxes({
+        "fieldset": {
+          "legend": {
+            "text": "Templates and folders",
+            "classes": "govuk-visually-hidden"
+          }
+        },
+        "asList": True,
+        "items": checkbox_items
+      }) }}
+    {% else %}
+      {% for item in template_list %}
+        <div class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
+          <h2 class="message-name">
+            {{ template_name_content_items[loop.index0] }}
+          </h2>
+          <p class="message-type govuk-!-margin-bottom-4">
+            {{ item.hint }}
+          </p>
+        </div>
+      {% endfor %}
+    {% endif %}
   </nav>
 {% endif %}

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -4,6 +4,7 @@
 {% from "components/checkbox.html" import checkbox, checkboxes %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/checkbox.html" import notifyCollapsibleCheckboxes %}
 
 {% block service_page_title %}
   {{ page_title_folder_path(template_folder_path) }}
@@ -26,7 +27,24 @@
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name, width='1-1') }}
     {% if current_user.has_permissions("manage_service") and form.users_with_permission.all_service_users %}
-      {{ checkboxes(form.users_with_permission, collapsible_opts={ 'field': 'team member' }) }}
+      {% set items = [] %}
+      {% for user in form.users_with_permission %}
+        {% set _ = items.append({
+          "name": user.name,
+          "text": user.label.text,
+          "value": user.data,
+          "checked": user.data in form.users_with_permission.data
+        }) %}
+      {% endfor %}
+      {{ notifyCollapsibleCheckboxes({
+        "fieldset": {
+          "legend": {
+            "text": "Team members who can see this folder",
+            "classes": "govuk-fieldset__legend--s"
+          }
+        },
+        "items": items
+      }, 'folder') }}
     {% endif %}
 
     {{ page_footer(

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox, checkboxes %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/checkbox.html" import notifyCollapsibleCheckboxes %}

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -26,15 +26,6 @@
   {% call form_wrapper(action=url_for('main.manage_template_folder', service_id=current_service.id, template_folder_id=template_folder_id)) %}
     {{ textbox(form.name, width='1-1') }}
     {% if current_user.has_permissions("manage_service") and form.users_with_permission.all_service_users %}
-      {% set items = [] %}
-      {% for user in form.users_with_permission %}
-        {% set _ = items.append({
-          "name": user.name,
-          "text": user.label.text,
-          "value": user.data,
-          "checked": user.data in form.users_with_permission.data
-        }) %}
-      {% endfor %}
       {{ notifyCollapsibleCheckboxes({
         "fieldset": {
           "legend": {
@@ -42,7 +33,7 @@
             "classes": "govuk-fieldset__legend--s"
           }
         },
-        "items": items
+        "items": wtforms_option_fields_to_govuk_items(form.users_with_permission)
       }, 'folder') }}
     {% endif %}
 

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -1,6 +1,5 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/checkbox.html" import checkbox %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,12 @@ const copy = {
         'footer',
         'back-link',
         'details',
-        'button'
+        'button',
+        'error-message',
+        'fieldset',
+        'hint',
+        'label',
+        'checkboxes'
       ];
       let done = 0;
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -678,7 +678,7 @@ def test_should_show_folder_permission_form_if_service_has_folder_permissions_en
 
     assert 'Invite a team member' in page.find('h1').text.strip()
 
-    folder_checkboxes = page.find('div', class_='checkboxes-nested').find_all('li')
+    folder_checkboxes = page.select('[data-module=collapsible-checkboxes] li')
     assert len(folder_checkboxes) == 3
 
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -395,7 +395,7 @@ def test_should_show_templates_folder_page(
         assert links_in_page[index].text.strip() == expected_link
 
     all_page_items = page.select('.template-list-item')
-    all_page_items_styled_with_checkboxes = page.select('.template-list-item-with-checkbox')
+    all_page_items_styled_with_checkboxes = page.select('.govuk-checkboxes__item')
 
     assert len(all_page_items) == len(all_page_items_styled_with_checkboxes)
 
@@ -527,8 +527,8 @@ def test_get_manage_folder_viewing_permissions_for_users(
     assert normalize_spaces(page.select_one('title').text) == (
         'folder_two – Templates – service one – GOV.UK Notify'
     )
-    form_labels = page.select('legend[class=form-label]')
-    assert normalize_spaces(form_labels[0].text) == "Team members who can see this folder"
+    form_legend = page.select_one('legend.govuk-fieldset__legend')
+    assert normalize_spaces(form_legend.text) == "Team members who can see this folder"
     checkboxes = page.select('input[name=users_with_permission]')
 
     assert len(checkboxes) == 2

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -167,7 +167,7 @@ def test_should_show_page_for_choosing_a_template(
     for index, expected_link in enumerate(expected_nav_links):
         assert links_in_page[index].text.strip() == expected_link
 
-    template_links = page.select('.message-name a')
+    template_links = page.select('.template-list-item a')
 
     assert len(template_links) == len(expected_templates)
 
@@ -236,7 +236,7 @@ def test_should_show_live_search_if_list_of_templates_taller_than_screen(
     assert search['data-module'] == 'live-search'
     assert search['data-targets'] == '#template-list .template-list-item'
 
-    assert len(page.select(search['data-targets'])) == len(page.select('.message-name')) == 14
+    assert len(page.select(search['data-targets'])) == len(page.select('.template-list-item')) == 14
 
 
 def test_should_show_live_search_if_service_has_lots_of_folders(
@@ -257,7 +257,7 @@ def test_should_show_live_search_if_service_has_lots_of_folders(
         service_id=SERVICE_ONE_ID,
     )
 
-    count_of_templates_and_folders = len(page.select('.message-name'))
+    count_of_templates_and_folders = len(page.select('.message-name, .template-list-item-label'))
     count_of_folders = len(page.select('.template-list-folder:first-child'))
     count_of_templates = count_of_templates_and_folders - count_of_folders
 

--- a/tests/javascripts/collapsibleCheckboxes.test.js
+++ b/tests/javascripts/collapsibleCheckboxes.test.js
@@ -14,49 +14,52 @@ afterAll(() => {
 
 describe('Collapsible fieldset', () => {
 
+  const _checkboxes = (start, end) => {
+    result = '';
+
+      for (let num = start; num <= end; num++) {
+        let id = `folder-permissions-${num}`;
+
+        result += `<li class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="${id}" name="folder-permissions" type="checkbox" value="${id}">
+          <label class="govuk-label govuk-checkboxes__label" for="${id}">
+            Folder ${id}
+          </label>
+        </li>`;
+      }
+
+      return result;
+  };
+  let wrapper;
+  let formGroup;
   let fieldset;
+  let checkboxesContainer;
   let checkboxes;
 
   beforeEach(() => {
-    const _checkboxes = (start, end, descendents) => {
-      result = '';
-
-        for (let num = start; num <= end; num++) {
-          let id = `folder-permissions-${num}`;
-
-          if (!descendents) { descendents = ''; }
-
-          result += `<li class="multiple-choice">
-            <input id="${id}" name="folder_permissions" type="checkbox" value="${id}">
-            <label class="block-label" for="{id}">
-              Folder 18
-            </label>
-            ${descendents}
-          </li>`;
-        }
-
-        return result;
-    };
 
     // set up DOM
     document.body.innerHTML =
-      `<div class="form-group" data-module="collapsible-checkboxes" data-field-label="folder">
-        <div class="selection-summary"></div>
-        <fieldset id="folder_permissions">
-          <legend class="form-label heading-small">
-            Folders this team member can see
-          </legend>
-          <div class="checkboxes-nested">
-            <ul>
+      `<div class="selection-wrapper" data-module="collapsible-checkboxes" data-field-label="folder">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" id="folder_permissions">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              Folders this team member can see
+              <span class="govuk-hint">
+                <div class="selection-summary" role="region" aria-live="polite"></div>
+              </span>
+            </legend>
+            <ul class="govuk-checkboxes">
               ${_checkboxes(1, 10)}
             </ul>
-          </div>
-        </fieldset>
+          </fieldset>
+        </div>
       </div>`;
 
-      formGroup = document.querySelector('.form-group');
+      wrapper = document.querySelector('.selection-wrapper');
+      formGroup = wrapper.querySelector('.govuk-form-group');
       fieldset = formGroup.querySelector('fieldset');
-      checkboxesContainer = fieldset.querySelector('.checkboxes-nested');
+      checkboxesContainer = fieldset.querySelector('.govuk-checkboxes');
       checkboxes = checkboxesContainer.querySelectorAll('input[type=checkbox]');
 
   });
@@ -141,6 +144,12 @@ describe('Collapsible fieldset', () => {
 
     });
 
+    test("removes the hint", () => {
+
+      expect(document.querySelector('.govuk-hint')).toBeNull();
+
+    });
+
   });
 
   test('has the right summary text when started with no checkboxes selected', () => {
@@ -187,7 +196,7 @@ describe('Collapsible fieldset', () => {
 
   test("the summary doesn't have a folder icon if fields aren't called 'folder'", () => {
 
-    formGroup.dataset.fieldLabel = 'team member';
+    wrapper.dataset.fieldLabel = 'team member';
 
     // start module
     window.GOVUK.modules.start();
@@ -277,35 +286,74 @@ describe('Collapsible fieldset', () => {
 
   describe("the footer (that wraps the button)", () => {
 
-    beforeEach(() => {
+    describe("is inserted", () => {
 
-      // track calls to sticky JS
-      window.GOVUK.stickAtBottomWhenScrolling.recalculate = jest.fn(() => {});
+      test("after the fieldset", () => {
 
-      // start module
-      window.GOVUK.modules.start();
+        // start module
+        window.GOVUK.modules.start();
 
-      // show the checkboxes
-      helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
+        // show the checkboxes
+        helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
+
+        expect(formGroup.querySelector('.selection-footer').previousElementSibling.nodeName).toBe('FIELDSET');
+
+      });
+
+      test("after the root fieldset if the checkboxes are nested", () => {
+
+        // add a nested list of checkboxes to the first checkbox item
+        const nestedCheckboxes = document.createElement('div');
+        nestedCheckboxes.className = 'govuk-form-group govuk-form-group--nested';
+        nestedCheckboxes.innerHTML = _checkboxes(11, 20);
+        checkboxesContainer.querySelector('.govuk-checkboxes__item').appendChild(nestedCheckboxes);
+
+        // start module
+        window.GOVUK.modules.start();
+
+        // show the checkboxes
+        helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
+
+        expect(formGroup.querySelector('.selection-footer').previousElementSibling.nodeName).toBe('FIELDSET');
+
+      });
 
     });
 
-    test("is made sticky when the fieldset is expanded", () => {
+    describe("its stickiness", () => {
 
-      expect(formGroup.querySelector('.selection-footer').classList.contains('js-stick-at-bottom-when-scrolling')).toBe(true);
-      expect(window.GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toBe(1);
+      beforeEach(() => {
+
+        // track calls to sticky JS
+        window.GOVUK.stickAtBottomWhenScrolling.recalculate = jest.fn(() => {});
+
+        // start module
+        window.GOVUK.modules.start();
+
+        // show the checkboxes
+        helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
+
+      });
+
+      test("is added when the fieldset is expanded", () => {
+
+        expect(formGroup.querySelector('.selection-footer').classList.contains('js-stick-at-bottom-when-scrolling')).toBe(true);
+        expect(window.GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toBe(1);
+
+      });
+
+      test("is removed when the fieldset is collapsed", () => {
+
+        // click the button to collapse the fieldset
+        helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
+
+        expect(formGroup.querySelector('.selection-footer').classList.contains('js-stick-at-bottom-when-scrolling')).toBe(false);
+        expect(window.GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toBe(2);
+
+      });
 
     });
 
-    test("has its stickiness removed when the fieldset is collapsed", () => {
-
-      // click the button to collapse the fieldset
-      helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
-
-      expect(formGroup.querySelector('.selection-footer').classList.contains('js-stick-at-bottom-when-scrolling')).toBe(false);
-      expect(window.GOVUK.stickAtBottomWhenScrolling.recalculate.mock.calls.length).toBe(2);
-
-    });
   });
 
   describe("when the selection changes", () => {
@@ -339,7 +387,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'folders'", () => {
 
-        formGroup.dataset.fieldLabel = 'folder';
+        wrapper.dataset.fieldLabel = 'folder';
 
         checkFirstCheckbox();
 
@@ -359,7 +407,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'team member'", () => {
 
-        formGroup.dataset.fieldLabel = 'team member';
+        wrapper.dataset.fieldLabel = 'team member';
 
         checkFirstCheckbox();
 
@@ -379,7 +427,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'arbitrary thing'", () => {
 
-        formGroup.dataset.fieldLabel = 'arbitrary thing';
+        wrapper.dataset.fieldLabel = 'arbitrary thing';
 
         checkFirstCheckbox();
 
@@ -403,7 +451,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'folder'", () => {
 
-        formGroup.dataset.fieldLabel = 'folder';
+        wrapper.dataset.fieldLabel = 'folder';
 
         checkAllCheckboxes();
 
@@ -423,7 +471,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'team member'", () => {
 
-        formGroup.dataset.fieldLabel = 'team member';
+        wrapper.dataset.fieldLabel = 'team member';
 
         checkAllCheckboxes();
 
@@ -447,7 +495,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'folder'", () => {
 
-        formGroup.dataset.fieldLabel = 'folder';
+        wrapper.dataset.fieldLabel = 'folder';
 
         checkAllCheckboxesButTheLast();
 
@@ -466,7 +514,7 @@ describe('Collapsible fieldset', () => {
 
       test("if fields are called 'team member'", () => {
 
-        formGroup.dataset.fieldLabel = 'team member';
+        wrapper.dataset.fieldLabel = 'team member';
 
         checkAllCheckboxesButTheLast();
 


### PR DESCRIPTION
Change all checkboxes to use the [GOVUK Frontend checkboxes component](https://design-system.service.gov.uk/components/checkboxes/).

https://www.pivotaltracker.com/story/show/170030071

## Types of checkboxes on the admin app

The admin app has 4 types of checkboxes:
1. single checkboxes, mainly used to mark a setting, like reply-to address, as the default
2. multiple checkboxes, like those for permissions on the Team member page
3. a tree of checkboxes, in a hierarchical list, like those to mark which folders a team member has access to on their page
4. a list of checkboxes where their labels are also links, used on the Templates page

## Macros added/removed by this work

### notifyCheckboxes

The GOVUK Frontend checkboxes can be used for 1. and 2. Types 3. and 4. needed a few things it doesn't yet support.

I added a new `notifyCheckboxes` macro (in https://github.com/alphagov/notifications-admin/pull/3358/commits/30f09b19fc1f0e193ff09f1f556aa101649555dd), based on `govukCheckboxes` but with an extended API to add the missing features.

### notifyCollapsibleCheckboxes

Types 2. and 3. can also be made collapsible with the collapsibleCheckboxes [JS module](https://github.com/alphagov/notifications-manuals/wiki/GOVUK-Modules-pattern) so I added a `notifyCollapsibleCheckboxes` macro (in https://github.com/alphagov/notifications-admin/pull/3358/commits/00ce7e114efe4f617364771999062e669b93afa3) to wrap this functionality.

### Existing checkbox macros

https://github.com/alphagov/notifications-admin/pull/3358/commits/98ec4a5fec3a34e75658710f4522bb4c65f6626b removes the existing macros.

## Global Jinja functions

The existing macros make their checkboxes from instances of [WTForms fields](https://wtforms.readthedocs.io/en/stable/fields.html). The GOVUK Frontend checkboxes component expects Dictionary objects with [these options](https://design-system.service.gov.uk/components/checkboxes/#options-checkboxes-example--items) instead.

I added some [helper functions](https://github.com/alphagov/notifications-admin/pull/3358/commits/b67ca3796d24d04d35c42a58e8bf276353d7f31e) for transforming WTForm fields to the GOVUK Frontend format. The reasoning is in the commit but I'd be interested in hearing some opinions on whether this is a sensible way of approaching the problem.

## Templates page

The templates page has its own data format for each checkbox so [I left the conversion to the GOVUK Frontend format in the Jinja for that page](https://github.com/alphagov/notifications-admin/pull/3358/commits/bb3f6355e990ac32daa59e52edf62d0ef4e0243d).