### PR TITLE
Fix preview of text messages on activity page

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -16,7 +16,7 @@ from notifications_python_client.errors import HTTPError
 from notifications_utils.template import (
     EmailPreviewTemplate,
     LetterPreviewTemplate,
-    SMSPreviewTemplate,
+    SMSBodyPreviewTemplate,
 )
 
 from app import (
@@ -421,11 +421,9 @@ def get_preview_of_content(notification):
         return notification['client_reference']
 
     if notification['template']['template_type'] == 'sms':
-        return str(SMSPreviewTemplate(
+        return str(SMSBodyPreviewTemplate(
             notification['template'],
             notification['personalisation'],
-            redact_missing_personalisation=True,
-            show_prefix=False,
         ))
 
     if notification['template']['template_type'] == 'email':

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,5 +23,5 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@37.0.0#egg=notifications-utils==37.0.0
+git+https://github.com/alphagov/notifications-utils.git@37.2.0#egg=notifications-utils==37.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -18,6 +18,7 @@ pytz==2019.3
 gunicorn==20.0.4
 eventlet==0.25.1
 notifications-python-client==5.5.1
+WTForms==2.2.1  # Pinned because of breaking change in 2.3.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pytz==2019.3
 gunicorn==20.0.4
 eventlet==0.25.1
 notifications-python-client==5.5.1
+WTForms==2.2.1  # Pinned because of breaking change in 2.3.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
@@ -74,6 +75,5 @@ texttable==1.6.2
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
-WTForms==2.3.0
 xlrd==1.2.0
 xlwt==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,14 +25,14 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@37.0.0#egg=notifications-utils==37.0.0
+git+https://github.com/alphagov/notifications-utils.git@37.2.0#egg=notifications-utils==37.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.39
+awscli==1.18.43
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.15.39
+botocore==1.15.43
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1
@@ -71,9 +71,9 @@ six==1.14.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.2
-urllib3==1.25.8
+urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
-WTForms==2.2.1
+WTForms==2.3.0
 xlrd==1.2.0
 xlwt==1.3.0

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -86,6 +86,7 @@ from tests.conftest import (
         ('test@example.com', 'test@example.com'),
     ]
 )
+@freeze_time('2020-01-01 01:00')
 def test_can_show_notifications(
     client_request,
     logged_in_client,
@@ -129,13 +130,28 @@ def test_can_show_notifications(
             page=page_argument,
             **extra_args
         )
-    text_of_first_row = page.select('tbody tr')[0].text
-    assert '07123456789' in text_of_first_row
-    assert (
-        'template content' in text_of_first_row or
-        'template subject' in text_of_first_row
+    first_row = page.select_one('tbody tr')
+    assert normalize_spaces(
+        first_row.select_one('a.file-list-filename.govuk-link').text
+    ) == (
+        '07123456789'
     )
-    assert 'Delivered' in text_of_first_row
+    assert normalize_spaces(
+        # We’re doing str() here not .text to make sure there’s no extra
+        # HTML sneaking in
+        str(first_row.select_one('.file-list-hint'))
+    ) == (
+        'template content'
+    ) or (
+        'template subject'
+    )
+
+    assert normalize_spaces(
+        first_row.select_one('.table-field-right-aligned .align-with-message-body').text
+    ) == (
+        'Delivered 1 January at 1:01am'
+    )
+
     assert page_title in page.h1.text.strip()
 
     path_to_json = page.find("div", {'data-key': 'notifications'})['data-resource']

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -134,6 +134,8 @@ def test_can_show_notifications(
     assert normalize_spaces(
         first_row.select_one('a.file-list-filename.govuk-link').text
     ) == (
+        # Comes from
+        # https://github.com/alphagov/notifications-admin/blob/8faffad508f9a087b0006989c197741c693cc2e2/tests/__init__.py#L436
         '07123456789'
     )
     assert normalize_spaces(
@@ -141,8 +143,12 @@ def test_can_show_notifications(
         # HTML sneaking in
         str(first_row.select_one('.file-list-hint'))
     ) == (
+        # Comes from
+        # https://github.com/alphagov/notifications-admin/blob/8faffad508f9a087b0006989c197741c693cc2e2/tests/__init__.py#L271
         'template content'
     ) or (
+        # Comes from
+        # https://github.com/alphagov/notifications-admin/blob/8faffad508f9a087b0006989c197741c693cc2e2/tests/__init__.py#L273
         'template subject'
     )
 


### PR DESCRIPTION
Also beefs up the tests a bit so we can be more confident that the right thing is getting displayed.

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/725