### PR TITLE
Let users choose when to end a broadcast

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -7,12 +7,14 @@
 
   let states = {
     'initial': Hogan.compile(`
-      <div class="radio-select__column">
-        <div class="multiple-choice js-multiple-choice">
-          <input checked="checked" id="{{name}}-0" name="{{name}}" type="radio" value="">
-          <label class="block-label js-block-label" for="{{name}}-0">Now</label>
+      {{#showNowAsDefault}}
+        <div class="radio-select__column">
+          <div class="multiple-choice js-multiple-choice">
+            <input checked="checked" id="{{name}}-0" name="{{name}}" type="radio" value="">
+            <label class="block-label js-block-label" for="{{name}}-0">Now</label>
+          </div>
         </div>
-      </div>
+      {{/showNowAsDefault}}
       <div class="radio-select__column">
         {{#categories}}
           <input type='button' class='govuk-button govuk-button--secondary radio-select__button--category' value='{{.}}' />
@@ -20,12 +22,14 @@
       </div>
     `),
     'choose': Hogan.compile(`
-      <div class="radio-select__column">
-        <div class="multiple-choice js-multiple-choice js-initial-option">
-          <input checked="checked" id="{{name}}-0" name="{{name}}" type="radio" value="">
-          <label for="{{name}}-0">Now</label>
+      {{#showNowAsDefault}}
+        <div class="radio-select__column">
+          <div class="multiple-choice js-multiple-choice js-initial-option">
+            <input checked="checked" id="{{name}}-0" name="{{name}}" type="radio" value="">
+            <label for="{{name}}-0">Now</label>
+          </div>
         </div>
-      </div>
+      {{/showNowAsDefault}}
       <div class="radio-select__column">
         {{#choices}}
           <div class="multiple-choice js-multiple-choice js-option">
@@ -37,12 +41,14 @@
       </div>
     `),
     'chosen': Hogan.compile(`
-      <div class="radio-select__column">
-        <div class="multiple-choice js-multiple-choice js-initial-option">
-          <input id="{{name}}-0" name="{{name}}" type="radio" value="">
-          <label for="{{name}}-0">Now</label>
+      {{#showNowAsDefault}}
+        <div class="radio-select__column">
+          <div class="multiple-choice js-multiple-choice js-initial-option">
+            <input id="{{name}}-0" name="{{name}}" type="radio" value="">
+            <label for="{{name}}-0">Now</label>
+          </div>
         </div>
-      </div>
+      {{/showNowAsDefault}}
       <div class="radio-select__column">
         {{#choices}}
           <div class="multiple-choice js-multiple-choice">
@@ -80,10 +86,15 @@
       let categories = $component.data('categories').split(',');
       let name = $component.find('input').eq(0).attr('name');
       let mousedownOption = null;
+      let showNowAsDefault = (
+        $component.data('show-now-as-default').toLowerCase() === 'true' ?
+        {'name': name} : false
+      );
       const reset = () => {
         render('initial', {
           'categories': categories,
-          'name': name
+          'name': name,
+          'showNowAsDefault': showNowAsDefault
         });
       };
       const selectOption = (value) => {
@@ -91,7 +102,8 @@
           'choices': choices.filter(
             element => element.value == value
           ),
-          'name': name
+          'name': name,
+          'showNowAsDefault': showNowAsDefault
         });
         focusSelected(component);
       };
@@ -153,7 +165,8 @@
               'choices': choices.filter(
                 element => element.value == $selection.eq(0).attr('value')
               ),
-              'name': name
+              'name': name,
+              'showNowAsDefault': showNowAsDefault
             });
 
           } else {
@@ -174,7 +187,8 @@
 
       render('initial', {
         'categories': categories,
-        'name': name
+        'name': name,
+        'showNowAsDefault': showNowAsDefault
       });
 
       $component.css({'height': 'auto'});

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -87,7 +87,7 @@
       let name = $component.find('input').eq(0).attr('name');
       let mousedownOption = null;
       let showNowAsDefault = (
-        $component.data('show-now-as-default').toLowerCase() === 'true' ?
+        $component.data('show-now-as-default').toString() === 'true' ?
         {'name': name} : false
       );
       const reset = () => {
@@ -131,7 +131,8 @@
             'choices': choices.filter(
               element => element.label.toLowerCase().indexOf(day) > -1
             ),
-            'name': name
+            'name': name,
+            'showNowAsDefault': showNowAsDefault
           });
           focusSelected(component);
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -100,7 +100,7 @@ def get_next_hours_until(until):
     now = datetime.utcnow()
     hours = int((until - now).total_seconds() / (60 * 60))
     return [
-        (now + timedelta(hours=i)).replace(minute=0, second=0).replace(tzinfo=pytz.utc)
+        (now + timedelta(hours=i)).replace(minute=0, second=0, microsecond=0).replace(tzinfo=pytz.utc)
         for i in range(1, hours + 1)
     ]
 
@@ -976,6 +976,24 @@ class ChooseTimeForm(StripWhitespaceForm):
     scheduled_for = RadioField(
         'When should Notify send these messages?',
         default='',
+    )
+
+
+class ChooseBroadcastDurationForm(StripWhitespaceForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.finishes_at.choices = [
+            get_time_value_and_label(hour) for hour in get_next_hours_until(
+                get_furthest_possible_scheduled_time()
+            )
+        ]
+        self.finishes_at.categories = get_next_days_until(
+            get_furthest_possible_scheduled_time()
+        )
+
+    finishes_at = RadioField(
+        'When should this broadcast end?',
     )
 
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -1,8 +1,12 @@
-from flask import abort, jsonify, redirect, render_template, request, url_for
+from flask import abort, jsonify, redirect, render_template, url_for
 
 from app import current_service
 from app.main import main
-from app.main.forms import BroadcastAreaForm, SearchByNameForm
+from app.main.forms import (
+    BroadcastAreaForm,
+    ChooseBroadcastDurationForm,
+    SearchByNameForm,
+)
 from app.models.broadcast_message import BroadcastMessage, BroadcastMessages
 from app.utils import service_has_permission, user_has_permissions
 
@@ -141,15 +145,19 @@ def preview_broadcast_message(service_id, broadcast_message_id):
         broadcast_message_id,
         service_id=current_service.id,
     )
-    if request.method == 'POST':
-        broadcast_message.request_approval()
+    form = ChooseBroadcastDurationForm()
+
+    if form.validate_on_submit():
+        broadcast_message.request_approval(until=form.finishes_at.data)
         return redirect(url_for(
             '.broadcast_dashboard',
             service_id=current_service.id,
         ))
+
     return render_template(
         'views/broadcast/preview-message.html',
         broadcast_message=broadcast_message,
+        form=form,
     )
 
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from notifications_utils.broadcast_areas import broadcast_area_libraries
 from notifications_utils.template import BroadcastPreviewTemplate
@@ -33,7 +33,6 @@ class BroadcastMessage(JSONModel):
         'approved_by_id',
         'cancelled_by_id',
     }
-    DEFAULT_TTL = timedelta(hours=72)
 
     libraries = broadcast_area_libraries
 
@@ -132,9 +131,9 @@ class BroadcastMessage(JSONModel):
             data=kwargs,
         )
 
-    def request_approval(self):
+    def request_approval(self, until):
         self._update(
-            finishes_at=(datetime.utcnow() + self.DEFAULT_TTL).isoformat(),
+            finishes_at=until,
         )
         self._set_status_to('pending-approval')
 

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -36,7 +36,7 @@
          </span>
        {% endif %}
      </legend>
-     <div class="radio-select" data-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default }}">
+     <div class="radio-select" data-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default|string|lower }}">
        <div class="radio-select-column">
        {% for option in field %}
          <div class="multiple-choice">

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -23,7 +23,8 @@
 {% macro radio_select(
  field,
  hint=None,
- wrapping_class='form-group'
+ wrapping_class='form-group',
+ show_now_as_default=True
 ) %}
  <div class="{{ wrapping_class }} {% if field.errors %} form-group-error{% endif %}">
    <fieldset>
@@ -35,7 +36,7 @@
          </span>
        {% endif %}
      </legend>
-     <div class="radio-select" data-module="radio-select" data-categories="{{ field.categories|join(',') }}">
+     <div class="radio-select" data-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default }}">
        <div class="radio-select-column">
        {% for option in field %}
          <div class="multiple-choice">

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -1,7 +1,8 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import sticky_page_footer %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/radios.html" import radio_select %}
 
 {% extends "withnav_template.html" %}
 
@@ -28,7 +29,11 @@
   {{ broadcast_message.template|string }}
 
   {% call form_wrapper() %}
-    {{ sticky_page_footer('Submit for approval') }}
+    {{ radio_select(
+      form.finishes_at,
+      show_now_as_default=False
+    ) }}
+    {{ page_footer('Submit for approval') }}
   {% endcall %}
 
 {% endblock %}

--- a/tests/app/main/test_choose_time_form.py
+++ b/tests/app/main/test_choose_time_form.py
@@ -11,19 +11,19 @@ def test_form_contains_next_24h(app_):
 
     # Friday
     assert choices[0] == ('', 'Now')
-    assert choices[1] == ('2016-01-01T12:00:00.061258', 'Today at midday')
-    assert choices[13] == ('2016-01-02T00:00:00.061258', 'Today at midnight')
+    assert choices[1] == ('2016-01-01T12:00:00', 'Today at midday')
+    assert choices[13] == ('2016-01-02T00:00:00', 'Today at midnight')
 
     # Saturday
-    assert choices[14] == ('2016-01-02T01:00:00.061258', 'Tomorrow at 1am')
-    assert choices[37] == ('2016-01-03T00:00:00.061258', 'Tomorrow at midnight')
+    assert choices[14] == ('2016-01-02T01:00:00', 'Tomorrow at 1am')
+    assert choices[37] == ('2016-01-03T00:00:00', 'Tomorrow at midnight')
 
     # Sunday
-    assert choices[38] == ('2016-01-03T01:00:00.061258', 'Sunday at 1am')
+    assert choices[38] == ('2016-01-03T01:00:00', 'Sunday at 1am')
 
     # Monday
-    assert choices[84] == ('2016-01-04T23:00:00.061258', 'Monday at 11pm')
-    assert choices[85] == ('2016-01-05T00:00:00.061258', 'Monday at midnight')
+    assert choices[84] == ('2016-01-04T23:00:00', 'Monday at 11pm')
+    assert choices[85] == ('2016-01-05T00:00:00', 'Monday at midnight')
 
     with pytest.raises(IndexError):
         assert choices[

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -99,7 +99,7 @@ describe('RadioSelect', () => {
         <legend class="form-label">
           When should Notify send these messages?
         </legend>
-        <div class="radio-select" data-module="radio-select" data-categories="${CATEGORIES.join(',')}">
+        <div class="radio-select" data-module="radio-select" data-categories="${CATEGORIES.join(',')}" data-show-now-as-default="True">
           <div class="radio-select__column">
             <div class="multiple-choice">
               <input checked="" id="scheduled_for-0" name="scheduled_for" type="radio" value="">

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -100,7 +100,7 @@ describe('RadioSelect', () => {
         <legend class="form-label">
           When should Notify send these messages?
         </legend>
-        <div class="radio-select" data-module="radio-select" data-categories="${CATEGORIES.join(',')}" data-show-now-as-default="True">
+        <div class="radio-select" data-module="radio-select" data-categories="${CATEGORIES.join(',')}" data-show-now-as-default="true">
           <div class="radio-select__column">
             <div class="multiple-choice">
               <input checked="" id="scheduled_for-0" name="scheduled_for" type="radio" value="">

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -114,7 +114,7 @@ describe('RadioSelect', () => {
         </div>
       </fieldset>`;
 
-      originalOptionsForAllCategories = Array.from(document.querySelector('.radio-select__column:nth-child(2) .multiple-choice'))
+      originalOptionsForAllCategories = Array.from(document.querySelectorAll('.radio-select__column:nth-child(2) .multiple-choice'))
                                           .map(option => getDataFromOption(option));
   });
 
@@ -173,7 +173,7 @@ describe('RadioSelect', () => {
         test("show the options for it, with the right label and value", () => {
 
           // check options this reveals against those originally in the page for this category
-          const options = document.querySelector('.radio-select__column:nth-child(2) .multiple-choice');
+          const options = document.querySelectorAll('.radio-select__column:nth-child(2) .multiple-choice');
 
           const optionsThatMatchOriginals = Array.from(options).filter((option, idx) => {
             const optionData = getDataFromOption(option);

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -68,11 +68,12 @@ describe('RadioSelect', () => {
 
         hours.forEach((hour, idx) => {
           const hourLabel = getHourLabel(hour);
+          const num = idx + 1;
 
           result +=
             `<div class="multiple-choice">
-              <input id="scheduled_for-${idx}" name="scheduled_for" type="radio" value="2019-05-${dayAsNumber}T${hour}:00:00.459156">
-              <label for="scheduled_for-${idx}">
+              <input id="scheduled_for-${num}" name="scheduled_for" type="radio" value="2019-05-${dayAsNumber}T${hour}:00:00.459156">
+              <label for="scheduled_for-${num}">
                 ${day} at ${hourLabel}
               </label>
             </div>`;

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -123,30 +123,60 @@ describe('RadioSelect', () => {
     document.body.innerHTML = '';
   });
 
-  describe("when the page has loaded it should have a button for each category", () => {
+  describe("when the page has loaded", () => {
 
-    let categoryButtons;
+    describe("if the 'data-show-now-as-default' attribute", () => {
 
-    beforeEach(() => {
+      test("is set to true the module should have a 'Now' option", () => {
 
-      // start module
-      window.GOVUK.modules.start();
+        // default is for it to be set to true
 
-      categoryButtons = document.querySelectorAll('.radio-select__column:nth-child(2) .radio-select__button--category');
+        // start module
+        window.GOVUK.modules.start();
+
+        expect(document.querySelectorAll('.radio-select__column').length).toEqual(2);
+
+      });
+
+      test("is set to false the module should not have a 'Now' option", () => {
+
+        document.querySelector('.radio-select').setAttribute('data-show-now-as-default', 'false');
+
+        // start module
+        window.GOVUK.modules.start();
+
+        expect(document.querySelectorAll('.radio-select__column').length).toEqual(1);
+
+      });
 
     });
 
-    test("the number of buttons should match the categories", () => {
+    describe("it should have a button for each category", () => {
 
-      expect(categoryButtons.length).toBe(CATEGORIES.length);
+      let categoryButtons;
 
-    });
+      beforeEach(() => {
 
-    test("each button's text should match their category", () => {
+        // start module
+        window.GOVUK.modules.start();
 
-      // check the buttons have the right text
-      CATEGORIES.forEach((category, idx) => {
-        expect(categoryButtons[idx].getAttribute('value')).toEqual(category);
+        categoryButtons = document.querySelectorAll('.radio-select__column:nth-child(2) .radio-select__button--category');
+
+      });
+
+      test("the number of buttons should match the categories", () => {
+
+        expect(categoryButtons.length).toBe(CATEGORIES.length);
+
+      });
+
+      test("each button's text should match their category", () => {
+
+        // check the buttons have the right text
+        CATEGORIES.forEach((category, idx) => {
+          expect(categoryButtons[idx].getAttribute('value')).toEqual(category);
+        });
+
       });
 
     });

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -159,10 +159,13 @@ describe('RadioSelect', () => {
 
       describe(`clicking the button for ${category} should`, () => {
 
+        const categoryRegExp = new RegExp('^' + category);
+        let originalOptionsForcategory;
+
         beforeEach(() => {
 
           // get all the options in the original page for this category
-          originalOptionsForCategory = originalOptionsForAllCategories.filter(option => option.label === category);
+          originalOptionsForCategory = originalOptionsForAllCategories.filter(option => categoryRegExp.test(option.label));
 
           // start module
           window.GOVUK.modules.start();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/355079/87656995-2332d100-c752-11ea-839d-74028a2a1e9a.png)


Different emergencies will need broadcasts to last for a variable amount of time. We give users some control over this by letting them stop a broadcast early. But we should also let them set a maximum broadcast time, for:
- when the duration of the danger is known
- when the broadcast has been live long enough to alert everyone who needs to know about it

This code re-uses the pattern for scheduling jobs, which has some constraints that are probably OK for now:
- end time is limited to an hour
- longest duration is 3 whole days (eg if you start broadcasting Friday you have the choice of Saturday, Sunday and all of Monday, up to midnight)

Pull requests that introduced the scheduling of jobs are:
- https://github.com/alphagov/notifications-admin/pull/903 (allowed users to choose a time in the next 24 hours to send a file)
- https://github.com/alphagov/notifications-admin/pull/979 (extended the time to the next 4 days)
