### PR TITLE
Turn off redis in all environments for rotation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -79,7 +79,7 @@ class Config(object):
     ANTIVIRUS_ENABLED = True
 
     REDIS_URL = os.environ.get('REDIS_URL')
-    REDIS_ENABLED = os.environ.get('REDIS_ENABLED') == '1'
+    REDIS_ENABLED = False
 
     ASSET_DOMAIN = ''
     ASSET_PATH = '/static/'


### PR DESCRIPTION
This is a very short term turn off for while we rotate creds. It will
then be followed immediately by a PR to turn it back on.