### PR TITLE
Update usage page to display international letters

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -521,6 +521,13 @@ def nl2br(value):
     return ''
 
 
+def format_number_in_pounds_as_currency(number):
+    if number >= 1:
+        return f"£{number:,.2f}"
+
+    return f"{number * 100:.0f}p"
+
+
 @login_manager.user_loader
 def load_user(user_id):
     return User.from_id(user_id)
@@ -798,6 +805,7 @@ def add_template_filters(application):
         format_notification_status_as_time,
         format_notification_status_as_field_status,
         format_notification_status_as_url,
+        format_number_in_pounds_as_currency,
         formatters.formatted_list,
         nl2br,
         format_phone_number_human_readable,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -1,4 +1,5 @@
 import calendar
+from collections import namedtuple
 from datetime import datetime
 from functools import partial
 from itertools import groupby
@@ -416,15 +417,21 @@ def get_free_paid_breakdown_for_billable_units(year, free_sms_fragment_limit, bi
             free_sms_fragment_limit, cumulative, previous_cumulative,
             [billing_month for billing_month in sms_units if billing_month['month'] == month]
         )
-        letter_billing = [(x['billing_units'], x['rate'], (x['billing_units'] * x['rate']), x['postage'])
+
+        LetterDetails = namedtuple('LetterDetails', ['billing_units', 'rate', 'cost', 'postage'])
+
+        letter_billing = [LetterDetails(billing_units=x['billing_units'],
+                                        rate=x['rate'],
+                                        cost=(x['billing_units'] * x['rate']),
+                                        postage=x['postage'])
                           for x in letter_units if x['month'] == month]
 
         if letter_billing:
-            letter_billing.sort(key=lambda x: (x[3], x[1]))
+            letter_billing.sort(key=lambda x: (x.postage, x.rate))
 
         letter_total = 0
         for x in letter_billing:
-            letter_total += x[2]
+            letter_total += x.cost
             letter_cumulative += letter_total
         yield {
             'name': month,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -456,7 +456,7 @@ def format_letter_details_for_month(letter_units_for_month):
 
         letter_details = LetterDetails(
             billing_units=sum(x['billing_units'] for x in rate_group),
-            rate=format_letter_rate(rate_group[0]['rate']),
+            rate=rate_group[0]['rate'],
             cost=(sum(x['billing_units'] for x in rate_group) * rate_group[0]['rate']),
             postage_description=rate_group[0]['postage']
         )
@@ -470,13 +470,6 @@ def get_postage_description(postage):
     if postage in ('first', 'second'):
         return f'{postage} class'
     return 'international'
-
-
-def format_letter_rate(number):
-    if number >= 1:
-        return f"£{number:,.2f}"
-
-    return f"{number * 100:.0f}p"
 
 
 def get_free_paid_breakdown_for_month(

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -110,7 +110,7 @@
               {% for letter in month.letters%}
                 {% if letter.billing_units %}
                   <li class="tabular-numbers">{{ "{:,} {}".format(letter.billing_units, letter.postage_description) }} {{ message_count_label(letter.billing_units, 'letter', '') }}at
-                  {{ letter.rate }}</li>
+                  {{ letter.rate | format_number_in_pounds_as_currency }}</li>
                 {% endif %}
               {% endfor %}
               {% if not (month.free or month.paid or month.letters) %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -109,8 +109,8 @@
               {% endif %}
               {% for letter in month.letters%}
                 {% if letter.billing_units %}
-                  <li class="tabular-numbers">{{ "{:,} {}".format(letter.billing_units, letter.postage)}} class {{ message_count_label(letter.billing_units, 'letter', '') }}at
-                  {{ '{:.0f}p'.format(letter.rate * 100) }}</li>
+                  <li class="tabular-numbers">{{ "{:,} {}".format(letter.billing_units, letter.postage_description) }} {{ message_count_label(letter.billing_units, 'letter', '') }}at
+                  {{ letter.rate }}</li>
                 {% endif %}
               {% endfor %}
               {% if not (month.free or month.paid or month.letters) %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -108,9 +108,9 @@
                 {{- ' {:.2f}p'.format(sms_rate * 100) }}</li>
               {% endif %}
               {% for letter in month.letters%}
-                {% if letter[0] %}
-                  <li class="tabular-numbers">{{ "{:,} {}".format(letter[0], letter[3])}} class {{ message_count_label(letter[0], 'letter', '') }}at
-                  {{ '{:.0f}p'.format(letter[1] * 100) }}</li>
+                {% if letter.billing_units %}
+                  <li class="tabular-numbers">{{ "{:,} {}".format(letter.billing_units, letter.postage)}} class {{ message_count_label(letter.billing_units, 'letter', '') }}at
+                  {{ '{:.0f}p'.format(letter.rate * 100) }}</li>
                 {% endif %}
               {% endfor %}
               {% if not (month.free or month.paid or month.letters) %}

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -3,7 +3,10 @@ from functools import partial
 import pytest
 from flask import url_for
 
-from app import format_notification_status_as_url
+from app import (
+    format_notification_status_as_url,
+    format_number_in_pounds_as_currency,
+)
 
 
 @pytest.mark.parametrize('status, notification_type, expected', (
@@ -33,3 +36,19 @@ def test_format_notification_status_as_url(
     assert format_notification_status_as_url(
         status, notification_type
     ) == expected()
+
+
+@pytest.mark.parametrize('input_number, formatted_number', [
+    (0, '0p'),
+    (0.01, '1p'),
+    (0.5, '50p'),
+    (1, '£1.00'),
+    (1.01, '£1.01'),
+    (1.006, '£1.01'),
+    (5.25, '£5.25'),
+    (5.7, '£5.70'),
+    (381, '£381.00'),
+    (144820, '£144,820.00'),
+])
+def test_format_number_in_pounds_as_currency(input_number, formatted_number):
+    assert format_number_in_pounds_as_currency(input_number) == formatted_number

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2627,7 +2627,21 @@ def mock_get_billable_units(mocker):
                 'rate': 0.33,
                 'billing_units': 5,
                 'postage': 'first',
-            }
+            },
+            {
+                'month': 'February',
+                'notification_type': 'letter',
+                'rate': 0.84,
+                'billing_units': 3,
+                'postage': 'europe',
+            },
+            {
+                'month': 'February',
+                'notification_type': 'letter',
+                'rate': 0.84,
+                'billing_units': 7,
+                'postage': 'rest-of-world',
+            },
         ]
 
     return mocker.patch(


### PR DESCRIPTION
The usage page splits letters by postage and rate. The API returns postage as `europe` or `rest-of-world`, so the data for international letters has to be aggregated into a new `international` category before we can display it.