### PR TITLE
Change cross icon to one with better contrast

### DIFF
--- a/app/assets/images/cross-grey.svg
+++ b/app/assets/images/cross-grey.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="19px" height="19px" viewBox="0 0 128 128"><polygon points="38,12 12,38 38,64 12,90 38,116 64,90 90,116 116,90 90,64 116,38 90,12 64,38" stroke="#6f777b" stroke-width="10px" fill="none"></polygon></svg>

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -17,8 +17,7 @@
   &-cross {
     @extend %tick-cross;
     color: $secondary-text-colour;
-    background-image: file-url('cross-grey.png');
-    box-shadow: inset 20px 0 0 0 rgba(255, 255, 255, 0.6);
+    background-image: file-url('cross-grey.svg');
   }
 
   &-list {


### PR DESCRIPTION
The current cross doesn't have enough contrast with the background.

https://www.pivotaltracker.com/story/show/174438122

This was picked up in the report by the Digital Accessibility Centre (DAC) as having failing the [WCAG success criteria 1.4.11, Non-text contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).

This changes it to a design:
- without fill
- with a stroke colour matching the text it sits with
- that is an SVG, to improve clarity and scaling under high zoom levels/DPI displays

Based on the guidance in 1.4.11, specifically [the section on graphical objects](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html#graphical-objects), and using the [colour contrast analyser](https://developer.paciellogroup.com/resources/contrastanalyser/), the new design provides enough contrast to pass at AA.

## Before

<img width="738" alt="old_cross_in_set_with_one_tick" src="https://user-images.githubusercontent.com/87140/92614859-6a51c400-f2b4-11ea-9926-4b60b83bb71f.png">

## After

<img width="733" alt="new_cross_in_set_with_one_tick" src="https://user-images.githubusercontent.com/87140/92614887-70e03b80-f2b4-11ea-85c8-a113c4becdf6.png">

<img width="745" alt="new_cross_in_set_with_all_ticks" src="https://user-images.githubusercontent.com/87140/92614915-79d10d00-f2b4-11ea-9d8d-e9d2133db395.png">

<img width="744" alt="new_cross_in_set_with_all_crosses" src="https://user-images.githubusercontent.com/87140/92614937-7e95c100-f2b4-11ea-80f1-c2b35771d389.png">

