### PR TITLE
Cache broadcast messages in Redis

### DIFF
--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -1,4 +1,4 @@
-from app.notify_client import NotifyAdminAPIClient, _attach_current_user
+from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 
 
 class BroadcastMessageAPIClient(NotifyAdminAPIClient):
@@ -27,15 +27,18 @@ class BroadcastMessageAPIClient(NotifyAdminAPIClient):
     def get_broadcast_messages(self, service_id):
         return self.get(f'/service/{service_id}/broadcast-message')['broadcast_messages']
 
+    @cache.set('broadcast-message-{broadcast_message_id}')
     def get_broadcast_message(self, *, service_id, broadcast_message_id):
         return self.get(f'/service/{service_id}/broadcast-message/{broadcast_message_id}')
 
+    @cache.delete('broadcast-message-{broadcast_message_id}')
     def update_broadcast_message(self, *, service_id, broadcast_message_id, data):
         self.post(
             f'/service/{service_id}/broadcast-message/{broadcast_message_id}',
             data=data,
         )
 
+    @cache.delete('broadcast-message-{broadcast_message_id}')
     def update_broadcast_message_status(self, status, *, service_id, broadcast_message_id):
         data = _attach_current_user({
             'status': status,

--- a/tests/app/notify_client/test_broadcast_message_client.py
+++ b/tests/app/notify_client/test_broadcast_message_client.py
@@ -1,0 +1,92 @@
+from app.notify_client.broadcast_message_api_client import (
+    BroadcastMessageAPIClient,
+)
+
+
+def test_create_broadcast_message(mocker):
+    client = BroadcastMessageAPIClient()
+    mocker.patch('app.notify_client.current_user', id='1')
+    mock_post = mocker.patch(
+        'app.notify_client.broadcast_message_api_client.BroadcastMessageAPIClient.post'
+    )
+    client.create_broadcast_message(
+        service_id='12345',
+        template_id='67890',
+    )
+    mock_post.assert_called_once_with(
+        '/service/12345/broadcast-message',
+        data={
+            'service_id': '12345',
+            'template_id': '67890',
+            'personalisation': {},
+            'created_by': '1',
+        },
+    )
+
+
+def test_get_broadcast_messages(mocker):
+    client = BroadcastMessageAPIClient()
+    mock_get = mocker.patch(
+        'app.notify_client.broadcast_message_api_client.BroadcastMessageAPIClient.get'
+    )
+    client.get_broadcast_messages('12345')
+    mock_get.assert_called_once_with(
+        '/service/12345/broadcast-message',
+    )
+
+
+def test_get_broadcast_message(mocker):
+    client = BroadcastMessageAPIClient()
+    mocker.patch('app.notify_client.current_user', id='1')
+    mock_get = mocker.patch(
+        'app.notify_client.broadcast_message_api_client.BroadcastMessageAPIClient.get',
+        return_value={'abc': 'def'},
+    )
+    mock_redis_set = mocker.patch('app.extensions.RedisClient.set')
+    client.get_broadcast_message(service_id='12345', broadcast_message_id='67890')
+    mock_get.assert_called_once_with(
+        '/service/12345/broadcast-message/67890',
+    )
+    mock_redis_set.assert_called_once_with(
+        'broadcast-message-67890',
+        '{"abc": "def"}',
+        ex=604_800,
+    )
+
+
+def test_update_broadcast_message(mocker):
+    client = BroadcastMessageAPIClient()
+    mocker.patch('app.notify_client.current_user', id='1')
+    mock_post = mocker.patch(
+        'app.notify_client.broadcast_message_api_client.BroadcastMessageAPIClient.post'
+    )
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    client.update_broadcast_message(
+        service_id='12345',
+        broadcast_message_id='67890',
+        data={'abc': 'def'},
+    )
+    mock_post.assert_called_once_with(
+        '/service/12345/broadcast-message/67890',
+        data={'abc': 'def'},
+    )
+    mock_redis_delete.assert_called_once_with('broadcast-message-67890')
+
+
+def test_update_broadcast_message_status(mocker):
+    client = BroadcastMessageAPIClient()
+    mocker.patch('app.notify_client.current_user', id='1')
+    mock_post = mocker.patch(
+        'app.notify_client.broadcast_message_api_client.BroadcastMessageAPIClient.post'
+    )
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    client.update_broadcast_message_status(
+        'cancelled',
+        service_id='12345',
+        broadcast_message_id='67890',
+    )
+    mock_post.assert_called_once_with(
+        '/service/12345/broadcast-message/67890/status',
+        data={'created_by': '1', 'status': 'cancelled'},
+    )
+    mock_redis_delete.assert_called_once_with('broadcast-message-67890')


### PR DESCRIPTION
This should make the pages slightly quicker to load, because Redis will return the JSON string faster than the API.

The only change that can happen to a broadcast which doesn’t go through the admin app is a broadcast ending at its scheduled time. So this could result in a cached broadcast having a status of `broadcasting` when it had in fact finished. We already account for this here though: https://github.com/alphagov/notifications-admin/blob/b2b58ec044f5247faf03777cd8f687649a768fc9/app/models/broadcast_message.py#L89-L94