### PR TITLE
Fix footer link to GOV.UK Notify blog

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -199,7 +199,7 @@
             "text": "Terms of use"
           },
           {
-            "href": "https://gds.blog.gov.uk/category/notify/",
+            "href": "https://gds.blog.gov.uk/category/gov-uk-notify/",
             "text": "Blog"
           }
         ]


### PR DESCRIPTION
This PR fixes the footer link to the GDS blog.

The URL changed at some point (possibly based on updated tagging) and we didn't update the footer link to match this.