### PR TITLE
Fix styling of ‘Training’ tag on tour step 6

### DIFF
--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -12,7 +12,7 @@
 
   <div class="navigation-service">
     <div class="navigation-service-name govuk-!-font-weight-bold">
-      {{ current_service.name }} <span class="navigation-service-type--training">Training</span>
+      {{ current_service.name }} <span class="navigation-service-type navigation-service-type--training">Training</span>
     </div>
   </div>
 


### PR DESCRIPTION
It was missing the base class so didn’t get all the styling (like the spacing and uppercase text) on this specific page.

# Before 

![image](https://user-images.githubusercontent.com/355079/94031360-ab6acd80-fdb6-11ea-87e7-d31618a54751.png)

# After 

![image](https://user-images.githubusercontent.com/355079/94031307-9ee67500-fdb6-11ea-9ada-ca46e0cb3c09.png)
