### PR TITLE
Optimise broadcast area code for fast page loads 

### DIFF
--- a/app/broadcast_areas/__init__.py
+++ b/app/broadcast_areas/__init__.py
@@ -29,24 +29,18 @@ class GetItemByIdMixin:
 class BroadcastArea(SortableMixin):
 
     def __init__(self, row):
-        id, name, feature, simple_feature = row
-
-        self.id = id
-        self.name = name
-
-        self._feature = feature
-        self._simple_feature = simple_feature
-
-        for coordinates in self.polygons:
-            if coordinates[0] != coordinates[-1]:
-                # The CAP XML format requires shapes to be closed
-                raise ValueError(
-                    f'Area {self.name} is not a closed shape '
-                    f'({coordinates[0]}, {coordinates[-1]})'
-                )
+        self.id, self.name = row
 
     def __eq__(self, other):
         return self.id == other.id
+
+    @property
+    def _feature(self):
+        return BroadcastAreasRepository().get_feature_for_area(self.id)
+
+    @property
+    def _simple_feature(self):
+        return BroadcastAreasRepository().get_simple_feature_for_area(self.id)
 
     def _polygons(self, feature):
         if feature['geometry']['type'] == 'MultiPolygon':

--- a/app/broadcast_areas/__init__.py
+++ b/app/broadcast_areas/__init__.py
@@ -119,9 +119,7 @@ class BroadcastAreaLibraries(SerialisedModelCollection, GetItemByIdMixin):
     model = BroadcastAreaLibrary
 
     def __init__(self):
-
-        self.libraries = BroadcastAreasRepository().get_libraries()
-        self.items = self.libraries
+        self.items = BroadcastAreasRepository().get_libraries()
 
     def get_areas(self, *area_ids):
         # allow people to call `get_areas('a', 'b') or get_areas(['a', 'b'])`

--- a/app/broadcast_areas/__init__.py
+++ b/app/broadcast_areas/__init__.py
@@ -105,13 +105,10 @@ class BroadcastAreaLibrary(SerialisedModelCollection, SortableMixin, GetItemById
         self.id = id
         self.name = name
         self.is_group = bool(is_group)
+        self.items = BroadcastAreasRepository().get_all_areas_for_library(self.id)
 
     def get_examples(self):
         return BroadcastAreasRepository().get_library_description(self.id)
-
-    @property
-    def items(self):
-        return BroadcastAreasRepository().get_all_areas_for_library(self.id)
 
 
 class BroadcastAreaLibraries(SerialisedModelCollection, GetItemByIdMixin):

--- a/app/broadcast_areas/repo.py
+++ b/app/broadcast_areas/repo.py
@@ -128,7 +128,7 @@ class BroadcastAreasRepository(object):
             cursor = conn.cursor()
 
             q = """
-            SELECT id, name, feature_geojson, simple_feature_geojson
+            SELECT id, name
             FROM broadcast_areas
             WHERE id IN ({})
             """.format(("?," * len(*area_ids))[:-1])
@@ -136,7 +136,7 @@ class BroadcastAreasRepository(object):
             results = cursor.fetchall()
 
             areas = [
-                (row[0], row[1], row[2], row[3])
+                (row[0], row[1])
                 for row in results
             ]
 
@@ -144,7 +144,7 @@ class BroadcastAreasRepository(object):
 
     def get_all_areas_for_library(self, library_id):
         q = """
-        SELECT id, name, feature_geojson, simple_feature_geojson
+        SELECT id, name
         FROM broadcast_areas
         WHERE broadcast_area_library_id = ?
         AND broadcast_area_library_group_id IS NULL
@@ -152,16 +152,14 @@ class BroadcastAreasRepository(object):
 
         results = self.query(q, library_id)
 
-        areas = [
-            (row[0], row[1], row[2], row[3])
+        return [
+            (row[0], row[1])
             for row in results
         ]
 
-        return areas
-
     def get_all_areas_for_group(self, group_id):
         q = """
-        SELECT id, name, feature_geojson, simple_feature_geojson
+        SELECT id, name
         FROM broadcast_areas
         WHERE broadcast_area_library_group_id = ?
         """
@@ -169,7 +167,7 @@ class BroadcastAreasRepository(object):
         results = self.query(q, group_id)
 
         areas = [
-            (row[0], row[1], row[2], row[3])
+            (row[0], row[1])
             for row in results
         ]
 
@@ -191,3 +189,25 @@ class BroadcastAreasRepository(object):
         ]
 
         return areas
+
+    def get_feature_for_area(self, area_id):
+        q = """
+        SELECT feature_geojson
+        FROM broadcast_areas
+        WHERE id = ?
+        """
+
+        results = self.query(q, area_id)
+
+        return results[0][0]
+
+    def get_simple_feature_for_area(self, area_id):
+        q = """
+        SELECT simple_feature_geojson
+        FROM broadcast_areas
+        WHERE id = ?
+        """
+
+        results = self.query(q, area_id)
+
+        return results[0][0]

--- a/app/broadcast_areas/repo.py
+++ b/app/broadcast_areas/repo.py
@@ -123,24 +123,21 @@ class BroadcastAreasRepository(object):
         description = self.query(q, library_id)[0][0]
         return description
 
-    def get_areas(self, *area_ids):
-        with self.conn() as conn:
-            cursor = conn.cursor()
+    def get_areas(self, area_ids):
+        q = """
+        SELECT id, name
+        FROM broadcast_areas
+        WHERE id IN ({})
+        """.format(("?," * len(area_ids))[:-1])
 
-            q = """
-            SELECT id, name
-            FROM broadcast_areas
-            WHERE id IN ({})
-            """.format(("?," * len(*area_ids))[:-1])
-            cursor.execute(q, *area_ids)
-            results = cursor.fetchall()
+        results = self.query(q, *area_ids)
 
-            areas = [
-                (row[0], row[1])
-                for row in results
-            ]
+        areas = [
+            (row[0], row[1])
+            for row in results
+        ]
 
-            return areas
+        return areas
 
     def get_all_areas_for_library(self, library_id):
         q = """


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/355079/89999945-69af1900-dc87-11ea-8544-609cb5a13644.png)

# After optimising the `SELECT`s (2× faster)

![image](https://user-images.githubusercontent.com/355079/90003924-b47f5f80-dc8c-11ea-8bbd-e343f54be191.png)

# After splitting into two tables (8× faster)

![image](https://user-images.githubusercontent.com/355079/90004088-f9a39180-dc8c-11ea-9692-e22080840881.png)

# After caching the area names in memory (24× faster)

![image](https://user-images.githubusercontent.com/355079/90000267-d88c7200-dc87-11ea-917a-8a8f289c7002.png)

# How

This disaggregates storing the big blobs of GeoJSON from the small strings of names and group IDs for an area. This means we can load the area names into memory, for speedy access. Then we can query the database for the GeoJSON blobs only when we need them. This is a sensible strategy because the preview page is only ever likely to need blobs of GeoJSON for 10 areas at once, but the page to show all the local authority names has 379 areas.

This is implemented back to front in the commit order, but commit-by-commit is probably the best way to review this.

I think that even with indexes querying the area names from one table is always going to be slow because there’s so much GeoJSON to scan past.