### PR TITLE
Combine pending and live alerts 

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -62,16 +62,10 @@ def broadcast_dashboard_updates(service_id):
 def get_broadcast_dashboard_partials(service_id):
     broadcast_messages = BroadcastMessages(service_id)
     return dict(
-        pending_approval_broadcasts=render_template(
+        current_broadcasts=render_template(
             'views/broadcast/partials/dashboard-table.html',
-            broadcasts=broadcast_messages.with_status('pending-approval'),
-            empty_message='You do not have any alerts waiting for approval',
-            view_broadcast_endpoint='.view_current_broadcast',
-        ),
-        live_broadcasts=render_template(
-            'views/broadcast/partials/dashboard-table.html',
-            broadcasts=broadcast_messages.with_status('broadcasting'),
-            empty_message='You do not have any live alerts at the moment',
+            broadcasts=broadcast_messages.with_status('pending-approval', 'broadcasting'),
+            empty_message='You do not have any current alerts',
             view_broadcast_endpoint='.view_current_broadcast',
         ),
     )

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -42,11 +42,13 @@ class BroadcastMessage(JSONModel):
     libraries = broadcast_area_libraries
 
     def __lt__(self, other):
-        return (
-            self.cancelled_at or self.finishes_at or self.created_at
-        ) < (
-            other.cancelled_at or other.finishes_at or self.created_at
-        )
+        if self.starts_at and other.starts_at:
+            return self.starts_at < other.starts_at
+        if self.starts_at and not other.starts_at:
+            return True
+        if not self.starts_at and other.starts_at:
+            return False
+        return self.updated_at < other.updated_at
 
     @classmethod
     def create(cls, *, service_id, template_id):

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -3,12 +3,10 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  Dashboard
+  Current alerts
 {% endblock %}
 
 {% block maincolumn_content %}
-
-  <h1 class="govuk-visually-hidden">Dashboard</h1>
 
   {% if current_user.has_permissions('manage_templates') and not current_service.all_templates %}
     <nav class="govuk-!-margin-top-2 govuk-!-margin-bottom-6">
@@ -18,20 +16,12 @@
     </nav>
   {% endif %}
 
-  <h2 class="heading-medium govuk-!-margin-bottom-2">Live alerts</h2>
+  <h1 class="heading-medium govuk-!-margin-bottom-2">Current alerts</h1>
 
   {{ ajax_block(
     partials,
     url_for('.broadcast_dashboard_updates', service_id=current_service.id),
-    'live_broadcasts'
-  ) }}
-
-  <h2 class="heading-medium govuk-!-margin-bottom-2">Waiting for approval</h2>
-
-  {{ ajax_block(
-    partials,
-    url_for('.broadcast_dashboard_updates', service_id=current_service.id),
-    'pending_approval_broadcasts'
+    'current_broadcasts'
   ) }}
 
 {% endblock %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -28,7 +28,7 @@
     {% call field(align='right') %}
       {% if item.status == 'pending-approval' %}
         <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0 govuk-hint">
-          Prepared by {{ item.created_by.name }}
+          Waiting for approval
         </p>
       {% elif item.status == 'broadcasting' %}
         <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-0 live-broadcast">

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -649,10 +649,12 @@ def broadcast_message_json(
     starts_at=None,
     finishes_at=None,
     cancelled_at=None,
+    updated_at=None,
     approved_by_id=None,
     cancelled_by_id=None,
     areas=None,
     content=None,
+    template_name='Example template',
 ):
     return {
         'id': id_,
@@ -661,7 +663,7 @@ def broadcast_message_json(
 
         'template_id': template_id,
         'template_version': 123,
-        'template_name': 'Example template',
+        'template_name': template_name,
         'content': content or 'This is a test',
 
         'personalisation': {},
@@ -677,7 +679,7 @@ def broadcast_message_json(
         'created_at': None,
         'approved_at': None,
         'cancelled_at': cancelled_at,
-        'updated_at': None,
+        'updated_at': updated_at,
 
         'created_by_id': created_by_id,
         'approved_by_id': approved_by_id,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -277,11 +277,13 @@ def test_empty_broadcast_dashboard(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
     )
+    assert normalize_spaces(page.select_one('h1').text) == (
+        'Current alerts'
+    )
     assert [
         normalize_spaces(row.text) for row in page.select('tbody tr .table-empty-message')
     ] == [
-        'You do not have any live alerts at the moment',
-        'You do not have any alerts waiting for approval',
+        'You do not have any current alerts',
     ]
 
 
@@ -298,23 +300,12 @@ def test_broadcast_dashboard(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert len(page.select('table')) == len(page.select('main h2')) == 2
+    assert len(page.select('table')) == len(page.select('h1')) == 1
 
-    assert normalize_spaces(page.select('main h2')[0].text) == (
-        'Live alerts'
-    )
     assert [
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
     ] == [
         'Example template This is a test England Scotland Live since today at 2:20am',
-    ]
-
-    assert normalize_spaces(page.select('main h2')[1].text) == (
-        'Waiting for approval'
-    )
-    assert [
-        normalize_spaces(row.text) for row in page.select('table')[1].select('tbody tr')
-    ] == [
         'Example template This is a test England Scotland Prepared by Test User',
     ]
 
@@ -336,13 +327,10 @@ def test_broadcast_dashboard_json(
 
     json_response = json.loads(response.get_data(as_text=True))
 
-    assert json_response.keys() == {
-        'pending_approval_broadcasts',
-        'live_broadcasts',
-    }
+    assert json_response.keys() == {'current_broadcasts'}
 
-    assert 'Prepared by Test User' in json_response['pending_approval_broadcasts']
-    assert 'Live since today at 2:20am' in json_response['live_broadcasts']
+    assert 'Prepared by Test User' in json_response['current_broadcasts']
+    assert 'Live since today at 2:20am' in json_response['current_broadcasts']
 
 
 @freeze_time('2020-02-20 02:20')

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -306,7 +306,7 @@ def test_broadcast_dashboard(
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
     ] == [
         'Example template This is a test England Scotland Live since today at 2:20am',
-        'Example template This is a test England Scotland Prepared by Test User',
+        'Example template This is a test England Scotland Waiting for approval',
     ]
 
 
@@ -329,7 +329,7 @@ def test_broadcast_dashboard_json(
 
     assert json_response.keys() == {'current_broadcasts'}
 
-    assert 'Prepared by Test User' in json_response['current_broadcasts']
+    assert 'Waiting for approval' in json_response['current_broadcasts']
     assert 'Live since today at 2:20am' in json_response['current_broadcasts']
 
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -305,8 +305,10 @@ def test_broadcast_dashboard(
     assert [
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
     ] == [
+        'Half an hour ago This is a test England Scotland Waiting for approval',
+        'Hour and a half ago This is a test England Scotland Waiting for approval',
         'Example template This is a test England Scotland Live since today at 2:20am',
-        'Example template This is a test England Scotland Waiting for approval',
+        'Example template This is a test England Scotland Live since today at 1:20am',
     ]
 
 
@@ -353,8 +355,8 @@ def test_previous_broadcasts_page(
     assert [
         normalize_spaces(row.text) for row in page.select('table')[0].select('tbody tr')
     ] == [
-        'Example template This is a test England Scotland Broadcast yesterday at 2:20am',
         'Example template This is a test England Scotland Broadcast yesterday at 2:20pm',
+        'Example template This is a test England Scotland Broadcast yesterday at 2:20am',
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4309,21 +4309,39 @@ def mock_get_broadcast_messages(
     def _get(service_id):
         partial_json = partial(
             broadcast_message_json,
-            id_=fake_uuid,
             service_id=service_id,
             template_id=fake_uuid,
             created_by_id=fake_uuid,
         )
         return [
             partial_json(
+                id_=uuid4(),
                 status='draft',
             ),
             partial_json(
+                id_=uuid4(),
                 status='pending-approval',
+                updated_at=(
+                    datetime.utcnow() - timedelta(minutes=30)
+                ).isoformat(),
+                template_name='Half an hour ago',
                 finishes_at=None,
             ),
             partial_json(
+                id_=uuid4(),
+                status='pending-approval',
+                updated_at=(
+                    datetime.utcnow() - timedelta(hours=1, minutes=30)
+                ).isoformat(),
+                template_name='Hour and a half ago',
+                finishes_at=None,
+            ),
+            partial_json(
+                id_=uuid4(),
                 status='broadcasting',
+                updated_at=(
+                    datetime.utcnow()
+                ).isoformat(),
                 starts_at=(
                     datetime.utcnow()
                 ).isoformat(),
@@ -4332,6 +4350,20 @@ def mock_get_broadcast_messages(
                 ).isoformat(),
             ),
             partial_json(
+                id_=uuid4(),
+                status='broadcasting',
+                updated_at=(
+                    datetime.utcnow() - timedelta(hours=1)
+                ).isoformat(),
+                starts_at=(
+                    datetime.utcnow() - timedelta(hours=1)
+                ).isoformat(),
+                finishes_at=(
+                    datetime.utcnow() + timedelta(hours=24)
+                ).isoformat(),
+            ),
+            partial_json(
+                id_=uuid4(),
                 status='completed',
                 starts_at=(
                     datetime.utcnow() - timedelta(hours=12)
@@ -4341,6 +4373,7 @@ def mock_get_broadcast_messages(
                 ).isoformat(),
             ),
             partial_json(
+                id_=uuid4(),
                 status='cancelled',
                 starts_at=(
                     datetime.utcnow() - timedelta(days=1)


### PR DESCRIPTION
Splitting the dashboard into multiple sections was confusing, and people sometimes mistook the headings as labels, especially when a section was empty. It just wasn’t clear what the hierarchy of the page was.

This pull request combines the current and pending broadcasts into one list on the dashboard. Previous broadcasts have already moved to their own page.

# Before

![image](https://user-images.githubusercontent.com/355079/97300837-dda49a80-184e-11eb-99b1-6fa4cb3ff67f.png)

# After

![image](https://user-images.githubusercontent.com/355079/97300766-cbc2f780-184e-11eb-91fd-47045c889930.png)
