### PR TITLE
Don’t show postage choice for international letters

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -859,9 +859,6 @@ class LetterUploadPostageForm(StripWhitespaceForm):
         default='second',
         validators=[DataRequired()]
     )
-    file_id = HiddenField(
-        validators=[DataRequired()]
-    )
 
 
 class ForgotPasswordForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -9,6 +9,7 @@ from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed
 from flask_wtf.file import FileField as FileField_wtf
 from notifications_utils.columns import Columns
+from notifications_utils.countries.data import Postage
 from notifications_utils.formatters import strip_whitespace
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import (
@@ -850,6 +851,19 @@ class LetterTemplatePostageForm(StripWhitespaceForm):
 
 
 class LetterUploadPostageForm(StripWhitespaceForm):
+
+    def __init__(self, *args, postage_zone, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        if postage_zone != Postage.UK:
+            self.postage.choices = [(postage_zone, '')]
+            self.postage.data = postage_zone
+
+    @property
+    def show_postage(self):
+        return len(self.postage.choices) > 1
+
     postage = RadioField(
         'Choose the postage for this letter',
         choices=[

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -299,8 +299,7 @@ def uploaded_letter_preview(service_id, file_id):
         message=error_message,
         error_code=error_shortcode,
         form=form,
-        recipient=postal_address.as_single_line,
-        international=postal_address.international,
+        postal_address=postal_address,
         re_upload_form=re_upload_form
     )
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -326,7 +326,7 @@ def view_letter_upload_as_preview(service_id, file_id):
 
 @main.route("/services/<uuid:service_id>/upload-letter/send/<uuid:file_id>", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
-def send_uploaded_letter(service_id, file_id=None):
+def send_uploaded_letter(service_id, file_id):
     if not (current_service.has_permission('letter') and current_service.has_permission('upload_letters')):
         abort(403)
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -252,23 +252,6 @@ def _get_error_from_upload_form(form_errors):
     return error
 
 
-def format_recipient(address):
-    '''
-    To format the recipient we need to:
-        - remove new line characters
-        - remove whitespace around the lines
-        - join the address lines, separated by a comma
-    '''
-    if not address:
-        return address
-    stripped_address_lines_no_trailing_commas = [
-        line.lstrip().rstrip(' ,')
-        for line in address.splitlines() if line
-    ]
-    one_line_address = ', '.join(stripped_address_lines_no_trailing_commas)
-    return one_line_address
-
-
 @main.route("/services/<uuid:service_id>/preview-letter/<uuid:file_id>")
 @user_has_permissions('send_messages')
 def uploaded_letter_preview(service_id, file_id):
@@ -316,7 +299,7 @@ def uploaded_letter_preview(service_id, file_id):
         message=error_message,
         error_code=error_shortcode,
         form=form,
-        recipient=format_recipient(postal_address.raw_address),
+        recipient=postal_address.as_single_line,
         international=postal_address.international,
         re_upload_form=re_upload_form
     )

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -338,15 +338,13 @@ def view_letter_upload_as_preview(service_id, file_id):
         return TemplatePreview.from_valid_pdf_file(pdf_file, page)
 
 
-@main.route("/services/<uuid:service_id>/upload-letter/send", methods=['POST'])
 @main.route("/services/<uuid:service_id>/upload-letter/send/<uuid:file_id>", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_uploaded_letter(service_id, file_id=None):
     if not (current_service.has_permission('letter') and current_service.has_permission('upload_letters')):
         abort(403)
 
-    form = LetterUploadPostageForm(file_id=file_id)
-    file_id = file_id or form.file_id.data
+    form = LetterUploadPostageForm()
 
     if not form.validate_on_submit():
         return uploaded_letter_preview(service_id, file_id)

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -48,11 +48,11 @@
     {% if status == 'valid' %}
     <div class="js-stick-at-bottom-when-scrolling">
       <p class="top-gutter-0 bottom-gutter-1-2 send-recipient" title="{{ recipient }}">
-        Recipient: {{ recipient }}
+        Recipient: {{ postal_address.as_single_line }}
       </p>
 
       {% if current_service.live %}
-        {% if international %}
+        {% if postal_address.international %}
           <p class="govuk-body">
             Postage: international
           </p>

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -52,12 +52,19 @@
       </p>
 
       {% if current_service.live %}
+        {% if international %}
+          <p class="govuk-body">
+            Postage: international
+          </p>
+        {% endif %}
         <form method="post" enctype="multipart/form-data" action="{{url_for(
             'main.send_uploaded_letter',
             service_id=current_service.id,
             file_id=file_id,
           )}}" class='page-footer'>
-            {{ radios(form.postage, hide_legend=true, inline=True) }}
+            {% if form.show_postage %}
+              {{ radios(form.postage, hide_legend=true, inline=True) }}
+            {% endif %}
             {{ page_footer("Send 1 letter") }}
         </form>
       {% endif %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,5 +23,5 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@39.2.0#egg=notifications-utils==39.2.0
+git+https://github.com/alphagov/notifications-utils.git@39.3.0#egg=notifications-utils==39.3.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,14 +25,14 @@ notifications-python-client==5.5.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@39.2.0#egg=notifications-utils==39.2.0
+git+https://github.com/alphagov/notifications-utils.git@39.3.0#egg=notifications-utils==39.3.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.61
+awscli==1.18.63
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.16.11
+botocore==1.16.13
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
@@ -49,7 +49,7 @@ jdcal==1.4.1
 Jinja2==2.11.2
 jmespath==0.10.0
 lml==0.0.9
-lxml==4.5.0
+lxml==4.5.1
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5

--- a/tests/app/main/views/test_uploads.py
+++ b/tests/app/main/views/test_uploads.py
@@ -8,7 +8,6 @@ from flask import make_response, url_for
 from freezegun import freeze_time
 from requests import RequestException
 
-from app.main.views.uploads import format_recipient
 from app.s3_client.s3_letter_upload_client import LetterMetadata
 from app.utils import normalize_spaces
 from tests.conftest import (
@@ -945,18 +944,6 @@ def test_send_uploaded_letter_when_metadata_states_pdf_is_invalid(
         _expected_status=403
     )
     assert not mock_send.called
-
-
-@pytest.mark.parametrize('original_address,expected_address', [
-    ('The Queen, Buckingham Palace, SW1 1AA', 'The Queen, Buckingham Palace, SW1 1AA'),
-    ('The Queen Buckingham Palace SW1 1AA', 'The Queen Buckingham Palace SW1 1AA'),
-    ('The Queen,\nBuckingham Palace,\r\nSW1 1AA', 'The Queen, Buckingham Palace, SW1 1AA'),
-    ('The Queen   ,,\nBuckingham Palace,\rSW1 1AA,', 'The Queen, Buckingham Palace, SW1 1AA'),
-    ('  The Queen\n Buckingham Palace\n SW1 1AA', 'The Queen, Buckingham Palace, SW1 1AA'),
-    ('', ''),
-])
-def test_format_recipient(original_address, expected_address):
-    assert format_recipient(original_address) == expected_address
 
 
 @pytest.mark.parametrize('user', (


### PR DESCRIPTION
All instances of the app will be posting to the URL with the `file_id` parameter now, so we can remove the old route without the ID now.

This means we can start getting the PDF metadata before building the form. Which means that we hide or show the postage options on the form based on whether or not the address is international.

![image](https://user-images.githubusercontent.com/355079/82542573-26428400-9b4a-11ea-8161-d4910c310a04.png)

***

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3454