### PR TITLE
Add a second URL for the email auth endpoint

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -28,7 +28,7 @@ def two_factor_email_sent():
     )
 
 
-@main.route('/email-auth/<token>', methods=['GET'])
+@main.route('/email-auth/<token>', methods=['GET', 'POST'])
 def two_factor_email(token):
     if current_user.is_authenticated:
         return redirect_when_logged_in(platform_admin=current_user.platform_admin)

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -253,6 +253,9 @@ def test_two_factor_should_activate_pending_user(
     assert mock_activate_user.called
 
 
+@pytest.mark.parametrize('http_method', (
+    'get', 'post',
+))
 def test_valid_two_factor_email_link_logs_in_user(
     client,
     valid_token,
@@ -260,10 +263,11 @@ def test_valid_two_factor_email_link_logs_in_user(
     mock_get_services_with_one_service,
     mocker,
     mock_create_event,
+    http_method,
 ):
     mocker.patch('app.user_api_client.check_verify_code', return_value=(True, ''))
 
-    response = client.get(
+    response = getattr(client, http_method)(
         url_for_endpoint_with_token('main.two_factor_email', token=valid_token),
     )
 


### PR DESCRIPTION
We’re going to add an interstitial page that redirects to this new URL. But we don’t want that redirect to 404 while the change is deploying, because some boxes will have the new URL and some won’t. So let’s deploy the new URL to all the boxes first, then the redirect page can safely
take over the new one.