### PR TITLE
Use new focus colour for remove area button

### DIFF
--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -48,7 +48,7 @@
         outline: none;
 
         &:before {
-          background: $focus-colour;
+          background: $govuk-focus-colour;
           color: $black;
           border-color: $black;
         }


### PR DESCRIPTION
It already adds a black border on focus so doesn’t need the thick lower border.

# Before 

![image](https://user-images.githubusercontent.com/355079/93466343-ffbc0c00-f8e3-11ea-8c64-7c310d6d279b.png)

# After 

![image](https://user-images.githubusercontent.com/355079/93466392-14000900-f8e4-11ea-9717-1984aedfd436.png)
