### PR TITLE
Fix template list item focus style

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -100,6 +100,34 @@ $message-type-bottom-spacing: govuk-spacing(4);
 
       }
 
+      .template-list-template,
+      .template-list-folder {
+
+        position: relative; /* contain absolutely positioned ::before pseudo element*/
+        display: block; /* fill horizontal space to allow hint/meta below to float */
+
+        &::before {
+          content: '';
+          position: absolute;
+          left: 0px;
+          bottom: -100%; /* extend link by 100% of vertical size so it covers the hint/meta */
+          width: 100%;
+          height: 100%;
+        }
+
+        &:active::before,
+        &:focus::before {
+          background-color: $govuk-focus-colour;
+          box-shadow: 0px -2px $govuk-focus-colour, 0px 4px $govuk-focus-text-colour;
+        }
+
+        & + .template-list-item-hint,
+        & + .message-type {
+          position: relative; /* needs to be non-static to have a z-index above the link :before element */
+        }
+
+      }
+
     }
 
     &-label {

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -152,17 +152,24 @@ $message-type-bottom-spacing: govuk-spacing(4);
 
   &-folder,
   &-template {
-    @include govuk-font($size: 24, $weight: bold, $line-height: 1.25);
+    @include govuk-font($size: 24, $weight: bold, $line-height: 1.5);
+    @include govuk-media-query($from: tablet) {
+      line-height: 1.25;
+    }
   }
 
   &-folder {
 
     display: inline;
-    padding-left: 40px;
+    padding-left: 35px;
     background-image: file-url('folder-blue-bold.svg');
     background-repeat: no-repeat;
     background-size: auto 20px;
     background-position: 0px 4px;
+
+    @include govuk-media-query($from: tablet) {
+      padding-left: 40px;
+    }
 
     &:hover {
       background-image: file-url('folder-blue-bold-hover.svg');

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -34,8 +34,6 @@ $message-type-bottom-spacing: govuk-spacing(4);
     margin: 0;
 
     a {
-      margin-bottom: -1 * govuk-spacing(6);
-      padding-bottom: govuk-spacing(6);
 
       &:hover .message-name-separator:before {
         border-color: $link-hover-colour;
@@ -59,6 +57,7 @@ $message-type-bottom-spacing: govuk-spacing(4);
   }
 
   &-type {
+    position: relative; /* needs to be non-static to have a z-index above the link :before element */
     color: $govuk-secondary-text-colour;
     margin: 0 0 $message-type-bottom-spacing 0;
     padding-left: 0;

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -28,34 +28,26 @@ $govuk-checkboxes-size: 40px;
 $govuk-checkboxes-label-padding-left-right: govuk-spacing(3);
 $message-type-bottom-spacing: govuk-spacing(4);
 
-.message {
+a {
 
-  &-name {
-    margin: 0;
-
-    a {
-
-      &:hover .message-name-separator:before {
-        border-color: $link-hover-colour;
-      }
-
-      .message-name-separator {
-
-        margin-right: -2px;
-        margin-left: -2px;
-
-        &:before {
-          border-color: $link-colour;
-        }
-      }
-    }
-
-    &-separator {
-      @include separator;
-    }
-
+  &:hover .message-name-separator:before {
+    border-color: $link-hover-colour;
   }
 
+  .message-name-separator {
+
+    margin-right: -2px;
+    margin-left: -2px;
+
+    &:before {
+      border-color: $link-colour;
+    }
+  }
+
+}
+
+.message-name-separator {
+  @include separator;
 }
 
 .template-list {
@@ -72,18 +64,20 @@ $message-type-bottom-spacing: govuk-spacing(4);
 
     &-without-ancestors {
 
-      .message-name {
+      a {
 
-        a {
+        display: block;
+
+        &:first-child {
           display: block;
+        }
 
-          &:first-child {
-            display: block;
-          }
+        &.template-list-folder:first-of-type {
+          background-position: 0 2px;
+          padding-left: 0;
+          text-indent: 35px;
 
-          &.template-list-folder:first-child {
-            background-position: 0 2px;
-            padding-left: 0;
+          @include govuk-media-query($from: tablet) {
             text-indent: 40px;
           }
 

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -56,14 +56,6 @@ $message-type-bottom-spacing: govuk-spacing(4);
 
   }
 
-  &-type {
-    position: relative; /* needs to be non-static to have a z-index above the link :before element */
-    color: $govuk-secondary-text-colour;
-    margin: 0 0 $message-type-bottom-spacing 0;
-    padding-left: 0;
-    pointer-events: none;
-  }
-
 }
 
 .template-list {

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -114,10 +114,19 @@ $message-type-bottom-spacing: govuk-spacing(4);
           height: 100%;
         }
 
-        &:active::before,
-        &:focus::before {
-          background-color: $govuk-focus-colour;
-          box-shadow: 0px -2px $govuk-focus-colour, 0px 4px $govuk-focus-text-colour;
+        &:active,
+        &:focus {
+
+          &::before {
+            background-color: $govuk-focus-colour;
+            box-shadow: 0px -2px $govuk-focus-colour, 0px 4px $govuk-focus-text-colour;
+          }
+
+          & + .template-list-item-hint,
+          & + .message-type {
+            color: #505A5F; /* TO DO: replace with $govuk-secondary-text-colour when GOVUK Frontend is past 3.x.x */
+          }
+
         }
 
         & + .template-list-item-hint,

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -123,8 +123,8 @@ $message-type-bottom-spacing: govuk-spacing(4);
           }
 
           & + .template-list-item-hint,
-          & + .message-type {
-            color: #505A5F; /* TO DO: replace with $govuk-secondary-text-colour when GOVUK Frontend is past 3.x.x */
+          .message-type {
+            color: $govuk-text-colour;
           }
 
         }

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -26,6 +26,10 @@
   <nav id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
     {% set checkboxes_data = [] %}
 
+    {% if not current_user.has_permissions('manage_templates') %}
+    <ul>
+    {% endif %}
+
     {% for item in template_list %}
 
       {% set item_link_content %}
@@ -73,16 +77,18 @@
       {% set _ = checkboxes_data.append(checkbox_config) %}
 
       {% if not current_user.has_permissions('manage_templates') %}
-        <div class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
-          <h2 class="message-name">
-            {{ item_link_content }}
-          </h2>
-          <p class="message-type govuk-!-margin-bottom-4">
+        <li class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
+          {{ item_link_content }}
+          <p class="template-list-item-hint govuk-!-margin-bottom-4">
             {{ item.hint }}
           </p>
-        </div>
+        </li>
       {% endif %}
     {% endfor %}
+
+    {% if not current_user.has_permissions('manage_templates') %}
+    </ul>
+    {% endif %}
 
     {% if current_user.has_permissions('manage_templates') %}
       {{ templates_and_folders_form.templates_and_folders(param_extensions={

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -44,7 +44,7 @@
             {% for ancestor in item.ancestors %}
                 <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
                 {{ ancestor.name }}
-              </a> <span class="message-name-separator">/</span>
+              </a> <span class="message-name-separator"></span>
             {% endfor %}
             {% if item.is_folder %}
               <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -51,7 +51,7 @@
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% else %}
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
+              <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
                 <span class="live-search-relevant">{{ item.name }}</span>
               </a>
             {% endif %}

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -38,29 +38,29 @@
     {{ live_search(target_selector='#template-list .template-list-item', show=True, form=search_form) }}
 
     <nav id="template-list">
+      <ul>
       {% for item in templates_and_folders %}
-        <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
-          <h2 class="message-name">
-            {% for ancestor in item.ancestors %}
-                <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {{ ancestor.name }}
-              </a> <span class="message-name-separator"></span>
-            {% endfor %}
-            {% if item.is_folder %}
-              <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                <span class="live-search-relevant">{{ item.name }}</span>
-              </a>
-            {% else %}
-              <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
-                <span class="live-search-relevant">{{ item.name }}</span>
-              </a>
-            {% endif %}
-          </h2>
-          <p class="message-type">
+        <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
+          {% for ancestor in item.ancestors %}
+              <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+              {{ ancestor.name }}
+            </a> <span class="message-name-separator"></span>
+          {% endfor %}
+          {% if item.is_folder %}
+            <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+              <span class="live-search-relevant">{{ item.name }}</span>
+            </a>
+          {% else %}
+            <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('.conversation_reply_with_template', service_id=current_service.id, template_id=item.id, notification_id=notification_id) }}">
+              <span class="live-search-relevant">{{ item.name }}</span>
+            </a>
+          {% endif %}
+          <p class="template-list-item-hint govuk-hint">
             {{ item.hint }}
           </p>
-        </div>
+        </li>
       {% endfor %}
+      </ul>
     </nav>
 
 

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -26,37 +26,37 @@
         autofocus=True
       ) }}
       <nav id="template-list">
+        <ul>
         {% for item in services_templates_and_folders %}
-          <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
-            <h2 class="message-name">
-              {% for ancestor in item.ancestors %}
-                {% if ancestor.is_service %}
-                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {% else %}
-                  <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                {% endif %}
-                  {{ ancestor.name }}
-                </a> <span class="message-name-separator"></span>
-              {% endfor %}
-              {% if item.is_service %}
-                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                  <span class="live-search-relevant">{{ item.name }}</span>
-                </a>
-              {% elif item.is_folder %}
-                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
-                  <span class="live-search-relevant">{{ item.name }}</span>
-                </a>
+          <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
+            {% for ancestor in item.ancestors %}
+              {% if ancestor.is_service %}
+                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% else %}
-                <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
-                  <span class="live-search-relevant">{{ item.name }}</span>
-                </a>
+                <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {% endif %}
-            </h2>
-            <p class="message-type">
+                {{ ancestor.name }}
+              </a> <span class="message-name-separator"></span>
+            {% endfor %}
+            {% if item.is_service %}
+              <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+                <span class="live-search-relevant">{{ item.name }}</span>
+              </a>
+            {% elif item.is_folder %}
+              <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=item.service_id, from_folder=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
+                <span class="live-search-relevant">{{ item.name }}</span>
+              </a>
+            {% else %}
+              <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
+                <span class="live-search-relevant">{{ item.name }}</span>
+              </a>
+            {% endif %}
+            <p class="template-list-item-hint govuk-hint">
               {{ item.hint }}
             </p>
-          </div>
+          </li>
         {% endfor %}
+        </ul>
       </nav>
     {% endif %}
 

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -47,7 +47,7 @@
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% else %}
-                <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
+                <a class="govuk-link govuk-link--no-visited-state template-list-template" href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
                   <span class="live-search-relevant">{{ item.name }}</span>
                 </a>
               {% endif %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -188,7 +188,7 @@ def test_should_show_page_for_choosing_a_template(
     for index, expected_link in enumerate(expected_nav_links):
         assert links_in_page[index].text.strip() == expected_link
 
-    template_links = page.select('#template-list .govuk-label a, .message-name a')
+    template_links = page.select('#template-list .govuk-label a, .template-list-item a')
 
     assert len(template_links) == len(expected_templates)
 


### PR DESCRIPTION
When the list items on the templates page were replaced (initially in https://github.com/alphagov/notifications-admin/pull/3358) their focus styles lost the work done to increase their click areas in https://github.com/alphagov/notifications-admin/pull/2750.

This is an attempt to give them back the larger click areas.

Also includes:
- tweaks to the spacing of item text on mobile
- a change of colour for hint text when focused, to meet colour contrast requirements

## Template items

### On desktop

#### Current style

<img width="755" alt="template_focused_current_style_desktop" src="https://user-images.githubusercontent.com/87140/97012627-f3108080-153f-11eb-9ef1-261b4a5baa6e.png">

#### New style

<img width="741" alt="template_focused_new_style_desktop" src="https://user-images.githubusercontent.com/87140/97018491-1db20780-1547-11eb-807a-fa74e51e5a6b.png">

### On mobile

#### Current style

<img width="312" alt="template_focused_current_style_mobile" src="https://user-images.githubusercontent.com/87140/97018322-ee9b9600-1546-11eb-83a6-b6be7362bc43.png">

#### New style

<img width="310" alt="template_focused_new_style_mobile" src="https://user-images.githubusercontent.com/87140/97018579-37ebe580-1547-11eb-8da2-2f6315861b39.png">

### On desktop with ancestors

#### Current style

<img width="735" alt="template_focused_with_ancestors_current_style_desktop" src="https://user-images.githubusercontent.com/87140/97018131-ad0aeb00-1546-11eb-998c-9daa3a527597.png">

#### New style

<img width="734" alt="template_focused_with_ancestors_new_style_desktop" src="https://user-images.githubusercontent.com/87140/97018150-b6945300-1546-11eb-89f2-36114f997d7f.png">

Note that this type didn't have the larger click area due to containing more than one link.

## Folder items

### On desktop

#### Current style

<img width="736" alt="folder_focused_current_style_desktop" src="https://user-images.githubusercontent.com/87140/97019091-cb251b00-1547-11eb-8d84-2ad25fd86d6d.png">

#### New style

<img width="734" alt="folder_focused_new_style_desktop" src="https://user-images.githubusercontent.com/87140/97019124-d4ae8300-1547-11eb-995a-e2ffd88be18b.png">

### On mobile

#### Current style

<img width="305" alt="folder_focused_current_style_mobile" src="https://user-images.githubusercontent.com/87140/97019270-09bad580-1548-11eb-98a1-ca3d7e02a961.png">

#### New style

<img width="311" alt="folder_focused_new_style_mobile" src="https://user-images.githubusercontent.com/87140/97019298-10e1e380-1548-11eb-8246-c995c0039a30.png">

## Without a checkbox

### Desktop

#### Current style

<img width="739" alt="folder_focused_no_checkbox_current_style_desktop" src="https://user-images.githubusercontent.com/87140/97019777-a4b3af80-1548-11eb-8515-9de0e51913f8.png">

#### New style

<img width="738" alt="folder_focused_no_checkbox_new_style_desktop" src="https://user-images.githubusercontent.com/87140/97019434-37a01a00-1548-11eb-96f4-844f4eb11b27.png">

### Mobile

#### Current style

<img width="308" alt="folder_focused_no_checkbox_current_style_mobile" src="https://user-images.githubusercontent.com/87140/97019928-d3318a80-1548-11eb-8e53-e4c5c6634d54.png">

#### New style

<img width="309" alt="folder_focused_no_checkbox_new_style_mobile" src="https://user-images.githubusercontent.com/87140/97019944-d9c00200-1548-11eb-94dc-2678b6c6d8fb.png">
