### PR TITLE
Ask API for less detailed JSON for all templates

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -276,7 +276,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         Retrieve all templates for service.
         """
-        endpoint = '/service/{service_id}/template'.format(
+        endpoint = '/service/{service_id}/template?detailed=False'.format(
             service_id=service_id)
         return self.get(endpoint)
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -275,7 +275,7 @@ def test_client_returns_count_of_service_templates(
             ],
             None,
             [
-                call('/service/{}/template'.format(SERVICE_ONE_ID))
+                call('/service/{}/template?detailed=False'.format(SERVICE_ONE_ID))
             ],
             [
                 call(


### PR DESCRIPTION
This should speed things up by:
- less time waiting for big blobs of JSON to come from Redis or the API
- less time spent deserialising big blobs of JSON

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/2880

***

Should clear the templates cache in Redis after deploying.