### PR TITLE
Use redis_client rather than wrapper method

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
 
@@ -132,7 +133,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     @cache.delete('service-{service_id}-templates')
     def archive_service(self, service_id, cached_service_user_ids):
         if cached_service_user_ids:
-            cache.delete(*map('user-{}'.format, cached_service_user_ids))
+            redis_client.delete(*map('user-{}'.format, cached_service_user_ids))
         return self.post('/service/{}/archive'.format(service_id), data=None)
 
     @cache.delete('service-{service_id}')

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3811,7 +3811,7 @@ def test_archive_service_after_confirm(
     user,
 ):
     mocked_fn = mocker.patch('app.service_api_client.post')
-    cache_delete_mock = mocker.patch('app.notify_client.service_api_client.cache.delete')
+    redis_delete_mock = mocker.patch('app.notify_client.service_api_client.redis_client.delete')
     client_request.login(user)
     page = client_request.post(
         'main.archive_service',
@@ -3825,7 +3825,7 @@ def test_archive_service_after_confirm(
         '‘service one’ was deleted'
     )
     # The one user which is part of this service has the sample_uuid as it's user ID
-    cache_delete_mock.assert_called_once_with(f"user-{sample_uuid()}")
+    assert call(f"user-{sample_uuid()}") in redis_delete_mock.call_args_list
 
 
 @pytest.mark.parametrize('user', (

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -482,9 +482,9 @@ def test_deletes_caches_when_modifying_templates(
 
 
 def test_deletes_cached_users_when_archiving_service(mocker):
-    mock_redis_delete = mocker.patch('app.notify_client.service_api_client.cache.delete')
+    mock_redis_delete = mocker.patch('app.notify_client.service_api_client.redis_client.delete')
     mocker.patch('notifications_python_client.base.BaseAPIClient.request')
 
     service_api_client.archive_service(SERVICE_ONE_ID, ["my-user-id1", "my-user-id2"])
 
-    assert mock_redis_delete.call_args_list == [call('user-my-user-id1', 'user-my-user-id2')]
+    assert call('user-my-user-id1', 'user-my-user-id2') in mock_redis_delete.call_args_list


### PR DESCRIPTION
Fixes a bug where we were calling a wrapper method when instead we
should have been calling the redis_client. This had resulted in no
actual calls to redis happening.