### PR TITLE
Remove July to September section from roadmap

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -16,9 +16,7 @@
   <h2 class="heading-medium">October to December 2020</h2>
 
   <ul class="list list-bullet">
-    <li>Let services attach forms to letter templates</li>
-    <li>Distribute the delivery of a batch of messages over several hours</li>
-    <li>Make it easy to see the replies from staff on an emergency contact list</li>
+    <li>Increase our capacity to meet the needs of NHS Test and Trace, and other COVID-19 services</li>
     <li>Explore ways to help teams send effective messages</li>
   </ul>
 
@@ -27,15 +25,17 @@
   <ul class="list list-bullet">
 
     <li>Use two-factor authentication to protect files sent by email</li>
-    <li>Explore other ways to pay for Notify</li>
-    <li>Add multilingual letter templates so services can provide information in several languages</li>
-    <li>Add large print letter templates</li>
     <li>Add a link shortening service</li>
-    <li>Specify an expiry period for undeliverable text messages</li>
     <li>Let users save draft templates</li>
+    <li>Explore other ways to pay for Notify</li>
+    <li>Let services attach forms to letter templates</li>
+    <li>Add large print letter templates</li>
+    <li>Add multilingual letter templates so services can provide information in several languages</li>
+    <li>Distribute the delivery of a batch of messages over several hours</li>
+    <li>Specify an expiry period for undeliverable text messages</li>
+    <li>Make it easy to see the replies from staff on an emergency contact list</li>
     <li>Start sending emails from NHS and Parliament email addresses</li>
     <li>Make it easier for software suppliers to set up Notify for their customers</li>
-
 
   </ul>
 

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -13,21 +13,13 @@
   <p class="govuk-body">Notify is in public beta. This means it’s fully operational and supported, but we’re still adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
   <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
-  <h2 class="heading-medium">July to September 2020</h2>
-
-  <ul class="list list-bullet">
-    <li>Let services send letters to international addresses</li>
-    <li>Start sending emails from NHS and Parliament email addresses</li>
-    <li>Make it easier for software suppliers set up Notify for their customers</li>
-    <li>Explore ways to help teams send effective messages</li>
-  </ul>
-
   <h2 class="heading-medium">October to December 2020</h2>
 
   <ul class="list list-bullet">
     <li>Let services attach forms to letter templates</li>
     <li>Distribute the delivery of a batch of messages over several hours</li>
     <li>Make it easy to see the replies from staff on an emergency contact list</li>
+    <li>Explore ways to help teams send effective messages</li>
   </ul>
 
   <h2 class="heading-medium">January 2021 onwards</h2>
@@ -41,6 +33,9 @@
     <li>Add a link shortening service</li>
     <li>Specify an expiry period for undeliverable text messages</li>
     <li>Let users save draft templates</li>
+    <li>Start sending emails from NHS and Parliament email addresses</li>
+    <li>Make it easier for software suppliers set up Notify for their customers</li>
+
 
   </ul>
 

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -26,13 +26,13 @@
 
     <li>Use two-factor authentication to protect files sent by email</li>
     <li>Add a link shortening service</li>
-    <li>Let users save draft templates</li>
-    <li>Explore other ways to pay for Notify</li>
     <li>Let services attach forms to letter templates</li>
     <li>Add large print letter templates</li>
     <li>Add multilingual letter templates so services can provide information in several languages</li>
+    <li>Let users save draft templates</li>
     <li>Distribute the delivery of a batch of messages over several hours</li>
     <li>Specify an expiry period for undeliverable text messages</li>
+    <li>Explore other ways to pay for Notify</li>
     <li>Make it easy to see the replies from staff on an emergency contact list</li>
     <li>Start sending emails from NHS and Parliament email addresses</li>
     <li>Make it easier for software suppliers to set up Notify for their customers</li>

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -34,7 +34,7 @@
     <li>Specify an expiry period for undeliverable text messages</li>
     <li>Let users save draft templates</li>
     <li>Start sending emails from NHS and Parliament email addresses</li>
-    <li>Make it easier for software suppliers set up Notify for their customers</li>
+    <li>Make it easier for software suppliers to set up Notify for their customers</li>
 
 
   </ul>


### PR DESCRIPTION
We're not ready to publish a detailed roadmap for 2021 yet – but we do need to:

* remove the July to September section so the page doesn't look too out of date
* reflect the work that we're actually doing in October to December
* move everything else into next year