### PR TITLE
Let people approve own broadcasts in training mode

### DIFF
--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,3 +1,4 @@
+{% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
@@ -7,46 +8,87 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  {{ broadcast_message.template_name }}
+  {% if broadcast_message.status == 'pending-approval' %}
+    {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
+      {{ broadcast_message.template_name }} is waiting for approval
+    {% elif current_user.has_permissions('send_messages') %}
+      {{ broadcast_message.created_by.name }} wants to broadcast
+      {{ broadcast_message.template_name }}
+    {% else %}
+      This alert is waiting for approval
+    {% endif %}
+  {% else %}
+    {{ broadcast_message.template_name }}
+  {% endif %}
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  {{ page_header(
-    broadcast_message.template_name,
-    back_link=url_for('.broadcast_dashboard', service_id=current_service.id)
-  ) }}
+  {{ govukBackLink({ "href": url_for('.broadcast_dashboard', service_id=current_service.id) }) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
     {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
       <div class="banner govuk-!-margin-bottom-6">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-3">Your broadcast is waiting for approval from another member of your team</h2>
-        {{ page_footer(
-          delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-          delete_link_text='Withdraw this broadcast'
-        ) }}
+        <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
+          {{ broadcast_message.template_name }} is waiting for approval
+        </h1>
+        {% if current_service.live %}
+          <p class="govuk-body">
+            You need another member of your team to approve your alert.
+          </p>
+          {{ page_footer(
+            delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+            delete_link_text='Withdraw this alert'
+          ) }}
+        {% else %}
+          <p class="govuk-body govuk-!-margin-bottom-3">
+            When you use a live account you’ll need another member of
+            your team to approve your alert.
+          </p>
+          <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
+            <summary class="govuk-details__summary govuk-clearfix">
+              Approve your own alert
+            </summary>
+            {% call form_wrapper() %}
+              <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3">
+                Because you’re in training mode you can approve
+                your own alerts, to see how it works.
+              </p>
+              <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+                No real alerts will be broadcast to anyone’s phone.
+              </p>
+              {{ page_footer(
+                "Start broadcasting now",
+                delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+                delete_link_text='Cancel this alert'
+              ) }}
+            {% endcall %}
+          </details>
+        {% endif %}
       </div>
     {% elif current_user.has_permissions('send_messages') %}
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
-        <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-          {{ broadcast_message.created_by.name }} wants to broadcast this
-          message.
-        </p>
+        <h1 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+          {{ broadcast_message.created_by.name }} wants to broadcast
+          {{ broadcast_message.template_name }}
+        </h1>
         {{ page_footer(
           "Start broadcasting now",
           delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-          delete_link_text='Reject this broadcast'
+          delete_link_text='Reject this alert'
         ) }}
       {% endcall %}
     {% else %}
       <div class="banner govuk-!-margin-bottom-6">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-3">This broadcast is waiting for approval</h2>
+        <h1 class="govuk-heading-m govuk-!-margin-bottom-3">This alert is waiting for approval</h1>
         <p class="govuk-body">
-          You don’t have permission to approve broadcasts.
+          You don’t have permission to approve alerts.
         </p>
       </div>
     {% endif %}
   {% else %}
+    {{ page_header(broadcast_message.template_name) }}
+
     <p class="govuk-body govuk-!-margin-bottom-3">
       Created by {{ broadcast_message.created_by.name }} and approved by
       {{ broadcast_message.approved_by.name }}.


### PR DESCRIPTION
We want to let users learn the system by trying it out. At the moment they can’t explore it fully by themselves because they’re blocked at the point of approving the broadcast, unless they involve in another member of their team. Having to involve another person is friction that will discourage people from exploring.

So this adds a button that lets people approve their own broadcasts in trial mode, with some rough-and-ready content that explains training mode and how it would be different to trial mode.

# Before

![image](https://user-images.githubusercontent.com/355079/90882183-762c2380-e3a3-11ea-8892-bf68247f74fb.png)

# After 

![image](https://user-images.githubusercontent.com/355079/90882217-87753000-e3a3-11ea-94a0-6826463e32aa.png)

![image](https://user-images.githubusercontent.com/355079/90882253-96f47900-e3a3-11ea-92f2-a408199a7c77.png)
