### PR TITLE
Remove POST param from agreement test

### DIFF
--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -272,12 +272,11 @@ def test_accept_agreement_page_populates(
     (
         {
             'version': '',
-            'who': '',
             'on_behalf_of_name': '',
             'on_behalf_of_email': '',
         },
         [
-            'This field is required.',
+            'Not a valid choice',
             'Must be a number',
         ],
     ),


### PR DESCRIPTION
This test sent an empty string to represent the 'who' field not having a value. The 'who' field is represented by a group of radios in the page.

In browsers, radios that aren't selected result in that field not being included in the HTTP parameters. This change makes the test match that.

The expected validation message is also changed to the one you see in a browser. Turns out [the WTForms DataRequired validator](https://wtforms.readthedocs.io/en/stable/validators.html#wtforms.validators.DataRequired) produces a different error message for an empty string vs the value being missing ("This field is required." vs "Not a valid choice").