### PR TITLE
Fix timestamp used for clearing old cookies

### DIFF
--- a/app/assets/javascripts/cookieMessage.js
+++ b/app/assets/javascripts/cookieMessage.js
@@ -9,14 +9,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // clear old cookie set by our previous JS, set on the www domain
     if (window.GOVUK.cookie('seen_cookie_message')) {
-      document.cookie = 'seen_cookie_message=;expires=' + new Date() + ';path=/';
+      document.cookie = 'seen_cookie_message=;expires=' + new Date().toGMTString() + ';path=/';
     }
 
     if (consent === null) {
       for (var i = 0; i < gaCookies.length; i++) {
         if (window.GOVUK.cookie(gaCookies[i])) {
           // GA cookies are set on the base domain so need the www stripping
-          var cookieString = gaCookies[i] + '=;expires=' + new Date() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/';
+          var cookieString = gaCookies[i] + '=;expires=' + new Date().toGMTString() + ';domain=' + window.location.hostname.replace(/^www\./, '.') + ';path=/';
           document.cookie = cookieString;
         }
       }


### PR DESCRIPTION
The change in the clocks broke the tests for the cookies JS. This is why:

The code in the test that added the 'old' cookies
uses Greenwich Mean Time (GMT) format:

https://github.com/alphagov/notifications-admin/blob/master/tests/javascripts/support/helpers/cookies.js#L19

The code that cleared any 'old' cookies doesn't
specify a time format so uses that set on the host
OS:

https://github.com/alphagov/notifications-admin/blob/master/app/assets/javascripts/cookieMessage.js#L12
https://github.com/alphagov/notifications-admin/blob/master/app/assets/javascripts/cookieMessage.js#L19

Cookies are deleted by setting the data to one
that has expired. Because of the hour difference
the date set to make the cookies expire didn't
work.

This fixes that by making the clearing up code use
GMT.