### PR TITLE
Remove reference to sending personally or commercially sensitive data

### DIFF
--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -23,7 +23,6 @@
     <li>not send unsolicited messages, only ones related to a transaction or something the user has subscribed to be updated about (<a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">check the Service Manual</a> if you’re not sure)</li>
     <li>
       send messages that meet the GOV.UK Service Manual standards for <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-manual/design/sending-emails-and-text-messages">writing text messages and emails</a></li>
-    <li>not send messages containing any personally or commercially sensitive information</li>
     <li>check that the data you add to Notify is accurate and complies with data protection legislation</li>
   </ul>
   <p class="govuk-body">If you do not keep to these terms, we might have to stop sending your messages.</p>


### PR DESCRIPTION
These data are fine to send if the service team determines they are. It's not for us to determine that.