### PR TITLE
Log ID when creating Zendesk ticket

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytz
-from flask import redirect, render_template, request, session, url_for
+from flask import current_app, redirect, render_template, request, session, url_for
 from flask_login import current_user
 from govuk_bank_holidays.bank_holidays import BankHolidays
 
@@ -119,13 +119,16 @@ def feedback(ticket_type):
             service_string,
         )
 
-        zendesk_client.create_ticket(
+        ticket = zendesk_client.create_ticket(
             subject='Notify feedback',
             message=feedback_msg,
             ticket_type=ticket_type,
             p1=out_of_hours_emergency,
             user_email=user_email,
             user_name=user_name
+        )
+        current_app.logger.info(
+            f'Created Zendesk ticket {ticket["id"]}'
         )
         return redirect(url_for(
             '.thanks',

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -137,7 +137,11 @@ def test_get_feedback_page(client, ticket_type, expected_status_code):
 @freeze_time('2016-12-12 12:00:00.000000')
 @pytest.mark.parametrize('ticket_type', [PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE])
 def test_passed_non_logged_in_user_details_through_flow(client, mocker, ticket_type):
-    mock_post = mocker.patch('app.main.views.feedback.zendesk_client.create_ticket')
+    mock_post = mocker.patch(
+        'app.main.views.feedback.zendesk_client.create_ticket',
+        return_value={'id': 12345},
+    )
+    mock_logger = mocker.patch('app.current_app.logger.info')
 
     data = {'feedback': 'blah', 'name': 'Steve Irwin', 'email_address': 'rip@gmail.com'}
 
@@ -161,6 +165,7 @@ def test_passed_non_logged_in_user_details_through_flow(client, mocker, ticket_t
         ticket_type=ticket_type,
         p1=ANY
     )
+    mock_logger.assert_called_once_with('Created Zendesk ticket 12345')
 
 
 @freeze_time("2016-12-12 12:00:00.000000")


### PR DESCRIPTION
Members of the public are still getting through to our support channel, and we don’t really understand where they’re coming from. We don’t have a way of tying their support ticket to anything in our logs.

By logging the ID of the ticket when we created it we should be able to work back to the request they made to create the ticket.

From there, we should be able to look at what other requests they made, to understand the journey they took to get to our support channel.

***

Depends on:

- [ ] https://github.com/alphagov/notifications-utils/pull/736