### PR TITLE
Add Leaflet.js for rendering slippy maps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,6 +95,12 @@ const copy = {
         )
       });
     }
+  },
+  leaflet: {
+    js: () => {
+      return src(paths.npm + 'leaflet/dist/leaflet.js')
+        .pipe(dest(paths.dist + 'javascripts/'))
+    }
   }
 };
 
@@ -182,7 +188,11 @@ const javascripts = () => {
 
 
 const sass = () => {
-  return src([paths.src + '/stylesheets/main*.scss', paths.src + '/stylesheets/print.scss'])
+  return src([
+      paths.src + '/stylesheets/main*.scss',
+      paths.src + '/stylesheets/print.scss',
+      paths.npm + '/leaflet/dist/leaflet.css'
+    ])
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass({
       outputStyle: 'nested',
@@ -264,7 +274,8 @@ const defaultTask = parallel(
   parallel(
     copy.govuk_frontend.fonts,
     copy.govuk_frontend.templates,
-    images
+    images,
+    copy.leaflet.js
   ),
   series(
     copy.error_pages,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp-uglify": "3.0.2",
     "hogan": "1.0.2",
     "jquery": "3.5.0",
+    "leaflet": "1.6.0",
     "query-command-supported": "1.0.0",
     "rollup": "1.23.1",
     "streamqueue": "1.1.2",


### PR DESCRIPTION
[Leaflet](https://leafletjs.com/) seems to be the go-to library for rendering maps these days. It will be useful for the broadcast work.

This commit add the Leaflet Javascript and CSS to our asset pipeline. The Javascript is already minified so all we need to do is copy it. The CSS is uncompressed so we put it through the same pipe as our other stylesheets.

I’m keeping these as separate files because they’re quite heavy (or the JS is at least – 38kb minified) so I want them to only be loaded on the pages where they’re used. Most users of Notify will never need to see a map.