### PR TITLE
Remove horizontal padding for pill items

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -31,7 +31,7 @@
     float: left;
     box-sizing: border-box;
     width: 100%;
-    padding: 10px;
+    padding: 10px 0px;
   }
 
   a {


### PR DESCRIPTION
The report from the Digital Accessibility Centre (DAC) described problems with the text of our 'pill' items being cropped when users zoomed to 400% on a 1280px browser width.

<img width="1227" alt="pill_items_before" src="https://user-images.githubusercontent.com/87140/90006669-3ec9c280-dc91-11ea-8b20-dba7cff7f4d4.png">

This removes the left and right padding to give the content more space:

<img width="1212" alt="pill_items_after" src="https://user-images.githubusercontent.com/87140/90006683-44270d00-dc91-11ea-9cce-78e0d2e690a9.png">

The 'pill' items are positioned using [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox), set to take up a quarter of the available space so this won't effect their width and they still have a 2px border which will prevent their content ever touching.