### PR TITLE
Fix template controls for screenreaders

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -260,8 +260,10 @@
     this.nothingSelectedButtons = $(`
       <div id="nothing_selected">
         <div class="js-stick-at-bottom-when-scrolling">
-          <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="add-new-template">New template</button>
-          <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="add-new-folder">New folder</button>
+          <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="add-new-template" aria-expanded="false">
+            New template
+          </button>
+          <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="add-new-folder" aria-expanded="false">New folder</button>
           <div class="template-list-selected-counter">
             <span class="template-list-selected-counter__count" aria-hidden="true">
               ${this.selectionStatus.default}
@@ -274,10 +276,10 @@
     this.itemsSelectedButtons = $(`
       <div id="items_selected">
         <div class="js-stick-at-bottom-when-scrolling">
-          <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="move-to-existing-folder">
+          <button class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="move-to-existing-folder" aria-expanded="false">
             Move<span class="govuk-visually-hidden"> selection to folder</span>
           </button>
-          <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="move-to-new-folder">Add to new folder</button>
+          <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="move-to-new-folder" aria-expanded="false">Add to new folder</button>
           <div class="template-list-selected-counter" aria-hidden="true">
             <span class="template-list-selected-counter__count" aria-hidden="true">
               ${this.selectionStatus.selected(1)}

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -19,10 +19,10 @@
       this.states = [
         {key: 'nothing-selected-buttons', $el: this.$form.find('#nothing_selected'), cancellable: false},
         {key: 'items-selected-buttons', $el: this.$form.find('#items_selected'), cancellable: false},
-        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios fieldset', true)},
-        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_new_folder_name', false)},
-        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_folder_name', false)},
-        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form fieldset', true)}
+        {key: 'move-to-existing-folder', $el: this.$form.find('#move_to_folder_radios'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_folder_radios fieldset', true), action: 'move to folder'},
+        {key: 'move-to-new-folder', $el: this.$form.find('#move_to_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#move_to_new_folder_name', false), action: 'move to new folder'},
+        {key: 'add-new-folder', $el: this.$form.find('#add_new_folder_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_folder_name', false), action: 'new folder'},
+        {key: 'add-new-template', $el: this.$form.find('#add_new_template_form'), cancellable: true, setFocus: this.getFocusRoutine('#add_new_template_form fieldset', true), action: 'new template'}
       ];
 
       // cancel/clear buttons only relevant if JS enabled, so
@@ -88,7 +88,7 @@
           this.selectActionButtons(selector);
         },
         'cancelSelector': selector,
-        'nonvisualText': "this step"
+        'nonvisualText': state.action
       });
 
       state.$el.find('[type=submit]').after($cancel);

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -176,6 +176,17 @@ $message-type-bottom-spacing: govuk-spacing(4);
 
 }
 
+.sticky-template-form {
+
+  padding: govuk-spacing(3);
+  margin: govuk-spacing(3) * -1;
+
+  &:focus {
+    outline: none;
+  }
+
+}
+
 .folder-heading {
 
   .govuk-grid-row & {

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -5,7 +5,7 @@
   <button type="submit" name="operation" value="unknown" hidden></button>
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
   {% if templates_and_folders_form.move_to.choices and template_list.templates_to_show %}
-    <div id="move_to_folder_radios">
+    <div id="move_to_folder_radios" class="sticky-template-form" role="region" aria-label="Choose the folder to move selected items to">
       <div class="js-will-stick-at-bottom-when-scrolling">
       {{ radios_nested(templates_and_folders_form.move_to, move_to_children, option_hints=option_hints) }}
       </div>
@@ -13,22 +13,20 @@
       {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder', button_text_hidden_suffix=' selection to folder') }}
       </div>
     </div>
-    <div id="move_to_new_folder_form">
-      <fieldset class="js-will-stick-at-bottom-when-scrolling">
-        <legend class="govuk-visually-hidden">Add to new folder</legend>
+    <div id="move_to_new_folder_form" class="sticky-template-form" role="region" aria-label="Enter name of the new folder to move selected items to">
+      <div class="js-will-stick-at-bottom-when-scrolling">
         {{ templates_and_folders_form.move_to_new_folder_name(param_extensions={"classes": "govuk-!-width-full"}) }}
         {{ page_footer('Add to new folder', button_name='operation', button_value='move-to-new-folder') }}
-      </fieldset>
+      </div>
     </div>
   {% endif %}
-  <div id="add_new_folder_form">
-    <fieldset class="js-will-stick-at-bottom-when-scrolling">
-      <legend class="govuk-visually-hidden">Add new folder</legend>
+  <div id="add_new_folder_form" class="sticky-template-form" role="region" aria-label="Enter name of the new folder">
+    <div class="js-will-stick-at-bottom-when-scrolling">
       {{ templates_and_folders_form.add_new_folder_name(param_extensions={"classes": "govuk-!-width-full"}) }}
       {{ page_footer('Add new folder', button_name='operation', button_value='add-new-folder') }}
-    </fieldset>
+    </div>
   </div>
-  <div id="add_new_template_form" {% if single_notification_channel %}data-channel="{{single_notification_channel}}" data-service="{{current_service.id}}"{% endif %}>
+  <div id="add_new_template_form" class="sticky-template-form" role="region" aria-label="Choose template type" {% if single_notification_channel %}data-channel="{{single_notification_channel}}" data-service="{{current_service.id}}"{% endif %}>
     <div class="js-will-stick-at-bottom-when-scrolling">
     {{ radios(templates_and_folders_form.add_template_by_template_type) }}
     </div>

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -261,6 +261,8 @@ describe('TemplateFolderForm', () => {
 
       expect(document.querySelector('button[value=add-new-template]')).not.toBeNull();
       expect(document.querySelector('button[value=add-new-folder]')).not.toBeNull();
+      expect(document.querySelector('button[value=add-new-template]').getAttribute('aria-expanded')).toEqual('false');
+      expect(document.querySelector('button[value=add-new-folder]').getAttribute('aria-expanded')).toEqual('false');
       expect(visibleCounter).not.toBeNull();
 
     });
@@ -544,6 +546,8 @@ describe('TemplateFolderForm', () => {
 
       expect(formControls.querySelector('button[value=move-to-new-folder]')).not.toBeNull();
       expect(formControls.querySelector('button[value=move-to-existing-folder]')).not.toBeNull();
+      expect(formControls.querySelector('button[value=move-to-new-folder]').getAttribute('aria-expanded')).toEqual('false');
+      expect(formControls.querySelector('button[value=move-to-existing-folder]').getAttribute('aria-expanded')).toEqual('false');
 
     });
 

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -386,6 +386,8 @@ describe('TemplateFolderForm', () => {
       const cancelLink = formControls.querySelector('.js-cancel');
 
       expect(cancelLink).not.toBeNull();
+      expect(cancelLink.querySelector('.govuk-visually-hidden')).not.toBeNull();
+      expect(cancelLink.querySelector('.govuk-visually-hidden').textContent.trim()).toEqual('new template');
 
     });
 
@@ -468,6 +470,16 @@ describe('TemplateFolderForm', () => {
 
       // check textbox has a label
       expect(formControls.querySelector(`label[for=${textbox.getAttribute('id')}]`)).not.toBeNull();
+
+    });
+
+    test("should show a 'Cancel' link", () => {
+
+      const cancelLink = formControls.querySelector('.js-cancel');
+
+      expect(cancelLink).not.toBeNull();
+      expect(cancelLink.querySelector('.govuk-visually-hidden')).not.toBeNull();
+      expect(cancelLink.querySelector('.govuk-visually-hidden').textContent.trim()).toEqual('new folder');
 
     });
 
@@ -663,6 +675,16 @@ describe('TemplateFolderForm', () => {
 
       });
 
+      test("should show a 'Cancel' link", () => {
+
+        const cancelLink = formControls.querySelector('.js-cancel');
+
+        expect(cancelLink).not.toBeNull();
+        expect(cancelLink.querySelector('.govuk-visually-hidden')).not.toBeNull();
+        expect(cancelLink.querySelector('.govuk-visually-hidden').textContent.trim()).toEqual('move to folder');
+
+      });
+
       test("focus the 'Choose a folder' fieldset", () => {
 
         expect(document.activeElement).toBe(formControls.querySelector('#move_to'));
@@ -732,6 +754,16 @@ describe('TemplateFolderForm', () => {
 
         // check textbox has a label
         expect(formControls.querySelector(`label[for=${textbox.getAttribute('id')}]`)).not.toBeNull();
+
+      });
+
+      test("should show a 'Cancel' link", () => {
+
+        const cancelLink = formControls.querySelector('.js-cancel');
+
+        expect(cancelLink).not.toBeNull();
+        expect(cancelLink.querySelector('.govuk-visually-hidden')).not.toBeNull();
+        expect(cancelLink.querySelector('.govuk-visually-hidden').textContent.trim()).toEqual('move to new folder');
 
       });
 


### PR DESCRIPTION
The controls at the bottom of the templates page, which let you perform various actions on templates and/or folders, work in a way that's confusing to non-visual screen reader users.

<img width="776" alt="image" src="https://user-images.githubusercontent.com/87140/94810867-8694dc80-03ec-11eb-805a-6ee95ea55374.png">

https://www.pivotaltracker.com/story/show/174440877

## What's confusing

When non-visual testers at the Digital Accessibility Centre (DAC) used these controls, they reported:
1. being unaware anything had happened when they clicked the buttons
2. they would expect, if appropriate, for focus to move to the new content when it opens
3. they expected descriptive announcements when changes on-screen content occur
4. the announcements heard when clicking the buttons differed a lot between types of screen readers

This pull request includes changes intended to fix those problems by me and @CrystalPea. I'm going to list each to explain how they do that.

## 1. being unaware anything had happened when they clicked the buttons

We followed advice from DAC and gave all the buttons `aria-expanded="false"` so users know:
- they control a section of the page
- that section is currently closed

```html
<button class="govuk-button govuk-button--secondary" value="add-new-template" aria-expanded="false">
  New template
</button>
```

## 2. that they would expect, if appropriate, for focus to move to the new content when it opens

The existing code did move focus but to elements _inside_ the new content, key to the action you want to perform. Either a group of radios or a textbox. This meant the other elements, a submit button and cancel link, were added to the page but ignored from announcements.

We gave the element that contains all the new content a role of [region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Region_role) and a label describing what its contents do. We also made it so this region is focused, instead of its child elements.

```html
<div id="add_new_folder_form" class="sticky-template-form" role="region" aria-label="Enter name of the new folder">
  ...
</div>
```

## 3. they expected descriptive announcements when changes on-screen content occur

We added a hidden paragraph at the start of the new region which explains how to use the form controls within. We used [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) to identify it as description for the region.

```html
<div id="add_new_folder_form" class="sticky-template-form" aria-describedby="add-new-folder__description" role="region" aria-label="Enter name of the new folder">
  <p class="govuk-visually-hidden" id="add-new-folder__description">
    Press add new folder to confirm name or cancel to close
  </p>
  ...
</div>
```

Note: screen readers announce descriptions when you first move to an element but also let users call it through a separate command when the element is focused.

## 4. the announcements heard when clicking the buttons differed a lot between types of screen readers

I will be testing these changes with the other screen readers DAC listed but they need to be on production so is out of scope for this pull request.

## What this sounds like

A set of recordings of what Voiceover announces when you press each button with these changes:
- [New template](https://drive.google.com/file/d/1529d1aoz_BCJZ6FnGD6dSwqvI2nWLy3u/view?usp=sharing)
- [New folder](https://drive.google.com/file/d/10zD92QEVjwx1EA3_96UAFgdOENPzc4io/view?usp=sharing)

When templates and/or folders are selected:
- [Move](https://drive.google.com/file/d/19V8hcG8dPN6-kW4rn4XFlDWbcMY1f_OC/view?usp=sharing)
- [Add to new folder](https://drive.google.com/file/d/1Zk3ltY7FIBq53cdT2UkSakAvUiEeQvQx/view?usp=sharing)