### PR TITLE
Don’t deep link to our support form

### DIFF
--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -35,7 +35,7 @@
     <!--<li>you can track when the recipient downloads your document</li>-->
     <li>email attachments are often marked as spam</li>
   </ul>
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> if you want to send files by email.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
   <p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h3 class="heading heading-small" id="reply-to">Add a reply-to address</h3>

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -24,7 +24,7 @@
   <h3 class="heading heading-small" id="receive">Receive text messages</h3>
   <p>Let people send messages to your service or reply to your texts.</p>
   <p>You can see and reply to the messages you receive when you sign in to Notify. If you’re using our API, you can set up your own automated processes to manage replies.</p>
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}">Contact us</a> to request a unique number for text message replies.</p>
+  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> to request a unique number for text message replies.</p>
 
   <h3 class="heading heading-small" id="sender">Show people who your texts are from</h3>
   <p>When you send a text message with Notify, the sender name tells people who it's from.</p>

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -11,24 +11,24 @@
 
   <p>The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
   <p>Notify is in public beta. This means it’s fully operational and supported, but we’re still adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
-  <p>You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
+  <p>You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
   <h2 class="heading-medium">January to March 2020</h2>
-  
+
   <ul class="list list-bullet">
     <li>Let services send letters to international addresses</li>
     <li>Automate the removal of inactive users and API keys</li>
   </ul>
 
   <h2 class="heading-medium">April to June 2020</h2>
-  
+
   <ul class="list list-bullet">
     <li>Use two-factor authentication to protect files sent by email</li>
     <li>Let services attach forms to letter templates</li>
   </ul>
 
   <h2 class="heading-medium">July to September 2020</h2>
-  
+
   <ul class="list list-bullet">
     <li>Add large print letter templates</li>
     <li>Add multilingual letter templates so services can provide information in several languages</li>
@@ -39,7 +39,7 @@
   <h2 class="heading-medium">October 2020 onwards</h2>
 
   <ul class="list list-bullet">
-    
+
     <li>Start sending emails from NHS and Parliament email addresses</li>
     <li>Add a link shortening service</li>
     <li>Specify an expiry period for undeliverable text messages</li>

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -39,7 +39,7 @@
   </ul>
 
   <h2 class="heading-medium">Leaving Notify</h2>
-  <p>You can leave Notify at any time. Just <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.feedback', ticket_type='ask-question-give-feedback')}}">contact us</a> and we’ll close your account.</p>
+  <p>You can leave Notify at any time. Just <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> and we’ll close your account.</p>
   <p>When you leave Notify, all your data will be deleted.</p>
 
 {% endblock %}


### PR DESCRIPTION
By deep linking to the support form we skip the question that asks if someone is a member of the public.

This seems like a helpful thing when we’re directing people to where they can ask for document download to be switched on. But what I think is happening (backed up from one example I can see in Kibana) is:

1. Someone searches for something like ‘email GOV.UK’
2. They land on https://www.notifications.service.gov.uk/features/email
3. They scan the page and think, hmm not sure what this is, I’m not seeing what I’m looking for here…
4. …but aha, there’s a link that says ‘contact us’
5. They click it and land on https://www.notifications.service.gov.uk/support/ask-question-give-feedback which has a nice big box to type in

This commit removes these deep links from non-logged-in pages, so that everyone has to go through the ‘are you a member of the public’ question before they get to the big typey box.

This should reduce the number of tickets we get from members of the public.