### PR TITLE
Update humanize from 1.0.0 to 2.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.93
-humanize==1.0.0
+humanize==2.2.0
 Flask==1.1.1
 Flask-WTF==0.14.3
 Flask-Login==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.93
-humanize==1.0.0
+humanize==2.2.0
 Flask==1.1.1
 Flask-WTF==0.14.3
 Flask-Login==0.4.1
@@ -28,10 +28,10 @@ git+https://github.com/alphagov/notifications-utils.git@36.9.3#egg=notifications
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.32
+awscli==1.18.33
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.15.32
+botocore==1.15.33
 certifi==2019.11.28
 chardet==3.0.4
 click==7.1.1
@@ -72,7 +72,7 @@ statsd==3.3.0
 texttable==1.6.2
 urllib3==1.25.8
 webencodings==0.5.1
-Werkzeug==1.0.0
+Werkzeug==1.0.1
 WTForms==2.2.1
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
Closes #3392 (which can’t be merged because of a breaking change to Flask-Login)