### PR TITLE
fix back links for broadcast libraries

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -147,6 +147,25 @@ def choose_broadcast_area(service_id, broadcast_message_id, library_slug):
     )
 
 
+def _get_broadcast_sub_area_back_link(service_id, broadcast_message_id, library_slug):
+    prev_area_slug = request.args.get('prev_area_slug')
+    if prev_area_slug:
+        return url_for(
+            '.choose_broadcast_sub_area',
+            service_id=service_id,
+            broadcast_message_id=broadcast_message_id,
+            library_slug=library_slug,
+            area_slug=prev_area_slug,
+        )
+    else:
+        return url_for(
+            '.choose_broadcast_area',
+            service_id=service_id,
+            broadcast_message_id=broadcast_message_id,
+            library_slug=library_slug,
+        )
+
+
 @main.route(
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>/<area_slug>',
     methods=['GET', 'POST'],
@@ -159,6 +178,8 @@ def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, ar
         service_id=current_service.id,
     )
     area = BroadcastMessage.libraries.get_areas(area_slug)[0]
+
+    back_link = _get_broadcast_sub_area_back_link(service_id, broadcast_message_id, library_slug)
 
     is_county = any(sub_area.sub_areas for sub_area in area.sub_areas)
 
@@ -185,6 +206,7 @@ def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, ar
             page_title=f'Choose an area of {area.name}',
             broadcast_message=broadcast_message,
             county=area,
+            back_link=back_link,
         )
 
     return render_template(
@@ -195,6 +217,7 @@ def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, ar
         library_slug=library_slug,
         page_title=f'Choose an area of {area.name}',
         broadcast_message=broadcast_message,
+        back_link=back_link,
     )
 
 

--- a/app/templates/views/broadcast/counties.html
+++ b/app/templates/views/broadcast/counties.html
@@ -15,7 +15,7 @@
 
   {{ page_header(
     page_title,
-    back_link=url_for('.choose_broadcast_library', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+    back_link=back_link,
   )}}
 
   {% call form_wrapper() %}
@@ -30,7 +30,7 @@
       {# these are districts within a county#}
         <a
           class="file-list-filename-large govuk-link govuk-link--no-visited-state"
-          href="{{ url_for('.choose_broadcast_sub_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, library_slug=library_slug, area_slug=area.id) }}"
+          href="{{ url_for('.choose_broadcast_sub_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, library_slug=library_slug, area_slug=area.id, prev_area_slug=county.id) }}"
         >{{ area.name }}</a>
       </div>
     {% endfor %}

--- a/app/templates/views/broadcast/sub-areas.html
+++ b/app/templates/views/broadcast/sub-areas.html
@@ -13,7 +13,7 @@
 
   {{ page_header(
     page_title,
-    back_link=url_for('.choose_broadcast_library', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+    back_link=back_link,
   )}}
 
   {% call form_wrapper() %}


### PR DESCRIPTION
the county page links to districts. add a `prev_area_slug` query param to those URLs, so we can make the back link go back to the county page, if the user came from there.

if the user came straight from the library page, don't add the query param and don't change behaviour.