### PR TITLE
Update accessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -47,7 +47,6 @@
     We know that the emails Notify sends are not fully accessible:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>NVDA screen reader announces the URL of the GOV.UK logo image in emails when you view them in Microsoft Outlook</li>
     <li>JAWS and NVDA screen readers announce extra spaces in emails when you view them in Microsoft Outlook</li>
   </ul>
 
@@ -113,10 +112,6 @@
   <h3 class="heading-small">
     Emails
   </h3>
-
-  <p class="govuk-body">
-    The NVDA screen reader announces the URL of the GOV.UK logo image in emails when viewed in Microsoft Outlook. This has been raised as <a class="govuk-link" href="https://github.com/alphagov/reported-bugs/issues/46">an issue on NVDA’s issue tracker</a>.
-  </p>
 
   <p class="govuk-body">
     The JAWS and NVDA screen readers announce extra spaces in emails when viewed in Microsoft Outlook.

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -44,12 +44,9 @@
   </ul>
 
   <p class="govuk-body">
-    We know that the emails Notify sends are not fully accessible:
+    We also know that the emails Notify sends are not fully accessible. The JAWS and NVDA screen readers announce extra spaces in emails when you view them in Microsoft Outlook.
   </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>JAWS and NVDA screen readers announce extra spaces in emails when you view them in Microsoft Outlook</li>
-  </ul>
-
+  
   <h2 class="heading-medium">Feedback and contact information</h2>
 
   <p class="govuk-body">
@@ -118,7 +115,7 @@
   </p>
 
   <p class="govuk-body">
-    We’ll continue to investigate the cause of these issues and, if possible, fix them by March 2021.
+    We’ll continue to investigate the cause of this issue and, if possible, fix it by March 2021.
   </p>
 
   <h3 class="heading-small">

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -158,6 +158,6 @@
   </p>
 
   <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 22 October 2020.
+    This statement was prepared on 23 September 2020. It was last reviewed on 19 November 2020.
   </p>
 {% endblock %}


### PR DESCRIPTION
The issue with the URL of images being read out by the NVDA screen reader, despite their having `alt=""`, is no longer happening. (see https://www.pivotaltracker.com/story/show/161183433/comments/219297211.)

We also updated our apps to reflect this in https://github.com/alphagov/notifications-api/pull/3038 and https://github.com/alphagov/notifications-admin/pull/3718.

This updates the accessibility statement to reflect that.