### PR TITLE
Fix API call to send one off letter

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1068,7 +1068,7 @@ def send_notification(service_id, template_id):
         noti = notification_api_client.send_notification(
             service_id,
             template_id=db_template['id'],
-            recipient=session['recipient'] or session['placeholders']['address line 1'],
+            recipient=session['recipient'] or Columns(session['placeholders'])['address line 1'],
             personalisation=session['placeholders'],
             sender_id=session['sender_id'] if 'sender_id' in session else None
         )

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3773,6 +3773,29 @@ def test_send_notification_submits_data(
     )
 
 
+@pytest.mark.parametrize('placeholders', (
+    {'address line 1': 'Foo'},
+    {'ADDRESSLINE_1': 'Foo'},
+))
+def test_send_notification_submits_data_for_letter(
+    client_request,
+    fake_uuid,
+    mock_send_notification,
+    mock_get_service_letter_template,
+    placeholders,
+):
+    with client_request.session_transaction() as session:
+        session['recipient'] = None
+        session['placeholders'] = placeholders
+
+    client_request.post(
+        'main.send_notification',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid
+    )
+    assert mock_send_notification.call_args[1]['recipient'] == 'Foo'
+
+
 def test_send_notification_clears_session(
     client_request,
     service_one,


### PR DESCRIPTION
As part of making the API call we extra the recipient from the first line of the address. This code was assuming that the recipient would always have the key `address line 1`, but we’re no longer guaranteeing that it will be capitalised and spaced exactly like that.