### PR TITLE
Make ‘Add another area’ button wrap where possible

### DIFF
--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -1,5 +1,7 @@
 .area-list {
 
+  display: inline-block;
+  
   &-item {
 
     display: inline-block;


### PR DESCRIPTION
Broke this while fixing the spacing between the buttons and the areas.

# Before 

![image](https://user-images.githubusercontent.com/355079/91284135-6b96d300-e783-11ea-84cf-d3fd162a297f.png)

# After 

![image](https://user-images.githubusercontent.com/355079/91284198-7e110c80-e783-11ea-8b3e-f7aadc1c8075.png)
