### PR TITLE
Update focus style to GOVUK Frontend 3 version

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -97,7 +97,10 @@
 
       color: $light-blue-25;
 
-      .big-number {
+      .big-number,
+      .big-number-number,
+      .big-number-smaller,
+      .big-number-label {
         color: $light-blue-25;
       }
 
@@ -105,7 +108,18 @@
 
     &:active,
     &:focus {
-      outline: 3px solid $yellow;
+      background: $govuk-focus-colour;
+      border: none;
+      padding: 2px; /* replace the spacing the border gave */
+      /* override the default focus style to inset the underline */
+      box-shadow: inset 0 -4px $govuk-focus-text-colour;
+
+      .big-number-number,
+      .big-number-smaller,
+      .big-number-label {
+        color: $govuk-focus-text-colour;
+        text-decoration: none;
+      }
     }
 
     .big-number,

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -147,6 +147,10 @@ $message-type-bottom-spacing: govuk-spacing(4);
       background-image: file-url('folder-blue-bold-hover.svg');
     }
 
+    &:focus {
+      background-image: file-url('folder-black-bold.svg');
+    }
+
   }
 
   &-template {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -73,11 +73,9 @@
       padding: $padding-top 0 $padding-bottom govuk-spacing(3);
 
       &:focus {
-        outline: none;
-        border-bottom: 1px solid $yellow;
-        border-left: 10px solid $yellow;
-        border-right: 3px solid $yellow;
-        right: -3px;
+        padding: $padding-top 0px $padding-bottom + 1px govuk-spacing(3) + 10;
+        /* override default focus style to inset bottom underline */
+        box-shadow: inset 0 -4px $govuk-focus-text-colour;
       }
 
     }
@@ -105,7 +103,7 @@
       position: absolute;
       top: -1px;
       bottom: 1px;
-      right: 7px;
+      right: 2px;
       width: 7px;
       height: 7px;
       margin: auto 0;
@@ -117,10 +115,13 @@
       border-color: $secondary-text-colour;
     }
 
+    &:focus:before {
+      border-color: $govuk-focus-text-colour;
+    }
+
     // hack to make the focus style fit in the navigation bar
     &:focus {
-      outline: none;
-      box-shadow: 0 1px 0 0 $focus-colour, -3px 0 0 0 $focus-colour, -3px 1px 0 0 $focus-colour;
+      box-shadow: inset 0 -3px $govuk-focus-text-colour, 0 1px $govuk-focus-text-colour;
     }
 
   }

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -55,6 +55,11 @@
     &:active,
     &:focus {
       z-index: 10;
+      color: $govuk-focus-text-colour;
+      /* override default focus styles to inset bottom underline */
+      box-shadow: inset 0 -4px $govuk-focus-text-colour;
+      border: none;
+      padding: 12px 2px; /* compensate for lack of border with padding */
     }
   }
 
@@ -77,7 +82,10 @@
     &:active,
     &:focus {
       z-index: 1000;
-      outline: 3px solid $yellow;
+      color: $govuk-focus-text-colour;
+      border: solid 2px $black;
+      padding: 10px 0px; /* reset padding to default */
+      box-shadow: inset 0 -2px $govuk-focus-text-colour; /* remove bottom border from underline */
     }
 
   }
@@ -92,6 +100,13 @@
       padding-left: govuk-spacing(2);
     }
 
+  }
+
+  &-item,
+  &-item--selected {
+    &:focus .pill-item__label {
+      text-decoration: none;
+    }
   }
 
   &-item--centered {
@@ -117,10 +132,17 @@
       text-decoration: underline;
     }
 
-    &:hover,
+    &:hover {
+      color: $light-blue-25;
+    }
+
     &:focus,
     &:link:focus {
-      color: $light-blue-25;
+      color: $govuk-focus-text-colour;
+      text-decoration: none;
+      background: $govuk-focus-colour;
+      /* override default focus style to inset bottom underline */
+      box-shadow: inset 0 -4px $govuk-focus-text-colour;
     }
 
   }

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -10,15 +10,14 @@
 
   &:focus {
 
-    outline: none;
-    color: $text-colour;
-    box-shadow: 0 -10px 0 0 $yellow;
-    border-color: $yellow;
+    border-color: transparent;
+    /* override default focus style to increase top yellow box-shadow */
+    box-shadow: 0 -15px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
 
     span {
-      background: $yellow;
       outline: none;
-      border-color: $text-colour;
+      border-color: transparent;
+      background-color: transparent;
     }
 
   }

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -145,11 +145,9 @@ $sticky-padding: govuk-spacing(4);
     color: $link-hover-colour;
   }
 
-  &:focus,
-  &:active, {
-    background: $yellow;
-    color: $govuk-blue;
-    outline: none;
+  &:focus {
+    /* override default box shadow to stop it looking so large vertically */
+    box-shadow: inset 0 -4px $govuk-focus-text-colour;
   }
 
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -337,6 +337,11 @@
     display: block;
     position: relative;
 
+    /* remove default focus styles in favour of those for :before pseudo class */
+    &:focus {
+      box-shadow: none;
+    }
+
     &:before {
       content: "";
       display: block;
@@ -353,10 +358,7 @@
 
     &:active:before,
     &:focus:before {
-      border-color: $yellow;
-      border-style: solid;
-      border-width: 15px 3px 15px 15px;
-      right: -3px;
+      box-shadow: inset 0px -4px $govuk-focus-text-colour, inset 0px 15px $govuk-focus-colour, inset 15px 0px $govuk-focus-colour, inset 0px -11px $govuk-focus-colour;
     }
 
   }

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -32,8 +32,7 @@ $indicator-colour: $black;
       position: relative;
 
       &:focus {
-        outline: none;
-        box-shadow: -3px 0 0 0 $focus-colour, 3px 0 0 0 $focus-colour;
+        box-shadow: inset 0 -4px $govuk-focus-text-colour;
         border-color: transparent;
         top: -1px;
         margin-bottom: -2px;

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -34,7 +34,7 @@ $is-ie: false !default;
   margin-bottom: govuk-spacing(6);
   margin-left: -1 * govuk-spacing(3);
   margin-right: -1 * govuk-spacing(3);
-  overflow: hidden;
+  @include govuk-clearfix;
 
   ul {
     margin: 0;
@@ -55,9 +55,12 @@ $is-ie: false !default;
       padding: govuk-spacing(3);
       text-decoration: none;
 
-      &:hover,
-      &:active {
+      &:hover {
         background-color: $canvas-colour;
+      }
+
+      &:focus {
+        background-color: $govuk-focus-colour;
       }
 
       .pagination-part-title {

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -12,28 +12,39 @@ $govuk-compatibility-govukelements: true;
 $govuk-assets-path: "/static/";
 
 @import "settings/all";
+// update to focus styles, remove when upgrading to GOVUK Frontend 3.x.x
+@import "./focus/settings";
 @import "tools/all";
 @import "helpers/all";
+// update to focus styles, remove when upgrading to GOVUK Frontend 3.x.x
+@import "./focus/helpers";
 
 @import "core/all";
+// update to focus styles, remove when upgrading to GOVUK Frontend 3.x.x
+@import "./focus/core";
 @import "objects/all";
 
-// section replacing @import 'components/all', specifying which components to include
-@import 'components/skip-link/_skip-link';
-@import 'components/header/_header';
-@import 'components/footer/_footer';
-@import 'components/back-link/_back-link';
-@import 'components/button/_button';
-@import 'components/details/_details';
-@import 'components/radios/_radios';
-@import 'components/checkboxes/_checkboxes';
-@import 'components/input/_input';
+// section replacing @import "components/all", specifying which components to include
+@import "components/skip-link/_skip-link";
+@import "components/header/_header";
+@import "components/footer/_footer";
+@import "components/back-link/_back-link";
+@import "components/button/_button";
+@import "components/details/_details";
+@import "components/radios/_radios";
+@import "components/checkboxes/_checkboxes";
+@import "components/input/_input";
+
+// update to focus styles, remove when upgrading to GOVUK Frontend 3.x.x
+@import "./focus/components";
 
 @import "utilities/all";
 @import "overrides/all";
 
 // Styles extending those from GOV.UK Frontend
-@import './extensions';
+@import "./extensions";
+// update to focus styles, remove when upgrading to GOVUK Frontend 3.x.x
+@import "./focus/extensions";
 
 // Styles for GOV.UK Frontend components specific to this application
-@import './overrides';
+@import "./overrides";

--- a/app/assets/stylesheets/govuk-frontend/focus/components.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/components.scss
@@ -54,3 +54,31 @@
 .govuk-details__summary:before {
   top: 0;
 }
+
+// Updates to buttons
+.govuk-button {
+  &:focus {
+    border-color: $govuk-focus-colour;
+    // When colours are overridden, for example when users have a dark mode,
+    // backgrounds and box-shadows disappear, so we need to ensure there's a
+    // transparent outline which will be set to a visible colour.
+    // Since Internet Explorer 8 does not support box-shadow, we want to force the user-agent outlines
+    @include govuk-not-ie8 {
+      outline: $govuk-focus-width solid transparent;
+      outline-offset: 0;
+    }
+    // Since Internet Explorer does not support `:not()` we set a clearer focus style to match user-agent outlines.
+    @include govuk-if-ie8 {
+      color: $govuk-text-colour;
+      background-color: $govuk-focus-colour;
+    }
+    box-shadow: inset 0 0 0 1px $govuk-focus-colour;
+  }
+
+  &:focus:not(:active):not(:hover) {
+    border-color: $govuk-focus-colour;
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
+    box-shadow: 0 2px 0 $govuk-focus-text-colour;
+  }
+}

--- a/app/assets/stylesheets/govuk-frontend/focus/components.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/components.scss
@@ -177,8 +177,9 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
   background: currentColor;
 }
 
-// Focused state
-.multiple-choice [type=radio]:focus + label::before {
+// Focused state (includes targeting for GOVUK radios, to apply version 3.x.x styles)
+.multiple-choice [type=radio]:focus + label::before,
+.govuk-radios__input:focus + .govuk-radios__label::before {
   border-width: 4px;
   // Since box-shadows are removed when users customise their colours we set a
   // transparent outline that is shown instead.

--- a/app/assets/stylesheets/govuk-frontend/focus/components.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/components.scss
@@ -1,0 +1,56 @@
+// Sass bringing in the new focus style from GOVUK Frontend 3.x.x
+// TO DO: Delete this file when we upgrade to GOVUK Frontend 3.x.x
+//
+// See the following for details of the update:
+// - https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/
+// - https://design-system.service.gov.uk/get-started/focus-states/
+// - https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0
+//
+// These styles were added in https://github.com/alphagov/govuk-frontend/pull/1309
+
+// Updates to skip-link component
+.govuk-skip-link {
+  @include govuk-typography-common;
+  @include govuk-focusable-fill;
+}
+
+// Updates to header component
+.govuk-header__link {
+  @include govuk-focusable-text-link;
+}
+
+.govuk-header__link--homepage {
+  // Remove any borders that show when focused and hovered.
+  &:focus {
+    border-bottom: 0;
+  }
+}
+
+// Updates to back-link component
+.govuk-back-link {
+  @include govuk-focusable-text-link;
+
+  // When the back link is focused, hide the bottom link border as the
+  // focus styles has a bottom border.
+  &:focus {
+    border-bottom-color: transparent;
+  }
+}
+
+// Updates to details component
+.govuk-details__summary {
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  @include govuk-focusable-text-link;
+}
+
+// Remove the underline when focussed to avoid duplicate borders
+.govuk-details__summary:focus .govuk-details__summary-text {
+  text-decoration: none;
+}
+
+.govuk-details__summary:before {
+  top: 0;
+}

--- a/app/assets/stylesheets/govuk-frontend/focus/components.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/components.scss
@@ -94,3 +94,106 @@
     box-shadow: 0 2px 0 $govuk-focus-text-colour;
   }
 }
+
+// Updates to form inputs
+.govuk-input {
+  &:focus {
+    // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width` - this is for consistency with
+    // components such as textarea where we avoid changing `border-width` as
+    // it will change the element size. Also, `outline` cannot be utilised
+    // here as it is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  }
+}
+.govuk-input--error {
+  &:focus {
+    border-color: $govuk-input-border-colour;
+    // Remove `box-shadow` inherited from `:focus` as `input--error`
+    // already has the thicker border.
+    box-shadow: none;
+  }
+}
+
+// Updates to form textareas (hacked to work with GOVUK Elements version)
+.form-control {
+  @include govuk-focusable;
+
+  &:focus {
+    // Double the border by adding its width again. Use `box-shadow` to do
+    // this instead of changing `border-width` (which changes element size) and
+    // since `outline` is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  }
+}
+.form-control-error {
+  &:focus {
+    border-color: $govuk-input-border-colour;
+    // Remove `box-shadow` inherited from `:focus` as `input--error`
+    // already has the thicker border.
+    box-shadow: none;
+  }
+}
+
+// Updates to form radios (hacked to work with GOVUK Elements version)
+
+$govuk-radios-size: 40px;
+// When the default focus width is used on a curved edge it looks visually smaller.
+// So for the circular radios we bump the default to make it look visually consistent.
+$govuk-radios-focus-width: $govuk-focus-width + 1px;
+
+// ( ) Radio ring
+.multiple-choice [type=radio] + label::before {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: $govuk-radios-size;
+  height: $govuk-radios-size;
+
+  border: $govuk-border-width-form-element solid currentColor;
+  border-radius: 50%;
+  background: transparent;
+}
+
+//  •  Radio button
+//
+// We create the 'button' entirely out of 'border' so that they remain
+// 'filled' even when colours are overridden in the browser.
+.multiple-choice [type=radio] + label::after {
+  content: "";
+
+  position: absolute;
+  top: govuk-spacing(2);
+  left: govuk-spacing(2);
+
+  width: 0;
+  height: 0;
+
+  border: govuk-spacing(2) solid currentColor;
+  border-radius: 50%;
+  opacity: 0;
+  background: currentColor;
+}
+
+// Focused state
+.multiple-choice [type=radio]:focus + label::before {
+  border-width: 4px;
+  // Since box-shadows are removed when users customise their colours we set a
+  // transparent outline that is shown instead.
+  // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+  outline: $govuk-focus-width solid transparent;
+  outline-offset: $govuk-focus-width;
+  box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
+}
+
+// Selected state
+.multiple-choice [type=radio]:checked + label::after {
+  opacity: 1;
+}
+
+// Updates to form checkboxes
+.govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  border-width: 4px;
+}

--- a/app/assets/stylesheets/govuk-frontend/focus/components.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/components.scss
@@ -26,6 +26,18 @@
   }
 }
 
+// Updates to footer component
+.govuk-footer__link {
+  text-decoration: none;
+
+  &:hover,
+  &:active {
+    text-decoration: underline;
+  }
+
+  @include govuk-focusable-text-link;
+}
+
 // Updates to back-link component
 .govuk-back-link {
   @include govuk-focusable-text-link;

--- a/app/assets/stylesheets/govuk-frontend/focus/core.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/core.scss
@@ -1,0 +1,14 @@
+// Sass bringing in the new focus style from GOVUK Frontend 3.x.x
+// TO DO: Delete this file when we upgrade to GOVUK Frontend 3.x.x
+//
+// See the following for details of the update:
+// - https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/
+// - https://design-system.service.gov.uk/get-started/focus-states/
+// - https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0
+//
+// These styles were added in https://github.com/alphagov/govuk-frontend/pull/1309
+
+// Hack to fix not being able to override the govuk-link-common mixin
+.govuk-link {
+  @include govuk-focusable-text-link;
+}

--- a/app/assets/stylesheets/govuk-frontend/focus/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/extensions.scss
@@ -1,0 +1,14 @@
+// Sass bringing in the new focus style from GOVUK Frontend 3.x.x
+// TO DO: Delete this file when we upgrade to GOVUK Frontend 3.x.x
+//
+// See the following for details of the update:
+// - https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/
+// - https://design-system.service.gov.uk/get-started/focus-states/
+// - https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0
+//
+// These styles were added in https://github.com/alphagov/govuk-frontend/pull/1309
+// (for the error summary component, which we don't use yet)
+
+.govuk-link--destructive:focus {
+  @include govuk-focusable-text-link;
+}

--- a/app/assets/stylesheets/govuk-frontend/focus/helpers.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/helpers.scss
@@ -1,0 +1,39 @@
+// Sass bringing in the new focus style from GOVUK Frontend 3.x.x
+// TO DO: Delete this file when we upgrade to GOVUK Frontend 3.x.x
+//
+// See the following for details of the update:
+// - https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/
+// - https://design-system.service.gov.uk/get-started/focus-states/
+// - https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0
+//
+// These styles were added in https://github.com/alphagov/govuk-frontend/pull/1309
+
+/// Focusable with box-shadow
+///
+/// Removes the visible outline and replace with box-shadow and background colour.
+/// Used for interactive text-based elements.
+
+@mixin govuk-focusable-text-link {
+  &:focus {
+    // When colours are overridden, for example when users have a dark mode,
+    // backgrounds and box-shadows disappear, so we need to ensure there's a
+    // transparent outline which will be set to a visible colour.
+
+    // Since Internet Explorer 8 does not support box-shadow, we want to force the user-agent outlines
+    @include govuk-not-ie8 {
+      outline: $govuk-focus-width solid transparent;
+      outline-offset: 0;
+    }
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
+    // sass-lint:disable indentation
+    box-shadow: -5px -1px 0 1px $govuk-focus-colour,
+                5px -1px 0 1px $govuk-focus-colour,
+                -3px 1px 0 3px $govuk-text-colour,
+                3px 1px 0 3px $govuk-text-colour;
+    // sass-lint:enable indentation
+    // When link is focussed, hide the default underline since the
+    // box shadow adds the "underline"
+    text-decoration: none;
+  }
+}

--- a/app/assets/stylesheets/govuk-frontend/focus/helpers.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/helpers.scss
@@ -7,7 +7,8 @@
 // - https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0
 //
 // These styles were added in https://github.com/alphagov/govuk-frontend/pull/1309
-
+// and edited in https://github.com/alphagov/govuk-frontend/pull/1455
+//
 /// Focusable with box-shadow
 ///
 /// Removes the visible outline and replace with box-shadow and background colour.
@@ -19,19 +20,10 @@
     // backgrounds and box-shadows disappear, so we need to ensure there's a
     // transparent outline which will be set to a visible colour.
 
-    // Since Internet Explorer 8 does not support box-shadow, we want to force the user-agent outlines
-    @include govuk-not-ie8 {
-      outline: $govuk-focus-width solid transparent;
-      outline-offset: 0;
-    }
-    color: $govuk-text-colour;
+    outline: $govuk-focus-width solid transparent;
+    color: $govuk-focus-text-colour;
     background-color: $govuk-focus-colour;
-    // sass-lint:disable indentation
-    box-shadow: -5px -1px 0 1px $govuk-focus-colour,
-                5px -1px 0 1px $govuk-focus-colour,
-                -3px 1px 0 3px $govuk-text-colour,
-                3px 1px 0 3px $govuk-text-colour;
-    // sass-lint:enable indentation
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
     // When link is focussed, hide the default underline since the
     // box shadow adds the "underline"
     text-decoration: none;

--- a/app/assets/stylesheets/govuk-frontend/focus/settings.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/settings.scss
@@ -1,0 +1,11 @@
+// Sass bringing in the new focus style from GOVUK Frontend 3.x.x
+// TO DO: Delete this file when we upgrade to GOVUK Frontend 3.x.x
+//
+// See the following for details of the update:
+// - https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/
+// - https://design-system.service.gov.uk/get-started/focus-states/
+// - https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0
+//
+// The new 'yellow' colour was added in https://github.com/alphagov/govuk-frontend/pull/1288
+
+$govuk-focus-colour: #ffdd00; // assign new 'yellow' colour directly to limit impact of change

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -96,6 +96,29 @@
 
 }
 
+/* The focus state for sibling links overlaps the hint so the hint's text colour needs to adapt */
+.govuk-link:focus {
+  &.file-list-filename,
+  &.file-list-filename-large,
+  & + .file-list-hint,
+  & + .file-list-hint-large {
+    /* link needs non-static position to overlap the cell border, hint so it isn't overlapped itself */
+    position: relative;
+  }
+
+  &.file-list-filename,
+  &.file-list-filename-large {
+    /* override box-shadow to push underline down a bit */
+    box-shadow: 0 -2px $govuk-focus-colour, 0 5px $govuk-focus-text-colour;
+  }
+
+  & + .file-list-hint,
+  & + .file-list-hint-large {
+    color: $govuk-focus-text-colour;
+  }
+
+}
+
 .failure-highlight {
   @include bold-19;
   color: $error-colour;

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -47,9 +47,13 @@ $button-shadow-size: $govuk-border-width-form-element;
         color: $white;
       }
 
-      &:hover,
-      &:active {
+      &:hover {
         color: $light-blue-25;
+      }
+
+      &:active,
+      &:focus {
+        color: $govuk-focus-text-colour;
       }
 
     }

--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -53,6 +53,11 @@ $item-top-padding: govuk-spacing(3);
       margin: 0;
     }
 
+    &:focus {
+      /* cancel default focus styling in favour of that from :before pseudo class */
+      box-shadow: none;
+    }
+
     &:before {
       content: "";
       display: block;
@@ -69,14 +74,13 @@ $item-top-padding: govuk-spacing(3);
 
     &:active:before,
     &:focus:before {
-      border-color: $yellow;
-      border-style: solid;
-      border-width: 15px 3px;
+      box-shadow: inset 0px -4px $govuk-focus-text-colour, inset 0px 16px $govuk-focus-colour, inset 3px 0px $govuk-focus-colour, inset 0px -15px $govuk-focus-colour, inset -3px 0px $govuk-focus-colour;
       right: -3px;
       left: -3px;
 
       @include govuk-media-query($from: tablet) {
         border-width: 15px 3px 15px 15px;
+        box-shadow: inset 0px -4px $govuk-focus-text-colour, inset 0px 16px $govuk-focus-colour, inset 15px 0px $govuk-focus-colour, inset 0px -15px $govuk-focus-colour, inset -3px 0px $govuk-focus-colour;
         left: -15px;
       }
     }


### PR DESCRIPTION
Updates our focus style to GOVUK's new one, to make the contrast compliant.

https://github.com/alphagov/notifications-admin/pull/3303/files

This is a draft proposal, intended to show where this work is so it can have some design work.

This includes:
1. changing the core focus style for links and buttons
2. updating all the variants of links and buttons custom to Notify

Number 2. includes an attempt to update the 'pill' items which probably needs some more work.

## New GOVUK Focus style

The new focus style is explained in [this blog post](https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/) and [this page on their docs](https://design-system.service.gov.uk/get-started/focus-states/).

The main thing to bear in mind, for any variants we introduce is:
- design system's design actually includes 2 styles (the colour and the underline) so part of it will always contrast with the background colour
- they need to comply with [WCAG 1.4.11](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html)

This [WCAG techniques article](https://www.w3.org/WAI/WCAG21/Techniques/css/C40) contains some useful tests for compliance of any similar design.

## Focus styles custom to Notify

Here's some screenshots of my attempt at updating the various links/buttons custom to Notify. I based this work on those found in https://github.com/alphagov/notifications-admin/pull/3303 so there's a chance I might have missed some...

### Link in dashboard table

<img width="750" alt="image" src="https://user-images.githubusercontent.com/87140/93191867-efb5f800-f73c-11ea-9f22-18bf7140adfa.png">

### Big numbers

<img width="243" alt="image" src="https://user-images.githubusercontent.com/87140/93191916-fe041400-f73c-11ea-9c9d-69ee06d898dc.png">

### Show more component

<img width="737" alt="image" src="https://user-images.githubusercontent.com/87140/93191943-08261280-f73d-11ea-9f52-864a4fe5f293.png">

### Service navigation links

<img width="205" alt="image" src="https://user-images.githubusercontent.com/87140/93192007-1b38e280-f73d-11ea-8422-1de6d44b8656.png">

### Org' navigation links

<img width="994" alt="image" src="https://user-images.githubusercontent.com/87140/93192066-2d1a8580-f73d-11ea-9db4-67196887fdd1.png">

### Previous/next navigation

<img width="415" alt="image" src="https://user-images.githubusercontent.com/87140/93192164-44f20980-f73d-11ea-9344-a32c4724c91b.png">

### Link in table cell

<img width="432" alt="image" src="https://user-images.githubusercontent.com/87140/93192241-5c30f700-f73d-11ea-9f65-2e1863216eba.png">

### Pill items

<img width="740" alt="image" src="https://user-images.githubusercontent.com/87140/93192295-6c48d680-f73d-11ea-95cc-a3ae32ab074c.png">

### Separate pill items

<img width="748" alt="image" src="https://user-images.githubusercontent.com/87140/93192334-779c0200-f73d-11ea-8e6d-10096aee2405.png">