### PR TITLE
Don’t filter ‘All of’ choice with live search

### DIFF
--- a/app/templates/views/broadcast/sub-areas.html
+++ b/app/templates/views/broadcast/sub-areas.html
@@ -22,9 +22,11 @@
       {{ form.select_all }}
     </div>
 
-    {{ live_search(target_selector='.govuk-checkboxes__item', show=show_search_form, form=search_form, label='Or by electoral ward') }}
+    {{ live_search(target_selector='#sub-areas .govuk-checkboxes__item', show=show_search_form, form=search_form, label='Or by electoral ward') }}
 
-    {{ form.areas }}
+    <div id="sub-areas">
+      {{ form.areas }}
+    </div>
 
     {{ sticky_page_footer('Add to broadcast') }}
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -468,21 +468,33 @@ def test_choose_broadcast_sub_area_page(
         'Choose an area of Aberdeen City'
     )
     live_search = page.select_one("[data-module=live-search]")
-    assert live_search['data-targets'] == '.govuk-checkboxes__item'
+    assert live_search['data-targets'] == '#sub-areas .govuk-checkboxes__item'
     assert live_search.select_one('input')['type'] == 'search'
-    choices = [
+    all_choices = [
         (
             choice.select_one('input')['value'],
             normalize_spaces(choice.select_one('label').text),
         )
         for choice in page.select('form[method=post] .govuk-checkboxes__item')
     ]
-    assert choices[:3] == [
+    sub_choices = [
+        (
+            choice.select_one('input')['value'],
+            normalize_spaces(choice.select_one('label').text),
+        )
+        for choice in page.select('form[method=post] #sub-areas .govuk-checkboxes__item')
+    ]
+    assert all_choices[:3] == [
         ('y', 'All of Aberdeen City'),
         ('wd20-S13002845', 'Airyhall/Broomhill/Garthdee'),
         ('wd20-S13002836', 'Bridge of Don'),
     ]
-    assert choices[-1:] == [
+    assert sub_choices[:3] == [
+        ('wd20-S13002845', 'Airyhall/Broomhill/Garthdee'),
+        ('wd20-S13002836', 'Bridge of Don'),
+        ('wd20-S13002835', 'Dyce/Bucksburn/Danestone'),
+    ]
+    assert all_choices[-1:] == sub_choices[-1:] == [
         ('wd20-S13002846', 'Torry/Ferryhill'),
     ]
 


### PR DESCRIPTION
Because the ‘All of’ choice appears above the search field, it shouldn’t be filtered by the search field.

We can fix this by wrapping the sub-areas in a `<div>` and make the selector more specific.

# Before

![image](https://user-images.githubusercontent.com/355079/91290442-840aeb80-e78b-11ea-87a6-7e57491122d6.png)

# After 

![image](https://user-images.githubusercontent.com/355079/91290394-75243900-e78b-11ea-9e19-80982a223178.png)
