### PR TITLE
Split dashboard into current and previous alerts

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -40,6 +40,17 @@ def broadcast_dashboard(service_id):
     )
 
 
+@main.route('/services/<uuid:service_id>/previous-alerts')
+@user_has_permissions()
+@service_has_permission('broadcast')
+def broadcast_dashboard_previous(service_id):
+    return render_template(
+        'views/broadcast/previous-broadcasts.html',
+        broadcasts=BroadcastMessages(service_id).with_status('cancelled', 'completed'),
+        empty_message='You do not have any previous alerts',
+    )
+
+
 @main.route('/services/<uuid:service_id>/broadcast-dashboard.json')
 @user_has_permissions()
 @service_has_permission('broadcast')

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -71,11 +71,6 @@ def get_broadcast_dashboard_partials(service_id):
             broadcasts=broadcast_messages.with_status('broadcasting'),
             empty_message='You do not have any live alerts at the moment',
         ),
-        previous_broadcasts=render_template(
-            'views/broadcast/partials/dashboard-table.html',
-            broadcasts=broadcast_messages.with_status('cancelled', 'completed'),
-            empty_message='You do not have any previous alerts',
-        ),
     )
 
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -30,7 +30,7 @@ def broadcast_tour(service_id, step_index):
     )
 
 
-@main.route('/services/<uuid:service_id>/broadcast-dashboard')
+@main.route('/services/<uuid:service_id>/current-alerts')
 @user_has_permissions()
 @service_has_permission('broadcast')
 def broadcast_dashboard(service_id):

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -358,6 +358,7 @@ class HeaderNavigation(Navigation):
         'who_its_for',
         'broadcast_tour',
         'broadcast_dashboard',
+        'broadcast_dashboard_previous',
         'broadcast_dashboard_updates',
         'broadcast',
         'preview_broadcast_areas',
@@ -393,6 +394,9 @@ class MainNavigation(Navigation):
             'template_usage',
             'view_notification',
             'view_notifications',
+        },
+        'previous_broadcasts': {
+            'broadcast_dashboard_previous',
         },
         'templates': {
             'action_blocked',
@@ -716,6 +720,7 @@ class CaseworkNavigation(Navigation):
         'dashboard': {
             'broadcast_tour',
             'broadcast_dashboard',
+            'broadcast_dashboard_previous',
             'broadcast_dashboard_updates',
         },
         'send-one-off': {
@@ -1354,6 +1359,7 @@ class OrgNavigation(Navigation):
         'who_its_for',
         'broadcast_tour',
         'broadcast_dashboard',
+        'broadcast_dashboard_previous',
         'broadcast_dashboard_updates',
         'broadcast',
         'preview_broadcast_areas',

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -5,7 +5,7 @@
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous_broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Previous alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -6,6 +6,7 @@
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous_broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Previous alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -34,12 +34,4 @@
     'pending_approval_broadcasts'
   ) }}
 
-  <h2 class="heading-medium govuk-!-margin-bottom-2">Previous alerts</h2>
-
-  {{ ajax_block(
-    partials,
-    url_for('.broadcast_dashboard_updates', service_id=current_service.id),
-    'previous_broadcasts'
-  ) }}
-
 {% endblock %}

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -1,0 +1,15 @@
+{% from 'components/ajax-block.html' import ajax_block %}
+
+{% extends "withnav_template.html" %}
+
+{% block service_page_title %}
+  Previous alerts
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <h1 class="heading-medium govuk-!-margin-bottom-2">Previous alerts</h1>
+
+  {% include('views/broadcast/partials/dashboard-table.html') %}
+
+{% endblock %}

--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -33,7 +33,7 @@
         </p>
         <p class="govuk-body heading-medium">
           <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
-            Continue to dashboard
+            Continue
           </a>
         </p>
       </div>

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -28,7 +28,7 @@
         </p>
         <p class="govuk-body heading-medium">
           <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
-            Continue to dashboard
+            Continue
           </a>
         </p>
       </div>

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -278,7 +278,6 @@ def test_empty_broadcast_dashboard(
     ] == [
         'You do not have any live alerts at the moment',
         'You do not have any alerts waiting for approval',
-        'You do not have any previous alerts',
     ]
 
 
@@ -294,6 +293,8 @@ def test_broadcast_dashboard(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
     )
+
+    assert len(page.select('table')) == len(page.select('main h2')) == 2
 
     assert normalize_spaces(page.select('main h2')[0].text) == (
         'Live alerts'
@@ -311,16 +312,6 @@ def test_broadcast_dashboard(
         normalize_spaces(row.text) for row in page.select('table')[1].select('tbody tr')
     ] == [
         'Example template To England and Scotland Prepared by Test User',
-    ]
-
-    assert normalize_spaces(page.select('main h2')[2].text) == (
-        'Previous alerts'
-    )
-    assert [
-        normalize_spaces(row.text) for row in page.select('table')[2].select('tbody tr')
-    ] == [
-        'Example template To England and Scotland Stopped 10 February at 2:20am',
-        'Example template To England and Scotland Finished yesterday at 8:20pm',
     ]
 
 
@@ -344,12 +335,10 @@ def test_broadcast_dashboard_json(
     assert json_response.keys() == {
         'pending_approval_broadcasts',
         'live_broadcasts',
-        'previous_broadcasts',
     }
 
     assert 'Prepared by Test User' in json_response['pending_approval_broadcasts']
     assert 'Live until tomorrow at 2:20am' in json_response['live_broadcasts']
-    assert 'Finished yesterday at 8:20pm' in json_response['previous_broadcasts']
 
 
 @freeze_time('2020-02-20 02:20')

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -23,6 +23,10 @@ sample_uuid = sample_uuid()
         403, 405,
     ),
     (
+        '.broadcast_dashboard_previous', {},
+        403, 405,
+    ),
+    (
         '.broadcast',
         {'template_id': sample_uuid},
         403, 405,
@@ -346,6 +350,31 @@ def test_broadcast_dashboard_json(
     assert 'Prepared by Test User' in json_response['pending_approval_broadcasts']
     assert 'Live until tomorrow at 2:20am' in json_response['live_broadcasts']
     assert 'Finished yesterday at 8:20pm' in json_response['previous_broadcasts']
+
+
+@freeze_time('2020-02-20 02:20')
+def test_previous_broadcasts_page(
+    client_request,
+    service_one,
+    mock_get_broadcast_messages,
+    mock_get_service_templates,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get(
+        '.broadcast_dashboard_previous',
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert normalize_spaces(page.select_one('main h1').text) == (
+        'Previous alerts'
+    )
+    assert len(page.select('table')) == 1
+    assert [
+        normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
+    ] == [
+        'Example template To England and Scotland Stopped 10 February at 2:20am',
+        'Example template To England and Scotland Finished yesterday at 8:20pm',
+    ]
 
 
 def test_broadcast_page(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -143,8 +143,8 @@ def test_broadcast_pages_403_for_user_without_permission(
     (2, 'Continue', partial(url_for, '.broadcast_tour', step_index=3)),
     (3, 'Continue', partial(url_for, '.broadcast_tour', step_index=4)),
     (4, 'Continue', partial(url_for, '.broadcast_tour', step_index=5)),
-    (5, 'Continue to dashboard', partial(url_for, '.service_dashboard')),
-    (6, 'Continue to dashboard', partial(url_for, '.service_dashboard')),
+    (5, 'Continue', partial(url_for, '.service_dashboard')),
+    (6, 'Continue', partial(url_for, '.service_dashboard')),
 ))
 def test_broadcast_tour_pages_have_continue_link(
     client_request,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -189,6 +189,7 @@ def test_navigation_for_services_with_broadcast_permission(
         a['href'] for a in page.select('.navigation a')
     ] == [
         '/services/{}/broadcast-dashboard'.format(SERVICE_ONE_ID),
+        '/services/{}/previous-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),
         '/services/{}/service-settings'.format(SERVICE_ONE_ID),

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -188,7 +188,7 @@ def test_navigation_for_services_with_broadcast_permission(
     assert [
         a['href'] for a in page.select('.navigation a')
     ] == [
-        '/services/{}/broadcast-dashboard'.format(SERVICE_ONE_ID),
+        '/services/{}/current-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/previous-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),


### PR DESCRIPTION
Previous alerts are much less important than ones that are live or waiting for approval.

Therefore we can make the dashboard more focused by moving previous alerts to their own page.

The dashboard for broadcast services is very specific<sup>1</sup>, so less like a dashboard. We can now reflect this by renaming it to ‘current alerts‘. This should reduce the amount of navigation surfing people need to do in order to find the thing they’re looking for.

# Before 

![image](https://user-images.githubusercontent.com/355079/95870068-fcd9fd00-0d63-11eb-9bb1-519e300d2a07.png)

# After 

![image](https://user-images.githubusercontent.com/355079/95869968-dc11a780-0d63-11eb-9124-e92d85843114.png)

***

1. The dashboard for normal services is more general, because it tells you a bit about channels, templates and spend
