### PR TITLE
Fix unnecessary call to organisation API endpoint

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -472,7 +472,7 @@ class Service(JSONModel):
 
     @property
     def organisation_name(self):
-        if not self.organisation:
+        if not self.organisation_id:
             return None
         return organisations_client.get_organisation_name(self.organisation_id)
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -296,7 +296,7 @@
 
           {% call row() %}
             {{ text_field('Live')}}
-            {% if current_service.trial_mode and not current_service.organisation %}
+            {% if current_service.trial_mode and not current_service.organisation_id %}
               {{ text_field('No (organisation must be set first)') }}
               {{ text_field('') }}
             {% else %}


### PR DESCRIPTION
We’re caching the organisation name, but still talking to the API to see if the organisation exists.

`Service().organisation_id` only goes to the JSON for the service.

`Service().organisation` makes a separate API call.

We only need the former to know if a service belongs to an organisation.