### PR TITLE
Don’t treat self arg of cache-decorated functions as special

### DIFF
--- a/app/notify_client/cache.py
+++ b/app/notify_client/cache.py
@@ -16,7 +16,7 @@ def _get_argument(argument_name, client_method, args, kwargs):
 
     with suppress(ValueError, IndexError):
         argument_index = list(signature(client_method).parameters).index(argument_name)
-        return args[argument_index - 1]  # -1 because `args` doesn’t include `self`
+        return args[argument_index]
 
     with suppress(KeyError):
         return signature(client_method).parameters[argument_name].default
@@ -38,12 +38,12 @@ def set(key_format):
     def _set(client_method):
 
         @wraps(client_method)
-        def new_client_method(client_instance, *args, **kwargs):
+        def new_client_method(*args, **kwargs):
             redis_key = _make_key(key_format, client_method, args, kwargs)
             cached = redis_client.get(redis_key)
             if cached:
                 return json.loads(cached.decode('utf-8'))
-            api_response = client_method(client_instance, *args, **kwargs)
+            api_response = client_method(*args, **kwargs)
             redis_client.set(
                 redis_key,
                 json.dumps(api_response),
@@ -60,9 +60,9 @@ def delete(key_format):
     def _delete(client_method):
 
         @wraps(client_method)
-        def new_client_method(client_instance, *args, **kwargs):
+        def new_client_method(*args, **kwargs):
             try:
-                api_response = client_method(client_instance, *args, **kwargs)
+                api_response = client_method(*args, **kwargs)
             finally:
                 redis_key = _make_key(key_format, client_method, args, kwargs)
                 redis_client.delete(redis_key)

--- a/tests/app/notify_client/test_cache.py
+++ b/tests/app/notify_client/test_cache.py
@@ -1,0 +1,105 @@
+import pytest
+
+from app.notify_client import cache
+
+
+@pytest.mark.parametrize('args, kwargs, expected_cache_key', (
+    (
+        [1, 2, 3], {}, '1-2-3-None-None-None'
+    ),
+    (
+        [1, 2, 3, 4, 5, 6], {}, '1-2-3-4-5-6'
+    ),
+    (
+        [1, 2, 3], {'x': 4, 'y': 5, 'z': 6}, '1-2-3-4-5-6'
+    ),
+    (
+        [1, 2, 3, 4], {'y': 5}, '1-2-3-4-5-None'
+    ),
+))
+def test_sets_cache(
+    mocker,
+    args,
+    kwargs,
+    expected_cache_key,
+):
+    mock_redis_set = mocker.patch(
+        'app.extensions.RedisClient.set',
+    )
+    mock_redis_get = mocker.patch(
+        'app.extensions.RedisClient.get',
+        return_value=None,
+    )
+
+    @cache.set('{a}-{b}-{c}-{x}-{y}-{z}')
+    def foo(a, b, c, x=None, y=None, z=None):
+        return 'bar'
+
+    assert foo(*args, **kwargs) == 'bar'
+
+    mock_redis_get.assert_called_once_with(expected_cache_key)
+
+    mock_redis_set.assert_called_once_with(
+        expected_cache_key,
+        '"bar"',
+        ex=604_800,
+    )
+
+
+def test_raises_if_key_doesnt_match_arguments():
+
+    @cache.set('{baz}')
+    def foo(bar):
+        pass
+
+    with pytest.raises(KeyError):
+        foo(1)
+
+    with pytest.raises(KeyError):
+        foo()
+
+
+def test_gets_from_cache(mocker):
+    mock_redis_get = mocker.patch(
+        'app.extensions.RedisClient.get',
+        return_value=b'"bar"',
+    )
+
+    @cache.set('{a}-{b}-{c}')
+    def foo(a, b, c):
+        # This function should not be called because the cache has
+        # returned a value
+        raise RuntimeError
+
+    assert foo(1, 2, 3) == 'bar'
+
+    mock_redis_get.assert_called_once_with('1-2-3')
+
+
+def test_deletes_from_cache(mocker):
+    mock_redis_delete = mocker.patch(
+        'app.extensions.RedisClient.delete'
+    )
+
+    @cache.delete('{a}-{b}-{c}')
+    def foo(a, b, c):
+        return 'bar'
+
+    assert foo(1, 2, 3) == 'bar'
+
+    mock_redis_delete.assert_called_once_with('1-2-3')
+
+
+def test_deletes_from_cache_even_if_call_raises(mocker):
+    mock_redis_delete = mocker.patch(
+        'app.extensions.RedisClient.delete'
+    )
+
+    @cache.delete('bar')
+    def foo():
+        raise RuntimeError
+
+    with pytest.raises(RuntimeError):
+        foo()
+
+    mock_redis_delete.assert_called_once_with('bar')


### PR DESCRIPTION
Our API client caching code assumes that what it’s decorating is a bound method, i.e. it’s first argument is `self`. It then does some trickery to make sure that you can’t use the value of `self` as part of the cache key. While using the value of `self` as part of the cache key would be
useless (because when turned to a string it contains the address of the object in memory, meaning it would not be a long-lived key) it does also stop us from using this decorator on plain functions.

This commit removes the handling of `self` as a special case, and adds some tests proving that it can now be used on plain functions.

This will be useful for when we extract this code for use in the API.