### PR TITLE
Rationalise broadcast libraries into one for national and one for local areas

### DIFF
--- a/app/broadcast_areas/__init__.py
+++ b/app/broadcast_areas/__init__.py
@@ -101,9 +101,10 @@ class BroadcastAreaLibrary(SerialisedModelCollection, SortableMixin, GetItemById
     model = BroadcastArea
 
     def __init__(self, row):
-        id, name, is_group = row
+        id, name, name_singular, is_group = row
         self.id = id
         self.name = name
+        self.name_singular = name_singular
         self.is_group = bool(is_group)
         self.items = BroadcastAreasRepository().get_all_areas_for_library(self.id)
 

--- a/app/broadcast_areas/create-broadcast-areas-db.py
+++ b/app/broadcast_areas/create-broadcast-areas-db.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import geojson
 import shapely.geometry as sgeom
-from notifications_utils.safe_string import make_string_safe_for_id
 
 from repo import BroadcastAreasRepository
 
@@ -76,7 +75,7 @@ simple_datasets = [
 for dataset_name, id_field, name_field in simple_datasets:
     filepath = package_path / "{}.geojson".format(dataset_name)
 
-    dataset_id = make_string_safe_for_id(dataset_name)
+    dataset_id = id_field[:-2]
     dataset_geojson = geojson.loads(filepath.read_text())
 
     repo.insert_broadcast_area_library(dataset_id, dataset_name, False)
@@ -112,8 +111,8 @@ ward_code_to_la_id_mapping = {
     for f in geojson.loads(las_filepath.read_text())["features"]
 }
 
-dataset_name = "Electoral Wards of the United Kingdom"
-dataset_id = make_string_safe_for_id(dataset_name)
+dataset_name = "Local authorities"
+dataset_id = "wd20-lad20"
 repo.insert_broadcast_area_library(dataset_id, dataset_name, True)
 
 areas_to_add = []
@@ -121,12 +120,12 @@ areas_to_add = []
 for f in geojson.loads(wards_filepath.read_text())["features"]:
     ward_code = f["properties"]["wd20cd"]
     ward_name = f["properties"]["wd20nm"]
-    ward_id = dataset_id + "-" + ward_code
+    ward_id = "wd20-" + ward_code
 
     print(ward_name)  # noqa: T001
 
     try:
-        la_id = dataset_id + "-" + ward_code_to_la_id_mapping[ward_code]
+        la_id = "lad20-" + ward_code_to_la_id_mapping[ward_code]
         la_name = ward_code_to_la_mapping[ward_code]
 
         sf = deepcopy(f)
@@ -152,7 +151,7 @@ for feature in geojson.loads(las_filepath.read_text())["features"]:
 
     print(group_name)  # noqa: T001
 
-    group_id = dataset_id + "-" + la_id
+    group_id = "lad20-" + la_id
 
     simple_feature = deepcopy(feature)
     simple_feature["geometry"] = simplify_geometry(simple_feature["geometry"])

--- a/app/broadcast_areas/create-broadcast-areas-db.py
+++ b/app/broadcast_areas/create-broadcast-areas-db.py
@@ -69,15 +69,20 @@ repo.delete_db()
 repo.create_tables()
 
 simple_datasets = [
-    ("Countries", "ctry19cd", "ctry19nm"),
+    ("Countries", "country", "ctry19cd", "ctry19nm"),
 ]
-for dataset_name, id_field, name_field in simple_datasets:
+for dataset_name, dataset_name_singular, id_field, name_field in simple_datasets:
     filepath = package_path / "{}.geojson".format(dataset_name)
 
     dataset_id = id_field[:-2]
     dataset_geojson = geojson.loads(filepath.read_text())
 
-    repo.insert_broadcast_area_library(dataset_id, dataset_name, False)
+    repo.insert_broadcast_area_library(
+        dataset_id,
+        name=dataset_name,
+        name_singular=dataset_name_singular,
+        is_group=False,
+    )
 
     for feature in dataset_geojson["features"]:
         f_id = dataset_id + "-" + feature["properties"][id_field]
@@ -111,8 +116,14 @@ ward_code_to_la_id_mapping = {
 }
 
 dataset_name = "Local authorities"
+dataset_name_singular = "local authority"
 dataset_id = "wd20-lad20"
-repo.insert_broadcast_area_library(dataset_id, dataset_name, True)
+repo.insert_broadcast_area_library(
+    dataset_id,
+    name=dataset_name,
+    name_singular=dataset_name_singular,
+    is_group=True,
+)
 
 areas_to_add = []
 

--- a/app/broadcast_areas/create-broadcast-areas-db.py
+++ b/app/broadcast_areas/create-broadcast-areas-db.py
@@ -70,7 +70,6 @@ repo.create_tables()
 
 simple_datasets = [
     ("Countries", "ctry19cd", "ctry19nm"),
-    ("Counties and Unitary Authorities in England and Wales", "ctyua16cd", "ctyua16nm"),
 ]
 for dataset_name, id_field, name_field in simple_datasets:
     filepath = package_path / "{}.geojson".format(dataset_name)

--- a/app/broadcast_areas/repo.py
+++ b/app/broadcast_areas/repo.py
@@ -21,6 +21,7 @@ class BroadcastAreasRepository(object):
             CREATE TABLE broadcast_area_libraries (
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL,
+                name_singular TEXT NOT NULL,
                 is_group BOOLEAN NOT NULL
             )""")
 
@@ -62,15 +63,15 @@ class BroadcastAreasRepository(object):
             ON broadcast_areas (broadcast_area_library_group_id);
             """)
 
-    def insert_broadcast_area_library(self, id, name, is_group):
+    def insert_broadcast_area_library(self, id, *, name, name_singular, is_group):
 
         q = """
-        INSERT INTO broadcast_area_libraries (id, name, is_group)
-        VALUES (?, ?, ?)
+        INSERT INTO broadcast_area_libraries (id, name, name_singular, is_group)
+        VALUES (?, ?, ?, ?)
         """
 
         with self.conn() as conn:
-            conn.execute(q, (id, name, is_group))
+            conn.execute(q, (id, name, name_singular, is_group))
 
     def insert_broadcast_areas(self, areas):
 
@@ -106,9 +107,9 @@ class BroadcastAreasRepository(object):
             return cursor.fetchall()
 
     def get_libraries(self):
-        q = "SELECT id, name, is_group FROM broadcast_area_libraries"
+        q = "SELECT id, name, name_singular, is_group FROM broadcast_area_libraries"
         results = self.query(q)
-        libraries = [(row[0], row[1], row[2]) for row in results]
+        libraries = [(row[0], row[1], row[2], row[3]) for row in results]
         return sorted(libraries)
 
     def get_library_description(self, library_id):

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -126,6 +126,7 @@ def choose_broadcast_area(service_id, broadcast_message_id, library_slug):
             search_form=SearchByNameForm(),
             show_search_form=(len(library) > 7),
             library=library,
+            page_title=f'Choose a {library.name_singular.lower()}',
             broadcast_message=broadcast_message,
         )
 
@@ -142,7 +143,7 @@ def choose_broadcast_area(service_id, broadcast_message_id, library_slug):
         form=form,
         search_form=SearchByNameForm(),
         show_search_form=(len(form.areas.choices) > 7),
-        page_title=library.name,
+        page_title=f'Choose {library.name.lower()}',
         broadcast_message=broadcast_message,
     )
 

--- a/app/templates/views/broadcast/areas-with-sub-areas.html
+++ b/app/templates/views/broadcast/areas-with-sub-areas.html
@@ -4,13 +4,13 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  {{ library.name }}
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    library.name,
+    page_title,
     back_link=url_for('.choose_broadcast_library', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
   )}}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -662,7 +662,7 @@ def broadcast_message_json(
 
         'personalisation': {},
         'areas': areas or [
-            'countries-E92000001', 'countries-S92000003',
+            'ctry19-E92000001', 'ctry19-S92000003',
         ],
 
         'status': status,

--- a/tests/app/broadcast_areas/test_broadcast_area.py
+++ b/tests/app/broadcast_areas/test_broadcast_area.py
@@ -11,11 +11,6 @@ def test_loads_libraries():
         (library.id, library.name, library.is_group) for library in sorted(broadcast_area_libraries)
     ] == [
         (
-            'ctyua16',
-            'Counties and Unitary Authorities in England and Wales',
-            False,
-        ),
-        (
             'ctry19',
             'Countries',
             False,
@@ -45,14 +40,7 @@ def test_examples():
     countries = broadcast_area_libraries.get('ctry19').get_examples()
     assert countries == 'England, Northern Ireland, Scotland, and Wales'
 
-    counties = broadcast_area_libraries.get(
-        'ctyua16',
-    ).get_examples()
-    assert counties == 'Barking and Dagenham, Barnet, Barnsley, and 170 more…'
-
-    wards = broadcast_area_libraries.get(
-        'wd20-lad20',
-    ).get_examples()
+    wards = broadcast_area_libraries.get('wd20-lad20').get_examples()
     assert wards == 'Aberdeen City, Aberdeenshire, Adur, and 375 more…'
 
 
@@ -76,11 +64,9 @@ def test_get_names_of_areas():
         'ctry19-W92000004',
         'lad20-W06000014',
         'ctry19-E92000001',
-        'ctyua16-E10000012',
-
     )
     assert [area.name for area in sorted(areas)] == [
-        'England', 'Essex', 'Vale of Glamorgan', 'Wales',
+        'England', 'Vale of Glamorgan', 'Wales',
     ]
 
 
@@ -88,18 +74,14 @@ def test_get_areas_accepts_lists():
     areas_from_list = broadcast_area_libraries.get_areas(
         [
             'ctry19-W92000004',
-            'ctyua16-W06000014',
             'ctry19-E92000001',
-            'ctyua16-E10000012',
         ]
     )
     areas_from_args = broadcast_area_libraries.get_areas(
         'ctry19-W92000004',
-        'ctyua16-W06000014',
         'ctry19-E92000001',
-        'ctyua16-E10000012',
     )
-    assert len(areas_from_args) == len(areas_from_list) == 4
+    assert len(areas_from_args) == len(areas_from_list) == 2
     assert areas_from_args == areas_from_list
 
 
@@ -180,9 +162,8 @@ def test_repository_has_all_libraries():
     repo = BroadcastAreasRepository()
     libraries = repo.get_libraries()
 
-    assert len(libraries) == 3
+    assert len(libraries) == 2
     assert [
-        'Counties and Unitary Authorities in England and Wales',
         'Countries',
         'Local authorities',
-    ] == sorted([name for _, name, _is_group in libraries])
+    ] == [name for _, name, _is_group in libraries]

--- a/tests/app/broadcast_areas/test_broadcast_area.py
+++ b/tests/app/broadcast_areas/test_broadcast_area.py
@@ -164,6 +164,6 @@ def test_repository_has_all_libraries():
 
     assert len(libraries) == 2
     assert [
-        'Countries',
-        'Local authorities',
-    ] == [name for _, name, _is_group in libraries]
+        ('Countries', 'country'),
+        ('Local authorities', 'local authority'),
+    ] == [(name, name_singular) for _, name, name_singular, _is_group in libraries]

--- a/tests/app/broadcast_areas/test_broadcast_area.py
+++ b/tests/app/broadcast_areas/test_broadcast_area.py
@@ -11,18 +11,18 @@ def test_loads_libraries():
         (library.id, library.name, library.is_group) for library in sorted(broadcast_area_libraries)
     ] == [
         (
-            'counties-and-unitary-authorities-in-england-and-wales',
+            'ctyua16',
             'Counties and Unitary Authorities in England and Wales',
             False,
         ),
         (
-            'countries',
+            'ctry19',
             'Countries',
             False,
         ),
         (
-            'electoral-wards-of-the-united-kingdom',
-            'Electoral Wards of the United Kingdom',
+            'wd20-lad20',
+            'Local authorities',
             True,
         ),
     ]
@@ -31,41 +31,41 @@ def test_loads_libraries():
 def test_loads_areas_from_library():
     assert [
         (area.id, area.name) for area in sorted(
-            broadcast_area_libraries.get('countries')
+            broadcast_area_libraries.get('ctry19')
         )
     ] == [
-        ('countries-E92000001', 'England'),
-        ('countries-N92000002', 'Northern Ireland'),
-        ('countries-S92000003', 'Scotland'),
-        ('countries-W92000004', 'Wales'),
+        ('ctry19-E92000001', 'England'),
+        ('ctry19-N92000002', 'Northern Ireland'),
+        ('ctry19-S92000003', 'Scotland'),
+        ('ctry19-W92000004', 'Wales'),
     ]
 
 
 def test_examples():
-    countries = broadcast_area_libraries.get('countries').get_examples()
+    countries = broadcast_area_libraries.get('ctry19').get_examples()
     assert countries == 'England, Northern Ireland, Scotland, and Wales'
 
     counties = broadcast_area_libraries.get(
-        'counties-and-unitary-authorities-in-england-and-wales',
+        'ctyua16',
     ).get_examples()
     assert counties == 'Barking and Dagenham, Barnet, Barnsley, and 170 more…'
 
     wards = broadcast_area_libraries.get(
-        'electoral-wards-of-the-united-kingdom',
+        'wd20-lad20',
     ).get_examples()
     assert wards == 'Aberdeen City, Aberdeenshire, Adur, and 375 more…'
 
 
 @pytest.mark.parametrize('id', (
-    'countries-E92000001',
-    'countries-N92000002',
-    'countries-S92000003',
-    'countries-W92000004',
+    'ctry19-E92000001',
+    'ctry19-N92000002',
+    'ctry19-S92000003',
+    'ctry19-W92000004',
     pytest.param('mercia', marks=pytest.mark.xfail(raises=KeyError)),
 ))
 def test_loads_areas_from_libraries(id):
     assert (
-        broadcast_area_libraries.get('countries').get(id)
+        broadcast_area_libraries.get('ctry19').get(id)
     ) == (
         broadcast_area_libraries.get_areas(id)[0]
     )
@@ -73,10 +73,10 @@ def test_loads_areas_from_libraries(id):
 
 def test_get_names_of_areas():
     areas = broadcast_area_libraries.get_areas(
-        'countries-W92000004',
-        'electoral-wards-of-the-united-kingdom-W06000014',
-        'countries-E92000001',
-        'counties-and-unitary-authorities-in-england-and-wales-E10000012',
+        'ctry19-W92000004',
+        'lad20-W06000014',
+        'ctry19-E92000001',
+        'ctyua16-E10000012',
 
     )
     assert [area.name for area in sorted(areas)] == [
@@ -87,52 +87,53 @@ def test_get_names_of_areas():
 def test_get_areas_accepts_lists():
     areas_from_list = broadcast_area_libraries.get_areas(
         [
-            'countries-W92000004',
-            'counties-and-unitary-authorities-in-england-and-wales-W06000014',
-            'countries-E92000001',
-            'counties-and-unitary-authorities-in-england-and-wales-E10000012',
+            'ctry19-W92000004',
+            'ctyua16-W06000014',
+            'ctry19-E92000001',
+            'ctyua16-E10000012',
         ]
     )
     areas_from_args = broadcast_area_libraries.get_areas(
-        'countries-W92000004',
-        'counties-and-unitary-authorities-in-england-and-wales-W06000014',
-        'countries-E92000001',
-        'counties-and-unitary-authorities-in-england-and-wales-E10000012',
+        'ctry19-W92000004',
+        'ctyua16-W06000014',
+        'ctry19-E92000001',
+        'ctyua16-E10000012',
     )
+    assert len(areas_from_args) == len(areas_from_list) == 4
     assert areas_from_args == areas_from_list
 
 
 def test_has_polygons():
 
     assert len(
-        broadcast_area_libraries.get_polygons_for_areas_long_lat('countries-E92000001')
+        broadcast_area_libraries.get_polygons_for_areas_long_lat('ctry19-E92000001')
     ) == 35
 
     assert len(
-        broadcast_area_libraries.get_polygons_for_areas_long_lat('countries-S92000003')
+        broadcast_area_libraries.get_polygons_for_areas_long_lat('ctry19-S92000003')
     ) == 195
 
     assert len(
         broadcast_area_libraries.get_polygons_for_areas_long_lat(
-            'countries-E92000001',
-            'countries-S92000003',
+            'ctry19-E92000001',
+            'ctry19-S92000003',
         )
     ) == 35 + 195 == 230
 
     assert len(
         broadcast_area_libraries.get_polygons_for_areas_lat_long(
-            'countries-E92000001',
-            'countries-S92000003',
+            'ctry19-E92000001',
+            'ctry19-S92000003',
         )
     ) == 35 + 195 == 230
 
-    assert broadcast_area_libraries.get_polygons_for_areas_lat_long('countries-E92000001')[0][0] == [
+    assert broadcast_area_libraries.get_polygons_for_areas_lat_long('ctry19-E92000001')[0][0] == [
         55.811085, -2.034358  # https://goo.gl/maps/wsf2LUWzYinwydMk8
     ]
 
 
 def test_polygons_are_enclosed_unless_asked_not_to_be():
-    england = broadcast_area_libraries.get('countries').get('countries-E92000001')
+    england = broadcast_area_libraries.get('ctry19').get('ctry19-E92000001')
 
     assert len(england.polygons) == len(england.unenclosed_polygons)
 
@@ -148,8 +149,8 @@ def test_polygons_are_enclosed_unless_asked_not_to_be():
 
 def test_lat_long_order():
 
-    lat_long = broadcast_area_libraries.get_polygons_for_areas_lat_long('countries-E92000001')
-    long_lat = broadcast_area_libraries.get_polygons_for_areas_long_lat('countries-E92000001')
+    lat_long = broadcast_area_libraries.get_polygons_for_areas_lat_long('ctry19-E92000001')
+    long_lat = broadcast_area_libraries.get_polygons_for_areas_long_lat('ctry19-E92000001')
     assert len(lat_long[0]) == len(long_lat[0]) == 2082  # Coordinates in polygon
     assert len(lat_long[0][0]) == len(long_lat[0][0]) == 2  # Axes in coordinates
     assert lat_long[0][0] == list(reversed(long_lat[0][0]))
@@ -157,19 +158,19 @@ def test_lat_long_order():
 
 def test_includes_electoral_wards():
 
-    areas = broadcast_area_libraries.get_areas(['electoral-wards-of-the-united-kingdom-E05009289'])
+    areas = broadcast_area_libraries.get_areas(['wd20-E05009289'])
     assert len(areas) == 1
 
 
 def test_electoral_wards_are_groupable_cardiff():
-    areas = broadcast_area_libraries.get_areas(['electoral-wards-of-the-united-kingdom-W06000015'])
+    areas = broadcast_area_libraries.get_areas(['lad20-W06000015'])
     assert len(areas) == 1
     cardiff = areas[0]
     assert len(cardiff.sub_areas) == 29
 
 
 def test_electoral_wards_are_groupable_ealing():
-    areas = broadcast_area_libraries.get_areas(['electoral-wards-of-the-united-kingdom-E09000009'])
+    areas = broadcast_area_libraries.get_areas(['lad20-E09000009'])
     assert len(areas) == 1
     ealing = areas[0]
     assert len(ealing.sub_areas) == 23
@@ -183,5 +184,5 @@ def test_repository_has_all_libraries():
     assert [
         'Counties and Unitary Authorities in England and Wales',
         'Countries',
-        'Electoral Wards of the United Kingdom',
+        'Local authorities',
     ] == sorted([name for _, name, _is_group in libraries])

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -320,6 +320,9 @@ def test_choose_broadcast_area_page(
         broadcast_message_id=fake_uuid,
         library_slug='ctry19',
     )
+    assert normalize_spaces(page.select_one('h1').text) == (
+        'Choose countries'
+    )
     assert [
         (
             choice.select_one('input')['value'],
@@ -346,6 +349,9 @@ def test_choose_broadcast_area_page_for_area_with_sub_areas(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         library_slug='wd20-lad20',
+    )
+    assert normalize_spaces(page.select_one('h1').text) == (
+        'Choose a local authority'
     )
     partial_url_for = partial(
         url_for,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -287,17 +287,15 @@ def test_choose_broadcast_library_page(
         broadcast_message_id=fake_uuid,
     )
 
-    titles = [
+    assert [
         normalize_spaces(title.text)
         for title in page.select('.file-list-filename-large')
-    ]
-    assert sorted(titles) == sorted([
-        'Counties and Unitary Authorities in England and Wales',
+    ] == [
         'Countries',
         'Local authorities',
-    ])
+    ]
 
-    assert normalize_spaces(page.select('.file-list-hint-large')[1].text) == (
+    assert normalize_spaces(page.select('.file-list-hint-large')[0].text) == (
         'England, Northern Ireland, Scotland, and Wales'
     )
 
@@ -305,7 +303,7 @@ def test_choose_broadcast_library_page(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='ctyua16',
+        library_slug='ctry19',
     )
 
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -294,7 +294,7 @@ def test_choose_broadcast_library_page(
     assert sorted(titles) == sorted([
         'Counties and Unitary Authorities in England and Wales',
         'Countries',
-        'Electoral Wards of the United Kingdom',
+        'Local authorities',
     ])
 
     assert normalize_spaces(page.select('.file-list-hint-large')[1].text) == (
@@ -305,7 +305,7 @@ def test_choose_broadcast_library_page(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='counties-and-unitary-authorities-in-england-and-wales',
+        library_slug='ctyua16',
     )
 
 
@@ -320,7 +320,7 @@ def test_choose_broadcast_area_page(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='countries',
+        library_slug='ctry19',
     )
     assert [
         (
@@ -329,10 +329,10 @@ def test_choose_broadcast_area_page(
         )
         for choice in page.select('form[method=post] .govuk-checkboxes__item')
     ] == [
-        ('countries-E92000001', 'England'),
-        ('countries-N92000002', 'Northern Ireland'),
-        ('countries-S92000003', 'Scotland'),
-        ('countries-W92000004', 'Wales'),
+        ('ctry19-E92000001', 'England'),
+        ('ctry19-N92000002', 'Northern Ireland'),
+        ('ctry19-S92000003', 'Scotland'),
+        ('ctry19-W92000004', 'Wales'),
     ]
 
 
@@ -347,14 +347,14 @@ def test_choose_broadcast_area_page_for_area_with_sub_areas(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='electoral-wards-of-the-united-kingdom',
+        library_slug='wd20-lad20',
     )
     partial_url_for = partial(
         url_for,
         'main.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='electoral-wards-of-the-united-kingdom',
+        library_slug='wd20-lad20',
     )
     choices = [
         (
@@ -366,17 +366,17 @@ def test_choose_broadcast_area_page_for_area_with_sub_areas(
     assert len(choices) == 379
     assert choices[:2] == [
         (
-            partial_url_for(area_slug='electoral-wards-of-the-united-kingdom-S12000033'),
+            partial_url_for(area_slug='lad20-S12000033'),
             'Aberdeen City',
         ),
         (
-            partial_url_for(area_slug='electoral-wards-of-the-united-kingdom-S12000034'),
+            partial_url_for(area_slug='lad20-S12000034'),
             'Aberdeenshire',
         ),
     ]
     assert choices[-1:] == [
         (
-            partial_url_for(area_slug='electoral-wards-of-the-united-kingdom-E06000014'),
+            partial_url_for(area_slug='lad20-E06000014'),
             'York',
         ),
     ]
@@ -393,8 +393,8 @@ def test_choose_broadcast_sub_area_page(
         'main.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='electoral-wards-of-the-united-kingdom',
-        area_slug='electoral-wards-of-the-united-kingdom-S12000033',
+        library_slug='wd20-lad20',
+        area_slug='lad20-S12000033',
     )
     assert normalize_spaces(page.select_one('h1').text) == (
         'Choose an area of Aberdeen City'
@@ -408,11 +408,11 @@ def test_choose_broadcast_sub_area_page(
     ]
     assert choices[:3] == [
         ('y', 'All of Aberdeen City'),
-        ('electoral-wards-of-the-united-kingdom-S13002845', 'Airyhall/Broomhill/Garthdee'),
-        ('electoral-wards-of-the-united-kingdom-S13002836', 'Bridge of Don'),
+        ('wd20-S13002845', 'Airyhall/Broomhill/Garthdee'),
+        ('wd20-S13002836', 'Bridge of Don'),
     ]
     assert choices[-1:] == [
-        ('electoral-wards-of-the-united-kingdom-S13002846', 'Torry/Ferryhill'),
+        ('wd20-S13002846', 'Torry/Ferryhill'),
     ]
 
 
@@ -428,16 +428,16 @@ def test_add_broadcast_area(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='countries',
+        library_slug='ctry19',
         _data={
-            'areas': ['countries-E92000001', 'countries-W92000004']
+            'areas': ['ctry19-E92000001', 'ctry19-W92000004']
         }
     )
     mock_update_broadcast_message.assert_called_once_with(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'areas': ['countries-E92000001', 'countries-S92000003', 'countries-W92000004']
+            'areas': ['ctry19-E92000001', 'ctry19-S92000003', 'ctry19-W92000004']
         },
     )
 
@@ -446,20 +446,20 @@ def test_add_broadcast_area(
     ({
         'select_all': 'y',
         'areas': [
-            'electoral-wards-of-the-united-kingdom-S13002845',
+            'wd20-S13002845',
         ]
     }, [
-        'electoral-wards-of-the-united-kingdom-S12000033',
-        # S13002845 is ignored because the user chose ‘Select all…’
+        'lad20-S12000033',
+        # wd20-S13002845 is ignored because the user chose ‘Select all…’
     ]),
     ({
         'areas': [
-            'electoral-wards-of-the-united-kingdom-S13002845',
-            'electoral-wards-of-the-united-kingdom-S13002836',
+            'wd20-S13002845',
+            'wd20-S13002836',
         ]
     }, [
-        'electoral-wards-of-the-united-kingdom-S13002845',
-        'electoral-wards-of-the-united-kingdom-S13002836',
+        'wd20-S13002845',
+        'wd20-S13002836',
     ]),
 ))
 def test_add_broadcast_sub_area(
@@ -476,8 +476,8 @@ def test_add_broadcast_sub_area(
         '.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        library_slug='countries',
-        area_slug='electoral-wards-of-the-united-kingdom-S12000033',
+        library_slug='wd20-lad20',
+        area_slug='lad20-S12000033',
         _data=post_data,
     )
     mock_update_broadcast_message.assert_called_once_with(
@@ -486,8 +486,8 @@ def test_add_broadcast_sub_area(
         data={
             'areas': [
                 # These two areas are on the broadcast already
-                'countries-E92000001',
-                'countries-S92000003',
+                'ctry19-E92000001',
+                'ctry19-S92000003',
             ] + expected_selected
         },
     )
@@ -505,7 +505,7 @@ def test_remove_broadcast_area_page(
         '.remove_broadcast_area',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
-        area_slug='countries-E92000001',
+        area_slug='ctry19-E92000001',
         _expected_redirect=url_for(
             '.preview_broadcast_areas',
             service_id=SERVICE_ONE_ID,
@@ -517,7 +517,7 @@ def test_remove_broadcast_area_page(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'areas': ['countries-S92000003']
+            'areas': ['ctry19-S92000003']
         },
     )
 

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -11,9 +11,9 @@ def test_simple_polygons(fake_uuid):
         created_by_id=fake_uuid,
         areas=[
             # Hackney Central
-            'electoral-wards-of-the-united-kingdom-E05009372',
+            'wd20-E05009372',
             # Hackney Wick
-            'electoral-wards-of-the-united-kingdom-E05009374',
+            'wd20-E05009374',
         ],
     ))
 


### PR DESCRIPTION
This PR does two main things:
- removes the ‘Counties and unitary authorities in England and Wales’ library because it’s redundant now we have the ‘Electoral wards in the United Kingdom’ library
- renames the libraries to local and national because we’ve observed this language during user research, and it’s has less
tongue-twisting ambiguity than county vs country

# Before 

![image](https://user-images.githubusercontent.com/355079/90132098-190ded80-dd65-11ea-9252-523061270089.png)

# After 

![image](https://user-images.githubusercontent.com/355079/90131837-b0267580-dd64-11ea-9548-e069c3661557.png)

