### PR TITLE
Use tabular figures for template statistics

### DIFF
--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -27,7 +27,7 @@
   text-align: left;
 
   &-bar {
-    @include bold-27;
+    @include bold-27($tabular-numbers: true);
     box-sizing: border-box;
     display: inline-block;
     overflow: visible;


### PR DESCRIPTION
We use tabular (not lining) figures everywhere else that we display counts, so that they don’t shift around as the AJAX updates the numbers.

There’s a good explanation of the difference here: https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/77742193-ff664680-700d-11ea-853b-8f9d9555590c.png) | ![image](https://user-images.githubusercontent.com/355079/77742274-202e9c00-700e-11ea-85a3-78e5197e33b8.png)
