### PR TITLE
Sort broadcasts by start time

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -43,9 +43,9 @@ class BroadcastMessage(JSONModel):
 
     def __lt__(self, other):
         return (
-            self.cancelled_at or self.finishes_at or self.created_at
+            self.starts_at or self.updated_at
         ) < (
-            other.cancelled_at or other.finishes_at or self.created_at
+            other.starts_at or other.updated_at
         )
 
     @classmethod


### PR DESCRIPTION
For emails and text messages we sort by the time the user (or API) sent them.

This makes sense for broadcasts too, since most users will receive the alert within seconds of it being broadcast.

For alerts that haven’t started yet we can sort by `updated_at`, which is when the user preparing the broadcast submitted it for approval.