### PR TITLE
Don’t allow or highlight personalisation in broadcast templates

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -47,6 +47,7 @@ from app.main.validators import (
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
     NoEmbeddedImagesInSVG,
+    NoPlaceholders,
     OnlySMSCharacters,
     ValidEmail,
     ValidGovEmail,
@@ -1217,6 +1218,7 @@ class SMSTemplateForm(BaseTemplateForm):
 class BroadcastTemplateForm(SMSTemplateForm):
     def validate_template_content(self, field):
         OnlySMSCharacters(template_type='broadcast')(None, field)
+        NoPlaceholders()(None, field)
 
 
 class LetterAddressForm(StripWhitespaceForm):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -108,6 +108,18 @@ class OnlySMSCharacters:
             )
 
 
+class NoPlaceholders:
+
+    def __init__(self, message=None):
+        self.message = message or (
+            'You can’t use ((double brackets)) to personalise this message'
+        )
+
+    def __call__(self, form, field):
+        if Field(field.data).placeholders:
+            raise ValidationError(self.message)
+
+
 class LettersNumbersFullStopsAndUnderscoresOnly:
 
     regex = re.compile(r'^[a-zA-Z0-9\s\._]+$')

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -24,7 +24,7 @@
         }) }}
       </div>
       <div class="govuk-grid-column-two-thirds">
-        {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=5) }}
+        {{ textbox(form.template_content, highlight_placeholders=False, width='1-1', rows=5) }}
         {{ sticky_page_footer('Save') }}
       </div>
     </div>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -399,6 +399,21 @@ def test_should_show_page_for_one_template(
     mock_get_service_template.assert_called_with(SERVICE_ONE_ID, template_id, None)
 
 
+def test_broadcast_template_doesnt_highlight_placeholders(
+    client_request,
+    service_one,
+    mock_get_broadcast_template,
+    fake_uuid,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get(
+        '.edit_service_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+    )
+    assert page.select_one('textarea')['data-highlight-placeholders'] == 'false'
+
+
 def test_caseworker_redirected_to_one_off(
     client_request,
     mock_get_service_templates,


### PR DESCRIPTION
Since we don’t have a way of filling in the personalisation at the moment we shouldn’t allow people to make templates that require it, or suggest that it’s possible by highlighting the ((double brackets)) in yellow.