### PR TITLE
Remove the `upload_letters` permission

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -67,7 +67,6 @@ from app.utils import (
 PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
     ('inbound_sms', {'title': 'Receive inbound SMS', 'requires': 'sms', 'endpoint': '.service_set_inbound_number'}),
     ('email_auth', {'title': 'Email authentication'}),
-    ('upload_letters', {'title': 'Uploading letters', 'requires': 'letter'}),
     ('international_letters', {'title': 'Send international letters', 'requires': 'letter'}),
     ('broadcast', {'title': 'Send cell broadcasts'}),
 ])

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -341,7 +341,7 @@ def view_letter_upload_as_preview(service_id, file_id):
 @main.route("/services/<uuid:service_id>/upload-letter/send/<uuid:file_id>", methods=['POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_uploaded_letter(service_id, file_id):
-    if not (current_service.has_permission('letter') and current_service.has_permission('upload_letters')):
+    if not current_service.has_permission('letter'):
         abort(403)
 
     metadata = get_letter_metadata(service_id, file_id)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -64,7 +64,6 @@ class Service(JSONModel):
         'international_letters',
         'international_sms',
         'upload_document',
-        'upload_letters',
         'broadcast',
     )
 

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -8,7 +8,7 @@
     caption="Recent files uploaded",
     caption_visible=False,
     empty_message=(
-      'Upload a letter and Notify will print, pack and post it for you.'
+      'Upload a letter and Notify will print, pack and post it for you.' if current_service.has_permission('letter') else 'You have not uploaded any files yet.'
     ),
     field_headings=[
       'File',

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -8,7 +8,7 @@
     caption="Recent files uploaded",
     caption_visible=False,
     empty_message=(
-      'Upload a letter and Notify will print, pack and post it for you.' if current_service.can_upload_letters else 'You have not uploaded any files yet'
+      'Upload a letter and Notify will print, pack and post it for you.'
     ),
     field_headings=[
       'File',

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -120,9 +120,6 @@ def test_service_set_permission(
     ({'permissions': ['sms']}, '.service_set_inbound_number', {},
         'Receive inbound SMS Off Change your settings for Receive inbound SMS'),
     ({'permissions': ['letter']},
-     '.service_set_permission', {'permission': 'upload_letters'},
-        'Uploading letters Off Change your settings for Uploading letters'),
-    ({'permissions': ['letter']},
      '.service_set_permission', {'permission': 'international_letters'},
         'Send international letters Off Change your settings for Send international letters'),
 ])

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -629,8 +629,7 @@ def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
 
 @pytest.mark.parametrize('permissions', [
     ['email'],
-    ['letter'],
-    ['upload_letters'],
+    ['sms'],
 ])
 def test_send_uploaded_letter_when_service_does_not_have_correct_permissions(
     mocker,


### PR DESCRIPTION
Every service has it now, and we haven’t had any services ask to toggle it off again.