### PR TITLE
Fix spacing in pill items

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -16,6 +16,17 @@
 
 }
 
+.pill .big-number-number {
+
+  // reduce padding until screen is bigger than 420px / zoomed below 300%
+  padding-left: govuk-spacing(1);
+
+  @include govuk-media-query($from: 420px) {
+    padding-left: govuk-spacing(2);
+  }
+
+}
+
 .big-number-dark {
   @extend %big-number;
   padding: govuk-spacing(3);

--- a/app/assets/stylesheets/components/cookie-message.scss
+++ b/app/assets/stylesheets/components/cookie-message.scss
@@ -1,6 +1,5 @@
 // GOV.UK Publishing components cookie banner styles
 // https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_cookie-banner.scss
-// sass-lint:disable mixins-before-declarations
 
 // component uses .govuk-body and .govuk-button classes from govuk-frontend
 @import 'core/typography';

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -31,7 +31,7 @@
     float: left;
     box-sizing: border-box;
     width: 100%;
-    padding: 10px;
+    padding: 10px 0;
   }
 
   a {
@@ -76,8 +76,20 @@
 
   }
 
+  &-label {
+
+    // reduce padding until screen is above 420px / zoomed below 300%
+    padding-left: govuk-spacing(1);
+
+    @include govuk-media-query($from: 420px) {
+      padding-left: govuk-spacing(2);
+    }
+
+  }
+
   &-centered-item {
     text-align: center;
+    padding-left: 0;
   }
 
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -259,7 +259,8 @@ const lint = {
         paths.src + 'stylesheets/views/*.scss',
       ])
       .pipe(plugins.sassLint({
-        'options': { 'formatter': 'stylish' }
+        'options': { 'formatter': 'stylish' },
+        'rules': { 'mixins-before-declarations': [2, { 'exclude': ['media', 'govuk-media-query'] } ] }
       }))
       .pipe(plugins.sassLint.format())
       .pipe(plugins.sassLint.failOnError());


### PR DESCRIPTION
Second attempt at fixing the horizontal spacing on the pill items.

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/87140/91319927-ddd3db80-e7b4-11ea-889d-08a7a9510ef1.png">

The first attempt, https://github.com/alphagov/notifications-admin/pull/3562, didn't consider all the different types of content they can contain so broke those with left-aligned text (details in https://github.com/alphagov/notifications-admin/pull/3571):

<img width="739" alt="pill_padding_issue" src="https://user-images.githubusercontent.com/87140/90127088-8ec18b80-dd5c-11ea-982a-74cc8b3be109.png">

# The problem

The report from the Digital Accessibility Centre (DAC) described problems with the text of our 'pill' items being cropped when users zoomed to 400% on a 1280px browser width. This broke [success criteria 1.4.10 of the Web Accessibility Guidelines (WCAG)](https://www.w3.org/TR/WCAG21/#reflow).

# Potential solutions

These changes:
1. remove the padding on the item containers, again
2. remove all padding on centrally-aligned items
3. add padding on the left of left-aligned items to give the start some room

Change number 3. also applies less padding on screens zoomed above 300% on a 1280px display (AKA 320 CSS pixels width).

## 0-300% zoom

<img width="1231" alt="left-aligned-300-percent" src="https://user-images.githubusercontent.com/87140/91336710-3eb9de80-e7ca-11ea-84a4-eed1064b2a41.png">

## Past 300% zoom

<img width="1217" alt="left-aligned-400-percent" src="https://user-images.githubusercontent.com/87140/91336729-44afbf80-e7ca-11ea-8189-6306e1611e50.png">