### PR TITLE
Update sent status label

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -479,7 +479,10 @@ def format_notification_status_as_field_status(status, notification_type):
             'virus-scan-failed': 'error',
             'returned-letter': None,
             'cancelled': 'error',
-        }
+        },
+        'sms': {
+            'sent': 'sent-international'
+        },
     }.get(
         notification_type,
         {

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -435,7 +435,7 @@ def format_notification_status(status, template_type):
             'sending': 'Sending',
             'created': 'Sending',
             'pending': 'Sending',
-            'sent': 'Sent internationally'
+            'sent': 'Sent to an international number'
         },
         'letter': {
             'failed': '',

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -225,6 +225,16 @@
 
     }
 
+    &-sent-international {
+
+      .status-hint {
+        display: block;
+        font-weight: normal;
+        margin-top: 5px;
+      }
+
+    }
+
     &-yes,
     &-no {
       display: block;

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -144,7 +144,7 @@
 
 {% macro notification_status_field(notification) %}
 
-  {% set displayed_on_single_line = notification.status in ['created', 'pending', 'pending-virus-check', 'sending', 'sent', 'delivered', 'returned-letter', 'accepted', 'received'] %}
+  {% set displayed_on_single_line = notification.status in ['created', 'pending', 'pending-virus-check', 'sending', 'delivered', 'returned-letter', 'accepted', 'received'] %}
 
   {% if not notification %}
     {% call field(align='right') %}{% endcall %}

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -53,7 +53,7 @@
     ) %}
       {% for message_length, charge in [
         ('Sending', 'Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. Notify is waiting for delivery information.'),
-        ('Sent internationally', 'The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.'),
+        ('Sent to an international number', 'The mobile networks in some countries do not provide any more delivery information.'),
         ('Delivered', 'The message was successfully delivered. Notify will not tell you if a user has opened or read a message.'),
         ('Not delivered', 'The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".support") }}">contact us</a>. If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.'|safe),
         ('Phone not accepting messages right now', 'The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.'),


### PR DESCRIPTION
We've had some feedback that the status label `sent internationally` can be confusing.

Unless the user checks the list of status descriptions, `sent internationally` doesn't make clear whether:

* the message was sent to an international phone number OR
* the message was sent to a UK number, but the recipient is outside the UK

