### PR TITLE
Add a page to view a single broadcast

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -152,6 +152,7 @@ def cancel_broadcast_message(service_id, broadcast_message_id):
         service_id=current_service.id,
     ).cancel_broadcast()
     return redirect(url_for(
-        '.broadcast_dashboard',
+        '.view_broadcast_message',
         service_id=current_service.id,
+        broadcast_message_id=broadcast_message_id,
     ))

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1,4 +1,4 @@
-from flask import redirect, render_template, request, url_for
+from flask import abort, redirect, render_template, request, url_for
 
 from app import current_service
 from app.main import main
@@ -19,7 +19,7 @@ def broadcast_dashboard(service_id):
     )
 
 
-@main.route('/services/<uuid:service_id>/broadcast/<uuid:template_id>')
+@main.route('/services/<uuid:service_id>/new-broadcast/<uuid:template_id>')
 @user_has_permissions('send_messages')
 @service_has_permission('broadcast')
 def broadcast(service_id, template_id):
@@ -123,6 +123,22 @@ def preview_broadcast_message(service_id, broadcast_message_id):
         ))
     return render_template(
         'views/broadcast/preview-message.html',
+        broadcast_message=broadcast_message,
+    )
+
+
+@main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>')
+@user_has_permissions('send_messages')
+@service_has_permission('broadcast')
+def view_broadcast_message(service_id, broadcast_message_id):
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=current_service.id,
+    )
+    if broadcast_message.status == 'draft':
+        abort(404)
+    return render_template(
+        'views/broadcast/view-message.html',
         broadcast_message=broadcast_message,
     )
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -5,6 +5,7 @@ from notifications_utils.template import BroadcastPreviewTemplate
 from orderedset import OrderedSet
 
 from app.models import JSONModel, ModelList
+from app.models.user import User
 from app.notify_client.broadcast_message_api_client import (
     broadcast_message_api_client,
 )
@@ -93,6 +94,18 @@ class BroadcastMessage(JSONModel):
         ):
             return 'completed'
         return self._dict['status']
+
+    @property
+    def created_by(self):
+        return User.from_id(self.created_by_id)
+
+    @property
+    def approved_by(self):
+        return User.from_id(self.approved_by_id)
+
+    @property
+    def cancelled_by(self):
+        return User.from_id(self.cancelled_by_id)
 
     def add_areas(self, *new_areas):
         broadcast_message_api_client.update_broadcast_message(

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -358,6 +358,7 @@ class HeaderNavigation(Navigation):
         'choose_broadcast_area',
         'remove_broadcast_area',
         'preview_broadcast_message',
+        'view_broadcast_message',
         'cancel_broadcast_message',
     }
 
@@ -414,6 +415,7 @@ class MainNavigation(Navigation):
             'choose_broadcast_area',
             'remove_broadcast_area',
             'preview_broadcast_message',
+            'view_broadcast_message',
             'cancel_broadcast_message',
         },
         'uploads': {
@@ -1003,6 +1005,7 @@ class CaseworkNavigation(Navigation):
         'choose_broadcast_area',
         'remove_broadcast_area',
         'preview_broadcast_message',
+        'view_broadcast_message',
         'cancel_broadcast_message',
     }
 
@@ -1321,5 +1324,6 @@ class OrgNavigation(Navigation):
         'choose_broadcast_area',
         'remove_broadcast_area',
         'preview_broadcast_message',
+        'view_broadcast_message',
         'cancel_broadcast_message',
     }

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -17,7 +17,7 @@
     ) %}
       {% call row_heading() %}
         <div class="file-list">
-          <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="#">{{ item.template_name }}</a>
+          <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_broadcast_message', service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template_name }}</a>
           <span class="file-list-hint-large">
             To {{ item.initial_area_names|formatted_list(before_each='', after_each='') }}
           </span>

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -25,9 +25,8 @@
       {% endcall %}
       {% call field(align='right') %}
         {% if item.status == 'broadcasting' %}
-          <p class="govuk-body letter-recipient-summary">
+          <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0">
             Live until {{ item.finishes_at|format_datetime_relative }}
-            <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=item.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcasting</a>
           </p>
         {% elif item.status == 'cancelled' %}
           <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0 govuk-hint">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,0 +1,54 @@
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import sticky_page_footer %}
+
+{% extends "withnav_template.html" %}
+
+{% block service_page_title %}
+  {{ broadcast_message.template_name }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(
+    broadcast_message.template_name,
+    back_link=url_for('.broadcast_dashboard', service_id=current_service.id)
+  ) }}
+
+  <p class="govuk-body govuk-!-margin-bottom-3">
+    Created by {{ broadcast_message.created_by.name }} and approved by
+    {{ broadcast_message.approved_by.name }}.
+  </p>
+
+  <p class="govuk-body govuk-!-margin-bottom-3">
+    Started broadcasting
+    {{ broadcast_message.starts_at|format_datetime_human }}.
+  </p>
+
+  <p class="govuk-body">
+    {% if broadcast_message.status == 'broadcasting' %}
+      Live until {{ broadcast_message.finishes_at|format_datetime_relative }}&ensp;<a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcast early</a>
+    {% elif broadcast_message.status == 'cancelled' %}
+      Stopped by {{ broadcast_message.cancelled_by.name }}
+      {{ broadcast_message.cancelled_at|format_datetime_human }}.
+    {% else %}
+      Finished broadcasting {{ broadcast_message.finishes_at|format_datetime_human }}.
+    {% endif %}
+  </p>
+
+  {% for area in broadcast_message.areas %}
+    {% if loop.first %}
+      <ul class="area-list">
+    {% endif %}
+        <li class="area-list-item area-list-item--unremoveable">
+          {{ area.name }}
+        </li>
+    {% if loop.last %}
+      </ul>
+    {% endif %}
+  {% endfor %}
+
+  {{ broadcast_message.template|string }}
+
+{% endblock %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -647,6 +647,8 @@ def broadcast_message_json(
     starts_at=None,
     finishes_at=None,
     cancelled_at=None,
+    approved_by_id=None,
+    cancelled_by_id=None,
 ):
     return {
         'id': id_,
@@ -673,6 +675,6 @@ def broadcast_message_json(
         'updated_at': None,
 
         'created_by_id': created_by_id,
-        'approved_by_id': None,
-        'cancelled_by_id': None,
+        'approved_by_id': approved_by_id,
+        'cancelled_by_id': cancelled_by_id,
     }

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -78,7 +78,7 @@ def test_broadcast_dashboard(
     assert [
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
     ] == [
-        'Example template To England and Scotland Live until tomorrow at 2:20am Stop broadcasting',
+        'Example template To England and Scotland Live until tomorrow at 2:20am',
     ]
     assert [
         normalize_spaces(row.text) for row in page.select('table')[1].select('tbody tr')

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -382,8 +382,9 @@ def test_cancel_broadcast(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=url_for(
-            '.broadcast_dashboard',
+            '.view_broadcast_message',
             service_id=SERVICE_ONE_ID,
+            broadcast_message_id=fake_uuid,
             _external=True,
         ),
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4192,6 +4192,34 @@ def mock_get_draft_broadcast_message(
 
 
 @pytest.fixture(scope='function')
+def mock_get_live_broadcast_message(
+    mocker,
+    fake_uuid,
+):
+    def _get(
+        *, service_id, broadcast_message_id
+    ):
+        return broadcast_message_json(
+            id_=broadcast_message_id,
+            service_id=service_id,
+            template_id=fake_uuid,
+            status='broadcasting',
+            created_by_id=fake_uuid,
+            starts_at=(
+                datetime.utcnow()
+            ).isoformat(),
+            finishes_at=(
+                datetime.utcnow() + timedelta(hours=24)
+            ).isoformat(),
+        )
+
+    return mocker.patch(
+        'app.broadcast_message_api_client.get_broadcast_message',
+        side_effect=_get,
+    )
+
+
+@pytest.fixture(scope='function')
 def mock_get_no_broadcast_messages(
     mocker,
     fake_uuid,


### PR DESCRIPTION
This pull request adds a page to view a single broadcast. This is important for two reasons:
- users need an audit of what happened when, and who else was involved in approving or cancelling a broadcast
- we need a place to put actions (approving, cancelling) on a broadcast so that you can confirm details of the message and the areas before performing the action

This means we can remove the ‘Stop broadcasting’ links from the dashboard.

Later we should add:
- a map preview
- a `get`/confirm/`post` loop for cancelling a broadcast

# Before

<img width="1098" alt="Screenshot 2020-07-10 at 15 29 20" src="https://user-images.githubusercontent.com/355079/87168303-2ea37980-c2c6-11ea-9320-748d732e2f52.png">

# After 

<img width="1088" alt="Screenshot 2020-07-10 at 15 28 55" src="https://user-images.githubusercontent.com/355079/87168324-3531f100-c2c6-11ea-8e87-26feadbfd7c6.png">

***

![image](https://user-images.githubusercontent.com/355079/87168880-0b2cfe80-c2c7-11ea-90e7-cf210770cea9.png)

***

![image](https://user-images.githubusercontent.com/355079/87525305-36c23700-c681-11ea-8f6d-9dd4711ede40.png)

***

<img width="764" alt="Screenshot 2020-07-10 at 14 20 50" src="https://user-images.githubusercontent.com/355079/87168342-3c58ff00-c2c6-11ea-921c-cfa64394de4a.png">

***

<img width="764" alt="Screenshot 2020-07-10 at 14 21 01" src="https://user-images.githubusercontent.com/355079/87168343-3cf19580-c2c6-11ea-9df2-27d2193118a1.png">
