### PR TITLE
Remove issue related to focus shifting onload

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -41,7 +41,6 @@
     <li>low vision users cannot access the table we use to show CSV data when viewed at high zoom</li>
     <li>screen reader users may find the process of moving templates and folders confusing</li>
     <li>one page links to a PDF document that is not fully accessible</li>
-    <li>screen readers users may be disorientated when pages load with the focus on a specific area</li>
     <li>the Notify status page has several accessibility issues</li>
   </ul>
 
@@ -103,10 +102,6 @@
 
   <p class="govuk-body">
     Screen reader users may find the process of moving templates and folders confusing. This fails <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/#name-role-value">WCAG 4.1.2 success criteria (Name, role, value)</a>. We plan to fix this by November 2020.
-  </p>
-
-  <p class="govuk-body">
-    Screen reader users may find it confusing that a specific part of some pages is focused when they load. This fails <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/#focus-order">WCAG 2.4.3 success criteria (Focus Order)</a>. We plan to fix this by October 2020.
   </p>
 
   <h3 class="heading-small">
@@ -173,6 +168,6 @@
   </p>
 
   <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 23 September 2020.
+    This statement was prepared on 23 September 2020. It was last reviewed on 29 September 2020.
   </p>
 {% endblock %}


### PR DESCRIPTION
The Digital Accessibility Centre (DAC) reported
that it was confusing that focus was moved to the
templates and folders search textbox when the page
loaded on the templates page.

We noted that this issue wasn't reported on the
page where you enter your SMS 2-factor code.

From this, we determined that pages with a single
task could benefit from focus moving to the part
of the page that lets you do that task.

Because of this we:
- found all the pages we shift focus on when they
  load
- kept it for pages where the focus shift is
  important for what users do on the page
- removed it for all other pages (including
  templates)

The first iteration of this work was pushed in https://github.com/alphagov/notifications-admin/pull/3622

That branch also changed the label of the focused
element as a hack to get the page title read out.

This normally happens on load to indicate a
navigation has happened but didn't in Voiceover
when we focused an element on load.

After testing with JAWS and NVDA we found only
Voiceover does this. As Voiceover has the smallest
market share, and navigation can be inferred by
other means, we removed it in https://github.com/alphagov/notifications-admin/pull/3673

That was deployed today.