### PR TITLE
Go to broadcast, not dashboard after submitting for approval

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -169,8 +169,9 @@ def preview_broadcast_message(service_id, broadcast_message_id):
     if form.validate_on_submit():
         broadcast_message.request_approval(until=form.finishes_at.data)
         return redirect(url_for(
-            '.broadcast_dashboard',
+            '.view_broadcast_message',
             service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
         ))
 
     return render_template(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -412,7 +412,13 @@ def test_start_broadcasting(
         broadcast_message_id=fake_uuid,
         _data={
             'finishes_at': end_time,
-        }
+        },
+        _expected_redirect=url_for(
+            'main.view_broadcast_message',
+            service_id=SERVICE_ONE_ID,
+            broadcast_message_id=fake_uuid,
+            _external=True,
+        ),
     ),
     mock_update_broadcast_message.assert_called_once_with(
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
Once you’ve created a broadcast you’re taken back to the dashboard. This feels too passive, and you might miss that the broadcast still needs approval.

We should be much more explicit that you now need to find someone to approve your broadcast. Taking someone directly to the page for a broadcast lets us give more information about the status of the broadcast and what the next steps should be.