### PR TITLE
Increase threshold for minimum polygon size

### DIFF
--- a/app/broadcast_areas/polygons.py
+++ b/app/broadcast_areas/polygons.py
@@ -41,7 +41,7 @@ class Polygons():
     # The threshold for removing very small areas from the map. These
     # areas are likely glitches in  the data where the shoreline hasn’t
     # been subtracted from the land properly
-    minimum_area_size_square_metres = 50 ** 2
+    minimum_area_size_square_metres = 14_000
 
     def __init__(self, polygons):
         if not polygons:


### PR DESCRIPTION
We filter out very small polygons from the original data to remove glitches. These glitches are caused by trying to subtract the water from a polygon that includes some land and some water, but using two different definitions or resolutions of mean high water line.

If we don’t do this then we end up with a bunch of very small polygons which lie far outside the understood area of a place, causing large overspill.

We need to increase the threshold for this process because we’re still seeing this problem around Bristol and Norwich.

This does mean we lose a few very small polygons in places like Shetland and the Scilly Isles, but not in such a way that we would avoid broadcasting to them (because they’d still be caught by the simplification and overspill).

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/93077417-adc77c00-f680-11ea-98db-97f474a36ae4.png) | ![image](https://user-images.githubusercontent.com/355079/93077284-7d7fdd80-f680-11ea-9366-d89577ceb2a0.png)
![image](https://user-images.githubusercontent.com/355079/93077446-b750e400-f680-11ea-8dde-4193c5c0d805.png) | ![image](https://user-images.githubusercontent.com/355079/93077330-8ec8ea00-f680-11ea-9374-7517c2956dde.png)
![image](https://user-images.githubusercontent.com/355079/93077481-c2a40f80-f680-11ea-98be-02e0c230073e.png) | ![image](https://user-images.githubusercontent.com/355079/93077350-95576180-f680-11ea-839f-725523299abd.png)

