### PR TITLE
Fix comparison in api_key component

### DIFF
--- a/app/templates/components/api-key.html
+++ b/app/templates/components/api-key.html
@@ -1,12 +1,12 @@
 {% macro api_key(key, name, thing="API key") %}
-  {% if name == thing %}
+  {% if name|lower == thing|lower %}
     <h2 class="api-key__name">
       {{ name }}
     </h2>
   {% endif %}
   <div data-module="api-key" data-key="{{ key }}" data-thing="{{ thing }}" data-name="{{ name }}">
     <span class="api-key__key">
-      {% if name != thing %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ key }}
+      {% if name|lower != thing|lower %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ key }}
     </span>
     <span class="api-key__notice" aria-live="assertive"></span>
   </div>


### PR DESCRIPTION
https://github.com/alphagov/notifications-admin/pull/3591 changed the comparison in the `api_key` component macro that decides if it has a heading. It needed both values to be the same case so broke when used on the template page:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/87140/91559650-61660780-e930-11ea-9451-61dbf99e1b8c.png">

This fixes the comparison, which fixes that issue:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/87140/91559735-878ba780-e930-11ea-81e8-eb796714b395.png">
