### PR TITLE
Visually tweak selected area state

### DIFF
--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -58,10 +58,8 @@
     &--unremoveable {
       padding-right: govuk-spacing(2);
       background: $light-blue-25;
-      border-color: $light-blue-25;
-      color: $govuk-blue;
-      font-weight: bold;
       margin-right: govuk-spacing(3);
+      margin-bottom: 0;
     }
 
   }


### PR DESCRIPTION
This brings it back a bit closer to the page with the map, so the two feel cohesive, while still making the selected areas look different to textboxes.

Before | After
---|---
<img width="767" alt="Screenshot 2020-07-09 at 14 13 23" src="https://user-images.githubusercontent.com/355079/87044553-9ab2ae80-c1ee-11ea-8cde-3125edea9728.png"> | <img width="767" alt="Screenshot 2020-07-09 at 14 13 23" src="https://user-images.githubusercontent.com/355079/87044553-9ab2ae80-c1ee-11ea-8cde-3125edea9728.png">
<img width="768" alt="Screenshot 2020-07-09 at 14 13 13" src="https://user-images.githubusercontent.com/355079/87044586-a69e7080-c1ee-11ea-9e79-b95009b5a0d3.png"> | <img width="764" alt="Screenshot 2020-07-09 at 14 13 06" src="https://user-images.githubusercontent.com/355079/87044582-a605da00-c1ee-11ea-9b0c-94c9dd96fb97.png">

