### PR TITLE
Fix incorrect redis key deleting

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -10,7 +10,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         templates_for_service = self.get_service_templates(service_id)['data']
         if templates_for_service:
             redis_client.delete(*[
-                f"template-{x['id']}-version-None"
+                f"service-{service_id}-template-{x['id']}-version-None"
                 for x in templates_for_service
             ])
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -550,5 +550,5 @@ def test_client_deletes_service_template_cache_when_service_is_updated(
     templates_to_delete = mock_redis_delete.call_args_list[0][0]
     assert len(templates_to_delete) == 6
     for template_key in templates_to_delete:
-        assert template_key.startswith('template-')
+        assert template_key.startswith('service-{}-template'.format(SERVICE_ONE_ID))
         assert template_key.endswith('version-None')

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -550,5 +550,5 @@ def test_client_deletes_service_template_cache_when_service_is_updated(
     templates_to_delete = mock_redis_delete.call_args_list[0][0]
     assert len(templates_to_delete) == 6
     for template_key in templates_to_delete:
-        assert template_key.startswith('service-{}-template'.format(SERVICE_ONE_ID))
+        assert template_key.startswith(f'service-{SERVICE_ONE_ID}-template')
         assert template_key.endswith('version-None')


### PR DESCRIPTION
We were trying to delete the old 'template-{template-id}' keys but
should have been deleting the new keys which have the service id as part
of the key name. This was causing the cache to not be correctly purged
when we did things like update sender names or set defaults. This should
fix it.