### PR TITLE
Slow down the update interval on the dashboard

### DIFF
--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -19,25 +19,25 @@
       {% include 'views/dashboard/write-first-messages.html' %}
     {% endif %}
 
-    {{ ajax_block(partials, updates_url, 'upcoming') }}
+    {{ ajax_block(partials, updates_url, 'upcoming', interval=20) }}
 
     <h2 class="heading-medium">
       In the last 7 days
     </h2>
 
-    {{ ajax_block(partials, updates_url, 'inbox') }}
+    {{ ajax_block(partials, updates_url, 'inbox', interval=20) }}
 
-    {{ ajax_block(partials, updates_url, 'totals') }}
+    {{ ajax_block(partials, updates_url, 'totals', interval=20) }}
     {{ show_more(
       url_for('.monthly', service_id=current_service.id),
       'See messages sent per month'
     ) }}
 
-    {{ ajax_block(partials, updates_url, 'template-statistics') }}
+    {{ ajax_block(partials, updates_url, 'template-statistics', interval=20) }}
 
     {% if current_user.has_permissions('manage_service') %}
       <h2 class='heading-medium'>This year</h2>
-      {{ ajax_block(partials, updates_url, 'usage') }}
+      {{ ajax_block(partials, updates_url, 'usage', interval=20) }}
       {{ show_more(
         url_for(".usage", service_id=current_service['id']),
         'See usage'

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -96,10 +96,10 @@
       </div>
     {% elif template.template_type == 'email' %}
       <div class="js-stick-at-bottom-when-scrolling">
-        {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
+        {{ ajax_block(partials, updates_url, 'status', interval=2, finished=finished) }}
       </div>
     {% elif template.template_type == 'sms' %}
-      {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
+      {{ ajax_block(partials, updates_url, 'status', interval=2, finished=finished) }}
     {% endif %}
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}


### PR DESCRIPTION
Dashboard is the most intensive page we AJAX, and also the highest traffic one. We’ve already slowed it from 2 to 5 seconds, this slows it further to 20 seconds to reduce the load.

This leaves other pages (for example looking at a single job) at the platform-level default of 5 seconds, because we think they cause less load and the real-timelyness isn’t critical to people’s business processes.

For looking at a single notification we know from research that someone sending these one-at-a-time often waits to see if they’re delivered, so let’s bring this back down to the previous value of 2 seconds.