### PR TITLE
Fix aria on jobs page

### DIFF
--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -11,7 +11,7 @@
       {% for label, option, link, count in items %}
         <li class="pill-item__container">
         {% if current_value == option %}
-          <a class="pill-item pill-item--selected govuk-link govuk-link--no-visited-state{% if not show_count %} pill-item--centered{% endif %}" href="{{ link }}" aria-current="page">
+          <a id="pill-selected-item" class="pill-item pill-item--selected govuk-link govuk-link--no-visited-state{% if not show_count %} pill-item--centered{% endif %}" href="{{ link }}" aria-current="page">
         {% else %}
           <a class="pill-item govuk-link govuk-link--no-visited-state" href="{{ link }}">
         {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
-<div class="ajax-block-container" aria-labelledby='pill-selected-item'>
+<section class="ajax-block-container" aria-labelledby="pill-selected-item">
   {% if job.scheduled %}
 
     <p class="govuk-body">
@@ -74,4 +74,4 @@
     {% endif %}
 
   {% endif %}
-</div>
+</section>


### PR DESCRIPTION
The jobs grouping on the job page has an `aria-labelledby` attribute intended to give it an accessible label matching the selected 'pill' item (ie. "5 sending") which was mis-configured. This fixes it.

https://www.pivotaltracker.com/story/show/174439704

It also turns the grouping from a `<div>` to a `<section>` to give it a role of "region". See https://w3c.github.io/html-aam/#el-section for details.

This was picked up in the report by the Digital Accessibility Centre (DAC) on page 36:

https://drive.google.com/file/d/10VZ1E-nBgFQrWWBYDgXSJ2n1trauwEN7/view?usp=sharing