### PR TITLE
Handle session expiring during service name change

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -112,6 +112,10 @@ def service_name_change(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_name_change_confirm(service_id):
+    if 'service_name_change' not in session:
+        flash("Session expired. Try again", 'error')
+        return redirect(url_for('main.service_name_change', service_id=service_id))
+
     # Validate password for form
     def _check_password(pwd):
         return user_api_client.verify_password(current_user.id, pwd)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -113,7 +113,7 @@ def service_name_change(service_id):
 @user_has_permissions('manage_service')
 def service_name_change_confirm(service_id):
     if 'service_name_change' not in session:
-        flash("Session expired. Try again", 'error')
+        flash("The change you made was not saved. Please try again.", 'error')
         return redirect(url_for('main.service_name_change', service_id=service_id))
 
     # Validate password for form

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -537,7 +537,8 @@ def validate_route_permission(mocker,
                               route,
                               permissions,
                               usr,
-                              service):
+                              service,
+                              session=None):
     usr['permissions'][str(service['id'])] = permissions
     usr['services'] = [service['id']]
     mocker.patch(
@@ -556,6 +557,10 @@ def validate_route_permission(mocker,
     with app_.test_request_context():
         with app_.test_client() as client:
             client.login(usr)
+            if session:
+                with client.session_transaction() as session_:
+                    for k, v in session.items():
+                        session_[k] = v
             resp = None
             if method == 'GET':
                 resp = client.get(route)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -717,7 +717,7 @@ def test_service_name_change_confirm_handles_expired_session(
     mock_verify_password.assert_not_called()
     mock_update_service.assert_not_called()
 
-    assert page.find('div', 'banner-dangerous').text.strip() == "Session expired. Try again"
+    assert page.find('div', 'banner-dangerous').text.strip() == "The change you made was not saved. Please try again."
 
 
 @pytest.mark.parametrize('volumes, consent_to_research, expected_estimated_volumes_item', [


### PR DESCRIPTION
We saw some errors earlier where session expired midway through service name change. This PR handles such edge cases.

Here is the fresh redirect with flash error message:
<img width="1007" alt="Screenshot 2020-05-22 at 15 34 21" src="https://user-images.githubusercontent.com/20957548/82679595-09d64280-9c43-11ea-9a8f-04c6aa9abb0b.png">
