### PR TITLE
Remove term ‘blacklist’ from codebase

### DIFF
--- a/app/main/_commonly_used_passwords.py
+++ b/app/main/_commonly_used_passwords.py
@@ -1,4 +1,4 @@
-blacklisted_passwords = [
+commonly_used_passwords = [
     'govuknotify',
     'GOVUKnotify',
     'GOV.UK Notify',

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -41,7 +41,7 @@ from wtforms.widgets import CheckboxInput, ListWidget
 
 from app import format_thousands
 from app.main.validators import (
-    Blacklist,
+    CommonlyUsedPassword,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     LettersNumbersFullStopsAndUnderscoresOnly,
@@ -184,7 +184,7 @@ def password(label='Password'):
     return PasswordField(label,
                          validators=[DataRequired(message='Cannot be empty'),
                                      Length(8, 255, message='Must be at least 8 characters'),
-                                     Blacklist(message='Choose a password that’s harder to guess')])
+                                     CommonlyUsedPassword(message='Choose a password that’s harder to guess')])
 
 
 class SMSCode(StringField):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -9,18 +9,18 @@ from notifications_utils.recipients import (
 from notifications_utils.sanitise_text import SanitiseSMS
 from wtforms import ValidationError
 
-from app.main._blacklisted_passwords import blacklisted_passwords
+from app.main._commonly_used_passwords import commonly_used_passwords
 from app.utils import Spreadsheet, is_gov_user
 
 
-class Blacklist:
+class CommonlyUsedPassword:
     def __init__(self, message=None):
         if not message:
-            message = 'Password is blacklisted.'
+            message = 'Password is in list of commonly used passwords.'
         self.message = message
 
     def __call__(self, form, field):
-        if field.data in blacklisted_passwords:
+        if field.data in commonly_used_passwords:
             raise ValidationError(self.message)
 
 

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -150,7 +150,7 @@ def test_should_add_user_details_to_session(
     assert session['user_details']['email'] == email_address
 
 
-def test_should_return_200_if_password_is_blacklisted(
+def test_should_return_200_if_password_is_on_list_of_commonly_used_passwords(
     client,
     mock_get_user_by_email,
     mock_login,


### PR DESCRIPTION
‘Commonly used passwords’ is more specific, and avoids the terminology ‘blacklist’ which the National Cyber Security Centre explain to be problematic:

> It's fairly common to say whitelisting and blacklisting to describe desirable and undesirable things in cyber security. For instance, when talking about which applications you will allow or deny on your corporate network; or deciding which bad passwords you want your users not to be able to use.
>
> However, there's an issue with the terminology. It only makes sense if you equate white with 'good, permitted, safe' and black with 'bad, dangerous, forbidden'. There are some obvious problems with this. So in the name of helping to stamp out racism in cyber security, we will avoid this casually pejorative wording on our website in the future. No, it's not the biggest issue in the world - but to borrow a slogan from elsewhere: every little helps.

– https://www.ncsc.gov.uk/blog-post/terminology-its-not-black-and-white