### PR TITLE
Fix nesting in content page sub nav

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -179,6 +179,12 @@
     list-style: none;
     padding: 0;
     margin: 0;
+
+    ol,
+    ul {
+      margin-top: govuk-spacing(2);
+      border-top: 1px $grey-3 solid;
+    }
   }
 
   &__item {
@@ -199,6 +205,11 @@
 
     ol ol & {
       padding-left: govuk-spacing(6);
+
+      &:last-of-type {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
     }
   }
 

--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -7,7 +7,18 @@
     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(item['link']) }}" itemprop="item">
       <span itemprop="name">{{item['name']}}</span>
     </a>
+    {% if caller %}
+      {{ caller() }}
+    {% endif %}
   </li>
+{% endmacro %}
+
+{% macro sub_navigation_item_sub_navigation(item) %}
+  <ol itemscope itemtype="http://schema.org/ItemList">
+    {% for sub_item in item.sub_navigation_items %}
+      {{ sub_navigation_item(sub_item) }}
+    {% endfor %}
+  </ol>
 {% endmacro %}
 
 {% macro sub_navigation(
@@ -16,13 +27,12 @@
   <nav class="sub-navigation">
     <ol itemscope itemtype="http://schema.org/ItemList">
       {% for item in item_set %}
-        {{ sub_navigation_item(item) }}
         {% if item.sub_navigation_items %}
-          <ol itemscope itemtype="http://schema.org/ItemList">
-            {% for sub_item in item.sub_navigation_items %}
-              {{ sub_navigation_item(sub_item) }}
-            {% endfor %}
-          </ol>
+          {% call sub_navigation_item(item) %}
+            {{ sub_navigation_item_sub_navigation(item) }}
+          {% endcall %}
+        {% else %}
+          {{ sub_navigation_item(item) }}
         {% endif %}
       {% endfor %}
     </ol>


### PR DESCRIPTION
Nested lists in the side navigation of content pages have incorrect HTML.

![image](https://user-images.githubusercontent.com/87140/99515185-8c3a8780-2984-11eb-8a38-ca69da0f1136.png)

They currently have `<ol>` tags as direct children of their parent lists when only `<li>`s are allowed:

## Currently

```
ol
- li
- li
- ol
  - li
- li
```

## After changes

```
ol
- li
- li
  - ol
    - li
- li
```

This fixes that and updates the CSS so there are no visual differences.

## 