### PR TITLE
Take user to page they are meant to visit in various sign-in flow scenarios

### DIFF
--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -1,4 +1,4 @@
-from flask import redirect, render_template, session, url_for
+from flask import redirect, render_template, request, session, url_for
 
 from app import user_api_client
 from app.main import main
@@ -19,16 +19,17 @@ def resend_email_verification():
 @redirect_to_sign_in
 def check_and_resend_text_code():
     user = User.from_email_address(session['user_details']['email'])
+    redirect_url = request.args.get('next')
 
     if user.state == 'active':
         # this is a verified user and therefore redirect to page to request resend without edit mobile
-        return render_template('views/verification-not-received.html')
+        return render_template('views/verification-not-received.html', redirect_url=redirect_url)
 
     form = TextNotReceivedForm(mobile_number=user.mobile_number)
     if form.validate_on_submit():
         user.send_verify_code(to=form.mobile_number.data)
         user.update(mobile_number=form.mobile_number.data)
-        return redirect(url_for('.verify'))
+        return redirect(url_for('.verify', next=redirect_url))
 
     return render_template('views/text-not-received.html', form=form)
 

--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -39,10 +39,11 @@ def check_and_resend_text_code():
 def check_and_resend_verification_code():
     user = User.from_email_address(session['user_details']['email'])
     user.send_verify_code()
+    redirect_url = request.args.get('next')
     if user.state == 'pending':
-        return redirect(url_for('main.verify'))
+        return redirect(url_for('main.verify', next=redirect_url))
     else:
-        return redirect(url_for('main.two_factor'))
+        return redirect(url_for('main.two_factor', next=redirect_url))
 
 
 @main.route('/email-not-received', methods=['GET'])

--- a/app/main/views/code_not_received.py
+++ b/app/main/views/code_not_received.py
@@ -49,7 +49,8 @@ def check_and_resend_verification_code():
 @main.route('/email-not-received', methods=['GET'])
 @redirect_to_sign_in
 def email_not_received():
-    return render_template('views/email-not-received.html')
+    redirect_url = request.args.get('next')
+    return render_template('views/email-not-received.html', redirect_url=redirect_url)
 
 
 @main.route('/send-new-email-token', methods=['GET'])

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -1,4 +1,4 @@
-from flask import render_template
+from flask import render_template, request
 from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
@@ -11,7 +11,7 @@ def forgot_password():
     form = ForgotPasswordForm()
     if form.validate_on_submit():
         try:
-            user_api_client.send_reset_password_url(form.email_address.data)
+            user_api_client.send_reset_password_url(form.email_address.data, next_string=request.args.get('next'))
         except HTTPError as e:
             if e.status_code == 404:
                 return render_template('views/password-reset-sent.html')

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -5,6 +5,7 @@ from flask import (
     flash,
     redirect,
     render_template,
+    request,
     session,
     url_for,
 )
@@ -46,6 +47,6 @@ def new_password(token):
         else:
             # send user a 2fa sms code
             user.send_verify_code()
-            return redirect(url_for('main.two_factor'))
+            return redirect(url_for('main.two_factor', next=request.args.get('next')))
     else:
         return render_template('views/new-password.html', token=token, form=form, user=user)

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -24,6 +24,7 @@ def sign_in():
         return redirect(url_for('main.show_accounts_or_dashboard'))
 
     form = LoginForm()
+    password_reset_url = url_for('.forgot_password', next=request.args.get('next'))
 
     if form.validate_on_submit():
 
@@ -51,9 +52,9 @@ def sign_in():
         # Vague error message for login in case of user not known, locked, inactive or password not verified
         flash(Markup(
             (
-                "The email address or password you entered is incorrect."
-                " <a href={password_reset}>Forgotten your password?</a>"
-            ).format(password_reset=url_for('.forgot_password'))
+                f"The email address or password you entered is incorrect."
+                f" <a href={password_reset_url}>Forgotten your password?</a>"
+            )
         ))
 
     other_device = current_user.logged_in_elsewhere()
@@ -61,7 +62,8 @@ def sign_in():
         'views/signin.html',
         form=form,
         again=bool(request.args.get('next')),
-        other_device=other_device
+        other_device=other_device,
+        password_reset_url=password_reset_url
     )
 
 

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -25,6 +25,7 @@ def sign_in():
 
     form = LoginForm()
     password_reset_url = url_for('.forgot_password', next=request.args.get('next'))
+    redirect_url = request.args.get('next')
 
     if form.validate_on_submit():
 
@@ -33,7 +34,7 @@ def sign_in():
         )
 
         if user and user.state == 'pending':
-            return redirect(url_for('main.resend_email_verification'))
+            return redirect(url_for('main.resend_email_verification', next=redirect_url))
 
         if user and session.get('invited_user'):
             invited_user = InvitedUser.from_session()
@@ -45,9 +46,9 @@ def sign_in():
                 invited_user.accept_invite()
         if user and user.sign_in():
             if user.sms_auth:
-                return redirect(url_for('.two_factor', next=request.args.get('next')))
+                return redirect(url_for('.two_factor', next=redirect_url))
             if user.email_auth:
-                return redirect(url_for('.two_factor_email_sent'))
+                return redirect(url_for('.two_factor_email_sent', next=redirect_url))
 
         # Vague error message for login in case of user not known, locked, inactive or password not verified
         flash(Markup(
@@ -61,7 +62,7 @@ def sign_in():
     return render_template(
         'views/signin.html',
         form=form,
-        again=bool(request.args.get('next')),
+        again=bool(redirect_url),
         other_device=other_device,
         password_reset_url=password_reset_url
     )

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -85,7 +85,8 @@ def two_factor():
 @main.route('/re-validate-email', methods=['GET'])
 def revalidate_email_sent():
     title = 'Email resent' if request.args.get('email_resent') else 'Check your email'
-    return render_template('views/re-validate-email-sent.html', title=title)
+    redirect_url = request.args.get('next')
+    return render_template('views/re-validate-email-sent.html', title=title, redirect_url=redirect_url)
 
 
 # see http://flask.pocoo.org/snippets/62/

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -36,6 +36,7 @@ def two_factor_email_interstitial(token):
 
 @main.route('/email-auth/<token>', methods=['POST'])
 def two_factor_email(token):
+    redirect_url = request.args.get('next')
     if current_user.is_authenticated:
         return redirect_when_logged_in(platform_admin=current_user.platform_admin)
 
@@ -48,14 +49,14 @@ def two_factor_email(token):
             current_app.config['EMAIL_2FA_EXPIRY_SECONDS']
         ))
     except SignatureExpired:
-        return render_template('views/email-link-invalid.html')
+        return render_template('views/email-link-invalid.html', redirect_url=redirect_url)
 
     user_id = token_data['user_id']
     # checks if code was already used
     logged_in, msg = user_api_client.check_verify_code(user_id, token_data['secret_code'], "email")
 
     if not logged_in:
-        return render_template('views/email-link-invalid.html')
+        return render_template('views/email-link-invalid.html', redirect_url=redirect_url)
     return log_in_user(user_id)
 
 

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -24,7 +24,8 @@ def two_factor_email_sent():
     title = 'Email resent' if request.args.get('email_resent') else 'Check your email'
     return render_template(
         'views/two-factor-email.html',
-        title=title
+        title=title,
+        redirect_url=request.args.get('next')
     )
 
 

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -70,15 +70,16 @@ def two_factor():
         return user_api_client.check_verify_code(user_id, code, "sms")
 
     form = TwoFactorForm(_check_code)
+    redirect_url = request.args.get('next')
 
     if form.validate_on_submit():
         if is_less_than_90_days_ago(user.email_access_validated_at):
             return log_in_user(user_id)
         else:
-            user_api_client.send_verify_code(user.id, 'email', None, request.args.get('next'))
-            return redirect(url_for('.revalidate_email_sent'))
+            user_api_client.send_verify_code(user.id, 'email', None, redirect_url)
+            return redirect(url_for('.revalidate_email_sent', next=redirect_url))
 
-    return render_template('views/two-factor.html', form=form)
+    return render_template('views/two-factor.html', form=form, redirect_url=redirect_url)
 
 
 @main.route('/re-validate-email', methods=['GET'])

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -165,9 +165,11 @@ class UserApiClient(NotifyAdminAPIClient):
         endpoint = '/user/{}/service/{}/permission'.format(user_id, service_id)
         self.post(endpoint, data=data)
 
-    def send_reset_password_url(self, email_address):
+    def send_reset_password_url(self, email_address, next_string=None):
         endpoint = '/user/reset-password'
         data = {'email': email_address}
+        if next_string:
+            data['next'] = next_string
         self.post(endpoint, data=data)
 
     def find_users_by_full_or_partial_email(self, email_address):

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -11,7 +11,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">The link has expired</h1>
 
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in') }}">Sign in again</a> to get a new link.</p>
+    <p class="govuk-body">
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in', next=redirect_url) }}">
+        Sign in again
+      </a> to get a new link.
+  </p>
 
   </div>
 </div>

--- a/app/templates/views/email-not-received.html
+++ b/app/templates/views/email-not-received.html
@@ -16,7 +16,7 @@
       {{ govukButton({
         "element": "a",
         "text": "Resend email link",
-        "href": url_for('main.resend_email_link')
+        "href": url_for('main.resend_email_link', next=redirect_url)
       }) }}
     </p>
 

--- a/app/templates/views/re-validate-email-sent.html
+++ b/app/templates/views/re-validate-email-sent.html
@@ -14,7 +14,7 @@
     <p class="govuk-body">We’ve sent you a link to sign in to Notify. The link will open in a new browser window, so you can close this one.</p>
 
     {{ page_footer(
-      secondary_link=url_for('main.email_not_received'),
+      secondary_link=url_for('main.email_not_received', next=redirect_url),
       secondary_link_text='Not received an email?'
     ) }}
   </div>

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -33,7 +33,7 @@
     {% call form_wrapper(autocomplete=True) %}
       {{ form.email_address(param_extensions={"autocomplete": "email"}) }}
       {{ form.password(param_extensions={"autocomplete": "current-password"}) }}
-      {{ page_footer("Continue", secondary_link=url_for('.forgot_password'), secondary_link_text="Forgotten your password?") }}
+      {{ page_footer("Continue", secondary_link=password_reset_url, secondary_link_text="Forgotten your password?") }}
     {% endcall %}
   </div>
 </div>

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -13,7 +13,7 @@
     <p class="govuk-body">We’ve emailed you a link to sign in to Notify.</p>
     <p class="govuk-body">Clicking the link will open Notify in a new browser window, so you can close this one.</p>
     {{ page_footer(
-      secondary_link=url_for('main.email_not_received'),
+      secondary_link=url_for('main.email_not_received', next=redirect_url),
       secondary_link_text='Not received an email?'
     ) }}
   </div>

--- a/app/templates/views/two-factor.html
+++ b/app/templates/views/two-factor.html
@@ -22,7 +22,7 @@
       }) }}
       {{ page_footer(
         "Continue",
-        secondary_link=url_for('main.check_and_resend_text_code'),
+        secondary_link=url_for('main.check_and_resend_text_code', next=redirect_url),
         secondary_link_text='Not received a text message?'
       ) }}
     {% endcall %}

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -16,7 +16,7 @@
       {{ govukButton({
         "element": "a",
         "text": "Resend security code",
-        "href": url_for('main.check_and_resend_verification_code')
+        "href": url_for('main.check_and_resend_verification_code', next=redirect_url)
       }) }}
     </p>
 

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -2,6 +2,8 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 
+from tests.conftest import SERVICE_ONE_ID
+
 
 def test_should_render_email_verification_resend_show_email_address_and_resend_verify_email(
     client,
@@ -29,7 +31,7 @@ def test_should_render_email_verification_resend_show_email_address_and_resend_v
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_should_render_correct_resend_template_for_active_user(
     client,
@@ -82,7 +84,7 @@ def test_should_render_correct_resend_template_for_pending_user(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 @pytest.mark.parametrize('phone_number_to_register_with', [
     '+447700900460',
@@ -121,7 +123,7 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_check_and_redirect_to_two_factor_if_user_active(
     client,
@@ -141,7 +143,7 @@ def test_check_and_redirect_to_two_factor_if_user_active(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_check_and_redirect_to_verify_if_user_pending(
     client,
@@ -180,7 +182,7 @@ def test_redirect_to_sign_in_if_not_logged_in(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_should_render_correct_email_not_received_template_for_active_user(
     client,

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -119,27 +119,37 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(
     )
 
 
+@pytest.mark.parametrize('redirect_url', [
+    None,
+    'blob',
+])
 def test_check_and_redirect_to_two_factor_if_user_active(
     client,
     api_user_active,
     mock_get_user_by_email,
     mock_send_verify_code,
+    redirect_url
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
             'id': api_user_active['id'],
             'email': api_user_active['email_address']}
-    response = client.get(url_for('main.check_and_resend_verification_code'))
+    response = client.get(url_for('main.check_and_resend_verification_code', next=redirect_url))
     assert response.status_code == 302
-    assert response.location == url_for('main.two_factor', _external=True)
+    assert response.location == url_for('main.two_factor', _external=True, next=redirect_url)
 
 
+@pytest.mark.parametrize('redirect_url', [
+    None,
+    'blob',
+])
 def test_check_and_redirect_to_verify_if_user_pending(
     client,
     mocker,
     api_user_pending,
     mock_get_user_pending,
     mock_send_verify_code,
+    redirect_url
 ):
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
@@ -148,9 +158,9 @@ def test_check_and_redirect_to_verify_if_user_pending(
         session['user_details'] = {
             'id': api_user_pending['id'],
             'email': api_user_pending['email_address']}
-    response = client.get(url_for('main.check_and_resend_verification_code'))
+    response = client.get(url_for('main.check_and_resend_verification_code', next=redirect_url))
     assert response.status_code == 302
-    assert response.location == url_for('main.verify', _external=True)
+    assert response.location == url_for('main.verify', _external=True, next=redirect_url)
 
 
 @pytest.mark.parametrize('endpoint', [

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -27,23 +27,32 @@ def test_should_render_email_verification_resend_show_email_address_and_resend_v
     mock_send_verify_email.assert_called_with(api_user_active['id'], api_user_active['email_address'])
 
 
+@pytest.mark.parametrize('redirect_url', [
+    None,
+    'blob',
+])
 def test_should_render_correct_resend_template_for_active_user(
     client,
     api_user_active,
     mock_get_user_by_email,
     mock_send_verify_code,
+    redirect_url
 ):
     with client.session_transaction() as session:
         session['user_details'] = {
             'id': api_user_active['id'],
             'email': api_user_active['email_address']}
-    response = client.get(url_for('main.check_and_resend_text_code'))
+    response = client.get(url_for('main.check_and_resend_text_code', next=redirect_url))
     assert response.status_code == 200
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string == 'Resend security code'
     # there shouldn't be a form for updating mobile number
     assert page.find('form') is None
+    assert page.find('a', class_="govuk-button")['href'] == url_for(
+        'main.check_and_resend_verification_code',
+        next=redirect_url
+    )
 
 
 def test_should_render_correct_resend_template_for_pending_user(
@@ -71,6 +80,10 @@ def test_should_render_correct_resend_template_for_pending_user(
     assert page.find('form').input['value'] == api_user_pending['mobile_number']
 
 
+@pytest.mark.parametrize('redirect_url', [
+    None,
+    'blob',
+])
 @pytest.mark.parametrize('phone_number_to_register_with', [
     '+447700900460',
     '+1800-555-555',
@@ -82,6 +95,7 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(
     mock_update_user_attribute,
     mock_send_verify_code,
     phone_number_to_register_with,
+    redirect_url
 ):
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_pending)
 
@@ -89,10 +103,10 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(
         session['user_details'] = {
             'id': api_user_pending['id'],
             'email': api_user_pending['email_address']}
-    response = client.post(url_for('main.check_and_resend_text_code'),
+    response = client.post(url_for('main.check_and_resend_text_code', next=redirect_url),
                            data={'mobile_number': phone_number_to_register_with})
     assert response.status_code == 302
-    assert response.location == url_for('main.verify', _external=True)
+    assert response.location == url_for('main.verify', _external=True, next=redirect_url)
 
     mock_update_user_attribute.assert_called_once_with(
         api_user_pending['id'],

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -4,6 +4,7 @@ from notifications_python_client.errors import HTTPError
 
 import app
 from tests import user_json
+from tests.conftest import SERVICE_ONE_ID
 
 
 def test_should_render_forgot_password(client):
@@ -42,11 +43,11 @@ def test_forgot_password_sends_next_link_with_reset_password_email_request(
     sample_user = user_json(email_address='test@user.gov.uk')
     mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
     response = client.post(
-        url_for('.forgot_password') + "?next=blob",
+        url_for('.forgot_password') + f"?next=/services/{SERVICE_ONE_ID}/templates",
         data={'email_address': sample_user['email_address']})
     assert response.status_code == 200
     app.user_api_client.send_reset_password_url.assert_called_once_with(
-        sample_user['email_address'], next_string="blob"
+        sample_user['email_address'], next_string=f'/services/{SERVICE_ONE_ID}/templates'
     )
 
 

--- a/tests/app/main/views/test_forgot_password.py
+++ b/tests/app/main/views/test_forgot_password.py
@@ -31,7 +31,23 @@ def test_should_redirect_to_password_reset_sent_for_valid_email(
     assert response.status_code == 200
     assert 'Click the link in the email to reset your password.' \
            in response.get_data(as_text=True)
-    app.user_api_client.send_reset_password_url.assert_called_once_with(sample_user['email_address'])
+    app.user_api_client.send_reset_password_url.assert_called_once_with(sample_user['email_address'], next_string=None)
+
+
+def test_forgot_password_sends_next_link_with_reset_password_email_request(
+    client,
+    fake_uuid,
+    mocker,
+):
+    sample_user = user_json(email_address='test@user.gov.uk')
+    mocker.patch('app.user_api_client.send_reset_password_url', return_value=None)
+    response = client.post(
+        url_for('.forgot_password') + "?next=blob",
+        data={'email_address': sample_user['email_address']})
+    assert response.status_code == 200
+    app.user_api_client.send_reset_password_url.assert_called_once_with(
+        sample_user['email_address'], next_string="blob"
+    )
 
 
 def test_should_redirect_to_password_reset_sent_for_missing_email(
@@ -48,4 +64,6 @@ def test_should_redirect_to_password_reset_sent_for_missing_email(
     assert response.status_code == 200
     assert 'Click the link in the email to reset your password.' \
            in response.get_data(as_text=True)
-    app.user_api_client.send_reset_password_url.assert_called_once_with(api_user_active['email_address'])
+    app.user_api_client.send_reset_password_url.assert_called_once_with(
+        api_user_active['email_address'], next_string=None
+    )

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -6,7 +6,7 @@ from flask import url_for
 from itsdangerous import SignatureExpired
 from notifications_utils.url_safe_token import generate_token
 
-from tests.conftest import url_for_endpoint_with_token
+from tests.conftest import SERVICE_ONE_ID, url_for_endpoint_with_token
 
 
 def test_should_render_new_password_template(
@@ -39,7 +39,7 @@ def test_should_return_404_when_email_address_does_not_exist(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_should_redirect_to_two_factor_when_password_reset_is_successful(
     app_,

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 from app.models.user import User
-from tests.conftest import normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 def test_render_sign_in_template_for_new_user(
@@ -31,10 +31,14 @@ def test_render_sign_in_template_with_next_link_for_password_reset(
     client_request
 ):
     client_request.logout()
-    page = client_request.get('main.sign_in', _optional_args="?next=blob", _test_page_title=False)
+    page = client_request.get(
+        'main.sign_in',
+        _optional_args=f"?next=/services/{SERVICE_ONE_ID}/templates",
+        _test_page_title=False
+    )
     forgot_password_link = page.find('a', class_="govuk-link govuk-link--no-visited-state page-footer-secondary-link")
     assert forgot_password_link.text == 'Forgotten your password?'
-    assert forgot_password_link['href'] == url_for('main.forgot_password') + "?next=blob"
+    assert forgot_password_link['href'] == url_for('main.forgot_password', next=f'/services/{SERVICE_ONE_ID}/templates')
 
 
 def test_sign_in_explains_session_timeout(client):
@@ -104,7 +108,7 @@ def test_logged_in_user_redirects_to_account(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 @pytest.mark.parametrize('email_address, password', [
     ('valid@example.gov.uk', 'val1dPassw0rd!'),
@@ -133,7 +137,7 @@ def test_process_sms_auth_sign_in_return_2fa_template(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_process_email_auth_sign_in_return_2fa_template(
     client,
@@ -197,7 +201,7 @@ def test_should_return_redirect_when_user_is_pending(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_should_attempt_redirect_when_user_is_pending(
     client,

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -27,6 +27,16 @@ def test_render_sign_in_template_for_new_user(
     assert 'Sign in again' not in normalize_spaces(page.text)
 
 
+def test_render_sign_in_template_with_next_link_for_password_reset(
+    client_request
+):
+    client_request.logout()
+    page = client_request.get('main.sign_in', _optional_args="?next=blob", _test_page_title=False)
+    forgot_password_link = page.find('a', class_="govuk-link govuk-link--no-visited-state page-footer-secondary-link")
+    assert forgot_password_link.text == 'Forgotten your password?'
+    assert forgot_password_link['href'] == url_for('main.forgot_password') + "?next=blob"
+
+
 def test_sign_in_explains_session_timeout(client):
     response = client.get(url_for('main.sign_in', next='/foo'))
     assert response.status_code == 200

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -11,10 +11,8 @@ from tests.conftest import (
 )
 
 
-@pytest.mark.parametrize('redirect_url', [
-    None,
-    'blob',
-])
+@pytest.mark.parametrize('request_url', ['two_factor_email_sent', 'revalidate_email_sent'])
+@pytest.mark.parametrize('redirect_url', [None, 'blob'])
 @pytest.mark.parametrize('email_resent, page_title', [
     (None, 'Check your email'),
     (True, 'Email resent')
@@ -23,9 +21,10 @@ def test_two_factor_email_sent_page(
     client,
     email_resent,
     page_title,
-    redirect_url
+    redirect_url,
+    request_url
 ):
-    response = client.get(url_for('main.two_factor_email_sent', next=redirect_url, email_resent=email_resent))
+    response = client.get(url_for(f'main.{request_url}', next=redirect_url, email_resent=email_resent))
     assert response.status_code == 200
 
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -12,7 +12,7 @@ from tests.conftest import (
 
 
 @pytest.mark.parametrize('request_url', ['two_factor_email_sent', 'revalidate_email_sent'])
-@pytest.mark.parametrize('redirect_url', [None, 'blob'])
+@pytest.mark.parametrize('redirect_url', [None, f'/services/{SERVICE_ONE_ID}/templates'])
 @pytest.mark.parametrize('email_resent, page_title', [
     (None, 'Check your email'),
     (True, 'Email resent')
@@ -38,7 +38,7 @@ def test_two_factor_email_sent_page(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_should_render_two_factor_page(
     client,
@@ -353,7 +353,7 @@ def test_valid_two_factor_email_link_logs_in_user(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_two_factor_email_link_has_expired(
     app_,
@@ -397,7 +397,7 @@ def test_two_factor_email_link_is_invalid(
 
 @pytest.mark.parametrize('redirect_url', [
     None,
-    'blob',
+    f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_two_factor_email_link_is_already_used(
     client,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -11,6 +11,32 @@ from tests.conftest import (
 )
 
 
+@pytest.mark.parametrize('redirect_url', [
+    None,
+    'blob',
+])
+@pytest.mark.parametrize('email_resent, page_title', [
+    (None, 'Check your email'),
+    (True, 'Email resent')
+])
+def test_two_factor_email_sent_page(
+    client,
+    email_resent,
+    page_title,
+    redirect_url
+):
+    response = client.get(url_for('main.two_factor_email_sent', next=redirect_url, email_resent=email_resent))
+    assert response.status_code == 200
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.h1.string == page_title
+    # there shouldn't be a form for updating mobile number
+    assert page.find('form') is None
+    resend_email_link = page.find('a', class_="govuk-link govuk-link--no-visited-state page-footer-secondary-link")
+    assert resend_email_link.text == 'Not received an email?'
+    assert resend_email_link['href'] == url_for('main.email_not_received', next=redirect_url)
+
+
 def test_should_render_two_factor_page(
     client,
     api_user_active,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3646,9 +3646,9 @@ def mock_create_event(mocker):
     return mocker.patch('app.events_api_client.create_event', side_effect=_add_event)
 
 
-def url_for_endpoint_with_token(endpoint, token):
+def url_for_endpoint_with_token(endpoint, token, next=None):
     token = token.replace('%2E', '.')
-    return url_for(endpoint, token=token)
+    return url_for(endpoint, token=token, next=next)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR makes sure user is redirected to the page they initially were meant to visit after they sign in. It makes sure redirects are passed through in various scenarios, like code or email not being received, password being reset etc.

This work started as making sure that users who reset their password see the broadcast tour, but the scope was widened to include all redirects and all or at least most sign-in scenarios.

Pivotal ticket: https://www.pivotaltracker.com/story/show/174488590
Goes together with: https://github.com/alphagov/notifications-api/pull/2991