### PR TITLE
Fix the ‘remove‘ link on broadcast areas

### DIFF
--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -68,7 +68,7 @@
       <ul class="area-list">
     {% endif %}
         <li class="area-list-item">
-          {{ area.name }} <a class="area-list-item-remove" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message_id, area_slug=area.id) }}">remove</a>
+          {{ area.name }} <a class="area-list-item-remove" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">remove</a>
         </li>
     {% if loop.last %}
       {{ govukButton({


### PR DESCRIPTION
https://github.com/alphagov/notifications-admin/blob/1a79a037f69e2955d0f2a4dcae58ccf7619a78d6/app/main/views/broadcast.py#L40-L46