### PR TITLE
Bump utils to 43.5.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
+git+https://github.com/alphagov/notifications-utils.git@43.5.2#egg=notifications-utils==43.5.2
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.1#egg=notifications-utils==43.5.1
+git+https://github.com/alphagov/notifications-utils.git@43.5.2#egg=notifications-utils==43.5.2
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
@@ -34,10 +34,10 @@ prometheus-client==0.9.0
 gds-metrics==0.2.4
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.180
+awscli==1.18.185
 bleach==3.1.4
 boto3==1.10.38
-botocore==1.19.20
+botocore==1.19.25
 cachetools==4.1.0
 certifi==2020.11.8
 chardet==3.0.4
@@ -56,7 +56,7 @@ jdcal==1.4.1
 Jinja2==2.11.2
 jmespath==0.10.0
 lml==0.1.0
-lxml==4.6.1
+lxml==4.6.2
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/808

Changes:
- https://github.com/alphagov/notifications-utils/compare/43.5.1...43.5.2