### PR TITLE
Hide template ID and redaction for broadcast templates

### DIFF
--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -46,9 +46,11 @@
     {% include 'views/templates/_template.html' %}
   </div>
 
-  <div class="bottom-gutter-1-2">
-    {{ api_key(template.id, name="Template ID", thing='template ID') }}
-  </div>
+  {% if template.template_type != 'broadcast' %}
+    <div class="bottom-gutter-1-2">
+      {{ api_key(template.id, name="Template ID", thing='template ID') }}
+    </div>
+  {% endif %}
 
   <div class="bottom-gutter-1-2">
     {% if template._template.updated_at %}
@@ -71,7 +73,7 @@
         </span>
         &emsp;
       {% endif %}
-      {% if template.template_type != 'letter' %}
+      {% if template.template_type not in ('letter', 'broadcast') %}
         {% if not template._template.redact_personalisation %}
           <span class="page-footer-delete-link page-footer-delete-link-without-button">
             <a class="govuk-link govuk-link--destructive" href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -728,6 +728,21 @@ def test_should_show_template_id_on_template_page(
     assert page.select('.api-key__key')[0].text == fake_uuid
 
 
+def test_should_hide_template_id_for_broadcast_templates(
+    client_request,
+    mock_get_broadcast_template,
+    mock_get_template_folders,
+    fake_uuid,
+):
+    page = client_request.get(
+        '.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+    assert not page.select('.api-key__key')
+
+
 def test_should_show_sms_template_with_downgraded_unicode_characters(
     client_request,
     mocker,
@@ -2243,6 +2258,25 @@ def test_should_not_show_redaction_stuff_for_letters(
 
     mocker.patch('app.main.views.templates.get_page_count_for_letter', return_value=1)
 
+    page = client_request.get(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert page.select('.hint') == []
+    assert 'personalisation' not in ' '.join(
+        link.text.lower() for link in page.select('a')
+    )
+
+
+def test_should_not_show_redaction_stuff_for_broadcasts(
+    client_request,
+    fake_uuid,
+    mock_get_broadcast_template,
+    mock_get_template_folders,
+):
     page = client_request.get(
         'main.view_template',
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
We’re not going to have an API for sending broadcasts at the moment, so you don’t need the template ID for anything.

Broadcast also won’t contain personal information, or tokenised links, etc, so there’s no need to redact them after sending.

Removing this things means the interface is less cluttered.