### PR TITLE
Check for invalid characters in letter addresses

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -853,6 +853,11 @@ class LetterAddressForm(StripWhitespaceForm):
                 f'Last line of the address must be a real UK postcode'
             )
 
+        if address.has_invalid_characters:
+            raise ValidationError(
+                'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
+            )
+
 
 class EmailTemplateForm(BaseTemplateForm):
     subject = TextAreaField(

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -90,6 +90,8 @@
                   {% else %}
                     Last line of the address must be a real UK postcode
                   {% endif %}
+                {% elif item.as_postal_address.has_invalid_characters %}
+                  Address lines must not start with any of the following characters: @ ( ) = [ ] ” \ / ,
                 {% endif %}
               </span>
             {% endcall %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -733,7 +733,17 @@ LETTER_VALIDATION_MESSAGES = {
             f'Validation failed because the address must be no more '
             f'than {PostalAddress.MAX_LINES} lines long.'
         ),
-    }
+    },
+    'invalid-char-in-address': {
+        'title': 'There’s a problem with the address for this letter',
+        'detail': (
+            "Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,"
+        ),
+        'summary': (
+            "Validation failed because address lines must not start with any of the "
+            "following characters: @ ( ) = [ ] ” \\ / ,"
+        ),
+    },
 }
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,7 +23,7 @@ notifications-python-client==5.6.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@40.3.1#egg=notifications-utils==40.3.1
+git+https://github.com/alphagov/notifications-utils.git@40.6.0#egg=notifications-utils==40.6.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ notifications-python-client==5.6.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@40.3.1#egg=notifications-utils==40.3.1
+git+https://github.com/alphagov/notifications-utils.git@40.6.0#egg=notifications-utils==40.6.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
@@ -33,16 +33,16 @@ prometheus-client==0.8.0
 gds-metrics==0.2.2
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.95
+awscli==1.18.106
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.17.18
+botocore==1.17.29
 cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
-dnspython==1.16.0
+dnspython==2.0.0
 docopt==0.6.2
 docutils==0.15.2
 et-xmlfile==1.0.1
@@ -55,7 +55,7 @@ jdcal==1.4.1
 Jinja2==2.11.2
 jmespath==0.10.0
 lml==0.0.9
-lxml==4.5.1
+lxml==4.5.2
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
@@ -71,13 +71,13 @@ python-json-logger==0.1.11
 PyYAML==5.3.1
 redis==3.5.3
 requests==2.24.0
-rsa==3.4.2
+rsa==4.5
 s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.2
-urllib3==1.25.9
+urllib3==1.25.10
 webencodings==0.5.1
 Werkzeug==1.0.1
 WTForms==2.3.1

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -614,6 +614,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
             Firstname Lastname, 123 Example St., France
                               , 123 Example St., SW!A !AA
             "1\n2\n3\n4\n5\n6\n7\n8"
+            =Firstname Lastname, 123 Example St., SW1A 1AA
         '''
     )
 
@@ -630,7 +631,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
         page.select_one('.banner-dangerous').text
     ) == (
         'There’s a problem with invalid.csv '
-        'You need to fix 4 addresses. '
+        'You need to fix 5 addresses. '
         'Skip to file contents'
     )
     assert [
@@ -647,6 +648,9 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
 
         '6 Address must be no more than 7 lines long',
         '1 2 3 4 5 6 7 8',
+
+        '7 Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,',
+        '=Firstname Lastname 123 Example St. SW1A 1AA',
     ]
 
 
@@ -2537,6 +2541,11 @@ def test_send_one_off_letter_address_populates_address_fields_in_session(
         '\n'.join(['a', 'b', 'c', 'd', 'e', 'f', 'g']),
         ['international_letters'],
         'Last line of the address must be a UK postcode or another country',
+    ),
+    (
+        'a\n(b\nSW1A 1AA',
+        [],
+        'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,',
     ),
 ])
 def test_send_one_off_letter_address_rejects_bad_addresses(

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -545,6 +545,18 @@ def test_get_letter_validation_error_for_unknown_error():
             'Validation failed because the address must be no more than 7 lines long.'
         ),
     ),
+    (
+        'invalid-char-in-address',
+        None,
+        'There’s a problem with the address for this letter',
+        (
+            'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
+        ),
+        (
+            'Validation failed because address lines must not start with any of the following '
+            'characters: @ ( ) = [ ] ” \\ / ,'
+        ),
+    ),
 ])
 def test_get_letter_validation_error_for_known_errors(
     client_request,


### PR DESCRIPTION
These characters `@ ( ) = [ ] ” \ / ,` can't be used at the start of address lines
because they cause issues for DVLA. A method to check for these characters
was added here https://github.com/alphagov/notifications-utils/pull/771

This PR brings in the new version of utils and uses the method to add
validation for invalid characters on the `LetterAddressForm` for one-off
letters. It also adds a validation failed message for uploaded letters,
precompiled letters sent through the API, and CSV rows with errors.

[Pivotal story](https://www.pivotaltracker.com/story/show/173892353)

**Sending a one-off letter**
![Screenshot 2020-07-28 at 13 56 32](https://user-images.githubusercontent.com/12881990/88668310-5a9e6780-d0da-11ea-845a-608126b1d088.png)

**CSV with an error**
![Screenshot 2020-07-28 at 13 56 08](https://user-images.githubusercontent.com/12881990/88668395-77d33600-d0da-11ea-80a1-d3c41566f9fa.png)

**Uploading a file**
![Screenshot 2020-07-28 at 13 57 11](https://user-images.githubusercontent.com/12881990/88668425-84578e80-d0da-11ea-889b-b3c932f30aa4.png)

**Viewing a precompiled letter sent through the API**
![Screenshot 2020-07-28 at 13 56 44](https://user-images.githubusercontent.com/12881990/88668457-920d1400-d0da-11ea-8d01-cd226aa4344a.png)
