### PR TITLE
Delete template cache if adding a new reply to email address

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -428,13 +428,15 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete('service-{service_id}')
     def add_reply_to_email_address(self, service_id, email_address, is_default=False):
-        return self.post(
+        ret = self.post(
             "/service/{}/email-reply-to".format(service_id),
             data={
                 "email_address": email_address,
                 "is_default": is_default
             }
         )
+        self._delete_template_cache_for_service(service_id)
+        return ret
 
     @cache.delete('service-{service_id}')
     def update_reply_to_email_address(self, service_id, reply_to_email_id, email_address, is_default=False):


### PR DESCRIPTION
As if this is chosen as default, then the template data will be stale as
they do not have the latest reply to address.

We are already doing this for create/update/delete for sms senders and
contact lists for letters, it was just the create we were missing for
email reply to addresses.