### PR TITLE
Allow adding broadcast templates

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -780,6 +780,10 @@ class SMSTemplateForm(BaseTemplateForm):
         OnlySMSCharacters()(None, field)
 
 
+class BroadcastTemplateForm(SMSTemplateForm):
+    pass
+
+
 class LetterAddressForm(StripWhitespaceForm):
 
     def __init__(self, *args, allow_international_letters=False, **kwargs):
@@ -1644,13 +1648,15 @@ class TemplateAndFoldersSelectionForm(Form):
         self,
         all_template_folders,
         template_list,
-        allow_adding_letter_template,
+        available_template_types,
         allow_adding_copy_of_template,
         *args,
         **kwargs
     ):
 
         super().__init__(*args, **kwargs)
+
+        self.available_template_types = available_template_types
 
         self.templates_and_folders.choices = template_list.as_id_and_name
 
@@ -1664,11 +1670,24 @@ class TemplateAndFoldersSelectionForm(Form):
         ]
 
         self.add_template_by_template_type.choices = list(filter(None, [
+            # We want to show email and text message to everyone,
+            # whether or not the service has them switched on. The
+            # option to add letter or broadcast templates should only
+            # be shown to services which have that permission
             ('email', 'Email'),
             ('sms', 'Text message'),
-            ('letter', 'Letter') if allow_adding_letter_template else None,
+            ('letter', 'Letter') if 'letter' in available_template_types else None,
+            ('broadcast', 'Broadcast') if 'broadcast' in available_template_types else None,
             ('copy-existing', 'Copy an existing template') if allow_adding_copy_of_template else None,
         ]))
+
+    @property
+    def trying_to_add_unavailable_template_type(self):
+        return all((
+            self.is_add_template_op,
+            self.add_template_by_template_type.data,
+            self.add_template_by_template_type.data not in self.available_template_types,
+        ))
 
     def is_selected(self, template_folder_id):
         return template_folder_id in (self.templates_and_folders.data or [])

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -777,11 +777,12 @@ class BaseTemplateForm(StripWhitespaceForm):
 
 class SMSTemplateForm(BaseTemplateForm):
     def validate_template_content(self, field):
-        OnlySMSCharacters()(None, field)
+        OnlySMSCharacters(template_type='sms')(None, field)
 
 
 class BroadcastTemplateForm(SMSTemplateForm):
-    pass
+    def validate_template_content(self, field):
+        OnlySMSCharacters(template_type='broadcast')(None, field)
 
 
 class LetterAddressForm(StripWhitespaceForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -88,12 +88,21 @@ class NoEmbeddedImagesInSVG:
 
 
 class OnlySMSCharacters:
+
+    def __init__(self, *args, template_type, **kwargs):
+        self._template_type = template_type
+        super().__init__(*args, **kwargs)
+
     def __call__(self, form, field):
         non_sms_characters = sorted(list(SanitiseSMS.get_non_compatible_characters(field.data)))
         if non_sms_characters:
             raise ValidationError(
-                'You cannot use {} in text messages. {} will not show up properly on everyone’s phones.'.format(
+                'You cannot use {} in {}. {} will not show up properly on everyone’s phones.'.format(
                     formatted_list(non_sms_characters, conjunction='or', before_each='', after_each=''),
+                    {
+                        'broadcast': 'broadcasts',
+                        'sms': 'text messages',
+                    }.get(self._template_type),
                     ('It' if len(non_sms_characters) == 1 else 'They')
                 )
             )

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -54,6 +54,7 @@ class Service(JSONModel):
         'email',
         'sms',
         'letter',
+        'broadcast',
     )
 
     ALL_PERMISSIONS = TEMPLATE_TYPES + (

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -132,6 +132,7 @@ class TemplateListTemplate(TemplateListItem):
             'email': 'Email template',
             'sms': 'Text message template',
             'letter': 'Letter template',
+            'broadcast': 'Broadcast template',
         }.get(template['template_type'])
 
 

--- a/app/templates/components/message-count-label.html
+++ b/app/templates/components/message-count-label.html
@@ -24,6 +24,12 @@
     {%- else -%}
       letters
     {%- endif -%}
+  {%- elif template_type == 'broadcast' -%}
+    {%- if count == 1 -%}
+      broadcast
+    {%- else -%}
+      broadcasts
+    {%- endif -%}
   {%- endif %} {{ suffix }}
 {%- endmacro %}
 

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -1,0 +1,31 @@
+{% extends "withnav_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import sticky_page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% block service_page_title %}
+  {{ heading_action }} broadcast template
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(
+    '{} broadcast template'.format(heading_action),
+    back_link=url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+  ) }}
+
+  {% call form_wrapper() %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ textbox(form.name, width='1-1', hint='Your recipients will not see this') }}
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=5) }}
+        {{ sticky_page_footer('Save') }}
+      </div>
+    </div>
+  {% endcall %}
+
+
+{% endblock %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -28,6 +28,14 @@
               </a>
             </div>
           {% endif %}
+        {% elif template.template_type == 'broadcast' %}
+          {% if current_user.has_permissions('manage_templates') %}
+            <div class="govuk-grid-column-full">
+              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
+                Edit
+              </a>
+            </div>
+          {% endif %}
         {% else %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
             <div class="govuk-grid-column-one-half">

--- a/app/url_converters.py
+++ b/app/url_converters.py
@@ -5,11 +5,12 @@ from app.models.feedback import (
     PROBLEM_TICKET_TYPE,
     QUESTION_TICKET_TYPE,
 )
+from app.models.service import Service
 
 
 class TemplateTypeConverter(BaseConverter):
 
-    regex = '(?:email|sms|letter)'
+    regex = '(?:{})'.format('|'.join(Service.TEMPLATE_TYPES))
 
 
 class TicketTypeConverter(BaseConverter):

--- a/app/utils.py
+++ b/app/utils.py
@@ -37,6 +37,7 @@ from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.take import Take
 from notifications_utils.template import (
+    BroadcastPreviewTemplate,
     EmailPreviewTemplate,
     LetterImageTemplate,
     LetterPreviewTemplate,
@@ -437,6 +438,10 @@ def get_template(
                 admin_base_url=current_app.config['ADMIN_BASE_URL'],
                 redact_missing_personalisation=redact_missing_personalisation,
             )
+    if 'broadcast' == template['template_type']:
+        return BroadcastPreviewTemplate(
+            template,
+        )
 
 
 def get_current_financial_year():

--- a/app/utils.py
+++ b/app/utils.py
@@ -461,10 +461,6 @@ def get_time_left(created_at, service_data_retention_days=7):
     )
 
 
-def email_or_sms_not_enabled(template_type, permissions):
-    return (template_type in ['email', 'sms']) and (template_type not in permissions)
-
-
 def get_logo_cdn_domain():
     parsed_uri = urlparse(current_app.config['ADMIN_BASE_URL'])
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,5 +23,5 @@ notifications-python-client==5.6.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@39.7.0#egg=notifications-utils==39.7.0
+git+https://github.com/alphagov/notifications-utils.git@40.1.0#egg=notifications-utils==40.1.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,14 +25,14 @@ notifications-python-client==5.6.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@39.7.0#egg=notifications-utils==39.7.0
+git+https://github.com/alphagov/notifications-utils.git@40.1.0#egg=notifications-utils==40.1.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.90
+awscli==1.18.91
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.17.13
+botocore==1.17.14
 cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -154,7 +154,7 @@ def test_for_commas_in_placeholders(
 
 @pytest.mark.parametrize('msg', ['The quick brown fox', 'Thé “quick” bröwn fox\u200B'])
 def test_sms_character_validation(client, msg):
-    OnlySMSCharacters()(None, _gen_mock_field(msg))
+    OnlySMSCharacters(template_type='sms')(None, _gen_mock_field(msg))
 
 
 @pytest.mark.parametrize('data, err_msg', [
@@ -175,7 +175,7 @@ def test_sms_character_validation(client, msg):
 ])
 def test_non_sms_character_validation(data, err_msg, client):
     with pytest.raises(ValidationError) as error:
-        OnlySMSCharacters()(None, _gen_mock_field(data))
+        OnlySMSCharacters(template_type='sms')(None, _gen_mock_field(data))
 
     assert str(error.value) == err_msg
 

--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -14,7 +14,8 @@ letters_urls = [
     ([], 403)
 ])
 def test_letters_access_restricted(
-    platform_admin_client,
+    client_request,
+    platform_admin_user,
     mocker,
     permissions,
     response_code,
@@ -23,12 +24,12 @@ def test_letters_access_restricted(
     service_one,
 ):
     service_one['permissions'] = permissions
-
-    mocker.patch('app.service_api_client.get_service', return_value={"data": service_one})
-
-    response = platform_admin_client.get(url(service_id=service_one['id']))
-
-    assert response.status_code == response_code
+    client_request.login(platform_admin_user)
+    client_request.get_url(
+        url(service_id=service_one['id']),
+        _follow_redirects=True,
+        _expected_status=response_code,
+    )
 
 
 @pytest.mark.parametrize('url', letters_urls)

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -280,6 +280,7 @@ def test_should_not_allow_files_to_be_uploaded_without_the_correct_permission(
         service_id=SERVICE_ONE_ID,
         template_id=template_id,
         _follow_redirects=True,
+        _expected_status=403,
     )
 
     assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."
@@ -312,10 +313,12 @@ def test_example_spreadsheet(
 
 def test_example_spreadsheet_for_letters(
     client_request,
+    service_one,
     mocker,
     mock_get_service_letter_template_with_placeholders,
     fake_uuid,
 ):
+    service_one['permissions'] += ['letter']
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=1)
 
     page = client_request.get(
@@ -600,6 +603,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
     mock_get_jobs,
     fake_uuid,
 ):
+    service_one['permissions'] += ['letter']
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
     mocker.patch(
         'app.main.views.send.s3download',
@@ -658,7 +662,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
     mock_get_jobs,
     fake_uuid,
 ):
-    service_one['permissions'] += ['international_letters']
+    service_one['permissions'] += ['letter', 'international_letters']
     mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
     mocker.patch(
         'app.main.views.send.s3download',
@@ -1328,6 +1332,7 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
         service_id=SERVICE_ONE_ID,
         template_id=template_id,
         _follow_redirects=True,
+        _expected_status=403,
     )
 
     assert page.select('main p')[0].text.strip() == "Sending text messages has been disabled for your service."

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -682,7 +682,6 @@ def test_view_broadcast_template(
     active_user_with_permissions,
     fake_uuid,
 ):
-    service_one['permissions']
     page = client_request.get(
         '.view_template',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -674,6 +674,42 @@ def test_should_be_able_to_view_a_template_with_links(
     )
 
 
+def test_view_broadcast_template(
+    client_request,
+    service_one,
+    mock_get_broadcast_template,
+    mock_get_template_folders,
+    active_user_with_permissions,
+    fake_uuid,
+):
+    service_one['permissions']
+    page = client_request.get(
+        '.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert [
+        (link.text.strip(), link['href'])
+        for link in page.select('.pill-separate-item')
+    ] == [
+        ('Edit', url_for(
+            '.edit_service_template',
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+        )),
+    ]
+
+    assert (
+        normalize_spaces(page.select_one('.template-container').text)
+    ) == (
+        normalize_spaces(page.select_one('.broadcast-message-wrapper').text)
+    ) == (
+        'This is a test'
+    )
+
+
 def test_should_show_template_id_on_template_page(
     client_request,
     mock_get_service_template,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1994,14 +1994,20 @@ def test_can_create_email_template_with_emoji(
     assert mock_create_service_template.called is True
 
 
-@pytest.mark.parametrize('template_type', (
-    'sms', 'broadcast'
+@pytest.mark.parametrize('template_type, expected_error', (
+    ('sms', (
+        'You cannot use 🍜 in text messages.'
+    )),
+    ('broadcast', (
+        'You cannot use 🍜 in broadcasts.'
+    )),
 ))
 def test_should_not_create_sms_or_broadcast_template_with_emoji(
     client_request,
     service_one,
     mock_create_service_template,
     template_type,
+    expected_error,
 ):
     service_one['permissions'] += [template_type]
     page = client_request.post(
@@ -2017,22 +2023,37 @@ def test_should_not_create_sms_or_broadcast_template_with_emoji(
         },
         _expected_status=200,
     )
-    assert "You cannot use 🍜 in text messages." in page.text
+    assert expected_error in page.text
     assert mock_create_service_template.called is False
 
 
-@pytest.mark.parametrize('template_type', (
-    'sms', 'broadcast'
+@pytest.mark.parametrize('template_type, expected_error', (
+    ('sms', (
+        'You cannot use 🍔 in text messages.'
+    )),
+    ('broadcast', (
+        'You cannot use 🍔 in broadcasts.'
+    )),
 ))
 def test_should_not_update_sms_template_with_emoji(
+    mocker,
     client_request,
     service_one,
     mock_get_service_template,
     mock_update_service_template,
     fake_uuid,
     template_type,
+    expected_error,
 ):
     service_one['permissions'] += [template_type]
+    return mocker.patch(
+        'app.service_api_client.get_service_template',
+        return_value=template_json(
+            SERVICE_ONE_ID,
+            fake_uuid,
+            type_=template_type,
+        ),
+    )
     page = client_request.post(
         '.edit_service_template',
         service_id=SERVICE_ONE_ID,
@@ -2047,7 +2068,7 @@ def test_should_not_update_sms_template_with_emoji(
         },
         _expected_status=200,
     )
-    assert "You cannot use 🍔 in text messages." in page.text
+    assert expected_error in page.text
     assert mock_update_service_template.called is False
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -842,6 +842,26 @@ def mock_get_service_email_template(mocker):
 
 
 @pytest.fixture(scope='function')
+def mock_get_broadcast_template(mocker):
+    def _get(service_id, template_id, version=None):
+        template = template_json(
+            service_id,
+            template_id,
+            'Test alert',
+            'broadcast',
+            'This is a test',
+        )
+        if version:
+            template.update({'version': version})
+        return {'data': template}
+
+    return mocker.patch(
+        'app.service_api_client.get_service_template',
+        side_effect=_get
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_service_email_template_without_placeholders(mocker):
     def _get(service_id, template_id, version=None):
         template = template_json(


### PR DESCRIPTION
At the moment the page is the same as for text message templates, except:
- different H1
- no guidance about personalisation, links, etc (until we decide how these should work)

For now you won’t be able to really create a broadcast template, because the API doesn’t support it (the API will respond with a 400). But that’s OK because no real services have the broadcast permission yet.

This required a bit of refactoring of how we check which template types a service can use, because there were some hard-coded assumptions about emails and text messages.

![image](https://user-images.githubusercontent.com/355079/86265186-6706d180-bbbb-11ea-9b96-6a39c488d8c8.png)

![image](https://user-images.githubusercontent.com/355079/86265218-6ff7a300-bbbb-11ea-856c-63e54e6d407c.png)

Note that this is not how the pages will finally look, because we’re not going to have services that can broadcast and send emails, or broadcast and send text messages. But getting the functionality to add a template gets us closer to having something working we can demo.