### PR TITLE
Fix copy to clipboard selection

### DIFF
--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -27,11 +27,27 @@
       `
     };
 
+    this.getRangeFromElement = function (keyElement) {
+      const range = document.createRange();
+      let prefixIndex = -1;
+
+      Array.from(keyElement.childNodes).forEach((el, idx) => {
+        if ((el.nodeType === 1) && el.classList.contains('govuk-visually-hidden')) {
+          prefixIndex = idx;
+        }
+      });
+
+      range.selectNodeContents(keyElement);
+      if (prefixIndex !== -1) { range.setStart(keyElement, prefixIndex + 1); }
+
+      return range;
+    };
+
     this.copyKey = function(keyElement, callback) {
       var selection = window.getSelection ? window.getSelection() : document.selection,
-          range = document.createRange();
+          range = this.getRangeFromElement(keyElement);
+
       selection.removeAllRanges();
-      range.selectNodeContents(keyElement);
       selection.addRange(range);
       document.execCommand('copy');
       selection.removeAllRanges();

--- a/tests/javascripts/apiKey.test.js
+++ b/tests/javascripts/apiKey.test.js
@@ -344,7 +344,7 @@ describe('API key', () => {
 
         });
 
-        test("the copied selection shouldn't include the prefix of the id", () => {
+        test("the copied selection (range) should start after the prefix of the id", () => {
 
           // that selection (a range) should have a startOffset past the first two nodes:
           // index 0: text node containing the whitespace before the prefix
@@ -388,7 +388,7 @@ describe('API key', () => {
 
         })
 
-        test("the copied selection should match the id", () => {
+        test("the copied selection (range) should start at the default position", () => {
 
           // that selection (a range) shouldn't call setStart to avoid the prefix:
           expect(rangeMock.setStart).not.toHaveBeenCalled();

--- a/tests/javascripts/apiKey.test.js
+++ b/tests/javascripts/apiKey.test.js
@@ -33,15 +33,11 @@ describe('API key', () => {
 
   };
 
-  beforeAll(() => {
+  beforeEach(() => {
 
     // mock objects used to manipulate the page selection
     selectionMock = new helpers.SelectionMock(jest);
     rangeMock = new helpers.RangeMock(jest);
-
-  });
-
-  beforeEach(() => {
 
     // plug gaps in JSDOM's API for manipulation of selections
     window.getSelection = jest.fn(() => selectionMock);
@@ -325,7 +321,7 @@ describe('API key', () => {
 
       describe("If it's one of many in the page", () => {
 
-        test("the button should have a hidden suffix naming the id it is for", () => {
+        beforeEach(() => {
 
           // If 'thing' (what the id is) and 'name' (its specific idenifier on the page) are
           // different, it will be one of others called the same 'thing'.
@@ -338,9 +334,28 @@ describe('API key', () => {
 
           helpers.triggerEvent(component.querySelector('button'), 'click');
 
+        });
+
+        test("the button should have a hidden suffix naming the id it is for", () => {
+
           const buttonSuffix = component.querySelector('button .govuk-visually-hidden');
           expect(buttonSuffix).not.toBeNull();
           expect(buttonSuffix.textContent).toEqual(' for Default');
+
+        });
+
+        test("the copied selection shouldn't include the prefix of the id", () => {
+
+          // that selection (a range) should have a startOffset past the first two nodes:
+          // index 0: text node containing the whitespace before the prefix
+          // index 1: the prefix node
+          expect(rangeMock.setStart).toHaveBeenCalled();
+          expect(rangeMock.setStart.mock.calls[0][1]).toEqual(2);
+
+          // reset any methods in the global space
+          window.queryCommandSupported = undefined;
+          window.getSelection = undefined;
+          document.createRange = undefined;
 
         });
 
@@ -372,6 +387,18 @@ describe('API key', () => {
           expect(buttonSuffix).toBeNull();
 
         })
+
+        test("the copied selection should match the id", () => {
+
+          // that selection (a range) shouldn't call setStart to avoid the prefix:
+          expect(rangeMock.setStart).not.toHaveBeenCalled();
+
+          // reset any methods in the global space
+          window.queryCommandSupported = undefined;
+          window.getSelection = undefined;
+          document.createRange = undefined;
+
+        });
 
       });
 

--- a/tests/javascripts/support/helpers/dom_interfaces.js
+++ b/tests/javascripts/support/helpers/dom_interfaces.js
@@ -30,7 +30,7 @@ class DOMInterfaceMock {
 class RangeMock extends DOMInterfaceMock {
 
   constructor (jest) {
-    super(jest, { props: [], methods: ['selectNodeContents'] });
+    super(jest, { props: [], methods: ['selectNodeContents', 'setStart'] });
   }
 
 }


### PR DESCRIPTION
🐛 spotted by @klssmith: since I added a hidden prefix to the key element on some variants of the `api_key` component, this got included in what was copied.

In other words, you got

`ID:ca6482bb-2ccf-4008-873d-ecf53db12ed5` 

...in your clipboard, not

`ca6482bb-2ccf-4008-873d-ecf53db12ed5`

This fixes it by moving the start of the selected [range](https://developer.mozilla.org/en-US/docs/Web/API/Range) so it starts after the prefix, if it exists.

## Notes

This also includes a change to the tests that makes some mocks renew before each test instead of just at the start. This is due to some state carrying across between tests.

## How to test this

Try copying an ID on `/service-settings/email-reply-to` (they have prefixes) and one on a template page (they don't).