### PR TITLE
Broadcast dashboard

### DIFF
--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -59,7 +59,6 @@
       padding-right: govuk-spacing(2);
       background: $light-blue-25;
       margin-right: govuk-spacing(3);
-      margin-bottom: 0;
     }
 
   }

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -3,7 +3,7 @@ from flask import redirect, render_template, request, url_for
 from app import current_service
 from app.main import main
 from app.main.forms import BroadcastAreaForm, SearchByNameForm
-from app.models.broadcast_message import BroadcastMessage
+from app.models.broadcast_message import BroadcastMessage, BroadcastMessages
 from app.utils import service_has_permission, user_has_permissions
 
 
@@ -11,8 +11,11 @@ from app.utils import service_has_permission, user_has_permissions
 @user_has_permissions()
 @service_has_permission('broadcast')
 def broadcast_dashboard(service_id):
+    broadcast_messages = BroadcastMessages(service_id)
     return render_template(
         'views/broadcast/dashboard.html',
+        live_broadcasts=broadcast_messages.with_status('broadcasting'),
+        previous_broadcasts=broadcast_messages.with_status('cancelled', 'completed'),
     )
 
 

--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -24,6 +24,9 @@ class BroadcastMessageAPIClient(NotifyAdminAPIClient):
 
         return broadcast_message
 
+    def get_broadcast_messages(self, service_id):
+        return self.get(f'/service/{service_id}/broadcast-message')['broadcast_messages']
+
     def get_broadcast_message(self, *, service_id, broadcast_message_id):
         return self.get(f'/service/{service_id}/broadcast-message/{broadcast_message_id}')
 

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -1,4 +1,42 @@
+{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+
 {% extends "withnav_template.html" %}
+
+{% macro broadcast_table(broadcasts, empty_message) %}
+  <div class='dashboard-table ajax-block-container'>
+    {% call(item, row_number) list_table(
+      broadcasts,
+      caption="Live broadcasts",
+      caption_visible=False,
+      empty_message=empty_message,
+      field_headings=[
+        'Template name',
+        'Status'
+      ],
+      field_headings_visible=False
+    ) %}
+      {% call row_heading() %}
+        <div class="file-list">
+          <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="#">{{ item.template_name }}</a>
+          <span class="file-list-hint-large">
+            To {{ item.initial_area_names|formatted_list(before_each='', after_each='') }}
+          </span>
+        </div>
+      {% endcall %}
+      {% call field(align='right') %}
+        <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0">
+          {% if item.status == 'broadcasting' %}
+            Live until {{ item.finishes_at|format_datetime_relative }}
+          {% elif item.status == 'cancelled' %}
+            Stopped {{ item.cancelled_at|format_datetime_relative }}
+          {% else %}
+            Finished {{ item.finishes_at|format_datetime_relative }}
+          {% endif %}
+        </p>
+      {% endcall %}
+    {% endcall %}
+  </div>
+{% endmacro %}
 
 {% block service_page_title %}
   Dashboard
@@ -8,8 +46,12 @@
 
   <h1 class="govuk-visually-hidden">Dashboard</h1>
 
-  <p class="govuk-body">
-    Broadcasts here
-  </p>
+  <h2 class="heading-medium govuk-!-margin-bottom-2">Live broadcasts</h2>
+
+  {{ broadcast_table(live_broadcasts, 'You do not have any live broadcasts at the moment') }}
+
+  <h2 class="heading-medium govuk-!-margin-bottom-2">Previous broadcasts</h2>
+
+  {{ broadcast_table(previous_broadcasts, 'You do not have any previous broadcasts') }}
 
 {% endblock %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -635,3 +635,44 @@ def assert_url_expected(actual, expected):
 
 def find_element_by_tag_and_partial_text(page, tag, string):
     return [e for e in page.find_all(tag) if string in e.text][0]
+
+
+def broadcast_message_json(
+    *,
+    id_,
+    service_id,
+    template_id,
+    status,
+    created_by_id,
+    starts_at=None,
+    finishes_at=None,
+    cancelled_at=None,
+):
+    return {
+        'id': id_,
+
+        'service_id': service_id,
+
+        'template_id': template_id,
+        'template_version': 123,
+        'template_name': 'Example template',
+
+        'personalisation': {},
+        'areas': [
+            'england', 'scotland',
+        ],
+
+        'status': status,
+
+        'starts_at': starts_at,
+        'finishes_at': finishes_at,
+
+        'created_at': None,
+        'approved_at': None,
+        'cancelled_at': cancelled_at,
+        'updated_at': None,
+
+        'created_by_id': created_by_id,
+        'approved_by_id': None,
+        'cancelled_by_id': None,
+    }

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -46,15 +46,46 @@ def test_dashboard_redirects_to_broadcast_dashboard(
     ),
 
 
+def test_empty_broadcast_dashboard(
+    client_request,
+    service_one,
+    mock_get_no_broadcast_messages,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get(
+        '.broadcast_dashboard',
+        service_id=SERVICE_ONE_ID,
+    )
+    assert [
+        normalize_spaces(row.text) for row in page.select('tbody tr .table-empty-message')
+    ] == [
+        'You do not have any live broadcasts at the moment',
+        'You do not have any previous broadcasts',
+    ]
+
+
+@freeze_time('2020-02-20 02:20')
 def test_broadcast_dashboard(
     client_request,
     service_one,
+    mock_get_broadcast_messages,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.get(
+    page = client_request.get(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
-    ),
+    )
+    assert [
+        normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
+    ] == [
+        'Example template To England and Scotland Live until tomorrow at 2:20am',
+    ]
+    assert [
+        normalize_spaces(row.text) for row in page.select('table')[1].select('tbody tr')
+    ] == [
+        'Example template To England and Scotland Finished yesterday at 8:20pm',
+        'Example template To England and Scotland Stopped 10 February at 2:20am',
+    ]
 
 
 def test_broadcast_page(


### PR DESCRIPTION
Add broadcasts to the dashboard

Shows current and previous broadcasts with a similar pattern to the uploads page.

Does not add a page for viewing an individual broadcast or cancelling broadcasts.

Broadcasts are split into live and previous. Draft broadcasts are excluded from the dashboard.

***

<img width="1187" alt="Screenshot 2020-07-09 at 15 51 10" src="https://user-images.githubusercontent.com/355079/87055586-7362de00-c1fc-11ea-9b3b-0ee23a797bb4.png">
