### PR TITLE
Catch errors when user register from invite

### DIFF
--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -93,5 +93,5 @@ def _add_invited_user_to_service(invited_user):
     invitation = InvitedUser(invited_user)
     user = User.from_id(session['user_id'])
     service_id = invited_user['service']
-    user_api_client.add_user_to_service(service_id, user.id, invitation.permissions, invitation.folder_permissions)
+    user.add_to_service(service_id, invitation.permissions, invitation.folder_permissions)
     return service_id

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -407,12 +407,18 @@ class User(JSONModel, UserMixin):
         session['current_session_id'] = self.current_session_id
 
     def add_to_service(self, service_id, permissions, folder_permissions):
-        user_api_client.add_user_to_service(
-            service_id,
-            self.id,
-            permissions,
-            folder_permissions,
-        )
+        try:
+            user_api_client.add_user_to_service(
+                service_id,
+                self.id,
+                permissions,
+                folder_permissions,
+            )
+        except HTTPError as exception:
+            if exception.status_code == 400 and 'already part of service' in exception.message:
+                pass
+            else:
+                raise exception
 
     def add_to_organisation(self, organisation_id):
         user_api_client.add_user_to_organisation(


### PR DESCRIPTION
API gives an error if it tries to add a user to a service and that user is
already a member of the service. This situation shouldn't occur - admin checks
if an invited user is a member of a service before calling API, but we
have seen this error occurring when there are two requests processing at
the same time.

This change catches the errors from API if a user is already a member of
a service and redirects the user to the service dashboard so that they
don't see an error page.

https://www.pivotaltracker.com/story/show/172622185