### PR TITLE
Format big numbers correctly when numbers too big

### DIFF
--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -1,3 +1,5 @@
+{% from "components/message-count-label.html" import recipient_count_label %}
+
 <h1 class='banner-title' data-module="track-error" data-error-type="Trial mode: too many recipients" data-error-label="{{ upload_id }}">
   {% if original_file_name %}
     Too many recipients
@@ -6,7 +8,7 @@
   {% endif %}
 </h1>
 <p class="govuk-body">
-  You can only send {{ current_service.message_limit }} messages per day
+  You can only send {{ current_service.message_limit|format_thousands }} messages per day
   {%- if current_service.trial_mode %}
     in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.trial_mode_new')}}">trial mode</a>
   {%- endif -%}
@@ -15,26 +17,10 @@
 {% if original_file_name %}
   <p class="govuk-body">
     {% if current_service.message_limit != remaining_messages %}
-      You can still send {{ remaining_messages }} messages today, but
+      You can still send {{ remaining_messages|format_thousands }} messages today, but
     {% endif %}
     ‘{{ original_file_name }}’ contains
-    {{ count_of_recipients }}
-    {% if count_of_recipients == 1 -%}
-      {%- if template.template_type == 'email' -%}
-        email address
-      {%- elif template.template_type == 'sms' -%}
-        phone number
-      {%- elif template.template_type == 'letter' -%}
-        address
-      {%- endif -%}
-    {%- else -%}
-      {%- if template.template_type == 'email' -%}
-        email addresses
-      {%- elif template.template_type == 'sms' -%}
-        phone numbers
-      {%- elif template.template_type == 'letter' -%}
-        addresses
-      {%- endif -%}
-    {%- endif -%}.
+    {{ count_of_recipients|format_thousands }}
+    {{ recipient_count_label(count_of_recipients, template.template_type) }}.
   </p>
 {% endif %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3329,8 +3329,8 @@ def test_go_to_dashboard_after_tour_link(
 
 
 @pytest.mark.parametrize('num_requested,expected_msg', [
-    (0, '‘valid.csv’ contains 100 phone numbers.'),
-    (1, 'You can still send 49 messages today, but ‘valid.csv’ contains 100 phone numbers.')
+    (0, '‘valid.csv’ contains 1,234 phone numbers.'),
+    (1, 'You can still send 49 messages today, but ‘valid.csv’ contains 1,234 phone numbers.')
 ], ids=['none_sent', 'some_sent'])
 def test_check_messages_shows_too_many_messages_errors(
     mocker,
@@ -3346,7 +3346,7 @@ def test_check_messages_shows_too_many_messages_errors(
 ):
     # csv with 100 phone numbers
     mocker.patch('app.main.views.send.s3download', return_value=',\n'.join(
-        ['phone number'] + ([mock_get_users_by_service(None)[0]['mobile_number']] * 100)
+        ['phone number'] + ([mock_get_users_by_service(None)[0]['mobile_number']] * 1234)
     ))
     mocker.patch('app.service_api_client.get_service_statistics', return_value={
         'sms': {'requested': num_requested, 'delivered': 0, 'failed': 0},
@@ -4291,7 +4291,7 @@ SERVICE_DAILY_LIMIT_MSG = 'Exceeded send limits (1000) for today'
     (
         SERVICE_DAILY_LIMIT_MSG,
         'Daily limit reached',
-        'You can only send 1000 messages per day in trial mode.'
+        'You can only send 1,000 messages per day in trial mode.'
     ),
 ])
 def test_send_notification_shows_error_if_400(


### PR DESCRIPTION
Comma should be used as the thousands separator. Code can be simplified by using macro to pluralise.