### PR TITLE
Fix aria on jobs page 2nd attempt

### DIFF
--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -11,7 +11,7 @@
       {% for label, option, link, count in items %}
         <li class="pill-item__container">
         {% if current_value == option %}
-          <a class="pill-item pill-item--selected govuk-link govuk-link--no-visited-state{% if not show_count %} pill-item--centered{% endif %}" href="{{ link }}" aria-current="page">
+          <a id="pill-selected-item" class="pill-item pill-item--selected govuk-link govuk-link--no-visited-state{% if not show_count %} pill-item--centered{% endif %}" href="{{ link }}" aria-current="page">
         {% else %}
           <a class="pill-item govuk-link govuk-link--no-visited-state" href="{{ link }}">
         {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
-<div class="ajax-block-container" aria-labelledby='pill-selected-item'>
+<div class="ajax-block-container" aria-labelledby='pill-selected-item' role="region">
   {% if job.scheduled %}
 
     <p class="govuk-body">


### PR DESCRIPTION
2nd attempt at fixing the aria on the jobs page (1st attempt: https://github.com/alphagov/notifications-admin/pull/3620).

https://www.pivotaltracker.com/story/show/174439704

The 1st attempt broke the JS that updates that area of the page (details in https://github.com/alphagov/notifications-admin/commit/51033d57fbb37c6fbd4826dd7326794cf9732adf). This takes a different approach that doesn't but achieves the same goal.