### PR TITLE
Remove reference to end time for approver

### DIFF
--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -30,7 +30,7 @@
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
           {{ broadcast_message.created_by.name }} wants to broadcast this
-          message until {{ broadcast_message.finishes_at|format_datetime_relative }}.
+          message.
         </p>
         {{ page_footer(
           "Start broadcasting now",

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -687,7 +687,7 @@ def test_view_pending_broadcast(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             created_by_id=fake_uuid,
-            finishes_at='2020-02-23T23:23:23.000000',
+            finishes_at=None,
             status='pending-approval',
         ),
     )
@@ -706,7 +706,7 @@ def test_view_pending_broadcast(
     assert (
         normalize_spaces(page.select_one('.banner').text)
     ) == (
-        'Test User wants to broadcast this message until tomorrow at 11:23pm. '
+        'Test User wants to broadcast this message. '
         'Start broadcasting now Reject this broadcast'
     )
 


### PR DESCRIPTION
Messages awaiting approval don’t have an end time – it’s set automatically once the message is approved.

We need to revisit the content on this page, but this is just a fix so that the page doesn’t `500`.