### PR TITLE
Make SVG alert icon show in Internet Explorer 10

### DIFF
--- a/app/assets/images/exclamation.svg
+++ b/app/assets/images/exclamation.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 17.5 14.5" style="enable-background:new 0 0 17.5 14.5;" xml:space="preserve">
+	 viewBox="0 0 17.5 14.5" width="17.5" height="14.5" style="enable-background:new 0 0 17.5 14.5;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#0B0B0B;}
 </style>


### PR DESCRIPTION
IE 10 supports using SVG<sup>1</sup> but has some buggy behaviour when they’re used as background images.

Without an explicit width/height it stretches the viewBox of the SVG to fill the containing element. This causes the content of the file to display centered within the viewBox.

Explicitly setting the width and height seems to be the thing that fixes this. Out of the suggested fixes on Stackoverflow<sup>2</sup> this one seems to be the most straightforward.

1. https://caniuse.com/#feat=svg
2. https://stackoverflow.com/questions/17944354/svg-background-image-position-is-always-centered-in-internet-explorer-despite-b