### PR TITLE
Remove hard-coded bank holidays

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytz
 from flask import redirect, render_template, request, session, url_for
 from flask_login import current_user
+from govuk_bank_holidays.bank_holidays import BankHolidays
 
 from app import convert_to_boolean, current_service, service_api_client
 from app.extensions import zendesk_client
@@ -18,6 +19,8 @@ from app.models.feedback import (
     PROBLEM_TICKET_TYPE,
     QUESTION_TICKET_TYPE,
 )
+
+bank_holidays = BankHolidays(use_cached_holidays=True)
 
 
 @main.route('/support', methods=['GET', 'POST'])
@@ -192,58 +195,7 @@ def is_weekend(time):
 
 
 def is_bank_holiday(time):
-    return time.strftime('%Y-%m-%d') in {
-        # taken from https://www.gov.uk/bank-holidays.json
-        # curl https://www.gov.uk/bank-holidays.json | jq '."england-and-wales".events[].date'
-        "2016-01-01",
-        "2016-03-25",
-        "2016-03-28",
-        "2016-05-02",
-        "2016-05-30",
-        "2016-08-29",
-        "2016-12-26",
-        "2016-12-27",
-        "2017-01-02",
-        "2017-04-14",
-        "2017-04-17",
-        "2017-05-01",
-        "2017-05-29",
-        "2017-08-28",
-        "2017-12-25",
-        "2017-12-26",
-        "2018-01-01",
-        "2018-03-30",
-        "2018-04-02",
-        "2018-05-07",
-        "2018-05-28",
-        "2018-08-27",
-        "2018-12-25",
-        "2018-12-26",
-        "2019-01-01",
-        "2019-04-19",
-        "2019-04-22",
-        "2019-05-06",
-        "2019-05-27",
-        "2019-08-26",
-        "2019-12-25",
-        "2019-12-26",
-        "2020-01-01",
-        "2020-04-10",
-        "2020-04-13",
-        "2020-05-08",
-        "2020-05-25",
-        "2020-08-31",
-        "2020-12-25",
-        "2020-12-28",
-        "2021-01-01",
-        "2021-04-02",
-        "2021-04-05",
-        "2021-05-03",
-        "2021-05-31",
-        "2021-08-30",
-        "2021-12-27",
-        "2021-12-28",
-    }
+    return bank_holidays.is_holiday(time.date())
 
 
 def has_live_services(user_id):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,6 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.93
+govuk-bank-holidays==0.6
 humanize==2.2.0
 Flask==1.1.1
 Flask-WTF==0.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.93
+govuk-bank-holidays==0.6
 humanize==2.2.0
 Flask==1.1.1
 Flask-WTF==0.14.3


### PR DESCRIPTION
Looks like someone in the Ministry of Justice has made a nice little Python package of them.

I’ve configured it to use the cached holidays that come with the package, rather than going to the GOV.UK website every time we start the app. This should be more reliable, and means we’ll only get updates when we do a version bump (PyUp should keep an eye on this for us).

https://github.com/ministryofjustice/govuk-bank-holidays