### PR TITLE
Fix examples on choose broadcast library page

### DIFF
--- a/app/templates/views/broadcast/libraries.html
+++ b/app/templates/views/broadcast/libraries.html
@@ -15,7 +15,7 @@
 
   {% for library in libraries|sort %}
     <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_broadcast_area', service_id=current_service.id, library_slug=library.id) }}">{{ library.name }}</a>
-    <p class="file-list-hint-large">{{ library.examples }}</p>
+    <p class="file-list-hint-large">{{ library.get_examples() }}</p>
   {% endfor %}
 
 {% endblock %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1,7 +1,7 @@
 import pytest
 from flask import url_for
 
-from tests.conftest import SERVICE_ONE_ID
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 @pytest.mark.parametrize('endpoint, extra_args', (
@@ -85,9 +85,33 @@ def test_choose_broadcast_library_page(
     service_one,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.get(
+    page = client_request.get(
         '.choose_broadcast_library',
         service_id=SERVICE_ONE_ID,
+    )
+    assert [
+        (normalize_spaces(title.text), normalize_spaces(hint.text))
+        for title, hint in list(zip(
+            page.select('.file-list-filename-large'), page.select('.file-list-hint-large')
+        ))
+    ] == [
+        (
+            'Counties and Unitary Authorities in England and Wales',
+            'Barking and Dagenham, Barnet, Barnsley and 171 more…',
+        ),
+        (
+            'Countries',
+            'England, Northern Ireland, Scotland and Wales',
+        ),
+        (
+            'Regions of England',
+            'East Midlands, East of England, London and 6 more…',
+        ),
+    ]
+    assert page.select_one('a.file-list-filename-large.govuk-link')['href'] == url_for(
+        '.choose_broadcast_area',
+        service_id=SERVICE_ONE_ID,
+        library_slug='counties-and-unitary-authorities-in-england-and-wales',
     )
 
 


### PR DESCRIPTION
It should be `.get_examples()` (a method) not `.examples` (a property) but Jinja swallows the error and prints nothing.

Method is defined here:

https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/broadcast_areas/__init__.py#L109-L119

***

![image](https://user-images.githubusercontent.com/355079/86935835-308a0300-c135-11ea-96ba-4ab9b8ea2882.png)
