### PR TITLE
Add ‘no templates’ message for broadcast services

### DIFF
--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -21,25 +21,19 @@
     <h1 class="heading-medium">
       {{ page_title }}
     </h1>
-    {% if current_user.has_permissions('manage_templates') %}
-       <p class="govuk-body">
+
+     <p class="govuk-body">
+       {% if current_user.has_permissions('manage_templates') %}
          You need a template before you can send
-         {% if 'letter' in current_service.permissions %}
-           emails, text messages or letters
-         {%- else -%}
-           emails or text messages
-         {%- endif %}.
-       </p>
-    {% else %}
-      <p class="govuk-body">
-        You need to ask your service manager to add templates before you can send
-        {% if 'letter' in current_service.permissions %}
-          emails, text messages or letters
-        {%- else -%}
-          emails or text messages
-        {%- endif %}.
-      </p>
-    {% endif %}
+       {% else %}
+         You need to ask your service manager to add templates before you can send
+       {% endif %}
+       {% if 'letter' in current_service.permissions %}
+         emails, text messages or letters
+       {%- else -%}
+         emails or text messages
+       {%- endif %}.
+     </p>
 
   {% else %}
 

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -31,12 +31,7 @@
        {% if current_service.has_permission('broadcast') %}
           prepare a broadcast
        {%- else %}
-          send
-          {% if 'letter' in current_service.permissions %}
-            emails, text messages or letters
-          {%- else -%}
-            emails or text messages
-          {%- endif %}
+          send emails, text messages or letters
        {%- endif %}.
      </p>
 

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -24,14 +24,19 @@
 
      <p class="govuk-body">
        {% if current_user.has_permissions('manage_templates') %}
-         You need a template before you can send
+         You need a template before you can
        {% else %}
-         You need to ask your service manager to add templates before you can send
+         You need to ask your service manager to add templates before you can
        {% endif %}
-       {% if 'letter' in current_service.permissions %}
-         emails, text messages or letters
-       {%- else -%}
-         emails or text messages
+       {% if current_service.has_permission('broadcast') %}
+          prepare a broadcast
+       {%- else %}
+          send
+          {% if 'letter' in current_service.permissions %}
+            emails, text messages or letters
+          {%- else -%}
+            emails or text messages
+          {%- endif %}
        {%- endif %}.
      </p>
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -29,15 +29,12 @@ from tests.conftest import (
 
 @pytest.mark.parametrize('permissions, expected_message', (
     (['email'], (
-        'You need a template before you can send emails or text messages.'
-    )),
-    (['sms'], (
-        'You need a template before you can send emails or text messages.'
-    )),
-    (['letter'], (
         'You need a template before you can send emails, text messages or letters.'
     )),
-    (['sms', 'letter'], (
+    (['sms'], (
+        'You need a template before you can send emails, text messages or letters.'
+    )),
+    (['letter'], (
         'You need a template before you can send emails, text messages or letters.'
     )),
     (['email', 'sms', 'letter'], (
@@ -88,7 +85,7 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
         'Templates'
     )
     assert normalize_spaces(page.select_one('main p').text) == (
-        'You need a template before you can send emails or text messages.'
+        'You need a template before you can send emails, text messages or letters.'
     )
     assert [
         (item['name'], item['value']) for item in page.select('[type=radio]')

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -27,12 +27,36 @@ from tests.conftest import (
 )
 
 
+@pytest.mark.parametrize('permissions, expected_message', (
+    (['email'], (
+        'You need a template before you can send emails or text messages.'
+    )),
+    (['sms'], (
+        'You need a template before you can send emails or text messages.'
+    )),
+    (['letter'], (
+        'You need a template before you can send emails, text messages or letters.'
+    )),
+    (['sms', 'letter'], (
+        'You need a template before you can send emails, text messages or letters.'
+    )),
+    (['email', 'sms', 'letter'], (
+        'You need a template before you can send emails, text messages or letters.'
+    )),
+    (['broadcast'], (
+        'You need a template before you can prepare a broadcast.'
+    )),
+))
 def test_should_show_empty_page_when_no_templates(
     client_request,
     service_one,
     mock_get_service_templates_when_no_templates_exist,
     mock_get_template_folders,
+    permissions,
+    expected_message,
 ):
+
+    service_one['permissions'] = permissions
 
     page = client_request.get(
         'main.choose_template',
@@ -43,7 +67,7 @@ def test_should_show_empty_page_when_no_templates(
         'Templates'
     )
     assert normalize_spaces(page.select_one('main p').text) == (
-        'You need a template before you can send emails or text messages.'
+        expected_message
     )
     assert page.select_one('#add_new_folder_form')
     assert page.select_one('#add_new_template_form')


### PR DESCRIPTION
The page shouldn’t talk about emails, text messages or letters.