### PR TITLE
Emergency alert tour – screen 2 update

### DIFF
--- a/app/templates/views/broadcast/tour/2.html
+++ b/app/templates/views/broadcast/tour/2.html
@@ -3,7 +3,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  In an emergency, broadcast an alert to every mobile phone in
+  In an emergency, you can broadcast an alert to every mobile phone in
   the affected area at exactly the same time.
 {% endblock %}
 
@@ -15,7 +15,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="heading-medium">
-          In an emergency, broadcast an alert to every mobile phone in
+          In an emergency, you can broadcast an alert to every mobile phone in
           the affected area at exactly the same time.
         </h1>
         <p class="govuk-body heading-medium govuk-!-margin-bottom-6">


### PR DESCRIPTION
This PR makes a small content update to screen 2 of the emergency alert tour.

Adding 'you can' makes the meaning of the sentence clearer.