### PR TITLE
Correct field_label attribute to 'users' on  manage folder page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2126,7 +2126,7 @@ class TemplateFolderForm(StripWhitespaceForm):
 
     users_with_permission = GovukCollapsibleCheckboxesField(
         'Team members who can see this folder',
-        field_label='folder')
+        field_label='team member')
     name = GovukTextInputField('Folder name', validators=[DataRequired(message='Cannot be empty')])
 
 


### PR DESCRIPTION
The checkbox component on the manage folder page, used for user permissions, generates a summary of what is selected. This is using the wrong noun to describe the type of permission.

![image](https://user-images.githubusercontent.com/87140/100098824-7a5e5600-2e56-11eb-88c9-10905cfd295b.png)

This fixes that by changing the `field_label`attribute that field uses to set the noun.

![image](https://user-images.githubusercontent.com/87140/100106634-b26a9680-2e60-11eb-89e9-82b69c5b9791.png)


Note: we don't use an icon for users so this doesn't use one, like the version for folder permissions does.