### PR TITLE
Reduce min sender length from 4 to 3

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1059,7 +1059,7 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
         validators=[
             DataRequired(message="Cannot be empty"),
             Length(max=11, message="Enter 11 characters or fewer"),
-            Length(min=4, message="Enter 4 characters or more"),
+            Length(min=3, message="Enter 3 characters or more"),
             LettersNumbersFullStopsAndUnderscoresOnly(),
             DoesNotStartWithDoubleZero(),
         ]

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -225,11 +225,11 @@ def test_sms_sender_form_validation(
     form.validate()
     assert not form.errors
 
-    form.sms_sender.data = '333'
+    form.sms_sender.data = '22'
     form.validate()
-    assert 'Enter 4 characters or more' == form.errors['sms_sender'][0]
+    assert 'Enter 3 characters or more' == form.errors['sms_sender'][0]
 
-    form.sms_sender.data = '4444'
+    form.sms_sender.data = '333'
     form.validate()
     assert not form.errors
 


### PR DESCRIPTION
This is now supported at the network and aggregator level. TEsting this locally shows no corresponding change is needed on the API