### PR TITLE
Put hidden email field on register from invite page

### DIFF
--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -17,6 +17,11 @@ Create an account
       <span class="nowrap">{{invited_user.email_address}}</span>
     </p>
     {% call form_wrapper() %}
+      {#
+        This field is to enable password managers to capture the username as
+        well as the password, but should not be visible to users, nor should
+        the view process the input.
+      #}
       <div class="visually-hidden">
         <input type="email" name="username" id="username" value="{{ invited_user.email_address }}" disabled="disabled" tabindex="-1" aria-hidden="true" autocomplete="username" />
       </div>

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -17,6 +17,9 @@ Create an account
       <span class="nowrap">{{invited_user.email_address}}</span>
     </p>
     {% call form_wrapper() %}
+      <div class="visually-hidden">
+        <input type="email" name="username" id="username" value="{{ invited_user.email_address }}" disabled="disabled" tabindex="-1" aria-hidden="true" autocomplete="username" />
+      </div>
       {{ textbox(form.name, width='3-4') }}
       {% if invited_user.auth_type == 'sms_auth' %}
         <div class="extra-tracking">

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -226,7 +226,7 @@ def test_shows_name_on_registration_page_from_invite(
     assert page.select_one('input[name=name]')['value'] == expected_value
 
 
-def test_shows_email_address_on_registration_page_from_invite(
+def test_shows_hidden_email_address_on_registration_page_from_invite(
     client_request,
     fake_uuid,
 ):


### PR DESCRIPTION
Password managers will try to guess what they should save as a username by looking at the fields on the page where you set up your password.

When registering from an invite the email address (what we use as a username) is predefined, and only shown on the page as text, not an input.

This commit also adds a hidden input field for password managers to pick up.

Adapted from: https://github.com/UKGovernmentBEIS/beis-opss-psd/blob/fbc08a397d0b8a040a92edf6c8dfe569dcb4e698/app/views/users/complete_registration.html.erb#L29-L36

Raised by @edwardhorsford 