### PR TITLE
Hide irrelevant things from nav for broadcast services

### DIFF
--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -11,15 +11,17 @@
     {% if not current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
+    {% if not current_service.has_permission('broadcast') %}
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
+    {% endif %}
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
-    {% if current_user.has_permissions('manage_service', allow_org_user=True) %}
+    {% if current_user.has_permissions('manage_service', allow_org_user=True) and not current_service.has_permission('broadcast') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
     {% endif %}
-    {% if current_user.has_permissions('manage_api_keys') %}
+    {% if current_user.has_permissions('manage_api_keys') and not current_service.has_permission('broadcast') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -177,6 +177,24 @@ def test_navigation_urls(
     ]
 
 
+def test_navigation_for_services_with_broadcast_permission(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
+    assert [
+        a['href'] for a in page.select('.navigation a')
+    ] == [
+        '/services/{}'.format(SERVICE_ONE_ID),
+        '/services/{}/templates'.format(SERVICE_ONE_ID),
+        '/services/{}/users'.format(SERVICE_ONE_ID),
+        '/services/{}/service-settings'.format(SERVICE_ONE_ID),
+    ]
+
+
 def test_caseworkers_get_caseworking_navigation(
     client_request,
     mocker,


### PR DESCRIPTION
Services doing broadcasts wont be sending through any other channels. This means that they wont:
- incur costs, so don’t need to see the usage page
- be sending anything by uploading, so don’t need to see the uploads page
- (for now) be sending anything using the API, so don’t need to see the API integration page