### PR TITLE
Remove custom `getattr` implementation from JSONModel

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -13,7 +13,7 @@ class JSONModel(SerialisedModel):
         # in the case of a bad request _dict may be `None`
         self._dict = _dict or {}
         for property in self.ALLOWED_PROPERTIES:
-            if property in self._dict and not hasattr(self, property):
+            if property in self._dict:
                 setattr(self, property, self._dict[property])
 
     def __bool__(self):

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -25,7 +25,6 @@ class Job(JSONModel):
     ALLOWED_PROPERTIES = {
         'id',
         'service',
-        'template',
         'template_version',
         'original_file_name',
         'created_at',

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -28,7 +28,6 @@ class Job(JSONModel):
         'template_version',
         'original_file_name',
         'created_at',
-        'processing_started',
         'notification_count',
         'created_by',
         'template_type',

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -31,11 +31,9 @@ class Service(JSONModel):
     ALLOWED_PROPERTIES = {
         'active',
         'contact_link',
-        'email_branding',
         'email_from',
         'id',
         'inbound_api',
-        'letter_branding',
         'message_limit',
         'name',
         'prefix_sms',

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -39,7 +39,6 @@ class User(JSONModel, UserMixin):
         'mobile_number',
         'password_changed_at',
         'permissions',
-        'platform_admin',
         'state',
     }
 

--- a/tests/app/models/test_base_model.py
+++ b/tests/app/models/test_base_model.py
@@ -11,7 +11,7 @@ def test_looks_up_from_dict():
     assert Custom({'foo': 'bar'}).foo == 'bar'
 
 
-def test_prefers_property_to_dict():
+def test_raises_when_overriding_custom_properties():
 
     class Custom(JSONModel):
 
@@ -19,9 +19,12 @@ def test_prefers_property_to_dict():
 
         @property
         def foo(self):
-            return 'bar'
+            pass
 
-    assert Custom({'foo': 'NOPE'}).foo == 'bar'
+    with pytest.raises(AttributeError) as e:
+        Custom({'foo': 'NOPE'})
+
+    assert str(e.value) == "can't set attribute"
 
 
 @pytest.mark.parametrize('json_response', (

--- a/tests/app/models/test_base_model.py
+++ b/tests/app/models/test_base_model.py
@@ -39,10 +39,7 @@ def test_model_raises_for_unknown_attributes(json_response):
     with pytest.raises(AttributeError) as e:
         model.foo
 
-    assert str(e.value) == (
-        "'Custom' object has no attribute 'foo' and 'foo' is not a "
-        "field in the underlying JSON"
-    )
+    assert str(e.value) == "'Custom' object has no attribute 'foo'"
 
 
 def test_model_raises_keyerror_if_item_missing_from_dict():
@@ -50,10 +47,10 @@ def test_model_raises_keyerror_if_item_missing_from_dict():
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = {'foo'}
 
-    with pytest.raises(KeyError) as e:
+    with pytest.raises(AttributeError) as e:
         Custom({}).foo
 
-    assert str(e.value) == "'foo'"
+    assert str(e.value) == "'Custom' object has no attribute 'foo'"
 
 
 @pytest.mark.parametrize('json_response', (
@@ -79,4 +76,6 @@ def test_dynamic_properties_are_introspectable():
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = {'foo', 'bar', 'baz'}
 
-    assert dir(Custom({}))[-3:] == ['bar', 'baz', 'foo']
+    model = Custom({'foo': None, 'bar': None, 'baz': None})
+
+    assert dir(model)[-3:] == ['bar', 'baz', 'foo']


### PR DESCRIPTION
We wrote custom `__getattr__` and `__getitem__` implementations to make it easier to find code that was accessing fields in the dictionary that we weren’t aware of (see https://github.com/alphagov/notifications-admin/commit/b48305c50d0d6b1674a39e0fd5a3c4768d281a66 for details and https://github.com/alphagov/notifications-admin/pull/2423 for more context).

Now that no view-layer code accesses the service dictionary directly we don’t need to support this behaviour any more. By removing it we can make the model code simpler, and closer to the `SerialisedModel` it inherits from.

It still needs some custom implementation because:
- a lot of our test fixtures are lazy and don’t set up all the expected fields, so we need to account for fields sometimes being present in the underlying dictionary and sometimes not
- we often implement a property that has the same name as one of the fields in the JSON, so we have to be careful not to try to override this property with the value from the underlying JSON