### PR TITLE
Fix one off letter journey if you have a placeholder from the address block

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1372,7 +1372,6 @@ def get_placeholder_form_instance(
     placeholder_name,
     dict_to_populate_from,
     template_type,
-    optional_placeholder=False,
     allow_international_phone_numbers=False,
 ):
 
@@ -1389,8 +1388,6 @@ def get_placeholder_form_instance(
             field = international_phone_number(label=placeholder_name)
         else:
             field = uk_mobile_number(label=placeholder_name)
-    elif optional_placeholder:
-        field = StringField(placeholder_name)
     else:
         field = StringField(placeholder_name, validators=[
             DataRequired(message='Cannot be empty')

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -399,7 +399,6 @@ def send_one_off_letter_address(service_id, template_id):
         ),
         template=template,
         form=form,
-        optional_placeholder=False,
         back_link=get_back_link(service_id, template, 0),
         help=False,
         link_to_upload=True,
@@ -478,12 +477,10 @@ def send_test_step(service_id, template_id, step_index):
     ):
         return redirect(url_for('.send_one_off_letter_address', service_id=service_id, template_id=template_id))
 
-    optional_placeholder = (current_placeholder in optional_address_columns)
     form = get_placeholder_form_instance(
         current_placeholder,
         dict_to_populate_from=get_normalised_placeholders_from_session(),
         template_type=template.template_type,
-        optional_placeholder=optional_placeholder,
         allow_international_phone_numbers=current_service.has_permission('international_sms'),
     )
 
@@ -540,7 +537,6 @@ def send_test_step(service_id, template_id, step_index):
         template=template,
         form=form,
         skip_link=skip_link,
-        optional_placeholder=optional_placeholder,
         back_link=back_link,
         help=get_help_argument(),
         link_to_upload=(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1022,7 +1022,9 @@ def _check_notification(service_id, template_id, exception=None):
         page_count=get_page_count_for_letter(db_template),
     )
 
-    back_link = get_back_link(service_id, template, len(fields_to_fill_in(template)))
+    placeholders = fields_to_fill_in(template)
+
+    back_link = get_back_link(service_id, template, len(placeholders), placeholders)
 
     if (
         (

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -472,10 +472,21 @@ def send_test_step(service_id, template_id, step_index):
         ))
 
     # if we're in a letter, we should show address block rather than "address line #" or "postcode"
-    if template.template_type == 'letter' and (
-        step_index < len(first_column_headings['letter'])
-    ):
-        return redirect(url_for('.send_one_off_letter_address', service_id=service_id, template_id=template_id))
+    if template.template_type == 'letter':
+        if step_index < len(first_column_headings['letter']):
+            return redirect(url_for(
+                '.send_one_off_letter_address',
+                service_id=service_id,
+                template_id=template_id,
+            ))
+        if current_placeholder in Columns(PostalAddress('').as_personalisation):
+            return redirect(url_for(
+                request.endpoint,
+                service_id=service_id,
+                template_id=template_id,
+                step_index=step_index + 1,
+                help=get_help_argument(),
+            ))
 
     form = get_placeholder_form_instance(
         current_placeholder,

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -524,19 +524,6 @@ def send_test_step(service_id, template_id, step_index):
     template.values = get_recipient_and_placeholders_from_session(template.template_type)
     template.values[current_placeholder] = None
 
-    if (
-        request.endpoint == 'main.send_one_off_step'
-        and step_index == 0
-        and template.template_type != 'letter'
-        and not (template.template_type == 'sms' and current_user.mobile_number is None)
-        and current_user.has_permissions('manage_templates', 'manage_service')
-    ):
-        skip_link = (
-            'Use my {}'.format(first_column_headings[template.template_type][0]),
-            url_for('.send_test', service_id=service_id, template_id=template.id),
-        )
-    else:
-        skip_link = None
     return render_template(
         'views/send-test.html',
         page_title=get_send_test_page_title(
@@ -547,7 +534,7 @@ def send_test_step(service_id, template_id, step_index):
         ),
         template=template,
         form=form,
-        skip_link=skip_link,
+        skip_link=get_skip_link(step_index, template),
         back_link=back_link,
         help=get_help_argument(),
         link_to_upload=(
@@ -987,6 +974,20 @@ def get_back_link(service_id, template, step_index, placeholders=None):
         template_id=template.id,
         step_index=step_index - 1,
     )
+
+
+def get_skip_link(step_index, template):
+    if (
+        request.endpoint == 'main.send_one_off_step'
+        and step_index == 0
+        and template.template_type != 'letter'
+        and not (template.template_type == 'sms' and current_user.mobile_number is None)
+        and current_user.has_permissions('manage_templates', 'manage_service')
+    ):
+        return (
+            'Use my {}'.format(first_column_headings[template.template_type][0]),
+            url_for('.send_test', service_id=current_service.id, template_id=template.id),
+        )
 
 
 @main.route("/services/<uuid:service_id>/template/<uuid:template_id>/notification/check", methods=['GET'])

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -18,10 +18,7 @@ from notifications_python_client.errors import HTTPError
 from notifications_utils import LETTER_MAX_PAGE_COUNT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.columns import Columns
 from notifications_utils.pdf import is_letter_too_long
-from notifications_utils.postal_address import (
-    PostalAddress,
-    address_lines_1_to_6_and_postcode_keys,
-)
+from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import (
     RecipientCSV,
     first_column_headings,
@@ -476,8 +473,8 @@ def send_test_step(service_id, template_id, step_index):
         ))
 
     # if we're in a letter, we should show address block rather than "address line #" or "postcode"
-    if template.template_type == 'letter' and current_placeholder in (
-        Columns.from_keys(address_lines_1_to_6_and_postcode_keys)
+    if template.template_type == 'letter' and (
+        step_index < len(first_column_headings['letter'])
     ):
         return redirect(url_for('.send_one_off_letter_address', service_id=service_id, template_id=template_id))
 

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -25,7 +25,6 @@
       <div class="govuk-grid-column-full {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}">
         {{ textbox(
           form.placeholder_value,
-          hint='Optional' if optional_placeholder else None,
           width='1-1',
         ) }}
       </div>

--- a/tests/app/main/test_placeholder_form.py
+++ b/tests/app/main/test_placeholder_form.py
@@ -9,11 +9,11 @@ def test_form_class_not_mutated(app_):
         method='POST',
         data={'placeholder_value': ''}
     ):
-        form1 = get_placeholder_form_instance('name', {}, 'sms', optional_placeholder=False)
-        form2 = get_placeholder_form_instance('city', {}, 'sms', optional_placeholder=True)
+        form1 = get_placeholder_form_instance('name', {}, 'sms')
+        form2 = get_placeholder_form_instance('city', {}, 'sms')
 
         assert not form1.validate_on_submit()
-        assert form2.validate_on_submit()
+        assert not form2.validate_on_submit()
 
         assert str(form1.placeholder_value.label) == '<label for="placeholder_value">name</label>'
         assert str(form2.placeholder_value.label) == '<label for="placeholder_value">city</label>'

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2091,11 +2091,11 @@ def test_send_one_off_letter_copes_with_placeholder_from_address_block(
         _follow_redirects=True,
     )
 
+    assert normalize_spaces(page.select_one('form label').text) == 'thing'
+    assert page.select_one('form input[type=text]')['name'] == 'placeholder_value'
+    assert page.select_one('form input[type=text]')['value'] == ''
+
     with client_request.session_transaction() as session:
-        assert normalize_spaces(page.select_one('form label').text) == placeholder
-        assert page.select_one('form input[type=text]')['value'] == (
-            session['placeholders'].get(placeholder, '')
-        )
         assert session['placeholders'] == {
             'address_line_1': 'foo',
             'address_line_2': 'bar',

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2061,6 +2061,7 @@ def test_send_one_off_letter_copes_with_placeholder_from_address_block(
     mocker,
     fake_uuid,
     mock_template_preview,
+    no_letter_contact_blocks,
     placeholder,
 ):
     mocker.patch(
@@ -2106,6 +2107,19 @@ def test_send_one_off_letter_copes_with_placeholder_from_address_block(
             'address_line_7': 'SW1A 1AA',
             'postcode': 'SW1A 1AA',
         }
+
+    back_link = page.select_one('.govuk-back-link')['href']
+    assert back_link == url_for(
+        'main.send_one_off_step',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        step_index=1,
+    )
+    previous_page = client_request.get_url(back_link, _follow_redirects=True)
+
+    # We’ve skipped past the address placeholder and gone back to the
+    # address block
+    assert normalize_spaces(previous_page.select_one('form label').text) == 'Address'
 
 
 def test_send_test_sms_message_puts_submitted_data_in_session(


### PR DESCRIPTION
Currently users are blocked from continuing if they have placeholder like `address line 1` or `postcode` in their template. They get redirected back to filling in the address block when they encounter one of these placeholders. So this commit:
- makes the flow skip over filling in these placeholders individually
- makes the flow skip over filling in these placeholders when clicking back through the sequence