### PR TITLE
Update permanent failure error message content

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -427,7 +427,7 @@ def format_notification_status(status, template_type):
             'failed': 'Failed',
             'technical-failure': 'Technical failure',
             'temporary-failure': 'Phone not accepting messages right now',
-            'permanent-failure': 'Phone number does not exist',
+            'permanent-failure': 'Not delivered',
             'delivered': 'Delivered',
             'sending': 'Sending',
             'created': 'Sending',

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -55,7 +55,7 @@
         ('Sending', 'Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. Notify is waiting for delivery information.'),
         ('Sent internationally', 'The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
-        ('Phone number does not exist', 'The provider could not deliver the message because the phone number was wrong. You should remove these phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist.'),
+        ('Not delivered', 'The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. You should check that these phone numbers are correct. If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.'),
         ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
         ('Technical failure', 'Your message was not sent because there was a problem between Notify and the provider. You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.'),
       ] %}

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -715,7 +715,7 @@ def test_big_numbers_dont_show_for_letters(
         ('sms', 'created', 'Sending since 27 September at 5:30pm', True),
         ('sms', 'sending', 'Sending since 27 September at 5:30pm', True),
         ('sms', 'temporary-failure', 'Phone not accepting messages right now 27 September at 5:31pm', False),
-        ('sms', 'permanent-failure', 'Phone number does not exist 27 September at 5:31pm', False),
+        ('sms', 'permanent-failure', 'Not delivered 27 September at 5:31pm', False),
         ('sms', 'delivered', 'Delivered 27 September at 5:31pm', True),
         ('letter', 'created', '27 September at 5:30pm', True),
         ('letter', 'pending-virus-check', '27 September at 5:30pm', True),

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -23,13 +23,13 @@ from tests.conftest import (
     (None, 'delivered', 'Delivered'),
     (None, 'failed', 'Failed'),
     (None, 'temporary-failure', 'Phone not accepting messages right now'),
-    (None, 'permanent-failure', 'Phone number does not exist'),
+    (None, 'permanent-failure', 'Not delivered'),
     (None, 'technical-failure', 'Technical failure'),
     ('team', 'delivered', 'Delivered'),
     ('live', 'delivered', 'Delivered'),
     ('test', 'sending', 'Sending (test)'),
     ('test', 'delivered', 'Delivered (test)'),
-    ('test', 'permanent-failure', 'Phone number does not exist (test)'),
+    ('test', 'permanent-failure', 'Not delivered (test)'),
 ])
 @pytest.mark.parametrize('user', [
     create_active_user_with_permissions(),


### PR DESCRIPTION
This PR updates the error and description content for a permanent failure.

The current error states that a permanent failure happens when a "phone number does not exist". This isn't always the case. Permanent failures can happen when numbers are blacklisted, not accepting text messages, or if the network operator rejects the message.

We've been contacted by users who have received this error when sending to numbers that definitely *do* exist.

Until we can offer more specific reasons for the failure, we're going to update the content to include some of the other possible causes.