### PR TITLE
Bump utils to 43.5.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@42.2.2#egg=notifications-utils==42.2.2
+git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@42.2.2#egg=notifications-utils==42.2.2
+git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
@@ -34,12 +34,12 @@ prometheus-client==0.8.0
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.169
+awscli==1.18.180
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.19.9
+botocore==1.19.20
 cachetools==4.1.0
-certifi==2020.6.20
+certifi==2020.11.8
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
@@ -71,14 +71,14 @@ python-dateutil==2.8.1
 python-json-logger==0.1.11
 PyYAML==5.3.1
 redis==3.5.3
-requests==2.24.0
+requests==2.25.0
 rsa==4.5
 s3transfer==0.3.3
 six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.3
-urllib3==1.25.11
+urllib3==1.26.2
 webencodings==0.5.1
 Werkzeug==1.0.1
 WTForms==2.3.3


### PR DESCRIPTION
Brings in the following changes:
- https://github.com/alphagov/notifications-utils/pull/800
  (Update colours used in email template to match design system)
- https://github.com/alphagov/notifications-utils/pull/801
  (Concern `BroadcastMessageTemplate` only with content, not XML)
- https://github.com/alphagov/notifications-utils/pull/802
  (Update pytest to 6.1.2)
- https://github.com/alphagov/notifications-utils/pull/798
  (Validate email message size is within SES limits)
- https://github.com/alphagov/notifications-utils/pull/804
  (Revert 798 validate email size)
- https://github.com/alphagov/notifications-utils/pull/805
  (Revert "Revert 798 validate email size")
- https://github.com/alphagov/notifications-utils/pull/806
  (Add service id to logs)
- https://github.com/alphagov/notifications-utils/pull/803
  (Take extended GSM characters into account in fragment count)
- https://github.com/alphagov/notifications-utils/pull/807
  (Remove alt text hack)

Of those, #801 is the only major version bump (from 42.3.0 to 43.0.0).