### PR TITLE
Bump eventlet

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -16,7 +16,7 @@ pyexcel-xlsx==0.5.8
 pyexcel-ods3==0.5.3
 pytz==2020.1
 gunicorn==20.0.4
-eventlet==0.25.2
+eventlet==0.26.1
 notifications-python-client==5.6.0
 
 # PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyexcel-xlsx==0.5.8
 pyexcel-ods3==0.5.3
 pytz==2020.1
 gunicorn==20.0.4
-eventlet==0.25.2
+eventlet==0.26.1
 notifications-python-client==5.6.0
 
 # PaaS
@@ -33,16 +33,16 @@ prometheus-client==0.8.0
 gds-metrics==0.2.2
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.106
+awscli==1.18.109
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.17.29
+botocore==1.17.32
 cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
-dnspython==2.0.0
+dnspython==1.16.0
 docopt==0.6.2
 docutils==0.15.2
 et-xmlfile==1.0.1
@@ -80,6 +80,6 @@ texttable==1.6.2
 urllib3==1.25.10
 webencodings==0.5.1
 Werkzeug==1.0.1
-WTForms==2.3.1
+WTForms==2.3.3
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
dnspython had been changed from 1.16.0 to 2.0.0 in a previous commit,
but this was not compatible with eventlet 0.25.2. This bumps eventlet to
a later version, which has the effect of downgrading dnspython again.