### PR TITLE
Fix styling of ‘Training’ tag on tour step 5

### DIFF
--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -12,7 +12,7 @@
 
   <div class="navigation-service">
     <div class="navigation-service-name govuk-!-font-weight-bold">
-      {{ current_service.name }} <span class="navigation-service-type--training">Training</span>
+      {{ current_service.name }} <span class="navigation-service-type navigation-service-type--training">Training</span>
     </div>
   </div>
 


### PR DESCRIPTION
It was missing the base class so didn’t get all the styling (like the spacing and uppercase text).

Already fixed this for step 6 in https://github.com/alphagov/notifications-admin/pull/3648 but less haste, more speed.