### PR TITLE
Bump utils to 39.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,5 +23,5 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@39.1.0#egg=notifications-utils==39.1.0
+git+https://github.com/alphagov/notifications-utils.git@39.2.0#egg=notifications-utils==39.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,14 +25,14 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@39.1.0#egg=notifications-utils==39.1.0
+git+https://github.com/alphagov/notifications-utils.git@39.2.0#egg=notifications-utils==39.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.60
+awscli==1.18.61
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.16.10
+botocore==1.16.11
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2


### PR DESCRIPTION
This will start logging Zendesk ticket IDs when people use the support pages:

![image](https://user-images.githubusercontent.com/355079/82205750-f0f62600-98fe-11ea-81c6-86a3a2ef5ff4.png)
