### PR TITLE
Suggest previously-used areas when adding new area

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -102,7 +102,10 @@ def choose_broadcast_library(service_id, broadcast_message_id):
     return render_template(
         'views/broadcast/libraries.html',
         libraries=BroadcastMessage.libraries,
-        broadcast_message_id=broadcast_message_id,
+        broadcast_message=BroadcastMessage.from_id(
+            broadcast_message_id,
+            service_id=current_service.id,
+        ),
     )
 
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -66,6 +66,16 @@ class BroadcastMessage(JSONModel):
         return self.get_areas(areas=self._dict['areas'])
 
     @property
+    def parent_areas(self):
+        return sorted(set(self._parent_areas_iterator))
+
+    @property
+    def _parent_areas_iterator(self):
+        for area in self.areas:
+            for parent in area.parents:
+                yield parent
+
+    @property
     def initial_area_names(self):
         return [
             area.name for area in self.areas

--- a/app/templates/views/broadcast/libraries.html
+++ b/app/templates/views/broadcast/libraries.html
@@ -10,11 +10,18 @@
 
   {{ page_header(
     "Choose where to broadcast to",
-    back_link=url_for(".preview_broadcast_areas", service_id=current_service.id, broadcast_message_id=broadcast_message_id)
+    back_link=url_for(".preview_broadcast_areas", service_id=current_service.id, broadcast_message_id=broadcast_message.id)
   ) }}
 
+  {% for area in broadcast_message.parent_areas %}
+    <a class="govuk-heading-m govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_broadcast_sub_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, library_slug=area.library_id, area_slug=area.id) }}">{{ area.name }}</a>
+    {% if loop.last %}
+      <div class="keyline-block"></div>
+    {% endif %}
+  {% endfor %}
+
   {% for library in libraries|sort %}
-    <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message_id, library_slug=library.id) }}">{{ library.name }}</a>
+    <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, library_slug=library.id) }}">{{ library.name }}</a>
     <p class="file-list-hint-large">{{ library.get_examples() }}</p>
   {% endfor %}
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -356,13 +356,65 @@ def test_preview_broadcast_areas_page(
     ]
 
 
+@pytest.mark.parametrize('areas, expected_list', (
+    ([], [
+        'Countries',
+        'Local authorities',
+    ]),
+    ([
+        # Countries have no parent areas
+        'ctry19-E92000001',
+        'ctry19-S92000003',
+    ], [
+        'Countries',
+        'Local authorities',
+    ]),
+    ([
+        # If you’ve chosen the whole of a county or unitary authority
+        # there’s no reason to  also pick districts of it
+        'ctyua19-E10000013',  # Gloucestershire, a county
+        'lad20-E06000052',  # Cornwall, a unitary authority
+    ], [
+        'Countries',
+        'Local authorities',
+    ]),
+    ([
+        'wd20-E05004299',  # Pitville, in Cheltenham, in Gloucestershire
+        'wd20-E05004290',  # Benhall and the Reddings, in Cheltenham, in Gloucestershire
+        'wd20-E05010951',  # Abbeymead, in Gloucester, in Gloucestershire
+        'wd20-S13002775',  # Shetland Central, in Shetland Isles
+        'lad20-E07000037',  # High Peak, a district in Derbyshire
+    ], [
+        'Cheltenham',
+        'Derbyshire',
+        'Gloucester',
+        'Gloucestershire',
+        'Shetland Islands',
+        # ---
+        'Countries',
+        'Local authorities',
+    ]),
+))
 def test_choose_broadcast_library_page(
+    mocker,
     client_request,
     service_one,
-    mock_get_draft_broadcast_message,
     fake_uuid,
+    areas,
+    expected_list,
 ):
     service_one['permissions'] += ['broadcast']
+    mocker.patch(
+        'app.broadcast_message_api_client.get_broadcast_message',
+        return_value=broadcast_message_json(
+            id_=fake_uuid,
+            template_id=fake_uuid,
+            created_by_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            status='draft',
+            areas=areas,
+        ),
+    )
     page = client_request.get(
         '.choose_broadcast_library',
         service_id=SERVICE_ONE_ID,
@@ -371,11 +423,8 @@ def test_choose_broadcast_library_page(
 
     assert [
         normalize_spaces(title.text)
-        for title in page.select('.file-list-filename-large')
-    ] == [
-        'Countries',
-        'Local authorities',
-    ]
+        for title in page.select('main a.govuk-link')
+    ] == expected_list
 
     assert normalize_spaces(page.select('.file-list-hint-large')[0].text) == (
         'England, Northern Ireland, Scotland and Wales'
@@ -386,6 +435,43 @@ def test_choose_broadcast_library_page(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         library_slug='ctry19',
+    )
+
+
+def test_suggested_area_has_correct_link(
+    mocker,
+    client_request,
+    service_one,
+    fake_uuid,
+):
+    service_one['permissions'] += ['broadcast']
+    mocker.patch(
+        'app.broadcast_message_api_client.get_broadcast_message',
+        return_value=broadcast_message_json(
+            id_=fake_uuid,
+            template_id=fake_uuid,
+            created_by_id=fake_uuid,
+            service_id=SERVICE_ONE_ID,
+            status='draft',
+            areas=[
+                'wd20-E05004299',  # Pitville, a ward of Cheltenham
+            ],
+        ),
+    )
+    page = client_request.get(
+        '.choose_broadcast_library',
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
+    )
+    link = page.select_one('main a.govuk-link')
+
+    assert link.text == 'Cheltenham'
+    assert link['href'] == url_for(
+        'main.choose_broadcast_sub_area',
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=fake_uuid,
+        library_slug='wd20-lad20-ctyua19',
+        area_slug='lad20-E07000078',
     )
 
 


### PR DESCRIPTION
If you’re adding another area to your broadcast it’s likely to be close to one of the areas you’ve already added.

But we make you start by choosing a library, then you have to find the local authority again from the long list. This is clunky, and it interrupts the task the user is trying to complete.

We thought about redirecting you somewhere deep into the hierarchy, perhaps by sending you to either:
- the parent of the last area you’d chosen
- the common ancestor of all the areas you’d chosen

This approach would however mean you’d need a way to navigate back up the hierarchy if we’d dropped you in the wrong place. And we don’t have a pattern for that at the moment.

So instead this commit adds some ‘shortcuts’ to the chose library page, giving you a choice of all the parents of the areas you’ve currently selected. In most cases this will be one (unitary authority) or two (county and district) choices, but it will scale to adding areas from multiple different authorities.

It does mean an extra click compared to the redirect approach, but this is still fewer, easier clicks compared to now.

# Before

The ‘Choose where to broadcast to’ page always looks like this, no matter where you’ve come from:

![image](https://user-images.githubusercontent.com/355079/93904173-79436800-fcf1-11ea-8f61-da0560e48c66.png)


# After 

If you click ‘Add another area’ on this page:
![image](https://user-images.githubusercontent.com/355079/93904058-4f8a4100-fcf1-11ea-9f63-cefb8185ac8b.png)

You get some extra choices:
![image](https://user-images.githubusercontent.com/355079/93904097-5e70f380-fcf1-11ea-9ea7-b82a275ce33f.png)


# Implementation details 

This meant a couple of under-the-hood changes:
- making `BroadcastArea`s hashable so it’s possible to do `set([BroadcastArea(…), BroadcastArea(…), BroadcastArea(…)])`
- making `BroadcastArea`s aware of which library they live in, so we can link to the correct _Choose area_ page
