### PR TITLE
Ensure H2 headings follow H1 headings

### DIFF
--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -11,7 +11,7 @@ $item-top-padding: govuk-spacing(3);
     border-top: 1px solid $border-colour;
     position: relative;
 
-    h3 {
+    &-heading {
 
       padding-right: govuk-spacing(3);
       white-space: nowrap;

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -22,7 +22,7 @@
   <div class="user-list">
     {% for user in users %}
       <div class="user-list-item">
-        <h3 title="{{ user.email_address }}">
+        <h2 class="user-list-item-heading" title="{{ user.email_address }}">
           {%- if user.name -%}
             <span class="heading-small live-search-relevant">{{ user.name }}</span>&ensp;
           {%- endif -%}
@@ -37,7 +37,7 @@
               <span class="live-search-relevant">{{ user.email_address }}</span>
             {% endif %}
           </span>
-        </h3>
+        </h2>
         <ul class="tick-cross-list govuk-grid-row">
           <div class="tick-cross-list-permissions govuk-grid-column-three-quarters">
             {% for permission, label in permissions %}

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -25,7 +25,7 @@
   <div class="user-list">
     {% for user in users %}
       <div class="user-list-item">
-        <h3>
+        <h2 class="user-list-item-heading">
           {%- if user.name -%}
             <span class="heading-small">{{ user.name }}</span>&ensp;
           {%- endif -%}
@@ -40,7 +40,7 @@
               {{ user.email_address }}
             {% endif %}
           </span>
-        </h3>
+        </h2>
         <ul class="tick-cross-list">
           <li class="tick-cross-list-edit-link">
             {% if user.status == 'pending' %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -23,13 +23,13 @@
     {% endif %}
     {% for item in current_service.email_reply_to_addresses %}
       <div class="user-list-item">
-        <h3>
+        <h2 class="user-list-item-heading">
           <span class="heading-small">{{ item.email_address }}</span>&ensp;<span class="hint">
             {%- if item.is_default -%}
               (default)
             {% endif %}
           </span>
-        </h3>
+        </h2>
         {% if current_user.has_permissions('manage_service') %}
           <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
         {% endif %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -23,7 +23,7 @@
     {% endif %}
     {% for item in current_service.sms_senders_with_hints %}
       <div class="user-list-item">
-        <h3>
+        <h2 class="user-list-item-heading">
           <span class="heading-small">{{ item.sms_sender }}</span>
           {% if item.hint %}
             &ensp;
@@ -31,7 +31,7 @@
               {{ item.hint }}
             </span>
           {% endif %}
-        </h3>
+        </h2>
         {% if current_user.has_permissions('manage_service') %}
           <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
         {% endif %}

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1170,7 +1170,7 @@ def test_manage_user_page_shows_how_many_folders_user_can_view(
 
     page = client_request.get('main.manage_users', service_id=service_one['id'])
 
-    user_div = page.select_one("h3[title='notify@digital.cabinet-office.gov.uk']").parent
+    user_div = page.select_one("h2[title='notify@digital.cabinet-office.gov.uk']").parent
     assert user_div.select_one('.tick-cross-list-hint:last-child').text.strip() == expected_message
 
 
@@ -1187,7 +1187,7 @@ def test_manage_user_page_doesnt_show_folder_hint_if_service_has_no_folders(
 
     page = client_request.get('main.manage_users', service_id=service_one['id'])
 
-    user_div = page.select_one("h3[title='notify@digital.cabinet-office.gov.uk']").parent
+    user_div = page.select_one("h2[title='notify@digital.cabinet-office.gov.uk']").parent
     assert user_div.find('.tick-cross-list-hint:last-child') is None
 
 
@@ -1206,7 +1206,7 @@ def test_manage_user_page_doesnt_show_folder_hint_if_service_cant_edit_folder_pe
 
     page = client_request.get('main.manage_users', service_id=service_one['id'])
 
-    user_div = page.select_one("h3[title='notify@digital.cabinet-office.gov.uk']").parent
+    user_div = page.select_one("h2[title='notify@digital.cabinet-office.gov.uk']").parent
     assert user_div.find('.tick-cross-list-hint:last-child') is None
 
 


### PR DESCRIPTION
We had some cases where an H3 heading followed an H1. This was flagged as something to change in the accessibility report.