### PR TITLE
Remove 's' to fix typo

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -114,7 +114,7 @@
   </h3>
 
   <p class="govuk-body">
-    One page links to a PDF documents that is not fully accessible. This is not a fail under any WCAG 2.1 success criterion.</p>
+    One page links to a PDF document that is not fully accessible. This is not a fail under any WCAG 2.1 success criterion.</p>
 
   <p class="govuk-body">
     We provide a written description of the information in the PDF on an HTML page as an accessible alternative.


### PR DESCRIPTION
Removes the plural version of 'documents' from the _PDFs_ section of the accessibility statement.