### PR TITLE
Give a specific error when trying to send an international letters from a service that has international letters switched off

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1252,6 +1252,10 @@ class LetterAddressForm(StripWhitespaceForm):
                 raise ValidationError(
                     f'Last line of the address must be a UK postcode or another country'
                 )
+            if address.international:
+                raise ValidationError(
+                    f'You do not have permission to send letters to other countries'
+                )
             raise ValidationError(
                 f'Last line of the address must be a real UK postcode'
             )

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -79,6 +79,8 @@
                 {% elif not item.as_postal_address.has_valid_last_line %}
                   {% if item.as_postal_address.allow_international_letters %}
                     Last line of the address must be a UK postcode or another country
+                  {% elif item.as_postal_address.international %}
+                    You do not have permission to send letters to other countries
                   {% else %}
                     Last line of the address must be a real UK postcode
                   {% endif %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -703,6 +703,15 @@ LETTER_VALIDATION_MESSAGES = {
             'Validation failed because the last line of the address is not a real UK postcode.'
         ),
     },
+    'cant-send-international-letters': {
+        'title': 'There’s a problem with the address for this letter',
+        'detail': (
+            'You do not have permission to send letters to other countries.'
+        ),
+        'summary': (
+            'Validation failed because your service cannot send letters to other countries.'
+        ),
+    },
     'not-a-real-uk-postcode-or-country': {
         'title': 'There’s a problem with the address for this letter',
         'detail': (

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -637,7 +637,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
         '3 Last line of the address must be a real UK postcode',
         'Firstname Lastname 123 Example St. SW!A !AA',
 
-        '4 Last line of the address must be a real UK postcode',
+        '4 You do not have permission to send letters to other countries',
         'Firstname Lastname 123 Example St. France',
 
         '5 Address must be at least 3 lines long',
@@ -2602,6 +2602,11 @@ def test_send_one_off_letter_address_populates_address_fields_in_session(
         '\n'.join(['a', 'b', 'c', 'd', 'e', 'f', 'g']),
         [],
         'Last line of the address must be a real UK postcode',
+    ),
+    (
+        '\n'.join(['a', 'b', 'c', 'd', 'e', 'france']),
+        [],
+        'You do not have permission to send letters to other countries',
     ),
     (
         '\n'.join(['a', 'b', 'c', 'd', 'e', 'f', 'g']),

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -512,6 +512,17 @@ def test_get_letter_validation_error_for_unknown_error():
         ),
     ),
     (
+        'cant-send-international-letters',
+        None,
+        'There’s a problem with the address for this letter',
+        (
+            'You do not have permission to send letters to other countries.'
+        ),
+        (
+            'Validation failed because your service cannot send letters to other countries.'
+        ),
+    ),
+    (
         'not-a-real-uk-postcode-or-country',
         None,
         'There’s a problem with the address for this letter',


### PR DESCRIPTION
If a service doesn’t have permission to send international letters but someone tries to upload a letter with a valid international address we just tell them that the last line must be a UK postcode.

This is a bit opaque and:
- suggests that we’re not recognising at all that it’s not a UK letter
- doesn’t explain why it must be a UK postcode

This pull request adds a new error message which tells users why their letter can’t be sent. And hopefully will give them a better idea of how to resolve the problem, if they really do need to be able to send international letters.