### PR TITLE
Add a back link to the conversation page

### DIFF
--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -1,4 +1,5 @@
 {% from "components/ajax-block.html" import ajax_block %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "withnav_template.html" %}
 
@@ -10,8 +11,10 @@
 
   <div class="dashboard">
 
+    {{ govukBackLink({ "href": url_for("main.inbox", service_id=current_service.id) }) }}
+
     <div class="bottom-gutter js-stick-at-top-when-scrolling">
-      <h1 class="heading-large">
+      <h1 class="heading-large govuk-!-margin-top-0">
         {{ user_number }}
       </h1>
     </div>


### PR DESCRIPTION
We must have missed this when adding back links to all the pages.

![image](https://user-images.githubusercontent.com/355079/96900627-390b0d00-148a-11eb-9f7c-0a6d3345e190.png)
