### PR TITLE
Add service permission decorator

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -33,6 +33,7 @@ from app.utils import (
     generate_next_dict,
     generate_previous_dict,
     get_current_financial_year,
+    service_has_permission,
     user_has_permissions,
 )
 
@@ -170,6 +171,7 @@ def monthly(service_id):
 
 @main.route("/services/<uuid:service_id>/inbox")
 @user_has_permissions('view_activity')
+@service_has_permission('inbound_sms')
 def inbox(service_id):
 
     return render_template(
@@ -181,6 +183,7 @@ def inbox(service_id):
 
 @main.route("/services/<uuid:service_id>/inbox.json")
 @user_has_permissions('view_activity')
+@service_has_permission('inbound_sms')
 def inbox_updates(service_id):
 
     return jsonify(get_inbox_partials(service_id))
@@ -212,9 +215,6 @@ def inbox_download(service_id):
 
 def get_inbox_partials(service_id):
     page = int(request.args.get('page', 1))
-    if not current_service.has_permission('inbound_sms'):
-        abort(403)
-
     inbound_messages_data = service_api_client.get_most_recent_inbound_sms(service_id, page=page)
     inbound_messages = inbound_messages_data['data']
     if not inbound_messages:

--- a/app/utils.py
+++ b/app/utils.py
@@ -83,7 +83,9 @@ def user_has_permissions(*permissions, **permission_kwargs):
 
 
 def service_has_permission(permission):
+
     from app import current_service
+
     def wrap(func):
         @wraps(func)
         def wrap_func(*args, **kwargs):

--- a/app/utils.py
+++ b/app/utils.py
@@ -82,6 +82,18 @@ def user_has_permissions(*permissions, **permission_kwargs):
     return wrap
 
 
+def service_has_permission(permission):
+    from app import current_service
+    def wrap(func):
+        @wraps(func)
+        def wrap_func(*args, **kwargs):
+            if not current_service or not current_service.has_permission(permission):
+                abort(403)
+            return func(*args, **kwargs)
+        return wrap_func
+    return wrap
+
+
 def user_is_gov_user(f):
     @wraps(f)
     def wrapped(*args, **kwargs):

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -396,6 +396,7 @@ def test_view_inbox_updates(
     mocker,
     mock_get_most_recent_inbound_sms_with_no_messages,
 ):
+    service_one['permissions'] += ['inbound_sms']
 
     mock_get_partials = mocker.patch(
         'app.main.views.dashboard.get_inbox_partials',


### PR DESCRIPTION
Similar to how we can restrict routes to only users with a given permission, this new decorator lets us restrict routes to services that have a given permission.

Having this as a decorator is cleaner than putting if statements inside the endpoint code.

I’ve also added the decorator to the inbox page, which is so far the only page we restrict access to based on a service permission. This proves that the decorator works, because the inbox code is already tested here:
https://github.com/alphagov/notifications-admin/blob/bad1e69cc3e658fa8bbd1c16d0ffff36f0548ee9/tests/app/main/views/test_dashboard.py#L353-L367

In the future this will be useful for restricting access to the broadcast pages