### PR TITLE
Remove line about beta from the roadmap

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -10,7 +10,7 @@
   <h1 class="heading-large">Roadmap</h1>
 
   <p class="govuk-body">The GOV.UK Notify roadmap shows the things we’re working on and when we hope to have them ready for you to use.</p>
-  <p class="govuk-body">Notify is in public beta. This means it’s fully operational and supported, but we’re still adding new features. The roadmap is a guide to what we have planned, but some things might change.</p>
+  <p class="govuk-body">The roadmap is a guide to what we have planned, but some things might change.</p>
   <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
   <h2 class="heading-medium">October to December 2020</h2>


### PR DESCRIPTION
We’re not in beta any more, and we don’t need to explain what beta means any more.