### PR TITLE
Make start time explicit when previewing a broadcast

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -993,7 +993,7 @@ class ChooseBroadcastDurationForm(StripWhitespaceForm):
         )
 
     finishes_at = RadioField(
-        'When should this broadcast end?',
+        'End time',
     )
 
 

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -24,11 +24,12 @@
  field,
  hint=None,
  wrapping_class='form-group',
- show_now_as_default=True
+ show_now_as_default=True,
+ bold_legend=False
 ) %}
  <div class="{{ wrapping_class }} {% if field.errors %} form-group-error{% endif %}">
    <fieldset>
-     <legend class="form-label">
+     <legend class="form-label {% if bold_legend %}govuk-!-font-weight-bold{% endif %}">
        {{ field.label.text }}
        {% if field.errors %}
          <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -29,9 +29,16 @@
   {{ broadcast_message.template|string }}
 
   {% call form_wrapper() %}
+    <h3 class="govuk-heading-s govuk-!-margin-top-6 govuk-!-margin-bottom-1">
+      Start time
+    </h3>
+    <p class="govuk-body govuk-!-margin-bottom-4">
+      Your broadcast will start when it’s approved by another member of your team.
+    </p>
     {{ radio_select(
       form.finishes_at,
-      show_now_as_default=False
+      show_now_as_default=False,
+      bold_legend=True
     ) }}
     {{ page_footer('Submit for approval') }}
   {% endcall %}


### PR DESCRIPTION
# Context

We [recently introduced](https://github.com/alphagov/notifications-admin/pull/3527) a form control that lets users choose when a broadcast ends:

![image (12)](https://user-images.githubusercontent.com/355079/88642288-33cf3980-d0b8-11ea-8145-13cf6b065920.png)

Based on the most recent research participant, we think:
- there is a specific misunderstanding of what this control does
- there is a general low level of understanding of what a ‘broadcast’ means

People will try to understand what a ‘broadcast’ is by using mental models they have for other kinds of messaging, for example text messages.

Other kinds of messaging are one-to-one, i.e. they go from a sender to a recipient. They are not ongoing in any way.

Emails and texts are sent at a specific time (and for all practicable purposes are received at that same time). So, when we present the user with a form that controls time, they might well assume it controls the time when the message will be sent.

We reinforce this assumption with the labelling of the form control. By front-loading it with the word ‘When’ we are playing to the users confirmation bias. In other words they are interpreting the meaning of the control in a way that confirms their prior beliefs about how messaging works.

Controlling when a message is sent is a feature we already offer to users uploading a spreadsheet of recipients. That’s where we’ve borrowed this pattern and language from:

![image](https://user-images.githubusercontent.com/355079/88642543-86a8f100-d0b8-11ea-969f-413b3e8ddbf8.png)

# The change

This pull request does two things:
- re-labels the form to front-load the word ‘End’ not ‘When’
- adds text to the page explaining when the broadcast will start, to interrupt that confirmation bias

![image (13)](https://user-images.githubusercontent.com/355079/88642735-c374e800-d0b8-11ea-9793-decc5db4c784.png)

If we can get users to go through this before sending a broadcast for real, it could help them learn what a broadcast is, and how it differs from sending text messages.