### PR TITLE
Show 2 previous financial years on usage page

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -142,8 +142,8 @@ def usage(service_id):
         selected_year=year,
         years=get_tuples_of_financial_years(
             partial(url_for, '.usage', service_id=service_id),
-            start=current_financial_year - 1,
-            end=current_financial_year + 1,
+            start=current_financial_year - 2,
+            end=current_financial_year,
         ),
         **calculate_usage(yearly_usage,
                           free_sms_allowance)
@@ -483,5 +483,5 @@ def get_tuples_of_financial_years(
             partial_url(year=year),
             '{} to {}'.format(year, year + 1),
         )
-        for year in range(start, end + 1)
+        for year in reversed(range(start, end + 1))
     )

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -499,9 +499,9 @@ def test_organisation_services_filters_by_financial_year(
     )
     mock.assert_called_once_with(ORGANISATION_ID, financial_year)
     assert normalize_spaces(page.select_one('.pill').text) == (
-        '2018 to 2019 financial year '
+        '2020 to 2021 financial year '
         '2019 to 2020 financial year '
-        '2020 to 2021 financial year'
+        '2018 to 2019 financial year'
     )
     assert normalize_spaces(page.select_one('.pill-selected-item').text) == (
         expected_selected

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -794,9 +794,9 @@ def test_stats_pages_show_last_3_years(
     )
 
     assert normalize_spaces(page.select_one('.pill').text) == (
-        '2012 to 2013 financial year '
+        '2014 to 2015 financial year '
         '2013 to 2014 financial year '
-        '2014 to 2015 financial year'
+        '2012 to 2013 financial year'
     )
 
 
@@ -952,9 +952,9 @@ def test_usage_page(
     nav = page.find('ul', {'class': 'pill', 'role': 'tablist'})
     nav_links = nav.find_all('a')
 
-    assert normalize_spaces(nav_links[0].text) == '2010 to 2011 financial year'
     assert normalize_spaces(nav.find('li', {'aria-selected': 'true'}).text) == '2011 to 2012 financial year'
-    assert normalize_spaces(nav_links[1].text) == '2012 to 2013 financial year'
+    assert normalize_spaces(nav_links[0].text) == '2010 to 2011 financial year'
+    assert normalize_spaces(nav_links[1].text) == '2009 to 2010 financial year'
     assert '252,190' in cols[1].text
     assert 'Text messages' in cols[1].text
 
@@ -994,9 +994,9 @@ def test_usage_page_with_letters(
     nav = page.find('ul', {'class': 'pill', 'role': 'tablist'})
     nav_links = nav.find_all('a')
 
-    assert normalize_spaces(nav_links[0].text) == '2010 to 2011 financial year'
     assert normalize_spaces(nav.find('li', {'aria-selected': 'true'}).text) == '2011 to 2012 financial year'
-    assert normalize_spaces(nav_links[1].text) == '2012 to 2013 financial year'
+    assert normalize_spaces(nav_links[0].text) == '2010 to 2011 financial year'
+    assert normalize_spaces(nav_links[1].text) == '2009 to 2010 financial year'
     assert '252,190' in cols[1].text
     assert 'Text messages' in cols[1].text
 
@@ -1486,8 +1486,8 @@ def test_get_tuples_of_financial_years():
         start=2040,
         end=2041,
     )) == [
-        ('financial year', 2040, 'http://example.com?year=2040', '2040 to 2041'),
         ('financial year', 2041, 'http://example.com?year=2041', '2041 to 2042'),
+        ('financial year', 2040, 'http://example.com?year=2040', '2040 to 2041'),
     ]
 
 
@@ -1495,7 +1495,7 @@ def test_get_tuples_of_financial_years_defaults_to_2015():
     assert 2015 in list(get_tuples_of_financial_years(
         lambda year: 'http://example.com?year={}'.format(year),
         end=2040,
-    ))[0]
+    ))[-1]
 
 
 def test_org_breadcrumbs_do_not_show_if_service_has_no_org(


### PR DESCRIPTION
# Before 

![image](https://user-images.githubusercontent.com/355079/81316147-1c694d00-9083-11ea-96b0-27a24eaebb9a.png)

# After 

![image](https://user-images.githubusercontent.com/355079/81316069-05c2f600-9083-11ea-9294-90739b6302f8.png)

***

From a question on cross-government Slack:

> re the Usage tab - currently it shows 3 financial years - last year, this year and next year. is it possible to replace the "next year" tab with something more useful? its always going to be blank! I was thinking it would be good to have 2 financial years ago, 1 financial year ago and this financial year.

This seems like a reasonable idea, and is something we’ve talked about before. The original intention<sup>1</sup> was that seeing your (unchanged) free allowance for next year would be useful, but that doesn’t really seem to be a user need.

***

1. See https://github.com/alphagov/notifications-admin/pull/1094
   > so that you can check what your SMS allowance is going to be before you actually get into it