### PR TITLE
Bump utils to 42.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@41.3.0#egg=notifications-utils==41.3.0
+git+https://github.com/alphagov/notifications-utils.git@42.2.0#egg=notifications-utils==42.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@41.3.0#egg=notifications-utils==41.3.0
+git+https://github.com/alphagov/notifications-utils.git@42.2.0#egg=notifications-utils==42.2.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
@@ -34,10 +34,10 @@ prometheus-client==0.8.0
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.134
+awscli==1.18.146
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.17.57
+botocore==1.18.5
 cachetools==4.1.0
 certifi==2020.6.20
 chardet==3.0.4
@@ -50,7 +50,7 @@ et-xmlfile==1.0.1
 flask-redis==0.4.0
 future==0.18.2
 geojson==2.5.0
-greenlet==0.4.16
+greenlet==0.4.17
 idna==2.10
 jdcal==1.4.1
 Jinja2==2.11.2

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -233,7 +233,7 @@ def test_upload_csv_file_shows_error_banner_for_too_many_rows(
 ):
     mocker.patch('app.models.contact_list.s3upload', return_value=fake_uuid)
     mocker.patch('app.models.contact_list.s3download', return_value='\n'.join(
-        ['phone number'] + (['07700900986'] * 50001)
+        ['phone number'] + (['07700900986'] * 100_001)
     ))
 
     page = client_request.post(
@@ -245,8 +245,8 @@ def test_upload_csv_file_shows_error_banner_for_too_many_rows(
 
     assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
         'Your file has too many rows '
-        'Notify can store files up to 50,000 rows in size. '
-        'Your file has 50,001 rows.'
+        'Notify can store files up to 100,000 rows in size. '
+        'Your file has 100,001 rows.'
     )
     assert len(page.select('tbody tr')) == 50
     assert normalize_spaces(page.select_one('.table-show-more-link').text) == (


### PR DESCRIPTION
Increases CSV row limit from 50,000 to 100,000

Changes: https://github.com/alphagov/notifications-utils/compare/41.3.0...42.2.0