### PR TITLE
Fix the error message for message-too-long

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -907,7 +907,10 @@ def get_template_error_dict(exception):
         error = 'not-allowed-to-send-to'
     elif 'Exceeded send limits' in exception.message:
         error = 'too-many-messages'
+    # the error from the api is changing for message-too-long, but we need both until the api is deployed.
     elif 'Content for template has a character count greater than the limit of' in exception.message:
+        error = 'message-too-long'
+    elif 'Text messages cannot be longer than' in exception.message:
         error = 'message-too-long'
     else:
         raise exception

--- a/app/templates/partials/check/message-too-long.html
+++ b/app/templates/partials/check/message-too-long.html
@@ -1,13 +1,7 @@
-{% from "components/banner.html" import banner_wrapper %}
-
-<div class="bottom-gutter">
-  {% call banner_wrapper(type='dangerous') %}
-    <h1 class='banner-title'>
-      Message too long
-    </h1>
-    <p>
-      Text messages cannot be longer than {{ SMS_CHAR_COUNT_LIMIT }} characters.
-      Your message is {{ template.content_count }} characters.
-    </p>
-  {% endcall %}
-</div>
+<h1 class='banner-title'>
+  Message too long
+</h1>
+<p>
+  Text messages cannot be longer than {{ SMS_CHAR_COUNT_LIMIT }} characters.
+  Your message is {{ template.content_count }} characters.
+</p>

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3560,7 +3560,7 @@ TRIAL_MODE_MSG = (
     'Cannot send to this recipient when service is in trial mode – '
     'see https://www.notifications.service.gov.uk/trial-mode'
 )
-TOO_LONG_MSG = 'Content for template has a character count greater than the limit of 612'
+TOO_LONG_MSG = 'Text messages cannot be longer than 612 characters. Your message is 654 characters.'
 SERVICE_DAILY_LIMIT_MSG = 'Exceeded send limits (1000) for today'
 
 


### PR DESCRIPTION
There was a bug that displayed the error message with 2 red error boxes around the error message.
Also need another else to handle a new error message from the API, the old one can be removed after the API is deployed. But this can go first. I tested this branch with API master and the API branch with the change. I tested one off SMS and a CSV upload.