### PR TITLE
Make the ‘will get alert’ and ‘likely to get alert‘ areas on the map clearer 

### DIFF
--- a/app/assets/images/dashed-border-govuk-blue.svg
+++ b/app/assets/images/dashed-border-govuk-blue.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#185FA0;stroke-width:2;stroke-miterlimit:10;}
+</style>
+<g>
+	<polyline class="st0" points="14,5.1 14,1 9.9,1 	"/>
+	<polyline class="st0" points="5.1,1 1,1 1,5.1 	"/>
+	<polyline class="st0" points="1,9.9 1,14 5.1,14 	"/>
+	<polyline class="st0" points="9.9,14 14,14 14,9.9 	"/>
+</g>
+</svg>

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -1,6 +1,6 @@
 .area-list {
 
-  display: inline-block;
+  display: inline;
 
   &-item {
 
@@ -104,17 +104,26 @@
 
   &--certain {
     &:before {
-      border: 4px solid rgba($white, 0.1);
-      background: rgba($govuk-blue, 0.6);
-      box-shadow: inset 0 0 0 2px $black;
+      border: 2px solid $black;
+      background: $light-blue-50;
     }
   }
 
   &--likely {
     &:before {
       padding: 1px;
-      border: 2px solid $govuk-blue;
-      background: rgba($govuk-blue, 0.2);
+      border: 2px dashed $govuk-blue;
+      border-image: file-url('dashed-border-govuk-blue.svg') 4 round;
+      background: $light-blue-25;
+    }
+  }
+
+  &--phone-estimate {
+    padding-left: govuk-spacing(1);
+    margin-right: 0;
+    float: right;
+    &:before {
+      display: none;
     }
   }
 

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -94,12 +94,13 @@
     content: "";
     display: block;
     position: absolute;
-    top: 0;
-    left: 0;
-    width: govuk-spacing(7);
-    height: govuk-spacing(7);
+    top: 4px;
+    left: govuk-spacing(1);
+    width: govuk-spacing(6);
+    height: govuk-spacing(6);
     box-sizing: border-box;
     margin-right: govuk-spacing(1);
+    transform: rotate(45deg);
   }
 
   &--certain {

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -94,7 +94,7 @@
     content: "";
     display: block;
     position: absolute;
-    top: 4px;
+    top: 3px;
     left: govuk-spacing(1);
     width: govuk-spacing(6);
     height: govuk-spacing(6);

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -128,7 +128,7 @@ class BroadcastMessage(JSONModel):
     def count_of_phones(self):
         return round_to_significant_figures(
             sum(area.count_of_phones for area in self.areas),
-            2
+            1
         )
 
     @property
@@ -136,7 +136,7 @@ class BroadcastMessage(JSONModel):
         area_estimate = self.simple_polygons.estimated_area
         bleed_area_estimate = self.simple_polygons.bleed.estimated_area - area_estimate
         return round_to_significant_figures(
-            self.count_of_phones * bleed_area_estimate / area_estimate,
+            self.count_of_phones + (self.count_of_phones * bleed_area_estimate / area_estimate),
             1
         )
 

--- a/app/templates/views/broadcast/macros/area-map.html
+++ b/app/templates/views/broadcast/macros/area-map.html
@@ -7,7 +7,7 @@
       </span>
       Will get
       <span class="visually-hidden">the</span>
-      alert ({{ broadcast_message.count_of_phones|format_thousands }} phones)
+      alert
     </li>
     <li class="area-key area-key--likely">
       <span class="visually-hidden">
@@ -18,7 +18,13 @@
         the
       </span>
       alert
-      ({{ broadcast_message.count_of_phones_likely|format_thousands }} phones)
+    </li>
+    <li class="area-key area-key--phone-estimate">
+      {% if broadcast_message.count_of_phones == broadcast_message.count_of_phones_likely %}
+        {{ broadcast_message.count_of_phones|format_thousands }} phones estimated
+      {% else %}
+        {{ broadcast_message.count_of_phones|format_thousands }} to {{ broadcast_message.count_of_phones_likely|format_thousands }} phones
+      {% endif %}
     </li>
   </ul>
 {% endmacro %}

--- a/app/templates/views/broadcast/partials/area-map-javascripts.html
+++ b/app/templates/views/broadcast/partials/area-map-javascripts.html
@@ -5,23 +5,13 @@
   {% for polygon in broadcast_message.simple_polygons.bleed.as_coordinate_pairs_lat_long %}
     polygons.push(
       L.polygon({{polygon}}, {
-        opacity: 0.8,
-        color: '#005ea5', // $light-blue
-        fillColor: '#005ea5', // $light-blue
+        opacity: 1,
+        color: '#005ea5',
+        fillColor: '#2B8CC4',
         fillOpacity: 0.15,
-        weight: 2
-      })
-    );
-  {% endfor %}
-
-  {% for polygon in broadcast_message.simple_polygons.as_coordinate_pairs_lat_long %}
-    polygons.push(
-      L.polygon({{polygon}}, {
-        opacity: 0.3,
-        color: '#005ea5', // $black
-        fillColor: '#005ea5', // $light-blue
-        fillOpacity: 0.3,
-        weight: 1
+        weight: 2,
+        dashArray: [6, 7],
+        lineCap: 'butt'
       })
     );
   {% endfor %}
@@ -29,8 +19,9 @@
   {% for polygon in broadcast_message.polygons.as_coordinate_pairs_lat_long %}
     polygons.push(
       L.polygon({{polygon}}, {
-        color: '#0b0b0c', // $black
-        fillOpacity: 0,
+        color: '#0b0b0c',
+        fillColor: '#005ea5',
+        fillOpacity: 0.3,
         weight: 2
       })
     );


### PR DESCRIPTION
# Restyle the map areas and key 

We’ve had some feedback that relying only on luminosity and position to differentiate between the ‘will get alert’ and ‘likely to get alert’ areas on the map might not be enough.

We don’t want to introduce another colour because:
- it will make the map look very busy
- not many other colours contrast with the map tiles as well as blue
- relying on colour only to communicate information is also bad for accessibility

Instead we can make one of the lines a different style. I’ve gone for dashed on the ‘likely’ line because it looks nice, and gives some suggestion of a porous boundary.

Implementing this means using CSS border image, because a `dashed` border in CSS (which we still have as a fallback) doesn’t render with consistent dash sizes from browser to browser. We need consistency to match the dashes that the map will be drawing (which use SVG not CSS so don’t have the same problem).

***

The map also looks a bit busy because we show both the actual boundary (black line) and the simplified boundary (dark blue area). This was useful for us to see to check how the simplification was working, but is probably too much implementation detail for someone preparing the alert to worry about. So we can make the map clearer by removing it.

***

We’ve also had some feedback that the map key icons look a bit like checkboxes, and that this might have confused a user during the research.

So we need a way of making them look different to checkboxes. We don’t want to change the border thickness because it matches what’s on the map. A different approach is changing the shape.

Shapes that might still be confusing:
- circles (look like radio buttons)
- triangles (look like a warning)

So this commit changes the shape to a diamond, which is easy to achieve by rotating the square 45 degrees.

# Make estimated phone count clearer

We’ve had some feedback from user research that difference between ‘will get alert’ and ‘likely to get alert’ is not clear, and it’s hard to tell if the latter is inclusive of the former. This leads people to question the validity of these numbers, which is important, because an the estimate should give you some idea of the impact of what you’re about to do.

This commit reformats the number as a range, for example 1,000 to 2,000 phones.

If the range is small, eg 40,000,000 to 40,800,000 then this suggests a false level of accuracy. So instead we just give one number and say it’s an estimate, eg ‘40,000,000 phones estimated’

# Before 

![image](https://user-images.githubusercontent.com/355079/94164832-6f506f00-fe81-11ea-8e77-3ea6ee60a079.png)

# After 

![image](https://user-images.githubusercontent.com/355079/94164776-5f388f80-fe81-11ea-90b3-2513f563ce4a.png)


