### PR TITLE
Validate maximum service name length

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1106,7 +1106,8 @@ class RenameServiceForm(StripWhitespaceForm):
         u'Service name',
         validators=[
             DataRequired(message='Cannot be empty'),
-            MustContainAlphanumericCharacters()
+            MustContainAlphanumericCharacters(),
+            Length(max=255, message='Service name must be 255 characters or fewer')
         ])
 
 
@@ -1115,7 +1116,8 @@ class RenameOrganisationForm(StripWhitespaceForm):
         u'Organisation name',
         validators=[
             DataRequired(message='Cannot be empty'),
-            MustContainAlphanumericCharacters()
+            MustContainAlphanumericCharacters(),
+            Length(max=255, message='Organisation name must be 255 characters or fewer')
         ])
 
 
@@ -1223,7 +1225,8 @@ class CreateServiceForm(StripWhitespaceForm):
         "What’s your service called?",
         validators=[
             DataRequired(message='Cannot be empty'),
-            MustContainAlphanumericCharacters()
+            MustContainAlphanumericCharacters(),
+            Length(max=255, message='Service name must be 255 characters or fewer')
         ])
     organisation_type = OrganisationTypeField('Who runs this service?')
 

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -20,6 +20,6 @@
     <li>Select <b class="govuk-!-font-weight-bold">Choose file</b>.</li>
   </ol>
 
-  <p class="govuk-body">Your file must meet our <a class="govuk-link" href="{{ url_for('main.letter_specification') }}">letter specification</a>.</p>
+  <p class="govuk-body">Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.letter_specification') }}">letter specification</a>.</p>
 
 {% endblock %}

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -35,7 +35,7 @@
     )}}
   </p>
 
-    <p class="govuk-body">Your file must meet our <a class="govuk-link" href="{{ url_for('main.letter_specification') }}">letter specification</a>.</p>
+    <p class="govuk-body">Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.letter_specification') }}">letter specification</a>.</p>
   </div>
 </div>
 {% endblock %}

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -288,30 +288,23 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     assert session['service_id'] == 101
 
 
-def test_should_return_form_errors_when_service_name_is_empty(
+@pytest.mark.parametrize('name, error_message', [
+    ('', 'Cannot be empty'),
+    ('.', 'Must include at least two alphanumeric characters'),
+    ('a' * 256, 'Service name must be 255 characters or fewer'),
+])
+def test_add_service_fails_if_service_name_fails_validation(
     client_request,
     mock_get_organisation_by_domain,
+    name,
+    error_message,
 ):
     page = client_request.post(
         'main.add_service',
-        _data={},
+        _data={"name": name},
         _expected_status=200,
     )
-    assert 'Cannot be empty' in page.text
-
-
-def test_add_service_fails_if_service_name_has_less_than_2_alphanumeric_characters(
-    client_request,
-    mock_get_organisation_by_domain,
-):
-    page = client_request.post(
-        'main.add_service',
-        _data={"name": "."},
-        _expected_status=200,
-    )
-
-    error_message = page.find("span", {"class": "govuk-error-message"}).text
-    assert 'Must include at least two alphanumeric characters' in error_message
+    assert error_message in page.find("span", {"class": "govuk-error-message"}).text
 
 
 def test_should_return_form_errors_with_duplicate_service_name_regardless_of_case(

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -294,7 +294,7 @@ def test_should_return_form_errors_when_service_name_is_empty(
 ):
     page = client_request.post(
         'main.add_service',
-        data={},
+        _data={},
         _expected_status=200,
     )
     assert 'Cannot be empty' in page.text
@@ -306,10 +306,12 @@ def test_add_service_fails_if_service_name_has_less_than_2_alphanumeric_characte
 ):
     page = client_request.post(
         'main.add_service',
-        data={"name": "."},
+        _data={"name": "."},
         _expected_status=200,
     )
-    assert page.find("span", {"class": "govuk-error-message"})
+
+    error_message = page.find("span", {"class": "govuk-error-message"}).text
+    assert 'Must include at least two alphanumeric characters' in error_message
 
 
 def test_should_return_form_errors_with_duplicate_service_name_regardless_of_case(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3480,7 +3480,7 @@ def test_should_send_branding_and_organisations_to_preview(
     client_request.login(platform_admin_user)
     client_request.post(
         endpoint,
-        data={
+        _data={
             'branding_type': 'org',
             'branding_style': '1'
         },

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -483,20 +483,27 @@ def test_should_not_hit_api_if_service_name_hasnt_changed(
     assert not mock_update_service.called
 
 
-def test_service_name_change_fails_if_new_name_has_less_than_2_alphanumeric_characters(
+@pytest.mark.parametrize('name, error_message', [
+    ('', 'Cannot be empty'),
+    ('.', 'Must include at least two alphanumeric characters'),
+    ('a' * 256, 'Service name must be 255 characters or fewer'),
+])
+def test_service_name_change_fails_if_new_name_fails_validation(
     client_request,
     mock_update_service,
     mock_service_name_is_unique,
+    name,
+    error_message,
 ):
     page = client_request.post(
         'main.service_name_change',
         service_id=SERVICE_ONE_ID,
-        _data={'name': "."},
+        _data={'name': name},
         _expected_status=200,
     )
     assert not mock_service_name_is_unique.called
     assert not mock_update_service.called
-    assert page.find("span", {"class": "govuk-error-message"})
+    assert error_message in page.find("span", {"class": "govuk-error-message"}).text
 
 
 @pytest.mark.parametrize('user, expected_text, expected_link', [

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -94,7 +94,7 @@ def test_should_render_change_email_continue_after_authenticate_email(
         session['new-email'] = 'new_notify@notify.gov.uk'
     page = client_request.post(
         'main.user_profile_email_authenticate',
-        data={'password': '12345'},
+        _data={'password': '12345'},
         _expected_status=200,
     )
     assert 'Click the link in the email to confirm the change to your email address.' in page.text


### PR DESCRIPTION
**Fix use of `client_request.post` in tests**
The `post` method of the `client_request` fixture has an argument called `_data`. There were a few places where we had used an argument of `data` instead by mistake.

We could change the code to raise an error if people pass `data` as kwarg to `client_request`, but I didn't do this in case we do need a `data` kwarg in some scenarios. 

**Add form validation for max service and org name length**
There was a recent error in the logs because a service tried to change its name to one exceeding 255 characters (which is a limit on the database field). We can easily catch these errors on the form, so that the user doesn't see an error page.