### PR TITLE
Update temporary failure error message content

### DIFF
--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -56,7 +56,7 @@
         ('Sent internationally', 'The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
         ('Not delivered', 'The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".support") }}">contact us</a>. If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.'|safe),
-        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or when their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
+        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
         ('Technical failure', 'Your message was not sent because there was a problem between Notify and the provider. You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.'),
       ] %}
         {% call row() %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -56,7 +56,7 @@
         ('Sent internationally', 'The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
         ('Not delivered', 'The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".support") }}">contact us</a>. If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.'|safe),
-        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off or out of signal, or when their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
+        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or when their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
         ('Technical failure', 'Your message was not sent because there was a problem between Notify and the provider. You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.'),
       ] %}
         {% call row() %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -56,7 +56,7 @@
         ('Sent internationally', 'The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
         ('Not delivered', 'The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".support") }}">contact us</a>. If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.'|safe),
-        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
+        ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off or out of signal, or when their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),
         ('Technical failure', 'Your message was not sent because there was a problem between Notify and the provider. You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.'),
       ] %}
         {% call row() %}


### PR DESCRIPTION
This PR updates the description for a temporary failure when sending a text message.

The current content says that a temporary failure happens when a "when the recipient’s phone is off". This isn't always the case. Temporary failures can happen for a number of reasons, including: 

* the recipient’s phone is out of signal
* the text message inbox is full

We've been contacted by users who have been confused by the current explanations of why they've received this error.

This change will be made across the API documentation too.

We'll also come up with a process and some content for handling support tickets about temporary failures.