### PR TITLE
Platform admin services layout

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -505,14 +505,7 @@ def format_stats_by_service(services):
         yield {
             'id': service['id'],
             'name': service['name'],
-            'stats': {
-                msg_type: {
-                    'sending': stats['requested'] - stats['delivered'] - stats['failed'],
-                    'delivered': stats['delivered'],
-                    'failed': stats['failed'],
-                }
-                for msg_type, stats in service['statistics'].items()
-            },
+            'stats': service['statistics'],
             'restricted': service['restricted'],
             'research_mode': service['research_mode'],
             'created_at': service['created_at'],

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -50,29 +50,18 @@
         {% call row() %}
           {% call field(border=False) %}
             <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
+            {% if not service['active'] %}
+              <span class="heading-medium hint">&ensp;Archived</span>
+            {% endif %}
           {% endcall %}
 
           {{ stats_fields('email', service['stats']) }}
         {% endcall %}
 
         {% call row() %}
-          {% if not service['active'] %}
-            {% call field(status='default', border=False) %}
-              <span class="heading-medium">archived</span>
-            {% endcall %}
-          {% elif service['research_mode'] %}
-            {% call field(border=False) %}
-              <span class="research-mode">research mode</span>
-            {% endcall %}
-          {% elif not service['restricted'] %}
-            {% call field(status='error', border=False) %}
-              <span class="heading-medium">Live</span>
-            {% endcall %}
-          {% else %}
-            {% call field(border=False) %}
-            {% endcall %}
-          {% endif %}
 
+          {% call field(border=False) %}
+          {% endcall %}
           {{ stats_fields('sms', service['stats']) }}
         {% endcall %}
 

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -9,38 +9,16 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/details/macro.njk" import govukDetails %}
 
-{% macro stats_fields(channel, data) -%}
-
-  {% call field(border=False) %}
-      <span class="heading-medium">{{ channel.title() }}</span>
-  {% endcall %}
-
-  {% call field(align='right', border=False) %}
-    {{ big_number(data[channel]['sending'], smaller=True) }}
-  {% endcall %}
-
-  {% call field(align='right', border=False) %}
-    {{ big_number(data[channel]['delivered'], smaller=True) }}
-  {% endcall %}
-
-  {% call field(align='right', status='error' if data[channel]['failed'], border=False) %}
-    {{ big_number(data[channel]['failed'], smaller=True) }}
-  {% endcall %}
-
-{%- endmacro %}
-
 {% macro services_table(services, caption) %}
   {% call(item, row_number) mapping_table(
     caption=caption,
     caption_visible=False,
     field_headings=[
-    'Service',
-    hidden_field_heading('Type'),
-    right_aligned_field_heading('Sending'),
-    right_aligned_field_heading('Delivered'),
-    right_aligned_field_heading('Failed')
+    right_aligned_field_heading('Emails'),
+    right_aligned_field_heading('Text messages'),
+    right_aligned_field_heading('Letters')
     ],
-    field_headings_visible=True
+    field_headings_visible=False,
   ) %}
 
     {% for service in services %}
@@ -48,30 +26,25 @@
       {% call row_group() %}
 
         {% call row() %}
-          {% call field(border=False) %}
-            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ service['name'] }}</a>
+          {% call field(border=False, colspan=3) %}
+            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="file-list-filename-large govuk-link govuk-link--no-visited-state govuk-!-padding-bottom-4">{{ service['name'] }}</a>
             {% if not service['active'] %}
               <span class="heading-medium hint">&ensp;Archived</span>
             {% endif %}
           {% endcall %}
 
-          {{ stats_fields('email', service['stats']) }}
         {% endcall %}
 
         {% call row() %}
-
-          {% call field(border=False) %}
-          {% endcall %}
-          {{ stats_fields('sms', service['stats']) }}
-        {% endcall %}
-
-        {% call row() %}
-
-          {% call field(border=False) %}
-
-          {% endcall %}
-            {{ stats_fields('letter', service['stats']) }}
-
+          {% for channel in ('email', 'sms', 'letter') %}
+            {% call field(border=False) %}
+              {{ big_number(
+                service['stats'][channel]['requested'],
+                smallest=True,
+                label=message_count_label(service['stats'][channel]['requested'], channel)
+              ) }}
+            {% endcall %}
+          {% endfor %}
         {% endcall %}
 
       {% endcall %}


### PR DESCRIPTION
This is a quick attempt at making the platform admin page a bit less broken by:
- removing the breakdown of sending/failed/delivered
- putting the service name on it own line so wide services don’t break the page 

# Before

![image](https://user-images.githubusercontent.com/355079/85542345-e707c700-b610-11ea-8097-2baa71115e87.png)

# After

![image](https://user-images.githubusercontent.com/355079/85542292-d6efe780-b610-11ea-9775-cfeebc7ab9e3.png)
