### PR TITLE
Fix bug where adding same reply-to-email twice for the same service caused a 5xx

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -391,7 +391,7 @@ def service_add_email_reply_to(service_id):
                 service_id, form.email_address.data
             )["data"]["id"]
         except HTTPError as e:
-            error_msg = "Your service already uses '{}' as an email reply-to address.".format(form.email_address.data)
+            error_msg = "Your service already uses ‘{}’ as an email reply-to address.".format(form.email_address.data)
             if e.status_code == 400 and error_msg == e.message:
                 flash(error_msg, 'error')
                 return redirect(url_for('.service_email_reply_to', service_id=service_id))
@@ -519,7 +519,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
                 service_id, form.email_address.data
             )["data"]["id"]
         except HTTPError as e:
-            error_msg = "Your service already uses ‘{}’ as a reply-to email address.".format(form.email_address.data)
+            error_msg = "Your service already uses ‘{}’ as an email reply-to address.".format(form.email_address.data)
             if e.status_code == 400 and error_msg == e.message:
                 flash(error_msg, 'error')
                 return redirect(url_for('.service_email_reply_to', service_id=service_id))

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -391,9 +391,8 @@ def service_add_email_reply_to(service_id):
                 service_id, form.email_address.data
             )["data"]["id"]
         except HTTPError as e:
-            error_msg = "Your service already uses ‘{}’ as an email reply-to address.".format(form.email_address.data)
-            if e.status_code == 400 and error_msg == e.message:
-                flash(error_msg, 'error')
+            if e.status_code == 409 or e.status_code == 400:
+                flash(e.message, 'error')
                 return redirect(url_for('.service_email_reply_to', service_id=service_id))
             else:
                 raise e
@@ -519,9 +518,8 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
                 service_id, form.email_address.data
             )["data"]["id"]
         except HTTPError as e:
-            error_msg = "Your service already uses ‘{}’ as an email reply-to address.".format(form.email_address.data)
-            if e.status_code == 400 and error_msg == e.message:
-                flash(error_msg, 'error')
+            if e.status_code == 400 or e.status_code == 409:
+                flash(e.message, 'error')
                 return redirect(url_for('.service_email_reply_to', service_id=service_id))
             else:
                 raise e


### PR DESCRIPTION
This was due to changed quotation marks in error message.

We ended up getting rid of error message check in favour of a more accurate error code that will make sure we are getting the right error.

This PR makes our code accept both 400 and 409 error codes. We can switch to solely accepting 409s after this PR is merged: https://github.com/alphagov/notifications-api/pull/2779

story ticket: https://www.pivotaltracker.com/story/show/171785534