### PR TITLE
Replace ‘broadcast’ with ‘alert’ on dashboard

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -53,17 +53,17 @@ def get_broadcast_dashboard_partials(service_id):
         pending_approval_broadcasts=render_template(
             'views/broadcast/partials/dashboard-table.html',
             broadcasts=broadcast_messages.with_status('pending-approval'),
-            empty_message='You do not have any broadcasts waiting for approval',
+            empty_message='You do not have any alerts waiting for approval',
         ),
         live_broadcasts=render_template(
             'views/broadcast/partials/dashboard-table.html',
             broadcasts=broadcast_messages.with_status('broadcasting'),
-            empty_message='You do not have any live broadcasts at the moment',
+            empty_message='You do not have any live alerts at the moment',
         ),
         previous_broadcasts=render_template(
             'views/broadcast/partials/dashboard-table.html',
             broadcasts=broadcast_messages.with_status('cancelled', 'completed'),
-            empty_message='You do not have any previous broadcasts',
+            empty_message='You do not have any previous alerts',
         ),
     )
 

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -18,7 +18,7 @@
     </nav>
   {% endif %}
 
-  <h2 class="heading-medium govuk-!-margin-bottom-2">Live broadcasts</h2>
+  <h2 class="heading-medium govuk-!-margin-bottom-2">Live alerts</h2>
 
   {{ ajax_block(
     partials,
@@ -34,7 +34,7 @@
     'pending_approval_broadcasts'
   ) }}
 
-  <h2 class="heading-medium govuk-!-margin-bottom-2">Previous broadcasts</h2>
+  <h2 class="heading-medium govuk-!-margin-bottom-2">Previous alerts</h2>
 
   {{ ajax_block(
     partials,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -164,9 +164,9 @@ def test_empty_broadcast_dashboard(
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr .table-empty-message')
     ] == [
-        'You do not have any live broadcasts at the moment',
-        'You do not have any broadcasts waiting for approval',
-        'You do not have any previous broadcasts',
+        'You do not have any live alerts at the moment',
+        'You do not have any alerts waiting for approval',
+        'You do not have any previous alerts',
     ]
 
 
@@ -184,7 +184,7 @@ def test_broadcast_dashboard(
     )
 
     assert normalize_spaces(page.select('main h2')[0].text) == (
-        'Live broadcasts'
+        'Live alerts'
     )
     assert [
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
@@ -202,7 +202,7 @@ def test_broadcast_dashboard(
     ]
 
     assert normalize_spaces(page.select('main h2')[2].text) == (
-        'Previous broadcasts'
+        'Previous alerts'
     )
     assert [
         normalize_spaces(row.text) for row in page.select('table')[2].select('tbody tr')


### PR DESCRIPTION
We’re moving away from ‘broadcast’ as a noun, so this commit updates the dashboard to be in line with changes in other PRs.