### PR TITLE
Don't prefix with the page title when focusing on load

### DIFF
--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -4,25 +4,13 @@
   Modules.Autofocus = function() {
     this.start = function(component) {
       var $component = $(component),
-          forceFocus = $component.data('forceFocus'),
-          labelText = $('label[for="' + $component.attr('id') + '"]').eq(0).text().trim(),
-          clearAriaLabel = evt => {
-            $component.removeAttr('aria-label');
-            $component.off('blur', clearAriaLabel);
-          };
+          forceFocus = $component.data('forceFocus');
 
       // if the page loads with a scroll position, we can't assume the item to focus onload
       // is still where users intend to start
       if (($(window).scrollTop() > 0) && !forceFocus) { return; }
 
-      // screenreaders announce the page title when a new page loads
-      // this will be lost when focus is moved to our form control so add it to the label instead
-      $component.attr('aria-label', document.title + ' - ' + labelText);
-
       $component.filter('input, textarea, select').eq(0).trigger('focus');
-
-      // the page title prefix is only needed on page load so remove once focus has shifted
-      $component.on('blur', clearAriaLabel);
 
     };
   };

--- a/tests/javascripts/autofocus.test.js
+++ b/tests/javascripts/autofocus.test.js
@@ -50,28 +50,6 @@ describe('Autofocus', () => {
 
   });
 
-  test('has a label including the page title when the module starts', () => {
-
-    // start module
-    window.GOVUK.modules.start();
-
-    expect(search.hasAttribute('aria-label')).toBe(true);
-    expect(search.getAttribute('aria-label')).toEqual(document.title + ' - ' + labelText);
-
-  });
-
-  test('gets the original label back when focus moves away', () => {
-
-    // start module
-    window.GOVUK.modules.start();
-
-    // shift focus away from textbox
-    helpers.triggerEvent(search, 'blur');
-
-    expect(search.hasAttribute('aria-label')).toBe(false);
-
-  });
-
   test('is not focused if the window has scrolled', () => {
 
     // mock the window being scrolled 25px


### PR DESCRIPTION
https://github.com/alphagov/notifications-admin/pull/3622 added a behaviour where a textbox is focused when the page loads¹ on pages where users would start there anyway.

Screen readers announce the page title when a new page loads. On Voiceover (the screen reader built into Apple products) focusing something on load mean this doesn't happen because its label gets announced instead.

To fix this, we added a hack which prefixed the label with the page title. After testing with other screen readers (JAWS and NVDA), it turns out Voiceover is the only one that ignores out the page title when you focus. The result is the page title gets announced twice 🤦🏻‍♂️.

This removes the hack. The confusion it adds in JAWS and NVDA is more problematic than that it relieves in Voiceover.

¹This has actually been around for ages but https://github.com/alphagov/notifications-admin/pull/3622 involved a redesign of it to better suit the admin app as it is.