### PR TITLE
Step 3 of renaming cache keys for templates

### DIFF
--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -31,7 +31,6 @@ class BroadcastMessageAPIClient(NotifyAdminAPIClient):
     def get_broadcast_message(self, *, service_id, broadcast_message_id):
         return self.get(f'/service/{service_id}/broadcast-message/{broadcast_message_id}')
 
-    @cache.delete('broadcast-message-{broadcast_message_id}')
     @cache.delete('service-{service_id}-broadcast-message-{broadcast_message_id}')
     def update_broadcast_message(self, *, service_id, broadcast_message_id, data):
         self.post(
@@ -39,7 +38,6 @@ class BroadcastMessageAPIClient(NotifyAdminAPIClient):
             data=data,
         )
 
-    @cache.delete('broadcast-message-{broadcast_message_id}')
     @cache.delete('service-{service_id}-broadcast-message-{broadcast_message_id}')
     def update_broadcast_message_status(self, status, *, service_id, broadcast_message_id):
         data = _attach_current_user({

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -190,8 +190,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('template-{id_}-version-None')
-    @cache.delete('template-{id_}-versions')
     @cache.delete('service-{service_id}-template-{id_}-version-None')
     @cache.delete('service-{service_id}-template-{id_}-versions')
     def update_service_template(
@@ -220,8 +218,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('template-{id_}-version-None')
-    @cache.delete('template-{id_}-versions')
     @cache.delete('service-{service_id}-template-{id_}-version-None')
     @cache.delete('service-{service_id}-template-{id_}-versions')
     def redact_service_template(self, service_id, id_):
@@ -233,8 +229,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('template-{template_id}-version-None')
-    @cache.delete('template-{template_id}-versions')
     @cache.delete('service-{service_id}-template-{template_id}-version-None')
     @cache.delete('service-{service_id}-template-{template_id}-versions')
     def update_service_template_sender(self, service_id, template_id, reply_to):
@@ -248,8 +242,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('template-{template_id}-version-None')
-    @cache.delete('template-{template_id}-versions')
     @cache.delete('service-{service_id}-template-{template_id}-version-None')
     @cache.delete('service-{service_id}-template-{template_id}-versions')
     def update_service_template_postage(self, service_id, template_id, postage):
@@ -308,8 +300,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         ])
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('template-{template_id}-version-None')
-    @cache.delete('template-{template_id}-versions')
     @cache.delete('service-{service_id}-template-{template_id}-version-None')
     @cache.delete('service-{service_id}-template-{template_id}-versions')
     def delete_service_template(self, service_id, template_id):

--- a/tests/app/notify_client/test_broadcast_message_client.py
+++ b/tests/app/notify_client/test_broadcast_message_client.py
@@ -1,5 +1,3 @@
-from unittest.mock import call
-
 from app.notify_client.broadcast_message_api_client import (
     BroadcastMessageAPIClient,
 )
@@ -72,10 +70,7 @@ def test_update_broadcast_message(mocker):
         '/service/12345/broadcast-message/67890',
         data={'abc': 'def'},
     )
-    mock_redis_delete.assert_has_calls([
-        call('service-12345-broadcast-message-67890'),
-        call('broadcast-message-67890'),
-    ])
+    mock_redis_delete.assert_called_once_with('service-12345-broadcast-message-67890')
 
 
 def test_update_broadcast_message_status(mocker):
@@ -94,7 +89,4 @@ def test_update_broadcast_message_status(mocker):
         '/service/12345/broadcast-message/67890/status',
         data={'created_by': '1', 'status': 'cancelled'},
     )
-    mock_redis_delete.assert_has_calls([
-        call('service-12345-broadcast-message-67890'),
-        call('broadcast-message-67890'),
-    ])
+    mock_redis_delete.assert_called_once_with('service-12345-broadcast-message-67890')

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -437,36 +437,26 @@ def test_deletes_service_cache(
     ('update_service_template', [FAKE_TEMPLATE_ID, 'foo', 'sms', 'bar', SERVICE_ONE_ID], [
         'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-template-{}-version-None'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
-        'template-{}-versions'.format(FAKE_TEMPLATE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('redact_service_template', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID], [
         'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-template-{}-version-None'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
-        'template-{}-versions'.format(FAKE_TEMPLATE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template_sender', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 'foo'], [
         'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-template-{}-version-None'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
-        'template-{}-versions'.format(FAKE_TEMPLATE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template_postage', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 'first'], [
         'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-template-{}-version-None'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
-        'template-{}-versions'.format(FAKE_TEMPLATE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('delete_service_template', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID], [
         'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-template-{}-version-None'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
-        'template-{}-versions'.format(FAKE_TEMPLATE_ID),
-        'template-{}-version-None'.format(FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('archive_service', [SERVICE_ONE_ID, []], [


### PR DESCRIPTION
Remove deleting of old redis key

At this point we are no longer setting this key, nor are we reading from
it so we are able to delete it.