### PR TITLE
Services can only create templates of types they have turned on

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -153,19 +153,20 @@
       return changed;
     };
 
-    this.$broadcastService = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-broadcast")
+    this.$singleNotificationChannel = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-channel");
+    this.$singleChannelService = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-service");
 
     this.actionButtonClicked = function(event) {
       event.preventDefault();
       this.currentState = $(event.currentTarget).val();
 
-      if (event.currentTarget.value === 'add-new-template' && this.$broadcastService) {
-        return window.location = "/services/" + this.$broadcastService + "/templates/add-broadcast";
+      if (event.currentTarget.value === 'add-new-template' && this.$singleNotificationChannel) {
+        window.location = "/services/" + this.$singleChannelService + "/templates/add-" + this.$singleNotificationChannel;
       } else {
         if (this.stateChanged()) {
           this.render();
-        };
-      };
+        }
+      }
     };
 
     this.selectionStatus = {

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -153,13 +153,19 @@
       return changed;
     };
 
+    this.$broadcastService = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-broadcast")
+
     this.actionButtonClicked = function(event) {
       event.preventDefault();
       this.currentState = $(event.currentTarget).val();
 
-      if (this.stateChanged()) {
-        this.render();
-      }
+      if (event.currentTarget.value === 'add-new-template' && this.$broadcastService) {
+        return window.location = "/services/" + this.$broadcastService + "/templates/add-broadcast";
+      } else {
+        if (this.stateChanged()) {
+          this.render();
+        };
+      };
     };
 
     this.selectionStatus = {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1997,12 +1997,8 @@ class TemplateAndFoldersSelectionForm(Form):
         ]
 
         self.add_template_by_template_type.choices = list(filter(None, [
-            # We want to show email and text message to everyone,
-            # whether or not the service has them switched on. The
-            # option to add letter or broadcast templates should only
-            # be shown to services which have that permission
-            ('email', 'Email'),
-            ('sms', 'Text message'),
+            ('email', 'Email') if 'email' in available_template_types else None,
+            ('sms', 'Text message') if 'sms' in available_template_types else None,
             ('letter', 'Letter') if 'letter' in available_template_types else None,
             ('broadcast', 'Broadcast') if 'broadcast' in available_template_types else None,
             ('copy-existing', 'Copy an existing template') if allow_adding_copy_of_template else None,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -31,6 +31,7 @@ from app.models.service import Service
 from app.models.template_list import TemplateList, TemplateLists
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
+    NOTIFICATION_TYPES,
     get_template,
     should_skip_template_page,
     user_has_permissions,
@@ -130,6 +131,11 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
     )
     option_hints = {template_folder_id: 'current folder'}
 
+    single_notification_channel = None
+    notification_channels = list(set(current_service.permissions).intersection(NOTIFICATION_TYPES))
+    if len(notification_channels) == 1:
+        single_notification_channel = notification_channels[0]
+
     if request.method == 'POST' and templates_and_folders_form.validate_on_submit():
         if not current_user.has_permissions('manage_templates'):
             abort(403)
@@ -168,6 +174,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         templates_and_folders_form=templates_and_folders_form,
         move_to_children=templates_and_folders_form.move_to.children(),
         user_has_template_folder_permission=user_has_template_folder_permission,
+        single_notification_channel=single_notification_channel,
         option_hints=option_hints
     )
 

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -5,13 +5,13 @@
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
-  {{ heading_action }} broadcast template
+  {{ heading_action }} template
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    '{} broadcast template'.format(heading_action),
+    '{} template'.format(heading_action),
     back_link=url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
   ) }}
 

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -28,7 +28,7 @@
       {{ page_footer('Add new folder', button_name='operation', button_value='add-new-folder') }}
     </fieldset>
   </div>
-  <div id="add_new_template_form">
+  <div id="add_new_template_form" {% if current_service.has_permission('broadcast') %}data-broadcast="{{current_service.id}}"{% endif %}>
     <div class="js-will-stick-at-bottom-when-scrolling">
     {{ radios(templates_and_folders_form.add_template_by_template_type) }}
     </div>

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -28,7 +28,7 @@
       {{ page_footer('Add new folder', button_name='operation', button_value='add-new-folder') }}
     </fieldset>
   </div>
-  <div id="add_new_template_form" {% if current_service.has_permission('broadcast') %}data-broadcast="{{current_service.id}}"{% endif %}>
+  <div id="add_new_template_form" {% if single_notification_channel %}data-channel="{{single_notification_channel}}" data-service="{{current_service.id}}"{% endif %}>
     <div class="js-will-stick-at-bottom-when-scrolling">
     {{ radios(templates_and_folders_form.add_template_by_template_type) }}
     </div>

--- a/app/utils.py
+++ b/app/utils.py
@@ -60,6 +60,8 @@ FAILURE_STATUSES = ['failed', 'temporary-failure', 'permanent-failure',
                     'technical-failure', 'virus-scan-failed', 'validation-failed']
 REQUESTED_STATUSES = SENDING_STATUSES + DELIVERED_STATUSES + FAILURE_STATUSES
 
+NOTIFICATION_TYPES = ["sms", "email", "letter", "broadcast"]
+
 
 with open('{}/email_domains.txt'.format(
     os.path.dirname(os.path.realpath(__file__))

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2052,6 +2052,26 @@ def test_route_invalid_permissions(
         service_one)
 
 
+@pytest.mark.parametrize('template_type, expected', (
+    ('email', 'New email template'),
+    ('sms', 'New text message template'),
+    ('broadcast', 'New template'),
+))
+def test_add_template_page_title(
+    client_request,
+    service_one,
+    template_type,
+    expected,
+):
+    service_one['permissions'] += [template_type]
+    page = client_request.get(
+        '.add_service_template',
+        service_id=SERVICE_ONE_ID,
+        template_type=template_type,
+    )
+    assert normalize_spaces(page.select_one('h1').text) == expected
+
+
 def test_can_create_email_template_with_emoji(
     client_request,
     mock_create_service_template

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -287,8 +287,8 @@ def test_should_show_live_search_if_service_has_lots_of_folders(
     assert count_of_templates == 4
 
 
-@pytest.mark.parametrize('extra_permissions, expected_values, expected_labels', (
-    pytest.param([], [
+@pytest.mark.parametrize('service_permissions, expected_values, expected_labels', (
+    pytest.param(['email', 'sms'], [
         'email',
         'sms',
         'copy-existing',
@@ -297,7 +297,12 @@ def test_should_show_live_search_if_service_has_lots_of_folders(
         'Text message',
         'Copy an existing template',
     ]),
-    pytest.param(['letter'], [
+    pytest.param(['broadcast'], [
+        'broadcast',
+    ], [
+        'Broadcast',
+    ]),
+    pytest.param(['email', 'sms', 'letter'], [
         'email',
         'sms',
         'letter',
@@ -314,11 +319,11 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
-    extra_permissions,
+    service_permissions,
     expected_values,
     expected_labels,
 ):
-    service_one['permissions'] += extra_permissions
+    service_one['permissions'] = service_permissions
 
     page = client_request.get(
         'main.choose_template',
@@ -337,6 +342,39 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
     assert [
         normalize_spaces(choice.text) for choice in page.select('#add_new_template_form label')
     ] == expected_labels
+
+
+@pytest.mark.parametrize("permissions,are_data_attrs_added", [
+    (['sms'], True),
+    (['email'], True),
+    (['letter'], True),
+    (['broadcast'], True),
+    (['sms', 'email'], False),
+])
+def test_should_add_data_attributes_for_services_that_only_allow_one_type_of_notifications(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    permissions,
+    are_data_attrs_added
+):
+    service_one['permissions'] = permissions
+
+    page = client_request.get(
+        'main.choose_template',
+        service_id=SERVICE_ONE_ID,
+    )
+
+    if not page.select('#add_new_template_form'):
+        raise ElementNotFound()
+
+    if are_data_attrs_added:
+        assert page.find(id='add_new_template_form').attrs['data-channel'] == permissions[0]
+        assert page.find(id='add_new_template_form').attrs['data-service'] == SERVICE_ONE_ID
+    else:
+        assert page.find(id='add_new_template_form').attrs.get('data-channel') is None
+        assert page.find(id='add_new_template_form').attrs.get('data-service') is None
 
 
 def test_should_show_page_for_one_template(

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -1,6 +1,6 @@
 const helpers = require('./support/helpers');
 
-function setFixtures (hierarchy) {
+function setFixtures (hierarchy, newTemplateDataModules = "") {
 
   const foldersCheckboxesHTML = function (filter) {
     let count = 0;
@@ -27,7 +27,7 @@ function setFixtures (hierarchy) {
 
   }();
 
-  function controlsHTML () {
+  function controlsHTML (newTemplateDataModules) {
 
     return `<div id="sticky_template_forms">
               <button type="submit" name="operation" value="unknown" hidden=""></button>
@@ -78,7 +78,7 @@ function setFixtures (hierarchy) {
                   </div>
                 </fieldset>
               </div>
-              <div id="add_new_template_form">
+              <div id="add_new_template_form" ${newTemplateDataModules}>
                 <div class="js-will-stick-at-bottom-when-scrolling">
                   <div class="form-group ">
                     <fieldset id="add_template_by_template_type">
@@ -127,7 +127,7 @@ function setFixtures (hierarchy) {
   document.body.innerHTML = `
     <form method="post" data-module="template-folder-form">
       ${helpers.templatesAndFoldersCheckboxes(hierarchy)}
-      ${controlsHTML()}
+      ${controlsHTML(newTemplateDataModules)}
     </form>`;
 
 };
@@ -308,6 +308,37 @@ describe('TemplateFolderForm', () => {
     });
 
   });
+
+  describe("Click 'New template' for single channel service", () => {
+    test("should redirect to new template page", () => {
+      setFixtures(hierarchy, "data-channel='sms' data-service='123'")
+      templateFolderForm = document.querySelector('form[data-module=template-folder-form]');
+
+      // start module
+      window.GOVUK.modules.start();
+
+      formControls = templateFolderForm.querySelector('#sticky_template_forms');
+
+      // reset sticky JS mocks called when the module starts
+      resetStickyMocks();
+      // add listener for url change
+      const descriptor1 = Object.getOwnPropertyDescriptor(window, 'location');
+      delete window.location
+
+      const mockCallback = jest.fn(x => {});
+
+      Object.defineProperty(window, 'location', {
+        set: mockCallback
+      });
+      // click
+      helpers.triggerEvent(formControls.querySelector('[value=add-new-template]'), 'click');
+      // expect url to change
+      expect(mockCallback).toHaveBeenCalledWith("/services/123/templates/add-sms")
+
+      setFixtures(hierarchy)
+      resetStickyMocks()
+    });
+  })
 
   describe("Clicking 'New template'", () => {
 


### PR DESCRIPTION
- Services can only create templates of types they have permissions for
- If service only has permission for one type of notification, "New Template" button takes it straight to new template page, without showing drop-down radios menu