### PR TITLE
Fix bug with letter job CSV downloads

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -157,7 +157,9 @@ def get_sample_template(template_type):
     if template_type == 'sms':
         return SMSPreviewTemplate({'content': 'any', 'template_type': 'sms'})
     if template_type == 'letter':
-        return LetterImageTemplate({'content': 'any', 'subject': '', 'template_type': 'letter'})
+        return LetterImageTemplate(
+            {'content': 'any', 'subject': '', 'template_type': 'letter'}, postage='second', image_url='x', page_count=1
+        )
 
 
 def generate_notifications_csv(**kwargs):

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 from freezegun import freeze_time
+from notifications_utils.template import Template
 
 from app import format_datetime_relative
 from app.utils import (
@@ -18,6 +19,7 @@ from app.utils import (
     get_letter_printing_statement,
     get_letter_validation_error,
     get_logo_cdn_domain,
+    get_sample_template,
     is_less_than_90_days_ago,
     printing_today_or_tomorrow,
 )
@@ -576,3 +578,9 @@ def test_get_letter_validation_error_for_known_errors(
 @freeze_time('2020-02-14T12:00:00')
 def test_is_less_than_90_days_ago(date_from_db, expected_result):
     assert is_less_than_90_days_ago(date_from_db) == expected_result
+
+
+@pytest.mark.parametrize("template_type", ["sms", "letter", "email"])
+def test_get_sample_template_returns_template(template_type):
+    template = get_sample_template(template_type)
+    assert isinstance(template, Template)


### PR DESCRIPTION
We were throwing an exception when instantiating a LetterImageTemplate
as we weren't giving it all the arguments it needed.

 Now we give it all the correct parameters and add a
test for the method. Ideally we would add a unit test for the flask
route for downloading a letter job CSV (which is currently lacking) but
I did the minimal to be confident I've fixed the bug as I think this
whole code may be fresh for a bit of a rewrite according to Chris.

Original error:
```
File "/Users/davidmcdonald/.virtualenvs/notifications-admin/lib/python3.6/site-packages/notifications_utils/template.py", line 669, in __init__
    raise TypeError('image_url is required')
TypeError: image_url is required
```

How to test:
Create a letter job with one or two letters, then head to the page for it and try and download the CSV report. It should download successfully. Note, you should inspect the file that is downloaded rather than just seeing that a file has been downloaded as previously it was downloading a 0 Kb file.