### PR TITLE
Replace horizontal padding on pill items

### DIFF
--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -31,7 +31,7 @@
     float: left;
     box-sizing: border-box;
     width: 100%;
-    padding: 10px 0px;
+    padding: 10px;
   }
 
   a {


### PR DESCRIPTION
Fixes issues brought in by https://github.com/alphagov/notifications-admin/pull/3562

If the text isn't centrally aligned, it needs the padding:

<img width="739" alt="pill_padding_issue" src="https://user-images.githubusercontent.com/87140/90127088-8ec18b80-dd5c-11ea-982a-74cc8b3be109.png">

The problem with the content being cropped when zoomed/on smaller screens will come back but I'm going to write it up into a story as it looks like being more than just a quick fix.