### PR TITLE
Let users without `send_messages` view broadcasts

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -182,7 +182,7 @@ def preview_broadcast_message(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>')
-@user_has_permissions('send_messages')
+@user_has_permissions()
 @service_has_permission('broadcast')
 def view_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -18,7 +18,7 @@
   ) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by == current_user %}
+    {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
       <div class="banner govuk-!-margin-bottom-6">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-3">Your broadcast is waiting for approval from another member of your team</h2>
         <p class="govuk-body">Once approved it will be live until
@@ -29,7 +29,7 @@
           delete_link_text='Withdraw this broadcast'
         ) }}
       </div>
-    {% else %}
+    {% elif current_user.has_permissions('send_messages') %}
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
           {{ broadcast_message.created_by.name }} wants to broadcast this
@@ -41,6 +41,13 @@
           delete_link_text='Reject this broadcast'
         ) }}
       {% endcall %}
+    {% else %}
+      <div class="banner govuk-!-margin-bottom-6">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-3">This broadcast is waiting for approval</h2>
+        <p class="govuk-body">
+          You don’t have permission to approve broadcasts.
+        </p>
+      </div>
     {% endif %}
   {% else %}
     <p class="govuk-body govuk-!-margin-bottom-3">

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -75,6 +75,63 @@ def test_broadcast_pages_403_without_permission(
     )
 
 
+@pytest.mark.parametrize('endpoint, extra_args, expected_get_status, expected_post_status', (
+    (
+        '.broadcast',
+        {'template_id': sample_uuid},
+        403, 405,
+    ),
+    (
+        '.preview_broadcast_areas', {'broadcast_message_id': sample_uuid},
+        403, 405,
+    ),
+    (
+        '.choose_broadcast_library', {'broadcast_message_id': sample_uuid},
+        403, 405,
+    ),
+    (
+        '.choose_broadcast_area', {'broadcast_message_id': sample_uuid, 'library_slug': 'countries'},
+        403, 403,
+    ),
+    (
+        '.remove_broadcast_area', {'broadcast_message_id': sample_uuid, 'area_slug': 'england'},
+        403, 405,
+    ),
+    (
+        '.preview_broadcast_message', {'broadcast_message_id': sample_uuid},
+        403, 403,
+    ),
+    (
+        '.cancel_broadcast_message', {'broadcast_message_id': sample_uuid},
+        403, 403,
+    ),
+))
+def test_broadcast_pages_403_for_user_without_permission(
+    mocker,
+    client_request,
+    service_one,
+    active_user_view_permissions,
+    endpoint,
+    extra_args,
+    expected_get_status,
+    expected_post_status,
+):
+    service_one['permissions'] += ['broadcast']
+    mocker.patch('app.user_api_client.get_user', return_value=active_user_view_permissions)
+    client_request.get(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+        _expected_status=expected_get_status,
+        **extra_args
+    )
+    client_request.post(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+        _expected_status=expected_post_status,
+        **extra_args
+    )
+
+
 def test_dashboard_redirects_to_broadcast_dashboard(
     client_request,
     service_one,
@@ -94,6 +151,7 @@ def test_dashboard_redirects_to_broadcast_dashboard(
 def test_empty_broadcast_dashboard(
     client_request,
     service_one,
+    active_user_view_permissions,
     mock_get_no_broadcast_messages,
     mock_get_service_templates_when_no_templates_exist,
 ):
@@ -157,6 +215,7 @@ def test_broadcast_dashboard(
 def test_broadcast_dashboard_json(
     logged_in_client,
     service_one,
+    active_user_view_permissions,
     mock_get_broadcast_messages,
 ):
     service_one['permissions'] += ['broadcast']


### PR DESCRIPTION
At the moment viewing a broadcast is limited to those users who have the `send_messages` permission.

This doesn’t match how we describe the permissions on the team members page:

![image](https://user-images.githubusercontent.com/355079/89782025-5fb4db00-db0c-11ea-80f0-ed94477ef76e.png)

This pull requests makes it so that any team member can see a broadcast that’s in any state other than `draft`.

It also adds tests to validate that users who don’t have the `send_messages` permission can’t see pages they shouldn’t.

***

Story: https://www.pivotaltracker.com/story/show/173963522