### PR TITLE
Stop posting file_id when sending an uploaded letter

### DIFF
--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -55,9 +55,9 @@
         <form method="post" enctype="multipart/form-data" action="{{url_for(
             'main.send_uploaded_letter',
             service_id=current_service.id,
+            file_id=file_id,
           )}}" class='page-footer'>
             {{ radios(form.postage, hide_legend=true, inline=True) }}
-            {{ form.file_id(value=file_id) }}
             {{ page_footer("Send 1 letter") }}
         </form>
       {% endif %}

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -371,7 +371,7 @@ def test_post_upload_letter_redirects_for_valid_file(
     assert page.find('h1').text == 'tests/test_pdf_files/one_page_pdf.pdf'
     assert not page.find(id='validation-error-message')
 
-    assert page.find('input', {'type': 'hidden', 'name': 'file_id', 'value': fake_uuid})
+    assert not page.find('input', {'name': 'file_id'})
     assert normalize_spaces(page.select('main button[type=submit]')[0].text) == 'Send 1 letter'
 
 


### PR DESCRIPTION
The endpoint works fine with it in the URL now instead, so we need stop posting it. We can’t stop expecting it yet, because some old instances will still be posting to the endpoint without the ID in the url.

***

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3453