### PR TITLE
Fix the autofocus component

### DIFF
--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -9,7 +9,7 @@
       // is still where users intend to start
       if (($(window).scrollTop() > 0) && !forceFocus) { return; }
 
-      $('input, textarea, select', component).eq(0).trigger('focus');
+      $(component).filter('input, textarea, select').eq(0).trigger('focus');
 
     };
   };

--- a/tests/javascripts/autofocus.test.js
+++ b/tests/javascripts/autofocus.test.js
@@ -15,11 +15,11 @@ describe('Autofocus', () => {
 
     // set up DOM
     document.body.innerHTML =
-      `<div data-module="autofocus">
+      `<div>
         <label class="form-label" for="search">
           Search by name
         </label>
-        <input autocomplete="off" class="form-control form-control-1-1" id="search" name="search" type="search" value="">
+        <input autocomplete="off" class="form-control form-control-1-1" id="search" name="search" type="search" value="" data-module="autofocus">
       </div>`;
 
     focusHandler = jest.fn();
@@ -63,7 +63,7 @@ describe('Autofocus', () => {
     $.prototype.scrollTop = jest.fn(() => 25);
 
     // set the force-focus flag
-    document.querySelector('div').setAttribute('data-force-focus', true);
+    document.querySelector('#search').setAttribute('data-force-focus', true);
 
     // start module
     window.GOVUK.modules.start();


### PR DESCRIPTION
Since moving textboxes to GOV.UK Frontend we’ve started putting the data attribute on the `input` element itself, not a wrapper around it.

This commit updates the Javascript accordingly.