### PR TITLE
Show address line 7 not postcode in example spreadsheet

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -20,7 +20,7 @@ from notifications_utils.columns import Columns
 from notifications_utils.pdf import is_letter_too_long
 from notifications_utils.postal_address import (
     PostalAddress,
-    address_lines_1_to_6_and_postcode_keys,
+    address_lines_1_to_7_keys,
 )
 from notifications_utils.recipients import RecipientCSV, first_column_headings
 from notifications_utils.sanitise_text import SanitiseASCII
@@ -63,7 +63,7 @@ from app.utils import (
 
 letter_address_columns = [
     column.replace('_', ' ')
-    for column in address_lines_1_to_6_and_postcode_keys
+    for column in address_lines_1_to_7_keys
 ]
 
 
@@ -102,7 +102,7 @@ def get_example_letter_address(key):
     return {
         'address line 1': 'A. Name',
         'address line 2': '123 Example Street',
-        'postcode': 'XM4 5HQ'
+        'address line 3': 'XM4 5HQ'
     }.get(key, '')
 
 
@@ -381,7 +381,7 @@ def send_one_off_letter_address(service_id, template_id):
         if all_placeholders_in_session(placeholders):
             return get_notification_check_endpoint(service_id, template)
 
-        first_non_address_placeholder_index = len(address_lines_1_to_6_and_postcode_keys)
+        first_non_address_placeholder_index = len(address_lines_1_to_7_keys)
 
         return redirect(url_for(
             'main.send_one_off_step',
@@ -475,7 +475,7 @@ def send_test_step(service_id, template_id, step_index):
 
     # if we're in a letter, we should show address block rather than "address line #" or "postcode"
     if template.template_type == 'letter':
-        if step_index < len(address_lines_1_to_6_and_postcode_keys):
+        if step_index < len(address_lines_1_to_7_keys):
             return redirect(url_for(
                 '.send_one_off_letter_address',
                 service_id=service_id,

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@41.0.1#egg=notifications-utils==41.0.1
+git+https://github.com/alphagov/notifications-utils.git@41.2.0#egg=notifications-utils==41.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@41.0.1#egg=notifications-utils==41.0.1
+git+https://github.com/alphagov/notifications-utils.git@41.2.0#egg=notifications-utils==41.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
@@ -34,10 +34,10 @@ prometheus-client==0.8.0
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.129
+awscli==1.18.133
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.17.52
+botocore==1.17.56
 cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4
@@ -77,7 +77,7 @@ s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
-texttable==1.6.2
+texttable==1.6.3
 urllib3==1.25.10
 webencodings==0.5.1
 Werkzeug==1.0.1

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -334,11 +334,11 @@ def test_example_spreadsheet_for_letters(
         ('1', '2'),
         ('address line 1', 'A. Name'),
         ('address line 2', '123 Example Street'),
-        ('address line 3', ''),
+        ('address line 3', 'XM4 5HQ'),
         ('address line 4', ''),
         ('address line 5', ''),
         ('address line 6', ''),
-        ('postcode', 'XM4 5HQ'),
+        ('address line 7', ''),
         ('name', 'example'),
         ('date', 'example'),
     ]
@@ -2133,7 +2133,7 @@ def test_send_test_letter_redirects_to_right_url(
             'address line 4': '',
             'address line 5': '',
             'address line 6': '',
-            'postcode': 'SW1 1AA',
+            'address line 7': 'SW1 1AA',
         }
 
     response = platform_admin_client.get(url_for(


### PR DESCRIPTION
Since the letter preview will now show address line 7, the example spreadsheet we give should match.

# Before

![image](https://user-images.githubusercontent.com/355079/92380315-e4d9e280-f100-11ea-9b7c-ae108c649d08.png)
![image](https://user-images.githubusercontent.com/355079/92380327-eb685a00-f100-11ea-8cde-c1835dd211a4.png)


# After 

![image](https://user-images.githubusercontent.com/355079/92380352-f622ef00-f100-11ea-9d80-8ced2b71ee19.png)
![image](https://user-images.githubusercontent.com/355079/92380371-0044ed80-f101-11ea-8fee-34c476959789.png)
