### PR TITLE
Fix font-size when Chrome autofills inputs

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -253,3 +253,7 @@ details .arrow {
   }
 
 }
+
+input:-webkit-autofill::first-line {
+  @include core-19;
+}


### PR DESCRIPTION
For some reason Chrome decides that using its own font declaration is preferable to keeping the input looking as it would without autofill.

This overrides that with our bigger, better font.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/91546162-ef82c380-e919-11ea-80ca-cccc2e6ade6a.png) | ![image](https://user-images.githubusercontent.com/355079/91546232-09240b00-e91a-11ea-8c37-fa4372f2f731.png)

https://stackoverflow.com/questions/57242841/input-text-very-small-when-hovering-on-autofill-suggestion