### PR TITLE
Make the status text of pending broadcasts grey

### DIFF
--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -22,7 +22,7 @@
     {% endcall %}
     {% call field(align='right') %}
       {% if item.status == 'pending-approval' %}
-        <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0">
+        <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0 govuk-hint">
           Prepared by {{ item.created_by.name }}
         </p>
       {% elif item.status == 'broadcasting' %}


### PR DESCRIPTION
Only live broadcasts have their status in black text. This is to emphasise them. Lost this in a merge conflict somewhere.