### PR TITLE
Use new guest list API URLs

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -327,11 +327,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get(url='/service/{}/notifications/monthly?year={}'.format(service_id, year))
 
     def get_guest_list(self, service_id):
-        return self.get(url='/service/{}/whitelist'.format(service_id))
+        return self.get(url='/service/{}/guest-list'.format(service_id))
 
     @cache.delete('service-{service_id}')
     def update_guest_list(self, service_id, data):
-        return self.put(url='/service/{}/whitelist'.format(service_id), data=data)
+        return self.put(url='/service/{}/guest-list'.format(service_id), data=data)
 
     def get_inbound_sms(self, service_id, user_number=''):
         # POST prevents the user phone number leaking into our logs

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -488,3 +488,27 @@ def test_deletes_cached_users_when_archiving_service(mocker):
     service_api_client.archive_service(SERVICE_ONE_ID, ["my-user-id1", "my-user-id2"])
 
     assert call('user-my-user-id1', 'user-my-user-id2') in mock_redis_delete.call_args_list
+
+
+def test_client_gets_guest_list(mocker):
+    client = ServiceAPIClient()
+    mock_get = mocker.patch.object(client, 'get', return_value=['a', 'b', 'c'])
+
+    response = client.get_guest_list('foo')
+
+    assert response == ['a', 'b', 'c']
+    mock_get.assert_called_once_with(
+        url='/service/foo/guest-list',
+    )
+
+
+def test_client_updates_guest_list(mocker):
+    client = ServiceAPIClient()
+    mock_put = mocker.patch.object(client, 'put')
+
+    client.update_guest_list('foo', data=['a', 'b', 'c'])
+
+    mock_put.assert_called_once_with(
+        url='/service/foo/guest-list',
+        data=['a', 'b', 'c'],
+    )


### PR DESCRIPTION
The API now accepts requests on `…/guest-list` as well as `…/whitelist`. This commit starts using the former, which means:
- the use of ‘whitelist’ is fully gone from the admin app
- the API can stop using it, at least in URLs

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/2928