### PR TITLE
Fix bug with copy to clipboard

### DIFF
--- a/app/assets/javascripts/apiKey.js
+++ b/app/assets/javascripts/apiKey.js
@@ -29,9 +29,10 @@
 
     this.getRangeFromElement = function (keyElement) {
       const range = document.createRange();
+      const childNodes = Array.prototype.slice.call(keyElement.childNodes);
       let prefixIndex = -1;
 
-      Array.from(keyElement.childNodes).forEach((el, idx) => {
+      childNodes.forEach((el, idx) => {
         if ((el.nodeType === 1) && el.classList.contains('govuk-visually-hidden')) {
           prefixIndex = idx;
         }

--- a/app/assets/stylesheets/components/api-key.scss
+++ b/app/assets/stylesheets/components/api-key.scss
@@ -22,6 +22,7 @@
 
     position: absolute;
     bottom: 2px;
+    left: 0px;
 
     &:active {
       top: auto;


### PR DESCRIPTION
Fixes for a few bugs when testing the 'copy-to-clipboard' buttons in IE11

They are:
1. a `Object doesn't support property or method 'from'` JS bug when you click the button
2. the button being positioned wrong

The first one is down to the JS using `Array.from`, which isn't supported. The second was this:

![image](https://user-images.githubusercontent.com/87140/94936869-c03a1600-04c6-11eb-9d3c-20f25a57d0ce.png)

...now fixed to look like this:

![image](https://user-images.githubusercontent.com/87140/94936897-ca5c1480-04c6-11eb-8912-24c7750574ef.png)
