### PR TITLE
Add nhs.scot

### DIFF
--- a/app/email_domains.txt
+++ b/app/email_domains.txt
@@ -7,6 +7,7 @@ parliament.scot
 parliament.uk
 nhs.uk
 nhs.net
+nhs.scot
 police.uk
 scotent.co.uk
 assembly.wales


### PR DESCRIPTION
some scottish nhs domains are migrating from nsh.net to nhs.scot. for example i found this article from nhs glasgow talking about it: https://www.nhsggc.org.uk/working-with-us/staff-communications/nhs-mail-and-office-365/nhs-mail-migration/