### PR TITLE
Remove old line from send file by email feature

### DIFF
--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -35,7 +35,6 @@
     <!--<li>you can track when the recipient downloads your document</li>-->
     <li>email attachments are often marked as spam</li>
   </ul>
-  <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.support') }}">Contact us</a> if you want to send files by email.</p>
   <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h3 class="heading heading-small" id="reply-to">Add a reply-to address</h3>


### PR DESCRIPTION
You do not need to contact us to use it anymore. You can set it up
yourself and is documented in our API docs.

Questionable whether this content should be more specific saying 'We do not currently offer this feature through our user interface' or saying 'it is only available for API users' but that's maybe an improvement for another day.