### PR TITLE
Fix link and button text across pages

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -246,7 +246,9 @@
     this.itemsSelectedButtons = $(`
       <div id="items_selected">
         <div class="js-stick-at-bottom-when-scrolling">
-          <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="move-to-existing-folder">Move</button>
+          <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="move-to-existing-folder">
+            Move<span class="govuk-visually-hidden"> selection to folder</span>
+          </button>
           <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="move-to-new-folder">Add to new folder</button>
           <div class="template-list-selected-counter" aria-hidden="true">
             <span class="template-list-selected-counter__count" aria-hidden="true">

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -690,7 +690,7 @@ def delete_service_template(service_id, template_id):
         else:
             raise e
 
-    flash(["Are you sure you want to delete ‘{}’?".format(template['name']), message], 'delete')
+    flash(["Are you sure you want to delete ‘{}’?".format(template['name']), message, template['name']], 'delete')
     return render_template(
         'views/templates/template.html',
         template=get_template(

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -1,7 +1,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
 
-{% macro banner(body, type=None, with_tick=False, delete_button=None, subhead=None, context=None, action=None, id=None) %}
+{% macro banner(body, type=None, with_tick=False, delete_button=None, subhead=None, context=None, action=None, id=None, thing=None) %}
   <div
     class='banner{% if type %}-{{ type }}{% endif %}{% if with_tick %}-with-tick{% endif %}'
     {% if type == 'dangerous' %}
@@ -25,7 +25,8 @@
       {% call form_wrapper(action=action) %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {{ govukButton({
-          "text": delete_button,
+          "text": "" if thing else delete_button,
+          "html": delete_button + "<span class=\"govuk-visually-hidden\"> ‘" + thing + "’</span>" if thing else "",
           "name": "delete",
           "classes": "govuk-button--warning govuk-!-margin-top-2",
         }) }}
@@ -34,6 +35,6 @@
   </div>
 {% endmacro %}
 
-{% macro banner_wrapper(type=None, with_tick=False, delete_button=None, subhead=None, action=None, id=None) %}
-  {{ banner(caller()|safe, type=type, with_tick=with_tick, delete_button=delete_button, subhead=subhead, action=action, id=id) }}
+{% macro banner_wrapper(type=None, with_tick=False, delete_button=None, subhead=None, action=None, id=None, thing=None) %}
+  {{ banner(caller()|safe, type=type, with_tick=with_tick, delete_button=delete_button, subhead=subhead, action=action, id=id, thing=thing) }}
 {% endmacro %}

--- a/app/templates/components/cookie-banner.html
+++ b/app/templates/components/cookie-banner.html
@@ -19,7 +19,7 @@
     <p class="notify-cookie-banner__confirmation-message govuk-body">
       You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.
     </p>
-    <button class="notify-cookie-banner__hide-button govuk-link" data-hide-cookie-banner="true" role="link">Hide</button>
+    <button class="notify-cookie-banner__hide-button govuk-link" data-hide-cookie-banner="true" role="link">Hide<span class="govuk-visually-hidden"> cookies message</span></button>
   </div>
 </div>
 {% endmacro %}

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -4,6 +4,7 @@
   button_text=None,
   button_name=None,
   button_value=None,
+  button_text_hidden_suffix=None,
   destructive=False,
   secondary_link=False,
   secondary_link_text=None,
@@ -20,6 +21,11 @@
       {% if centered_button %}{% set _ = button_data.update({"classes": "page-footer__button--centred"}) %}{% endif %}
       {% if button_name %}{% set _ = button_data.update({"name": button_name}) %}{% endif %}
       {% if button_value %}{% set _ = button_data.update({"value": button_value}) %}{% endif %}
+      {% if button_text_hidden_suffix %}
+        {% set _ = button_data.update({
+          "text": "", "html": button_text + "<span class=\"govuk-visually-hidden\"> " + button_text_hidden_suffix + "</span>"
+        }) %}
+      {% endif %}
 
       {{ govukButton(button_data) }}
 

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -121,10 +121,13 @@
   {% endcall %}
 {%- endmacro %}
 
-{% macro edit_field(text, link, permissions=[]) -%}
+{% macro edit_field(text, link, permissions=[], suffix=None) -%}
   {% call field(align='right') %}
     {% if not permissions or current_user.has_permissions(*permissions) %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">{{ text }}</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ link }}">
+        {{ text }}
+        {%- if suffix %}<span class="govuk-visually-hidden"> {{ suffix }}</span>{% endif -%}
+      </a>
     {% endif %}
   {% endcall %}
 {%- endmacro %}

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -15,7 +15,8 @@
           'default' if ((category == 'default') or (category == 'default_with_tick')) else 'dangerous',
           delete_button=delete_button_text,
           with_tick=True if category == 'default_with_tick' else False,
-          context=message[1] if message is not string
+          context=message[1] if message is not string,
+          thing=message[2] if message is not string and message[2]
         )}}
       </div>
     {% endfor %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -73,7 +73,7 @@
           {% if current_user.has_permissions('manage_service') %}
             <li class="tick-cross-list-edit-link">
               {% if user.status == 'pending' %}
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation<span class="govuk-visually-hidden"> for {{ user.email_address }}</span></a>
               {% elif user.state == 'active' and current_user.id != user.id %}
                 <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details<span class="govuk-visually-hidden"> for {{ user.name }} {{ user.email_address }}</a>
               {% endif %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -75,7 +75,7 @@
               {% if user.status == 'pending' %}
                 <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.cancel_invited_user', service_id=current_service.id, invited_user_id=user.id)}}">Cancel invitation</a>
               {% elif user.state == 'active' and current_user.id != user.id %}
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id)}}">Change details<span class="govuk-visually-hidden"> for {{ user.name }} {{ user.email_address }}</a>
               {% endif %}
             </li>
           {% endif %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -25,7 +25,8 @@
           {{ edit_field(
               'Change',
               url_for('.service_name_change', service_id=current_service.id),
-              permissions=['manage_service']
+              permissions=['manage_service'],
+              suffix='service name',
             )
           }}
         {% endcall %}
@@ -39,9 +40,9 @@
           ) }}
           {{ edit_field(
               'Change',
-              url_for('.service_set_auth_type',
-              service_id=current_service.id),
-              permissions=['manage_service']
+              url_for('.service_set_auth_type', service_id=current_service.id),
+              permissions=['manage_service'],
+              suffix='sign-in method',
             )
           }}
         {% endcall %}
@@ -66,7 +67,8 @@
                 channel='email',
                 service_id=current_service.id
               ),
-              permissions=['manage_service']
+              permissions=['manage_service'],
+              suffix='your settings for sending emails',
             )}}
           {% endcall %}
 
@@ -82,9 +84,9 @@
             {% endcall %}
             {{ edit_field(
                 'Manage',
-                url_for('.service_email_reply_to',
-                service_id=current_service.id),
-                permissions=['manage_service','manage_api_keys']
+                url_for('.service_email_reply_to', service_id=current_service.id),
+                permissions=['manage_service','manage_api_keys'],
+                suffix='reply-to email addresses',
               )
             }}
           {% endcall %}
@@ -96,6 +98,7 @@
               'Change',
               url_for('.branding_request', service_id=current_service.id, branding_type="email"),
               permissions=['manage_service'],
+              suffix='email branding',
             )}}
           {% endcall %}
 
@@ -106,6 +109,7 @@
               'Manage',
               url_for('.send_files_by_email_contact_details', service_id=current_service.id),
               permissions=['manage_service'],
+              suffix='sending files by email',
             )}}
           {% endcall %}
 
@@ -128,7 +132,8 @@
                 service_id=current_service.id,
                 channel='sms'
               ),
-              permissions=['manage_service']
+              permissions=['manage_service'],
+              suffix='your settings for sending text messages',
             )}}
           {% endcall %}
 
@@ -144,9 +149,9 @@
             {% endcall %}
             {{ edit_field(
                 'Manage',
-                url_for('.service_sms_senders',
-                service_id=current_service.id),
-                permissions=['manage_service','manage_api_keys']
+                url_for('.service_sms_senders', service_id=current_service.id),
+                permissions=['manage_service','manage_api_keys'],
+                suffix='text message senders',
             )
             }}
           {% endcall %}
@@ -156,9 +161,9 @@
             {{ boolean_field(current_service.prefix_sms) }}
             {{ edit_field(
                 'Change',
-                url_for('.service_set_sms_prefix',
-                service_id=current_service.id),
-                permissions=['manage_service']
+                url_for('.service_set_sms_prefix', service_id=current_service.id),
+                permissions=['manage_service'],
+                suffix='your settings for starting text messages with service name',
             )
             }}
           {% endcall %}
@@ -168,9 +173,9 @@
             {{ boolean_field('international_sms' in current_service.permissions) }}
             {{ edit_field(
                 'Change',
-                url_for('.service_set_international_sms',
-                service_id=current_service.id),
-                permissions=['manage_service']
+                url_for('.service_set_international_sms', service_id=current_service.id),
+                permissions=['manage_service'],
+                suffix='your settings for sending international text messages',
             )
             }}
           {% endcall %}
@@ -180,9 +185,9 @@
             {{ boolean_field('inbound_sms' in current_service.permissions) }}
             {{ edit_field(
                 'Change',
-                url_for('.service_set_inbound_sms',
-                service_id=current_service.id),
-                permissions=['manage_service']
+                url_for('.service_set_inbound_sms', service_id=current_service.id),
+                permissions=['manage_service'],
+                suffix='your settings for receiving text messages',
             )
             }}
           {% endcall %}
@@ -206,7 +211,8 @@
                 channel='letter',
                 service_id=current_service.id
               ),
-              permissions=['manage_service']
+              permissions=['manage_service'],
+              suffix='your settings for sending letters',
             )}}
           {% endcall %}
 
@@ -228,9 +234,9 @@
             {% endcall %}
             {{ edit_field(
                 'Manage',
-                url_for('.service_letter_contact_details',
-                service_id=current_service.id),
-                permissions=['manage_service','manage_api_keys']
+                url_for('.service_letter_contact_details', service_id=current_service.id),
+                permissions=['manage_service','manage_api_keys'],
+                suffix='sender addresses',
             )
             }}
           {% endcall %}
@@ -241,7 +247,8 @@
             {{ edit_field(
               'Change',
               url_for('.branding_request', service_id=current_service.id, branding_type="letter"),
-              permissions=['manage_service']
+              permissions=['manage_service'],
+              suffix='letter branding',
             )}}
           {% endcall %}
 
@@ -308,14 +315,14 @@
               {{ text_field('') }}
             {% else %}
               {{ boolean_field(not current_service.trial_mode) }}
-              {{ edit_field('Change', url_for('.service_switch_live', service_id=current_service.id)) }}
+              {{ edit_field('Change', url_for('.service_switch_live', service_id=current_service.id), suffix='service status') }}
             {% endif %}
           {% endcall %}
 
           {% call row() %}
             {{ text_field('Count in list of live services')}}
             {{ text_field('Yes' if current_service.count_as_live else 'No') }}
-            {{ edit_field('Change', url_for('.service_switch_count_as_live', service_id=current_service.id)) }}
+            {{ edit_field('Change', url_for('.service_switch_count_as_live', service_id=current_service.id), suffix='if service is counted in list of live services') }}
           {% endcall %}
 
           {% call row() %}
@@ -334,30 +341,30 @@
                 </div>
               {% endif %}
             {% endcall %}
-            {{ edit_field('Change', url_for('.link_service_to_organisation', service_id=current_service.id)) }}
+            {{ edit_field('Change', url_for('.link_service_to_organisation', service_id=current_service.id), suffix='organisation for service') }}
           {% endcall %}
 
           {% call row() %}
             {{ text_field('Free text message allowance')}}
             {{ text_field('{:,}'.format(current_service.free_sms_fragment_limit)) }}
-            {{ edit_field('Change', url_for('.set_free_sms_allowance', service_id=current_service.id)) }}
+            {{ edit_field('Change', url_for('.set_free_sms_allowance', service_id=current_service.id), suffix='free text message allowance') }}
           {% endcall %}
           {% call row() %}
             {{ text_field('Email branding' )}}
             {{ text_field(current_service.email_branding_name) }}
-            {{ edit_field('Change', url_for('.service_set_email_branding', service_id=current_service.id)) }}
+            {{ edit_field('Change', url_for('.service_set_email_branding', service_id=current_service.id), suffix='email branding (admin view)') }}
           {% endcall %}
           {% call row() %}
             {{ text_field('Letter branding')}}
             {{ optional_text_field(current_service.letter_branding.name) }}
-            {{ edit_field('Change', url_for('.service_set_letter_branding', service_id=current_service.id)) }}
+            {{ edit_field('Change', url_for('.service_set_letter_branding', service_id=current_service.id), suffix='letter branding (admin view)') }}
           {% endcall %}
           {% call row() %}
             {{ text_field('Data retention')}}
             {% call field() %}
                 {{ current_service.data_retention | join(', ', attribute='notification_type') }}
             {% endcall %}
-            {{ edit_field('Change', url_for('.data_retention', service_id=current_service.id)) }}
+            {{ edit_field('Change', url_for('.data_retention', service_id=current_service.id), suffix='data retention') }}
           {% endcall %}
 
           {% for permission in service_permissions %}
@@ -365,7 +372,15 @@
               {% call row() %}
                 {{ text_field(service_permissions[permission].title)}}
                 {{ boolean_field(current_service.has_permission(permission)) }}
-                {{ edit_field('Change', url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None)) }}
+                {{ edit_field(
+                    'Change',
+                    url_for(
+                      service_permissions[permission].endpoint or '.service_set_permission',
+                      service_id=current_service.id,
+                      permission=permission if not service_permissions[permission].endpoint else None
+                    ),
+                    suffix='your settings for ' + service_permissions[permission].title,
+                  ) }}
               {% endcall %}
             {% endif %}
           {% endfor %}

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -10,7 +10,7 @@
       {{ radios_nested(templates_and_folders_form.move_to, move_to_children, option_hints=option_hints) }}
       </div>
       <div class="js-will-stick-at-bottom-when-scrolling">
-      {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder') }}
+      {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder', button_text_hidden_suffix=' selection to folder') }}
       </div>
     </div>
     <div id="move_to_new_folder_form">

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -24,7 +24,7 @@
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
-                Send
+                Send<span class="govuk-visually-hidden"> a message using this template</span>
               </a>
             </div>
           {% endif %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -39,7 +39,7 @@
           {% if current_user.has_permissions('manage_templates') %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
-                Edit
+                Edit<span class="govuk-visually-hidden"> this template</span>
               </a>
             </div>
           {% endif %}
@@ -47,7 +47,7 @@
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
-                Send
+                Send<span class="govuk-visually-hidden"> a message using this template</span>
               </a>
             </div>
           {% endif %}

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -114,13 +114,16 @@ def test_service_set_permission(
 
 
 @pytest.mark.parametrize('service_fields, endpoint, kwargs, text', [
-    ({'restricted': True}, '.service_switch_live', {}, 'Live Off Change'),
-    ({'restricted': False}, '.service_switch_live', {}, 'Live On Change'),
-    ({'permissions': ['sms']}, '.service_set_inbound_number', {}, 'Receive inbound SMS Off Change'),
+    ({'restricted': True}, '.service_switch_live', {}, 'Live Off Change service status'),
+    ({'restricted': False}, '.service_switch_live', {}, 'Live On Change service status'),
+    ({'permissions': ['sms']}, '.service_set_inbound_number', {},
+        'Receive inbound SMS Off Change your settings for Receive inbound SMS'),
     ({'permissions': ['letter']},
-     '.service_set_permission', {'permission': 'upload_letters'}, 'Uploading letters Off Change'),
+     '.service_set_permission', {'permission': 'upload_letters'},
+        'Uploading letters Off Change your settings for Uploading letters'),
     ({'permissions': ['letter']},
-     '.service_set_permission', {'permission': 'international_letters'}, 'Send international letters Off Change'),
+     '.service_set_permission', {'permission': 'international_letters'},
+        'Send international letters Off Change your settings for Send international letters'),
 ])
 def test_service_setting_toggles_show(
     mocker,

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -36,7 +36,7 @@ from tests.conftest import (
             'Cannot Add and edit templates '
             'Cannot Manage settings, team and usage '
             'Cannot Manage API integration '
-            'Change details'
+            'Change details for ZZZZZZZZ zzzzzzz@example.gov.uk'
         )
     ),
     (
@@ -1050,7 +1050,7 @@ def test_cancel_invited_user_doesnt_work_if_user_not_invited_to_this_service(
         'Cannot Add and edit templates '
         'Can Manage settings, team and usage '
         'Can Manage API integration '
-        'Cancel invitation'
+        'Cancel invitation for invited_user@test.gov.uk'
     )),
     ('cancelled', (
         'invited_user@test.gov.uk (cancelled invite) '

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -55,59 +55,59 @@ def mock_get_service_settings_page_common(
     (create_active_user_with_permissions(), [
 
         'Label Value Action',
-        'Service name Test Service Change',
-        'Sign-in method Text message code Change',
+        'Service name Test Service Change service name',
+        'Sign-in method Text message code Change sign-in method',
 
         'Label Value Action',
-        'Send emails On Change',
-        'Reply-to email addresses Not set Manage',
-        'Email branding GOV.UK Change',
-        'Send files by email contact_us@gov.uk Manage',
+        'Send emails On Change your settings for sending emails',
+        'Reply-to email addresses Not set Manage reply-to email addresses',
+        'Email branding GOV.UK Change email branding',
+        'Send files by email contact_us@gov.uk Manage sending files by email',
 
         'Label Value Action',
-        'Send text messages On Change',
-        'Text message senders GOVUK Manage',
-        'Start text messages with service name On Change',
-        'Send international text messages Off Change',
-        'Receive text messages Off Change',
+        'Send text messages On Change your settings for sending text messages',
+        'Text message senders GOVUK Manage text message senders',
+        'Start text messages with service name On Change your settings for starting text messages with service name',
+        'Send international text messages Off Change your settings for sending international text messages',
+        'Receive text messages Off Change your settings for receiving text messages',
 
         'Label Value Action',
-        'Send letters Off Change',
+        'Send letters Off Change your settings for sending letters',
 
     ]),
     (create_platform_admin_user(), [
 
         'Label Value Action',
-        'Service name Test Service Change',
-        'Sign-in method Text message code Change',
+        'Service name Test Service Change service name',
+        'Sign-in method Text message code Change sign-in method',
 
         'Label Value Action',
-        'Send emails On Change',
-        'Reply-to email addresses Not set Manage',
-        'Email branding GOV.UK Change',
-        'Send files by email contact_us@gov.uk Manage',
+        'Send emails On Change your settings for sending emails',
+        'Reply-to email addresses Not set Manage reply-to email addresses',
+        'Email branding GOV.UK Change email branding',
+        'Send files by email contact_us@gov.uk Manage sending files by email',
 
         'Label Value Action',
-        'Send text messages On Change',
-        'Text message senders GOVUK Manage',
-        'Start text messages with service name On Change',
-        'Send international text messages Off Change',
-        'Receive text messages Off Change',
+        'Send text messages On Change your settings for sending text messages',
+        'Text message senders GOVUK Manage text message senders',
+        'Start text messages with service name On Change your settings for starting text messages with service name',
+        'Send international text messages Off Change your settings for sending international text messages',
+        'Receive text messages Off Change your settings for receiving text messages',
 
         'Label Value Action',
-        'Send letters Off Change',
+        'Send letters Off Change your settings for sending letters',
 
         'Label Value Action',
-        'Live Off Change',
-        'Count in list of live services Yes Change',
-        'Organisation Test organisation Central government Change',
-        'Free text message allowance 250,000 Change',
-        'Email branding GOV.UK Change',
-        'Letter branding Not set Change',
-        'Data retention email Change',
-        'Receive inbound SMS Off Change',
-        'Email authentication Off Change',
-        'Send cell broadcasts Off Change',
+        'Live Off Change service status',
+        'Count in list of live services Yes Change if service is counted in list of live services',
+        'Organisation Test organisation Central government Change organisation for service',
+        'Free text message allowance 250,000 Change free text message allowance',
+        'Email branding GOV.UK Change email branding (admin view)',
+        'Letter branding Not set Change letter branding (admin view)',
+        'Data retention email Change data retention',
+        'Receive inbound SMS Off Change your settings for Receive inbound SMS',
+        'Email authentication Off Change your settings for Email authentication',
+        'Send cell broadcasts Off Change your settings for Send cell broadcasts',
     ]),
 ])
 def test_should_show_overview(
@@ -165,7 +165,7 @@ def test_no_go_live_link_for_service_without_organisation(
 
     organisation = find_element_by_tag_and_partial_text(page, tag='td', string='Organisation')
     assert normalize_spaces(organisation.find_next_siblings()[0].text) == 'Not set Central government'
-    assert normalize_spaces(organisation.find_next_siblings()[1].text) == 'Change'
+    assert normalize_spaces(organisation.find_next_siblings()[1].text) == 'Change organisation for service'
 
 
 def test_organisation_name_links_to_org_dashboard(
@@ -194,8 +194,8 @@ def test_organisation_name_links_to_org_dashboard(
 
 
 @pytest.mark.parametrize('service_contact_link,expected_text', [
-    ('contact.me@gov.uk', 'Send files by email contact.me@gov.uk Manage'),
-    (None, 'Send files by email Not set up Manage'),
+    ('contact.me@gov.uk', 'Send files by email contact.me@gov.uk Manage sending files by email'),
+    (None, 'Send files by email Not set up Manage sending files by email'),
 ])
 def test_send_files_by_email_row_on_settings_page(
     client_request,
@@ -230,69 +230,69 @@ def test_send_files_by_email_row_on_settings_page(
 @pytest.mark.parametrize('permissions, expected_rows', [
     (['email', 'sms', 'inbound_sms', 'international_sms'], [
 
-        'Service name service one Change',
-        'Sign-in method Text message code Change',
+        'Service name service one Change service name',
+        'Sign-in method Text message code Change sign-in method',
 
         'Label Value Action',
-        'Send emails On Change',
-        'Reply-to email addresses test@example.com Manage',
-        'Email branding Organisation name Change',
-        'Send files by email Not set up Manage',
+        'Send emails On Change your settings for sending emails',
+        'Reply-to email addresses test@example.com Manage reply-to email addresses',
+        'Email branding Organisation name Change email branding',
+        'Send files by email Not set up Manage sending files by email',
 
         'Label Value Action',
-        'Send text messages On Change',
-        'Text message senders GOVUK Manage',
-        'Start text messages with service name On Change',
-        'Send international text messages On Change',
-        'Receive text messages On Change',
+        'Send text messages On Change your settings for sending text messages',
+        'Text message senders GOVUK Manage text message senders',
+        'Start text messages with service name On Change your settings for starting text messages with service name',
+        'Send international text messages On Change your settings for sending international text messages',
+        'Receive text messages On Change your settings for receiving text messages',
 
         'Label Value Action',
-        'Send letters Off Change',
+        'Send letters Off Change your settings for sending letters',
 
     ]),
     (['email', 'sms', 'email_auth'], [
 
-        'Service name service one Change',
-        'Sign-in method Email link or text message code Change',
+        'Service name service one Change service name',
+        'Sign-in method Email link or text message code Change sign-in method',
 
         'Label Value Action',
-        'Send emails On Change',
-        'Reply-to email addresses test@example.com Manage',
-        'Email branding Organisation name Change',
-        'Send files by email Not set up Manage',
+        'Send emails On Change your settings for sending emails',
+        'Reply-to email addresses test@example.com Manage reply-to email addresses',
+        'Email branding Organisation name Change email branding',
+        'Send files by email Not set up Manage sending files by email',
 
         'Label Value Action',
-        'Send text messages On Change',
-        'Text message senders GOVUK Manage',
-        'Start text messages with service name On Change',
-        'Send international text messages Off Change',
-        'Receive text messages Off Change',
+        'Send text messages On Change your settings for sending text messages',
+        'Text message senders GOVUK Manage text message senders',
+        'Start text messages with service name On Change your settings for starting text messages with service name',
+        'Send international text messages Off Change your settings for sending international text messages',
+        'Receive text messages Off Change your settings for receiving text messages',
 
         'Label Value Action',
-        'Send letters Off Change',
+        'Send letters Off Change your settings for sending letters',
 
     ]),
     (['letter'], [
 
-        'Service name service one Change',
-        'Sign-in method Text message code Change',
+        'Service name service one Change service name',
+        'Sign-in method Text message code Change sign-in method',
 
         'Label Value Action',
-        'Send emails Off Change',
+        'Send emails Off Change your settings for sending emails',
 
         'Label Value Action',
-        'Send text messages Off Change',
+        'Send text messages Off Change your settings for sending text messages',
 
         'Label Value Action',
-        'Send letters On Change',
-        'Sender addresses 1 Example Street Manage',
-        'Letter branding Not set Change',
+        'Send letters On Change your settings for sending letters',
+        'Sender addresses 1 Example Street Manage sender addresses',
+        'Letter branding Not set Change letter branding',
 
     ]),
     (['broadcast'], [
 
-        'Service name service one Change',
-        'Sign-in method Text message code Change',
+        'Service name service one Change service name',
+        'Sign-in method Text message code Change sign-in method',
 
     ]),
 ])
@@ -2063,9 +2063,11 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
             find_element_by_tag_and_partial_text(page, tag='tr', string=label).text
         )
 
-    assert get_row(page, 'Reply-to email addresses') == "Reply-to email addresses test@example.com …and 2 more Manage"
-    assert get_row(page, 'Text message senders') == "Text message senders Example …and 2 more Manage"
-    assert get_row(page, 'Sender addresses') == "Sender addresses 1 Example Street …and 2 more Manage"
+    assert get_row(page, 'Reply-to email addresses') == \
+        "Reply-to email addresses test@example.com …and 2 more Manage reply-to email addresses"
+    assert get_row(page, 'Text message senders') == \
+        "Text message senders Example …and 2 more Manage text message senders"
+    assert get_row(page, 'Sender addresses') == "Sender addresses 1 Example Street …and 2 more Manage sender addresses"
 
 
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -757,7 +757,7 @@ def test_view_broadcast_template(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
         )),
-        ('Edit', url_for(
+        ('Edit this template', url_for(
             '.edit_service_template',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,


### PR DESCRIPTION
Some of our buttons and links share the same text so cause confusion to anyone using a screenreader, where you often view them out of the context of the page:

<img width="646" alt="links_with_duplicate_text" src="https://user-images.githubusercontent.com/87140/91288580-0e058500-e789-11ea-9a29-e01520135e92.png">

This should fix all those with this problem, based on the findings of the report from the Digital Accessibility Centre (DAC).

https://www.pivotaltracker.com/story/show/174187762

All the content here was discussed with @karlchillmaid. We went with the approach of adding some extra words as a hidden suffix to the link/button text. The intention being, when reading left-to-right, you can stop as soon as you get enough of the context to understand.