### PR TITLE
Add ‘Who it’s for’ page

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -43,11 +43,10 @@ class ValidGovEmail:
             return
 
         from flask import url_for
-        message = (
-            'Enter a government email address.'
-            ' If you think you should have access'
-            ' <a class="govuk-link govuk-link--no-visited-state" href="{}">contact us</a>'
-        ).format(url_for('main.support'))
+        message = '''
+            Enter a public sector email address or
+            <a class="govuk-link govuk-link--no-visited-state" href="{}">find out who can use Notify</a>
+        '''.format(url_for('main.who_its_for'))
         if not is_gov_user(field.data.lower()):
             raise ValidationError(message)
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -320,6 +320,14 @@ def get_started():
     )
 
 
+@main.route('/using-notify/who-its-for')
+def who_its_for():
+    return render_template(
+        'views/guidance/who-its-for.html',
+        navigation_links=using_notify_nav(),
+    )
+
+
 @main.route('/trial-mode')
 @main.route('/features/trial-mode')
 def trial_mode():

--- a/app/main/views/sub_navigation_dictionaries.py
+++ b/app/main/views/sub_navigation_dictionaries.py
@@ -53,6 +53,10 @@ def using_notify_nav():
             "link": "main.get_started",
         },
         {
+            "name": "Who it’s for",
+            "link": "main.who_its_for",
+        },
+        {
             "name": "Trial mode",
             "link": "main.trial_mode_new",
         },

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -346,6 +346,7 @@ class HeaderNavigation(Navigation):
         'no_cookie.view_template_version_preview',
         'view_template_versions',
         'whitelist',
+        'who_its_for',
     }
 
     # header HTML now comes from GOVUK Frontend so requires a boolean, not an attribute
@@ -659,6 +660,7 @@ class MainNavigation(Navigation):
         'view_provider',
         'view_providers',
         'no_cookie.view_template_version_preview',
+        'who_its_for',
     }
 
 
@@ -963,6 +965,7 @@ class CaseworkNavigation(Navigation):
         'no_cookie.view_template_version_preview',
         'view_template_versions',
         'whitelist',
+        'who_its_for',
     }
 
 
@@ -1268,4 +1271,5 @@ class OrgNavigation(Navigation):
         'no_cookie.view_template_version_preview',
         'view_template_versions',
         'whitelist',
+        'who_its_for',
     }

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -218,6 +218,10 @@
             "text": "Get started"
           },
           {
+            "href": url_for("main.who_its_for"),
+            "text": "Who it’s for",
+          },
+          {
             "href": url_for("main.trial_mode_new"),
             "text": "Trial mode"
           },

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -15,21 +15,9 @@
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Check if GOV.UK Notify is right for you</h2>
     <p>Read about our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features') }}">features</a>, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a> and <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.roadmap') }}">roadmap</a>.</p>
-    {{ govukDetails({
-      "summaryText": "Organisations that can use Notify",
-      "html": '''
-        <div id="eligible-organisations">
-          <p>Notify is available to:</p>
-          <ul class="list list-bullet">
-            <li>central government departments</li>
-            <li>local authorities</li>
-            <li>state-funded schools</li>
-            <li>the NHS</li>
-            <li>companies running a service on behalf of a public sector organisation</li>
-          </ul>
-          <p>Notify is not currently available to charities.</p>
-        </div>'''
-    }) }}
+    <p class="govuk-body">
+      Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_its_for') }}">whether your organisation can use Notify</a>.
+    </p>
   </li>
 
   <li class="get-started-list__item">

--- a/app/templates/views/guidance/who-its-for.html
+++ b/app/templates/views/guidance/who-its-for.html
@@ -16,9 +16,10 @@
   </p>
   <ul class="list list-bullet">
     <li>central government departments</li>
+    <li>emergency services</li>
     <li>local authorities</li>
-    <li>the NHS</li>
-    <li>police forces and fire services</li>
+    <li>the armed forces</li>
+    <li>the NHS and GP practices</li>
     <li>state-funded schools</li>
   </ul>
   <p class="govuk-body">

--- a/app/templates/views/guidance/who-its-for.html
+++ b/app/templates/views/guidance/who-its-for.html
@@ -1,0 +1,48 @@
+{% extends "content_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block per_page_title %}
+  Who it’s for
+{% endblock %}
+
+{% block content_column_content %}
+
+  {{ page_header(
+    'Who it’s for'
+  ) }}
+
+  <p class="govuk-body">
+    GOV.UK Notify is available to:
+  </p>
+  <ul class="list list-bullet">
+    <li>central government departments</li>
+    <li>local authorities</li>
+    <li>the NHS</li>
+    <li>police forces and fire services</li>
+    <li>state-funded schools</li>
+  </ul>
+  <p class="govuk-body">
+    Notify is not currently available to charities.
+  </p>
+  <p class="govuk-body">
+    If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
+  </p>
+
+  <h2 class="govuk-heading-m">Suppliers</h2>
+  <p class="govuk-body">
+    If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
+  </p>
+  <p class="govuk-body">
+    Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
+  </p>
+
+  <h2 class="govuk-heading-m">Members of the public</h2>
+  <p class="govuk-body">
+    The GOV.UK Notify service is only for people who work in the government
+    or other public sector organisations.
+  </p>
+  <p class="govuk-body">
+    <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk">Find government services and information on GOV.UK</a>.
+  </p>
+
+{% endblock %}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -14,7 +14,7 @@ Create an account
     <h1 class="heading-large">Create an account</h1>
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.name, width='3-4') }}
-      {{ textbox(form.email_address, hint="Must be from a government organisation", width='3-4', safe_error_message=True, autocomplete='email') }}
+      {{ textbox(form.email_address, hint="Must be from a public sector organisation", width='3-4', safe_error_message=True, autocomplete='email') }}
       <div class="extra-tracking">
         {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
       </div>

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -36,7 +36,7 @@ def test_valid_email_not_in_valid_domains(
 ):
     form = RegisterUserForm(email_address="test@test.com", mobile_number='441231231231')
     assert not form.validate()
-    assert "Enter a government email address" in form.errors['email_address'][0]
+    assert "Enter a public sector email address" in form.errors['email_address'][0]
 
 
 def test_valid_email_in_valid_domains(

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -83,7 +83,7 @@ def test_robots(client):
     'features_letters', 'how_to_pay', 'get_started',
     'guidance_index', 'branding_and_customisation',
     'create_and_send_messages', 'edit_and_format_messages',
-    'send_files_by_email', 'upload_a_letter',
+    'send_files_by_email', 'upload_a_letter', 'who_its_for',
 ])
 def test_static_pages(
     client_request,

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1192,7 +1192,7 @@ def test_edit_user_email_cannot_change_a_gov_email_address_to_a_non_gov_email_ad
         },
         _expected_status=200,
     )
-    assert 'Enter a government email address.' in page.find('span', class_='error-message').text
+    assert 'Enter a public sector email address' in page.select_one('.error-message').text
     with client_request.session_transaction() as session:
         assert 'team_member_email_change-'.format(active_user_with_permissions['id']) not in session
 


### PR DESCRIPTION
We have a policy about how suppliers are allowed to use Notify. But we don’t explain it anywhere. Which drives contact to our support form.

This pull request adds a new page that explains the policy.

It then links to the page from the error message that someone gets if they try to sign up with an email domain we don’t recognise.

# Before

![image](https://user-images.githubusercontent.com/355079/77651009-181a2200-6f64-11ea-9e16-47d976b67c8c.png)

# After

![image](https://user-images.githubusercontent.com/355079/77648306-d5564b00-6f5f-11ea-98a6-a91ff0a1b519.png)

***

![image](https://user-images.githubusercontent.com/355079/77654382-ece60180-6f68-11ea-99cc-8bbdff81ddc4.png)
