### PR TITLE
Update content

### DIFF
--- a/app/templates/views/support/public.html
+++ b/app/templates/views/support/public.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 
 {% block per_page_title %}
-  The GOV.UK Notify team can’t give advice to members of the public
+  The GOV.UK Notify team cannot give advice to members of the public
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -17,7 +17,7 @@
     ) }}
 
     <p class="govuk-body">
-      We can’t give advice to the public. We don’t have access to information about you held by government departments.
+      We cannot give advice to the public. We do not have access to information about you held by government departments.
     </p>
 
     <p class="govuk-body">
@@ -28,19 +28,19 @@
       <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/coronavirus">Coronavirus (COVID-19)</a>
     </h2>
     <p class="govuk-body">
-      What you need to do
+      Find guidance and support.
     </p>
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
       <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/contact">Contact the government</a>
     </h2>
     <p class="govuk-body">
-      Ask about benefits, driving, transport, tax, and more
+      Find out about benefits, driving, transport, tax, and more.
     </p>
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
-      <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/report-suspicious-emails-websites-phishing">Avoid and report internet scams and phishing</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/report-suspicious-emails-websites-phishing">Report internet scams and phishing</a>
     </h2>
     <p class="govuk-body">
-      Advice on suspicious emails and text messages
+      Advice on suspicious emails and text messages.
     </p>
   </div>
 </div>

--- a/app/templates/views/support/public.html
+++ b/app/templates/views/support/public.html
@@ -34,7 +34,7 @@
       <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/contact">Contact the government</a>
     </h2>
     <p class="govuk-body">
-      Find out about benefits, driving, transport, tax, and more.
+      Ask about benefits, driving, transport, tax, and more.
     </p>
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
       <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/report-suspicious-emails-websites-phishing">Report internet scams and phishing</a>


### PR DESCRIPTION
This PR updates the content on the page shown to members of the public looking for support on GOV.UK Notify.

Summary of changes:

* remove negative contractions in line with GOV.UK style guide
* update the descriptions so they more closely reflect the pages and services
* shorten one of the h2 link titles so it sounds more like an action
* add full stops to the descriptions

We'll need to revisit the Coronavirus stuff as the landing page (and the situation) continues to change.