### PR TITLE
Handle postcode validation for precompiled letters

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -651,20 +651,12 @@ LETTER_VALIDATION_MESSAGES = {
         ),
     },
     'not-a-real-uk-postcode': {
-        'title': 'Postcode in the address block is not a real UK postcode',
+        'title': 'There’s a problem with the address on this letter',
         'detail': (
-            'You need to give us a real UK postcode.<br>'
-            'Files must meet our '
-            '<a class="govuk-link govuk-link--destructive" href="{letter_spec_guidance}" target="_blank">'
-            'letter specification'
-            '</a>.'
+            'The last line of the address must be a real UK postcode.'
         ),
         'summary': (
-            'Validation failed because the postcode is not a real UK postcode.<br>'
-            'Files must meet our '
-            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec}" target="_blank">'
-            'letter specification'
-            '</a>.'
+            'Validation failed because the last line of the address is not a real UK postcode.'
         ),
     }
 }

--- a/app/utils.py
+++ b/app/utils.py
@@ -649,6 +649,23 @@ LETTER_VALIDATION_MESSAGES = {
             'letter specification'
             '</a>.'
         ),
+    },
+    'not-a-real-uk-postcode': {
+        'title': 'Postcode in the address block is not a real UK postcode',
+        'detail': (
+            'You need to give us a real UK postcode.<br>'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--destructive" href="{letter_spec_guidance}" target="_blank">'
+            'letter specification'
+            '</a>.'
+        ),
+        'summary': (
+            'Validation failed because the postcode is not a real UK postcode.<br>'
+            'Files must meet our '
+            '<a class="govuk-link govuk-link--no-visited-state" href="{letter_spec}" target="_blank">'
+            'letter specification'
+            '</a>.'
+        ),
     }
 }
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -651,7 +651,7 @@ LETTER_VALIDATION_MESSAGES = {
         ),
     },
     'not-a-real-uk-postcode': {
-        'title': 'There’s a problem with the address on this letter',
+        'title': 'There’s a problem with the address for this letter',
         'detail': (
             'The last line of the address must be a real UK postcode.'
         ),

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -483,6 +483,30 @@ def test_get_letter_validation_error_for_unknown_error():
             'Save a new copy of your file and try again.'
         ),
     ),
+    (
+        'address-is-empty',
+        None,
+        'The address block is empty',
+        (
+            'You need to add a recipient address.'
+            'Files must meet our letter specification.'
+        ),
+        (
+            'Validation failed because the address block is empty.'
+            'Files must meet our letter specification.'
+        ),
+    ),
+    (
+        'not-a-real-uk-postcode',
+        None,
+        'There’s a problem with the address for this letter',
+        (
+            'The last line of the address must be a real UK postcode.'
+        ),
+        (
+            'Validation failed because the last line of the address is not a real UK postcode.'
+        ),
+    ),
 ])
 def test_get_letter_validation_error_for_known_errors(
     client_request,


### PR DESCRIPTION
Needs to go in before: https://github.com/alphagov/notifications-template-preview/pull/434

I'd love some eyes on the content for this.

<img width="1004" alt="Screenshot 2020-04-02 at 11 54 52" src="https://user-images.githubusercontent.com/20957548/78242767-8322a600-74da-11ea-9f75-7bec820e193e.png">
<img width="1014" alt="Screenshot 2020-04-02 at 11 54 32" src="https://user-images.githubusercontent.com/20957548/78242770-83bb3c80-74da-11ea-9397-f9b65287775c.png">

