### PR TITLE
Bump WTForms to 2.3.1

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -8,7 +8,6 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.sanitise_text import SanitiseSMS
 from wtforms import ValidationError
-from wtforms.validators import Email
 
 from app.main._blacklisted_passwords import blacklisted_passwords
 from app.utils import Spreadsheet, is_gov_user
@@ -51,10 +50,9 @@ class ValidGovEmail:
             raise ValidationError(message)
 
 
-class ValidEmail(Email):
+class ValidEmail:
 
-    def __init__(self):
-        super().__init__('Enter a valid email address')
+    message = 'Enter a valid email address'
 
     def __call__(self, form, field):
 
@@ -65,8 +63,6 @@ class ValidEmail(Email):
             validate_email_address(field.data)
         except InvalidEmailError:
             raise ValidationError(self.message)
-
-        return super().__call__(form, field)
 
 
 class NoCommasInPlaceHolders:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -18,7 +18,6 @@ pytz==2019.3
 gunicorn==20.0.4
 eventlet==0.25.1
 notifications-python-client==5.5.1
-WTForms==2.2.1  # Pinned because of breaking change in 2.3.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ pytz==2019.3
 gunicorn==20.0.4
 eventlet==0.25.1
 notifications-python-client==5.5.1
-WTForms==2.2.1  # Pinned because of breaking change in 2.3.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
@@ -30,10 +29,10 @@ git+https://github.com/alphagov/notifications-utils.git@37.2.0#egg=notifications
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.43
+awscli==1.18.44
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.15.43
+botocore==1.15.44
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1
@@ -75,5 +74,6 @@ texttable==1.6.2
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
+WTForms==2.3.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -36,8 +36,8 @@ def test_return_validation_error_when_key_name_exists(
 
 @pytest.mark.parametrize(
     'key_type, expected_error', [
-        ('', 'This field is required.'),
-        ('invalid', 'Not a valid choice')
+        ('', 'Select the type of key'),
+        ('invalid', 'Select the type of key')
     ]
 )
 def test_return_validation_error_when_key_type_not_chosen(client, key_type, expected_error):

--- a/tests/app/main/test_service_contact_details_form.py
+++ b/tests/app/main/test_service_contact_details_form.py
@@ -9,7 +9,7 @@ def test_form_fails_validation_with_no_radio_buttons_selected(app_):
 
         assert not form.validate_on_submit()
         assert len(form.errors) == 1
-        assert form.errors['contact_details_type'] == ['Not a valid choice']
+        assert form.errors['contact_details_type'] == ['Select an option']
 
 
 @pytest.mark.parametrize('selected_radio_button, selected_text_box, text_box_data', [

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -158,8 +158,8 @@ def test_create_new_organisation_validates(
         for error in page.select('.error-message')
     ] == [
         ('name', 'Cannot be empty'),
-        ('organisation_type', 'Not a valid choice'),
-        ('crown_status', 'Not a valid choice'),
+        ('organisation_type', 'Select the type of organisation'),
+        ('crown_status', 'Select whether this organisation is a crown body'),
     ]
     assert mock_create_organisation.called is False
 
@@ -334,7 +334,7 @@ def test_gps_can_name_their_organisation(
         {
             'name': 'Dr. Example',
         },
-        'Not a valid choice',
+        'Select yes or no',
     ),
     (
         {

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -178,7 +178,7 @@ def test_add_service_has_to_choose_org_type(
         _expected_status=200,
     )
     assert normalize_spaces(page.select_one('.error-message').text) == (
-        'Not a valid choice'
+        'Select the type of organisation'
     )
     assert mock_create_service.called is False
     assert mock_create_service_template.called is False

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -278,7 +278,7 @@ def test_accept_agreement_page_populates(
             'on_behalf_of_email': '',
         },
         [
-            'Not a valid choice',
+            'Select an option',
             'Must be a number',
         ],
     ),

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -396,7 +396,7 @@ def test_doesnt_lose_message_if_post_across_closing(
     )
 
     with client_request.session_transaction() as session:
-        assert page.find('textarea', {'name': 'feedback'}).text == 'foo'
+        assert page.find('textarea', {'name': 'feedback'}).text == '\r\nfoo'
         assert 'feedback_message' not in session
 
 

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -792,7 +792,7 @@ def test_clear_cache_requires_option(client_request, platform_admin_user, mocker
 
     page = client_request.post('main.clear_cache', _data={}, _expected_status=200)
 
-    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Not a valid choice'
+    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Select an option'
     assert not redis.delete_cache_keys_by_pattern.called
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2119,7 +2119,7 @@ def test_send_one_off_back_link_populates_address_textarea(
 
     textarea = form.select_one('textarea')
     assert textarea.attrs['name'] == 'address'
-    assert textarea.text == 'foo\nbar'
+    assert textarea.text == '\r\nfoo\nbar'
 
 
 @pytest.mark.parametrize('placeholder', (

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1377,7 +1377,7 @@ def test_should_show_persist_estimated_volumes(
             'consent_to_research': '',
         },
         '[data-error-label="consent_to_research"]',
-        'This field is required.'
+        'Select yes or no'
     ),
 ))
 def test_should_error_if_bad_estimations_given(
@@ -4109,7 +4109,7 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
         },
         _follow_redirects=True
     )
-    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Not a valid choice'
+    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Select an option'
     assert normalize_spaces(page.h1.text) == "Send files by email"
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1182,7 +1182,7 @@ def test_load_edit_template_with_copy_of_template(
         expected_name
     )
     assert page.select_one('textarea').text == (
-        'Your ((thing)) is due soon'
+        '\r\nYour ((thing)) is due soon'
     )
     mock_get_service_email_template.assert_called_once_with(
         SERVICE_TWO_ID,


### PR DESCRIPTION
This version includes three changes which broke our code.

To validate email addresses, the optional dependency `email-validator` must be installed<sup>1</sup>. But since we don’t use WTForms’ email validation, we shouldn’t need to subclass it – it can just be its own self contained thing. Then we don’t need to add the extra dependency.

When rendering textareas, and extra `\r\n` is inserted at the beginning <sup>2</sup>. Browsers will strip this when displaying the textbox and submitting the form, but some of our tests need updating to account for this.

The error message for when you don’t choose an option from some radio buttons has now changed. Rather than just accepting WTForms’ new message, this commit makes the error messages like the examples from the Design System<sup>3</sup>. By default it will say ‘Select an option’, but by passing in an extra parameter (`thing`) it can be customised to be more specific, for example ‘Select a type of organisation’.

***

1. wtforms/wtforms#429
2. wtforms/wtforms#238
3. https://design-system.service.gov.uk/components/radios/#error-messages