### PR TITLE
Make only the scrollable table focusable

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -48,6 +48,7 @@
             .clone()
             .addClass('fullscreen-fixed-table')
             .removeClass('fullscreen-scrollable-table')
+            .removeAttr('role aria-labelledby tabindex')
             .attr('aria-hidden', true)
         )
         .append(

--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -37,6 +37,7 @@
 
     this.insertShims = () => {
 
+      const attributesForFocus = 'role aria-labelledby tabindex';
       let captionId = this.$table.find('caption').text().toLowerCase().replace(/[^A-Za-z]+/g, '');
 
       this.$table.find('caption').attr('id', captionId);
@@ -48,7 +49,7 @@
             .clone()
             .addClass('fullscreen-fixed-table')
             .removeClass('fullscreen-scrollable-table')
-            .removeAttr('role aria-labelledby tabindex')
+            .removeAttr(attributesForFocus)
             .attr('aria-hidden', true)
         )
         .append(

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -145,7 +145,7 @@ describe('FullscreenTable', () => {
 
     });
 
-    test("it has a role of 'region' and an accessible name matching the caption", () => {
+    test("the scrolling section is focusable and has an accessible name matching the table caption", () => {
 
       // start module
       window.GOVUK.modules.start();
@@ -157,6 +157,21 @@ describe('FullscreenTable', () => {
       expect(tableFrame.getAttribute('role')).toEqual('region');
       expect(tableFrame.hasAttribute('aria-labelledby')).toBe(true);
       expect(tableFrame.getAttribute('aria-labelledby')).toEqual(caption.getAttribute('id'));
+
+    });
+
+    test("the section providing the fixed row headers is not focusable and is hidden from assistive tech'", () => {
+
+      // start module
+      window.GOVUK.modules.start();
+
+      fixedRowHeaders = document.querySelector('.fullscreen-fixed-table');
+
+      expect(fixedRowHeaders.hasAttribute('role')).toBe(false);
+      expect(fixedRowHeaders.hasAttribute('aria-labelledby')).toBe(false);
+      expect(fixedRowHeaders.hasAttribute('tabindex')).toBe(false);
+      expect(fixedRowHeaders.hasAttribute('aria-hidden')).toBe(true);
+      expect(fixedRowHeaders.getAttribute('aria-hidden')).toEqual('true');
 
     });
 


### PR DESCRIPTION
The JS clones the scrollable table so was passing its attributes across to the fixed one (which provides the row headings).

This bug was pushed in:

https://github.com/alphagov/notifications-admin/pull/3637