### PR TITLE
Fix live search when selecting broadcast sub areas

### DIFF
--- a/app/templates/views/broadcast/sub-areas.html
+++ b/app/templates/views/broadcast/sub-areas.html
@@ -22,7 +22,7 @@
       {{ form.select_all }}
     </div>
 
-    {{ live_search(target_selector='.multiple-choice', show=show_search_form, form=search_form, label='Or by electoral ward') }}
+    {{ live_search(target_selector='.govuk-checkboxes__item', show=show_search_form, form=search_form, label='Or by electoral ward') }}
 
     {{ form.areas }}
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -350,6 +350,9 @@ def test_choose_broadcast_area_page_for_area_with_sub_areas(
         broadcast_message_id=fake_uuid,
         library_slug='electoral-wards-of-the-united-kingdom',
     )
+    live_search = page.select_one("[data-module=live-search]")
+    assert live_search['data-targets'] == '.file-list-item'
+    assert live_search.select_one('input')['type'] == 'search'
     partial_url_for = partial(
         url_for,
         'main.choose_broadcast_sub_area',
@@ -400,6 +403,9 @@ def test_choose_broadcast_sub_area_page(
     assert normalize_spaces(page.select_one('h1').text) == (
         'Choose an area of Aberdeen City'
     )
+    live_search = page.select_one("[data-module=live-search]")
+    assert live_search['data-targets'] == '.govuk-checkboxes__item'
+    assert live_search.select_one('input')['type'] == 'search'
     choices = [
         (
             choice.select_one('input')['value'],


### PR DESCRIPTION
It was targeting the wrong element because it hadn’t been updated to reflect that we’re now using the Design System checkboxes.