### PR TITLE
Fix copy to clipboard

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -807,6 +807,7 @@ def add_template_filters(application):
         format_notification_status_as_url,
         format_number_in_pounds_as_currency,
         formatters.formatted_list,
+        formatters.normalise_lines,
         nl2br,
         format_phone_number_human_readable,
         format_thousands,

--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -6,13 +6,24 @@
   Modules.ApiKey = function() {
 
     const states = {
-      'keyVisible': (key, thing) => `
-        <span class="api-key__key">${key}</span>
-        <input type='button' class='govuk-button govuk-button--secondary api-key__button--copy' value='Copy ${thing} to clipboard' />
+      'keyVisible': (options) => `
+        <span class="api-key__key">
+          ${options.keyLabel ? '<span class="govuk-visually-hidden">' + options.thing + ': </span>' : ''}${options.key}
+        </span>
+        <span class="api-key__notice govuk-visually-hidden" aria-live="assertive">
+          ${options.onload ? '' : options.thing + ' returned to page, press button to copy to clipboard'}
+        </span>
+        <button class="govuk-button govuk-button--secondary api-key__button--copy">
+          Copy ${options.thing} to clipboard${options.name ? '<span class="govuk-visually-hidden"> for ' + options.name + '</span>' : ''}
+        </button>
       `,
-      'keyCopied': thing => `
-        <span class="api-key__key">Copied to clipboard</span>
-        <input type='button' class='govuk-button govuk-button--secondary api-key__button--show' value='Show ${thing}' />
+      'keyCopied': (options) => `
+        <span class="api-key__notice" aria-live="assertive">
+          <span class="govuk-visually-hidden">${options.thing} </span>Copied to clipboard<span class="govuk-visually-hidden">, press button to show in page</span>
+        </span>
+        <button class="govuk-button govuk-button--secondary api-key__button--show">
+          Show ${options.thing}${options.name ? '<span class="govuk-visually-hidden"> for ' + options.name + '</span>' : ''}
+        </button>
       `
     };
 
@@ -30,24 +41,38 @@
     this.start = function(component) {
 
       const $component = $(component),
-            key = $component.data('key'),
-            thing = $component.data('thing');
+            stateOptions = {
+              key: $component.data('key'),
+              thing: $component.data('thing')
+            },
+            name = $component.data('name');
+
+      // if the name is distinct from the thing:
+      // - it will be used in the rendering
+      // - the key won't be identified by a heading so needs its own label
+      if (name !== stateOptions.thing) {
+        stateOptions.name = name;
+        stateOptions.keyLabel = true;
+      }
 
       $component
         .addClass('api-key')
         .css('min-height', $component.height())
-        .html(states.keyVisible(key, thing))
-        .attr('aria-live', 'polite')
+        .html(states.keyVisible($.extend({ 'onload': true }, stateOptions)))
         .on(
           'click', '.api-key__button--copy', () =>
             this.copyKey(
               $('.api-key__key', component)[0], () =>
-                $component.html(states.keyCopied(thing))
+                $component
+                  .html(states.keyCopied(stateOptions))
+                  .find('.govuk-button').focus()
             )
         )
         .on(
           'click', '.api-key__button--show', () =>
-            $component.html(states.keyVisible(key, thing))
+            $component
+              .html(states.keyVisible(stateOptions))
+              .find('.govuk-button').focus()
         );
 
       if ('stickAtBottomWhenScrolling' in GOVUK) {

--- a/app/assets/stylesheets/components/api-key.scss
+++ b/app/assets/stylesheets/components/api-key.scss
@@ -9,6 +9,7 @@
     margin-bottom: 5px;
   }
 
+  &__notice,
   &__key {
     font-family: monospace;
     display: block;

--- a/app/templates/components/api-key.html
+++ b/app/templates/components/api-key.html
@@ -1,11 +1,13 @@
-{% macro api_key(key, name, thing="API key", heading=True) %}
-  {% if heading %}
+{% macro api_key(key, name, thing="API key") %}
+  {% if name == thing %}
     <h2 class="api-key__name">
       {{ name }}
     </h2>
   {% endif %}
-  <div data-module="api-key" data-key="{{ key }}" data-thing="{{ thing }}"{% if not heading %}data-name="{{ name }}"{% endif %}>
-    <span class="api-key__key"><span class="govuk-visually-hidden">{{ thing }}: </span>{{ key }}</span>
+  <div data-module="api-key" data-key="{{ key }}" data-thing="{{ thing }}" data-name="{{ name }}">
+    <span class="api-key__key">
+      {% if name != thing %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ key }}
+    </span>
     <span class="api-key__notice" aria-live="assertive"></span>
   </div>
 {% endmacro %}

--- a/app/templates/components/api-key.html
+++ b/app/templates/components/api-key.html
@@ -1,10 +1,11 @@
-{% macro api_key(key, name=None, thing="API key") %}
-  {% if name %}
+{% macro api_key(key, name, thing="API key", heading=True) %}
+  {% if heading %}
     <h2 class="api-key__name">
       {{ name }}
     </h2>
   {% endif %}
-  <div data-module="api-key" data-key="{{ key }}" data-thing="{{ thing }}" aria-live="assertive">
-    <span class="api-key__key">{{ key }}</span>
+  <div data-module="api-key" data-key="{{ key }}" data-thing="{{ thing }}"{% if not heading %}data-name="{{ name }}"{% endif %}>
+    <span class="api-key__key"><span class="govuk-visually-hidden">{{ thing }}: </span>{{ key }}</span>
+    <span class="api-key__notice" aria-live="assertive"></span>
   </div>
 {% endmacro %}

--- a/app/templates/views/api/keys/show.html
+++ b/app/templates/views/api/keys/show.html
@@ -24,7 +24,8 @@
 
       {{ api_key(
         '{}-{}-{}'.format(key_name, service_id, secret),
-        'API key'
+        name='API key',
+        thing='API key'
       ) }}
 
       {{ page_footer(

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -34,7 +34,7 @@
           <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
         {% endif %}
         {% if current_service.count_email_reply_to_addresses > 1 %}
-          {{ api_key(item.id, thing="ID") }}
+          {{ api_key(item.id, item.email_address, thing="ID", heading=False) }}
         {% endif %}
       </div>
     {% endfor %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -34,7 +34,7 @@
           <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
         {% endif %}
         {% if current_service.count_email_reply_to_addresses > 1 %}
-          {{ api_key(item.id, item.email_address, thing="ID", heading=False) }}
+          {{ api_key(item.id, name=item.email_address, thing="ID") }}
         {% endif %}
       </div>
     {% endfor %}

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -43,7 +43,8 @@
         <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
         {% endif %}
         {% if letter_contact_details|length  > 1 %}
-          {{ api_key(item.id, thing="ID") }}
+          {% set first_line_of_contact_block = item.contact_block|normalise_lines|first %}
+          {{ api_key(item.id, name=first_line_of_contact_block, thing="ID") }}
         {% endif %}
       </div>
     {% endfor %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -36,7 +36,7 @@
           <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
         {% endif %}
         {% if current_service.count_sms_senders > 1 %}
-          {{ api_key(item.id, thing="ID") }}
+          {{ api_key(item.id, name=item.sms_sender, thing="ID") }}
         {% endif %}
       </div>
     {% endfor %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2106,9 +2106,9 @@ def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
         'app.service_api_client.get_reply_to_email_addresses',
         create_multiple_email_reply_to_addresses(),
         [
-            'test@example.com (default) Change 1234',
-            'test2@example.com Change 5678',
-            'test3@example.com Change 9457',
+            'test@example.com (default) Change ID: 1234',
+            'test2@example.com Change ID: 5678',
+            'test3@example.com Change ID: 9457',
         ],
     ), (
         'main.service_letter_contact_details',
@@ -2116,18 +2116,18 @@ def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
         create_multiple_letter_contact_blocks(),
         [
             'Blank Make default',
-            '1 Example Street (default) Change 1234',
-            '2 Example Street Change 5678',
-            'foo<bar>baz Change 9457',
+            '1 Example Street (default) Change ID: 1234',
+            '2 Example Street Change ID: 5678',
+            'foo<bar>baz Change ID: 9457',
         ],
     ), (
         'main.service_sms_senders',
         'app.service_api_client.get_sms_senders',
         create_multiple_sms_senders(),
         [
-            'Example (default and receives replies) Change 1234',
-            'Example 2 Change 5678',
-            'Example 3 Change 9457',
+            'Example (default and receives replies) Change ID: 1234',
+            'Example 2 Change ID: 5678',
+            'Example 3 Change ID: 9457',
         ],
     ),
     ]

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -785,7 +785,7 @@ def test_should_show_template_id_on_template_page(
         template_id=fake_uuid,
         _test_page_title=False,
     )
-    assert page.select('.api-key__key')[0].text == fake_uuid
+    assert fake_uuid in page.select('.api-key__key')[0].text
 
 
 def test_should_hide_template_id_for_broadcast_templates(


### PR DESCRIPTION
Changes how the aria live-region is implemented in the 'Copy to clipboard' (AKA `api_key`) component so what is announced is clearer.

https://www.pivotaltracker.com/story/show/174294716

# The problem

The 'copy to clipboard' button failed the Web Content Accessibility Guidelines (WCAG) on [success criteria 4.1.3 Status messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html). The tester reported that the content injected into the page is not announced.

The changes _are_ actually announced but the announcement is unclear because the whole component is an [aria live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) so it announces the button and text above it whenever its state changes:

<img width="569" alt="copy_to_clipboard_current_live_region" src="https://user-images.githubusercontent.com/87140/91194427-0ba31c80-e6f0-11ea-98cb-8f9d296d63fd.png">

# Proposed solution

## Before (using Voiceover)

- Focus moves to the button
- `Copy to clipboard, button` announced
- user clicks button
- `Press copy to clipboard, copied to clipboard, show ID` announced
- user clicks button
- `Press show ID, 8b31d0eb-4d15-4a42-9d0a-6aaea0bcdbd1, copy to clipboard` announced

[Audio version of existing flow](https://drive.google.com/file/d/1fnGDgy4OoKJMWSQlebldEyKwuXx-tg2T/view?usp=sharing)

## After (using Voiceover)

- Focus moves to the button
- `Copy to clipboard for tom.byers+notify-reply@digital-cabinet.office.gov.uk, Button` announced
- user clicks button
- `Id copied to clipboard, press button to show in page` announced
- user clicks button
- `Id returned to page, press button to copy to clipboard` announced

[Audio version of new flow](https://drive.google.com/file/d/1HZfXzoxuR_0n2mEEiVCCjrHUfOPdnqzk/view?usp=sharing)

# Changes to the code

There aren't many changes but I think they all need explaining in a bit of depth. They are:
1. move the live region so it only contains text we want announced and add some hidden text to explain how to:
    a. show the ID again when it's copied
    b. copy the ID when it is shown in the page again
2. add hidden text to the ID string to say what it is
3. add some hidden suffix text to the button so it works isolated from its context in the page

## 1. Move the live region so it only contains text we want announced

The live region is now a separate `<span>` which is shown when the ID is copied (as: "Copied to clipboard") and hidden when the ID is returned to the page, to make space for the ID string.

```html
<span class="api-key__notice" aria-live="assertive">
    ID </span>Copied to clipboard<span class="govuk-visually-hidden">, press button to show in page</span> 
</span>
```

The extra, hidden, text was added because the live region is set to `assertive` so it speaks over any other announcements. This means when the state changes it's not clear what the button does now.

The text says "press button to show in page" when copied and "press button to copy to clipboard" when shown again.

## 2. Add hidden text to the ID string to say what it is

If the component doesn't show its heading, we add a hidden prefix to the ID so it is labelled.

```html
<span class="api-key__key">
    <span class="govuk-visually-hidden">ID: </span>8b31d0eb-4d15-4a42-9d0a-6aaea0bcdbd1
</span>
```

## 3. Add extra text to the button so it works isolated from its context in the page

If you have multiple 'Copy to clipboard' components in the page, the buttons all have the same text.

```html
<button class="govuk-button govuk-button--secondary api-key__button--show">
    Show ID<span class="govuk-visually-hidden"> for tom.byers+notify-reply@digital.cabinet-office.gov.uk</span>
</button>
```

Fixes the issue raised in this story: https://www.pivotaltracker.com/story/show/174187762

# Changes to the tests

I rewrote the testsuite for `app/assets/javascripts/apiKey.js` so it tests all the variations of HTML the `api_key` component can give it onload. Seeing their output is the best way to understand the changes I made to the component code.

You can run them on their own by running this in your terminal:
```bash
npx jest --config tests/javascripts/jest.config.js tests/javascripts/apiKey.test.js
```