### PR TITLE
Allow invite form to be pre-populated with an existing user

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -70,6 +70,10 @@ def invite_user(service_id, user_id=None):
                 'views/user-already-invited.html',
                 user_to_invite=user_to_invite,
             )
+        if not user_to_invite.default_organisation:
+            abort(403)
+        if user_to_invite.default_organisation.id != current_service.organisation_id:
+            abort(403)
         form.email_address.data = user_to_invite.email_address
     else:
         user_to_invite = None

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -65,7 +65,10 @@ def invite_user(service_id, user_id=None):
 
     if user_id:
         user_to_invite = User.from_id(user_id)
-        if user_to_invite.belongs_to_service(current_service.id):
+        if (
+            user_to_invite.belongs_to_service(current_service.id)
+            or current_service.invite_pending_for(user_to_invite.email_address)
+        ):
             return render_template(
                 'views/user-already-invited.html',
                 user_to_invite=user_to_invite,

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -65,10 +65,12 @@ def invite_user(service_id, user_id=None):
 
     if user_id:
         user_to_invite = User.from_id(user_id)
-        if (
-            user_to_invite.belongs_to_service(current_service.id)
-            or current_service.invite_pending_for(user_to_invite.email_address)
-        ):
+        if user_to_invite.belongs_to_service(current_service.id):
+            return render_template(
+                'views/user-already-team-member.html',
+                user_to_invite=user_to_invite,
+            )
+        if current_service.invite_pending_for(user_to_invite.email_address):
             return render_template(
                 'views/user-already-invited.html',
                 user_to_invite=user_to_invite,

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -65,6 +65,11 @@ def invite_user(service_id, user_id=None):
 
     if user_id:
         user_to_invite = User.from_id(user_id)
+        if user_to_invite.belongs_to_service(current_service.id):
+            return render_template(
+                'views/user-already-invited.html',
+                user_to_invite=user_to_invite,
+            )
         form.email_address.data = user_to_invite.email_address
     else:
         user_to_invite = None

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -48,8 +48,9 @@ def manage_users(service_id):
 
 
 @main.route("/services/<uuid:service_id>/users/invite", methods=['GET', 'POST'])
+@main.route("/services/<uuid:service_id>/users/invite/<uuid:user_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
-def invite_user(service_id):
+def invite_user(service_id, user_id=None):
 
     if current_service.has_permission('broadcast'):
         form_class = BroadcastInviteUserForm
@@ -61,6 +62,12 @@ def invite_user(service_id):
         all_template_folders=current_service.all_template_folders,
         folder_permissions=[f['id'] for f in current_service.all_template_folders]
     )
+
+    if user_id:
+        user_to_invite = User.from_id(user_id)
+        form.email_address.data = user_to_invite.email_address
+    else:
+        user_to_invite = None
 
     service_has_email_auth = current_service.has_permission('email_auth')
     if not service_has_email_auth:
@@ -85,6 +92,7 @@ def invite_user(service_id):
         form=form,
         service_has_email_auth=service_has_email_auth,
         mobile_number=True,
+        user_to_invite=user_to_invite,
     )
 
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -160,6 +160,12 @@ class Service(JSONModel):
     def invited_users(self):
         return InvitedUsers(self.id)
 
+    def invite_pending_for(self, email_address):
+        return email_address.lower() in (
+            invited_user.email_address.lower()
+            for invited_user in self.invited_users
+        )
+
     @cached_property
     def active_users(self):
         return Users(self.id)

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -10,18 +10,24 @@
 {% block maincolumn_content %}
 
   {{ page_header(
-    'Invite a team member',
+    'Invite {}'.format(user_to_invite.name if user_to_invite else 'a team member') ,
     back_link=url_for('main.manage_users', service_id=current_service.id)
   ) }}
 
   {% call form_wrapper() %}
 
-    {{ form.email_address(
-      param_extensions={
-        "classes": "govuk-!-width-full"
-      },
-      error_message_with_html=True
-    ) }}
+    {% if user_to_invite %}
+      <p class="govuk-body">
+        {{ user_to_invite.email_address }}
+      </p>
+    {% else %}
+      {{ form.email_address(
+        param_extensions={
+          "classes": "govuk-!-width-full"
+        },
+        error_message_with_html=True
+      ) }}
+    {% endif %}
 
     {% include 'views/manage-users/permissions.html' %}
 

--- a/app/templates/views/user-already-invited.html
+++ b/app/templates/views/user-already-invited.html
@@ -1,0 +1,19 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block service_page_title %}
+  This person is already a team member
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(
+    '{} is already a team member'.format(user_to_invite.name),
+    back_link=url_for('main.manage_users', service_id=current_service.id)
+  ) }}
+
+  <p class="govuk-body">
+    Someone’s already invited them. You do not need to do anything.
+  </p>
+
+{% endblock %}

--- a/app/templates/views/user-already-team-member.html
+++ b/app/templates/views/user-already-team-member.html
@@ -2,19 +2,18 @@
 {% from "components/page-header.html" import page_header %}
 
 {% block service_page_title %}
-  This person has already received an invite
+  This person is already a team member
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    'This person has already received an invite',
+    'This person is already a team member',
     back_link=url_for('main.manage_users', service_id=current_service.id)
   ) }}
 
   <p class="govuk-body">
-    {{ user_to_invite.name }} has not accepted their invitation to
-    ‘{{ current_service.name }}’ yet. You do not need to do anything.
+    {{ user_to_invite.name }} is already member of ‘{{ current_service.name }}’.
   </p>
 
 {% endblock %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -806,6 +806,29 @@ def test_should_show_page_for_inviting_user(
     assert not page.find('div', class_='checkboxes-nested')
 
 
+def test_should_show_page_for_inviting_user_with_email_prefilled(
+    client_request,
+    mock_get_template_folders,
+    fake_uuid,
+):
+    page = client_request.get(
+        'main.invite_user',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+        # We have the user’s name in the H1 but don’t want it duplicated
+        # in the page title
+        _test_page_title=False,
+    )
+
+    assert normalize_spaces(page.select_one('h1').text) == (
+        'Invite Test User'
+    )
+    assert normalize_spaces(page.select_one('main .govuk-body').text) == (
+        'test@user.gov.uk'
+    )
+    assert not page.select("input#email_address") or page.select("input[type=email]")
+
+
 def test_should_show_folder_permission_form_if_service_has_folder_permissions_enabled(
     client_request,
     mocker,
@@ -875,6 +898,44 @@ def test_invite_user(
                                                                 expected_permissions,
                                                                 'sms_auth',
                                                                 [])
+
+
+def test_invite_user_when_email_address_is_prefilled(
+    client_request,
+    active_user_with_permissions,
+    active_caseworking_user,
+    fake_uuid,
+    mocker,
+    sample_invite,
+    mock_get_template_folders,
+):
+    mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
+        # First call is to get the current user
+        active_user_with_permissions,
+        # Second call gets the user to invite
+        active_caseworking_user,
+    ])
+    mocker.patch('app.invite_api_client.create_invite', return_value=sample_invite)
+    client_request.post(
+        'main.invite_user',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+        _data={
+            # No posted email address
+            'permissions_field': [
+                'send_messages',
+            ],
+        },
+    )
+
+    app.invite_api_client.create_invite.assert_called_once_with(
+        active_user_with_permissions['id'],
+        SERVICE_ONE_ID,
+        active_caseworking_user['email_address'],
+        {'send_messages'},
+        'sms_auth',
+        [],
+    )
 
 
 @pytest.mark.parametrize('auth_type', [

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -865,19 +865,16 @@ def test_should_show_page_if_prefilled_user_is_already_a_team_member(
         'main.invite_user',
         service_id=SERVICE_ONE_ID,
         user_id=fake_uuid,
-        # We have the user’s name in the H1 but don’t want it duplicated
-        # in the page title
-        _test_page_title=False,
     )
 
     assert normalize_spaces(page.select_one('title').text).startswith(
         'This person is already a team member'
     )
     assert normalize_spaces(page.select_one('h1').text) == (
-        'Test User is already a team member'
+        'This person is already a team member'
     )
     assert normalize_spaces(page.select_one('main .govuk-body').text) == (
-        'Someone’s already invited them. You do not need to do anything.'
+        'Test User is already member of ‘service one’.'
     )
     assert not page.select("form")
 
@@ -904,14 +901,19 @@ def test_should_show_page_if_prefilled_user_is_already_invited(
         'main.invite_user',
         service_id=SERVICE_ONE_ID,
         user_id=fake_uuid,
-        # We have the user’s name in the H1 but don’t want it duplicated
-        # in the page title
-        _test_page_title=False,
     )
 
     assert normalize_spaces(page.select_one('title').text).startswith(
-        'This person is already a team member'
+        'This person has already received an invite'
     )
+    assert normalize_spaces(page.select_one('h1').text) == (
+        'This person has already received an invite'
+    )
+    assert normalize_spaces(page.select_one('main .govuk-body').text) == (
+        'Service Two User has not accepted their invitation to '
+        '‘service one’ yet. You do not need to do anything.'
+    )
+    assert not page.select("form")
 
 
 def test_should_403_if_trying_to_prefill_email_address_for_user_with_no_organisation(

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -807,10 +807,54 @@ def test_should_show_page_for_inviting_user(
 
 
 def test_should_show_page_for_inviting_user_with_email_prefilled(
+    mocker,
     client_request,
     mock_get_template_folders,
     fake_uuid,
+    active_user_with_permissions,
+    active_user_with_permission_to_other_service,
 ):
+    mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
+        # First call is to get the current user
+        active_user_with_permissions,
+        # Second call gets the user to invite
+        active_user_with_permission_to_other_service,
+    ])
+
+    page = client_request.get(
+        'main.invite_user',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+        # We have the user’s name in the H1 but don’t want it duplicated
+        # in the page title
+        _test_page_title=False,
+    )
+    assert normalize_spaces(page.select_one('title').text).startswith(
+        'Invite a team member'
+    )
+    assert normalize_spaces(page.select_one('h1').text) == (
+        'Invite Service Two User'
+    )
+    assert normalize_spaces(page.select_one('main .govuk-body').text) == (
+        'service-two-user@test.gov.uk'
+    )
+    assert not page.select("input#email_address") or page.select("input[type=email]")
+
+
+def test_should_show_page_if_prefilled_user_is_already_a_team_member(
+    mocker,
+    client_request,
+    mock_get_template_folders,
+    fake_uuid,
+    active_user_with_permissions,
+    active_caseworking_user,
+):
+    mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
+        # First call is to get the current user
+        active_user_with_permissions,
+        # Second call gets the user to invite
+        active_caseworking_user,
+    ])
     page = client_request.get(
         'main.invite_user',
         service_id=SERVICE_ONE_ID,
@@ -820,13 +864,16 @@ def test_should_show_page_for_inviting_user_with_email_prefilled(
         _test_page_title=False,
     )
 
+    assert normalize_spaces(page.select_one('title').text).startswith(
+        'This person is already a team member'
+    )
     assert normalize_spaces(page.select_one('h1').text) == (
-        'Invite Test User'
+        'Test User is already a team member'
     )
     assert normalize_spaces(page.select_one('main .govuk-body').text) == (
-        'test@user.gov.uk'
+        'Someone’s already invited them. You do not need to do anything.'
     )
-    assert not page.select("input#email_address") or page.select("input[type=email]")
+    assert not page.select("form")
 
 
 def test_should_show_folder_permission_form_if_service_has_folder_permissions_enabled(
@@ -903,7 +950,7 @@ def test_invite_user(
 def test_invite_user_when_email_address_is_prefilled(
     client_request,
     active_user_with_permissions,
-    active_caseworking_user,
+    active_user_with_permission_to_other_service,
     fake_uuid,
     mocker,
     sample_invite,
@@ -913,7 +960,7 @@ def test_invite_user_when_email_address_is_prefilled(
         # First call is to get the current user
         active_user_with_permissions,
         # Second call gets the user to invite
-        active_caseworking_user,
+        active_user_with_permission_to_other_service,
     ])
     mocker.patch('app.invite_api_client.create_invite', return_value=sample_invite)
     client_request.post(
@@ -931,7 +978,7 @@ def test_invite_user_when_email_address_is_prefilled(
     app.invite_api_client.create_invite.assert_called_once_with(
         active_user_with_permissions['id'],
         SERVICE_ONE_ID,
-        active_caseworking_user['email_address'],
+        active_user_with_permission_to_other_service['email_address'],
         {'send_messages'},
         'sms_auth',
         [],

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -7,6 +7,8 @@ from flask import url_for
 import app
 from app.utils import is_gov_user
 from tests.conftest import (
+    ORGANISATION_ID,
+    ORGANISATION_TWO_ID,
     SERVICE_ONE_ID,
     USER_ONE_ID,
     create_active_user_empty_permissions,
@@ -807,13 +809,16 @@ def test_should_show_page_for_inviting_user(
 
 
 def test_should_show_page_for_inviting_user_with_email_prefilled(
-    mocker,
     client_request,
+    mocker,
+    service_one,
     mock_get_template_folders,
     fake_uuid,
     active_user_with_permissions,
     active_user_with_permission_to_other_service,
+    mock_get_organisation_by_domain,
 ):
+    service_one['organisation'] = ORGANISATION_ID
     mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
         # First call is to get the current user
         active_user_with_permissions,
@@ -874,6 +879,56 @@ def test_should_show_page_if_prefilled_user_is_already_a_team_member(
         'Someone’s already invited them. You do not need to do anything.'
     )
     assert not page.select("form")
+
+
+def test_should_403_if_trying_to_prefill_email_address_for_user_with_no_organisation(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_template_folders,
+    fake_uuid,
+    active_user_with_permissions,
+    active_user_with_permission_to_other_service,
+    mock_get_no_organisation_by_domain,
+):
+    service_one['organisation'] = ORGANISATION_ID
+    mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
+        # First call is to get the current user
+        active_user_with_permissions,
+        # Second call gets the user to invite
+        active_user_with_permission_to_other_service,
+    ])
+    client_request.get(
+        'main.invite_user',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+        _expected_status=403,
+    )
+
+
+def test_should_403_if_trying_to_prefill_email_address_for_user_from_other_organisation(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_template_folders,
+    fake_uuid,
+    active_user_with_permissions,
+    active_user_with_permission_to_other_service,
+    mock_get_organisation_by_domain,
+):
+    service_one['organisation'] = ORGANISATION_TWO_ID
+    mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
+        # First call is to get the current user
+        active_user_with_permissions,
+        # Second call gets the user to invite
+        active_user_with_permission_to_other_service,
+    ])
+    client_request.get(
+        'main.invite_user',
+        service_id=SERVICE_ONE_ID,
+        user_id=fake_uuid,
+        _expected_status=403,
+    )
 
 
 def test_should_show_folder_permission_form_if_service_has_folder_permissions_enabled(
@@ -949,13 +1004,16 @@ def test_invite_user(
 
 def test_invite_user_when_email_address_is_prefilled(
     client_request,
+    service_one,
     active_user_with_permissions,
     active_user_with_permission_to_other_service,
     fake_uuid,
     mocker,
     sample_invite,
     mock_get_template_folders,
+    mock_get_organisation_by_domain,
 ):
+    service_one['organisation'] = ORGANISATION_ID
     mocker.patch('app.models.user.user_api_client.get_user', side_effect=[
         # First call is to get the current user
         active_user_with_permissions,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3417,8 +3417,8 @@ def mock_get_organisation(mocker):
 
 @pytest.fixture(scope='function')
 def mock_get_organisation_by_domain(mocker):
-    def _get_organisation_by_domain(org_id):
-        return organisation_json(org_id)
+    def _get_organisation_by_domain(domain):
+        return organisation_json(ORGANISATION_ID)
 
     return mocker.patch(
         'app.organisations_client.get_organisation_by_domain',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1316,6 +1316,21 @@ def active_user_with_permission_to_two_services(fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def active_user_with_permission_to_other_service(
+    active_user_with_permission_to_two_services
+):
+    active_user_with_permission_to_two_services['permissions'].pop(SERVICE_ONE_ID)
+    active_user_with_permission_to_two_services['services'].pop(0)
+    active_user_with_permission_to_two_services['name'] = (
+        'Service Two User'
+    )
+    active_user_with_permission_to_two_services['email_address'] = (
+        'service-two-user@test.gov.uk'
+    )
+    return active_user_with_permission_to_two_services
+
+
+@pytest.fixture(scope='function')
 def active_caseworking_user(fake_uuid):
 
     user_data = {


### PR DESCRIPTION
At the moment users must be invited to join a service. But this means:
- users must know that a service already exists
- they need to know who to ask for an invite

If the user doesn’t know these thing then sometimes they just go ahead and set up a new service. Which means they have to get all the way to the point of requesting to go live before we tell them that there’s already a service with a similar name or purpose.

So we should let users:
1. discover what other services exist in their organisation
2. apply to join a service
3. automatically notify the service managers of their interest
4. be invited by a service manager
5. accept the invite

This commit implements step 4. We can just link them to the invite form in step 3., but we should make it easy for them to send the invite, without having to copy and paste email addresses.

So this commit let the invite form be pre-populated with an existing user’s email address.

![image](https://user-images.githubusercontent.com/355079/103415105-a1582800-4b78-11eb-9f5a-aac4628efe91.png)
