### PR TITLE
Bump gds metrics to 0.2.2 to bring in bug fix

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -28,4 +28,4 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.8.0
-gds-metrics==0.2.0
+gds-metrics==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.8.0
-gds-metrics==0.2.0
+gds-metrics==0.2.2
 
 ## The following requirements were added by pip freeze:
 awscli==1.18.95


### PR DESCRIPTION
https://github.com/alphagov/gds_metrics_python/blob/master/CHANGELOG.md#021

This will mean that if an exception is thrown in any `before_request`
functions that run before the gds metrics `before_request` function,
then we will no longer throw an uncaught exception.

Note, this could still be the case (and has been seen in production) as
`init_app(application)` in `create_app` in `init.py` can indeed throw
exceptions, for example when it can't find the current service. We could
move our init app for gds metrics further up if we wanted to to further
counter this.