### PR TITLE
Pull in version of utils that validates postcodes for CSVs

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,5 +24,5 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
+git+https://github.com/alphagov/notifications-utils.git@36.9.1#egg=notifications-utils==36.9.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,17 +26,17 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/alphagov/notifications-utils.git@36.6.2#egg=notifications-utils==36.6.2
+git+https://github.com/alphagov/notifications-utils.git@36.9.1#egg=notifications-utils==36.9.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.13
-bleach==3.1.1
+awscli==1.18.23
+bleach==3.1.3
 boto3==1.10.38
-botocore==1.15.13
+botocore==1.15.23
 certifi==2019.11.28
 chardet==3.0.4
-Click==7.0
+click==7.1.1
 colorama==0.4.3
 dnspython==1.16.0
 docopt==0.6.2

--- a/tests/app/main/test_errors_for_csv.py
+++ b/tests/app/main/test_errors_for_csv.py
@@ -45,6 +45,16 @@ MockRecipients = namedtuple(
             ['fix 3 email addresses']
         ),
         (
+            {2}, [], [], [],
+            'letter',
+            ['fix 1 address']
+        ),
+        (
+            {2, 4}, [], [], [],
+            'letter',
+            ['fix 2 addresses']
+        ),
+        (
             {2}, {3}, [], [],
             'sms',
             [

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2321,7 +2321,10 @@ def test_letter_can_only_be_sent_now(
     mock_get_jobs,
     fake_uuid,
 ):
-    mocker.patch('app.main.views.send.s3download', return_value="addressline1, addressline2, postcode\na,b,c")
+    mocker.patch(
+        'app.main.views.send.s3download',
+        return_value="addressline1, addressline2, postcode\na,b,sw1 1aa"
+    )
     mocker.patch('app.main.views.send.set_metadata_on_csv_upload')
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=1)
 
@@ -3021,8 +3024,8 @@ def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
 
     mocker.patch('app.main.views.send.s3download', return_value='\n'.join(
         ['address_line_1,address_line_2,postcode,'] +
-        ['              ,              ,11SW1 1AA'] +
-        ['              ,              ,11SW1 1AA']
+        ['              ,              ,SW1 1AA'] +
+        ['              ,              ,SW1 1AA']
     ))
 
     mocker.patch(


### PR DESCRIPTION
This will mean that a user can not send a CSV for letters with invalid
postcodes and must fix their data.

See https://github.com/alphagov/notifications-utils/pull/704

![image](https://user-images.githubusercontent.com/7228605/76548005-0295fa00-6486-11ea-87c6-386868477b6e.png)
