### PR TITLE
Show error when user cannot be archived

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -1,5 +1,6 @@
 from flask import flash, redirect, render_template, request, url_for
 from flask_login import current_user
+from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
 from app.event_handlers import create_archive_user_event
@@ -36,7 +37,13 @@ def user_information(user_id):
 @user_is_platform_admin
 def archive_user(user_id):
     if request.method == 'POST':
-        user_api_client.archive_user(user_id)
+        try:
+            user_api_client.archive_user(user_id)
+        except HTTPError as e:
+            if e.status_code == 400 and 'manage_settings' in e.message:
+                flash('User can’t be removed from a service - '
+                      'check all services have another team member with manage_settings')
+                return redirect(url_for('main.user_information', user_id=user_id))
         create_archive_user_event(str(user_id), current_user.id)
 
         return redirect(url_for('.user_information', user_id=user_id))

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -255,20 +255,15 @@ def test_archive_user_shows_error_message_if_user_cannot_be_archived(
     ) == 'User can’t be removed from a service - check all services have another team member with manage_settings'
 
 
-def test_archive_user_does_not_create_event_if_user_client_raises_exception(
+def test_archive_user_does_not_create_event_if_user_client_raises_unexpected_exception(
     platform_admin_client,
     api_user_active,
     mocker,
     mock_events,
 ):
-    mock_user_client = mocker.patch('app.user_api_client.post', side_effect=Exception())
-
     with pytest.raises(Exception):
-        response = platform_admin_client.post(
+        platform_admin_client.post(
             url_for('main.archive_user', user_id=api_user_active.id)
         )
 
-        assert response.status_code == 500
-        assert response.location == url_for('main.user_information', user_id=api_user_active['id'], _external=True)
-        mock_user_client.assert_called_once_with('/user/{}/archive'.format(api_user_active['id']), data=None)
-        assert not mock_events.called
+    assert not mock_events.called


### PR DESCRIPTION
A user can't be archived if they are the only member of their service with `manage_settings` permission. `notifications-api` returns a `400` and an error message if that is the case, however this PR to remove the `400` error handler #3320 stopped the error message from showing. This meant that instead of seeing a message about why a user couldn't be archived, we would just show a `500` error page instead. This change checks the response from `notifications-api` and shows an error banner with a message if the user can't be archived.