### PR TITLE
Add content about the extended character set

### DIFF
--- a/app/assets/stylesheets/local/_typography.scss
+++ b/app/assets/stylesheets/local/_typography.scss
@@ -60,3 +60,9 @@
 .destructive-link--no-visited-state {
   @include destructive-link-style-no-visited-state;
 }
+
+// Font override classes
+.extended-gsm-characters {
+  font-family: $govuk-font-family-tabular;
+  letter-spacing: 0.5em;
+}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -43,7 +43,9 @@
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
-  <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message:</p>
+  <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message.</p>
+  <p class="govuk-body">The following characters are charged as 2 characters each: [ ] { } ^ \ | ~ €</p>
+
   <div class="bottom-gutter-3-2">
     {% call mapping_table(
       caption='Text message pricing',
@@ -66,10 +68,6 @@
       {% endfor %}
     {% endcall %}
   </div>
-  <h3 class="heading-small" id="accents">DRAFT Other characters - heading TBC</h3>
-  <p class="govuk-body">DRAFT Some characters count as 2 of the 160 characters of a text messages.</p>
-  <p class="govuk-body">DRAFT The following characters are charged as 2 characters each: [ ] { } ^ \ | ~ €</p>
-
   <h3 class="heading-small" id="accents">Accents and accented characters</h3>
   <p class="govuk-body">Some languages, such as Welsh, use accented characters.</p>
   <p class="govuk-body">Text messages containing the following accented characters are charged at the normal rate: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -44,7 +44,10 @@
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message.</p>
-  <p class="govuk-body">The following characters are charged as 2 characters each: [ ] { } ^ \ | ~ €</p>
+  <p class="govuk-body">
+    The following characters are charged as 2 characters each:<br />
+    <span class="extended-gsm-characters">[]{}^\|~€</span>
+  </p>
 
   <div class="bottom-gutter-3-2">
     {% call mapping_table(

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -66,6 +66,10 @@
       {% endfor %}
     {% endcall %}
   </div>
+  <h3 class="heading-small" id="accents">DRAFT Other characters - heading TBC</h3>
+  <p class="govuk-body">DRAFT Some characters count as 2 characters.</p>
+  <p class="govuk-body">DRAFT The following characters are charged as 2 characters each: [ ] { } ^ \ | ~ €</p>
+
   <h3 class="heading-small" id="accents">Accents and accented characters</h3>
   <p class="govuk-body">Some languages, such as Welsh, use accented characters.</p>
   <p class="govuk-body">Text messages containing the following accented characters are charged at the normal rate: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -67,7 +67,7 @@
     {% endcall %}
   </div>
   <h3 class="heading-small" id="accents">DRAFT Other characters - heading TBC</h3>
-  <p class="govuk-body">DRAFT Some characters count as 2 characters.</p>
+  <p class="govuk-body">DRAFT Some characters count as 2 of the 160 characters of a text messages.</p>
   <p class="govuk-body">DRAFT The following characters are charged as 2 characters each: [ ] { } ^ \ | ~ €</p>
 
   <h3 class="heading-small" id="accents">Accents and accented characters</h3>


### PR DESCRIPTION
We need to update the pricing page to explain the 9 characters that are charged as 2 characters each.

See the [Pivotal ticket for details](https://www.pivotaltracker.com/n/projects/1443052/stories/175457294).