### PR TITLE
Add GOVUK radios [part 1]

### DIFF
--- a/app/assets/javascripts/modules/all.mjs
+++ b/app/assets/javascripts/modules/all.mjs
@@ -9,6 +9,7 @@
 import Header from 'govuk-frontend/components/header/header';
 import Details from 'govuk-frontend/components/details/details';
 import Button from 'govuk-frontend/components/button/button';
+import Radios from 'govuk-frontend/components/radios/radios';
 
 /**
  * TODO: Ideally this would be a NodeList.prototype.forEach polyfill
@@ -46,6 +47,11 @@ function initAll (options) {
   // Find first header module to enhance.
   var $toggleButton = scope.querySelector('[data-module="header"]')
   new Header($toggleButton).init()
+
+  var $radios = scope.querySelectorAll('[data-module="radios"]')
+  nodeListForEach($radios, function ($radio) {
+    new Radios($radio).init()
+  })
 }
 
 // Create separate namespace for GOVUK Frontend.

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1294,14 +1294,13 @@ class BaseTemplateForm(StripWhitespaceForm):
             NoCommasInPlaceHolders()
         ]
     )
-    process_type = RadioField(
+    process_type = GovukRadiosField(
         "Use priority queue?",
         choices=[
             ('priority', 'Yes'),
             ('normal', 'No'),
         ],
         thing='yes or no',
-        validators=[DataRequired()],
         default='normal'
     )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -688,7 +688,7 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
     auth_type = HiddenField('auth_type', validators=[DataRequired()])
 
 
-class govukCheckboxesMixin:
+class GovukCheckboxesMixin:
 
     def extend_params(self, params, extensions):
         items = None
@@ -714,10 +714,10 @@ class govukCheckboxesMixin:
                         params['items'][idx].update(items[idx])
 
 
-class govukCheckboxField(govukCheckboxesMixin, BooleanField):
+class GovukCheckboxField(GovukCheckboxesMixin, BooleanField):
 
     def __init__(self, label='', validators=None, param_extensions=None, **kwargs):
-        super(govukCheckboxField, self).__init__(label, validators, false_values=None, **kwargs)
+        super(GovukCheckboxField, self).__init__(label, validators, false_values=None, **kwargs)
         self.param_extensions = param_extensions
 
     # self.__call__ renders the HTML for the field by:
@@ -766,12 +766,12 @@ class govukCheckboxField(govukCheckboxesMixin, BooleanField):
 
 
 # based on work done by @richardjpope: https://github.com/richardjpope/recourse/blob/master/recourse/forms.py#L6
-class govukCheckboxesField(govukCheckboxesMixin, SelectMultipleField):
+class GovukCheckboxesField(GovukCheckboxesMixin, SelectMultipleField):
 
     render_as_list = False
 
     def __init__(self, label='', validators=None, param_extensions=None, **kwargs):
-        super(govukCheckboxesField, self).__init__(label, validators, **kwargs)
+        super(GovukCheckboxesField, self).__init__(label, validators, **kwargs)
         self.param_extensions = param_extensions
 
     def get_item_from_option(self, option):
@@ -834,11 +834,11 @@ class govukCheckboxesField(govukCheckboxesMixin, SelectMultipleField):
             render_template('forms/fields/checkboxes/macro.njk', params=params))
 
 
-# Extends fields using the govukCheckboxesField interface to wrap their render in HTML needed by the collapsible JS
-class govukCollapsibleCheckboxesMixin:
+# Extends fields using the GovukCheckboxesField interface to wrap their render in HTML needed by the collapsible JS
+class GovukCollapsibleCheckboxesMixin:
     def __init__(self, label='', validators=None, field_label='', param_extensions=None, **kwargs):
 
-        super(govukCollapsibleCheckboxesMixin, self).__init__(label, validators, param_extensions, **kwargs)
+        super(GovukCollapsibleCheckboxesMixin, self).__init__(label, validators, param_extensions, **kwargs)
         self.field_label = field_label
 
     def widget(self, field, **kwargs):
@@ -856,19 +856,19 @@ class govukCollapsibleCheckboxesMixin:
             f'<div class="selection-wrapper"'
             f'     data-module="collapsible-checkboxes"'
             f'     data-field-label="{self.field_label}">'
-            f'  {super(govukCollapsibleCheckboxesMixin, self).widget(field, **kwargs)}'
+            f'  {super(GovukCollapsibleCheckboxesMixin, self).widget(field, **kwargs)}'
             f'</div>'
         )
 
 
-class govukCollapsibleCheckboxesField(govukCollapsibleCheckboxesMixin, govukCheckboxesField):
+class GovukCollapsibleCheckboxesField(GovukCollapsibleCheckboxesMixin, GovukCheckboxesField):
     pass
 
 
-# govukCollapsibleCheckboxesMixin adds an ARIA live-region to the hint and wraps the render in HTML needed by the
+# GovukCollapsibleCheckboxesMixin adds an ARIA live-region to the hint and wraps the render in HTML needed by the
 # collapsible JS
 # NestedFieldMixin puts the items into a tree hierarchy, pre-rendering the sub-trees of the top-level items
-class govukCollapsibleNestedCheckboxesField(govukCollapsibleCheckboxesMixin, NestedFieldMixin, govukCheckboxesField):
+class GovukCollapsibleNestedCheckboxesField(GovukCollapsibleCheckboxesMixin, NestedFieldMixin, GovukCheckboxesField):
     NONE_OPTION_VALUE = None
     render_as_list = True
 
@@ -899,7 +899,7 @@ class BasePermissionsForm(StripWhitespaceForm):
                 (item['id'], item['name']) for item in ([{'name': 'Templates', 'id': None}] + all_template_folders)
             ]
 
-    folder_permissions = govukCollapsibleNestedCheckboxesField(
+    folder_permissions = GovukCollapsibleNestedCheckboxesField(
         'Folders this team member can see',
         field_label='folder')
 
@@ -913,7 +913,7 @@ class BasePermissionsForm(StripWhitespaceForm):
         validators=[DataRequired()]
     )
 
-    permissions_field = govukCheckboxesField(
+    permissions_field = GovukCheckboxesField(
         'Permissions',
         filters=[filter_by_permissions],
         choices=[
@@ -946,7 +946,7 @@ class PermissionsForm(BasePermissionsForm):
 
 class BroadcastPermissionsForm(BasePermissionsForm):
 
-    permissions_field = govukCheckboxesField(
+    permissions_field = GovukCheckboxesField(
         'Permissions',
         choices=[
             (value, label) for value, label in broadcast_permissions
@@ -1567,7 +1567,7 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
 
 class ServiceReplyToEmailForm(StripWhitespaceForm):
     email_address = email_address(label='Reply-to email address', gov_user=False)
-    is_default = govukCheckboxField("Make this email address the default")
+    is_default = GovukCheckboxField("Make this email address the default")
 
 
 class ServiceSmsSenderForm(StripWhitespaceForm):
@@ -1581,11 +1581,11 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
             DoesNotStartWithDoubleZero(),
         ]
     )
-    is_default = govukCheckboxField("Make this text message sender the default")
+    is_default = GovukCheckboxField("Make this text message sender the default")
 
 
 class ServiceEditInboundNumberForm(StripWhitespaceForm):
-    is_default = govukCheckboxField("Make this text message sender the default")
+    is_default = GovukCheckboxField("Make this text message sender the default")
 
 
 class ServiceLetterContactBlockForm(StripWhitespaceForm):
@@ -1595,7 +1595,7 @@ class ServiceLetterContactBlockForm(StripWhitespaceForm):
             NoCommasInPlaceHolders()
         ]
     )
-    is_default = govukCheckboxField("Set as your default address")
+    is_default = GovukCheckboxField("Set as your default address")
 
     def validate_letter_contact_block(self, field):
         line_count = field.data.strip().count('\n')
@@ -1765,7 +1765,7 @@ class GuestList(StripWhitespaceForm):
 class DateFilterForm(StripWhitespaceForm):
     start_date = GovukDateField("Start Date", [validators.optional()])
     end_date = GovukDateField("End Date", [validators.optional()])
-    include_from_test_key = govukCheckboxField("Include test keys")
+    include_from_test_key = GovukCheckboxField("Include test keys")
 
 
 class RequiredDateFilterForm(StripWhitespaceForm):
@@ -2047,7 +2047,7 @@ class TemplateFolderForm(StripWhitespaceForm):
                 (item.id, item.name) for item in all_service_users
             ]
 
-    users_with_permission = govukCollapsibleCheckboxesField(
+    users_with_permission = GovukCollapsibleCheckboxesField(
         'Team members who can see this folder',
         field_label='folder')
     name = GovukTextInputField('Folder name', validators=[DataRequired(message='Cannot be empty')])
@@ -2150,7 +2150,7 @@ class TemplateAndFoldersSelectionForm(Form):
             return self.move_to_new_folder_name.data
         return None
 
-    templates_and_folders = govukCheckboxesField(
+    templates_and_folders = GovukCheckboxesField(
         'Choose templates or folders',
         validators=[required_for_ops('move-to-new-folder', 'move-to-existing-folder')],
         choices=[],  # added to keep order of arguments, added properly in __init__
@@ -2260,7 +2260,7 @@ class AcceptAgreementForm(StripWhitespaceForm):
 
 class BroadcastAreaForm(StripWhitespaceForm):
 
-    areas = govukCheckboxesField('Choose areas to broadcast to')
+    areas = GovukCheckboxesField('Choose areas to broadcast to')
 
     def __init__(self, choices, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2277,7 +2277,7 @@ class BroadcastAreaForm(StripWhitespaceForm):
 
 class BroadcastAreaFormWithSelectAll(BroadcastAreaForm):
 
-    select_all = govukCheckboxField('Select all')
+    select_all = GovukCheckboxField('Select all')
 
     @classmethod
     def from_library(cls, library, select_all_choice):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -160,7 +160,7 @@ class UKMobileNumber(TelField):
     # 2. calls field.widget
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, param_extensions=None, **kwargs):
-        return govuk_field_widget(self, field, type="tel", param_extensions=param_extensions, **kwargs)
+        return govuk_text_input_field_widget(self, field, type="tel", param_extensions=param_extensions, **kwargs)
 
     def pre_validate(self, form):
         try:
@@ -179,7 +179,7 @@ class InternationalPhoneNumber(TelField):
     # 2. calls field.widget
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, param_extensions=None, **kwargs):
-        return govuk_field_widget(self, field, type="tel", param_extensions=param_extensions, **kwargs)
+        return govuk_text_input_field_widget(self, field, type="tel", param_extensions=param_extensions, **kwargs)
 
     def pre_validate(self, form):
         try:
@@ -212,7 +212,7 @@ def password(label='Password'):
     )
 
 
-def govuk_field_widget(self, field, type=None, param_extensions=None, **kwargs):
+def govuk_text_input_field_widget(self, field, type=None, param_extensions=None, **kwargs):
     value = kwargs["value"] if kwargs.get("value") else field.data
 
     # error messages
@@ -260,7 +260,7 @@ class GovukTextInputField(StringField):
     # 2. calls field.widget
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, **kwargs):
-        return govuk_field_widget(self, field, **kwargs)
+        return govuk_text_input_field_widget(self, field, **kwargs)
 
 
 class GovukPasswordField(PasswordField):
@@ -273,7 +273,7 @@ class GovukPasswordField(PasswordField):
     # 2. calls field.widget
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, param_extensions=None, **kwargs):
-        return govuk_field_widget(self, field, type="password", param_extensions=param_extensions, **kwargs)
+        return govuk_text_input_field_widget(self, field, type="password", param_extensions=param_extensions, **kwargs)
 
 
 class GovukEmailField(EmailField):
@@ -290,7 +290,7 @@ class GovukEmailField(EmailField):
         params = {"attributes": {"spellcheck": "false"}}  # email addresses don't need to be spellchecked
         merge_jsonlike(params, param_extensions)
 
-        return govuk_field_widget(self, field, type="email", param_extensions=params, **kwargs)
+        return govuk_text_input_field_widget(self, field, type="email", param_extensions=params, **kwargs)
 
 
 class GovukSearchField(SearchField):
@@ -307,7 +307,7 @@ class GovukSearchField(SearchField):
         params = {"classes": "govuk-!-width-full"}  # email addresses don't need to be spellchecked
         merge_jsonlike(params, param_extensions)
 
-        return govuk_field_widget(self, field, type="search", param_extensions=params, **kwargs)
+        return govuk_text_input_field_widget(self, field, type="search", param_extensions=params, **kwargs)
 
 
 class GovukDateField(DateField):
@@ -320,7 +320,7 @@ class GovukDateField(DateField):
     # 2. calls field.widget
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, param_extensions=None, **kwargs):
-        return govuk_field_widget(self, field, param_extensions=param_extensions, **kwargs)
+        return govuk_text_input_field_widget(self, field, param_extensions=param_extensions, **kwargs)
 
 
 class GovukIntegerField(IntegerField):
@@ -333,7 +333,7 @@ class GovukIntegerField(IntegerField):
     # 2. calls field.widget
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, param_extensions=None, **kwargs):
-        return govuk_field_widget(self, field, param_extensions=param_extensions, **kwargs)
+        return govuk_text_input_field_widget(self, field, param_extensions=param_extensions, **kwargs)
 
 
 class SMSCode(GovukTextInputField):

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -2,7 +2,6 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -26,7 +25,7 @@
           {{ textbox(form.subject, width='1-1', highlight_placeholders=True, rows=2) }}
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=8) }}
           {% if current_user.platform_admin %}
-             {{ radios(form.process_type) }}
+             {{ form.process_type }}
           {% endif %}
           {{ sticky_page_footer(
             'Save'

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -2,7 +2,6 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -27,7 +26,7 @@
         <div class="govuk-grid-column-two-thirds">
           {{ textbox(form.template_content, highlight_placeholders=True, width='1-1', rows=5) }}
           {% if current_user.platform_admin %}
-            {{ radios(form.process_type) }}
+            {{ form.process_type }}
           {% endif %}
           {{ sticky_page_footer(
             'Save'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,6 +71,7 @@ const copy = {
         'hint',
         'label',
         'checkboxes',
+        'radios',
         'input'
       ];
       let done = 0;


### PR DESCRIPTION
Initial piece of work for migrating Notify's radio buttons to use the [GOV.UK Frontend radios component](https://design-system.service.gov.uk/components/radios/).

This pull request:
- refactors the existing classes in `app/main/forms.py` that render GOV.UK Frontend components so they do that in a consistent way
- adds a basic `GovukRadiosField` class
- plugs it into a few pages

Part 1 of https://www.pivotaltracker.com/story/show/170030262.

## How to review

This pull request is written to be reviewed commit-by-commit.