### PR TITLE
Make sure the correct navigation item is highlighted when viewing broadcasts

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -292,17 +292,39 @@ def view_broadcast(service_id, broadcast_message_id):
     )
     if broadcast_message.status == 'draft':
         abort(404)
+
+    if (
+        broadcast_message.status in {'completed', 'cancelled', 'rejected'}
+        and request.endpoint != 'main.view_previous_broadcast'
+    ):
+        return redirect(url_for(
+            '.view_previous_broadcast',
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
+        ))
+
+    if (
+        broadcast_message.status in {'broadcasting', 'pending-approval'}
+        and request.endpoint != 'main.view_current_broadcast'
+    ):
+        return redirect(url_for(
+            '.view_current_broadcast',
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
+        ))
+
+    back_link_endpoint = {
+        'main.view_current_broadcast': '.broadcast_dashboard',
+        'main.view_previous_broadcast': '.broadcast_dashboard_previous',
+    }[request.endpoint]
+
     return render_template(
         'views/broadcast/view-message.html',
         broadcast_message=broadcast_message,
-        back_link={
-            'main.view_current_broadcast': url_for(
-                '.broadcast_dashboard', service_id=current_service.id
-            ),
-            'main.view_previous_broadcast': url_for(
-                '.broadcast_dashboard_previous', service_id=current_service.id
-            ),
-        }[request.endpoint],
+        back_link=url_for(
+            back_link_endpoint,
+            service_id=current_service.id,
+        ),
     )
 
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -295,6 +295,14 @@ def view_broadcast(service_id, broadcast_message_id):
     return render_template(
         'views/broadcast/view-message.html',
         broadcast_message=broadcast_message,
+        back_link={
+            'main.view_current_broadcast': url_for(
+                '.broadcast_dashboard', service_id=current_service.id
+            ),
+            'main.view_previous_broadcast': url_for(
+                '.broadcast_dashboard_previous', service_id=current_service.id
+            ),
+        }[request.endpoint],
     )
 
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -48,7 +48,7 @@ def broadcast_dashboard_previous(service_id):
         'views/broadcast/previous-broadcasts.html',
         broadcasts=BroadcastMessages(service_id).with_status('cancelled', 'completed'),
         empty_message='You do not have any previous alerts',
-        single_endpoint='.view_previous_broadcast',
+        view_broadcast_endpoint='.view_previous_broadcast',
     )
 
 
@@ -66,13 +66,13 @@ def get_broadcast_dashboard_partials(service_id):
             'views/broadcast/partials/dashboard-table.html',
             broadcasts=broadcast_messages.with_status('pending-approval'),
             empty_message='You do not have any alerts waiting for approval',
-            single_endpoint='.view_current_broadcast',
+            view_broadcast_endpoint='.view_current_broadcast',
         ),
         live_broadcasts=render_template(
             'views/broadcast/partials/dashboard-table.html',
             broadcasts=broadcast_messages.with_status('broadcasting'),
             empty_message='You do not have any live alerts at the moment',
-            single_endpoint='.view_current_broadcast',
+            view_broadcast_endpoint='.view_current_broadcast',
         ),
     )
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -368,7 +368,8 @@ class HeaderNavigation(Navigation):
         'choose_broadcast_sub_area',
         'remove_broadcast_area',
         'preview_broadcast_message',
-        'view_broadcast_message',
+        'view_current_broadcast',
+        'view_previous_broadcast',
         'approve_broadcast_message',
         'reject_broadcast_message',
         'cancel_broadcast_message',
@@ -384,8 +385,6 @@ class MainNavigation(Navigation):
     mapping = {
         'dashboard': {
             'broadcast_tour',
-            'broadcast_dashboard',
-            'broadcast_dashboard_updates',
             'conversation',
             'inbox',
             'monthly',
@@ -396,8 +395,14 @@ class MainNavigation(Navigation):
             'view_notification',
             'view_notifications',
         },
-        'previous_broadcasts': {
+        'current-broadcasts': {
+            'broadcast_dashboard',
+            'broadcast_dashboard_updates',
+            'view_current_broadcast',
+        },
+        'previous-broadcasts': {
             'broadcast_dashboard_previous',
+            'view_previous_broadcast',
         },
         'templates': {
             'action_blocked',
@@ -432,7 +437,6 @@ class MainNavigation(Navigation):
             'choose_broadcast_sub_area',
             'remove_broadcast_area',
             'preview_broadcast_message',
-            'view_broadcast_message',
             'approve_broadcast_message',
             'reject_broadcast_message',
             'cancel_broadcast_message',
@@ -1041,7 +1045,8 @@ class CaseworkNavigation(Navigation):
         'choose_broadcast_sub_area',
         'remove_broadcast_area',
         'preview_broadcast_message',
-        'view_broadcast_message',
+        'view_current_broadcast',
+        'view_previous_broadcast',
         'approve_broadcast_message',
         'reject_broadcast_message',
         'cancel_broadcast_message',
@@ -1372,7 +1377,8 @@ class OrgNavigation(Navigation):
         'choose_broadcast_sub_area',
         'remove_broadcast_area',
         'preview_broadcast_message',
-        'view_broadcast_message',
+        'view_current_broadcast',
+        'view_previous_broadcast',
         'approve_broadcast_message',
         'reject_broadcast_message',
         'cancel_broadcast_message',

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -5,8 +5,8 @@
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous_broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Previous alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Previous alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -14,7 +14,7 @@
   ) %}
     {% call row_heading() %}
       <div class="file-list">
-        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_broadcast_message', service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template_name }}</a>
+        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(single_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template_name }}</a>
         <span class="file-list-hint-large govuk-!-margin-bottom-1">
           {{ item.content }}
         </span>

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -14,7 +14,7 @@
   ) %}
     {% call row_heading() %}
       <div class="file-list">
-        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(single_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template_name }}</a>
+        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template_name }}</a>
         <span class="file-list-hint-large govuk-!-margin-bottom-1">
           {{ item.content }}
         </span>

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -34,7 +34,7 @@
 
 {% block maincolumn_content %}
 
-  {{ govukBackLink({ "href": url_for('.broadcast_dashboard', service_id=current_service.id) }) }}
+  {{ govukBackLink({ "href": back_link }) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
     {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -52,8 +52,12 @@ sample_uuid = sample_uuid()
         403, 403,
     ),
     (
-        '.view_broadcast_message', {'broadcast_message_id': sample_uuid},
+        '.view_current_broadcast', {'broadcast_message_id': sample_uuid},
         403, 403,
+    ),
+    (
+        '.view_previous_broadcast', {'broadcast_message_id': sample_uuid},
+        403, 405,
     ),
     (
         '.cancel_broadcast_message', {'broadcast_message_id': sample_uuid},
@@ -1019,7 +1023,7 @@ def test_start_broadcasting(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=url_for(
-            'main.view_broadcast_message',
+            'main.view_current_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
             _external=True,
@@ -1099,7 +1103,7 @@ def test_view_broadcast_message_page(
     service_one['permissions'] += ['broadcast']
 
     page = client_request.get(
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
     )
@@ -1136,7 +1140,7 @@ def test_view_pending_broadcast(
     service_one['permissions'] += ['broadcast']
 
     page = client_request.get(
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
     )
@@ -1190,7 +1194,7 @@ def test_cant_approve_own_broadcast(
     service_one['permissions'] += ['broadcast']
 
     page = client_request.get(
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
     )
@@ -1243,7 +1247,7 @@ def test_can_approve_own_broadcast_in_trial_mode(
     service_one['permissions'] += ['broadcast']
 
     page = client_request.get(
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
     )
@@ -1319,7 +1323,7 @@ def test_view_only_user_cant_approve_broadcast(
     service_one['permissions'] += ['broadcast']
 
     page = client_request.get(
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
     )
@@ -1338,7 +1342,7 @@ def test_view_only_user_cant_approve_broadcast(
 @pytest.mark.parametrize('trial_mode, initial_status, expected_approval, expected_redirect', (
     (True, 'draft', False, partial(
         url_for,
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         broadcast_message_id=sample_uuid,
     )),
     (True, 'pending-approval', True, partial(
@@ -1348,22 +1352,22 @@ def test_view_only_user_cant_approve_broadcast(
     )),
     (False, 'pending-approval', True, partial(
         url_for,
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         broadcast_message_id=sample_uuid,
     )),
     (True, 'rejected', False, partial(
         url_for,
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         broadcast_message_id=sample_uuid,
     )),
     (True, 'broadcasting', False, partial(
         url_for,
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         broadcast_message_id=sample_uuid,
     )),
     (True, 'cancelled', False, partial(
         url_for,
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         broadcast_message_id=sample_uuid,
     )),
 ))
@@ -1396,7 +1400,7 @@ def test_request_approval(
     service_one['permissions'] += ['broadcast']
 
     client_request.post(
-        '.view_broadcast_message',
+        '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=expected_redirect(
@@ -1502,7 +1506,7 @@ def test_cant_reject_broadcast_in_wrong_state(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=url_for(
-            '.view_broadcast_message',
+            '.view_current_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
             _external=True,
@@ -1513,15 +1517,20 @@ def test_cant_reject_broadcast_in_wrong_state(
     assert mock_update_broadcast_message_status.called is False
 
 
+@pytest.mark.parametrize('endpoint', (
+    '.view_current_broadcast',
+    '.view_previous_broadcast',
+))
 def test_no_view_page_for_draft(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
+    endpoint,
 ):
     service_one['permissions'] += ['broadcast']
     client_request.get(
-        '.view_broadcast_message',
+        endpoint,
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_status=404,
@@ -1574,7 +1583,7 @@ def test_confirm_cancel_broadcast(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=url_for(
-            '.view_broadcast_message',
+            '.view_previous_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
             _external=True,
@@ -1602,7 +1611,7 @@ def test_cant_cancel_broadcast_in_a_different_state(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=url_for(
-            '.view_broadcast_message',
+            '.view_current_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
             _external=True,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1118,26 +1118,31 @@ def test_view_broadcast_message_page(
     '.view_current_broadcast',
     '.view_previous_broadcast',
 ))
-@pytest.mark.parametrize('status, expected_highlighted_navigation_item', (
+@pytest.mark.parametrize('status, expected_highlighted_navigation_item, expected_back_link_endpoint', (
     (
         'pending-approval',
         'Current alerts',
+        '.broadcast_dashboard',
     ),
     (
         'broadcasting',
         'Current alerts',
+        '.broadcast_dashboard',
     ),
     (
         'completed',
         'Previous alerts',
+        '.broadcast_dashboard_previous',
     ),
     (
         'cancelled',
         'Previous alerts',
+        '.broadcast_dashboard_previous',
     ),
     (
         'rejected',
         'Previous alerts',
+        '.broadcast_dashboard_previous',
     ),
 ))
 @freeze_time('2020-02-22T22:22:22.000000')
@@ -1151,6 +1156,7 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
     endpoint,
     status,
     expected_highlighted_navigation_item,
+    expected_back_link_endpoint,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -1179,6 +1185,11 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
         page.select_one('.navigation .selected').text
     ) == (
         expected_highlighted_navigation_item
+    )
+
+    assert page.select_one('.govuk-back-link')['href'] == url_for(
+        expected_back_link_endpoint,
+        service_id=SERVICE_ONE_ID,
     )
 
 


### PR DESCRIPTION
Once a broadcast has been submitted for approval it either lives on the ‘Current alerts’ or ‘Previous alerts’ page, depending on where it is in its lifecycle.

Therefore when clicking into a broadcast from one of those pages the selected navigation item should match the page you’ve come from, and the status of the broadcast.