### PR TITLE
Add a confirmation step to cancelling a broadcast

### DIFF
--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -2,7 +2,7 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
     {% for category, message in messages %}
-      {% if category in ['cancel', 'delete', 'suspend', 'resume', 'remove', 'revoke this API key'] %}
+      {% if category in ['cancel', 'delete', 'suspend', 'resume', 'remove', 'revoke this API key', 'stop broadcasting'] %}
         {% set delete_button_text = "Yes, {}".format(category) %}
       {% elif category == 'try again' %}
         {% set delete_button_text = category|capitalize %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -43,7 +43,10 @@
       {% if broadcast_message.status == 'pending-approval' %}
         Will broadcast until {{ broadcast_message.finishes_at|format_datetime_relative }}.
       {% elif broadcast_message.status == 'broadcasting' %}
-        Live until {{ broadcast_message.finishes_at|format_datetime_relative }}&ensp;<a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcast early</a>
+        Live until {{ broadcast_message.finishes_at|format_datetime_relative }}&ensp;
+        {%- if not hide_stop_link %}
+          <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcast early</a>
+        {% endif %}
       {% elif broadcast_message.status == 'cancelled' %}
         Stopped by {{ broadcast_message.cancelled_by.name }}
         {{ broadcast_message.cancelled_at|format_datetime_human }}.

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -10,25 +10,66 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 sample_uuid = sample_uuid()
 
 
-@pytest.mark.parametrize('endpoint, extra_args', (
-    ('.broadcast_dashboard', {}),
-    ('.broadcast_dashboard_updates', {}),
-    ('.broadcast', {'template_id': sample_uuid}),
-    ('.preview_broadcast_areas', {'broadcast_message_id': sample_uuid}),
-    ('.choose_broadcast_library', {'broadcast_message_id': sample_uuid}),
-    ('.choose_broadcast_area', {'broadcast_message_id': sample_uuid, 'library_slug': 'countries'}),
-    ('.remove_broadcast_area', {'broadcast_message_id': sample_uuid, 'area_slug': 'england'}),
-    ('.preview_broadcast_message', {'broadcast_message_id': sample_uuid}),
+@pytest.mark.parametrize('endpoint, extra_args, expected_get_status, expected_post_status', (
+    (
+        '.broadcast_dashboard', {},
+        403, 405,
+    ),
+    (
+        '.broadcast_dashboard_updates', {},
+        403, 405,
+    ),
+    (
+        '.broadcast',
+        {'template_id': sample_uuid},
+        403, 405,
+    ),
+    (
+        '.preview_broadcast_areas', {'broadcast_message_id': sample_uuid},
+        403, 405,
+    ),
+    (
+        '.choose_broadcast_library', {'broadcast_message_id': sample_uuid},
+        403, 405,
+    ),
+    (
+        '.choose_broadcast_area', {'broadcast_message_id': sample_uuid, 'library_slug': 'countries'},
+        403, 403,
+    ),
+    (
+        '.remove_broadcast_area', {'broadcast_message_id': sample_uuid, 'area_slug': 'england'},
+        403, 405,
+    ),
+    (
+        '.preview_broadcast_message', {'broadcast_message_id': sample_uuid},
+        403, 403,
+    ),
+    (
+        '.view_broadcast_message', {'broadcast_message_id': sample_uuid},
+        403, 403,
+    ),
+    (
+        '.cancel_broadcast_message', {'broadcast_message_id': sample_uuid},
+        403, 403,
+    ),
 ))
 def test_broadcast_pages_403_without_permission(
     client_request,
     endpoint,
     extra_args,
+    expected_get_status,
+    expected_post_status,
 ):
     client_request.get(
         endpoint,
         service_id=SERVICE_ONE_ID,
-        _expected_status=403,
+        _expected_status=expected_get_status,
+        **extra_args
+    )
+    client_request.post(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+        _expected_status=expected_post_status,
         **extra_args
     )
 


### PR DESCRIPTION
It’s an irreversible action if you do click it, so it feels like an ‘Are you sure?’ step is sensible. Follows the same pattern for deleting templates, etc.

![image](https://user-images.githubusercontent.com/355079/87795191-9bc38b80-c83f-11ea-88e0-e2d0b25242de.png)
