### PR TITLE
Fix typo on letter specification page

### DIFF
--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -11,7 +11,7 @@
 
   <p class="govuk-body">Page size and layout: A4 portrait (210 × 297 mm)</p>
   <p class="govuk-body">Maximum file size: 2 MB</p>
-  <p class="govuk-body">Your letter must 10 pages or less (5 double-sided sheets of paper).</p>
+  <p class="govuk-body">Your letter must be 10 pages or less (5 double-sided sheets of paper).</p>
   <p class="govuk-body">The content of your letter must appear inside the printable area.</p>
 
   <p class="govuk-body">To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification as a PDF</a>.</p>


### PR DESCRIPTION
Looks like I missed the word 'be' when we published the new letter specification page in a hurry.