### PR TITLE
Make table focusable

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -21,7 +21,8 @@
 
       this.$scrollableTable
         .on('scroll', this.toggleShadows)
-        .on('scroll', this.maintainHeight);
+        .on('scroll', this.maintainHeight)
+        .on('focus blur', () => this.$component.toggleClass('js-focus-style'));
 
       if (
         window.GOVUK.stickAtBottomWhenScrolling &&
@@ -36,7 +37,10 @@
 
     this.insertShims = () => {
 
-      this.$table.wrap('<div class="fullscreen-scrollable-table"/>');
+      let captionId = this.$table.find('caption').text().toLowerCase().replace(/[^A-Za-z]+/g, '');
+
+      this.$table.find('caption').attr('id', captionId);
+      this.$table.wrap(`<div class="fullscreen-scrollable-table" role="region" aria-labelledby="${captionId}" tabindex="0"/>`);
 
       this.$component
         .append(

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -144,3 +144,12 @@
   }
 
 }
+
+.js-focus-style {
+  outline: 3px solid $govuk-focus-text-colour;
+  box-shadow: 0 0 0 7px $govuk-focus-colour;
+
+  *:focus {
+    outline: none;
+  }
+}

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -145,6 +145,21 @@ describe('FullscreenTable', () => {
 
     });
 
+    test("it has a role of 'region' and an accessible name matching the caption", () => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      tableFrame = document.querySelector('.fullscreen-scrollable-table');
+      caption = tableFrame.querySelector('caption');
+
+      expect(tableFrame.hasAttribute('role')).toBe(true);
+      expect(tableFrame.getAttribute('role')).toEqual('region');
+      expect(tableFrame.hasAttribute('aria-labelledby')).toBe(true);
+      expect(tableFrame.getAttribute('aria-labelledby')).toEqual(caption.getAttribute('id'));
+
+    });
+
   });
 
   describe("the height of the table should fit the vertical space available to it", () => {
@@ -312,6 +327,26 @@ describe('FullscreenTable', () => {
 
       expect(numberColumnFrame.classList.contains('fullscreen-scrolled-table')).toBe(true);
       expect(rightEdgeShadow.classList.contains('visible')).toBe(true);
+
+    });
+
+  });
+
+  describe("when the table is focused", () => {
+
+    beforeEach(() => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      tableFrame = document.querySelector('.fullscreen-scrollable-table');
+      tableFrame.focus();
+
+    });
+
+    test("it should make the parent frame a focus style", () => {
+
+      expect(container.classList.contains('js-focus-style')).toBe(true);
 
     });
 


### PR DESCRIPTION
This makes the table we use to display uploaded lists focusable so it can be scrolled by keyboard-only users and those using voice activation software.

Part of https://www.pivotaltracker.com/story/show/174439429

![table_focus_state](https://user-images.githubusercontent.com/87140/93688125-6f382400-fabb-11ea-95e3-7f9e75785ec7.gif)

## How to test

Try scrolling the table using only the keyboard.