### PR TITLE
Fix how template list item focus extends

### DIFF
--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -1,3 +1,6 @@
+$app-body-text-line-height-default: get-govuk-typography-style($size: 19, $breakpoint: null, $property: "line-height");
+$app-body-text-line-height-tablet: get-govuk-typography-style($size: 19, $breakpoint: tablet, $property: "line-height");
+
 @mixin separator {
   display: inline-block;
   vertical-align: top;
@@ -95,9 +98,14 @@ a {
           content: '';
           position: absolute;
           left: 0px;
-          bottom: -100%; /* extend link by 100% of vertical size so it covers the hint/meta */
+          bottom: -1 * $app-body-text-line-height-default; /* extend link by line height of hint/meta so it covers it */
           width: 100%;
-          height: 100%;
+          height: $app-body-text-line-height-default;
+
+          @include govuk-media-query($from: tablet) {
+            bottom: -1 * $app-body-text-line-height-tablet;
+            height: $app-body-text-line-height-tablet;
+          }
         }
 
         &:active,

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -1,3 +1,16 @@
+// Gives access to the Sass variables used in the GOVUK Frontend typographic styles
+// See: https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-typography-scale
+@function get-govuk-typography-style($size, $breakpoint, $property) {
+  $size-map: map-get($govuk-typography-scale, $size);
+  $breakpoint-map: map-get($size-map, $breakpoint);
+
+  @if not map-has-key($breakpoint-map, $property) {
+    @error "Unknown property #{$property} - expected a property from the typography scale for #{$size}.";
+  }
+
+  @return map-get($breakpoint-map, $property);
+}
+
 // Extends footer column styles to allow 4 columns
 @include mq ($from: desktop) {
   .govuk-footer__list--columns-4 {


### PR DESCRIPTION
We use a hack to extend the focus style of single links in template list items (those not part of a path of links).

It extends the visual focus (orangey-yellow box) downwards so it includes the hint text below. The height it extends is the same as that the link element occupies. This blows up when the link wraps to multiple lines because the hint is always on one line so the focus extends too far:

<img width="763" alt="focus_issue_before" src="https://user-images.githubusercontent.com/87140/98376468-73a0a800-203b-11eb-855f-49b3530c10b0.png">

This pull request fixes that by making it extend by the height of the hint:

<img width="745" alt="focus_issue_after" src="https://user-images.githubusercontent.com/87140/98376636-b3678f80-203b-11eb-9a09-5c8af128616c.png">

It includes a Sass function to ensure the line height used is tied to GOVUK Frontend variables so less likely to break if they change any sizes.

Note: the original code was added in https://github.com/alphagov/notifications-admin/pull/3700.