### PR TITLE
Stop live services requesting to go live

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -187,6 +187,9 @@ def estimate_usage(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/request-to-go-live", methods=['GET'])
 @user_has_permissions('manage_service')
 def request_to_go_live(service_id):
+    if current_service.live:
+        return render_template('views/service-settings/service-already-live.html')
+
     return render_template(
         'views/service-settings/request-to-go-live.html'
     )

--- a/app/templates/views/service-settings/service-already-live.html
+++ b/app/templates/views/service-settings/service-already-live.html
@@ -1,0 +1,28 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+{% block service_page_title %}
+  Your service is already live
+{% endblock %}
+
+{% block maincolumn_content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {{ page_header('Your service is already live') }}
+
+      <p class="govuk-body">
+        {% if current_service.go_live_at %}
+          ‘{{ current_service.name }}’ went live on {{ current_service.go_live_at | format_date_normal }}.
+        {% else %}
+          ‘{{ current_service.name }}’ is already live.
+        {% endif %}
+        </p>
+
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_account') }}">Switch service</a>
+         if you want to make a different service live.
+      </p>
+
+    </div>
+  </div>
+{% endblock %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1037,6 +1037,28 @@ def test_should_not_show_go_live_button_if_checklist_not_complete(
         )
 
 
+@pytest.mark.parametrize('go_live_at, message', [
+    (None, '‘service one’ is already live.'),
+    ('2020-10-09 13:55:20', '‘service one’ went live on 9 October 2020.'),
+])
+def test_request_to_go_live_redirects_if_service_already_live(
+    client_request,
+    service_one,
+    go_live_at,
+    message,
+):
+    service_one['restricted'] = False
+    service_one['go_live_at'] = go_live_at
+
+    page = client_request.get(
+        'main.request_to_go_live',
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert page.h1.text == 'Your service is already live'
+    assert normalize_spaces(page.select_one('main p').text) == message
+
+
 @pytest.mark.parametrize((
     'estimated_sms_volume,'
     'organisation_type,'


### PR DESCRIPTION
Live services shouldn't be able to request to go live again. Once a service is live we remove the option to go live from the Settings page, but we still link to the page to request to go live from other places e.g. the 'Get started' page. As a result, we've seen some services make a request to go live when their service has already been live for months - this change will stop that from happening.

@karlchillmaid is going to look at the content for this

_Screenshot now updated with the agreed content_

![Screenshot 2020-11-06 at 17 54 11](https://user-images.githubusercontent.com/12881990/98550501-181d2700-2294-11eb-8991-4a02e562567e.png)

