### PR TITLE
bump deployment timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	cf v3-cancel-zdt-push ${CF_APP} || true
 
 	cf v3-apply-manifest ${CF_APP} -f <(make -s generate-manifest)
-	cf v3-zdt-push ${CF_APP} --wait-for-deploy-complete  # fails after 5 mins if deploy doesn't work
+	CF_STARTUP_TIMEOUT=10 cf v3-zdt-push ${CF_APP} --wait-for-deploy-complete  # fails after 5 mins if deploy doesn't work
 
 .PHONY: cf-deploy-prototype
 cf-deploy-prototype: cf-target ## Deploys the first prototype to Cloud Foundry


### PR DESCRIPTION
5 minutes isn't long enough to deploy ten instances of the admin app - it turns out it takes marginally longer than 5 minutes to roll each instance one after the next. this can lead to confusion as the build fails, functional tests don't run, but the code may have deployed fine and be running on production.

we already do this elsewhere, eg https://github.com/alphagov/notifications-template-preview/pull/401