### PR TITLE
Remove line about contact lists from uploads

### DIFF
--- a/app/templates/views/jobs/jobs.html
+++ b/app/templates/views/jobs/jobs.html
@@ -15,14 +15,9 @@
         <p class="govuk-body">
           You have not uploaded any files recently.
         </p>
-        {% if current_user.has_permissions('send_messages') %}
-          {% if current_service.has_permission('letter') %}
-            <p class="govuk-body">
-              Upload a letter and Notify will print, pack and post it for you.
-            </p>
-          {% endif %}
+        {% if current_user.has_permissions('send_messages') and current_service.has_permission('letter')%}
           <p class="govuk-body">
-            To upload a list of contact details, first <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.choose_template', service_id=current_service.id) }}">choose a template</a>.
+            Upload a letter and Notify will print, pack and post it for you.
           </p>
         {% endif %}
       {% endif %}

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -66,13 +66,11 @@ def test_all_users_have_upload_contact_list(
 
 @pytest.mark.parametrize('extra_permissions, expected_empty_message', (
     ([], (
-        'You have not uploaded any files recently. '
-        'To upload a list of contact details, first choose a template.'
+        'You have not uploaded any files recently.'
     )),
     (['letter'], (
         'You have not uploaded any files recently. '
-        'Upload a letter and Notify will print, pack and post it for you. '
-        'To upload a list of contact details, first choose a template.'
+        'Upload a letter and Notify will print, pack and post it for you.'
     )),
 ))
 def test_get_upload_hub_with_no_uploads(


### PR DESCRIPTION
This line doesn’t make sense now that you can upload a contact list in advance of having a template.