### PR TITLE
Limit jobs sent from contact list by data retention

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -517,7 +517,10 @@ def contact_list(service_id, contact_list_id):
     return render_template(
         'views/uploads/contact-list/contact-list.html',
         contact_list=contact_list,
-        jobs=contact_list.get_jobs(page=1),
+        jobs=contact_list.get_jobs(
+            page=1,
+            limit_days=current_service.get_days_of_retention(contact_list.template_type),
+        ),
     )
 
 

--- a/app/models/contact_list.py
+++ b/app/models/contact_list.py
@@ -137,11 +137,12 @@ class ContactList(JSONModel):
         file_name, extention = path.splitext(self.original_file_name)
         return f'{file_name}.csv'
 
-    def get_jobs(self, *, page):
+    def get_jobs(self, *, page, limit_days=None):
         return PaginatedJobsAndScheduledJobs(
             self.service_id,
             contact_list_id=self.id,
             page=page,
+            limit_days=limit_days,
         )
 
 

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -235,12 +235,13 @@ class PaginatedJobs(PaginatedModelList, ImmediateJobs):
     client_method = job_api_client.get_page_of_jobs
     statuses = None
 
-    def __init__(self, service_id, *, contact_list_id=None, page=None):
+    def __init__(self, service_id, *, contact_list_id=None, page=None, limit_days=None):
         super().__init__(
             service_id,
             contact_list_id=contact_list_id,
             statuses=self.statuses,
             page=page,
+            limit_days=limit_days,
         )
 
 

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -53,12 +53,13 @@ class JobApiClient(NotifyAdminAPIClient):
             if job['job_status'] != 'cancelled'
         )
 
-    def get_page_of_jobs(self, service_id, *, page, statuses=None, contact_list_id=None):
+    def get_page_of_jobs(self, service_id, *, page, statuses=None, contact_list_id=None, limit_days=None):
         return self.get_jobs(
             service_id,
             statuses=statuses or self.NON_SCHEDULED_JOB_STATUSES,
             page=page,
             contact_list_id=contact_list_id,
+            limit_days=limit_days,
         )
 
     def get_immediate_jobs(self, service_id):

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -491,6 +491,21 @@ def test_view_contact_list(
         service_id=SERVICE_ONE_ID,
         contact_list_id=fake_uuid,
     )
+    mock_get_no_jobs.assert_called_once_with(
+        SERVICE_ONE_ID,
+        contact_list_id=fake_uuid,
+        limit_days=7,
+        statuses={
+            'finished',
+            'in progress',
+            'pending',
+            'ready to send',
+            'scheduled',
+            'sending limits exceeded',
+            'sent to dvla',
+        },
+        page=1,
+    )
     assert normalize_spaces(page.select_one('h1').text) == (
         'EmergencyContactList.xls'
     )

--- a/tests/app/models/test_contact_list.py
+++ b/tests/app/models/test_contact_list.py
@@ -28,4 +28,5 @@ def test_get_jobs(mock_get_jobs):
             'in progress',
         },
         page=123,
+        limit_days=None,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2034,7 +2034,7 @@ def mock_get_no_uploads(mocker, api_user_active):
 
 @pytest.fixture(scope='function')
 def mock_get_no_jobs(mocker, api_user_active):
-    mocker.patch(
+    return mocker.patch(
         'app.models.job.PaginatedJobs.client_method',
         return_value={
             'data': [],


### PR DESCRIPTION
On the uploads page we only show jobs which are within a service’s data retention.

This commit does the same for when we’re listing the jobs for a contact list. This matches the UI, which says:
https://github.com/alphagov/notifications-admin/blob/4b2744b684c4e688210206d00f2c9fb8cf62b00f/app/templates/views/uploads/contact-list/contact-list.html#L27-L29