### PR TITLE
Don’t allow paragraphs without class attribute

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -93,7 +93,7 @@ def create_api_key(service_id):
         disabled_options = [KEY_TYPE_NORMAL]
         option_hints[KEY_TYPE_NORMAL] = Markup(
             'Not available because your service is in '
-            '<a href="/features/trial-mode">trial mode</a>'
+            '<a class="govuk-link govuk-link--no-visited-state" href="/features/trial-mode">trial mode</a>'
         )
     if current_service.has_permission('letter'):
         option_hints[KEY_TYPE_TEAM] = 'Cannot be used to send letters'

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -22,7 +22,8 @@ def accept_invite(token):
         message = Markup("""
             You’re signed in as {}.
             This invite is for another email address.
-            <a href={}>Sign out</a> and click the link again to accept this invite.
+            <a href={} class="govuk-link govuk-link--no-visited-state">Sign out</a>
+            and click the link again to accept this invite.
             """.format(
             current_user.email_address,
             url_for("main.sign_out", _external=True)))
@@ -78,7 +79,8 @@ def accept_org_invite(token):
         message = Markup("""
             You’re signed in as {}.
             This invite is for another email address.
-            <a href={}>Sign out</a> and click the link again to accept this invite.
+            <a class="govuk-link govuk-link--no-visited-state" href={}>Sign out</a>
+            and click the link again to accept this invite.
             """.format(
             current_user.email_address,
             url_for("main.sign_out", _external=True)))

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -17,7 +17,7 @@
     {%- endif -%}
     {{ body }}
     {% if context %}
-    <p>
+    <p class="govuk-body">
       {{ context }}
     </p>
     {% endif %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -4,6 +4,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
     <h1>You’re not authorised to see this page</h1>
-      <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
+      <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
   </div>
 {% endblock %}

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -6,7 +6,7 @@
         <h1 class="heading-large">
           You’re not allowed to see this page
         </h1>
-        <p>
+        <p class="govuk-body">
           To check your permissions, speak to a member of your team who can manage settings, team and usage.
         </p>
       </div>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -6,13 +6,13 @@
         <h1 class="heading-large">
           Page not found
         </h1>
-        <p>
+        <p class="govuk-body">
           If you typed the web address, check it is correct.
         </p>
-        <p>
+        <p class="govuk-body">
           If you pasted the web address, check you copied the entire address.
         </p>
-        <p>
+        <p class="govuk-body">
           If the web address is correct or you selected a link or button, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
         </p>
       </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -6,13 +6,13 @@
         <h1 class="heading-large">
           Page not found
         </h1>
-        <p>
+        <p class="govuk-body">
           If you typed the web address, check it is correct.
         </p>
-        <p>
+        <p class="govuk-body">
           If you pasted the web address, check you copied the entire address.
         </p>
-        <p>
+        <p class="govuk-body">
           If the web address is correct or you selected a link or button, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
         </p>
       </div>

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -8,10 +8,10 @@
         </h1>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <p>
+            <p class="govuk-body">
               Files must be smaller than 5 MB.
             </p>
-            <p>
+            <p class="govuk-body">
               <a class="govuk-link govuk-link--no-visited-state" href="javascript: history.go(-1)">Go back and try again.</a>
             </p>
           </div>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -6,13 +6,13 @@
       <h1 class="heading-large">
         Sorry, there’s a problem with GOV.UK Notify
       </h1>
-      <p>
+      <p class="govuk-body">
         Try again later.
       </p>
-      <p>
+      <p class="govuk-body">
         You can check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
       </p>
-      <p>
+      <p class="govuk-body">
         To report a problem, email <a class="govuk-link govuk-link--no-visited-state" href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
       </p>
     </div>

--- a/app/templates/partials/check/letter-too-long.html
+++ b/app/templates/partials/check/letter-too-long.html
@@ -1,7 +1,7 @@
 <h1 h1 class="banner-title" data-module="track-error" data-error-type="letter-too-long" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
   Your letter is too long
 </h1>
-<p>
+<p class="govuk-body">
   Letters must be {{ letter_max_pages }} pages or less ({{ letter_max_pages // 2 }} double-sided sheets of paper).
   <br>
   Your letter is {{ page_count }} pages long.

--- a/app/templates/partials/check/letter-validation-failed-banner.html
+++ b/app/templates/partials/check/letter-validation-failed-banner.html
@@ -10,7 +10,7 @@
       {{ message.title }}
     </h1>
     {% if message.detail %}
-      <p>
+      <p class="govuk-body">
         {{ message.detail | safe }}
       </p>
     {% endif %}

--- a/app/templates/partials/check/message-too-long.html
+++ b/app/templates/partials/check/message-too-long.html
@@ -1,7 +1,7 @@
 <h1 class='banner-title'>
   Message too long
 </h1>
-<p>
+<p class="govuk-body">
   Text messages cannot be longer than {{ SMS_CHAR_COUNT_LIMIT }} characters.
   Your message is {{ template.content_count }} characters.
 </p>

--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -6,7 +6,7 @@
     {{ 'es' if 'email address' == template_type_label else 's' }}
   {%- endif %}
 </h1>
-<p>
+<p class="govuk-body">
   In <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new') }}">trial mode</a> you can only
   send to yourself and members of your team
 </p>

--- a/app/templates/partials/check/sent-previously.html
+++ b/app/templates/partials/check/sent-previously.html
@@ -1,6 +1,6 @@
 <h1 class='banner-title' data-module="track-error" data-error-type="File previously sent" data-error-label="{{ upload_id }}">
   These messages have already been sent today
 </h1>
-<p>
+<p class="govuk-body">
   If you need to resend them, rename the file and upload it again.
 </p>

--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -5,7 +5,7 @@
     Daily limit reached
   {% endif %}
 </h1>
-<p>
+<p class="govuk-body">
   You can only send {{ current_service.message_limit }} messages per day
   {%- if current_service.trial_mode %}
     in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new')}}">trial mode</a>
@@ -13,7 +13,7 @@
   .
 </p>
 {% if original_file_name %}
-  <p>
+  <p class="govuk-body">
     {% if current_service.message_limit != remaining_messages %}
       You can still send {{ remaining_messages }} messages today, but
     {% endif %}

--- a/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
+++ b/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
@@ -2,7 +2,7 @@
   You cannot send
   {{ 'this letter' if count_of_recipients == 1 else 'these letters' }}
 </h1>
-<p>
+<p class="govuk-body">
   In <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new') }}">trial mode</a> you
   can only preview how your letters will look
 </p>

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -5,7 +5,7 @@
 <div class="ajax-block-container" aria-labelledby='pill-selected-item'>
   {% if job.scheduled %}
 
-    <p>
+    <p class="govuk-body">
       Sending
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_template_version', service_id=current_service.id, template_id=job.template.id, version=job.template_version) }}">{{ job.template.name }}</a>
       {{ job.scheduled_for|format_datetime_relative }}

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -4,7 +4,7 @@
       {% if job.processing_started %}
         Sent by {{ job.created_by.name }} on {{ job.processing_started|format_datetime_short }}
         {% if job.template.template_type == "letter" %}
-          <p id="printing-info">
+          <p class="govuk-body" id="printing-info">
             {{ letter_print_day }}
           </p>
         {% endif %}
@@ -14,7 +14,7 @@
     {% else %}
       Sent by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
       {% if job.template.template_type == "letter" %}
-        <p id="printing-info">
+        <p class="govuk-body" id="printing-info">
           {{ letter_print_day }}
         </p>
       {% endif %}

--- a/app/templates/partials/notifications/notifications.html
+++ b/app/templates/partials/notifications/notifications.html
@@ -16,7 +16,7 @@
     field_headings_visible=False
   ) %}
     {% call row_heading() %}
-      <p>{{ item.to }}</p>
+      <p class="govuk-body">{{ item.to }}</p>
     {% endcall %}
     {{ notification_status_field(item) }}
   {% endcall %}

--- a/app/templates/partials/templates/guidance-character-count.html
+++ b/app/templates/partials/templates/guidance-character-count.html
@@ -1,8 +1,8 @@
 <h2 class="heading-medium">Message length</h2>
-<p>
+<p class="govuk-body">
   If your message is long then it will
   cost more.
 </p>
-<p>
+<p class="govuk-body">
   See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a> for details.
 </p>

--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -1,27 +1,27 @@
 <h2 class="heading-medium">Formatting</h2>
-<p>
+<p class="govuk-body">
   To put a heading in your template, use a hash:
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     # This is a heading
   </p>
 </div>
-<p>
+<p class="govuk-body">
   To make bullet points, use asterisks:
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     * point 1<br/>
     * point 2<br/>
     * point 3<br/>
   </p>
 </div>
-<p>
+<p class="govuk-body">
   To insert a page break, use three asterisks:
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     Content on page 1<br/>
     <br/>
     ***<br/>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -3,7 +3,7 @@
   To put a title in your template, use a hash:
 </p>
 <div class="panel panel-border-wide bottom-gutter">
-  <p>
+  <p class="govuk-body">
     # This is a title
   </p>
 </div>
@@ -11,7 +11,7 @@
   To make bullet points, use asterisks:
 </p>
 <div class="panel panel-border-wide bottom-gutter">
-  <p>
+  <p class="govuk-body">
     * point 1<br/>
     * point 2<br/>
     * point 3<br/>
@@ -21,7 +21,7 @@
   To add inset text, use a caret:
 </p>
 <div class="panel panel-border-wide bottom-gutter">
-  <p>
+  <p class="govuk-body">
     ^ You must tell us if your circumstances change
   </p>
 </div>
@@ -29,13 +29,13 @@
   To add a horizontal line, use three dashes:
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     First paragraph
   </p>
   <p style="letter-spacing: 1px;">
     ---
   </p>
-  <p>
+  <p class="govuk-body">
     Second paragraph
   </p>
 </div>

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -3,7 +3,7 @@
   Always use full URLs, starting with https://
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     Apply now at https://www.gov.uk/example
   </p>
 </div>

--- a/app/templates/partials/templates/guidance-optional-content.html
+++ b/app/templates/partials/templates/guidance-optional-content.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">
   Optional content
 </h2>
-<p>
+<p class="govuk-body">
   Use double brackets and ‘??’ to define optional content.
 </p>
 <p class="bottom-gutter-1-3">
@@ -9,12 +9,12 @@
   18:
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     ((under18??Please get your application signed by a parent or
     guardian.))
   </p>
 </div>
-<p>
+<p class="govuk-body">
   For each person you send this message to, specify ‘yes’ or ‘no’ to
   show or hide this content.
 </p>

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -5,7 +5,7 @@
   Use double brackets to personalise your message:
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     Hello ((first name)), your reference is ((ref number))
   </p>
 </div>

--- a/app/templates/partials/templates/guidance-postage.html
+++ b/app/templates/partials/templates/guidance-postage.html
@@ -1,15 +1,15 @@
 <h2 class="heading-medium">
   Delivery times
 </h2>
-<p>
+<p class="govuk-body">
   Letters sent before 5:30pm are dispatched the next working day (Monday to Friday).
 </p>
-<p>
+<p class="govuk-body">
   First class letters are delivered one day after they're dispatched. Second class letters are delivered 2 days after they're dispatched.
 </p>
-<p>
+<p class="govuk-body">
   Royal Mail delivers from Monday to Saturday, excluding bank holidays.
 </p>
-<p>
+<p class="govuk-body">
   See a list of <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') + '#letters'}}">postage prices</a>.
 </p>

--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -1,11 +1,11 @@
 <h2 class="heading-medium">
   Send a document by email
 </h2>
-<p>
+<p class="govuk-body">
   Use double brackets to add a placeholder field to your template. This will contain a secure link to download the document.
 </p>
 <div class="panel panel-border-wide">
-  <p>
+  <p class="govuk-body">
     Download your document at: ((link_to_file))
   </p>
 </div>

--- a/app/templates/partials/tour.html
+++ b/app/templates/partials/tour.html
@@ -7,7 +7,7 @@
         <p class="heading-large" style="float: left;">1.</p>
       </div>
       <div class="govuk-grid-column-five-sixths">
-        <p>
+        <p class="govuk-body">
           Every message is sent from a template
         </p>
       </div>
@@ -17,7 +17,7 @@
         <p class="heading-large">2.</p>
       </div>
       <div class="govuk-grid-column-five-sixths">
-        <p>
+        <p class="govuk-body">
           The template pulls in the data you provide
         </p>
       </div>
@@ -27,7 +27,7 @@
         <p class="heading-large">3.</p>
       </div>
       <div class="govuk-grid-column-five-sixths">
-        <p>
+        <p class="govuk-body">
           Notify delivers the message
         </p>
         {% if help == '3' %}

--- a/app/templates/views/agreement/agreement-confirm.html
+++ b/app/templates/views/agreement/agreement-confirm.html
@@ -20,11 +20,11 @@
     {% call form_wrapper(class='top-gutter') %}
 
       {% if current_service.organisation.agreement_signed_on_behalf_of_name and current_service.organisation.agreement_signed_on_behalf_of_email_address %}
-        <p>
+        <p class="govuk-body">
           I confirm that I have the legal authority to accept the GOV.UK Notify data sharing and financial agreement (version {{ current_service.organisation.agreement_signed_version }}) on behalf of {{ current_service.organisation.agreement_signed_on_behalf_of_name }} ({{ current_service.organisation.agreement_signed_on_behalf_of_email_address }}) and that {{ current_service.organisation.name }} will be bound by it.
         </p>
       {% else %}
-        <p>
+        <p class="govuk-body">
           I confirm that I have the legal authority to accept the GOV.UK Notify data sharing and financial agreement (version {{ current_service.organisation.agreement_signed_version }}) and that {{ current_service.organisation.name }} will be bound by it.
         </p>
       {% endif %}

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -14,10 +14,10 @@
       Download the GOV.UK Notify data sharing and financial agreement
     </h1>
 
-    <p>
+    <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ download_link }}">Download the agreement</a>{% if owner %} for {{ owner }}{% endif %}.
     </p>
-    <p>
+    <p class="govuk-body">
       The agreement contains commercially sensitive information. Do not share it outside your organisation.
     </p>
 

--- a/app/templates/views/agreement/service-agreement-choose.html
+++ b/app/templates/views/agreement/service-agreement-choose.html
@@ -15,19 +15,19 @@
       back_link=url_for('main.request_to_go_live', service_id=current_service.id)
     )}}
 
-    <p>
+    <p class="govuk-body">
       Before you can use GOV.UK Notify, you need to accept our data sharing and financial agreement.
     </p>
-    <p>
+    <p class="govuk-body">
       This must be done by, or on behalf of, someone with the authority to sign contracts for your organisation.
     </p>
-    <p>
+    <p class="govuk-body">
       Once accepted, the agreement covers all Notify services from your organisation.
     </p>
-    <p>
+    <p class="govuk-body">
       There are different agreements for crown and non-crown organisations.
     </p>
-    <p>
+    <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact us</a> to tell us
       whether or not you work for a crown organisation. If you’re not sure
       we’ll help you work it out.

--- a/app/templates/views/agreement/service-agreement-signed.html
+++ b/app/templates/views/agreement/service-agreement-signed.html
@@ -15,13 +15,13 @@
       back_link=url_for('main.request_to_go_live', service_id=current_service.id)
     )}}
 
-    <p>
+    <p class="govuk-body">
       {{ current_service.organisation.name }} has already accepted the GOV.UK
       Notify data sharing and financial agreement.
     </p>
-    <p>For more information, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">download a copy of the agreement</a>.
+    <p class="govuk-body">For more information, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">download a copy of the agreement</a>.
     </p>
-    <p>
+    <p class="govuk-body">
       The agreement is confidential and should not be shared outside your organisation.
     </p>
 

--- a/app/templates/views/agreement/service-agreement.html
+++ b/app/templates/views/agreement/service-agreement.html
@@ -16,19 +16,19 @@
       back_link=url_for('main.request_to_go_live', service_id=current_service.id)
     )}}
 
-    <p>
+    <p class="govuk-body">
       Before you can use GOV.UK Notify, you need to accept our data sharing and financial agreement.
     </p>
-    <p>
+    <p class="govuk-body">
       This must be done by, or on behalf of, someone with the authority to sign contracts for {{ current_service.organisation.name }}.
     </p>
-    <p>
+    <p class="govuk-body">
       Once accepted, the agreement covers all Notify services from {{ current_service.organisation.name }}.
     </p>
-    <p>
+    <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">Download a copy of the data sharing and financial agreement</a>.
     </p>
-    <p>
+    <p class="govuk-body">
       The agreement is confidential and should not be shared outside your organisation.
     </p>
     {{ govukButton({

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -17,7 +17,7 @@
         back_link=url_for(back_link, service_id=current_service.id)
       ) }}
 
-      <p>
+      <p class="govuk-body">
         When you send an email or text message, we can tell you if Notify was able to deliver it.
         Read the Callbacks section of our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a> for more information.
       </p>

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -15,7 +15,7 @@
   ) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-      <p>
+      <p class="govuk-body">
         When you receive a text message in Notify, we can forward it to your system.
         Check the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.callbacks') }}"> callback documentation </a> for more information.
       </p>

--- a/app/templates/views/api/keys/show.html
+++ b/app/templates/views/api/keys/show.html
@@ -13,10 +13,10 @@
       New API key
     </h1>
 
-    <p>
+    <p class="govuk-body">
       Copy your key to somewhere safe.
     </p>
-    <p>
+    <p class="govuk-body">
       You will not be able to see it again once you leave this page.
     </p>
 

--- a/app/templates/views/api/whitelist.html
+++ b/app/templates/views/api/whitelist.html
@@ -18,7 +18,7 @@
       <h1 class='banner-title'>
         There was a problem with your whitelist
       </h1>
-      <p>Fix these errors:</p>
+      <p class="govuk-body">Fix these errors:</p>
       <ul>
         {% if form.email_addresses.errors %}
           <li>
@@ -39,7 +39,7 @@
     ) }}
   {% endif %}
 
-  <p>
+  <p class="govuk-body">
     You and members of
     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.manage_users', service_id=current_service.id) }}">your team</a>
     are included in the whitelist automatically.

--- a/app/templates/views/cancelled-invitation.html
+++ b/app/templates/views/cancelled-invitation.html
@@ -6,10 +6,10 @@
         <h1 class="heading-large">
           The invitation you were sent has been cancelled
         </h1>
-        <p>
+        <p class="govuk-body">
           {{ from_user }} decided to cancel this invitation.
         </p>
-        <p>
+        <p class="govuk-body">
           If you need access to {{ service_name or organisation_name }}, you’ll have to ask them to invite you again.
         </p>
       </div>

--- a/app/templates/views/change-email-continue.html
+++ b/app/templates/views/change-email-continue.html
@@ -7,7 +7,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Check your email​</h1>
-  <p>An email has been sent to {{ new_email }}.</p>
-  <p>Click the link in the email to confirm the change to your email address.</p>
+  <p class="govuk-body">An email has been sent to {{ new_email }}.</p>
+  <p class="govuk-body">Click the link in the email to confirm the change to your email address.</p>
 
 {% endblock %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -29,7 +29,7 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file has too many rows
         </h1>
-        <p>
+        <p class="govuk-body">
           Notify can process up to
           {{ "{:,}".format(recipients.max_rows) }} rows at once. Your
           file has {{ "{:,}".format(recipients|length) }} rows.
@@ -41,14 +41,14 @@
           Your file is missing some rows
         </h1>
         {% if recipients.missing_column_headers %}
-          <p>
+          <p class="govuk-body">
             It needs at least one row of data, and {{ recipients.missing_column_headers | sort() | formatted_list(
               prefix='a column called',
               prefix_plural='columns called'
             ) }}.
           </p>
         {% else %}
-          <p>
+          <p class="govuk-body">
             It needs at least one row of data.
           </p>
         {% endif %}
@@ -59,16 +59,16 @@
           There’s a problem with your column names
         </h1>
         {% if template.template_type == 'letter' %}
-          <p>
+          <p class="govuk-body">
             Your file needs at least 3 address columns, for example ‘address line 1’,
             ‘address line 2’ and ‘address line 3’.
           </p>
         {% else %}
-          <p>
+          <p class="govuk-body">
             Your file needs a column called ‘{{ first_recipient_column }}’.
           </p>
         {% endif %}
-          <p>
+          <p class="govuk-body">
             Right now it has {{ recipients.column_headers | formatted_list(
               prefix='one column, called ',
               prefix_plural='columns called '
@@ -80,7 +80,7 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Duplicate recipient columns" data-error-label="{{ upload_id }}">
           There’s a problem with your column names
         </h1>
-           <p>
+           <p class="govuk-body">
             We found more than one column called {{ (
             recipients.duplicate_recipient_column_headers
             ) | formatted_list(
@@ -89,7 +89,7 @@
               prefix_plural=''
             ) }}.
           </p>
-        <p>
+        <p class="govuk-body">
           Delete or rename one of these columns and try again.
         </p>
 
@@ -98,7 +98,7 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Missing placeholder columns" data-error-label="{{ upload_id }}">
           Your column names need to match the double brackets in your template
         </h1>
-          <p>
+          <p class="govuk-body">
             Your file is missing {{ recipients.missing_column_headers | formatted_list(
               conjunction='and',
               prefix='a column called ',

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -27,14 +27,14 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There’s a problem with {{ original_file_name }}
         </h1>
-        <p>
+        <p class="govuk-body">
           You need to {{ row_errors[0] }}.
         </p>
       {% else %}
         <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There are some problems with {{ original_file_name }}
         </h1>
-        <p>
+        <p class="govuk-body">
           You need to:
         </p>
         <ul class="list-bullet">

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -21,10 +21,10 @@
     <p class="summary">
         Cookies are small files saved on your phone, tablet or computer when you visit a website.
     </p>
-    <p>We use cookies to make GOV.UK Notify work and collect information about how you use our service.</p>
+    <p class="govuk-body">We use cookies to make GOV.UK Notify work and collect information about how you use our service.</p>
 
     <h2 class="heading-medium">Essential cookies</h2>
-    <p>
+    <p class="govuk-body">
       Essential cookies keep your information secure while you use Notify. We do not need to ask permission to use them.
     </p>
     <table>
@@ -63,13 +63,13 @@
     </table>
 
     <h2 class="heading-medium">Analytics cookies (optional)</h2>
-    <p>
+    <p class="govuk-body">
       With your permission, we use Google Analytics to collect data about how you use Notify. This information helps us to improve our service.
     </p>
-    <p>
+    <p class="govuk-body">
       Google is not allowed to use or share our analytics data with anyone.
     </p>
-    <p>
+    <p class="govuk-body">
       Google Analytics stores anonymised information about:
     </p>
     <ul class="govuk-list govuk-list--bullet">
@@ -113,7 +113,7 @@
     </table>
     <div class="cookie-settings__no-js">
       <h2 class="govuk-heading-s govuk-!-margin-top-6">Do you want to accept analytics cookies?</h2>
-      <p>We use Javascript to set our analytics cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
+      <p class="govuk-body">We use Javascript to set our analytics cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>reloading the page</li>
         <li>turning on Javascript in your browser</li>

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -7,9 +7,9 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Documentation</h1>
-    <p>This documentation is for developers who want to integrate the GOV.UK Notify API with a web application or back office system.</p>
+    <p class="govuk-body">This documentation is for developers who want to integrate the GOV.UK Notify API with a web application or back office system.</p>
   <h2 class="heading-medium">Client libraries</h2>
-    <p>Links to documentation open in a new tab.</p>
+    <p class="govuk-body">Links to documentation open in a new tab.</p>
   <ul class="list list-bullet">
     {% for key, label in [
       ('java', 'Java'),
@@ -22,9 +22,9 @@
       <li><a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/{{ key }}.html" target="_blank" rel="noopener">{{ label }}</a></li>
     {% endfor %}
   </ul>
-    <p>A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
+    <p class="govuk-body">A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
   <h2 class="heading-medium">Integrate directly with the API</h2>
-    <p>If you cannot use the client libraries, you can integrate directly with the API instead.</p>
-<p>Read the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/rest-api.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
+    <p class="govuk-body">If you cannot use the client libraries, you can integrate directly with the API instead.</p>
+<p class="govuk-body">Read the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/rest-api.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
 
 {% endblock %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -24,14 +24,14 @@
     back_link=url_for('main.manage_users', service_id=current_service.id)
   ) }}
 
-  <p>
+  <p class="govuk-body">
     {{ user.email_address }}&emsp;
     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_email', service_id=current_service.id, user_id=user.id)}}">
     Change<span class="govuk-visually-hidden"> email address</span>
     </a>
   </p>
   {% if mobile_number %}
-    <p id="user_mobile_number">
+    <p class="govuk-body" id="user_mobile_number">
       {{ mobile_number }}&emsp;
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_mobile_number', service_id=current_service.id, user_id=user.id)}}">
       Change<span class="govuk-visually-hidden"> mobile number</span>

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -23,7 +23,7 @@
           <img src="https://{{ cdn_url }}/{{ logo }}"/>
         </div>
       {% endif %}
-      <p>
+      <p class="govuk-body">
         Logos should be PNG files, 108px high
       </p>
       {{ file_upload(form.file, button_text='{} logo'.format('Update' if email_branding else 'Upload')) }}

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">The link has expired</h1>
 
-    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>
 
   </div>
 </div>

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -11,8 +11,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Resend email link</h1>
 
-    <p>Emails sometimes take a few minutes to arrive. If you do not receive an email link, Notify can send you a new one.</p>
-    <p>
+    <p class="govuk-body">Emails sometimes take a few minutes to arrive. If you do not receive an email link, Notify can send you a new one.</p>
+    <p class="govuk-body">
       {{ govukButton({
         "element": "a",
         "text": "Resend email link",
@@ -21,7 +21,7 @@
     </p>
 
     <h2 class="heading-medium">If your email address has changed</h2>
-    <p>You’ll need to:</p>
+    <p class="govuk-body">You’ll need to:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>find a member of your team who has permission to manage settings, team and usage</li>
       <li>ask them to change the email address for your account</li>

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -9,40 +9,40 @@
 {% block content_column_content %}
 
 <h1 class="heading-large">Features</h1>
-<p>If you work for central government, a local authority or the NHS, you can use GOV.UK Notify to keep your users updated.</p>
-<p>Notify makes it easy to create, customise and send:</p>
+<p class="govuk-body">If you work for central government, a local authority or the NHS, you can use GOV.UK Notify to keep your users updated.</p>
+<p class="govuk-body">Notify makes it easy to create, customise and send:</p>
 <ul class="list list-bullet">
   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_email') }}">emails</a></li>
   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_sms') }}">text messages</a></li>
   <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features_letters') }}">letters</a></li>
 </ul>
-<p>You do not need any technical knowledge to use Notify.</p>
+<p class="govuk-body">You do not need any technical knowledge to use Notify.</p>
 {% if not current_user.is_authenticated %}
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> for free and try it yourself.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> for free and try it yourself.</p>
 {% endif %}
 
 <h2 class="heading-medium" id="templates">Reusable message templates</h2>
-<p>To send an email, text or letter with Notify, you need to create a reusable message template first.</p>
-<p>Templates let you send the same thing to lots of people, as often as you need to, without writing a new message each time.</p>
+<p class="govuk-body">To send an email, text or letter with Notify, you need to create a reusable message template first.</p>
+<p class="govuk-body">Templates let you send the same thing to lots of people, as often as you need to, without writing a new message each time.</p>
 
 <h2 class="heading-medium" id="personalised-messages">Personalised content</h2>
-<p>Notify makes it easy to send personalised messages from a single template.</p>
-<p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages', _anchor='personalised-content') }}">how to personalise your content</a>.</p>
+<p class="govuk-body">Notify makes it easy to send personalised messages from a single template.</p>
+<p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages', _anchor='personalised-content') }}">how to personalise your content</a>.</p>
 
 <h2 class="heading-medium" id="bulk-sending">Bulk sending</h2>
-<p>To send a batch of messages at once, upload a list of contact details to Notify. If you’re sending emails and text messages, you can also schedule the date and time you want them to be sent.</p>
+<p class="govuk-body">To send a batch of messages at once, upload a list of contact details to Notify. If you’re sending emails and text messages, you can also schedule the date and time you want them to be sent.</p>
 
 <h2 class="heading-medium" id="api">API integration</h2>
-<p>You can integrate the Notify API with your web application or back-office system to send messages automatically.</p>
-<p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
+<p class="govuk-body">You can integrate the Notify API with your web application or back-office system to send messages automatically.</p>
+<p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
 <h2 class="heading-medium" id="reporting">Reporting</h2>
-<p>Notify’s real-time dashboard lets you see the number of messages sent. You can also check the current status of any message to see when it was delivered.</p>
-<p>Read more about the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.message_status') }}">delivery status</a> of your messages.</p>
+<p class="govuk-body">Notify’s real-time dashboard lets you see the number of messages sent. You can also check the current status of any message to see when it was delivered.</p>
+<p class="govuk-body">Read more about the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.message_status') }}">delivery status</a> of your messages.</p>
 
 <h2 class="heading-medium" id="permissions">Permissions</h2>
-<p>Control which members of your team can see, create, edit and send messages.</p>
-<p>Notify lets you:</p>
+<p class="govuk-body">Control which members of your team can see, create, edit and send messages.</p>
+<p class="govuk-body">Notify lets you:</p>
 <ul class="list list-bullet">
   <li>set different permission levels for each team member</li>
   <li>invite team members who do not have a government email address</li>
@@ -50,28 +50,28 @@
 </ul>
 
 <h2 class="heading-medium" id="performance">Performance</h2>
-<p>Notify commits to:</p>
+<p class="govuk-body">Notify commits to:</p>
 <ul class="list list-bullet">
   <li>sending 95% of emails and text messages within 10 seconds</li>
   <li>printing and posting letters by 3pm the next working day (if you send them to us before 5:30pm)</li>
 </ul>
 
-<p>We send messages through several different providers. If one provider fails, Notify switches to another so that your messages are not affected.</p>
+<p class="govuk-body">We send messages through several different providers. If one provider fails, Notify switches to another so that your messages are not affected.</p>
 
-<p>Visit GOV.UK Performance to <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/performance/govuk-notify">see how Notify is performing</a>.</p>
+<p class="govuk-body">Visit GOV.UK Performance to <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/performance/govuk-notify">see how Notify is performing</a>.</p>
 
 <h2 class="heading-medium" id="security">Security</h2>
-<p>Notify protects and manages data to meet the needs of government services.</p>
+<p class="govuk-body">Notify protects and manages data to meet the needs of government services.</p>
 
 <h3 class="heading-small">Hide sensitive information</h3>
-<p>Notify lets you redact personal information from your messages after they have been sent. This means that only the recipient can see that information.</p>
+<p class="govuk-body">Notify lets you redact personal information from your messages after they have been sent. This means that only the recipient can see that information.</p>
 
 <h3 class="heading-small">Two-factor authentication</h3>
-<p>Notify uses two-factor authentication (2FA) to keep your account secure. When you sign in, we’ll send a unique one-time code to your phone and ask you to enter it before we let you use your account.</p>
-<p>Read more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.security') }}">security</a>.
+<p class="govuk-body">Notify uses two-factor authentication (2FA) to keep your account secure. When you sign in, we’ll send a unique one-time code to your phone and ask you to enter it before we let you use your account.</p>
+<p class="govuk-body">Read more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.security') }}">security</a>.
 
 <h2 class="heading-medium" id="support">Support</h2>
-<p>Notify provides 24-hour online support. If you have an emergency outside office hours, we’ll reply within 30 minutes.</p>
-<p>Find out more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">support</a>.</p>
+<p class="govuk-body">Notify provides 24-hour online support. If you have an emergency outside office hours, we’ll reply within 30 minutes.</p>
+<p class="govuk-body">Find out more about <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">support</a>.</p>
 
 {% endblock %}

--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -8,43 +8,43 @@
 {% block content_column_content %}
 
   <h1 class="heading heading-large">Emails</h1>
-  <p>Send an unlimited number of emails for free with GOV.UK Notify.</p>
+  <p class="govuk-body">Send an unlimited number of emails for free with GOV.UK Notify.</p>
   {% if not current_user.is_authenticated %}
-    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
   {% endif %}
 
   <h2 class="heading heading-medium">Features</h2>
-  <p>Notify makes it easy to:</p>
+  <p class="govuk-body">Notify makes it easy to:</p>
   <ul class="list list-bullet">
     <li>create reusable email templates</li>
     <li>personalise the content of your emails</li>
     <li>send and schedule bulk messages</li>
   </ul>
-  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send emails automatically.</p>
+  <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send emails automatically.</p>
 
   <h3 class="heading heading-small" id="branding">Email branding</h3>
-  <p>Add your organisation’s logo and brand colour to email templates.</p>
-  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='email-branding') }}">how to change your email branding</a>.</p>
+  <p class="govuk-body">Add your organisation’s logo and brand colour to email templates.</p>
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='email-branding') }}">how to change your email branding</a>.</p>
 
   <h3 class="heading heading-small" id="send-files">Send files by email</h3>
-  <p>Notify offers a safe and reliable way to send files by email.</p>
-  <p>Upload a file using our API, then send your users an email with a link to download it.</p>
-  <p>Notify uses encrypted links instead of email attachments because:</p>
+  <p class="govuk-body">Notify offers a safe and reliable way to send files by email.</p>
+  <p class="govuk-body">Upload a file using our API, then send your users an email with a link to download it.</p>
+  <p class="govuk-body">Notify uses encrypted links instead of email attachments because:</p>
   <ul class="list list-bullet">
     <li>they’re more secure</li>
     <!--<li>you can track when the recipient downloads your document</li>-->
     <li>email attachments are often marked as spam</li>
   </ul>
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
-  <p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
+  <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h3 class="heading heading-small" id="reply-to">Add a reply-to address</h3>
-  <p>Notify lets you choose the email address that users reply to.</p>
-  <p>Emails with a reply-to address seem more trustworthy and are less likely to be labelled as spam.</p>
-  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='reply-to-address') }}">how to add a reply-to address</a>.</p>
+  <p class="govuk-body">Notify lets you choose the email address that users reply to.</p>
+  <p class="govuk-body">Emails with a reply-to address seem more trustworthy and are less likely to be labelled as spam.</p>
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='reply-to-address') }}">how to add a reply-to address</a>.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>
-  <p>It’s free to send emails through Notify.</p>
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+  <p class="govuk-body">It’s free to send emails through Notify.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -8,42 +8,42 @@
 {% block content_column_content %}
 
   <h1 class="heading heading-large">Letters</h1>
-  <p>GOV.UK Notify will print, pack and post your letters for you.</p>
+  <p class="govuk-body">GOV.UK Notify will print, pack and post your letters for you.</p>
   {% if not current_user.is_authenticated %}
-    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
   {% endif %}
 
   <h2 class="heading heading-medium">Features</h2>
-  <p>Notify makes it easy to:</p>
+  <p class="govuk-body">Notify makes it easy to:</p>
   <ul class="list list-bullet">
     <li>create reusable letter templates</li>
     <li>personalise the content of your letter</li>
     <li>send bulk mail</li>
   </ul>
-  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send letters automatically.</p>
+  <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send letters automatically.</p>
 
   <h3 class="heading-small" id="postage">Choose your postage</h3>
-  <p>Notify can send letters by first or second class post.</p>
-  <p>First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched.</p>
-  <p>Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday). Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
+  <p class="govuk-body">Notify can send letters by first or second class post.</p>
+  <p class="govuk-body">First class letters are delivered one day after they’re dispatched. Second class letters are delivered 2 days after they’re dispatched.</p>
+  <p class="govuk-body">Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday). Royal Mail delivers from Monday to Saturday, excluding bank holidays.</p>
 
   <h3 class="heading-small" id="branding">Branding</h3>
-  <p>Add your organisation’s logo to your letter templates.</p>
-  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='letter-branding') }}">how to change your letter branding</a>.</p>
+  <p class="govuk-body">Add your organisation’s logo to your letter templates.</p>
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='letter-branding') }}">how to change your letter branding</a>.</p>
 
   <h3 class="heading heading-small" id="upload-letters">Upload your own letters</h3>
-  <p>You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>
-  <p>Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
+  <p class="govuk-body">You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>
+  <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>
-  <p>It costs between 35p and 81p (plus VAT) to send a letter. Prices include:</p>
+  <p class="govuk-body">It costs between 35p and 81p (plus VAT) to send a letter. Prices include:</p>
   <ul class="list list-bullet">
      <li>paper</li>
      <li>double-sided colour printing</li>
      <li>C5 size envelopes with an address window</li>
      <li>first or second class postage</li>
   </ul>
-  <p>Letters can be up to 10 pages long (5 double-sided sheets of paper).</p>
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+  <p class="govuk-body">Letters can be up to 10 pages long (5 double-sided sheets of paper).</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -8,34 +8,34 @@
 {% block content_column_content %}
 
   <h1 class="heading heading-large">Text messages</h1>
-  <p>Send thousands of free text messages to UK and international numbers with GOV.UK Notify.</p>
+  <p class="govuk-body">Send thousands of free text messages to UK and international numbers with GOV.UK Notify.</p>
   {% if not current_user.is_authenticated %}
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> and try Notify for yourself.</p>
   {% endif %}
 
   <h2 class="heading heading-medium">Features</h2>
-  <p>Notify makes it easy to:</p>
+  <p class="govuk-body">Notify makes it easy to:</p>
   <ul class="list list-bullet">
     <li>create reusable text message templates</li>
     <li>personalise the content of your texts</li>
     <li>send and schedule bulk messages</li></ul>
-  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send text messages automatically.<p>
+  <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send text messages automatically.<p class="govuk-body">
 
   <h3 class="heading heading-small" id="receive">Receive text messages</h3>
-  <p>Let people send messages to your service or reply to your texts.</p>
-  <p>You can see and reply to the messages you receive when you sign in to Notify. If you’re using our API, you can set up your own automated processes to manage replies.</p>
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> to request a unique number for text message replies.</p>
+  <p class="govuk-body">Let people send messages to your service or reply to your texts.</p>
+  <p class="govuk-body">You can see and reply to the messages you receive when you sign in to Notify. If you’re using our API, you can set up your own automated processes to manage replies.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> to request a unique number for text message replies.</p>
 
   <h3 class="heading heading-small" id="sender">Show people who your texts are from</h3>
-  <p>When you send a text message with Notify, the sender name tells people who it's from.</p>
-  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='text-message-sender') }}">how to change the text message sender</a>.</p>
+  <p class="govuk-body">When you send a text message with Notify, the sender name tells people who it's from.</p>
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='text-message-sender') }}">how to change the text message sender</a>.</p>
 
   <h2 class="heading heading-medium">Pricing<h2>
-    <p>Each service you add has a free annual allowance. After that it costs 1.58 pence (plus VAT) to send a text to a UK number.</p>
-    <p>The free allowance is:</p>
+    <p class="govuk-body">Each service you add has a free annual allowance. After that it costs 1.58 pence (plus VAT) to send a text to a UK number.</p>
+    <p class="govuk-body">The free allowance is:</p>
     <ul class="list list-bullet">
       <li>250,000 free text messages for central government services</li>
       <li>25,000 free text messages for other public sector services</li></ul>
-    <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -11,7 +11,7 @@
       <h1 class="heading-large">
         {{ user.name }}
       </h1>
-      <p>{{ user.email_address }}</p>
+      <p class="govuk-body">{{ user.email_address }}</p>
       <p class="{{ '' if user.mobile_number else 'hint' }}">{{ user.mobile_number or 'No mobile number'}}</p>
       <h2 class="heading-medium">Live services</h2>
       <nav class="browse-list">
@@ -49,7 +49,7 @@
       {% if not user.logged_in_at %}
       <p class="hint">This person has never logged in</p>
       {% else %}
-      <p>Last logged in
+      <p class="govuk-body">Last logged in
         <time class="timeago" datetime="{{ user.logged_in_at }}">
           {{ user.logged_in_at|format_delta }}
         </time>

--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -13,7 +13,7 @@ Create a new password
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Forgotten your password?</h1>
 
-    <p>We’ll send you an email to create a new password.</p>
+    <p class="govuk-body">We’ll send you an email to create a new password.</p>
 
     {% call form_wrapper() %}
       {{ textbox(form.email_address, safe_error_message=True) }}

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -14,7 +14,7 @@
 <ol class="get-started-list">
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Check if GOV.UK Notify is right for you</h2>
-    <p>Read about our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features') }}">features</a>, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a> and <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.roadmap') }}">roadmap</a>.</p>
+    <p class="govuk-body">Read about our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.features') }}">features</a>, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">pricing</a> and <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.roadmap') }}">roadmap</a>.</p>
     <p class="govuk-body">
       Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_can_use_notify') }}">whether your organisation can use Notify</a>.
     </p>
@@ -23,42 +23,42 @@
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Create an account</h2>
     {% if not current_user.is_authenticated %}
-      <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.register') }}">Create an account</a> for free and add your first Notify service. When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+      <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.register') }}">Create an account</a> for free and add your first Notify service. When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
     {% else %}
-      <p>Create an account for free and add your first Notify service. When you add a new service, it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+      <p class="govuk-body">Create an account for free and add your first Notify service. When you add a new service, it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
     {% endif %}
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Write some messages</h2>
-    <p>Add message templates with examples of the content you plan to send. You can use our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_index') }}">guidance</a> to help you.</p>
+    <p class="govuk-body">Add message templates with examples of the content you plan to send. You can use our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_index') }}">guidance</a> to help you.</p>
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Set up your service</h2>
     {% if not current_user.is_authenticated or not current_service %}
-    <p>Review your settings to add message branding, reply-to addresses and sender information.</p>
-    <p>Add team members and check their permissions.</p>
+    <p class="govuk-body">Review your settings to add message branding, reply-to addresses and sender information.</p>
+    <p class="govuk-body">Add team members and check their permissions.</p>
     {% else %}
-    <p>Review your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_settings', service_id=current_service.id) }}">settings</a> to add message branding, reply-to addresses and sender information.</p>
-    <p>Add <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a> and check their permissions.</p>
+    <p class="govuk-body">Review your <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_settings', service_id=current_service.id) }}">settings</a> to add message branding, reply-to addresses and sender information.</p>
+    <p class="govuk-body">Add <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a> and check their permissions.</p>
     {% endif %}
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Set up an API integration (optional)</h2>
-    <p>You can use the Notify API to send messages automatically.</p>
-    <p>Our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation</a> explains how to integrate the API with a web application or back office system.</p>
+    <p class="govuk-body">You can use the Notify API to send messages automatically.</p>
+    <p class="govuk-body">Our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation</a> explains how to integrate the API with a web application or back office system.</p>
   </li>
 
   <li class="get-started-list__item">
     <h2 class="get-started-list__heading">Start sending messages</h2>
     {% if not current_user.is_authenticated or not current_service %}
-    <p>When you’re ready to send messages to people outside your team, go to the <b class="govuk-!-font-weight-bold">Settings</b> page and select <b class="govuk-!-font-weight-bold">Request to go live</b>. We’ll approve your request within one working day.</p>
+    <p class="govuk-body">When you’re ready to send messages to people outside your team, go to the <b class="govuk-!-font-weight-bold">Settings</b> page and select <b class="govuk-!-font-weight-bold">Request to go live</b>. We’ll approve your request within one working day.</p>
     {% else %}
-    <p>You should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
+    <p class="govuk-body">You should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a> when you’re ready to send messages to people outside your team. We’ll approve your request within one working day.</p>
     {% endif %}
-    <p>Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a> if you’re planning to send letters or exceed the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing', _anchor='text-messages') }}">free text message allowance</a>.</p>
+    <p class="govuk-body">Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a> if you’re planning to send letters or exceed the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing', _anchor='text-messages') }}">free text message allowance</a>.</p>
   </li>
 
 </ol>

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -9,7 +9,7 @@
 
   <h1 class="heading-large">Branding and customisation</h1>
 
-  <p>This page explains how to:</p>
+  <p class="govuk-body">This page explains how to:</p>
 
   <ul class="list list-bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="#email-branding">change your email branding</a></li>
@@ -20,9 +20,9 @@
 
   <h2 class="heading-medium" id="email-branding">Change your email branding</h2>
 
-  <p>The default branding for email templates is the GOV.UK logo.</p>
+  <p class="govuk-body">The default branding for email templates is the GOV.UK logo.</p>
 
-  <p>To change your email branding:</p>
+  <p class="govuk-body">To change your email branding:</p>
 
   <ol class="list list-number">
     <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
@@ -31,9 +31,9 @@
 
   <h2 class="heading-medium" id="reply-to-address">Add a reply-to email address</h2>
 
-  <p>You can choose the email address that your users reply to. You must add at least one reply-to address for your service before you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">request to go live</a>.</p>
+  <p class="govuk-body">You can choose the email address that your users reply to. You must add at least one reply-to address for your service before you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">request to go live</a>.</p>
 
-  <p>To add a reply-to email address:</p>
+  <p class="govuk-body">To add a reply-to email address:</p>
 
   <ol class="list list-number">
     <li>Go to the <b class="govuk-!-font-weight-bold">Email settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
@@ -43,9 +43,9 @@
 
   <h2 class="heading-medium" id="text-message-sender">Change the text message sender</h2>
 
-  <p>The text message sender tells your users who the message is from.</p>
+  <p class="govuk-body">The text message sender tells your users who the message is from.</p>
 
-  <p>To change the text message sender from the default of ‘GOVUK’:</p>
+  <p class="govuk-body">To change the text message sender from the default of ‘GOVUK’:</p>
 
   <ol class="list list-number">
     <li>Go to the <b class="govuk-!-font-weight-bold">Text message settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>
@@ -55,9 +55,9 @@
 
   <h2 class="heading-medium" id="letter-branding">Change your letter branding</h2>
 
-  <p>Letter templates do not have default branding.</p>
+  <p class="govuk-body">Letter templates do not have default branding.</p>
 
-  <p>To add a logo to your letters:</p>
+  <p class="govuk-body">To add a logo to your letters:</p>
 
   <ol class="list list-number">
     <li>Go to the <b class="govuk-!-font-weight-bold">Letter settings</b> section of the {{ service_link(current_service, 'main.service_settings', 'settings') }} page.</li>

--- a/app/templates/views/guidance/create-and-send-messages.html
+++ b/app/templates/views/guidance/create-and-send-messages.html
@@ -9,11 +9,11 @@
 
   <h1 class="heading-large">Send messages</h1>
 
-  <p><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> to see a short tutorial explaining how to create and send messages.</p>
+  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> to see a short tutorial explaining how to create and send messages.</p>
 
   <h2 class="heading-medium" id="bulk-sending">Bulk sending</h2>
 
-  <p>To send a batch of messages at once:</p>
+  <p class="govuk-body">To send a batch of messages at once:</p>
   <ol class="list list-number">
     <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page and choose an existing template.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Send</b>.</li>

--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -9,7 +9,7 @@
 
   <h1 class="heading-large">Edit and format messages</h1>
 
-  <p>This page explains how to:</p>
+  <p class="govuk-body">This page explains how to:</p>
   <ul class="list list-bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="#formatting">format your content</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="#links">add links</a></li>
@@ -19,14 +19,14 @@
 
   <h2 class="heading-medium" id="formatting">Format your content</h2>
 
-  <p>You can see a list of formatting instructions on the edit template page:</p>
+  <p class="govuk-body">You can see a list of formatting instructions on the edit template page:</p>
 
   <ol class="list list-number">
     <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Edit</b>.</li>
   </ol>
 
-  <p>Email templates can include:</p>
+  <p class="govuk-body">Email templates can include:</p>
   <ul class="list list-bullet">
     <li>headings</li>
     <li>bullets</li>
@@ -34,17 +34,17 @@
     <li>horizontal rules</li>
   </ul>
 
-  <p>Letter templates can include headings and bullets.</p>
+  <p class="govuk-body">Letter templates can include headings and bullets.</p>
 
-  <p>Notify does not allow bold, italics, subheadings, underlined text or different fonts. This is because they can make it harder for users to read what you’ve written.</p>
+  <p class="govuk-body">Notify does not allow bold, italics, subheadings, underlined text or different fonts. This is because they can make it harder for users to read what you’ve written.</p>
 
   <h2 class="heading-medium" id="links">Add links</h2>
 
-  <p>When composing an email or text message, write URLs in full and Notify will convert them into links for you.</p>
+  <p class="govuk-body">When composing an email or text message, write URLs in full and Notify will convert them into links for you.</p>
 
-  <p>You cannot convert text into a link. Research shows that people like to check a URL looks genuine before clicking the link in an email. This is hard to do if the URL is hidden behind clickable link text.</p>
+  <p class="govuk-body">You cannot convert text into a link. Research shows that people like to check a URL looks genuine before clicking the link in an email. This is hard to do if the URL is hidden behind clickable link text.</p>
 
-  <p>We do not recommend using a third-party link shortening service because:</p>
+  <p class="govuk-body">We do not recommend using a third-party link shortening service because:</p>
 
   <ul class="list list-bullet">
     <li>your users cannot see where the link will take them</li>
@@ -54,11 +54,11 @@
 
   <h2 class="heading-medium" id="personalised-content">Personalise your content</h2>
 
-  <p>To personalise the content of your messages, add a placeholder to the template.</p>
+  <p class="govuk-body">To personalise the content of your messages, add a placeholder to the template.</p>
 
-  <p>Placeholders are filled in with details, like a name or reference number, each time you send a message.</p>
+  <p class="govuk-body">Placeholders are filled in with details, like a name or reference number, each time you send a message.</p>
 
-  <p>To add a placeholder to the template:</p>
+  <p class="govuk-body">To add a placeholder to the template:</p>
 
   <ol class="list list-number">
     <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
@@ -67,18 +67,18 @@
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>
   </ol>
 
-  <p>When you send a message you can either:</p>
+  <p class="govuk-body">When you send a message you can either:</p>
 
   <ul class="list list-bullet">
     <li>manually fill in the placeholders yourself</li>
     <li>upload a list of personal details and let Notify do it for you</li>
   </ul>
 
-  <p>If you upload a list, the column names need to match the placeholders in your template.</p>
+  <p class="govuk-body">If you upload a list, the column names need to match the placeholders in your template.</p>
 
   <h2 class="heading-medium" id="optional-content">Add optional content</h2>
 
-  <p>To add optional content to your emails and text messages:</p>
+  <p class="govuk-body">To add optional content to your emails and text messages:</p>
 
   <ol class="list list-number">
     <li>Go to the {{ service_link(current_service, 'main.choose_template', 'templates') }} page.</li>
@@ -87,15 +87,15 @@
     <li>Select <b class="govuk-!-font-weight-bold">Save</b>.</li>
   </ol>
 
-  <p>For each person you send this message to, specify ‘yes’ or ‘no’ to show or hide this content. You can either:</p>
+  <p class="govuk-body">For each person you send this message to, specify ‘yes’ or ‘no’ to show or hide this content. You can either:</p>
 
   <ul class="list list-bullet">
     <li>do this yourself</li>
     <li>upload a list of personal details and let Notify do it for you</li>
   </ul>
 
-  <p>If you upload a list, the column names need to match the optional content in your template.</p>
+  <p class="govuk-body">If you upload a list, the column names need to match the optional content in your template.</p>
 
-  <p>You cannot add optional content to a letter.</p>
+  <p class="govuk-body">You cannot add optional content to a letter.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/index.html
+++ b/app/templates/views/guidance/index.html
@@ -10,9 +10,9 @@
 
   <h1 class="heading-large">Guidance</h1>
 
-  <p>This guidance is for teams using GOV.UK Notify to send emails, text messages and letters.</p>
+  <p class="govuk-body">This guidance is for teams using GOV.UK Notify to send emails, text messages and letters.</p>
 
-  <p>It explains how to:</p>
+  <p class="govuk-body">It explains how to:</p>
 
   <ul class="list list-bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages') }}">edit and format messages</a></li>
@@ -23,7 +23,7 @@
 
   <h2 class="heading-medium">More information</h2>
 
-  <p>The GOV.UK Service Manual has advice on:</p>
+  <p class="govuk-body">The GOV.UK Service Manual has advice on:</p>
 
   <ul class="list list-bullet">
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">planning and writing text messages and emails</a></li>

--- a/app/templates/views/guidance/send-files-by-email.html
+++ b/app/templates/views/guidance/send-files-by-email.html
@@ -8,8 +8,8 @@
 
   <h1 class="heading-large">Send files by email</h1>
 
-  <p>To send a file by email, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a>.</p>
+  <p class="govuk-body">To send a file by email, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a>.</p>
 
-  <p>This is an API-only feature.</p>
+  <p class="govuk-body">This is an API-only feature.</p>
 
 {% endblock %}

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -9,10 +9,10 @@
 
   <h1 class="heading-large">Upload a letter</h1>
 
-  <p>Upload a one-off letter as a PDF and we’ll print, pack and post it for you.</p>
-  <p>You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
+  <p class="govuk-body">Upload a one-off letter as a PDF and we’ll print, pack and post it for you.</p>
+  <p class="govuk-body">You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
 
-  <p>To upload and send a letter from a PDF file:</p>
+  <p class="govuk-body">To upload and send a letter from a PDF file:</p>
 
   <ol class="list list-number">
     <li>Go to the {{ service_link(current_service, 'main.uploads', 'uploads') }} page.</li>
@@ -22,9 +22,9 @@
 
   <h2 class="heading-medium" id="letter-specification">Your file must meet our letter specification</h2>
 
-  <p>The content of your letter must appear inside the printable area.</p>
+  <p class="govuk-body">The content of your letter must appear inside the printable area.</p>
 
-  <p>Your file must be:</p>
+  <p class="govuk-body">Your file must be:</p>
 
   <ul class="list list-bullet">
     <li>a PDF</li>
@@ -33,6 +33,6 @@
     <li>smaller than 2MB</li>
   </ul>
 
-  <p>To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a>.</p>
+  <p class="govuk-body">To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a>.</p>
 
 {% endblock %}

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -11,9 +11,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Integration testing</h1>
 
-    <p>This information has moved.</p>
+    <p class="govuk-body">This information has moved.</p>
 
-    <p>
+    <p class="govuk-body">
       Refer to the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation
       for the client library you are using.
     </p>

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -22,7 +22,7 @@
           <img src="https://{{ cdn_url }}/{{ logo }}"/>
         </div>
       {% endif %}
-      <p>
+      <p class="govuk-body">
         Logos should be SVG files, cropped to artwork bounds and with all fonts outlined.
       </p>
       {{ file_upload(file_upload_form.file, button_text='{} logo'.format('Update' if is_update else 'Upload')) }}

--- a/app/templates/views/manage-users/confirm-edit-user-email.html
+++ b/app/templates/views/manage-users/confirm-edit-user-email.html
@@ -17,11 +17,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
   {% call form_wrapper() %}
-    <p>New email address:</p>
+    <p class="govuk-body">New email address:</p>
     <div class="panel panel-border-wide bottom-gutter">
-      <p>{{ new_email }}</p>
+      <p class="govuk-body">{{ new_email }}</p>
     </div>
-    <p>We will send {{ user.name }} an email to tell them about the change.</p>
+    <p class="govuk-body">We will send {{ user.name }} an email to tell them about the change.</p>
     {{ page_footer('Confirm') }}
   {% endcall %}
   </div>

--- a/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
+++ b/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
@@ -17,11 +17,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
   {% call form_wrapper() %}
-    <p>New mobile number:</p>
+    <p class="govuk-body">New mobile number:</p>
     <div class="panel panel-border-wide bottom-gutter">
-      <p>{{ new_mobile_number }}</p>
+      <p class="govuk-body">{{ new_mobile_number }}</p>
     </div>
-    <p>We will send {{ user.name }} a text message to tell them about the change.</p>
+    <p class="govuk-body">We will send {{ user.name }} a text message to tell them about the change.</p>
     {{ page_footer('Confirm') }}
   {% endcall %}
   </div>

--- a/app/templates/views/manage-users/edit-user-email.html
+++ b/app/templates/views/manage-users/edit-user-email.html
@@ -15,7 +15,7 @@
     back_link=url_for('main.edit_user_permissions', service_id=current_service.id, user_id=user.id)
   ) }}
 
-  <p id="user_name">This will change the email address for {{ user.name }}.</p>
+  <p class="govuk-body" id="user_name">This will change the email address for {{ user.name }}.</p>
   {% call form_wrapper() %}
     {{ textbox(form.email_address, width='1-1', safe_error_message=True) }}
     {{ page_footer('Save') }}

--- a/app/templates/views/manage-users/edit-user-mobile.html
+++ b/app/templates/views/manage-users/edit-user-mobile.html
@@ -15,7 +15,7 @@
     back_link=url_for('main.edit_user_permissions', service_id=current_service.id, user_id=user.id)
   ) }}
 
-  <p id="user_name">This will change the mobile number for {{ user.name }}.</p>
+  <p class="govuk-body" id="user_name">This will change the mobile number for {{ user.name }}.</p>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper(class="extra-tracking") %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -9,10 +9,10 @@
 
   <h1 class="heading-large">Delivery status</h1>
 
-  <p>Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered.</p>
-  <p>For <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("main.security") }}">security</a>, this information is only available for 7 days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
-  <p>This page describes the statuses you’ll see when you’re signed in to Notify.</p>
-  <p>If you’re using the Notify API, read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p>
+  <p class="govuk-body">Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered.</p>
+  <p class="govuk-body">For <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("main.security") }}">security</a>, this information is only available for 7 days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
+  <p class="govuk-body">This page describes the statuses you’ll see when you’re signed in to Notify.</p>
+  <p class="govuk-body">If you’re using the Notify API, read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p class="govuk-body">
 
   <h2 id="email-statuses" class="heading-medium">Emails</h2>
   <div class="bottom-gutter-3-2">
@@ -38,10 +38,10 @@
   </div>
   
   <h3 id="spam" class="heading-small">Spam</h3>
-  <p>If an email is marked as spam, Notify receives a ‘complaint’ from the email provider. We’ll contact you if we receive a complaint about any of your emails. When this happens you should remove the recipient’s email address from your list.</p>
+  <p class="govuk-body">If an email is marked as spam, Notify receives a ‘complaint’ from the email provider. We’ll contact you if we receive a complaint about any of your emails. When this happens you should remove the recipient’s email address from your list.</p>
 
   <h3 id="open-rates" class="heading-small">Open rates and click-throughs</h3>
-  <p>Notify cannot tell you if your users open an email or click on the links in an email. We do not track open rates and click-throughs because there are privacy issues. Tracking emails without asking permission from users could breach General Data Protection Regulations (GDPR).</p>
+  <p class="govuk-body">Notify cannot tell you if your users open an email or click on the links in an email. We do not track open rates and click-throughs because there are privacy issues. Tracking emails without asking permission from users could breach General Data Protection Regulations (GDPR).</p>
 
   <h2 id="sms-statuses" class="heading-medium">Text messages</h2>
   <div class="bottom-gutter-3-2">
@@ -91,8 +91,8 @@
 
   <h3 id="returned-mail" class="heading-small">Undelivered letters and returned mail</h3>
 
-  <p>Every letter we send includes our printer’s address on the back of the envelope. It’s not possible to customise the return address.</p>
-  <p>Returned mail is destroyed by our printer.</p>
-  <p>Each letter has a unique ID. Our printer sends us the ID of every letter they destroy. We’ll contact you if the IDs match any of your letters. This is a partly manual process, so it can take a few weeks.</p>
+  <p class="govuk-body">Every letter we send includes our printer’s address on the back of the envelope. It’s not possible to customise the return address.</p>
+  <p class="govuk-body">Returned mail is destroyed by our printer.</p>
+  <p class="govuk-body">Each letter has a unique ID. Our printer sends us the ID of every letter they destroy. We’ll contact you if the IDs match any of your letters. This is a partly manual process, so it can take a few weeks.</p>
 
 {% endblock %}

--- a/app/templates/views/new-password.html
+++ b/app/templates/views/new-password.html
@@ -15,7 +15,7 @@
       <h1 class="heading-large">
         Create a new password
       </h1>
-      <p>
+      <p class="govuk-body">
         You can now create a new password for your account.
       </p>
       {% call form_wrapper() %}
@@ -23,7 +23,7 @@
         {{ page_footer("Continue") }}
       {% endcall %}
     {% else %}
-      <p>
+      <p class="govuk-body">
         Message about email address does not exist. Some one needs to figure out the words here.
       </p>
     {% endif %}

--- a/app/templates/views/notifications/invalid_precompiled_letter.html
+++ b/app/templates/views/notifications/invalid_precompiled_letter.html
@@ -8,7 +8,7 @@
 
     <h1 class="heading-large">Letter</h1>
 
-    <p>
+    <p class="govuk-body">
       Provided as PDF on {{ created_at|format_datetime_short }}
     </p>
     <p class="notification-status-cancelled">

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -15,7 +15,7 @@
       message_count_label(1, template.template_type, suffix='') | capitalize,
       back_link=back_link
     ) }}
-    <p>
+    <p class="govuk-body">
       {% if is_precompiled_letter %}
         {% if created_by %}
           Uploaded
@@ -58,19 +58,19 @@
       {% else %}
         {% if sent_with_test_key %}
           {% if is_precompiled_letter %}
-            <p>
+            <p class="govuk-body">
               This letter passed our checks, but we will not print it because you used a test key.
             </p>
           {% else %}
-            <p>
+            <p class="govuk-body">
               We will not print this letter because you used a test key.
             </p>
           {% endif %}
         {% else %}
-          <p>
+          <p class="govuk-body">
             {{ letter_print_day }}
           </p>
-          <p>
+          <p class="govuk-body">
             Estimated delivery date: {{ estimated_letter_delivery_date|format_day_of_week }} {{ estimated_letter_delivery_date|format_date_short }}
           </p>
         {% endif %}
@@ -103,7 +103,7 @@
     {% endif %}
 
     {% if current_user.has_permissions('send_messages') and current_user.has_permissions('view_activity') and template.template_type == 'sms' and can_receive_inbound %}
-      <p>
+      <p class="govuk-body">
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.conversation', service_id=current_service.id, notification_id=notification_id, _anchor='n{}'.format(notification_id)) }}">See all text messages sent to this phone number</a>
       </p>
     {% endif %}

--- a/app/templates/views/organisations/add-nhs-local-organisation.html
+++ b/app/templates/views/organisations/add-nhs-local-organisation.html
@@ -16,7 +16,7 @@
     back_link=url_for('main.request_to_go_live', service_id=current_service.id)
   ) }}
   {% call form_wrapper() %}
-    <p>
+    <p class="govuk-body">
       {{ form.organisations.label.text }}
     </p>
     {{ live_search(target_selector='.multiple-choice', show=True, form=search_form, label='Search by name') }}

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -17,7 +17,7 @@
   ) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-      <p>
+      <p class="govuk-body">
         If a user’s email addresses ends with one of these domains then
         any services they create will be associated with this organisation.
       </p>

--- a/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
@@ -16,7 +16,7 @@
   ) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-      <p>
+      <p class="govuk-body">
         Text entered here will be displayed in the Zendesk ticket when a service
         belonging to this organisation requests to go live.
       </p>

--- a/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name/confirm.html
@@ -20,7 +20,7 @@
 
     {% call form_wrapper() %}
       {{ textbox(form.password, autocomplete='current-password') }}
-      <p> Your organisation name will be changed from {{ current_org.name }} to {{ new_name }} </p>
+      <p class="govuk-body"> Your organisation name will be changed from {{ current_org.name }} to {{ new_name }} </p>
       {{ page_footer('Confirm') }}
     {% endcall %}
     </div>

--- a/app/templates/views/organisations/organisation/users/user/index.html
+++ b/app/templates/views/organisations/organisation/users/user/index.html
@@ -15,7 +15,7 @@
     back_link=url_for('.manage_org_users', org_id=current_org.id)
   ) }}
 
-  <p>
+  <p class="govuk-body">
     {{ user.email_address }}
   </p>
 

--- a/app/templates/views/password-reset-sent.html
+++ b/app/templates/views/password-reset-sent.html
@@ -10,7 +10,7 @@ Check your email
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Check your email</h1>
 
-    <p>Click the link in the email to reset your password.</p>
+    <p class="govuk-body">Click the link in the email to reset your password.</p>
 
   </div>
 </div>

--- a/app/templates/views/platform-admin/reports.html
+++ b/app/templates/views/platform-admin/reports.html
@@ -10,18 +10,18 @@
     Reports
   </h1>
 
-<p>
+<p class="govuk-body">
   <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ url_for('main.live_services_csv') }}">Download live services csv report</a>
 </p>
 
-<p>
+<p class="govuk-body">
   <a class="govuk-link govuk-link--no-visited-state" target="_blank" href="{{ url_for('main.performance_platform_xlsx') }}">Download performance platform report (.xlsx)</a>
-<p>
+<p class="govuk-body">
 
-<p>
+<p class="govuk-body">
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.notifications_sent_by_service') }}">Monthly notification statuses for live services</a>
-<p>
-<p>
+<p class="govuk-body">
+<p class="govuk-body">
   <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.usage_for_all_services') }}">Usage for all services</a>
 </p>
 {% endblock %}

--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -13,7 +13,7 @@
       Invoices
     </h2>
 
-    <p>
+    <p class="govuk-body">
       We’ll send your organisation an invoice each quarter if you:
     </p>
 
@@ -22,15 +22,15 @@
       <li>send letters</li>
     </ul>
 
-    <p>
+    <p class="govuk-body">
       If your organisation has more than one service, you'll see a breakdown of each service on your invoice.
     </p>
 
-    <p>
+    <p class="govuk-body">
       If the value of an invoice is less than £250 (before <abbr title="Value Added Tax">VAT</abbr>), we’ll add it to the total for the next quarter to save time and effort.
     </p>
 
-    <p>
+    <p class="govuk-body">
       You can pay by BACS, debit card, or credit card.
     </p>
 
@@ -38,19 +38,19 @@
       Purchase orders
     </h2>
 
-    <p>
+    <p class="govuk-body">
       If your organisation’s estimated spend is more than £500 per quarter (before <abbr title="Value Added Tax">VAT</abbr>), you need to send us a purchase order (PO).
     </p>
 
-    <p>
+    <p class="govuk-body">
       Your organisation should raise a single <abbr title="purchase order">PO</abbr> for the estimated cost of all its services. You can update the PO anytime if your usage increases.
     </p>
 
-    <p>
+    <p class="govuk-body">
       You may need to set up the Cabinet Office as a supplier before you can raise a <abbr title="purchase order">PO</abbr>.
     </p>
 
-    <p>
+    <p class="govuk-body">
        <a class="govuk-link govuk-link--no-visited-state" href="{{ support_link }}">Contact us</a> if you need help raising a purchase order.
     </p>
 

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -11,14 +11,14 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Pricing</h1>
-  <p>To use GOV.UK Notify, there’s:</p>
+  <p class="govuk-body">To use GOV.UK Notify, there’s:</p>
   <ul class="list list-bullet">
     <li>no monthly charge</li>
     <li>no setup fee</li>
     <li>no procurement cost</li>
   </ul>
 
-  <p>
+  <p class="govuk-body">
     {% if not current_user.is_authenticated %}
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many different services as you need to.</p>
     {% else %}
@@ -26,24 +26,24 @@
     {% endif %}
   </p>
 
-  <p>When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
+  <p class="govuk-body">When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a>.</p>
 
   <h2 class="heading-medium" id="emails">Emails</h2>
-  <p>It’s free to send emails through Notify.</p>
+  <p class="govuk-body">It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
-  <p>Every service you add has an annual allowance of free text messages.</p>
-  <p>If your organisation has more than one service on Notify, they each have a separate allowance.</p>
-  <p>The allowance is:</p>
+  <p class="govuk-body">Every service you add has an annual allowance of free text messages.</p>
+  <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
+  <p class="govuk-body">The allowance is:</p>
   <ul class="list list-bullet">
     <li>250,000 free text messages for central government services</li>
     <li>25,000 free text messages for other public sector services</li>
   </ul>
-  <p>It costs 1.58 pence (plus VAT) for each text message you send after you've used your free allowance.</p>
-  <p>See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
+  <p class="govuk-body">It costs 1.58 pence (plus VAT) for each text message you send after you've used your free allowance.</p>
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
-  <p>If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message:</p>
+  <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message:</p>
   <div class="bottom-gutter-3-2">
     {% call mapping_table(
       caption='Text message pricing',
@@ -67,9 +67,9 @@
     {% endcall %}
   </div>
   <h3 class="heading-small" id="accents">Accents and accented characters</h3>
-  <p>Some languages, such as Welsh, use accented characters.</p>
-  <p>Text messages containing the following accented characters are charged at the normal rate: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>
-  <p>Using other accented characters can increase the cost of sending text messages.<p>
+  <p class="govuk-body">Some languages, such as Welsh, use accented characters.</p>
+  <p class="govuk-body">Text messages containing the following accented characters are charged at the normal rate: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>
+  <p class="govuk-body">Using other accented characters can increase the cost of sending text messages.<p class="govuk-body">
   {% set accentedChars %}
     <div class="bottom-gutter-3-2">
       {% call mapping_table(
@@ -159,7 +159,7 @@
   </div>
 
   <h3 class="heading-small" id="international-numbers">Sending text messages to international numbers</h3>
-  <p>It might cost more to send text messages to international numbers than UK ones, depending on the country.</p>
+  <p class="govuk-body">It might cost more to send text messages to international numbers than UK ones, depending on the country.</p>
   {% set smsIntRates %}
     {{ live_search(target_selector='#international-pricing .table-row', show=True, form=search_form, label='Search by country name or code') }}
 
@@ -191,7 +191,7 @@
   }) }}
 
   <h2 class="heading-medium" id="letters">Letters</h2>
-  <p>The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
+  <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
   <div>
     {% call mapping_table(
@@ -216,9 +216,9 @@
     {% endcall %}
   </div>
   <div class="panel panel-border-wide">
-    <p>These prices were updated on 1 October 2019.</p>
+    <p class="govuk-body">These prices were updated on 1 October 2019.</p>
   </div>
-  <p>Prices include:</p>
+  <p class="govuk-body">Prices include:</p>
   <ul class="list list-bullet">
      <li>paper</li>
      <li>double-sided colour printing</li>

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -10,25 +10,25 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Privacy notice: how we use your data</h1>
 
-    <p>Last update: 5 March 2019</p>
+    <p class="govuk-body">Last update: 5 March 2019</p>
 
     <h2 class="heading-medium">Who we are</h2>
 
-    <p>GOV.UK Notify is a service that lets public service teams in the UK send emails, text messages, and letters
+    <p class="govuk-body">GOV.UK Notify is a service that lets public service teams in the UK send emails, text messages, and letters
       to users of their service.</p>
 
-    <p>GOV.UK Notify is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.</p>
+    <p class="govuk-body">GOV.UK Notify is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.</p>
 
-    <p>Organisations sending notifications using GOV.UK Notify are the data controller and Cabinet Office is the data processor. The data controller must tell you about what they are doing with your personal data.</p>
+    <p class="govuk-body">Organisations sending notifications using GOV.UK Notify are the data controller and Cabinet Office is the data processor. The data controller must tell you about what they are doing with your personal data.</p>
 
-    <p>For the credentials used to access GOV.UK Notify, Cabinet Office is the data controller.</p>
+    <p class="govuk-body">For the credentials used to access GOV.UK Notify, Cabinet Office is the data controller.</p>
 
-    <p>For more information see the Information Commissioner’s Office (ICO) <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/esdwebpages/search">Data Protection Public Register</a>.
+    <p class="govuk-body">For more information see the Information Commissioner’s Office (ICO) <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/esdwebpages/search">Data Protection Public Register</a>.
       The Cabinet Office registration number is: Z7414053</p>
 
     <h2 class="heading-medium">What data we collect from you</h2>
 
-    <p>The personal data we collect from public sector employees that create a GOV.UK Notify account will include:</p>
+    <p class="govuk-body">The personal data we collect from public sector employees that create a GOV.UK Notify account will include:</p>
 
     <ul class="list list-bullet">
         <li>Your name</li>
@@ -37,54 +37,54 @@
         <li>The IP address you use to access GOV.UK Notify</li>
     </ul>
 
-    <p>The legal basis for processing this data is public task – allowing you to access GOV.UK Notify to send notifications
+    <p class="govuk-body">The legal basis for processing this data is public task – allowing you to access GOV.UK Notify to send notifications
       to users of your public service.</p>
 
     <h2 class="heading-medium">Why we need your data</h2>
 
-    <p>We require your personal data to ensure only legitimate users of GOV.UK Notify can use it to send notifications.</p>
+    <p class="govuk-body">We require your personal data to ensure only legitimate users of GOV.UK Notify can use it to send notifications.</p>
 
     <h2 class="heading-medium">What we do with your data</h2>
 
-    <p>We use your data to check that you are allowed to access GOV.UK Notify and to record your activity when using it.</p>
+    <p class="govuk-body">We use your data to check that you are allowed to access GOV.UK Notify and to record your activity when using it.</p>
 
-    <p>We will not:</p>
+    <p class="govuk-body">We will not:</p>
 
     <ul class="list list-bullet">
         <li>sell or rent your data to third parties</li>
         <li>share your data with third parties for marketing purposes</li>
     </ul>
 
-    <p>We will share your data if we are required to do so by law – for example, by court order, or to prevent fraud or other crime.</p>
+    <p class="govuk-body">We will share your data if we are required to do so by law – for example, by court order, or to prevent fraud or other crime.</p>
 
     <h2 class="heading-medium">How long we keep your data</h2>
 
-    <p>We will retain your personal data for as long as you have a GOV.UK Notify account.</p>
+    <p class="govuk-body">We will retain your personal data for as long as you have a GOV.UK Notify account.</p>
 
     <h2 class="heading-medium">Where your data is processed and stored</h2>
 
-    <p>We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s
+    <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s
       processed and when it’s stored.</p>
 
-    <p>Your personal data will not be transferred outside of the European Economic Area (EEA) throughout the course of its
+    <p class="govuk-body">Your personal data will not be transferred outside of the European Economic Area (EEA) throughout the course of its
       processing at GDS or any third party suppliers.</p>
 
     <h2 class="heading-medium">How we protect your data and keep it secure</h2>
 
-    <p>We are committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have
+    <p class="govuk-body">We are committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have
       put in place technical and organisational procedures to secure the data we collect about you – for example, we protect your
       data using varying levels of encryption. We also make sure that any third parties that we deal with have an obligation to
       keep all personal data they process on our behalf secure.</p>
 
     <h2 class="heading-medium">Children’s privacy protection</h2>
 
-    <p>We understand the importance of protecting children’s privacy online. Our services are not designed for, or intentionally
+    <p class="govuk-body">We understand the importance of protecting children’s privacy online. Our services are not designed for, or intentionally
       targeted at, children 13 years of age or younger. It is not our policy to intentionally collect or maintain data about anyone
       under the age of 13.</p>
 
     <h2 class="heading-medium">What are your rights</h2>
 
-    <p>You have the right to request:</p>
+    <p class="govuk-body">You have the right to request:</p>
 
     <ul class="list list-bullet">
       <li>information about how your personal data is processed</li>
@@ -92,7 +92,7 @@
       <li>that anything inaccurate in your personal data is corrected immediately</li>
     </ul>
 
-    <p>You can also:</p>
+    <p class="govuk-body">You can also:</p>
 
     <ul class="list list-bullet">
       <li>raise an objection about how your personal data is processed</li>
@@ -100,34 +100,34 @@
       <li>ask that the processing of your personal data is restricted in certain circumstances</li>
     </ul>
 
-    <p>If you have any of these requests, get in contact with our Data Protection Officer - you can find their contact details below.</p>
+    <p class="govuk-body">If you have any of these requests, get in contact with our Data Protection Officer - you can find their contact details below.</p>
 
     <h2 class="heading-medium">Changes to this notice</h2>
 
-    <p>We may modify or amend this privacy notice at our discretion at any time. When we make changes to this notice, we will
+    <p class="govuk-body">We may modify or amend this privacy notice at our discretion at any time. When we make changes to this notice, we will
       amend the last modified date at the top of this page. Any modification or amendment to this privacy notice will be applied
       to you and your data as of that revision date. We encourage you to periodically review this privacy notice to be informed
       about how we are protecting your data.</p>
 
     <h2 class="heading-medium">Questions and complaints</h2>
 
-    <p>Contact the GDS Privacy Team if you either:</p>
+    <p class="govuk-body">Contact the GDS Privacy Team if you either:</p>
 
     <ul class="list list-bullet">
       <li>have any questions about anything in this document</li>
       <li>think that your personal data has been misused or mishandled</li>
     </ul>
 
-    <p>
+    <p class="govuk-body">
     GDS Privacy Team<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a>
     </p>
 
-    <p>
+    <p class="govuk-body">
     You can also contact the Cabinet Office Data Protection Officer.
     </p>
 
-    <p>
+    <p class="govuk-body">
     Data Protection Officer<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br>
     Data Protection Officer<br>
@@ -136,9 +136,9 @@
     London SW1A 2AS
     </p>
 
-    <p>If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
+    <p class="govuk-body">If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
 
-    <p>
+    <p class="govuk-body">
     Information Commissioner’s Office<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
     0303 123 1113</br>

--- a/app/templates/views/providers/edit-provider.html
+++ b/app/templates/views/providers/edit-provider.html
@@ -18,7 +18,7 @@ Provider - {{provider.display_name}}
           back_link=url_for('.view_providers')
         ) }}
 
-        <p>Update provider:</p>
+        <p class="govuk-body">Update provider:</p>
 
         <ul class="list-bullet">
             <li>We only send from the highest priority provider</li>

--- a/app/templates/views/re-validate-email-sent.html
+++ b/app/templates/views/re-validate-email-sent.html
@@ -10,8 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
-    <p>For security, we need to check if you still have access to your email address.</p>
-    <p>We’ve sent you a link to sign in to Notify. The link will open in a new browser window, so you can close this one.</p>
+    <p class="govuk-body">For security, we need to check if you still have access to your email address.</p>
+    <p class="govuk-body">We’ve sent you a link to sign in to Notify. The link will open in a new browser window, so you can close this one.</p>
 
     {{ page_footer(
       secondary_link=url_for('main.email_not_received'),

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -12,7 +12,7 @@ Create an account
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
-    <p>
+    <p class="govuk-body">
       Your account will be created with this email address:
       <span class="nowrap">{{invited_user.email_address}}</span>
     </p>

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -12,7 +12,7 @@ Create an account
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Create an account</h1>
-    <p>Your account will be created with this email: {{invited_org_user.email_address}}</p>
+    <p class="govuk-body">Your account will be created with this email: {{invited_org_user.email_address}}</p>
     {% call form_wrapper() %}
       {{ textbox(form.name, width='3-4') }}
       <div class="extra-tracking">

--- a/app/templates/views/registration-continue.html
+++ b/app/templates/views/registration-continue.html
@@ -7,7 +7,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Check your email​</h1>
-  <p>An email has been sent to {{ session['user_details']['email'] }}.</p>
-  <p>Click the link in the email to continue your registration.</p>
+  <p class="govuk-body">An email has been sent to {{ session['user_details']['email'] }}.</p>
+  <p class="govuk-body">Click the link in the email to continue your registration.</p>
 
 {% endblock %}

--- a/app/templates/views/resend-email-verification.html
+++ b/app/templates/views/resend-email-verification.html
@@ -9,7 +9,7 @@
 {% block maincolumn_content %}
 
 <h1 class="heading-large">Check your email</h1>
-<p>A new confirmation email has been sent to {{ email }}</p>
-<p>Click the link in the email to continue your registration.</p>
+<p class="govuk-body">A new confirmation email has been sent to {{ email }}</p>
+<p class="govuk-body">Click the link in the email to continue your registration.</p>
 
 {% endblock %}

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -9,9 +9,9 @@
 
   <h1 class="heading-large">Roadmap</h1>
 
-  <p>The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
-  <p>Notify is in public beta. This means it’s fully operational and supported, but we’re still adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
-  <p>You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
+  <p class="govuk-body">The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
+  <p class="govuk-body">Notify is in public beta. This means it’s fully operational and supported, but we’re still adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
+  <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
   <h2 class="heading-medium">January to March 2020</h2>
 

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -8,7 +8,7 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Security</h1>
-  <p>GOV.UK Notify is built for the needs of government services. It has processes in place to:</p>
+  <p class="govuk-body">GOV.UK Notify is built for the needs of government services. It has processes in place to:</p>
   <ul class="list list-bullet">
     <li>protect user data</li>
     <li>keep systems secure</li>
@@ -16,15 +16,15 @@
   </ul>
 
   <h2 class="heading-medium">Data</h2>
-  <p>On Notify, data is encrypted:</p>
+  <p class="govuk-body">On Notify, data is encrypted:</p>
   <ul class="list list-bullet">
     <li>when it passes through the service</li>
     <li>when it’s stored on the service</li>
   </ul>
-  <p>Any user data you upload is only held for 7 days.</p>
-  <p>The Cabinet Office acts as data processor for Notify. Your organisation is the data controller.</p>
+  <p class="govuk-body">Any user data you upload is only held for 7 days.</p>
+  <p class="govuk-body">The Cabinet Office acts as data processor for Notify. Your organisation is the data controller.</p>
   <h3 class="heading-small">Data Protection Act</h3>
-  <p>Notify complies with data protection law. To make sure it stays compliant, there are regular legal reviews of the service’s:</p>
+  <p class="govuk-body">Notify complies with data protection law. To make sure it stays compliant, there are regular legal reviews of the service’s:</p>
   <ul class="list list-bullet">
     <li>privacy policy</li>
     <li>terms of use</li>
@@ -32,7 +32,7 @@
   </ul>
 
   <h2 class="heading-medium">Technical security</h2>
-  <p>Other technical security controls on Notify include:</p>
+  <p class="govuk-body">Other technical security controls on Notify include:</p>
   <ul class="list list-bullet">
     <li>compliance with National Cyber Security Centre (NCSC) Cloud Security Principles</li>
     <li>protective monitoring to record activity, and raise alerts about any suspicious activity</li>
@@ -40,30 +40,30 @@
   </ul>
 
   <h3 class="heading-small">Protect sensitive information</h3>
-  <p>Some messages include sensitive information like security codes or password reset links.</p>
-  <p>If you’re sending a message with sensitive information, you can choose to hide those details on the Notify dashboard once the message has been sent. This means that only the message recipient will be able to see that information.</p>
+  <p class="govuk-body">Some messages include sensitive information like security codes or password reset links.</p>
+  <p class="govuk-body">If you’re sending a message with sensitive information, you can choose to hide those details on the Notify dashboard once the message has been sent. This means that only the message recipient will be able to see that information.</p>
 
   <h2 class="heading-medium">User permissions and signing in</h2>
-  <p>You can set different user permissions in Notify. This lets you control who in your team has access to certain parts of the service.</p>
+  <p class="govuk-body">You can set different user permissions in Notify. This lets you control who in your team has access to certain parts of the service.</p>
   <h3 class="heading-small">Two-factor authentication</h3>
-  <p>To sign in to Notify, you’ll need to enter:</p>
+  <p class="govuk-body">To sign in to Notify, you’ll need to enter:</p>
   <ul class="list list-bullet">
     <li>your email address and password</li>
     <li>a text message code that Notify sends to your phone</li>
   </ul>
-  <p>If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
+  <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
 
   <h2 class="heading-medium">Information risk management</h2>
-  <p>Our approach to information risk management follows NCSC guidance. It assesses:</p>
+  <p class="govuk-body">Our approach to information risk management follows NCSC guidance. It assesses:</p>
   <ul class="list list-bullet">
     <li>how Notify is built</li>
     <li>the infrastructure Notify is built upon</li>
     <li>support for the Notify service</li>
   </ul>
-  <p>This approach also applies to the service providers Notify uses to send messages.</p>
+  <p class="govuk-body">This approach also applies to the service providers Notify uses to send messages.</p>
 
   <h2 class="heading-medium">How we manage risks on Notify</h2>
-  <p>Things we do to manage risks on Notify include:</p>
+  <p class="govuk-body">Things we do to manage risks on Notify include:</p>
   <ul class="list list-bullet">
     <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 2700:2011</a> and National Cyber Security Centre guidance</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.cesg.gov.uk/articles/check-fundamental-principles">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
@@ -73,12 +73,12 @@
   </ul>
 
   <h2 class="heading-medium">Cabinet Office approval</h2>
-  <p>Notify has been assessed and approved by the Cabinet Office Senior Information Risk Officer (SIRO). The SIRO checks this approval once a year.</p>
-  <p>Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
+  <p class="govuk-body">Notify has been assessed and approved by the Cabinet Office Senior Information Risk Officer (SIRO). The SIRO checks this approval once a year.</p>
+  <p class="govuk-body">Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
 
   <h2 class="heading-medium">Classifications and security vetting</h2>
-  <p>You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
-  <p>You must not use Notify to send ‘<a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/special-category-data/">special category data</a>’, as defined in the General Data Protection Regulation (GDPR).</p>
-  <p>The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/guidance/security-vetting-and-clearance">United Kingdom Security Vetting</a> (UKSV).</p>
+  <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
+  <p class="govuk-body">You must not use Notify to send ‘<a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/special-category-data/">special category data</a>’, as defined in the General Data Protection Regulation (GDPR).</p>
+  <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/guidance/security-vetting-and-clearance">United Kingdom Security Vetting</a> (UKSV).</p>
 
 {% endblock %}

--- a/app/templates/views/send-contact-list.html
+++ b/app/templates/views/send-contact-list.html
@@ -23,7 +23,7 @@
           You cannot use a saved contact list with this template because it
           is personalised with {{ list_of_placeholders(template.placeholders) }}.
         </p>
-        <p>
+        <p class="govuk-body">
           Saved contact lists can only store email addresses or phone
           numbers.
         </p>

--- a/app/templates/views/send-one-off-letter-address.html
+++ b/app/templates/views/send-one-off-letter-address.html
@@ -32,7 +32,7 @@
         ) }}
       </div>
     </div>
-    <p>
+    <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.send_messages', service_id=current_service.id, template_id=template.id) }}">
         Upload a list of {{ recipient_count_label(999, template.template_type) }}
       </a>

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -43,7 +43,7 @@
       {% endif %}
     </div>
     {% if link_to_upload %}
-      <p>
+      <p class="govuk-body">
 
       </p>
     {% endif %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -249,7 +249,7 @@
     {% if current_service.trial_mode %}
       <h2 class="heading-medium top-gutter-0">Your service is in trial mode</h2>
 
-      <p>You can only:</p>
+      <p class="govuk-body">You can only:</p>
 
       <ul class='list list-bullet'>
         <li>send {{ current_service.message_limit }} text messages and emails per day</li>
@@ -257,24 +257,24 @@
         <li>create letter templates, but not send them</li>
       </ul>
 
-      <p>
+      <p class="govuk-body">
         {% if current_user.has_permissions('manage_service') %}
           To remove these restrictions, you can send us a
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
         {% else %}
           Your service manager can ask to have these restrictions removed.
         {% endif %}
-        </p>
+      </p>
 
     {% else %}
       <h2 class="heading-medium top-gutter-0">Your service is live</h2>
 
-      <p>
+      <p class="govuk-body">
         You can send up to
         {{ "{:,}".format(current_service.message_limit) }} messages
         per day.
       </p>
-      <p>
+      <p class="govuk-body">
         Problems or comments?
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Give feedback</a>.
       </p>
@@ -386,7 +386,7 @@
       </p>
     {% endif %}
     {% if (not current_service.active) and current_user.platform_admin %}
-      <p>
+      <p class="govuk-body">
         <div class="hint bottom-gutter-1-2">
           Service suspended
         </div>

--- a/app/templates/views/service-settings/branding/branding-options.html
+++ b/app/templates/views/service-settings/branding/branding-options.html
@@ -17,12 +17,12 @@
     back_link=url_for('.view_template', service_id=current_service.id, template_id=from_template) if from_template else url_for('.service_settings', service_id=current_service.id)
   ) }}
 
-  <p>
+  <p class="govuk-body">
     Your {{ branding_type }}s currently have {{ branding_name }} branding.
   </p>
 
   {% if current_service.needs_to_change_email_branding and branding_type == "email" %}
-    <p>
+    <p class="govuk-body">
       You should be using your own branding instead. We can help you to set this up.
     </p>
   {% endif %}

--- a/app/templates/views/service-settings/delete.html
+++ b/app/templates/views/service-settings/delete.html
@@ -15,7 +15,7 @@
 
       <h1 class="heading-large">Delete this service from GOV.UK Notify</h1>
 
-      <p>
+      <p class="govuk-body">
         This cannot be undone. You will lose:
       </p>
 

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -7,14 +7,14 @@
 
 <div class="ajax-block-container">
   {% if verification_status == "pending" %}
-    <p>
+    <p class="govuk-body">
       We’re checking that ‘{{ reply_to_email_address }}’ is a real email address.
     </p>
-    <p>
-  <span class='loading-indicator'>This can take a minute</span>
+    <p class="govuk-body">
+      <span class='loading-indicator'>This can take a minute</span>
     </p>
 
-    <p class="js-hidden">
+    <p class="js-hidden govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_verify_reply_to_address', service_id=service_id, notification_id=notification_id, is_default=is_default, replace=replace) }}">Refresh</a>
     </p>
   {% elif verification_status == "success" %}
@@ -32,10 +32,10 @@
         <h2 class='banner-title' data-module="track-error" data-error-type="reply-to-email-not-working" data-error-label="{{ upload_id }}">
           There’s a problem with your reply-to address
         </h2>
-        <p>
+        <p class="govuk-body">
           We sent an email to ‘{{ reply_to_email_address }}’ but it could not be delivered.
         </p>
-        <p>
+        <p class="govuk-body">
           You can try again, or use a different address.
         </p>
       {% endcall %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -52,10 +52,10 @@
       {% endif %}
     </div>
     <div class="govuk-grid-column-five-sixths">
-      <p>
+      <p class="govuk-body">
         You need to add at least one reply-to address so recipients can reply to your messages.
       </p>
-      <p>
+      <p class="govuk-body">
         Emails with a reply-to address:
       </p>
       <ul class="list list-bullet">

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -31,7 +31,7 @@
     </div>
     {% for item in letter_contact_details %}
       <div class="user-list-item">
-        <p>
+        <p class="govuk-body">
           {{ item.contact_block | nl2br }}
         </p>
         <p class="hint">

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -18,13 +18,13 @@
 
   <div class="form-group">
     {% if current_service.prefix_sms %}
-      <p>Users will see your service name:</p>
+      <p class="govuk-body">Users will see your service name:</p>
       <ul class="list-bullet">
         <li>at the start of every text message</li>
         <li>as your email sender name</li>
       </ul>
     {% else %}
-      <p>Users will see your service name as your email sender name.</p>
+      <p class="govuk-body">Users will see your service name as your email sender name.</p>
     {% endif %}
   </div>
 

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -57,15 +57,15 @@
         {% endif %}
       {% endcall %}
       {% if not current_user.is_gov_user %}
-        <p>
+        <p class="govuk-body">
           Only team members with a government email address can request to go live.
         </p>
       {% elif (not current_service.go_live_checklist_completed) or (current_service.able_to_accept_agreement and not current_service.organisation.agreement_signed) %}
-        <p>
+        <p class="govuk-body">
           You must complete these steps before you can request to go live.
         </p>
       {% else %}
-        <p>
+        <p class="govuk-body">
           When we receive your request we’ll get back to you within one working day.
         </p>
         <p class="bottom-gutter">

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -21,7 +21,7 @@
         This is an API-only feature.
       </p>
       <p class="govuk-body">
-        To send a file by email, follow the instructions in our <a href={{ url_for('main.documentation') }}>API documentation</a>.
+        To send a file by email, follow the instructions in our <a class="govuk-link govuk-link--no-visited-state" href={{ url_for('main.documentation') }}>API documentation</a>.
       </p>
       <h2 class="heading-medium">{% if contact_details %}Change contact details for{% else %}Add contact details to{% endif %} the file download page</h2>
       <p class="govuk-body">

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -17,14 +17,14 @@
         'Send files by email',
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
-      <p>
+      <p class="govuk-body">
         This is an API-only feature.
-        </p>
-        <p>
+      </p>
+      <p class="govuk-body">
         To send a file by email, follow the instructions in our <a href={{ url_for('main.documentation') }}>API documentation</a>.
       </p>
       <h2 class="heading-medium">{% if contact_details %}Change contact details for{% else %}Add contact details to{% endif %} the file download page</h2>
-      <p>
+      <p class="govuk-body">
         You need to include contact details for your service so your users can get in touch if there’s a problem. For example, if the link to download the file you sent them has expired.
       </p>
       {% call form_wrapper() %}

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -19,21 +19,21 @@
         <p class="heading-small bottom-gutter-2-3">
           Email link or text message code
         </p>
-        <p>
+        <p class="govuk-body">
           Your team members can sign in with either a text message code
           or an email link.
         </p>
-        <p>
+        <p class="govuk-body">
           You can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}">set the sign-in method for individual team members</a>.
         </p>
       {% else %}
         <p class="heading-small bottom-gutter-2-3">
           Text message code
         </p>
-        <p>
+        <p class="govuk-body">
           Your team members sign in with a text message code.
         </p>
-        <p>
+        <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if signing in with a text message is a problem for your team.
         </p>
       {% endif %}

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -16,7 +16,7 @@
         'Send emails',
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
-      <p>
+      <p class="govuk-body">
         It’s free to send emails through GOV.UK Notify.
       </p>
       {% call form_wrapper() %}

--- a/app/templates/views/service-settings/set-inbound-number.html
+++ b/app/templates/views/service-settings/set-inbound-number.html
@@ -15,9 +15,9 @@
       back_link=url_for('.service_settings', service_id=current_service.id)
     ) }}
     {% if current_service.has_inbound_number %}
-    <p> This service already has an inbound number </p>
+    <p class="govuk-body"> This service already has an inbound number </p>
     {% elif no_available_numbers %}
-    <p> No available inbound numbers </p>
+    <p class="govuk-body"> No available inbound numbers </p>
     {% else %}
     {% call form_wrapper() %}
 	    {{ radios(form.inbound_number) }}

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -16,38 +16,38 @@
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
       {% if 'inbound_sms' in current_service.permissions %}
-        <p>
+        <p class="govuk-body">
           Your service can receive text messages sent to {{ current_service.inbound_number }}.
         </p>
-        <p>
+        <p class="govuk-body">
           You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.
         </p>
-        <p>
+        <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to switch this feature off.
         </p>
         {% if current_user.has_permissions('manage_api_keys') %}
-          <p>
+          <p class="govuk-body">
             You can set up callbacks for received text messages on the
             <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.api_callbacks', service_id=current_service.id) }}">API integration page</a>.
           </p>
         {% endif %}
       {% else %}
-        <p>
+        <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to be able to receive text messages from your users.
         </p>
-        <p>
+        <p class="govuk-body">
           We’ll create a unique phone number for your service that they can reply to.
         </p>
-        <p>
+        <p class="govuk-body">
           Text messages you send will come from this phone number instead of your sender name (currently {{ current_service.default_sms_sender }}).
         </p>
-        <p>
+        <p class="govuk-body">
           You can still send text messages from a sender name if you need to, but users will not be able to reply to those messages.
         </p>
-        <p>
+        <p class="govuk-body">
           You can see and reply to the messages you receive when you sign in to Notify, or get them using the API.
         </p>
-        <p>
+        <p class="govuk-body">
           It does not cost you anything to receive text messages. Users will pay their standard text message rate.
         </p>
       {% endif %}

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -16,10 +16,10 @@
         'Send international text messages',
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
-      <p>
+      <p class="govuk-body">
         Messages to international mobile numbers are charged at 1, 2, or
         3 times the cost of messages to UK mobile numbers.</p>
-      <p>
+      <p class="govuk-body">
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing") }}">pricing</a> for the list
         of rates.
       </p>

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -16,10 +16,10 @@
         'Send letters',
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
-      <p>
+      <p class="govuk-body">
         It costs between 35p and 81p to send a letter using Notify.
       </p>
-      <p>
+      <p class="govuk-body">
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for the list
         of rates.
       </p>

--- a/app/templates/views/service-settings/set-reply-to-email.html
+++ b/app/templates/views/service-settings/set-reply-to-email.html
@@ -15,18 +15,18 @@
     back_link=url_for('.service_settings', service_id=current_service.id)
   ) }}
 
-  <p>
+  <p class="govuk-body">
     Your emails will be sent from
     {{ current_service.email_from }}@notifications.service.gov.uk.
     This is so they have the best chance of being delivered.
     This email address cannot receive replies.
   </p>
-  <p>
+  <p class="govuk-body">
     Set up a separate email address to receive replies from
     your users, then enter it here.
   </p>
   {% if current_service.trial_mode %}
-    <p>
+    <p class="govuk-body">
       Your service cannot go live until you’ve done this.
     </p>
   {% endif %}

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -16,16 +16,16 @@
         'Send text messages',
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
-      <p>
+      <p class="govuk-body">
         You have a free allowance of
         {{ '{:,}'.format(current_service.free_sms_fragment_limit) }} text messages each
         financial year.
       </p>
-      <p>
+      <p class="govuk-body">
         It costs 1.58 pence (plus VAT) for each text message you send
         after your free allowance.
       </p>
-      <p>
+      <p class="govuk-body">
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for more details.
       </p>
       {% call form_wrapper() %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -18,7 +18,7 @@
   ) }}
   {% call form_wrapper() %}
     {% if inbound_number %}
-      <p>
+      <p class="govuk-body">
         <span class="bottom-gutter-1-3"> {{ sms_sender.sms_sender }} </span>
         <span class="hint"> This phone number receives replies and cannot be changed </span>
       </p>

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -53,7 +53,7 @@
       </div>
     </div>
   {% endif %}
-  <p>
+  <p class="govuk-body">
     The text message sender tells your users who the message is from.
   </p>
 {% endblock %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -28,7 +28,7 @@
           <h1>
             Send emails, text messages and letters to your users
           </h1>
-          <p>
+          <p class="govuk-body">
             Try GOV.UK Notify now if you work in central government, a&nbsp;local authority, or the NHS.
           </p>
           <div class="button-container">
@@ -52,7 +52,7 @@
         <h2>
           Control your content
         </h2>
-        <p>
+        <p class="govuk-body">
           You do not need any technical knowledge to create email,
           text&nbsp;message or letter templates.
         </p>
@@ -68,7 +68,7 @@
         <h2>
           See how your messages perform
         </h2>
-        <p>
+        <p class="govuk-body">
           Track how many messages you’ve sent and
           find out which ones are not being delivered.
         </p>
@@ -87,7 +87,7 @@
     </h2>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <p>
+        <p class="govuk-body">
           Upload a spreadsheet of email&nbsp;addresses or
           phone&nbsp;numbers and Notify sends the messages.
         </p>
@@ -97,7 +97,7 @@
         >
       </div>
       <div class="govuk-grid-column-one-half">
-        <p>
+        <p class="govuk-body">
           Integrate the GOV.UK Notify API with your web&nbsp;application or
           back office system.
         </p>
@@ -133,7 +133,7 @@
           organisations
         </div>
       </div>
-      <p>
+      <p class="govuk-body">
         See the
         <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/performance/govuk-notify/government-services">list of services and organisations</a>.
       </p>
@@ -163,7 +163,7 @@
           <p class="align-with-big-number-hint">
             There’s no monthly charge, no setup fee and no&nbsp;procurement process.
           </p>
-          <p>Find out more about <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/pricing">pricing</a>.
+          <p class="govuk-body">Find out more about <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/pricing">pricing</a>.
           </p>
         </div>
       </div>
@@ -175,11 +175,11 @@
         <h2 class="with-keyline">
           The team
         </h2>
-        <p>
+        <p class="govuk-body">
           GOV.UK Notify is built by the Government Digital Service
           and is supported 24 hours a day, 7 days a week.
         </p>
-        <p>
+        <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact us</a> if you have a question or want
           to give feedback.
         </p>

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -15,17 +15,17 @@
     {% if again %}
       <h1 class="heading-large">You need to sign in again</h1>
       {% if other_device %}
-        <p>
+        <p class="govuk-body">
           We signed you out because you logged in to Notify on another device.
         </p>
       {% else %}
-        <p>
+        <p class="govuk-body">
           We signed you out because you have not used Notify for a while.
         </p>
       {% endif %}
     {% else %}
       <h1 class="heading-large">Sign in</h1>
-      <p>
+      <p class="govuk-body">
         If you do not have an account, you can
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.register') }}">create one now</a>.
       </p>

--- a/app/templates/views/styleguide.html
+++ b/app/templates/views/styleguide.html
@@ -19,14 +19,14 @@
     <a class="govuk-link govuk-link--no-visited-state" href="http://www.notify.works/_styleguide" style="text-decoration: none;">www.notify.works/_styleguide</a>
   </h1>
 
-  <p>
+  <p class="govuk-body">
     <a class="govuk-link govuk-link--no-visited-state" href="https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/styleguide.html">View source</a>
   </p>
 
   <h2 class="heading-large">Banner</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <p>Used to show the status of a thing or action.</p>
+      <p class="govuk-body">Used to show the status of a thing or action.</p>
 
       {{ banner("You sent 1,234 text messages", with_tick=True) }}
 
@@ -40,7 +40,7 @@
 
   <h2 class="heading-large">Big number</h2>
 
-  <p>Used to show some important statistics.</p>
+  <p class="govuk-body">Used to show some important statistics.</p>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
@@ -53,7 +53,7 @@
 
   <h2 class="heading-large">Browse list</h2>
 
-  <p>Used to navigate to child pages.</p>
+  <p class="govuk-body">Used to navigate to child pages.</p>
 
   {{ browse_list([
     {
@@ -75,14 +75,14 @@
 
   <h2 class="heading-large">Page footer</h2>
 
-  <p>
+  <p class="govuk-body">
     Used to submit forms and optionally provide a link to go back to the
     previous page.
   </p>
-  <p>
+  <p class="govuk-body">
     Must be used inside a form.
   </p>
-  <p>
+  <p class="govuk-body">
     Adds a hidden CSRF token to the page.
   </p>
 
@@ -111,7 +111,7 @@
   <h2 class="heading-large">Tables</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <p>
+      <p class="govuk-body">
         Used for comparing rows of data.
       </p>
       {% call mapping_table(
@@ -194,19 +194,19 @@
 
   <h2 class="heading-large">Formatted list</h2>
 
-  <p>
+  <p class="govuk-body">
     {{ 'A' | formatted_list(prefix="one item called") }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {{ 'AB' | formatted_list(prefix_plural="two items called") }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {{ 'ABC' | formatted_list }}
   </p>
 
-  <p>
+  <p class="govuk-body">
     {{ 'ABCD' | formatted_list(before_each='<strike>', after_each='</strike>', conjunction='or') }}
   </p>
 

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -15,21 +15,21 @@
     )}}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p>
+        <p class="govuk-body">
           First, check the
           <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status page</a>.
           You do not need to contact us if
           the problem you’re having is listed on that page.
         </p>
-        <p>
+        <p class="govuk-body">
           Otherwise, contact us using the emergency email address we
           gave you or your service manager when we made your service live.
         </p>
-        <p>
+        <p class="govuk-body">
           We’ll reply within 30 minutes and give you hourly updates
           until the problem’s fixed.
         </p>
-        <p>
+        <p class="govuk-body">
           We do not offer out of hours support if your service is in
           trial mode.
         </p>

--- a/app/templates/views/support/form.html
+++ b/app/templates/views/support/form.html
@@ -19,7 +19,7 @@
       <div class="govuk-grid-column-two-thirds">
         {% if show_status_page_banner %}
           <div class="panel panel-border-wide">
-            <p>
+            <p class="govuk-body">
               Check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a>
               page to see if there are any known issues with GOV.UK Notify.
             </p>
@@ -31,7 +31,7 @@
               {{ textbox(form.name, width='1-1') }}
               {{ textbox(form.email_address, width='1-1') }}
             {% else %}
-              <p>We’ll reply to {{ current_user.email_address }}</p>
+              <p class="govuk-body">We’ll reply to {{ current_user.email_address }}</p>
             {% endif %}
             {{ sticky_page_footer('Send') }}
         {% endcall %}

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Support</h1>
-  <p>We provide 24-hour online support for teams with a live service on GOV.UK&nbsp;Notify.</p>
+  <p class="govuk-body">We provide 24-hour online support for teams with a live service on GOV.UK&nbsp;Notify.</p>
 
   {% call form_wrapper() %}
     {% if current_user.is_authenticated %}
@@ -24,19 +24,19 @@
     {{ page_footer('Continue') }}
   {% endcall %}
 
-  <p>You can also <a class="govuk-link govuk-link--no-visited-state" href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">contact us on Slack</a>.</p>
+  <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href="https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC">contact us on Slack</a>.</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="heading-medium">Office hours</h2>
-    <p>Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>
-    <p>When you report a problem in office hours, we’ll aim to read it within 30 minutes and reply within one working day.</p>
+    <p class="govuk-body">Our office hours are 9:30am to 5:30pm, Monday to Friday.</p>
+    <p class="govuk-body">When you report a problem in office hours, we’ll aim to read it within 30 minutes and reply within one working day.</p>
 
     <h2 class="heading-medium">Out-of-hours</h2>
-    <p>Outside office hours, response times depend on whether you’re reporting an emergency.</p>
-    <p>If it’s an emergency, we’ll reply within 30 minutes and update you every hour until the problem’s fixed.</p>
-    <p>If your problem is not an emergency, we’ll reply within one working day.</p>
-    <p>A problem is only classed as an emergency if:</p>
+    <p class="govuk-body">Outside office hours, response times depend on whether you’re reporting an emergency.</p>
+    <p class="govuk-body">If it’s an emergency, we’ll reply within 30 minutes and update you every hour until the problem’s fixed.</p>
+    <p class="govuk-body">If your problem is not an emergency, we’ll reply within one working day.</p>
+    <p class="govuk-body">A problem is only classed as an emergency if:</p>
     <ul class="list list-bullet">
       <li>nobody on your team can sign in</li>
       <li>a ‘technical difficulties’ error appears when you try to upload a file</li>

--- a/app/templates/views/support/thanks.html
+++ b/app/templates/views/support/thanks.html
@@ -13,7 +13,7 @@
       'Thanks for contacting us',
       back_link=url_for('.support')
     ) }}
-    <p>
+    <p class="govuk-body">
       {% if out_of_hours_emergency %}
         We’ll reply in the next 30 minutes.
       {% else %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -16,10 +16,10 @@
         '{} are disabled'.format(notification_type.capitalize()),
         back_link=back_link,
       ) }}
-      <p>
+      <p class="govuk-body">
         Sending {{ message_count_label(999, notification_type, suffix='') -}} has been disabled for your service.
       </p>
-      <p>
+      <p class="govuk-body">
         If you need to send {{ message_count_label(999, notification_type, suffix='') }}
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">get in touch with the GOV.UK Notify team</a>.
       </p>

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -18,14 +18,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
       {% if template_change.placeholders_removed %}
-        <p>
+        <p class="govuk-body">
           You removed {{ list_of_placeholders(template_change.placeholders_removed) }}
         </p>
       {% endif %}
-      <p>
+      <p class="govuk-body">
         You added {{ list_of_placeholders(template_change.placeholders_added) }}
       </p>
-      <p>
+      <p class="govuk-body">
         Before you send any messages, make sure your API calls include {{ list_of_code_snippets(template_change.placeholders_added) }}.
       </p>
     </div>

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -27,7 +27,7 @@
         "href": url_for('.choose_template', service_id=current_service.id, initial_state='add-new-template')
       }) }}
     {% else %}
-      <p>
+      <p class="govuk-body">
         You need to ask your service manager to add templates before you
         can send text messages.
       </p>

--- a/app/templates/views/templates/choose_history.html
+++ b/app/templates/views/templates/choose_history.html
@@ -13,7 +13,7 @@
       {% endwith %}
     {% endfor %}
   </div>
-  <p>
+  <p class="govuk-body">
     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".choose_template", service_id=current_service.id) }}">Back to current templates</a>
   </p>
 {% endblock %}

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -9,12 +9,12 @@
 
   <h1 class="heading-large">Terms of use</h1>
 
-  <p>
+  <p class="govuk-body">
     These terms apply to your service’s use of GOV.UK&nbsp;Notify. You must be the service manager to accept them.
   </p>
 
   <h2 class="heading-medium">When using Notify</h2>
-  <p>You must:</p>
+  <p class="govuk-body">You must:</p>
   <ul class="list list-bullet">
     <li>complete your organisation’s information assurance process (you do not need to include Notify or our delivery partners, we’ve already done that)</li>
     <li>tell us immediately if you have any security breaches</li>
@@ -26,9 +26,9 @@
     <li>not send messages containing any personally or commercially sensitive information</li>
     <li>check that the data you add to Notify is accurate and complies with data protection legislation</li>
   </ul>
-  <p>If you do not keep to these terms, we might have to stop sending your messages.</p>
+  <p class="govuk-body">If you do not keep to these terms, we might have to stop sending your messages.</p>
 
-  <p>Notify will:</p>
+  <p class="govuk-body">Notify will:</p>
   <ul class="list list-bullet">
     <li>send all the messages you pass to us, as long as they meet our guidelines</li>
     <li>
@@ -39,7 +39,7 @@
   </ul>
 
   <h2 class="heading-medium">Leaving Notify</h2>
-  <p>You can leave Notify at any time. Just <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> and we’ll close your account.</p>
-  <p>When you leave Notify, all your data will be deleted.</p>
+  <p class="govuk-body">You can leave Notify at any time. Just <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> and we’ll close your account.</p>
+  <p class="govuk-body">When you leave Notify, all your data will be deleted.</p>
 
 {% endblock %}

--- a/app/templates/views/text-not-received.html
+++ b/app/templates/views/text-not-received.html
@@ -13,7 +13,7 @@ Check your mobile number
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Check your mobile number</h1>
 
-    <p>Check your mobile phone number is correct and then resend the security code.</p>
+    <p class="govuk-body">Check your mobile phone number is correct and then resend the security code.</p>
 
       {% call form_wrapper() %}
         {{ textbox(form.mobile_number) }}

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -8,8 +8,8 @@
 
   <h1 class="heading-large">Trial mode</h1>
 
-  <p>When you add a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
-  <p>While your service is in trial mode you can only:</p>
+  <p class="govuk-body">When you add a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
+  <p class="govuk-body">While your service is in trial mode you can only:</p>
     <ul class="list list-bullet">
      <li>send 50 text messages and emails per day</li>
       <li>send messages to yourself and other people in your team</li>
@@ -17,10 +17,10 @@
    </ul>
 
     {% if current_service and current_service.trial_mode %}
-  <p>
+  <p class="govuk-body">
     To remove these restrictions, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.</p>
     {% else %}
-  <p>
+  <p class="govuk-body">
     To remove these restrictions:
   </p>
   <ol class="list list-number">
@@ -29,11 +29,11 @@
     <li>Select <b class="govuk-!-font-weight-bold">Request to go live</b>.</li>
   </ol>
     {% endif %}
- <p>
+ <p class="govuk-body">
     When we receive your request we’ll get back to you within one working day.
   </p>
   <h2 class="heading-medium" id="before-you-request-to-go-live">Before you request to go live</h2>
-  <p>You must:</p>
+  <p class="govuk-body">You must:</p>
   <ul class="list list-bullet">
     <li>add examples of the messages you want to send</li>
     <li>update your settings so you’re ready to send and receive messages</li>

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -10,8 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">{{ title }}</h1>
-    <p>We’ve emailed you a link to sign in to Notify.</p>
-    <p>Clicking the link will open Notify in a new browser window, so you can close this one.</p>
+    <p class="govuk-body">We’ve emailed you a link to sign in to Notify.</p>
+    <p class="govuk-body">Clicking the link will open Notify in a new browser window, so you can close this one.</p>
     {{ page_footer(
       secondary_link=url_for('main.email_not_received'),
       secondary_link_text='Not received an email?'

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Check your phone</h1>
 
-    <p>We’ve sent you a text message with a security code.</p>
+    <p class="govuk-body">We’ve sent you a text message with a security code.</p>
 
     {% call form_wrapper(class="extra-tracking") %}
       {{ textbox(

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -14,7 +14,7 @@
       {% call banner_wrapper(type='dangerous') %}
         <h1 class="banner-title">{{ error.title }}</h1>
         {% if error.detail %}
-          <p>{{ error.detail | safe }}</p>
+          <p class="govuk-body">{{ error.detail | safe }}</p>
         {% endif %}
       {% endcall %}
     {% else %}
@@ -22,11 +22,11 @@
         'Upload a letter',
         back_link=url_for('main.uploads', service_id=current_service.id)
     ) }}
-    <p>Upload a single letter as a PDF and we’ll print, pack and post it for you.</p>
-    <p>You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
+    <p class="govuk-body">Upload a single letter as a PDF and we’ll print, pack and post it for you.</p>
+    <p class="govuk-body">You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
     {% endif %}
 
-  <p>
+  <p class="govuk-body">
     {{ file_upload(
       form.file,
       action=url_for('main.upload_letter', service_id=current_service.id),
@@ -37,9 +37,9 @@
 
   <h2 class="heading-medium">Your file must meet our letter specification</h2>
 
-  <p>The content of your letter must appear inside the printable area.</p>
+  <p class="govuk-body">The content of your letter must appear inside the printable area.</p>
 
-  <p>Your file must be:</p>
+  <p class="govuk-body">Your file must be:</p>
 
     <ul class="list list-bullet">
       <li>a PDF</li>
@@ -48,7 +48,7 @@
       <li>smaller than 2MB</li>
     </ul>
 
-  <p>To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a>.</p>
+  <p class="govuk-body">To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification document (PDF)</a>.</p>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -29,7 +29,7 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file has too many rows
         </h1>
-        <p>
+        <p class="govuk-body">
           Notify can store files up to
           {{ "{:,}".format(recipients.max_rows) }} rows in size. Your
           file has {{ "{:,}".format(recipients|length) }} rows.
@@ -42,7 +42,7 @@
           {{ 'this' if recipients|length == 1 else 'these' }}
           {{ recipient_count_label(recipients|length, recipients.template_type) }}
         </h1>
-        <p>
+        <p class="govuk-body">
           In <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new') }}">trial mode</a> you can only
           send to yourself and members of your team
         </p>

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -27,14 +27,14 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There’s a problem with {{ original_file_name }}
         </h1>
-        <p>
+        <p class="govuk-body">
           You need to {{ row_errors[0] }}.
         </p>
       {% else %}
         <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There are some problems with {{ original_file_name }}
         </h1>
-        <p>
+        <p class="govuk-body">
           You need to:
         </p>
         <ul class="list-bullet">

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -29,7 +29,7 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="No rows" data-error-label="{{ upload_id }}">
           Your file is missing some rows
         </h1>
-        <p>
+        <p class="govuk-body">
           It needs at least one row of data
           {%- if template_type %}.{% else %}, in a column called ‘email address’ or ‘phone number’.{% endif %}
         </p>
@@ -39,7 +39,7 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file needs a column called ‘email address’ or ‘phone number’.
         </h1>
-        <p>
+        <p class="govuk-body">
           Right now it has 1 column called ‘{{ recipients._raw_column_headers[0] }}’.
         </p>
 
@@ -48,10 +48,10 @@
         <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file has too many columns
         </h1>
-        <p>
+        <p class="govuk-body">
           It needs to have 1 column, called ‘email address’ or ‘phone number’.
         </p>
-        <p>
+        <p class="govuk-body">
           Right now it has {{ recipients._raw_column_headers|length }} columns called {{ recipients._raw_column_headers | formatted_list }}.
         </p>
 

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -13,7 +13,7 @@
     {% call banner_wrapper(type='dangerous') %}
       <h1 class="banner-title">{{ error.title }}</h1>
       {% if error.detail %}
-        <p>{{ error.detail | safe }}</p>
+        <p class="govuk-body">{{ error.detail | safe }}</p>
       {% endif %}
     {% endcall %}
   {% else %}

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -17,7 +17,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <p>
+      <p class="govuk-body">
         We’ve sent a security code to your new {{ thing }}.
       </p>
       {% call form_wrapper() %}

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -15,9 +15,9 @@
 
     <h1 class="heading-large">Using Notify</h1>
 
-    <p>The information on this page has moved.</p>
+    <p class="govuk-body">The information on this page has moved.</p>
 
-    <p>Find out more about:</p>
+    <p class="govuk-body">Find out more about:</p>
     <ul class="list list-bullet">
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode_new') }}">trial mode</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.message_status') }}">message status types</a></li>

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -11,8 +11,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Resend security code</h1>
 
-    <p>Text messages sometimes take a few minutes to arrive. If you do not receive a security code, Notify can send you a new one.</p>
-    <p>
+    <p class="govuk-body">Text messages sometimes take a few minutes to arrive. If you do not receive a security code, Notify can send you a new one.</p>
+    <p class="govuk-body">
       {{ govukButton({
         "element": "a",
         "text": "Resend security code",
@@ -21,7 +21,7 @@
     </p>
 
     <h2 class="heading-medium">If your mobile number has changed</h2>
-    <p>You’ll need to:</p>
+    <p class="govuk-body">You’ll need to:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>find a member of your team who has permission to manage settings, team and usage</li>
       <li>ask them to change the mobile number for your account</li>

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -453,7 +453,7 @@ def test_signed_in_existing_user_cannot_use_anothers_invite(
     assert page.h1.string.strip() == 'You’re not allowed to see this page'
     flash_banners = page.find_all('div', class_='banner-dangerous')
     assert len(flash_banners) == 1
-    banner_contents = flash_banners[0].text.strip()
+    banner_contents = normalize_spaces(flash_banners[0].text)
     assert "You’re signed in as test@user.gov.uk." in banner_contents
     assert "This invite is for another email address." in banner_contents
     assert "Sign out and click the link again to accept this invite." in banner_contents

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -284,6 +284,7 @@ def test_letter_template_preview_links_to_the_correct_image(
     page = client_request.get(
         'main.letter_template',
         _test_page_title=False,
+        _test_for_elements_without_class=False,
         branding_style=branding_style
     )
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -284,6 +284,7 @@ def test_letter_template_preview_links_to_the_correct_image(
     page = client_request.get(
         'main.letter_template',
         _test_page_title=False,
+        # Letter HTML doesn’t use the Design System, so elements won’t have class attributes
         _test_for_elements_without_class=False,
         branding_style=branding_style
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3030,6 +3030,7 @@ def client_request(
             if _test_for_elements_without_class and _expected_status not in (301, 302):
                 for tag, hint in (
                     ('p', 'govuk-body'),
+                    ('a', 'govuk-link govuk-link--no-visited-state'),
                 ):
                     element = page.select_one(f'{tag}:not([class])')
                     if (


### PR DESCRIPTION
All paragraphs should have `class="govuk-body"`, or be otherwise custom-styled. This commit adds some extra checks to our test fixture that looks for paragraphs that don’t have any styling. Our test coverage is pretty good, so this should check almost all pages, and prevent regressions.

I’ve done this in such a way that it can be extended for other elements (e.g. links) in the future.

![image](https://user-images.githubusercontent.com/355079/83281386-f17c9f80-a1cf-11ea-9a92-9cae1144507f.png)
