### PR TITLE
Tell users that they can search whole postal address

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -171,9 +171,7 @@ def view_notifications(service_id, message_type=None):
         things_you_can_search_by={
             'email': ['email address'],
             'sms': ['phone number'],
-            # This should become ‘postal address’ not ‘first line…’ once
-            # we’ve finished populating normalised addresses
-            'letter': ['first line of address', 'file name'],
+            'letter': ['postal address', 'file name'],
             # We say recipient here because combining all 3 types, plus
             # reference gets too long for the hint text
             None: ['recipient'],

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -19,7 +19,7 @@
         {% if item.status in ('pending-virus-check', 'virus-scan-failed') %}
           <span class="file-list-filename loading-indicator">Checking</span>
         {% else %}
-          <a class="govuk-link govuk-link--no-visited-state file-list-filename" href="{{ single_notification_url(notification_id=item.id) }}">{{ item.to.splitlines()[0].lstrip().rstrip(' ,') if item.to else '' }}</a>
+          <a class="govuk-link govuk-link--no-visited-state file-list-filename" href="{{ single_notification_url(notification_id=item.id) }}">{{ item.to.splitlines()|join(', ') if item.to else '' }}</a>
         {% endif %}
         <p class="file-list-hint">
           {{ item.preview_of_content }}

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -402,7 +402,7 @@ def test_shows_message_when_no_notifications(
         {
             'to': 'Firstname Lastname',
         },
-        'Search by first line of address or file name',
+        'Search by postal address or file name',
         'Firstname Lastname',
     ),
 ])
@@ -448,7 +448,7 @@ def test_search_recipient_form(
     (None, 'Search by recipient or reference'),
     ('sms', 'Search by phone number or reference'),
     ('email', 'Search by email address or reference'),
-    ('letter', 'Search by first line of address, file name or reference'),
+    ('letter', 'Search by postal address, file name or reference'),
 ])
 def test_api_users_are_told_they_can_search_by_reference_when_service_has_api_keys(
     client_request,
@@ -473,7 +473,7 @@ def test_api_users_are_told_they_can_search_by_reference_when_service_has_api_ke
     (None, 'Search by recipient'),
     ('sms', 'Search by phone number'),
     ('email', 'Search by email address'),
-    ('letter', 'Search by first line of address or file name'),
+    ('letter', 'Search by postal address or file name'),
 ])
 def test_api_users_are_not_told_they_can_search_by_reference_when_service_has_no_api_keys(
     client_request,

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -757,8 +757,8 @@ def test_sending_status_hint_displays_correctly_on_notifications_page(
 
 
 @pytest.mark.parametrize("is_precompiled_letter,expected_address,expected_hint", [
-    (True, "Full Name,\nFirst address line\npostcode", "ref"),
-    (False, "Full Name,\nFirst address line\npostcode", "template subject")
+    (True, "Full Name\nFirst address line\npostcode", "ref"),
+    (False, "Full Name\nFirst address line\npostcode", "template subject")
 ])
 def test_should_show_address_and_hint_for_letters(
     client_request,
@@ -786,5 +786,5 @@ def test_should_show_address_and_hint_for_letters(
         message_type='letter',
     )
 
-    assert page.select_one('a.file-list-filename').text == 'Full Name'
+    assert page.select_one('a.file-list-filename').text == 'Full Name, First address line, postcode'
     assert page.find('p', {'class': 'file-list-hint'}).text.strip() == expected_hint


### PR DESCRIPTION
We’re now [normalising and storing the whole address in the `normalised_to` field](https://github.com/alphagov/notifications-api/pull/2814). Previously we were only storing the first line of the address.

Enough time should now have passed that the field will have been populated for all letters in the database. This means that users can already search by any part of the address, but we’re not telling them that they can.

We can now tell users that it’s not just the first line they can search by.

This also changes the notification page to show the whole address, comma separated, so it’s a bit more obvious why the search is returning the results it is.