### PR TITLE
Fix setting of broadcast permission

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -318,10 +318,7 @@ def service_set_broadcast_permission(service_id):
     if form.validate_on_submit():
 
         if form.enabled.data:
-            current_service.force_permission('broadcast', on=True)
-            current_service.force_permission('email', on=False)
-            current_service.force_permission('sms', on=False)
-            current_service.force_permission('letter', on=False)
+            current_service.force_broadcast_permission_on()
         else:
             current_service.force_permission('broadcast', on=False)
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -99,6 +99,11 @@ class Service(JSONModel):
             permissions | permission if on else permissions - permission,
         )
 
+    def force_broadcast_permission_on(self):
+        return self.update_permissions(
+            set(self.permissions) - {'email', 'sms', 'letter'} | {'broadcast'}
+        )
+
     def update_permissions(self, permissions):
         return self.update(permissions=list(permissions))
 


### PR DESCRIPTION
This was broken because `current_service` doesn’t update itself after calling the `update` method of the API. So we thought we were changing the permissions in this order:
```python
['email', 'sms', 'letter']
['email', 'sms', 'letter', 'broadcast']
['sms', 'letter', 'broadcast']
['letter', 'broadcast']
['broadcast']
```

But actually we were doing this:
```python
['email', 'sms', 'letter']
['email', 'sms', 'letter', 'broadcast']
['sms', 'letter']
['email', 'letter']
['email', 'sms']
```

This commit changes the code to update the permissions like this:
```python
['email', 'sms', 'letter']
['broadcast']
```

It does so by adding a new method to the service model which changes all the permissions in one API call, and updates the tests to mock the underlying API call, not the method on the model.