### PR TITLE
Remove issue from accessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -38,7 +38,6 @@
     We know some parts of this website are not fully accessible:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>low vision users cannot access the table we use to show CSV data when viewed at high zoom</li>
     <li>screen reader users may find the process of moving templates and folders confusing</li>
     <li>one page links to a PDF document that is not fully accessible</li>
     <li>the Notify status page has several accessibility issues</li>
@@ -95,10 +94,6 @@
   </p>
 
   <h3 class="heading-small">Non compliance with the accessibility regulations</h3>
-
-  <p class="govuk-body">
-    Low vision users cannot access the table we use to show CSV data when viewed at high zoom. This fails <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/#reflow">WCAG 1.4.10 success criteria (Reflow)</a>. We plan to fix this by the end of 2020.
-  </p>
 
   <p class="govuk-body">
     Screen reader users may find the process of moving templates and folders confusing. This fails <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/#name-role-value">WCAG 4.1.2 success criteria (Name, role, value)</a>. We plan to fix this by November 2020.
@@ -168,6 +163,6 @@
   </p>
 
   <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 9 October 2020.
+    This statement was prepared on 23 September 2020. It was last reviewed on 22 October 2020.
   </p>
 {% endblock %}

--- a/tests/app/test_accessibility_statement.py
+++ b/tests/app/test_accessibility_statement.py
@@ -1,0 +1,24 @@
+import re
+import subprocess
+from datetime import datetime
+
+
+def test_last_review_date():
+    statement_file_path = "app/templates/views/accessibility_statement.html"
+
+    # test local changes against master for a full diff of what will be merged
+    statement_diff = subprocess.run([f"git diff --exit-code origin/master -- {statement_file_path}"],
+                                    stdout=subprocess.PIPE, shell=True)
+
+    # if statement has changed, test the review date was part of those changes
+    if statement_diff.returncode == 1:
+        raw_diff = statement_diff.stdout.decode('utf-8')
+        today = datetime.now().strftime('%d %B %Y')
+        with open(statement_file_path, 'r') as statement_file:
+            current_review_date = re.search((r'This statement was prepared on 23 September 2020\. '
+                                             r'It was last reviewed on (\d{1,2} [A-Z]{1}[a-z]+ \d{4})'),
+                                            statement_file.read()).group(1)
+
+        # guard against changes that don't need to update the review date
+        if current_review_date != today:
+            assert 'This statement was prepared on 23 September 2020. It was last reviewed on' in raw_diff


### PR DESCRIPTION
The following issues were raised with the table that replays CSV data to users:
1. the table could not be located by low vision
   users using the reflow technique
2. the content should be presented in a single
   column when the reflow technique is used

Number 2. came from the Web Content Accessibility guidelines (WCAG) success criteria 1.4.10 Reflow.

I wasn't able to reproduce number 1. so asked the Digital Accessibility Centre (DAC), who tested it originally, for help. Tom Shaw from DAC kindly retested it and found the problem was gone so I am considering it fixed.

I am treating number 2. as a misinterpretation of the success criteria as it lists data tables as an exception to the rule:

```txt
Except for parts of the content which require two-dimensional layout for usage or meaning.

...Examples of content which requires two-dimensional layout are images, maps, diagrams, video, games, presentations, data tables, and interfaces where it is necessary to keep toolbars in view while manipulating content.
```

The full page is here:

https://www.w3.org/WAI/WCAG21/Understanding/reflow.html

## Also includes a test(!)

This pull request also includes a test that checks changes to the statement include updates to the line at the bottom that lists the last day it was reviewed.

I'm not sure if it is a sensible test, to run locally or on concourse so any input on this would be appreciated :)