### PR TITLE
Add international letter rates to pricing page

### DIFF
--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -36,7 +36,7 @@
   <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
 
   <h2 class="heading heading-medium">Pricing</h2>
-  <p class="govuk-body">It costs between 35p and 81p (plus VAT) to send a letter. Prices include:</p>
+  <p class="govuk-body">It costs between 35p and £1.16 (plus VAT) to send a letter. Prices include:</p>
   <ul class="list list-bullet">
      <li>paper</li>
      <li>double-sided colour printing</li>

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -35,6 +35,10 @@
   <p class="govuk-body">You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>
   <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
 
+  <h2 class="heading heading-medium">International letters</h2>
+  <p class="govuk-body">Notify checks for international addresses and will automatically charge you the correct postage.</p>
+  <p class="govuk-body">Letters to Europe are delivered 3 to 5 days after they’re dispatched. Letters sent anywhere else in the world take 5 to 7 days to arrive.</p>
+
   <h2 class="heading heading-medium">Pricing</h2>
   <p class="govuk-body">It costs between 35p and £1.16 (plus VAT) to send a letter. Prices include:</p>
   <ul class="list list-bullet">

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -35,7 +35,7 @@
   <p class="govuk-body">You can create reusable letter templates in Notify, or upload and send your own letters with the Notify API.</p>
   <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a>.</p>
 
-  <h2 class="heading heading-medium">International letters</h2>
+  <h3 class="heading heading-small" id="international-letters">International letters</h3>
   <p class="govuk-body">Notify checks for international addresses and will automatically charge you the correct postage.</p>
   <p class="govuk-body">Letters to Europe are delivered 3 to 5 days after they’re dispatched. Letters sent anywhere else in the world take 5 to 7 days to arrive.</p>
 

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -193,24 +193,33 @@
   <h2 class="heading-medium" id="letters">Letters</h2>
   <p class="govuk-body">The cost of sending a letter depends on the postage you choose and how many sheets of paper you need.</p>
 
+  <p class="govuk-body">Prices include:</p>
+  <ul class="list list-bullet">
+     <li>paper</li>
+     <li>postage</li>
+     <li>double-sided colour printing</li>
+     <li>C5 size envelopes with an address window</li>
+  </ul>
+
   <div>
     {% call mapping_table(
       caption='Letter pricing',
-      field_headings=['Paper', 'Second class', 'First class'],
+      field_headings=['Paper', 'Second class', 'First class', 'International'],
       field_headings_visible=True,
       caption_visible=False
     ) %}
-      {% for sheets, second, first in [
-        ('1 sheet', '35', '61'),
-        ('2 sheets', '40', '66'),
-        ('3 sheets', '45', '71'),
-        ('4 sheets', '50', '76'),
-        ('5 sheets', '55', '81'),
+      {% for sheets, second, first, international in [
+        ('1 sheet', '35p', '61p', '84p'),
+        ('2 sheets', '40p', '66p', '92p'),
+        ('3 sheets', '45p', '71p', '£1'),
+        ('4 sheets', '50p', '76p', '£1.08'),
+        ('5 sheets', '55p', '81p', '£1.16'),
       ] %}
         {% call row() %}
-          {% call row_heading() %} {{ sheets }} (double-sided) {% endcall %}
-          {{ text_field(second + 'p + VAT') }}
-          {{ text_field(first + 'p + VAT') }}
+          {% call row_heading() %} {{ sheets }} {% endcall %}
+          {{ text_field(second + ' + VAT') }}
+          {{ text_field(first + ' + VAT') }}
+          {{ text_field(international + ' + VAT') }}
         {% endcall %}
       {% endfor %}
     {% endcall %}
@@ -218,12 +227,5 @@
   <div class="panel panel-border-wide">
     <p class="govuk-body">These prices were updated on 1 October 2019.</p>
   </div>
-  <p class="govuk-body">Prices include:</p>
-  <ul class="list list-bullet">
-     <li>paper</li>
-     <li>double-sided colour printing</li>
-     <li>C5 size envelopes with an address window</li>
-     <li>first or second class postage</li>
-  </ul>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -225,7 +225,7 @@
     {% endcall %}
   </div>
   <div class="panel panel-border-wide">
-    <p class="govuk-body">These prices were updated on 1 October 2019.</p>
+    <p class="govuk-body">These prices were updated on 7 September 2020.</p>
   </div>
 
 {% endblock %}

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -17,7 +17,7 @@
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
       <p class="govuk-body">
-        It costs between 35p and 81p to send a letter using Notify.
+        It costs between 35p and £1.16 to send a letter using Notify.
       </p>
       <p class="govuk-body">
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for the list

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3674,7 +3674,7 @@ def test_unknown_channel_404s(
 ), [
     (
         'letter',
-        'It costs between 35p and 81p to send a letter using Notify.',
+        'It costs between 35p and £1.16 to send a letter using Notify.',
         'Send letters',
         ['email', 'sms'],
         'False',
@@ -3683,7 +3683,7 @@ def test_unknown_channel_404s(
     ),
     (
         'letter',
-        'It costs between 35p and 81p to send a letter using Notify.',
+        'It costs between 35p and £1.16 to send a letter using Notify.',
         'Send letters',
         ['email', 'sms', 'letter'],
         'True',


### PR DESCRIPTION
This also updates a few pages where we listed the minimum and maximum letter price.

This shouldn't be merged until we're ready to go live with international letters.

[Pivotal story](https://www.pivotaltracker.com/story/show/171622825)