### PR TITLE
Allow spaces and dashes in the two factor code

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -177,6 +177,10 @@ class SMSCode(StringField):
     def __call__(self, **kwargs):
         return super().__call__(type='tel', pattern='[0-9]*', **kwargs)
 
+    def process_formdata(self, valuelist):
+        if valuelist:
+            self.data = Columns.make_key(valuelist[0])
+
 
 class ForgivingIntegerField(StringField):
 

--- a/tests/app/main/test_two_factor_form.py
+++ b/tests/app/main/test_two_factor_form.py
@@ -11,6 +11,8 @@ def _check_code(code):
 @pytest.mark.parametrize('post_data', [
     {'sms_code': '12345'},
     {'sms_code': ' 12345 '},
+    {'sms_code': '12 34 5'},
+    {'sms_code': '1-23-45'},
 ])
 def test_form_is_valid_returns_no_errors(
     app_,
@@ -21,6 +23,7 @@ def test_form_is_valid_returns_no_errors(
         form = TwoFactorForm(_check_code)
         assert form.validate() is True
         assert form.errors == {}
+    mock_check_verify_code.assert_called_once_with('1', '12345', 'sms')
 
 
 @pytest.mark.parametrize('post_data, expected_error', (
@@ -38,6 +41,10 @@ def test_form_is_valid_returns_no_errors(
     ),
     (
         {'sms_code': '12E45'},
+        'Numbers only',
+    ),
+    (
+        {'sms_code': ' ! 2 3 4 5'},
         'Numbers only',
     ),
 ))


### PR DESCRIPTION
I noticed when using the dication software that saying ‘one two three four five’ got dictated as `123 45`. This tripped the validation, because the space character isn’t a digit.

So this commit normalises out spaces (and other spacing characters like dashes and underscores) before validating the code and sending it to the API.

I can also imagine that some people might like to space out the code to make it easier to transcribe (like you might do with a credit card number).