### PR TITLE
Catch error when organisation domain already in use

### DIFF
--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -991,6 +991,38 @@ def test_update_organisation_domains(
     )
 
 
+def test_update_organisation_domains_when_domain_already_exists(
+    mocker,
+    client_request,
+    fake_uuid,
+    organisation_one,
+    mock_get_organisation,
+):
+    user = create_platform_admin_user()
+    client_request.login(user)
+
+    mocker.patch('app.organisations_client.update_organisation', side_effect=HTTPError(
+        response=Mock(
+            status_code=400,
+            json={'result': 'error', 'message': 'Domain already exists'}
+        ),
+        message="Domain already exists")
+    )
+
+    response = client_request.post(
+        'main.edit_organisation_domains',
+        org_id=ORGANISATION_ID,
+        _data={
+            'domains': [
+                'example.gov.uk',
+            ]
+        },
+        _expected_status=200,
+    )
+
+    assert response.find("div", class_="banner-dangerous").text.strip() == "This domain is already in use"
+
+
 def test_update_organisation_name(
     platform_admin_client,
     organisation_one,


### PR DESCRIPTION
Up till now, when adding new organisation domain, if it was already
in use, we didn't handle the 400 we got back from API. This PR
adds handling for that error.

![Screenshot 2020-05-15 at 17 52 46](https://user-images.githubusercontent.com/20957548/82075924-ed7f5680-96d4-11ea-994b-69cfa4ee80b5.png)