### PR TITLE
Ship the contact lists feature

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -178,7 +178,7 @@ class Live(Config):
     HTTP_PROTOCOL = 'https'
     STATSD_ENABLED = True
     CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
-    CONTACT_LIST_UPLOAD_BUCKET_NAME = 'live-contact-list'
+    CONTACT_LIST_UPLOAD_BUCKET_NAME = 'production-contact-list'
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-production'
     MOU_BUCKET_NAME = 'notifications.service.gov.uk-mou'
     TRANSIENT_UPLOADED_LETTERS = 'production-transient-uploaded-letters'

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -530,6 +530,7 @@ def send_from_contact_list(service_id, template_id, contact_list_id):
         template_id=template_id,
         upload_id=contact_list.copy_to_uploads(),
         original_file_name=contact_list.original_file_name,
+        contact_list_id=contact_list.id,
     ))
 
 
@@ -742,7 +743,8 @@ def start_job(service_id, upload_id):
     job_api_client.create_job(
         upload_id,
         service_id,
-        scheduled_for=request.form.get('scheduled_for', '')
+        scheduled_for=request.form.get('scheduled_for', ''),
+        contact_list_id=request.form.get('contact_list_id', ''),
     )
 
     session.pop('sender_id', None)

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -429,9 +429,8 @@ def check_contact_list(service_id, upload_id):
 def save_contact_list(service_id, upload_id):
     ContactList.create(current_service.id, upload_id)
     return redirect(url_for(
-        '.contact_list',
+        '.uploads',
         service_id=current_service.id,
-        contact_list_id=upload_id,
     ))
 
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -78,11 +78,14 @@ class JobApiClient(NotifyAdminAPIClient):
     def has_jobs(self, service_id):
         return bool(self.get_jobs(service_id)['data'])
 
-    def create_job(self, job_id, service_id, scheduled_for=None):
+    def create_job(self, job_id, service_id, scheduled_for=None, contact_list_id=None):
         data = {"id": job_id}
 
         if scheduled_for:
             data.update({'scheduled_for': scheduled_for})
+
+        if contact_list_id:
+            data.update({'contact_list_id': contact_list_id})
 
         data = _attach_current_user(data)
         job = self.post(url='/service/{}/job'.format(service_id), data=data)

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -37,6 +37,7 @@
     <form method="post" enctype="multipart/form-data" action="{{url_for('main.start_job', service_id=current_service.id, upload_id=upload_id, original_file_name=original_file_name)}}" class='page-footer'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="help" value="{{ '3' if help else 0 }}" />
+      <input type="hidden" name="contact_list_id" value="{{ request.args.get('contact_list_id', '') }}" />
       {% if choose_time_form and template.template_type != 'letter' %}
         {{ radio_select(
           choose_time_form.scheduled_for,

--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -31,25 +31,22 @@
         </p>
       {% endif %}
       {{ previous_next_navigation(prev_page, next_page) }}
-      {% if (
-        current_service.can_upload_letters and
-        current_user.has_permissions('send_messages')
-      ) or current_user.platform_admin %}
+      {% if current_user.has_permissions('send_messages') %}
         <div class="js-stick-at-bottom-when-scrolling">
-          {{ govukButton({
-            "element": "a",
-            "text": "Upload a letter",
-            "href": url_for('.upload_letter', service_id=current_service.id),
-            "classes": "govuk-button--secondary"
-          }) }}
-          {% if current_user.platform_admin %}
+          {% if current_service.has_permission('letter') %}
             {{ govukButton({
               "element": "a",
-              "text": "Upload an emergency contact list",
-              "href": url_for('.upload_contact_list', service_id=current_service.id),
-              "classes": "govuk-button--secondary govuk-!-margin-left-3"
+              "text": "Upload a letter",
+              "href": url_for('.upload_letter', service_id=current_service.id),
+              "classes": "govuk-button--secondary"
             }) }}
           {% endif %}
+          {{ govukButton({
+            "element": "a",
+            "text": "Upload an emergency contact list",
+            "href": url_for('.upload_contact_list', service_id=current_service.id),
+            "classes": "govuk-button--secondary govuk-!-margin-left-3"
+          }) }}
         </div>
       {% endif %}
     </div>

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -33,7 +33,7 @@
         <div class="govuk-grid-column-full">
           {% if link_to_upload %}
             <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-3" href="{{ url_for('.send_messages', service_id=current_service.id, template_id=template.id) }}">Upload a list of {{ recipient_count_label(999, template.template_type) }}</a>
-            {% if current_user.platform_admin and current_service.contact_lists %}
+            {% if current_service.contact_lists %}
               <a class="govuk-link govuk-link--no-visited-state govuk-!-margin-right-3" href="{{ url_for('.choose_from_contact_list', service_id=current_service.id, template_id=template.id) }}">Use a saved list</a>
             {% endif %}
           {% endif %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1066,6 +1066,7 @@ def test_send_test_step_redirects_if_session_not_setup(
     mock_get_service_statistics,
     mock_get_users_by_service,
     mock_has_no_jobs,
+    mock_get_no_contact_lists,
     fake_uuid,
     user,
     endpoint,
@@ -1180,6 +1181,7 @@ def test_send_one_off_or_test_has_correct_page_titles(
     logged_in_client,
     service_one,
     mock_has_no_jobs,
+    mock_get_no_contact_lists,
     fake_uuid,
     mocker,
     template_type,
@@ -1241,6 +1243,7 @@ def test_send_one_off_or_test_shows_placeholders_in_correct_order(
     client_request,
     fake_uuid,
     mock_has_no_jobs,
+    mock_get_no_contact_lists,
     mock_get_service_template_with_multiple_placeholders,
     endpoint,
     step_index,
@@ -1292,6 +1295,7 @@ def test_send_one_off_has_skip_link(
     fake_uuid,
     mock_get_service_email_template,
     mock_has_no_jobs,
+    mock_get_no_contact_lists,
     mocker,
     template_type,
     expected_link_text,
@@ -1334,6 +1338,7 @@ def test_send_one_off_has_sticky_header_for_email_and_letter(
     client_request,
     fake_uuid,
     mock_has_no_jobs,
+    mock_get_no_contact_lists,
     template_type,
     expected_sticky,
 ):
@@ -1362,6 +1367,7 @@ def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(
     fake_uuid,
     mock_get_service_template,
     mock_has_no_jobs,
+    mock_get_no_contact_lists,
     mocker,
     user,
 ):
@@ -1387,6 +1393,7 @@ def test_send_one_off_offers_link_to_upload(
     fake_uuid,
     mock_get_service_template,
     mock_has_jobs,
+    mock_get_no_contact_lists,
     user,
 ):
     client_request.login(user)
@@ -1411,24 +1418,13 @@ def test_send_one_off_offers_link_to_upload(
     )
 
 
-@pytest.mark.parametrize('user', (
-    pytest.param(
-        create_platform_admin_user(),
-    ),
-    pytest.param(
-        create_active_user_with_permissions(),
-        marks=pytest.mark.xfail(raises=AssertionError),
-    ),
-))
-def test_platform_admin_has_link_to_use_existing_list(
+def test_send_one_off_has_link_to_use_existing_list(
     client_request,
     mock_get_service_template,
     mock_has_jobs,
     mock_get_contact_lists,
     fake_uuid,
-    user,
 ):
-    client_request.login(user)
     page = client_request.get(
         'main.send_one_off',
         service_id=SERVICE_ONE_ID,
@@ -3787,6 +3783,7 @@ def test_reply_to_is_previewed_if_chosen(
     mock_get_service_statistics,
     mock_get_job_doesnt_exist,
     mock_get_jobs,
+    mock_get_no_contact_lists,
     get_default_reply_to_email_address,
     fake_uuid,
     endpoint,
@@ -3838,6 +3835,7 @@ def test_sms_sender_is_previewed(
     mock_get_service_statistics,
     mock_get_job_doesnt_exist,
     mock_get_jobs,
+    mock_get_no_contact_lists,
     get_default_sms_sender,
     fake_uuid,
     endpoint,

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -20,15 +20,18 @@ from tests.conftest import (
 
 
 @pytest.mark.parametrize('extra_permissions', (
-    [],
-    ['letter'],
-    ['upload_letters'],
     pytest.param(
-        ['letter', 'upload_letters'],
+        [],
         marks=pytest.mark.xfail(raises=AssertionError),
     ),
+    pytest.param(
+        ['upload_letters'],
+        marks=pytest.mark.xfail(raises=AssertionError),
+    ),
+    ['letter'],
+    ['letter', 'upload_letters'],
 ))
-def test_no_upload_letters_button_without_permission(
+def test_upload_letters_button_only_with_letters_permission(
     client_request,
     service_one,
     mock_get_uploads,
@@ -38,19 +41,14 @@ def test_no_upload_letters_button_without_permission(
 ):
     service_one['permissions'] += extra_permissions
     page = client_request.get('main.uploads', service_id=SERVICE_ONE_ID)
-    assert not page.find('a', text=re.compile('Upload a letter'))
+    assert page.find('a', text=re.compile('Upload a letter'))
 
 
 @pytest.mark.parametrize('user', (
-    pytest.param(
-        create_platform_admin_user(),
-    ),
-    pytest.param(
-        create_active_user_with_permissions(),
-        marks=pytest.mark.xfail(raises=AssertionError),
-    ),
+    create_platform_admin_user(),
+    create_active_user_with_permissions(),
 ))
-def test_platform_admin_has_upload_contact_list(
+def test_all_users_have_upload_contact_list(
     client_request,
     mock_get_uploads,
     mock_get_jobs,

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -1138,9 +1138,8 @@ def test_save_contact_list(
         upload_id=fake_uuid,
         _expected_status=302,
         _expected_redirect=url_for(
-            'main.contact_list',
+            'main.uploads',
             service_id=SERVICE_ONE_ID,
-            contact_list_id=fake_uuid,
             _external=True,
         )
     )

--- a/tests/app/notify_client/test_job_client.py
+++ b/tests/app/notify_client/test_job_client.py
@@ -50,6 +50,21 @@ def test_client_schedules_job(mocker, fake_uuid):
     assert mock_post.call_args[1]['data']['scheduled_for'] == when
 
 
+def test_client_links_job_to_contact_list(mocker, fake_uuid):
+
+    mocker.patch('app.notify_client.current_user', id='1')
+
+    contact_list_id = uuid.uuid4()
+
+    mock_post = mocker.patch('app.notify_client.job_api_client.JobApiClient.post')
+
+    JobApiClient().create_job(
+        fake_uuid, 1, contact_list_id=contact_list_id
+    )
+
+    assert mock_post.call_args[1]['data']['contact_list_id'] == contact_list_id
+
+
 def test_client_gets_job_by_service_and_job(mocker):
     service_id = 'service_id'
     job_id = 'job_id'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1638,7 +1638,7 @@ def mock_check_verify_code_code_expired(mocker):
 
 @pytest.fixture(scope='function')
 def mock_create_job(mocker, api_user_active):
-    def _create(job_id, service_id, scheduled_for=None):
+    def _create(job_id, service_id, scheduled_for=None, contact_list_id=None):
         return job_json(
             service_id,
             api_user_active,


### PR DESCRIPTION
This reveals the links that we were only showing to platform admin users so that everyone can discover the new feature.

It also:
- makes a slight tweak to the user journey based on how it felt trying it out on preview
- put stuff in the right bucket on production (got the name wrong)
- starts telling the API which contact list a job has been sent from (the API will ignore this for now, but there is a pull request coming) 

