### PR TITLE
Fix or remove skip links on bulk send and contact list upload pages

### DIFF
--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -6,13 +6,6 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/message-count-label.html" import message_count_label %}
 
-{% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
-
 {% block service_page_title %}
   Error
 {% endblock %}
@@ -135,8 +128,6 @@
 
       {% endif %}
 
-      {{ skip_to_file_contents() }}
-
     {% endcall %}
   </div>
 
@@ -158,7 +149,7 @@
 
     {% set column_headers = recipients._raw_column_headers if recipients.duplicate_recipient_column_headers else recipients.column_headers %}
 
-    <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
+    <h2 class="heading-medium" id="file-preview">{{ original_file_name }}</h2>
 
     <div class="fullscreen-content" data-module="fullscreen-table">
       {% call(item, row_number) list_table(

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -5,13 +5,9 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/message-count-label.html" import message_count_label %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/skip-link/macro.njk" import govukSkipLink %}
 
 {% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
 
 {% block service_page_title %}
   {{ "Preview of {}".format(template.name) }}
@@ -30,7 +26,10 @@
     {% endcall %}
   {% endif %}
 
-  {{ skip_to_file_contents() }}
+  {{ govukSkipLink({
+    "text": "Skip to file contents",
+    "href": "#" + file_contents_header_id
+  }) }}
 
   {{ template|string }}
   <div class="bottom-gutter-3-2">

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -6,13 +6,6 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/message-count-label.html" import message_count_label %}
 
-{% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
-
 {% block service_page_title %}
   Error
 {% endblock %}
@@ -43,7 +36,6 @@
           {% endfor %}
         </ul>
       {% endif %}
-      {{ skip_to_file_contents() }}
     {% endcall %}
   </div>
 
@@ -60,7 +52,7 @@
 
   <div class="fullscreen-content" data-module="fullscreen-table">
     {% call(item, row_number) mapping_table(
-      caption=original_file_name,
+      caption="Errors in " + original_file_name,
       caption_visible=False,
       field_headings=[
         '<span class="govuk-visually-hidden">Row in file</span><span aria-hidden="true" class="table-field-invisible-error">1</span>'|safe

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -6,13 +6,6 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/message-count-label.html" import message_count_label, recipient_count_label %}
 
-{% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
-
 {% block service_page_title %}
   Error
 {% endblock %}
@@ -48,9 +41,6 @@
         </p>
 
       {% endif %}
-
-      {{ skip_to_file_contents() }}
-
     {% endcall %}
   </div>
 
@@ -66,7 +56,7 @@
     <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
-    <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
+    <h2 class="heading-medium" id="file-preview">{{ original_file_name }}</h2>
 
     {% call(item, row_number) list_table(
       recipients.displayed_rows,

--- a/app/templates/views/uploads/contact-list/ok.html
+++ b/app/templates/views/uploads/contact-list/ok.html
@@ -6,13 +6,6 @@
 {% from "components/message-count-label.html" import message_count_label, recipient_count_label %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
-
 {% block service_page_title %}
   {{ original_file_name }}
 {% endblock %}

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -6,12 +6,6 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/message-count-label.html" import message_count_label %}
 
-{% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
 
 {% block service_page_title %}
   Error
@@ -43,7 +37,6 @@
           {% endfor %}
         </ul>
       {% endif %}
-      {{ skip_to_file_contents() }}
     {% endcall %}
   </div>
 

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -6,12 +6,6 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/message-count-label.html" import message_count_label %}
 
-{% set file_contents_header_id = 'file-preview' %}
-{% macro skip_to_file_contents() %}
-  <p class="govuk-visually-hidden">
-    <a class="govuk-link govuk-link--no-visited-state" href="#{{ file_contents_header_id }}">Skip to file contents</a>
-  </p>
-{% endmacro %}
 
 {% block service_page_title %}
   Error
@@ -56,9 +50,6 @@
         </p>
 
       {% endif %}
-
-      {{ skip_to_file_contents() }}
-
     {% endcall %}
   </div>
 
@@ -76,7 +67,7 @@
 
     {% set column_headers = recipients._raw_column_headers if recipients.duplicate_recipient_column_headers else recipients.column_headers %}
 
-    <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
+    <h2 class="heading-medium" id="file-preview">{{ original_file_name }}</h2>
 
     <div class="fullscreen-content" data-module="fullscreen-table">
       {% call(item, row_number) list_table(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -515,8 +515,7 @@ def test_upload_csv_file_with_empty_message_shows_check_page_with_errors(
         page.select_one('.banner-dangerous').text
     ) == (
         'There’s a problem with invalid.csv '
-        'You need to check you have content for the empty message in 1 row. '
-        'Skip to file contents'
+        'You need to check you have content for the empty message in 1 row.'
     )
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr')
@@ -571,8 +570,7 @@ def test_upload_csv_file_with_very_long_placeholder_shows_check_page_with_errors
         page.select_one('.banner-dangerous').text
     ) == (
         'There’s a problem with invalid.csv '
-        'You need to shorten the messages in 2 rows. '
-        'Skip to file contents'
+        'You need to shorten the messages in 2 rows.'
     )
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr')
@@ -631,8 +629,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
         page.select_one('.banner-dangerous').text
     ) == (
         'There’s a problem with invalid.csv '
-        'You need to fix 5 addresses. '
-        'Skip to file contents'
+        'You need to fix 5 addresses.'
     )
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr')
@@ -692,8 +689,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         page.select_one('.banner-dangerous').text
     ) == (
         'There’s a problem with invalid.csv '
-        'You need to fix 2 addresses. '
-        'Skip to file contents'
+        'You need to fix 2 addresses.'
     )
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr')
@@ -715,8 +711,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         (
             'There’s a problem with your column names '
             'Your file needs a column called ‘phone number’. '
-            'Right now it has columns called ‘telephone’ and ‘name’. '
-            'Skip to file contents'
+            'Right now it has columns called ‘telephone’ and ‘name’.'
         )
     ),
     (
@@ -726,8 +721,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         """,
         (
             'Your column names need to match the double brackets in your template '
-            'Your file is missing a column called ‘name’. '
-            'Skip to file contents'
+            'Your file is missing a column called ‘name’.'
         )
     ),
     (
@@ -738,8 +732,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         (
             'There’s a problem with your column names '
             'We found more than one column called ‘phone number’ or ‘PHONE_NUMBER’. '
-            'Delete or rename one of these columns and try again. '
-            'Skip to file contents'
+            'Delete or rename one of these columns and try again.'
         )
     ),
     (
@@ -748,24 +741,21 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         """,
         (
             'Your file is missing some rows '
-            'It needs at least one row of data. '
-            'Skip to file contents'
+            'It needs at least one row of data.'
         )
     ),
     (
         "+447700900986",
         (
             'Your file is missing some rows '
-            'It needs at least one row of data, and columns called ‘name’ and ‘phone number’. '
-            'Skip to file contents'
+            'It needs at least one row of data, and columns called ‘name’ and ‘phone number’.'
         )
     ),
     (
         "",
         (
             'Your file is missing some rows '
-            'It needs at least one row of data, and columns called ‘name’ and ‘phone number’. '
-            'Skip to file contents'
+            'It needs at least one row of data, and columns called ‘name’ and ‘phone number’.'
         )
     ),
     (
@@ -777,8 +767,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to enter missing data in 1 row. '
-            'Skip to file contents'
+            'You need to enter missing data in 1 row.'
         )
     ),
     (
@@ -790,8 +779,7 @@ def test_upload_csv_file_with_international_letters_permission_shows_appropriate
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to enter missing data in 1 row. '
-            'Skip to file contents'
+            'You need to enter missing data in 1 row.'
         )
     ),
 ])
@@ -3343,8 +3331,7 @@ def test_check_messages_shows_trial_mode_error(
         page.find('div', class_='banner-dangerous').text.split()
     ) == (
         'You cannot send to this phone number '
-        'In trial mode you can only send to yourself and members of your team '
-        'Skip to file contents'
+        'In trial mode you can only send to yourself and members of your team'
     )
 
 
@@ -3406,8 +3393,7 @@ def test_check_messages_shows_trial_mode_error_for_letters(
     if error_should_be_shown:
         assert normalize_spaces(error[0].text) == (
             '{} '
-            'In trial mode you can only preview how your letters will look '
-            'Skip to file contents'
+            'In trial mode you can only preview how your letters will look'
         ).format(expected_error_message)
     else:
         assert not error
@@ -3509,8 +3495,7 @@ def test_check_messages_shows_data_errors_before_trial_mode_errors_for_letters(
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
         'There’s a problem with example.xlsx '
-        'You need to fix 2 addresses. '
-        'Skip to file contents'
+        'You need to fix 2 addresses.'
     )
     assert not page.select('.table-field-index a')
 
@@ -3551,8 +3536,7 @@ def test_warns_if_file_sent_already(
         page.select_one('.banner-dangerous').text
     ) == (
         'These messages have already been sent today '
-        'If you need to resend them, rename the file and upload it again. '
-        'Skip to file contents'
+        'If you need to resend them, rename the file and upload it again.'
     )
 
     mock_get_jobs.assert_called_once_with(SERVICE_ONE_ID, limit_days=0)
@@ -3600,8 +3584,7 @@ def test_check_messages_column_error_doesnt_show_optional_columns(
         'There’s a problem with your column names '
         'Your file needs at least 3 address columns, for example ‘address line 1’, '
         '‘address line 2’ and ‘address line 3’. '
-        'Right now it has columns called ‘address_line_1’, ‘address_line_2’ and ‘foo’. '
-        'Skip to file contents'
+        'Right now it has columns called ‘address_line_1’, ‘address_line_2’ and ‘foo’.'
     )
 
 
@@ -3697,8 +3680,7 @@ def test_letters_from_csv_files_dont_have_download_link(
         page.select_one('.banner-dangerous').text
     ) == normalize_spaces(
         'You cannot send this letter '
-        'In trial mode you can only preview how your letters will look '
-        'Skip to file contents'
+        'In trial mode you can only preview how your letters will look'
     )
 
     assert len(page.select('.letter img')) == 5
@@ -3873,8 +3855,7 @@ def test_check_messages_shows_over_max_row_error(
     ) == (
         'Your file has too many rows '
         'Notify can process up to 11,111 rows at once. '
-        'Your file has 99,999 rows. '
-        'Skip to file contents'
+        'Your file has 99,999 rows.'
     )
 
 

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -40,8 +40,7 @@ def test_upload_contact_list_page(client_request):
         (
             'Your file has too many columns '
             'It needs to have 1 column, called ‘email address’ or ‘phone number’. '
-            'Right now it has 2 columns called ‘telephone’ and ‘name’. '
-            'Skip to file contents'
+            'Right now it has 2 columns called ‘telephone’ and ‘name’.'
         ),
         'Row in file 1 telephone name',
         '2 +447700900986',
@@ -54,8 +53,7 @@ def test_upload_contact_list_page(client_request):
         (
             'Your file has too many columns '
             'It needs to have 1 column, called ‘email address’ or ‘phone number’. '
-            'Right now it has 2 columns called ‘phone number’ and ‘email address’. '
-            'Skip to file contents'
+            'Right now it has 2 columns called ‘phone number’ and ‘email address’.'
         ),
         'Row in file 1 phone number email address',
         '2 +447700900986 test@example.com',
@@ -67,8 +65,7 @@ def test_upload_contact_list_page(client_request):
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to fix 1 email address. '
-            'Skip to file contents'
+            'You need to fix 1 email address.'
         ),
         'Row in file 1 email address',
         '2 Not a valid email address +447700900986',
@@ -80,8 +77,7 @@ def test_upload_contact_list_page(client_request):
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to fix 1 phone number. '
-            'Skip to file contents'
+            'You need to fix 1 phone number.'
         ),
         'Row in file 1 phone number',
         '2 Must not contain letters or symbols test@example.com',
@@ -94,8 +90,7 @@ def test_upload_contact_list_page(client_request):
         (
             'Your file has too many columns '
             'It needs to have 1 column, called ‘email address’ or ‘phone number’. '
-            'Right now it has 3 columns called ‘phone number’, ‘phone number’ and ‘PHONE_NUMBER’. '
-            'Skip to file contents'
+            'Right now it has 3 columns called ‘phone number’, ‘phone number’ and ‘PHONE_NUMBER’.'
         ),
         'Row in file 1 phone number phone number PHONE_NUMBER',
         '2 +447700900333 +447700900333 +447700900333',
@@ -106,8 +101,7 @@ def test_upload_contact_list_page(client_request):
         """,
         (
             'Your file is missing some rows '
-            'It needs at least one row of data. '
-            'Skip to file contents'
+            'It needs at least one row of data.'
         ),
         'Row in file 1 phone number',
         '',
@@ -117,8 +111,7 @@ def test_upload_contact_list_page(client_request):
         (
             'Your file is missing some rows '
             'It needs at least one row of data, in a column called '
-            '‘email address’ or ‘phone number’. '
-            'Skip to file contents'
+            '‘email address’ or ‘phone number’.'
         ),
         'Row in file 1 +447700900986',
         '',
@@ -128,8 +121,7 @@ def test_upload_contact_list_page(client_request):
         (
             'Your file is missing some rows '
             'It needs at least one row of data, in a column called '
-            '‘email address’ or ‘phone number’. '
-            'Skip to file contents'
+            '‘email address’ or ‘phone number’.'
         ),
         'Row in file 1',
         '',
@@ -143,8 +135,7 @@ def test_upload_contact_list_page(client_request):
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to enter missing data in 1 row. '
-            'Skip to file contents'
+            'You need to enter missing data in 1 row.'
         ),
         'Row in file 1 phone number',
         (
@@ -158,8 +149,7 @@ def test_upload_contact_list_page(client_request):
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to fix 1 phone number. '
-            'Skip to file contents'
+            'You need to fix 1 phone number.'
         ),
         'Row in file 1 phone number',
         '2 Not enough digits +447700900',
@@ -173,8 +163,7 @@ def test_upload_contact_list_page(client_request):
         """,
         (
             'There’s a problem with invalid.csv '
-            'You need to fix 2 email addresses. '
-            'Skip to file contents'
+            'You need to fix 2 email addresses.'
         ),
         'Row in file 1 email address',
         (
@@ -257,8 +246,7 @@ def test_upload_csv_file_shows_error_banner_for_too_many_rows(
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
         'Your file has too many rows '
         'Notify can store files up to 50,000 rows in size. '
-        'Your file has 50,001 rows. '
-        'Skip to file contents'
+        'Your file has 50,001 rows.'
     )
     assert len(page.select('tbody tr')) == 50
     assert normalize_spaces(page.select_one('.table-show-more-link').text) == (
@@ -288,8 +276,7 @@ def test_upload_csv_shows_trial_mode_error(
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
         'You cannot save this phone number '
-        'In trial mode you can only send to yourself and members of your team '
-        'Skip to file contents'
+        'In trial mode you can only send to yourself and members of your team'
     )
     assert page.select_one('.banner-dangerous a')['href'] == url_for(
         'main.trial_mode_new'


### PR DESCRIPTION
From DAC accessibility audit of Notify:

```
There is a skip link present on the page that is not visible for all users. A keyboard-only user
can tab to this link although the reason for their temporary loss of focus is not clear.
Voice activations users using Dragon NaturallySpeaking can tag the link, but it will also be
unclear what this relates to. Links such as this are highly beneficial for screen readers when
there are large blocks of content present, however, we feel it may not be required in this
instance.
```

We fixed one such link (on the page for bulk-sending notifications by uploading a CSV with personalisation). Now it is visible when highlighted / tabbed to. This will make it usable to keyboard and voice activation users.

We removed the links from other pages, where file contents the link skipped to were directly below the skip link, making the skip link redundant.