### PR TITLE
Don’t use $yellow to indicate local environment

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -20,3 +20,7 @@ $(() => GOVUK.modules.start());
 $(() => $('.error-message').eq(0).parent('label').next('input').trigger('focus'));
 
 $(() => $('.banner-dangerous').eq(0).trigger('focus'));
+
+$(() => $('.govuk-header__container').on('click', function() {
+  $(this).css('border-color', '#005ea5');
+}));

--- a/app/config.py
+++ b/app/config.py
@@ -45,7 +45,7 @@ class Config(object):
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api
     EMAIL_2FA_EXPIRY_SECONDS = 1800  # 30 Minutes
-    HEADER_COLOUR = '#FFBF47'  # $yellow
+    HEADER_COLOUR = '#81878b'  # mix(govuk-colour("dark-grey"), govuk-colour("mid-grey"))
     HTTP_PROTOCOL = 'http'
     MAX_FAILED_LOGIN_COUNT = 10
     NOTIFY_APP_NAME = 'admin'


### PR DESCRIPTION
It clashes with the new `$govuk-focus-colour` now. This commit changes it to half way between `govuk-colour("dark-grey")` (`#505a5f`) and `govuk-colour("mid-grey")` (`#b1b4b6`) from the Design System to get `#81878b`. Dark was too dark and mid was too light.

It also adds a line of JS to let us easily switch the header to blue by clicking on it, which is useful for taking screenshots etc.

# Before 

![image](https://user-images.githubusercontent.com/355079/93998368-56b25d00-fd8c-11ea-8c9a-56aba257dda0.png)

# After 

![image](https://user-images.githubusercontent.com/355079/93998397-629e1f00-fd8c-11ea-82f5-d4b1245a83e8.png)

![image](https://user-images.githubusercontent.com/355079/93998435-7184d180-fd8c-11ea-9672-efc6c7d41951.png)

![image](https://user-images.githubusercontent.com/355079/93998475-7cd7fd00-fd8c-11ea-81c9-6fffa37e2cb5.png)

![image](https://user-images.githubusercontent.com/355079/93998517-8c574600-fd8c-11ea-9cc2-13d687a8b6b8.png)
