### PR TITLE
Revert #3539 and #3541

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -853,11 +853,6 @@ class LetterAddressForm(StripWhitespaceForm):
                 f'Last line of the address must be a real UK postcode'
             )
 
-        if address.has_invalid_characters:
-            raise ValidationError(
-                'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
-            )
-
 
 class EmailTemplateForm(BaseTemplateForm):
     subject = TextAreaField(

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -90,8 +90,6 @@
                   {% else %}
                     Last line of the address must be a real UK postcode
                   {% endif %}
-                {% elif item.as_postal_address.has_invalid_characters %}
-                  Address lines must not start with any of the following characters: @ ( ) = [ ] ” \ / ,
                 {% endif %}
               </span>
             {% endcall %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -734,16 +734,6 @@ LETTER_VALIDATION_MESSAGES = {
             f'than {PostalAddress.MAX_LINES} lines long.'
         ),
     },
-    'invalid-char-in-address': {
-        'title': 'There’s a problem with the address for this letter',
-        'detail': (
-            "Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,"
-        ),
-        'summary': (
-            "Validation failed because address lines must not start with any of the "
-            "following characters: @ ( ) = [ ] ” \\ / ,"
-        ),
-    },
 }
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -16,14 +16,14 @@ pyexcel-xlsx==0.5.8
 pyexcel-ods3==0.5.3
 pytz==2020.1
 gunicorn==20.0.4
-eventlet==0.26.1
+eventlet==0.25.2
 notifications-python-client==5.6.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@40.6.0#egg=notifications-utils==40.6.0
+git+https://github.com/alphagov/notifications-utils.git@40.3.1#egg=notifications-utils==40.3.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,14 +18,14 @@ pyexcel-xlsx==0.5.8
 pyexcel-ods3==0.5.3
 pytz==2020.1
 gunicorn==20.0.4
-eventlet==0.26.1
+eventlet==0.25.2
 notifications-python-client==5.6.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@40.6.0#egg=notifications-utils==40.6.0
+git+https://github.com/alphagov/notifications-utils.git@40.3.1#egg=notifications-utils==40.3.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
@@ -33,10 +33,10 @@ prometheus-client==0.8.0
 gds-metrics==0.2.2
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.109
+awscli==1.18.95
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.17.32
+botocore==1.17.18
 cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4
@@ -55,7 +55,7 @@ jdcal==1.4.1
 Jinja2==2.11.2
 jmespath==0.10.0
 lml==0.0.9
-lxml==4.5.2
+lxml==4.5.1
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
@@ -71,15 +71,15 @@ python-json-logger==0.1.11
 PyYAML==5.3.1
 redis==3.5.3
 requests==2.24.0
-rsa==4.5
+rsa==3.4.2
 s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.2
-urllib3==1.25.10
+urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
-WTForms==2.3.3
+WTForms==2.3.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -614,7 +614,6 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
             Firstname Lastname, 123 Example St., France
                               , 123 Example St., SW!A !AA
             "1\n2\n3\n4\n5\n6\n7\n8"
-            =Firstname Lastname, 123 Example St., SW1A 1AA
         '''
     )
 
@@ -631,7 +630,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
         page.select_one('.banner-dangerous').text
     ) == (
         'There’s a problem with invalid.csv '
-        'You need to fix 5 addresses. '
+        'You need to fix 4 addresses. '
         'Skip to file contents'
     )
     assert [
@@ -648,9 +647,6 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
 
         '6 Address must be no more than 7 lines long',
         '1 2 3 4 5 6 7 8',
-
-        '7 Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,',
-        '=Firstname Lastname 123 Example St. SW1A 1AA',
     ]
 
 
@@ -2541,11 +2537,6 @@ def test_send_one_off_letter_address_populates_address_fields_in_session(
         '\n'.join(['a', 'b', 'c', 'd', 'e', 'f', 'g']),
         ['international_letters'],
         'Last line of the address must be a UK postcode or another country',
-    ),
-    (
-        'a\n(b\nSW1A 1AA',
-        [],
-        'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,',
     ),
 ])
 def test_send_one_off_letter_address_rejects_bad_addresses(

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -545,18 +545,6 @@ def test_get_letter_validation_error_for_unknown_error():
             'Validation failed because the address must be no more than 7 lines long.'
         ),
     ),
-    (
-        'invalid-char-in-address',
-        None,
-        'There’s a problem with the address for this letter',
-        (
-            'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
-        ),
-        (
-            'Validation failed because address lines must not start with any of the following '
-            'characters: @ ( ) = [ ] ” \\ / ,'
-        ),
-    ),
 ])
 def test_get_letter_validation_error_for_known_errors(
     client_request,


### PR DESCRIPTION
There were issues with the dnspython and Eventlet dependencies in notifications-api
when deploying to preview. Admin was still running, but this reverts the
changes anyway so that we can look into things a bit further and be sure
everything works as expected.