### PR TITLE
Require email address for all support tickets

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -894,7 +894,7 @@ class SupportType(StripWhitespaceForm):
 
 class Feedback(StripWhitespaceForm):
     name = StringField('Name')
-    email_address = email_address(label='Email address', gov_user=False, required=False)
+    email_address = email_address(label='Email address', gov_user=False, required=True)
     feedback = TextAreaField('Your message', validators=[DataRequired(message="Cannot be empty")])
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -893,7 +893,7 @@ class SupportType(StripWhitespaceForm):
 
 
 class Feedback(StripWhitespaceForm):
-    name = StringField('Name')
+    name = StringField('Name (optional)')
     email_address = email_address(label='Email address', gov_user=False, required=True)
     feedback = TextAreaField('Your message', validators=[DataRequired(message="Cannot be empty")])
 

--- a/app/templates/views/support/ask-question-give-feedback.html
+++ b/app/templates/views/support/ask-question-give-feedback.html
@@ -19,8 +19,6 @@
         {% call form_wrapper() %}
             {{ textbox(form.feedback, width='1-1', hint='', rows=10, autosize=True) }}
             {% if not current_user.is_authenticated %}
-              <h3 class="heading-medium">Do you want a reply?</h3>
-              <p>Leave your details below if you’d like a response.</p>
               {{ textbox(form.name, width='1-1') }}
               {{ textbox(form.email_address, width='1-1') }}
             {% else %}

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -204,34 +204,15 @@ def test_passes_user_details_through_flow(
     {'feedback': 'blah', 'name': 'Fred'},
     {'feedback': 'blah'},
 ])
-@pytest.mark.parametrize('ticket_type, expected_response, expected_redirect, expected_error', [
-    (
-        PROBLEM_TICKET_TYPE,
-        200,
-        lambda: None,
-        element.Tag,
-    ),
-    (
-        QUESTION_TICKET_TYPE,
-        302,
-        partial(
-            url_for,
-            '.thanks',
-            email_address_provided=False,
-            out_of_hours_emergency=False,
-            _external=True,
-        ),
-        type(None),
-    ),
+@pytest.mark.parametrize('ticket_type', [
+    PROBLEM_TICKET_TYPE,
+    QUESTION_TICKET_TYPE,
 ])
-def test_email_address_required_for_problems(
+def test_email_address_required_for_problems_and_questions(
     client_request,
     mocker,
     data,
     ticket_type,
-    expected_response,
-    expected_redirect,
-    expected_error
 ):
     mocker.patch('app.main.views.feedback.zendesk_client')
     client_request.logout()
@@ -239,10 +220,9 @@ def test_email_address_required_for_problems(
         'main.feedback',
         ticket_type=ticket_type,
         _data=data,
-        _expected_status=expected_response,
-        _expected_redirect=expected_redirect(),
+        _expected_status=200
     )
-    assert isinstance(page.find('span', {'class': 'error-message'}), expected_error)
+    assert isinstance(page.find('span', {'class': 'error-message'}), element.Tag)
 
 
 @freeze_time('2016-12-12 12:00:00.000000')


### PR DESCRIPTION
We are seeing little benefit of allowing users to not put in their email
address. This will mean that you must provide it for feedback, not just
problems with the site.

There could maybe be some more refactoring of the support templates as
this is now very similar to the report a problem page but this is a
quick fix so haven't gone too in depth.

![image](https://user-images.githubusercontent.com/7228605/77311926-f5d09c00-6cf8-11ea-9540-64ad87071204.png)
