### PR TITLE
Remove word ‘still’ from training mode slide

### DIFF
--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -3,7 +3,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  Notify has not broadcast your alert because you’re still in training mode.
+  Notify has not broadcast your alert because you’re in training mode.
 {% endblock %}
 
 {% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-0" %}
@@ -20,7 +20,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="heading-medium">
-          Notify has not broadcast your alert because you’re still in training mode.
+          Notify has not broadcast your alert because you’re in training mode.
         </h1>
         <p class="govuk-body heading-medium">
           In a real emergency, every mobile phone in the area


### PR DESCRIPTION
You might alternate between training mode and live mode. It’s not like normal Notify where you start in one mode and then transition out of it – which is what ‘still’ implies.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/97474814-6c471380-1944-11eb-8b82-f1f6c0ca41a4.png) | ![image](https://user-images.githubusercontent.com/355079/97474783-60f3e800-1944-11eb-85fb-6aba2fcf02f9.png)
