### PR TITLE
move service to broadcast org when broadcasting is enabled

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -84,6 +84,8 @@ class Config(object):
     ASSET_DOMAIN = ''
     ASSET_PATH = '/static/'
 
+    BROADCAST_ORGANISATION_ID = os.environ.get('BROADCAST_ORGANISATION_ID')
+
     NOTIFY_SERVICE_ID = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
 
 
@@ -176,6 +178,8 @@ class Live(Config):
     CHECK_PROXY_HEADER = False
     ASSET_DOMAIN = 'static.notifications.service.gov.uk'
     ASSET_PATH = 'https://static.notifications.service.gov.uk/'
+
+    BROADCAST_ORGANISATION_ID = '38e4bf69-93b0-445d-acee-53ea53fe02df'
 
 
 class CloudFoundryConfig(Config):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -100,9 +100,16 @@ class Service(JSONModel):
         )
 
     def force_broadcast_permission_on(self):
-        return self.update_permissions(
+        ret = self.update_permissions(
             set(self.permissions) - {'email', 'sms', 'letter'} | {'broadcast'}
         )
+        broadcast_org_id = current_app.config['BROADCAST_ORGANISATION_ID']
+        if broadcast_org_id:
+            organisations_client.update_service_organisation(
+                service_id=self.id,
+                org_id=broadcast_org_id
+            )
+        return ret
 
     def update_permissions(self, permissions):
         return self.update(permissions=list(permissions))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3360,7 +3360,7 @@ def mock_get_service_organisation(
 
 @pytest.fixture(scope='function')
 def mock_update_service_organisation(mocker):
-    def _update_service_organisation(service_id, organisation_id):
+    def _update_service_organisation(service_id, org_id):
         return
 
     return mocker.patch(
@@ -3504,7 +3504,7 @@ def mock_organisation_name_is_unique(mocker):
 
 @pytest.fixture(scope='function')
 def mock_update_organisation(mocker):
-    def _update_org(organisation_id, **kwargs):
+    def _update_org(org, **kwargs):
         return
 
     return mocker.patch('app.organisations_client.update_organisation', side_effect=_update_org)


### PR DESCRIPTION
we want to keep track of all broadcast services across govt easily. As such, when broadcasting is enabled for a service, we've decided we're going to add the service to a special broadcasting organisation.

This organisation is defined in the config file. It's hard coded based on the db migration in the api pr referenced.

This organisation already exists on production(https://www.notifications.service.gov.uk/organisations/38e4bf69-93b0-445d-acee-53ea53fe02df). 