### PR TITLE
Add service name hint text for local authorities

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -87,6 +87,7 @@ def add_service():
                 heading=heading,
                 default_organisation_type=default_organisation_type,
             )
+
         return render_template(
             'views/add-service.html',
             form=form,

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -80,6 +80,13 @@ def add_service():
             template_id=example_sms_template['data']['id']
         ))
     else:
+        if default_organisation_type == 'local':
+            return render_template(
+                'views/add-service-local.html',
+                form=form,
+                heading=heading,
+                default_organisation_type=default_organisation_type,
+            )
         return render_template(
             'views/add-service.html',
             form=form,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -104,6 +104,12 @@ def service_name_change(service_id):
         session['service_name_change'] = form.name.data
         return redirect(url_for('.service_name_change_confirm', service_id=service_id))
 
+    if current_service.organisation_type == 'local':
+        return render_template(
+            'views/service-settings/name-local.html',
+            form=form,
+        )
+
     return render_template(
         'views/service-settings/name.html',
         form=form,

--- a/app/templates/views/add-service-local.html
+++ b/app/templates/views/add-service-local.html
@@ -17,13 +17,13 @@
     {{ page_header('About your service') }}
 
     <p class="govuk-body">Give your service a name that tells users what your messages are about, as well as who they’re from. For example:</p>
-        <ul class="list-bullet">
+        <ul class="govuk-list govuk-list--bullet">
           <li>School admissions - {{ current_user.default_organisation.name }}</li>
           <li>Electoral services - {{ current_user.default_organisation.name }}</li>
           <li>Blue Badge - {{ current_user.default_organisation.name }}</li>
         </ul>
         <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
-    
+
     {% call form_wrapper() %}
 
       {{ textbox(form.name, hint="You can change this later") }}

--- a/app/templates/views/add-service-local.html
+++ b/app/templates/views/add-service-local.html
@@ -1,0 +1,38 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/radios.html" import radios %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% block per_page_title %}
+    About your service
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {{ page_header('About your service') }}
+
+    <p class="govuk-body">Give your service a name that tells users what your messages are about, as well as who they’re from. For example:</p>
+        <ul class="list-bullet">
+          <li>School admissions - {{ current_user.default_organisation.name }}</li>
+          <li>Electoral services - {{ current_user.default_organisation.name }}</li>
+          <li>Blue Badge - {{ current_user.default_organisation.name }}</li>
+        </ul>
+        <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
+    
+    {% call form_wrapper() %}
+
+      {{ textbox(form.name, hint="You can change this later") }}
+
+      {{ page_footer('Add service') }}
+
+    {% endcall %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/views/add-service-local.html
+++ b/app/templates/views/add-service-local.html
@@ -18,9 +18,9 @@
 
     <p class="govuk-body">Give your service a name that tells users what your messages are about, as well as who they’re from. For example:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>School admissions - {{ current_user.default_organisation.name }}</li>
-          <li>Electoral services - {{ current_user.default_organisation.name }}</li>
-          <li>Blue Badge - {{ current_user.default_organisation.name }}</li>
+          <li>School admissions – {{ current_user.default_organisation.name }}</li>
+          <li>Electoral services – {{ current_user.default_organisation.name }}</li>
+          <li>Blue Badge – {{ current_user.default_organisation.name }}</li>
         </ul>
         <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
 

--- a/app/templates/views/service-settings/name-local.html
+++ b/app/templates/views/service-settings/name-local.html
@@ -18,10 +18,11 @@
 
   <p class="govuk-body">Your service name should tell users what the message is about as well as who it’s from. For example:</p>
     <ul class="list-bullet">
-        <li>School admissions - Brighton & Hove City Council</li>
-        <li>Electoral services - London Borough of Bromley</li>
-        <li>Blue Badge - Redcar & Cleveland Borough Council</li>
+      <li>School admissions - {{ current_user.default_organisation.name }}</li>
+      <li>Electoral services - {{ current_user.default_organisation.name }}</li>
+      <li>Blue Badge - {{ current_user.default_organisation.name }}</li>
     </ul>
+    
   <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
 
   <div class="form-group">

--- a/app/templates/views/service-settings/name-local.html
+++ b/app/templates/views/service-settings/name-local.html
@@ -17,7 +17,7 @@
   ) }}
 
   <p class="govuk-body">Your service name should tell users what the message is about as well as who it’s from. For example:</p>
-    <ul class="list-bullet">
+    <ul class="govuk-list govuk-list--bullet">
       <li>School admissions - {{ current_user.default_organisation.name }}</li>
       <li>Electoral services - {{ current_user.default_organisation.name }}</li>
       <li>Blue Badge - {{ current_user.default_organisation.name }}</li>
@@ -28,7 +28,7 @@
   <div class="form-group">
     {% if current_service.prefix_sms %}
       <p class="govuk-body">Users will see your service name:</p>
-      <ul class="list-bullet">
+      <ul class="govuk-list govuk-list--bullet">
         <li>at the start of every text message</li>
         <li>as your email sender name</li>
       </ul>

--- a/app/templates/views/service-settings/name-local.html
+++ b/app/templates/views/service-settings/name-local.html
@@ -1,0 +1,44 @@
+
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% block service_page_title %}
+  Change your service name
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(
+    'Change your service name',
+    back_link=url_for('main.service_settings', service_id=current_service.id)
+  ) }}
+
+  <p class="govuk-body">Your service name should tell users what the message is about as well as who it’s from. For example:</p>
+    <ul class="list-bullet">
+        <li>School admissions - Brighton & Hove City Council</li>
+        <li>Electoral services - London Borough of Bromley</li>
+        <li>Blue Badge - Redcar & Cleveland Borough Council</li>
+    </ul>
+  <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
+
+  <div class="form-group">
+    {% if current_service.prefix_sms %}
+      <p class="govuk-body">Users will see your service name:</p>
+      <ul class="list-bullet">
+        <li>at the start of every text message</li>
+        <li>as your email sender name</li>
+      </ul>
+    {% else %}
+      <p class="govuk-body">Users will see your service name as your email sender name.</p>
+    {% endif %}
+  </div>
+
+  {% call form_wrapper() %}
+    {{ textbox(form.name) }}
+    {{ page_footer('Save') }}
+  {% endcall %}
+
+{% endblock %}

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -88,7 +88,7 @@ def test_show_different_page_if_user_org_type_is_local(
     assert page.select_one('h1').text.strip() == 'About your service'
     assert page.select_one('input[name=name]')['value'] == ''
     assert page.select_one('main .govuk-body').text.strip() == (
-        'Give your service a name that tells users what your'
+        'Give your service a name that tells users what your '
         'messages are about, as well as who they’re from. For example:')
 
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -76,6 +76,22 @@ def test_get_should_not_render_radios_if_org_type_known(
     assert not page.select('.multiple-choice')
 
 
+def test_show_different_page_if_user_org_type_is_local(
+    client_request,
+    mocker,
+):
+    mocker.patch(
+        'app.organisations_client.get_organisation_by_domain',
+        return_value=organisation_json(organisation_type='local'),
+    )
+    page = client_request.get('main.add_service')
+    assert page.select_one('h1').text.strip() == 'About your service'
+    assert page.select_one('input[name=name]')['value'] == ''
+    assert page.select_one('main .govuk-body').text.strip() == (
+        'Give your service a name that tells users what your'
+        'messages are about, as well as who they’re from. For example:')
+
+
 @pytest.mark.parametrize('email_address', (
     # User’s email address doesn’t matter when the organisation is known
     'test@example.gov.uk',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -383,6 +383,26 @@ def test_should_show_service_name(
     app.service_api_client.get_service.assert_called_with(SERVICE_ONE_ID)
 
 
+def test_should_show_different_change_service_name_page_for_local_services(
+    client_request,
+    service_one,
+    mocker,
+):
+    mocker.patch(
+        'app.organisations_client.get_organisation_by_domain',
+        return_value=organisation_json(organisation_type='local'),
+    )
+    service_one['organisation_type'] = 'local'
+    page = client_request.get('main.service_name_change', service_id=SERVICE_ONE_ID)
+    assert page.find('h1').text == 'Change your service name'
+    assert page.find('input', attrs={"type": "text"})['value'] == 'service one'
+    assert page.select_one('main .govuk-body').text.strip() == (
+        'Your service name should tell users what the message is about as well as who it’s from. For example:'
+    )
+
+    app.service_api_client.get_service.assert_called_with(SERVICE_ONE_ID)
+
+
 def test_should_show_service_name_with_no_prefixing(
     client_request,
     service_one,


### PR DESCRIPTION
## What

This PR adds a new version of the:
* add service page
* change service name page in settings

These pages are only shown to users with a service that belongs to a local authority organisation. 

The pages include some additional content, designed to encourage users to give their service a more descriptive name.

## How

When users go to `/add-service` or `/<service_id>/service_settings/name`, we check the `organisation_type` for their service.

If it’s ‘local’ we show them pages with hints tailored for local organisations. Otherwise we show them the generic versions of those pages.

When creating a service, the `organisation_type` is determined by looking at the domain of that user email address (this can be changed later).

When changing a service name, the `organisation_type` is based on the organisation that the service belongs to.

## Why

Inconsistent and hard-to-understand service names cause problems for recipients, organisations' finance teams and Notify.

Encouraging users to choose better service names will help:

* recipients to trust the messages they receive
* finance teams to understand what they're paying Notify for
* Notify team members to decide if a service meets our terms when they request to go live


### Add service page variation for local org users:
<img width="1012" alt="Screenshot 2020-07-01 at 12 03 21" src="https://user-images.githubusercontent.com/20957548/86250100-1043cc80-bba8-11ea-8a46-034ca6c26c57.png">

### Update service name page variation for local org users:
![Screenshot_2020-07-01 Change your service name – Toms service – GOV UK Notify](https://user-images.githubusercontent.com/87140/86250401-6d3f8280-bba8-11ea-99d5-9a0fb029309b.png)
