### PR TITLE
Use tabular numbers for dashboard banner counts

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -150,7 +150,7 @@
   }
 
   &-count {
-    @include govuk-font(36, $weight: bold);
+    @include govuk-font(36, $weight: bold, $tabular: true);
     padding-right: 8px;
     position: relative;
     // remove the top of the extra line-height this introduces


### PR DESCRIPTION
We use tabular (not lining) figures everywhere else that we display counts, so that they don’t shift around as the AJAX updates the numbers.

There’s a good explanation of the difference here: https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures

# Before

![image](https://user-images.githubusercontent.com/355079/80596983-1a6a1300-8a1f-11ea-8819-91a820e67074.png)

# After

![image](https://user-images.githubusercontent.com/355079/80597056-38d00e80-8a1f-11ea-9566-7fe278cee6c4.png)

