### PR TITLE
Add a tour screen once a broadcast is approved

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -23,7 +23,7 @@ from app.utils import service_has_permission, user_has_permissions
 @user_has_permissions()
 @service_has_permission('broadcast')
 def broadcast_tour(service_id, step_index):
-    if step_index not in (1, 2, 3, 4, 5):
+    if step_index not in (1, 2, 3, 4, 5, 6):
         abort(404)
     return render_template(
         f'views/broadcast/tour/{step_index}.html'
@@ -274,6 +274,13 @@ def approve_broadcast_message(service_id, broadcast_message_id):
         ))
 
     broadcast_message.approve_broadcast()
+
+    if current_service.trial_mode:
+        return redirect(url_for(
+            '.broadcast_tour',
+            service_id=current_service.id,
+            step_index=6,
+        ))
 
     return redirect(url_for(
         '.view_broadcast_message',

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -1,0 +1,41 @@
+{% from "components/banner.html" import banner_wrapper %}
+
+{% extends "admin_template.html" %}
+
+{% block per_page_title %}
+  You’re still in training mode. Notify has not broadcast your alert.
+{% endblock %}
+
+{% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-0" %}
+
+{% block content %}
+
+  <div class="navigation-service">
+    <div class="navigation-service-name govuk-!-font-weight-bold">
+      {{ current_service.name }} <span class="navigation-service-type--training">Training</span>
+    </div>
+  </div>
+
+  <div class="banner-tour banner-tour-no-fixed-height banner-tour-with-service-name">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <h1 class="heading-medium">
+          You’re still in training mode. Notify has not broadcast your alert.
+        </h1>
+        <p class="govuk-body heading-medium">
+          In a real emergency, every mobile phone in the area
+          you chose would make a loud alarm noise.
+        </p>
+        <p class="govuk-body heading-medium">
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
+            Continue to dashboard
+          </a>
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <img src="{{ asset_url('images/broadcast-tour/3.png') }}" alt="">
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -3,7 +3,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  You’re still in training mode. Notify has not broadcast your alert.
+  Notify has not broadcast your alert because you’re still in training mode.
 {% endblock %}
 
 {% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-0" %}
@@ -20,7 +20,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="heading-medium">
-          You’re still in training mode. Notify has not broadcast your alert.
+          Notify has not broadcast your alert because you’re still in training mode.
         </h1>
         <p class="govuk-body heading-medium">
           In a real emergency, every mobile phone in the area


### PR DESCRIPTION
For a training broadcast the user doesn’t get that immediate feedback that something has happened, like they would with a real alert, or even sending themselves a text message.

This commit adds another tour-style page which will interrupt their journey and hopefully reinforce the message we’ve given them earlier in the tour.

We’re adding this because we’ve found in research that users don’t have a good grasp of the consequences and severity of emergency alerts, versus regular text messages.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/93458680-8965dc80-f8d8-11ea-858e-39a69e53c77b.png) | ![image](https://user-images.githubusercontent.com/355079/93458680-8965dc80-f8d8-11ea-858e-39a69e53c77b.png)
↓ |↓
![image](https://user-images.githubusercontent.com/355079/93458836-c0d48900-f8d8-11ea-9321-7c16a09f8635.png) | ![image](https://user-images.githubusercontent.com/355079/93472445-8f65b880-f8ec-11ea-81dc-ec9a7f6f81de.png)



