### PR TITLE
Allow rate limit to be updated

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -107,7 +107,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             'consent_to_research',
             'count_as_live',
             'go_live_user',
-            'go_live_at'
+            'go_live_at',
+            'rate_limit',
         }
         if disallowed_attributes:
             raise TypeError('Not allowed to update service attributes: {}'.format(


### PR DESCRIPTION
This bit of code is just a safety check to make sure we don’t inadvertently updating something we shouldn’t (see
0cfe10639a0018553080885569b4ba125341122d for context).

`rate_limit` is something we allow the admin app to update now (as of 939029a9bed6c068346d1b62626947cd4b40dda4).