### PR TITLE
Fix paragraphs with reversed-out text

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -82,6 +82,7 @@
 
     margin-top: 0;
     margin-bottom: govuk-spacing(6);
+    color: $white;
 
     &:last-child {
       margin-bottom: 0;

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -36,6 +36,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
     p {
       @include core-24;
+      color: $white;
       margin: govuk-spacing(3) 0 govuk-spacing(6);
     }
 


### PR DESCRIPTION
Since these two paragraphs sit on a blue background, they should have white text. But this was getting overridden when the `govuk-body` class was [added in a previous pull request](https://github.com/alphagov/notifications-admin/pull/3467), and the paragraphs appeared with black text.

Previously these paragraphs were inheriting their colour from a parent element. But a class applied directly to the element is more specific. So this commit fixes the problem by being more specific again, by applying the colour to the element, in the context of it’s parent’s class.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/83508953-9219da80-a4c2-11ea-953f-feb75fd5c080.png) | ![image](https://user-images.githubusercontent.com/355079/83508975-9a721580-a4c2-11ea-8356-e5778dd5eaa1.png)
