### PR TITLE
Fix extra tracking on numeric inputs

### DIFF
--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -56,7 +56,7 @@
   text-align: right;
 }
 
-.extra-tracking .form-control {
+.extra-tracking .govuk-input {
   @include core-19($tabular-numbers: true);
   padding-left: 5px;
   letter-spacing: 0.04em;


### PR DESCRIPTION
Since we moved to using text boxes from GOV.UK Frontend the old class wasn’t appearing in the page.

# Broken

![image](https://user-images.githubusercontent.com/355079/92469031-081d9400-f1cc-11ea-8ede-bd02feeefdcc.png)

# Fixed 

![image](https://user-images.githubusercontent.com/355079/92468985-fb00a500-f1cb-11ea-92c9-b362d8ceb9d5.png)

***

Context for why we do this: https://github.com/alphagov/notifications-admin/pull/2820