### PR TITLE
Remove duplicate live search control

### DIFF
--- a/app/templates/views/broadcast/areas.html
+++ b/app/templates/views/broadcast/areas.html
@@ -19,8 +19,6 @@
 
   {{ live_search(target_selector='.multiple-choice', show=show_search_form, form=search_form, label='Search by name') }}
 
-  {{ live_search(target_selector='.multiple-choice', show=show_search_form, form=search_form, label='Search by name') }}
-
   {% call form_wrapper() %}
     {{ checkboxes(form.areas, hide_legend=True) }}
     {{ sticky_page_footer('Add to broadcast') }}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -188,7 +188,7 @@ def test_navigation_for_services_with_broadcast_permission(
     assert [
         a['href'] for a in page.select('.navigation a')
     ] == [
-        '/services/{}'.format(SERVICE_ONE_ID),
+        '/services/{}/broadcast-dashboard'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),
         '/services/{}/service-settings'.format(SERVICE_ONE_ID),


### PR DESCRIPTION
I must have introduced this while resolving a merge conflict. Oops.

***

![image](https://user-images.githubusercontent.com/355079/86928668-c3726f80-c12c-11ea-9b79-cb3ee5906bae.png)

***

PR also fixes the tests which were broken by merging two PRs which had different opinions about the dashboard URL.