### PR TITLE
Fix last date statement was updated

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -168,6 +168,6 @@
   </p>
 
   <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 29 September 2020.
+    This statement was prepared on 23 September 2020. It was last reviewed on 9 October 2020.
   </p>
 {% endblock %}


### PR DESCRIPTION
The accessibility statement was last updated on 9
October 2020 but without the 'last reviewed' date
being updated.

The changes were contained in this pull request
which was merged the same day and reached
production at 2.13pm.

https://github.com/alphagov/notifications-admin/pull/3677

I will attempt to add a test for this in a future pull request but wanted to get it fixed ASAP. Also: 🤦🏻‍♂️