### PR TITLE
Give email preview page a sensible page title

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -123,7 +123,7 @@ def email_template():
 
     template = {
         'template_type': 'email',
-        'subject': 'foo',
+        'subject': 'Email branding preview',
         'content': (
             'Lorem Ipsum is simply dummy text of the printing and typesetting '
             'industry.\n\nLorem Ipsum has been the industry’s standard dummy '

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -261,11 +261,12 @@ def test_email_branding_preview(
     extra_args,
     email_branding_retrieved,
 ):
-    client_request.get(
+    page = client_request.get(
         'main.email_template',
         _test_page_title=False,
         **extra_args
     )
+    assert page.title.text == 'Email branding preview'
     assert mock_get_email_branding.called is email_branding_retrieved
 
 


### PR DESCRIPTION
It’s derived from the subject line of the email now as of https://github.com/alphagov/notifications-utils/pull/793