### PR TITLE
Let users search for letters

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -169,8 +169,12 @@ def view_notifications(service_id, message_type=None):
         things_you_can_search_by={
             'email': ['email address'],
             'sms': ['phone number'],
-            'letter': [],
-            None: ['email address', 'phone number'],
+            # This should become ‘postal address’ not ‘first line…’ once
+            # we’ve finished populating normalised addresses
+            'letter': ['first line of address', 'file name'],
+            # We say recipient here because combining all 3 types, plus
+            # reference gets too long for the hint text
+            None: ['recipient'],
         }.get(message_type) + {
             True: ['reference'],
             False: [],

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -34,41 +34,38 @@
       'counts'
     ) }}
 
-    {% call form_wrapper(
-      action=url_for('.view_notifications', service_id=current_service.id, message_type=message_type),
-      class="govuk-grid-row"
-    ) %}
-      <div class="govuk-grid-column-three-quarters {% if message_type == 'sms' %}extra-tracking{% endif %}">
-        {{ textbox(
-          search_form.to,
-          width='1-1',
-          label=things_you_can_search_by|formatted_list(
-            conjunction='or',
-            before_each='',
-            after_each='',
-            prefix='Search by',
-            prefix_plural='Search by'
-          )
-        ) }}
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        {{ govukButton({
-          "text": "Search",
-          "classes": "search-form__button"
-        }) }}
-      </div>
-    {% endcall %}
-
-    {% call form_wrapper(id="search-form") %}
-      <input type="hidden" name="to" value="{{ search_form.to.data }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    {% endcall %}
-  {% else %}
-    {% call form_wrapper(id="search-form") %}
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    {% endcall %}
   {% endif %}
+
+  {% call form_wrapper(
+    action=url_for('.view_notifications', service_id=current_service.id, message_type=message_type),
+    class="govuk-grid-row"
+  ) %}
+    <div class="govuk-grid-column-three-quarters {% if message_type == 'sms' %}extra-tracking{% endif %}">
+      {{ textbox(
+        search_form.to,
+        width='1-1',
+        label=things_you_can_search_by|formatted_list(
+          conjunction='or',
+          before_each='',
+          after_each='',
+          prefix='Search by',
+          prefix_plural='Search by'
+        )
+      ) }}
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      {{ govukButton({
+        "text": "Search",
+        "classes": "search-form__button"
+      }) }}
+    </div>
+  {% endcall %}
+
+  {% call form_wrapper(id="search-form") %}
+    <input type="hidden" name="to" value="{{ search_form.to.data }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {% endcall %}
 
   {% if current_user.has_permissions('view_activity') %}
     <p class="bottom-gutter">

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -340,7 +340,7 @@ def test_shows_message_when_no_notifications(
     (
         {},
         {},
-        'Search by email address or phone number',
+        'Search by recipient',
         '',
     ),
     (
@@ -372,6 +372,16 @@ def test_shows_message_when_no_notifications(
         },
         'Search by email address',
         'test@example.com',
+    ),
+    (
+        {
+            'message_type': 'letter',
+        },
+        {
+            'to': 'Firstname Lastname',
+        },
+        'Search by first line of address or file name',
+        'Firstname Lastname',
     ),
 ])
 def test_search_recipient_form(
@@ -413,9 +423,10 @@ def test_search_recipient_form(
 
 
 @pytest.mark.parametrize('message_type, expected_search_box_label', [
-    (None, 'Search by email address, phone number or reference'),
+    (None, 'Search by recipient or reference'),
     ('sms', 'Search by phone number or reference'),
     ('email', 'Search by email address or reference'),
+    ('letter', 'Search by first line of address, file name or reference'),
 ])
 def test_api_users_are_told_they_can_search_by_reference_when_service_has_api_keys(
     client_request,
@@ -437,7 +448,7 @@ def test_api_users_are_told_they_can_search_by_reference_when_service_has_api_ke
 
 
 @pytest.mark.parametrize('message_type, expected_search_box_label', [
-    (None, 'Search by email address or phone number'),
+    (None, 'Search by recipient'),
     ('sms', 'Search by phone number'),
     ('email', 'Search by email address'),
 ])
@@ -615,10 +626,10 @@ def test_redacts_templates_that_should_be_redacted(
     "message_type, tablist_visible, search_bar_visible", [
         ('email', True, True),
         ('sms', True, True),
-        ('letter', False, False)
+        ('letter', False, True)
     ]
 )
-def test_big_numbers_and_search_dont_show_for_letters(
+def test_big_numbers_dont_show_for_letters(
     client_request,
     service_one,
     mock_get_notifications,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -451,6 +451,7 @@ def test_api_users_are_told_they_can_search_by_reference_when_service_has_api_ke
     (None, 'Search by recipient'),
     ('sms', 'Search by phone number'),
     ('email', 'Search by email address'),
+    ('letter', 'Search by first line of address or file name'),
 ])
 def test_api_users_are_not_told_they_can_search_by_reference_when_service_has_no_api_keys(
     client_request,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -623,10 +623,10 @@ def test_redacts_templates_that_should_be_redacted(
 
 
 @pytest.mark.parametrize(
-    "message_type, tablist_visible, search_bar_visible", [
-        ('email', True, True),
-        ('sms', True, True),
-        ('letter', False, True)
+    "message_type, tablist_visible", [
+        ('email', True),
+        ('sms', True),
+        ('letter', False)
     ]
 )
 def test_big_numbers_dont_show_for_letters(
@@ -639,7 +639,6 @@ def test_big_numbers_dont_show_for_letters(
     mock_get_no_api_keys,
     message_type,
     tablist_visible,
-    search_bar_visible
 ):
     page = client_request.get(
         'main.view_notifications',
@@ -650,7 +649,7 @@ def test_big_numbers_dont_show_for_letters(
     )
 
     assert (len(page.select("[role=tablist]")) > 0) == tablist_visible
-    assert (len(page.select("[type=search]")) > 0) == search_bar_visible
+    assert (len(page.select("[type=search]")) > 0) is True
 
 
 @freeze_time("2017-09-27 16:30:00.000000")


### PR DESCRIPTION
Like we have search by email address or phone number, finding an individual letter is a common task. At the moment users are having to click through pages and pages of letters to find the one they’re looking for.

Users of the API will also be able to search by reference, same as for emails and text messages. But we only show this hint text to users who have some API keys.

![image](https://user-images.githubusercontent.com/355079/79869304-10ba2d00-83d9-11ea-80c0-701fd69371e3.png)

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/2814