### PR TITLE
Show errors that aren’t specific to a single spreadsheet column across the whole table row

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -65,12 +65,12 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro field(align='left', status='', border=True) -%}
+{% macro field(align='left', status='', border=True, colspan=None) -%}
 
     {% set field_alignment = 'table-field-right-aligned' if align == 'right' else 'table-field-left-aligned' %}
     {% set border = '' if border else 'table-field-noborder' %}
 
-    <td class="{{ [field_alignment, border]|join(' ') }}">
+    <td class="{{ [field_alignment, border]|join(' ') }}" {% if colspan %}colspan="{{ colspan }}"{% endif %}>
       <div class="{{ 'table-field-status-' + status if status }}">{{ caller() }}</div>
     </td>
 {%- endmacro %}
@@ -81,8 +81,8 @@
   </th>
 {%- endmacro %}
 
-{% macro index_field(text=None) -%}
-  <td class="table-field-index">
+{% macro index_field(text=None, rowspan=None) -%}
+  <td class="table-field-index" {% if rowspan %}rowspan="{{ rowspan }}"{% endif %}>
     {{ text if text != None else caller()  }}
   </td>
 {%- endmacro %}

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import mapping_table, row, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/message-count-label.html" import message_count_label %}
@@ -59,38 +59,41 @@
   </div>
 
   <div class="fullscreen-content" data-module="fullscreen-table">
-    {% call(item, row_number) list_table(
-      recipients.displayed_rows,
+    {% call(item, row_number) mapping_table(
       caption=original_file_name,
       caption_visible=False,
       field_headings=[
         '<span class="govuk-visually-hidden">Row in file</span><span aria-hidden="true" class="table-field-invisible-error">1</span>'|safe
       ] + recipients.column_headers
     ) %}
-      {% call index_field() %}
-        <span class="{% if item.has_errors %}table-field-error{% endif %}">
-          {{ item.index + 2 }}
-        </span>
-      {% endcall %}
-      {% for column in recipients.column_headers %}
-        {% if item[column].error and not recipients.missing_column_headers %}
-          {% call field() %}
-            <span>
-              <span class="table-field-error-label">{{ item[column].error }}</span>
-              {{ item[column].data if item[column].data != None }}
+      {% for item in recipients.displayed_rows %}
+        {% call row(item.id) %}
+          {% call index_field() %}
+            <span class="{% if item.has_errors %}table-field-error{% endif %}">
+              {{ item.index + 2 }}
             </span>
           {% endcall %}
-        {% elif item[column].ignore %}
-          {{ text_field(item[column].data or '', status='default') }}
-        {% else %}
-          {{ text_field(item[column].data or '') }}
-        {% endif %}
+          {% for column in recipients.column_headers %}
+            {% if item[column].error and not recipients.missing_column_headers %}
+              {% call field() %}
+                <span>
+                  <span class="table-field-error-label">{{ item[column].error }}</span>
+                  {{ item[column].data if item[column].data != None }}
+                </span>
+              {% endcall %}
+            {% elif item[column].ignore %}
+              {{ text_field(item[column].data or '', status='default') }}
+            {% else %}
+              {{ text_field(item[column].data or '') }}
+            {% endif %}
+          {% endfor %}
+          {% if item[None].data %}
+            {% for column in item[None].data %}
+              {{ text_field(column, status='default') }}
+            {% endfor %}
+          {% endif %}
+        {% endcall %}
       {% endfor %}
-      {% if item[None].data %}
-        {% for column in item[None].data %}
-          {{ text_field(column, status='default') }}
-        {% endfor %}
-      {% endif %}
     {% endcall %}
   </div>
   {% if count_of_displayed_recipients < count_of_recipients %}

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -67,12 +67,32 @@
       ] + recipients.column_headers
     ) %}
       {% for item in recipients.displayed_rows %}
-        {% call row(item.id) %}
-          {% call index_field() %}
-            <span class="{% if item.has_errors %}table-field-error{% endif %}">
-              {{ item.index + 2 }}
-            </span>
+        {% if item.has_error_spanning_multiple_cells %}
+          {% call row() %}
+            {% call index_field(rowspan=2) %}
+              <span class="table-field-error">
+                {{ item.index + 2 }}
+              </span>
+            {% endcall %}
+            {% call field(colspan=recipients.column_headers|length) %}
+              <span class="table-field-error-label">
+                {% if item.message_empty %}
+                  No content for this message
+                {% elif item.message_too_long %}
+                  Message is too long
+                {% endif %}
+              </span>
+            {% endcall %}
           {% endcall %}
+        {% endif %}
+        {% call row(item.id) %}
+          {% if not item.has_error_spanning_multiple_cells %}
+            {% call index_field() %}
+              <span class="{% if item.has_errors %}table-field-error{% endif %}">
+                {{ item.index + 2 }}
+              </span>
+            {% endcall %}
+          {% endif %}
           {% for column in recipients.column_headers %}
             {% if item[column].error and not recipients.missing_column_headers %}
               {% call field() %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -475,9 +475,19 @@ def test_upload_csv_file_with_empty_message_shows_check_page_with_errors(
         assert 'file_uploads' not in session
 
     assert response.status_code == 200
-    content = response.get_data(as_text=True)
-    assert 'There’s a problem with invalid.csv' in content
-    assert 'check you have content for the empty message in 1 row' in content
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert normalize_spaces(
+        page.select_one('.banner-dangerous').text
+    ) == (
+        'There’s a problem with invalid.csv '
+        'You need to check you have content for the empty message in 1 row. '
+        'Skip to file contents'
+    )
+    assert [
+        normalize_spaces(row.text) for row in page.select('tbody tr')
+    ] == [
+        '3 +447700900986 no',
+    ]
 
 
 @pytest.mark.parametrize('file_contents, expected_error,', [

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -486,8 +486,16 @@ def test_upload_csv_file_with_empty_message_shows_check_page_with_errors(
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr')
     ] == [
-        '3 +447700900986 no',
+        '3 No content for this message',
+        '+447700900986 no',
     ]
+    assert normalize_spaces(page.select_one('.table-field-index').text) == '3'
+    assert page.select_one('.table-field-index')['rowspan'] == '2'
+    assert normalize_spaces(page.select('tbody tr td')[0].text) == '3'
+    assert normalize_spaces(page.select('tbody tr td')[1].text) == (
+        'No content for this message'
+    )
+    assert page.select('tbody tr td')[1]['colspan'] == '2'
 
 
 @pytest.mark.parametrize('file_contents, expected_error,', [


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/355079/79329589-f92e0080-7f0f-11ea-99fc-481c4571fbec.png)

# After

![image](https://user-images.githubusercontent.com/355079/79328749-7bb5c080-7f0e-11ea-8447-8e657599c4fd.png)

***

The reason for making this improvement now is because, in the future, letter address errors won’t be related to specific cells, but to the combination of all the address columns.

***

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/719