### PR TITLE
Tell template preview whether an uploaded letter can be sent internationally

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -115,7 +115,12 @@ def upload_letter(service_id):
         file_location = get_transient_letter_file_location(service_id, upload_id)
 
         try:
-            response = sanitise_letter(BytesIO(pdf_file_bytes))
+            response = sanitise_letter(
+                BytesIO(pdf_file_bytes),
+                allow_international_letters=current_service.has_permission(
+                    'international_letters'
+                ),
+            )
             response.raise_for_status()
         except RequestException as ex:
             if ex.response is not None and ex.response.status_code == 400:

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -94,9 +94,12 @@ def get_page_count_for_letter(template, values=None):
     return page_count
 
 
-def sanitise_letter(pdf_file):
+def sanitise_letter(pdf_file, *, allow_international_letters):
     return requests.post(
-        '{}/precompiled/sanitise'.format(current_app.config['TEMPLATE_PREVIEW_API_HOST']),
+        '{}/precompiled/sanitise?allow_international_letters={}'.format(
+            current_app.config['TEMPLATE_PREVIEW_API_HOST'],
+            'true' if allow_international_letters else 'false',
+        ),
         data=pdf_file,
         headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
     )

--- a/app/utils.py
+++ b/app/utils.py
@@ -669,6 +669,17 @@ LETTER_VALIDATION_MESSAGES = {
             'Validation failed because the last line of the address is not a real UK postcode.'
         ),
     },
+    'not-a-real-uk-postcode-or-country': {
+        'title': 'There’s a problem with the address for this letter',
+        'detail': (
+            'The last line of the address must be a UK postcode or '
+            'another country.'
+        ),
+        'summary': (
+            'Validation failed because the last line of the address is '
+            'not a UK postcode or another country.'
+        ),
+    },
     'not-enough-address-lines': {
         'title': 'There’s a problem with the address for this letter',
         'detail': (

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,7 +9,7 @@ Flask-WTF==0.14.3
 Flask-Login==0.5.0
 
 blinker==1.4
-pyexcel==0.6.0
+pyexcel==0.6.1
 pyexcel-io==0.5.20
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Flask-WTF==0.14.3
 Flask-Login==0.5.0
 
 blinker==1.4
-pyexcel==0.6.0
+pyexcel==0.6.1
 pyexcel-io==0.5.20
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8
@@ -29,10 +29,10 @@ git+https://github.com/alphagov/notifications-utils.git@39.0.0#egg=notifications
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.48
+awscli==1.18.51
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.15.48
+botocore==1.16.1
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
@@ -63,13 +63,14 @@ PyPDF2==1.26.0
 python-dateutil==2.8.1
 python-json-logger==0.1.11
 PyYAML==5.3.1
-redis==3.4.1
+redis==3.5.0
 requests==2.23.0
 rsa==3.4.2
 s3transfer==0.3.3
 six==1.14.0
 smartypants==2.0.1
 statsd==3.3.0
+texttable==1.6.2
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -164,13 +164,21 @@ def test_from_example_template_makes_request(mocker):
     )
 
 
-def test_sanitise_letter_calls_template_preview_sanitise_endoint_with_file(mocker):
+@pytest.mark.parametrize('allow_international_letters, expected_url', (
+    (False, 'http://localhost:9999/precompiled/sanitise?allow_international_letters=false'),
+    (True, 'http://localhost:9999/precompiled/sanitise?allow_international_letters=true'),
+))
+def test_sanitise_letter_calls_template_preview_sanitise_endoint_with_file(
+    mocker,
+    allow_international_letters,
+    expected_url,
+):
     request_mock = mocker.patch('app.template_previews.requests.post')
 
-    sanitise_letter('pdf_data')
+    sanitise_letter('pdf_data', allow_international_letters=allow_international_letters)
 
     request_mock.assert_called_once_with(
-        'http://localhost:9999/precompiled/sanitise',
+        expected_url,
         headers={'Authorization': 'Token my-secret-key'},
         data='pdf_data'
     )

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -509,6 +509,19 @@ def test_get_letter_validation_error_for_unknown_error():
         ),
     ),
     (
+        'not-a-real-uk-postcode-or-country',
+        None,
+        'There’s a problem with the address for this letter',
+        (
+            'The last line of the address must be a UK postcode or '
+            'another country.'
+        ),
+        (
+            'Validation failed because the last line of the address is '
+            'not a UK postcode or another country.'
+        ),
+    ),
+    (
         'not-enough-address-lines',
         None,
         'There’s a problem with the address for this letter',


### PR DESCRIPTION
If a service has permission to send international letters then the admin app should tell template preview, so that template preview knows what rules to apply when it’s validating the address of the letter.

We don’t need to wait for template preview to start looking at this query string argument – it will just ignore it until alphagov/notifications-template-preview#445 is merged and deployed.