### PR TITLE
Fix the focus colour on edit template links

### DIFF
--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -20,6 +20,10 @@
     color: $light-blue-25;
   }
 
+  &:focus {
+    color: $govuk-text-colour;
+  }
+
 }
 
 .edit-template-link-letter-contact {


### PR DESCRIPTION
Since the focus background colour is now Design System yellow, the text should be black for sufficient contrast.

This wasn’t happening because the `:link` selector’s definition had greater specificity.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/98827368-b34a0400-242e-11eb-8b38-16ec971cce7b.png) | ![image](https://user-images.githubusercontent.com/355079/98827396-ba711200-242e-11eb-9f2b-9dedf452c699.png)
