### PR TITLE
Give links context on letter template page

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -68,12 +68,12 @@
     {% if not current_service.letter_branding_id %}
       <a href="{{ url_for(".branding_request", service_id=current_service.id, branding_type="letter", from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-branding">Add logo</a>
     {% endif %}
-    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-postage">Change</a>
-    <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-body">Edit</a>
+    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-postage">Change<span class="govuk-visually-hidden"> postage</span></a>
+    <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> letter template</span></a>
     {% if current_service.count_letter_contact_details %}
-      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit</a>
+      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
     {% else %}
-      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit</a>
+      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
     {% endif %}
   {% endif %}
   {{ template|string }}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -498,7 +498,7 @@ def test_user_with_only_send_and_view_sees_letter_page(
     (
         TEMPLATE_ONE_ID,
         partial(url_for, 'main.edit_template_postage', template_id=TEMPLATE_ONE_ID),
-        'Change',
+        'Change postage',
     ),
 ))
 def test_letter_with_default_branding_has_add_logo_button(


### PR DESCRIPTION
Gives context to a few links missed from [the pull request for adding context to links and buttons](https://github.com/alphagov/notifications-admin/pull/3593)

https://www.pivotaltracker.com/story/show/174737405