### PR TITLE
Add an approval loop for broadcasts

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -24,6 +24,10 @@
     @include copy-19;
   }
 
+  .page-footer {
+    margin-bottom: govuk-spacing(1);
+  }
+
 }
 
 %banner-with-tick,

--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -7,6 +7,7 @@
 
     line-height: 40px;
     padding: 1px 0 0 15px;
+    font-weight: normal;
 
   }
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -142,7 +142,7 @@ def preview_broadcast_message(service_id, broadcast_message_id):
         service_id=current_service.id,
     )
     if request.method == 'POST':
-        broadcast_message.start_broadcast()
+        broadcast_message.request_approval()
         return redirect(url_for(
             '.broadcast_dashboard',
             service_id=current_service.id,

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -13,7 +13,7 @@ from app.utils import service_has_permission, user_has_permissions
 def broadcast_dashboard(service_id):
     return render_template(
         'views/broadcast/dashboard.html',
-        partials=get_broadcast_dashboard_partials(current_service.id)
+        partials=get_broadcast_dashboard_partials(current_service.id),
     )
 
 
@@ -27,6 +27,11 @@ def broadcast_dashboard_updates(service_id):
 def get_broadcast_dashboard_partials(service_id):
     broadcast_messages = BroadcastMessages(service_id)
     return dict(
+        pending_approval_broadcasts=render_template(
+            'views/broadcast/partials/dashboard-table.html',
+            broadcasts=broadcast_messages.with_status('pending-approval'),
+            empty_message='You do not have any broadcasts waiting for approval',
+        ),
         live_broadcasts=render_template(
             'views/broadcast/partials/dashboard-table.html',
             broadcasts=broadcast_messages.with_status('broadcasting'),

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -169,6 +169,32 @@ def view_broadcast_message(service_id, broadcast_message_id):
     )
 
 
+@main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>', methods=['POST'])
+@user_has_permissions('send_messages')
+@service_has_permission('broadcast')
+def approve_broadcast_message(service_id, broadcast_message_id):
+
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=current_service.id,
+    )
+
+    if broadcast_message.status != 'pending-approval':
+        return redirect(url_for(
+            '.view_broadcast_message',
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
+        ))
+
+    broadcast_message.approve_broadcast()
+
+    return redirect(url_for(
+        '.view_broadcast_message',
+        service_id=current_service.id,
+        broadcast_message_id=broadcast_message.id,
+    ))
+
+
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/cancel')
 @user_has_permissions('send_messages')
 @service_has_permission('broadcast')

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -195,6 +195,31 @@ def approve_broadcast_message(service_id, broadcast_message_id):
     ))
 
 
+@main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/reject')
+@user_has_permissions('send_messages')
+@service_has_permission('broadcast')
+def reject_broadcast_message(service_id, broadcast_message_id):
+
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=current_service.id,
+    )
+
+    if broadcast_message.status != 'pending-approval':
+        return redirect(url_for(
+            '.view_broadcast_message',
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
+        ))
+
+    broadcast_message.reject_broadcast()
+
+    return redirect(url_for(
+        '.broadcast_dashboard',
+        service_id=current_service.id,
+    ))
+
+
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/cancel')
 @user_has_permissions('send_messages')
 @service_has_permission('broadcast')

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -132,12 +132,11 @@ class BroadcastMessage(JSONModel):
             data=kwargs,
         )
 
-    def start_broadcast(self):
+    def request_approval(self):
         self._update(
-            starts_at=datetime.utcnow().isoformat(),
             finishes_at=(datetime.utcnow() + self.DEFAULT_TTL).isoformat(),
         )
-        self._set_status_to('broadcasting')
+        self._set_status_to('pending-approval')
 
     def cancel_broadcast(self):
         self._set_status_to('cancelled')

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -138,6 +138,12 @@ class BroadcastMessage(JSONModel):
         )
         self._set_status_to('pending-approval')
 
+    def approve_broadcast(self):
+        self._update(
+            starts_at=datetime.utcnow().isoformat(),
+        )
+        self._set_status_to('broadcasting')
+
     def cancel_broadcast(self):
         self._set_status_to('cancelled')
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -144,6 +144,9 @@ class BroadcastMessage(JSONModel):
         )
         self._set_status_to('broadcasting')
 
+    def reject_broadcast(self):
+        self._set_status_to('rejected')
+
     def cancel_broadcast(self):
         self._set_status_to('cancelled')
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -362,6 +362,7 @@ class HeaderNavigation(Navigation):
         'preview_broadcast_message',
         'view_broadcast_message',
         'approve_broadcast_message',
+        'reject_broadcast_message',
         'cancel_broadcast_message',
     }
 
@@ -421,6 +422,7 @@ class MainNavigation(Navigation):
             'preview_broadcast_message',
             'view_broadcast_message',
             'approve_broadcast_message',
+            'reject_broadcast_message',
             'cancel_broadcast_message',
         },
         'uploads': {
@@ -1015,6 +1017,7 @@ class CaseworkNavigation(Navigation):
         'preview_broadcast_message',
         'view_broadcast_message',
         'approve_broadcast_message',
+        'reject_broadcast_message',
         'cancel_broadcast_message',
     }
 
@@ -1337,5 +1340,6 @@ class OrgNavigation(Navigation):
         'preview_broadcast_message',
         'view_broadcast_message',
         'approve_broadcast_message',
+        'reject_broadcast_message',
         'cancel_broadcast_message',
     }

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -361,6 +361,7 @@ class HeaderNavigation(Navigation):
         'remove_broadcast_area',
         'preview_broadcast_message',
         'view_broadcast_message',
+        'approve_broadcast_message',
         'cancel_broadcast_message',
     }
 
@@ -419,6 +420,7 @@ class MainNavigation(Navigation):
             'remove_broadcast_area',
             'preview_broadcast_message',
             'view_broadcast_message',
+            'approve_broadcast_message',
             'cancel_broadcast_message',
         },
         'uploads': {
@@ -1012,6 +1014,7 @@ class CaseworkNavigation(Navigation):
         'remove_broadcast_area',
         'preview_broadcast_message',
         'view_broadcast_message',
+        'approve_broadcast_message',
         'cancel_broadcast_message',
     }
 
@@ -1333,5 +1336,6 @@ class OrgNavigation(Navigation):
         'remove_broadcast_area',
         'preview_broadcast_message',
         'view_broadcast_message',
+        'approve_broadcast_message',
         'cancel_broadcast_message',
     }

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -10,6 +10,14 @@
 
   <h1 class="govuk-visually-hidden">Dashboard</h1>
 
+  <h2 class="heading-medium govuk-!-margin-bottom-2">Waiting for approval</h2>
+
+  {{ ajax_block(
+    partials,
+    url_for('.broadcast_dashboard_updates', service_id=current_service.id),
+    'pending_approval_broadcasts'
+  ) }}
+
   <h2 class="heading-medium govuk-!-margin-bottom-2">Live broadcasts</h2>
 
   {{ ajax_block(

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -21,7 +21,11 @@
       </div>
     {% endcall %}
     {% call field(align='right') %}
-      {% if item.status == 'broadcasting' %}
+      {% if item.status == 'pending-approval' %}
+        <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0">
+          Prepared by {{ item.created_by.name }}
+        </p>
+      {% elif item.status == 'broadcasting' %}
         <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0">
           Live until {{ item.finishes_at|format_datetime_relative }}
         </p>

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -28,7 +28,7 @@
   {{ broadcast_message.template|string }}
 
   {% call form_wrapper() %}
-    {{ sticky_page_footer('Start broadcast') }}
+    {{ sticky_page_footer('Submit for approval') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,7 +1,7 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import sticky_page_footer %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% extends "withnav_template.html" %}
 
@@ -17,10 +17,15 @@
   ) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
-    <p class="govuk-body govuk-!-margin-bottom-3">
-      {{ broadcast_message.created_by.name }} wants to broadcast this
-      message until {{ broadcast_message.finishes_at|format_datetime_relative }}.
-    </p>
+    {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
+      <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+        {{ broadcast_message.created_by.name }} wants to broadcast this
+        message until {{ broadcast_message.finishes_at|format_datetime_relative }}.
+      </p>
+      {{ page_footer(
+        "Start broadcasting now"
+      ) }}
+    {% endcall %}
   {% else %}
     <p class="govuk-body govuk-!-margin-bottom-3">
       Created by {{ broadcast_message.created_by.name }} and approved by

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -16,26 +16,35 @@
     back_link=url_for('.broadcast_dashboard', service_id=current_service.id)
   ) }}
 
-  <p class="govuk-body govuk-!-margin-bottom-3">
-    Created by {{ broadcast_message.created_by.name }} and approved by
-    {{ broadcast_message.approved_by.name }}.
-  </p>
+  {% if broadcast_message.status == 'pending-approval' %}
+    <p class="govuk-body govuk-!-margin-bottom-3">
+      {{ broadcast_message.created_by.name }} wants to broadcast this
+      message until {{ broadcast_message.finishes_at|format_datetime_relative }}.
+    </p>
+  {% else %}
+    <p class="govuk-body govuk-!-margin-bottom-3">
+      Created by {{ broadcast_message.created_by.name }} and approved by
+      {{ broadcast_message.approved_by.name }}.
+    </p>
 
-  <p class="govuk-body govuk-!-margin-bottom-3">
-    Started broadcasting
-    {{ broadcast_message.starts_at|format_datetime_human }}.
-  </p>
+    <p class="govuk-body govuk-!-margin-bottom-3">
+      Started broadcasting
+      {{ broadcast_message.starts_at|format_datetime_human }}.
+    </p>
 
-  <p class="govuk-body">
-    {% if broadcast_message.status == 'broadcasting' %}
-      Live until {{ broadcast_message.finishes_at|format_datetime_relative }}&ensp;<a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcast early</a>
-    {% elif broadcast_message.status == 'cancelled' %}
-      Stopped by {{ broadcast_message.cancelled_by.name }}
-      {{ broadcast_message.cancelled_at|format_datetime_human }}.
-    {% else %}
-      Finished broadcasting {{ broadcast_message.finishes_at|format_datetime_human }}.
-    {% endif %}
-  </p>
+    <p class="govuk-body">
+      {% if broadcast_message.status == 'pending-approval' %}
+        Will broadcast until {{ broadcast_message.finishes_at|format_datetime_relative }}.
+      {% elif broadcast_message.status == 'broadcasting' %}
+        Live until {{ broadcast_message.finishes_at|format_datetime_relative }}&ensp;<a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcast early</a>
+      {% elif broadcast_message.status == 'cancelled' %}
+        Stopped by {{ broadcast_message.cancelled_by.name }}
+        {{ broadcast_message.cancelled_at|format_datetime_human }}.
+      {% else %}
+        Finished broadcasting {{ broadcast_message.finishes_at|format_datetime_human }}.
+      {% endif %}
+    </p>
+  {% endif %}
 
   {% for area in broadcast_message.areas %}
     {% if loop.first %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -23,7 +23,9 @@
         message until {{ broadcast_message.finishes_at|format_datetime_relative }}.
       </p>
       {{ page_footer(
-        "Start broadcasting now"
+        "Start broadcasting now",
+        delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+        delete_link_text='Reject this broadcast'
       ) }}
     {% endcall %}
   {% else %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -62,6 +62,7 @@ def test_empty_broadcast_dashboard(
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr .table-empty-message')
     ] == [
+        'You do not have any broadcasts waiting for approval',
         'You do not have any live broadcasts at the moment',
         'You do not have any previous broadcasts',
     ]
@@ -78,13 +79,29 @@ def test_broadcast_dashboard(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
     )
+    assert normalize_spaces(page.select('main h2')[0].text) == (
+        'Waiting for approval'
+    )
     assert [
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
     ] == [
-        'Example template To England and Scotland Live until tomorrow at 2:20am',
+        'Example template To England and Scotland Prepared by Test User',
     ]
+
+    assert normalize_spaces(page.select('main h2')[1].text) == (
+        'Live broadcasts'
+    )
     assert [
         normalize_spaces(row.text) for row in page.select('table')[1].select('tbody tr')
+    ] == [
+        'Example template To England and Scotland Live until tomorrow at 2:20am',
+    ]
+
+    assert normalize_spaces(page.select('main h2')[2].text) == (
+        'Previous broadcasts'
+    )
+    assert [
+        normalize_spaces(row.text) for row in page.select('table')[2].select('tbody tr')
     ] == [
         'Example template To England and Scotland Stopped 10 February at 2:20am',
         'Example template To England and Scotland Finished yesterday at 8:20pm',
@@ -107,8 +124,13 @@ def test_broadcast_dashboard_json(
 
     json_response = json.loads(response.get_data(as_text=True))
 
-    assert json_response.keys() == {'live_broadcasts', 'previous_broadcasts'}
+    assert json_response.keys() == {
+        'pending_approval_broadcasts',
+        'live_broadcasts',
+        'previous_broadcasts',
+    }
 
+    assert 'Prepared by Test User' in json_response['pending_approval_broadcasts']
     assert 'Live until tomorrow at 2:20am' in json_response['live_broadcasts']
     assert 'Finished yesterday at 8:20pm' in json_response['previous_broadcasts']
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -313,12 +313,11 @@ def test_start_broadcasting(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'starts_at': '2020-02-02T02:02:02.222222',
             'finishes_at': '2020-02-05T02:02:02.222222',
         },
     )
     mock_update_broadcast_message_status.assert_called_once_with(
-        'broadcasting',
+        'pending-approval',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4271,6 +4271,9 @@ def mock_get_broadcast_messages(
                 status='draft',
             ),
             partial_json(
+                status='pending-approval',
+            ),
+            partial_json(
                 status='broadcasting',
                 starts_at=(
                     datetime.utcnow()


### PR DESCRIPTION
At the moment a broadcast starts straight away, with no oversight. By default, it should require two people to look at a broadcast before it goes out. So this pull request adds an approval process.

It doesn’t:
- restrict who can approve a broadcast, except to those who have the `send_messages` permission – this means you can approve your own broadcast – but we’ll change this soon
- have any way of overriding the approval process and forcing a broadcast to go out – we’ll want to explore the user needs here

# Before 

<img width="1042" alt="Screenshot 2020-07-15 at 19 52 58" src="https://user-images.githubusercontent.com/355079/87584145-f7253a80-c6d4-11ea-80f7-500858547754.png">

# After

<img width="1030" alt="Screenshot 2020-07-15 at 19 52 19" src="https://user-images.githubusercontent.com/355079/87584142-f5f40d80-c6d4-11ea-8f31-ad6a6b81fd4b.png">

<img width="1046" alt="Screenshot 2020-07-15 at 19 53 32" src="https://user-images.githubusercontent.com/355079/87584147-f7bdd100-c6d4-11ea-95ee-7efb9942e76a.png">

<img width="1061" alt="Screenshot 2020-07-15 at 19 53 53" src="https://user-images.githubusercontent.com/355079/87584149-f8566780-c6d4-11ea-84fc-49392b2971be.png">
