### PR TITLE
link_to_file, not link_to_document

### DIFF
--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -6,7 +6,7 @@
 </p>
 <div class="panel panel-border-wide">
   <p>
-    Download your document at: ((link_to_document))
+    Download your document at: ((link_to_file))
   </p>
 </div>
   Next, use the API to upload your document. Follow the instructions to send a document by email in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a>.


### PR DESCRIPTION
this partial appears underneath the edit template page. we changed all our docs to say "link_to_file" everywhere but here