### PR TITLE
Don’t cache page count for one off letters

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -298,7 +298,6 @@ def get_sender_details(service_id, template_type):
 def send_test(service_id, template_id):
     session['recipient'] = None
     session['placeholders'] = {}
-    session['send_test_letter_page_count'] = None
 
     db_template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
     if db_template['template_type'] == 'letter':
@@ -351,8 +350,6 @@ def send_one_off_letter_address(service_id, template_id):
 
     db_template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
-    session['send_test_letter_page_count'] = get_page_count_for_letter(db_template)
-
     template = get_template(
         db_template,
         current_service,
@@ -363,7 +360,7 @@ def send_one_off_letter_address(service_id, template_id):
             template_id=template_id,
             filetype='png',
         ),
-        page_count=session['send_test_letter_page_count'],
+        page_count=get_page_count_for_letter(db_template),
         email_reply_to=None,
         sms_sender=None
     )
@@ -436,8 +433,6 @@ def send_test_step(service_id, template_id, step_index):
 
     db_template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
-    if not session.get('send_test_letter_page_count'):
-        session['send_test_letter_page_count'] = get_page_count_for_letter(db_template)
     email_reply_to = None
     sms_sender = None
     if db_template['template_type'] == 'email':
@@ -454,7 +449,7 @@ def send_test_step(service_id, template_id, step_index):
             template_id=template_id,
             filetype='png',
         ),
-        page_count=session['send_test_letter_page_count'],
+        page_count=get_page_count_for_letter(db_template),
         email_reply_to=email_reply_to,
         sms_sender=sms_sender
     )


### PR DESCRIPTION
Why we did this originally<sup>1</sup>:

> Calculating the number of pages in a letter is quite slow. And the send yourself a test pages need to load _fast_. Since filling in placeholders is very unlikely to change the number of pages in the resultant letter, it’s pretty safe to cache that count, and makes the subsequent pages load a lot faster.

However things have changed since then:
- this journey is used for sending real letters, not just test ones
- we’re doing enough letters that even an unlikely discrepancy will (and does) happen
- we cache the generation of the PDF now<sup>2</sup>, so at least it’s not generating the PDF twice, once for the preview and once for the page count
- it’s no longer necessary to step through each address placeholder to populate a one-off letter<sup>3</sup>, so a little bit slower isn’t so bad

1. https://github.com/alphagov/notifications-admin/pull/1277/commits/e7896f283a0d34d433d032987ec90ef430dd0ba9
2. https://github.com/alphagov/notifications-template-preview/blob/c9c6271aa09fc6b2d271604d66939f72e76250ad/app/preview.py#L140
3. https://github.com/alphagov/notifications-admin/pull/3368