### PR TITLE
Add confirmation step when cancelling user invites

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -278,9 +278,12 @@ def confirm_edit_user_mobile_number(service_id, user_id):
     )
 
 
-@main.route("/services/<uuid:service_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
+@main.route("/services/<uuid:service_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def cancel_invited_user(service_id, invited_user_id):
-    current_service.cancel_invite(invited_user_id)
+    if request.method == 'POST':
+        current_service.cancel_invite(invited_user_id)
+        return redirect(url_for('main.manage_users', service_id=service_id))
 
-    return redirect(url_for('main.manage_users', service_id=service_id))
+    flash('Are you sure you want to cancel this invitation?', 'cancel')
+    return manage_users(service_id)

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -232,12 +232,15 @@ def remove_user_from_organisation(org_id, user_id):
     )
 
 
-@main.route("/organisations/<uuid:org_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>/cancel-invited-user/<uuid:invited_user_id>", methods=['GET', 'POST'])
 @user_has_permissions()
 def cancel_invited_org_user(org_id, invited_user_id):
-    org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
+    if request.method == 'POST':
+        org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
+        return redirect(url_for('main.manage_org_users', org_id=org_id))
 
-    return redirect(url_for('main.manage_org_users', org_id=org_id))
+    flash('Are you sure you want to cancel this invitation?', 'cancel')
+    return manage_org_users(org_id)
 
 
 @main.route("/organisations/<uuid:org_id>/settings/", methods=['GET'])

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -997,15 +997,35 @@ def test_invite_user_to_broadcast_service(
     )
 
 
+def test_cancel_invited_user_asks_for_confirmation(
+    client_request,
+    mock_get_invites_for_service,
+    sample_invite,
+    mock_get_template_folders,
+    mock_get_users_by_service,
+):
+    page = client_request.get(
+        'main.cancel_invited_user',
+        service_id=SERVICE_ONE_ID,
+        invited_user_id=sample_invite['id']
+    )
+
+    assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
+        'Are you sure you want to cancel this invitation? '
+        'Yes, cancel'
+    )
+    assert 'action' not in page.select_one('.banner-dangerous form')
+    assert page.select_one('.banner-dangerous form')['method'] == 'post'
+
+
 def test_cancel_invited_user_cancels_user_invitations(
     client_request,
     mock_get_invites_for_service,
     sample_invite,
-    active_user_with_permissions,
     mocker,
 ):
     mock_cancel = mocker.patch('app.invite_api_client.cancel_invited_user')
-    client_request.get(
+    client_request.post(
         'main.cancel_invited_user',
         service_id=SERVICE_ONE_ID,
         invited_user_id=sample_invite['id'],
@@ -1026,7 +1046,7 @@ def test_cancel_invited_user_doesnt_work_if_user_not_invited_to_this_service(
     mocker,
 ):
     mock_cancel = mocker.patch('app.invite_api_client.cancel_invited_user')
-    client_request.get(
+    client_request.post(
         'main.cancel_invited_user',
         service_id=SERVICE_ONE_ID,
         invited_user_id=sample_uuid(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 from contextlib import contextmanager
@@ -2398,8 +2399,6 @@ def mock_create_invite(mocker, sample_invite):
 
 @pytest.fixture(scope='function')
 def mock_get_invites_for_service(mocker, service_one, sample_invite):
-    import copy
-
     def _get_invites(service_id):
         data = []
         for i in range(0, 5):
@@ -3435,6 +3434,19 @@ def sample_org_invite(mocker, organisation_one):
     status = 'pending'
 
     return org_invite_json(id_, invited_by, organisation, email_address, created_at, status)
+
+
+@pytest.fixture(scope='function')
+def mock_get_invites_for_organisation(mocker, sample_org_invite):
+    def _get_org_invites(org_id):
+        data = []
+        for i in range(0, 5):
+            invite = copy.copy(sample_org_invite)
+            invite['email_address'] = 'user_{}@testnotify.gov.uk'.format(i)
+            data.append(invite)
+        return data
+
+    return mocker.patch('app.models.user.OrganisationInvitedUsers.client_method', side_effect=_get_org_invites)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/174294749)

This adds a confirmation banner when cancelling a user invite for a service or an organisation since this was something that the accessibility audit noted was missing.