### PR TITLE
Fix pages which assume broadcasts have a finish time

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -41,9 +41,9 @@ class BroadcastMessage(JSONModel):
 
     def __lt__(self, other):
         return (
-            self.cancelled_at or self.finishes_at
+            self.cancelled_at or self.finishes_at or self.created_at
         ) < (
-            other.cancelled_at or other.finishes_at
+            other.cancelled_at or other.finishes_at or self.created_at
         )
 
     @classmethod

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -21,9 +21,6 @@
     {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
       <div class="banner govuk-!-margin-bottom-6">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-3">Your broadcast is waiting for approval from another member of your team</h2>
-        <p class="govuk-body">Once approved it will be live until
-          {{ broadcast_message.finishes_at|format_datetime_relative }}
-        </p>
         {{ page_footer(
           delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
           delete_link_text='Withdraw this broadcast'

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -760,7 +760,6 @@ def test_cant_approve_own_broadcast(
         normalize_spaces(page.select_one('.banner').text)
     ) == (
         'Your broadcast is waiting for approval from another member of your team '
-        'Once approved it will be live until tomorrow at 11:23pm '
         'Withdraw this broadcast'
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4284,6 +4284,7 @@ def mock_get_broadcast_messages(
             ),
             partial_json(
                 status='pending-approval',
+                finishes_at=None,
             ),
             partial_json(
                 status='broadcasting',


### PR DESCRIPTION
They no longer have a finish time until they have been approved. Previously it was the person preparing the broadcast who chose when it should finish.