### PR TITLE
Fix incorrect processing started time on jobs

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -16,7 +16,7 @@ from app import user_api_client
 from app.main import main
 from app.main.forms import TwoFactorForm
 from app.models.user import User
-from app.utils import is_less_than_90_days_ago, redirect_to_sign_in
+from app.utils import is_less_than_days_ago, redirect_to_sign_in
 
 
 @main.route('/two-factor-email-sent', methods=['GET'])
@@ -70,7 +70,7 @@ def two_factor():
     form = TwoFactorForm(_check_code)
 
     if form.validate_on_submit():
-        if is_less_than_90_days_ago(user.email_access_validated_at):
+        if is_less_than_days_ago(user.email_access_validated_at, 90):
             return log_in_user(user_id)
         else:
             user_api_client.send_verify_code(user.id, 'email', None, request.args.get('next'))

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytz
 from notifications_utils.letter_timings import (
@@ -6,17 +6,18 @@ from notifications_utils.letter_timings import (
     get_letter_timings,
     letter_can_be_cancelled,
 )
-from notifications_utils.timezones import (
-    local_timezone,
-    utc_string_to_aware_gmt_datetime,
-)
+from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList
 from app.notify_client.job_api_client import job_api_client
 from app.notify_client.notification_api_client import notification_api_client
 from app.notify_client.service_api_client import service_api_client
-from app.utils import get_letter_printing_statement, set_status_filters
+from app.utils import (
+    get_letter_printing_statement,
+    is_less_than_days_ago,
+    set_status_filters,
+)
 
 
 class Job(JSONModel):
@@ -123,11 +124,7 @@ class Job(JSONModel):
             # must have been created recently enough to not have any
             # notifications yet
             return True
-        return (
-            datetime.utcnow().astimezone(local_timezone) - utc_string_to_aware_gmt_datetime(
-                self.processing_started
-            )
-        ).days < 1
+        return is_less_than_days_ago(self.processing_started, 1)
 
     @property
     def template_id(self):

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -67,7 +67,7 @@ class Job(JSONModel):
     def processing_started(self):
         if not self._dict.get('processing_started'):
             return None
-        return utc_string_to_aware_gmt_datetime(self._dict['processing_started'])
+        return self._dict['processing_started']
 
     def _aggregate_statistics(self, *statuses):
         return sum(
@@ -124,7 +124,9 @@ class Job(JSONModel):
             # notifications yet
             return True
         return (
-            datetime.utcnow().astimezone(local_timezone) - self.processing_started
+            datetime.utcnow().astimezone(local_timezone) - utc_string_to_aware_gmt_datetime(
+                self.processing_started
+            )
         ).days < 1
 
     @property

--- a/app/utils.py
+++ b/app/utils.py
@@ -822,7 +822,7 @@ def format_thousands(value):
 
 def is_less_than_days_ago(date_from_db, number_of_days):
     return (
-        datetime.utcnow().astimezone(pytz.utc) - parser.parse(date_from_db).astimezone(pytz.utc)
+        datetime.utcnow().astimezone(pytz.utc) - parser.parse(date_from_db)
     ).days < number_of_days
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -820,10 +820,10 @@ def format_thousands(value):
     return value
 
 
-def is_less_than_90_days_ago(date_from_db):
-    return (datetime.utcnow() - datetime.strptime(
-        date_from_db, "%Y-%m-%dT%H:%M:%S.%fZ"
-    )).days < 90
+def is_less_than_days_ago(date_from_db, number_of_days):
+    return (
+        datetime.utcnow().astimezone(pytz.utc) - parser.parse(date_from_db).astimezone(pytz.utc)
+    ).days < number_of_days
 
 
 def hide_from_search_engines(f):

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -690,8 +690,8 @@ def test_should_show_updates_for_scheduled_job_as_json(
         service_one['id'],
         created_by=user_json(),
         job_id=fake_uuid,
-        scheduled_for='2016-06-01T13:00:00',
-        processing_started='2016-06-01T15:00:00',
+        scheduled_for='2016-06-01T13:00:00+00:00',
+        processing_started='2016-06-01T15:00:00+00:00',
     )})
 
     response = logged_in_client.get(url_for('main.view_job_updates', service_id=service_one['id'], job_id=fake_uuid))

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -706,7 +706,7 @@ def test_should_show_updates_for_scheduled_job_as_json(
     assert 'Status' in content['notifications']
     assert 'Delivered' in content['notifications']
     assert '12:01am' in content['notifications']
-    assert 'Sent by Test User on 1 June at 5:00pm' in content['status']
+    assert 'Sent by Test User on 1 June at 4:00pm' in content['status']
 
 
 @pytest.mark.parametrize(

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -20,7 +20,7 @@ from app.utils import (
     get_letter_validation_error,
     get_logo_cdn_domain,
     get_sample_template,
-    is_less_than_90_days_ago,
+    is_less_than_days_ago,
     merge_jsonlike,
     printing_today_or_tomorrow,
     round_to_significant_figures,
@@ -597,10 +597,11 @@ def test_get_letter_validation_error_for_known_errors(
 @pytest.mark.parametrize("date_from_db, expected_result", [
     ('2019-11-17T11:35:21.726132Z', True),
     ('2019-11-16T11:35:21.726132Z', False),
+    ('2019-11-16T11:35:21+0000', False),
 ])
 @freeze_time('2020-02-14T12:00:00')
-def test_is_less_than_90_days_ago(date_from_db, expected_result):
-    assert is_less_than_90_days_ago(date_from_db) == expected_result
+def test_is_less_than_days_ago(date_from_db, expected_result):
+    assert is_less_than_days_ago(date_from_db, 90) == expected_result
 
 
 @pytest.mark.parametrize("template_type", ["sms", "letter", "email"])


### PR DESCRIPTION
We were doing the UTC to BST conversion twice, meaning the job was shown as being started 2 hours later than UTC, and 1 hour later than actual BST.

Bug in the wild, where the notifications are showing the correct time but the job is showing the wrong time:
<img width="758" alt="Screenshot 2020-09-28 at 14 54 15" src="https://user-images.githubusercontent.com/355079/94441663-e98f3500-019a-11eb-9ff0-be30f28cc9c6.png">
