### PR TITLE
Update link to reflect withdrawn guidance

### DIFF
--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -78,6 +78,6 @@
 
   <h2 class="heading-medium">Classifications and security vetting</h2>
   <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
-  <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/guidance/security-vetting-and-clearance">United Kingdom Security Vetting</a> (UKSV).</p>
+  <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/organisations/united-kingdom-security-vetting">United Kingdom Security Vetting</a> (UKSV).</p>
 
 {% endblock %}


### PR DESCRIPTION
United Kingdom Security Vetting have their own organisation page on GOV.UK now