### PR TITLE
Include template values when calculating letter page count

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -436,6 +436,9 @@ def send_test_step(service_id, template_id, step_index):
         email_reply_to = get_email_reply_to_address_from_session()
     elif db_template['template_type'] == 'sms':
         sms_sender = get_sms_sender_from_session()
+
+    template_values = get_recipient_and_placeholders_from_session(db_template['template_type'])
+
     template = get_template(
         db_template,
         current_service,
@@ -446,7 +449,7 @@ def send_test_step(service_id, template_id, step_index):
             template_id=template_id,
             filetype='png',
         ),
-        page_count=get_page_count_for_letter(db_template),
+        page_count=get_page_count_for_letter(db_template, values=template_values),
         email_reply_to=email_reply_to,
         sms_sender=sms_sender
     )
@@ -520,7 +523,7 @@ def send_test_step(service_id, template_id, step_index):
 
     back_link = get_back_link(service_id, template, step_index, placeholders)
 
-    template.values = get_recipient_and_placeholders_from_session(template.template_type)
+    template.values = template_values
     template.values[current_placeholder] = None
 
     return render_template(
@@ -1039,6 +1042,7 @@ def _check_notification(service_id, template_id, exception=None):
 
     template.values = get_recipient_and_placeholders_from_session(template.template_type)
     page_count = get_page_count_for_letter(db_template, template.values)
+    template.page_count = page_count
     return dict(
         template=template,
         back_link=back_link,


### PR DESCRIPTION
When sending a letter we check how many pages it has and this number
then determines how many PNG images we ask template preview for. When
calculating the page count, we were getting the page count for the
template as it comes from the database (so without any placeholders
filled in). But filling in placeholders in a letter may cause the number
of pages to change, which was the cause of the 'Letter does not have a
page x' errors we were seeing from template-preview.

Now, when we calculate the letter page count during sending, we take the
placeholders that have already been filled in into account.

**To test:** Make a copy of [this template](https://www.notify.works/services/d33f763f-d8b6-4591-b272-ec6127572e5a/templates/2dd69cce-c0d2-470f-a6c1-8900a5368e04) and try sending it without any of the
optional placeholders. There should now be no errors