### PR TITLE
Use new API endpoint to get single contact list

### DIFF
--- a/app/models/contact_list.py
+++ b/app/models/contact_list.py
@@ -32,11 +32,10 @@ class ContactList(JSONModel):
 
     @classmethod
     def from_id(cls, contact_list_id, *, service_id):
-        # This is temporary until we have a get single list endpoint
-        for contact_list in ContactLists(service_id):
-            if contact_list.id == contact_list_id:
-                return contact_list
-        abort(404)
+        return cls(contact_list_api_client.get_contact_list(
+            service_id=service_id,
+            contact_list_id=contact_list_id,
+        ))
 
     @staticmethod
     def get_bucket_name():

--- a/app/notify_client/contact_list_api_client.py
+++ b/app/notify_client/contact_list_api_client.py
@@ -25,7 +25,10 @@ class ContactListApiClient(NotifyAdminAPIClient):
         return job
 
     def get_contact_lists(self, service_id):
-        return self.get('/service/{}/contact-list'.format(service_id))
+        return self.get(f'/service/{service_id}/contact-list')
+
+    def get_contact_list(self, *, service_id, contact_list_id):
+        return self.get(f'/service/{service_id}/contact-list/{contact_list_id}')
 
 
 contact_list_api_client = ContactListApiClient()

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3988,7 +3988,7 @@ def test_send_from_contact_list(
     mocker,
     client_request,
     fake_uuid,
-    mock_get_contact_lists,
+    mock_get_contact_list,
 ):
     new_uuid = uuid.uuid4()
     mock_download = mocker.patch('app.models.contact_list.s3download', return_value='contents')

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -1183,7 +1183,7 @@ def test_cant_save_bad_contact_list(
 def test_view_contact_list(
     mocker,
     client_request,
-    mock_get_contact_lists,
+    mock_get_contact_list,
     fake_uuid,
 ):
     mocker.patch('app.models.contact_list.s3download', return_value='\n'.join(
@@ -1225,7 +1225,7 @@ def test_view_contact_list(
 
 def test_view_contact_list_404s_for_non_existing_list(
     client_request,
-    mock_get_contact_lists,
+    mock_get_no_contact_list,
     fake_uuid,
 ):
     client_request.get(
@@ -1240,7 +1240,7 @@ def test_download_contact_list(
     mocker,
     logged_in_client,
     fake_uuid,
-    mock_get_contact_lists,
+    mock_get_contact_list,
 ):
     mocker.patch(
         'app.models.contact_list.s3download',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1870,6 +1870,36 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def mock_get_contact_list(mocker, api_user_active, fake_uuid):
+    def _get(*, service_id, contact_list_id):
+        return {
+            'created_at': '2020-03-13 10:59:56',
+            'created_by': 'Test User',
+            'id': fake_uuid,
+            'original_file_name': 'EmergencyContactList.xls',
+            'row_count': 100,
+            'service_id': service_id,
+            'template_type': 'email',
+        }
+
+    return mocker.patch(
+        'app.models.contact_list.contact_list_api_client.get_contact_list',
+        side_effect=_get,
+    )
+
+
+@pytest.fixture(scope='function')
+def mock_get_no_contact_list(mocker, api_user_active, fake_uuid):
+    def _get(*, service_id, contact_list_id):
+        raise HTTPError(response=Mock(status_code=404))
+
+    return mocker.patch(
+        'app.models.contact_list.contact_list_api_client.get_contact_list',
+        side_effect=_get,
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_no_contact_lists(mocker):
     return mocker.patch(
         'app.models.contact_list.ContactLists.client_method',


### PR DESCRIPTION
When we first built the contact list feature this endpoint didn’t exist. Now it does we can remove the slightly cludgy looping-through-all-the-lists code.

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/2750