### PR TITLE
Replace uses of $yellow for focus

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -56,7 +56,7 @@
   text-align: left;
 
   &:focus {
-    outline: 3px solid $yellow;
+    outline: 3px solid $govuk-focus-colour;
   }
 
   .list {
@@ -134,16 +134,17 @@
       color: $white;
     }
 
-    &:focus,
-    &:active {
-      color: $govuk-focus-text-colour;
-      outline: 10px solid $yellow;
-    }
-
     &:hover {
       color: $white;
       background-color: $link-hover-colour;
-      outline: 10px solid $link-hover-colour;
+      box-shadow: 0 0 0 10px solid $link-hover-colour;
+    }
+
+    &:focus,
+    &:active {
+      color: $govuk-focus-text-colour;
+      background-color: $govuk-focus-colour;
+      box-shadow: 0 0 0 10px $govuk-focus-colour, 0 4px 0 10px $govuk-focus-text-colour;
     }
 
   }

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -23,7 +23,8 @@
       z-index: -1;
 
       &:focus + .file-upload-button {
-        outline: 3px solid $yellow;
+        background: $govuk-focus-colour;
+        color: $govuk-focus-text-colour;
       }
 
     }

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -41,13 +41,6 @@ $message-type-bottom-spacing: govuk-spacing(4);
         border-color: $link-hover-colour;
       }
 
-      &:focus {
-        // Use box shadow instead of outline to avoid buggy outline
-        // rendering in Firefox
-        outline: none;
-        box-shadow: 0 0 0 3px $yellow;
-      }
-
       .message-name-separator {
 
         margin-right: -2px;

--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -2,7 +2,7 @@
 .placeholder {
 
   display: inline;
-  background: $yellow;
+  background: $govuk-focus-colour;
   color: $text-colour;
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -53,7 +53,7 @@
   }
 
   *:focus + p & {
-    box-shadow: inset 0 -0.35em 0 0 $yellow;
+    box-shadow: inset 0 -0.35em 0 0 $govuk-focus-colour;
   }
 
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -272,8 +272,11 @@
 
       &:focus {
 
+        box-shadow: none;
+
         &:before {
-          background: $yellow;
+          background: $govuk-focus-colour;
+          box-shadow: inset 0 -4px 0 0 $govuk-focus-text-colour;
           z-index: -1;
         }
 


### PR DESCRIPTION
There are a few places where we missed updating to the new focus styles because they were using the `$yellow` SASS variable and not the `$focus-colour` variable.

This commit updates them to the new colour, and where needed adds the black lower border to match.