### PR TITLE
International letters permission

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -68,6 +68,7 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
     ('inbound_sms', {'title': 'Receive inbound SMS', 'requires': 'sms', 'endpoint': '.service_set_inbound_number'}),
     ('email_auth', {'title': 'Email authentication'}),
     ('upload_letters', {'title': 'Uploading letters', 'requires': 'letter'}),
+    ('international_letters', {'title': 'Send international letters', 'requires': 'letter'}),
 ])
 
 

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -36,7 +36,7 @@
   <p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>
-  <p>It costs between 30p and 76p (plus VAT) to send a letter. Prices include:</p>
+  <p>It costs between 35p and 81p (plus VAT) to send a letter. Prices include:</p>
   <ul class="list list-bullet">
      <li>paper</li>
      <li>double-sided colour printing</li>

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -17,7 +17,7 @@
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
       <p>
-        It costs between 30p and 76p to send a letter using Notify.
+        It costs between 35p and 81p to send a letter using Notify.
       </p>
       <p>
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for the list

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -42,6 +42,8 @@ def test_service_set_permission_requires_platform_admin(
     ('inbound_sms', 'False', False),
     ('email_auth', 'True', True),
     ('email_auth', 'False', False),
+    ('international_letters', 'True', True),
+    ('international_letters', 'False', False),
 ])
 def test_service_set_permission(
     mocker,
@@ -70,6 +72,8 @@ def test_service_set_permission(
     ({'permissions': ['sms']}, '.service_set_inbound_number', {}, 'Receive inbound SMS Off Change'),
     ({'permissions': ['letter']},
      '.service_set_permission', {'permission': 'upload_letters'}, 'Uploading letters Off Change'),
+    ({'permissions': ['letter']},
+     '.service_set_permission', {'permission': 'international_letters'}, 'Send international letters Off Change'),
 ])
 def test_service_setting_toggles_show(get_service_settings_page, service_one, service_fields, endpoint, kwargs, text):
     link_url = url_for(endpoint, **kwargs, service_id=service_one['id'])

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -3,6 +3,7 @@ import functools
 import pytest
 from flask import url_for
 
+from app.main.views.service_settings import PLATFORM_ADMIN_SERVICE_PERMISSIONS
 from tests.conftest import normalize_spaces
 
 
@@ -91,7 +92,7 @@ def test_service_setting_toggles_show(get_service_settings_page, service_one, se
         marks=pytest.mark.xfail(raises=IndexError)
     )
 ])
-def test_service_setting_button_toggles(
+def test_service_setting_link_toggles(
     get_service_settings_page,
     service_one,
     service_fields,
@@ -99,12 +100,12 @@ def test_service_setting_button_toggles(
     index,
     text,
 ):
-    button_url = url_for(endpoint, service_id=service_one['id'])
+    link_url = url_for(endpoint, service_id=service_one['id'])
     service_one.update(service_fields)
     page = get_service_settings_page()
     link = page.select('.page-footer-delete-link a')[index]
     assert normalize_spaces(link.text) == text
-    assert link['href'] == button_url
+    assert link['href'] == link_url
 
 
 @pytest.mark.parametrize('permissions,permissions_text,visible', [
@@ -126,20 +127,20 @@ def test_service_settings_doesnt_show_option_if_parent_permission_disabled(
     assert any(cell for cell in cells if permissions_text in cell.text) is visible
 
 
-@pytest.mark.parametrize('service_fields, hidden_button_text', [
+@pytest.mark.parametrize('service_fields, link_text', [
     # can't archive or suspend inactive service. Can't resume active service.
     ({'active': False}, 'Archive service'),
     ({'active': False}, 'Suspend service'),
     ({'active': True}, 'Resume service'),
 ])
-def test_service_setting_toggles_dont_show(get_service_settings_page, service_one, service_fields, hidden_button_text):
+def test_service_setting_toggles_dont_show(get_service_settings_page, service_one, service_fields, link_text):
     service_one.update(service_fields)
     page = get_service_settings_page()
-    toggles = page.find_all('a', {'class': 'button'})
-    assert not any(button for button in toggles if hidden_button_text in button.text)
+    toggles = page.find_all('a', {'class': 'govuk-link'})
+    assert not any(link for link in toggles if link_text in link.text)
 
 
-def test_normal_user_doesnt_see_any_toggle_buttons(
+def test_normal_user_doesnt_see_any_platform_admin_settings(
     client_request,
     service_one,
     no_reply_to_email_addresses,
@@ -152,5 +153,7 @@ def test_normal_user_doesnt_see_any_toggle_buttons(
     mock_get_service_data_retention
 ):
     page = client_request.get('main.service_settings', service_id=service_one['id'])
-    toggles = page.find('a', {'class': 'button'})
-    assert toggles is None
+    platform_admin_settings = [permission['title'] for permission in PLATFORM_ADMIN_SERVICE_PERMISSIONS.values()]
+
+    for permission in platform_admin_settings:
+        assert permission not in page

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3616,7 +3616,7 @@ def test_unknown_channel_404s(
 ), [
     (
         'letter',
-        'It costs between 30p and 76p to send a letter using Notify.',
+        'It costs between 35p and 81p to send a letter using Notify.',
         'Send letters',
         ['email', 'sms'],
         'False', 'True',
@@ -3624,7 +3624,7 @@ def test_unknown_channel_404s(
     ),
     (
         'letter',
-        'It costs between 30p and 76p to send a letter using Notify.',
+        'It costs between 35p and 81p to send a letter using Notify.',
         'Send letters',
         ['email', 'sms', 'letter'],
         'True', 'False',

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -112,7 +112,7 @@ def test_get_upload_letter(client_request):
 
     assert page.find('h1').text == 'Upload a letter'
     assert page.find('input', class_='file-upload-field')
-    assert page.select('button[type=submit]')
+    assert page.select('main button[type=submit]')
     assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Choose file'
 
 
@@ -339,7 +339,7 @@ def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid)
         )
 
     assert page.find('div', class_='banner-dangerous').find('h1', {"data-error-type": 'content-outside-printable-area'})
-    assert not page.find('button', {'class': 'button', 'type': 'submit'})
+    assert not page.find('button', {'class': 'page-footer__button', 'type': 'submit'})
 
 
 def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client_request, fake_uuid):
@@ -438,7 +438,7 @@ def test_uploaded_letter_preview(
     assert page.find('h1').text == 'my_letter.pdf'
     assert page.find('div', class_='letter-sent')
     assert not page.find("label", {"class": "file-upload-button"})
-    assert page.find('button', {'class': 'govuk-button', 'type': 'submit'})
+    assert page.find('button', {'class': 'page-footer__button', 'type': 'submit'})
 
 
 def test_uploaded_letter_preview_does_not_show_send_button_if_service_in_trial_mode(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171622699

Add international_letters permission as a permission which can only be turned on / off by Platform Admin.

Also fixes a few tests and updates letter pricing on a few pages.

**Requires this to be merged first**
- [x] https://github.com/alphagov/notifications-api/pull/2743