### PR TITLE
Remove jobs from the dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -309,10 +309,6 @@ def get_dashboard_partials(service_id):
                 [row['count'] for row in template_statistics] or [0]
             ),
         ),
-        'jobs': render_template(
-            'views/dashboard/_jobs.html',
-            jobs=current_service.immediate_jobs,
-        ),
         'usage': render_template(
             'views/dashboard/_usage.html',
             **calculate_usage(yearly_usage, free_sms_allowance),

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -8,14 +8,10 @@
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
-    {% if current_user.has_permissions('view_activity') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
-    {% else %}
+    {% if not current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
-      {% if current_service.has_jobs or current_service.can_upload_letters %}
-        <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
-      {% endif %}
     {% endif %}
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -35,14 +35,6 @@
 
     {{ ajax_block(partials, updates_url, 'template-statistics') }}
 
-    {% if current_service.immediate_jobs and not current_service.has_permission('upload_letters') %}
-      {{ ajax_block(partials, updates_url, 'jobs') }}
-      {{ show_more(
-        url_for('.view_jobs', service_id=current_service.id),
-        'See all uploaded files'
-      ) }}
-    {% endif %}
-
     {% if current_user.has_permissions('manage_service') %}
       <h2 class='heading-medium'>This year</h2>
       {{ ajax_block(partials, updates_url, 'usage') }}

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -384,6 +384,7 @@ def test_service_navigation_for_org_user(
         (
             'Templates',
             'Sent messages',
+            'Uploads',
             'Team members',
         ),
         403,
@@ -393,6 +394,7 @@ def test_service_navigation_for_org_user(
         (
             'Templates',
             'Sent messages',
+            'Uploads',
             'Team members',
             'Usage',
         ),

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -191,7 +191,7 @@ def test_caseworkers_get_caseworking_navigation(
     )
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one('header + .govuk-width-container nav').text) == (
-        'Templates Sent messages Team members'
+        'Templates Sent messages Uploads Team members'
     )
 
 


### PR DESCRIPTION
We’ve done this already for services with the upload letters permission. And all services can upload letters now.

But we’re still returning it in the JSON response we use to AJAX-ify the page.

Since the jobs response can query stats for up to 50 jobs at a time this puts some load on the API/database. Hopefully this might drop that load a bit.