### PR TITLE
Add confirmation banner when cancelling user invites

### DIFF
--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -283,4 +283,7 @@ def confirm_edit_user_mobile_number(service_id, user_id):
 def cancel_invited_user(service_id, invited_user_id):
     current_service.cancel_invite(invited_user_id)
 
+    invited_user = InvitedUser.by_id_and_service_id(service_id, invited_user_id)
+
+    flash(f'Invitation cancelled for {invited_user.email_address}', 'default_with_tick')
     return redirect(url_for('main.manage_users', service_id=service_id))

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -237,6 +237,9 @@ def remove_user_from_organisation(org_id, user_id):
 def cancel_invited_org_user(org_id, invited_user_id):
     org_invite_api_client.cancel_invited_user(org_id=org_id, invited_user_id=invited_user_id)
 
+    invited_org_user = InvitedOrgUser.by_id_and_org_id(org_id, invited_user_id)
+
+    flash(f'Invitation cancelled for {invited_org_user.email_address}', 'default_with_tick')
     return redirect(url_for('main.manage_org_users', org_id=org_id))
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -464,6 +464,12 @@ class InvitedUser(JSONModel):
             folder_permissions,
         ))
 
+    @classmethod
+    def by_id_and_service_id(cls, service_id, invited_user_id):
+        return cls(
+            invite_api_client.get_invited_user(service_id, invited_user_id)
+        )
+
     def accept_invite(self):
         invite_api_client.accept_invite(self.service, self.id)
 
@@ -585,6 +591,12 @@ class InvitedOrgUser(JSONModel):
     def from_session(cls):
         invited_org_user = session.get('invited_org_user')
         return cls(invited_org_user) if invited_org_user else None
+
+    @classmethod
+    def by_id_and_org_id(cls, org_id, invited_user_id):
+        return cls(
+            org_invite_api_client.get_invited_user(org_id, invited_user_id)
+        )
 
     def serialize(self, permissions_as_string=False):
         data = {'id': self.id,

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -37,6 +37,11 @@ class InviteApiClient(NotifyAdminAPIClient):
             '/service/{}/invite'.format(service_id)
         )['data']
 
+    def get_invited_user(self, service_id, invited_user_id):
+        return self.get(
+            f'/service/{service_id}/invite/{invited_user_id}'
+        )['data']
+
     def get_count_of_invites_with_permission(self, service_id, permission):
         if permission not in roles.keys():
             raise TypeError('{} is not a valid permission'.format(permission))

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -23,6 +23,11 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
         resp = self.get(endpoint)
         return resp['data']
 
+    def get_invited_user(self, org_id, invited_org_user_id):
+        return self.get(
+            f'/organisation/{org_id}/invite/{invited_org_user_id}'
+        )['data']
+
     def check_token(self, token):
         resp = self.get(url='/invite/organisation/{}'.format(token))
         return resp['data']

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -631,6 +631,34 @@ def test_organisation_trial_mode_services_doesnt_work_if_not_platform_admin(
     )
 
 
+def test_cancel_invited_org_user_cancels_user_invitations(
+    client_request,
+    mock_get_invites_for_organisation,
+    sample_org_invite,
+    mock_get_organisation,
+    mock_get_users_for_organisation,
+    mocker,
+):
+    mock_cancel = mocker.patch('app.org_invite_api_client.cancel_invited_user')
+    mocker.patch('app.org_invite_api_client.get_invited_user', return_value=sample_org_invite)
+
+    page = client_request.get(
+        'main.cancel_invited_org_user',
+        org_id=ORGANISATION_ID,
+        invited_user_id=sample_org_invite['id'],
+        _follow_redirects=True
+    )
+    assert normalize_spaces(page.h1.text) == 'Team members'
+    flash_banner = normalize_spaces(
+        page.find('div', class_='banner-default-with-tick').text
+    )
+    assert flash_banner == f"Invitation cancelled for {sample_org_invite['email_address']}"
+    mock_cancel.assert_called_once_with(
+        org_id=ORGANISATION_ID,
+        invited_user_id=sample_org_invite['id'],
+    )
+
+
 def test_organisation_settings_platform_admin_only(
     client_request,
     mock_get_organisation,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 from contextlib import contextmanager
@@ -2398,8 +2399,6 @@ def mock_create_invite(mocker, sample_invite):
 
 @pytest.fixture(scope='function')
 def mock_get_invites_for_service(mocker, service_one, sample_invite):
-    import copy
-
     def _get_invites(service_id):
         data = []
         for i in range(0, 5):
@@ -3435,6 +3434,19 @@ def sample_org_invite(mocker, organisation_one):
     status = 'pending'
 
     return org_invite_json(id_, invited_by, organisation, email_address, created_at, status)
+
+
+@pytest.fixture(scope='function')
+def mock_get_invites_for_organisation(mocker, sample_org_invite):
+    def _get_org_invites(org_id):
+        data = []
+        for i in range(0, 5):
+            invite = copy.copy(sample_org_invite)
+            invite['email_address'] = 'user_{}@testnotify.gov.uk'.format(i)
+            data.append(invite)
+        return data
+
+    return mocker.patch('app.models.user.OrganisationInvitedUsers.client_method', side_effect=_get_org_invites)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
This shows the green banner with a tick when cancelling a user's
invitation to a service or organisation. The accessibility audit noted
that 'When cancelling an invite a new page loads, however, there is no
immediate indication that the invite has been cancelled.'

In order to display the invited user's email address as part of the
flash message, this adds new methods to the api clients for invites to get
a single invite.

[Pivotal story](https://www.pivotaltracker.com/story/show/174294749)