### PR TITLE
Make custom data retention look a bit nicer

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -370,9 +370,19 @@
             {{ edit_field('Change', url_for('.service_set_letter_branding', service_id=current_service.id), suffix='letter branding (admin view)') }}
           {% endcall %}
           {% call row() %}
-            {{ text_field('Data retention')}}
+            {{ text_field('Custom data retention')}}
             {% call field() %}
-                {{ current_service.data_retention | join(', ', attribute='notification_type') }}
+              {% for channel in current_service.data_retention %}
+                {% if loop.first %}
+                  <ul>
+                {% endif %}
+                  <li>{{ channel.notification_type|format_notification_type }} – {{ channel.days_of_retention }} days</li>
+                {% if loop.last %}
+                  </ul>
+                {% endif %}
+              {% else %}
+                <div class="table-field-status-default">Not set</div>
+              {% endfor %}
             {% endcall %}
             {{ edit_field('Change', url_for('.data_retention', service_id=current_service.id), suffix='data retention') }}
           {% endcall %}

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -45,7 +45,7 @@
       {% for item in current_service.data_retention %}
           {% call row() %}
             {{ text_field(item.notification_type | format_notification_type)}}
-            {{ text_field(item.days_of_retention) }}
+            {{ text_field(item.days_of_retention|string + ' days') }}
             {{ edit_field('Change', url_for('.edit_data_retention', service_id=current_service.id, data_retention_id=item.id)) }}
           {% endcall %}
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -104,7 +104,7 @@ def mock_get_service_settings_page_common(
         'Free text message allowance 250,000 Change free text message allowance',
         'Email branding GOV.UK Change email branding (admin view)',
         'Letter branding Not set Change letter branding (admin view)',
-        'Data retention email Change data retention',
+        'Custom data retention Email – 7 days Change data retention',
         'Receive inbound SMS Off Change your settings for Receive inbound SMS',
         'Email authentication Off Change your settings for Email authentication',
         'Send cell broadcasts Off Change your settings for Send cell broadcasts',
@@ -5029,7 +5029,7 @@ def test_show_service_data_retention(
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     rows = page.select('tbody tr')
     assert len(rows) == 1
-    assert normalize_spaces(rows[0].text) == 'Email 5 Change'
+    assert normalize_spaces(rows[0].text) == 'Email 5 days Change'
 
 
 def test_view_add_service_data_retention(


### PR DESCRIPTION
This should make it easier to see what’s set without having to click into the table.

# Before 

![image](https://user-images.githubusercontent.com/355079/96475289-ba189900-122b-11eb-8d35-2fee4d092bae.png)

# After 

![image](https://user-images.githubusercontent.com/355079/96475917-7d00d680-122c-11eb-8ff9-f25dfc76496a.png)

***

![image](https://user-images.githubusercontent.com/355079/96475815-5e024480-122c-11eb-824f-ffee158efa31.png)
