### PR TITLE
Increase all ajax calls to 5 seconds

### DIFF
--- a/app/templates/components/ajax-block.html
+++ b/app/templates/components/ajax-block.html
@@ -1,4 +1,4 @@
-{% macro ajax_block(partials, url, key, interval=2, finished=False, form='') %}
+{% macro ajax_block(partials, url, key, interval=5, finished=False, form='') %}
   {% if not finished %}
     <div
       data-module="update-content"

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -19,24 +19,24 @@
       {% include 'views/dashboard/write-first-messages.html' %}
     {% endif %}
 
-    {{ ajax_block(partials, updates_url, 'upcoming', interval=5) }}
+    {{ ajax_block(partials, updates_url, 'upcoming') }}
 
     <h2 class="heading-medium">
       In the last 7 days
     </h2>
 
-    {{ ajax_block(partials, updates_url, 'inbox', interval=5) }}
+    {{ ajax_block(partials, updates_url, 'inbox') }}
 
-    {{ ajax_block(partials, updates_url, 'totals', interval=5) }}
+    {{ ajax_block(partials, updates_url, 'totals') }}
     {{ show_more(
       url_for('.monthly', service_id=current_service.id),
       'See messages sent per month'
     ) }}
 
-    {{ ajax_block(partials, updates_url, 'template-statistics', interval=5) }}
+    {{ ajax_block(partials, updates_url, 'template-statistics') }}
 
     {% if current_service.immediate_jobs and not current_service.has_permission('upload_letters') %}
-      {{ ajax_block(partials, updates_url, 'jobs', interval=5) }}
+      {{ ajax_block(partials, updates_url, 'jobs') }}
       {{ show_more(
         url_for('.view_jobs', service_id=current_service.id),
         'See all uploaded files'


### PR DESCRIPTION
The default is 2 seconds and this will mean that we are halving traffic
for these ajax calls which can only be good for trying to limit queries
on the database.

I think the user impact on this will likely not be noticable.

Debatable whether we should up them all even further to 10 seconds but
this is definitely a quick although maybe small win.