### PR TITLE
Add GOVUK radios [part 2]

### DIFF
--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -129,9 +129,8 @@
     display: none;
   }
 
-  .multiple-choice {
+  .govuk-radios__item {
 
-    display: inline-block;
     margin-right: 0;
     padding: 0;
     width: 38px;

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1414,7 +1414,7 @@ class LetterUploadPostageForm(StripWhitespaceForm):
     def show_postage(self):
         return len(self.postage.choices) > 1
 
-    postage = RadioField(
+    postage = GovukRadiosField(
         'Choose the postage for this letter',
         choices=[
             ('first', 'First class post'),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1545,7 +1545,7 @@ class FeedbackOrProblem(StripWhitespaceForm):
 
 
 class Triage(StripWhitespaceForm):
-    severe = RadioField(
+    severe = GovukRadiosField(
         'Is it an emergency?',
         choices=[
             ('yes', 'Yes'),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1597,10 +1597,18 @@ class ProviderForm(StripWhitespaceForm):
 
 class ProviderRatioForm(StripWhitespaceForm):
 
-    ratio = RadioField(choices=[
-        (str(value), '{}% / {}%'.format(value, 100 - value))
-        for value in range(100, -10, -10)
-    ])
+    ratio = GovukRadiosField(choices=[
+            (str(value), '{}% / {}%'.format(value, 100 - value))
+            for value in range(100, -10, -10)
+        ],
+        param_extensions={
+            "classes": "govuk-radios--inline",
+            "fieldset": {
+                "legend": {
+                    "classes": "govuk-visually-hidden"
+                }
+            }
+        })
 
     @property
     def percentage_left(self):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1753,7 +1753,7 @@ class ServiceUpdateEmailBranding(StripWhitespaceForm):
         }
     )
     file = FileField_wtf('Upload a PNG logo', validators=[FileAllowed(['png'], 'PNG Images only!')])
-    brand_type = RadioField(
+    brand_type = GovukRadiosField(
         "Brand type",
         choices=[
             ('both', 'GOV.UK and branding'),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1516,7 +1516,7 @@ class CreateKeyForm(StripWhitespaceForm):
 
 
 class SupportType(StripWhitespaceForm):
-    support_type = RadioField(
+    support_type = GovukRadiosField(
         'How can we help you?',
         choices=[
             (PROBLEM_TICKET_TYPE, 'Report a problem'),
@@ -1526,12 +1526,15 @@ class SupportType(StripWhitespaceForm):
 
 
 class SupportRedirect(StripWhitespaceForm):
-    who = RadioField(
+    who = GovukRadiosField(
         'What do you need help with?',
         choices=[
             ('public-sector', 'I work in the public sector and need to send emails, text messages or letters'),
             ('public', 'I’m a member of the public with a question for the government'),
         ],
+        param_extensions={
+            "fieldset": {"legend": {"classes": "govuk-visually-hidden"}}
+        }
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1916,7 +1916,7 @@ class ServiceInboundNumberForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
         self.inbound_number.choices = kwargs['inbound_number_choices']
 
-    inbound_number = RadioField(
+    inbound_number = GovukRadiosField(
         "Select your inbound number",
         thing='an inbound number',
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1569,13 +1569,16 @@ class EstimateUsageForm(StripWhitespaceForm):
         things='letters',
         format_error_suffix='you expect to send',
     )
-    consent_to_research = RadioField(
+    consent_to_research = GovukRadiosField(
         'Can we contact you when we’re doing user research?',
         choices=[
             ('yes', 'Yes'),
             ('no', 'No'),
         ],
         thing='yes or no',
+        param_extensions={
+            'hint': {'text': 'You do not have to take part and you can unsubscribe at any time'}
+        }
     )
 
     at_least_one_volume_filled = True

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1182,16 +1182,21 @@ class OrganisationCrownStatusForm(StripWhitespaceForm):
 
 
 class OrganisationAgreementSignedForm(StripWhitespaceForm):
-    agreement_signed = RadioField(
-        (
-            'Has this organisation signed the agreement?'
-        ),
+    agreement_signed = GovukRadiosField(
+        'Has this organisation signed the agreement?',
         choices=[
             ('yes', 'Yes'),
             ('no', 'No'),
             ('unknown', 'No (but we have some service-specific agreements in place)'),
         ],
         thing='whether this organisation has signed the agreement',
+        param_extensions={
+            'items': [
+                {'hint': {'html': 'Users will be told their organisation has already signed the agreement'}},
+                {'hint': {'html': 'Users will be prompted to sign the agreement before they can go live'}},
+                {'hint': {'html': 'Users will not be prompted to sign the agreement'}}
+            ]
+        }
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2272,7 +2272,7 @@ class TemplateAndFoldersSelectionForm(Form):
 
 
 class ClearCacheForm(StripWhitespaceForm):
-    model_type = RadioField(
+    model_type = GovukRadiosField(
         'What do you want to clear today',
     )
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -981,7 +981,7 @@ class BasePermissionsForm(StripWhitespaceForm):
         'Folders this team member can see',
         field_label='folder')
 
-    login_authentication = RadioField(
+    login_authentication = GovukRadiosField(
         'Sign in using',
         choices=[
             ('sms_auth', 'Text message code'),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2009,7 +2009,7 @@ class LinkOrganisationsForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
         self.organisations.choices = kwargs['choices']
 
-    organisations = RadioField(
+    organisations = GovukRadiosField(
         'Select an organisation',
         validators=[
             DataRequired()

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1157,7 +1157,7 @@ class AddNHSLocalOrganisationForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
         self.organisations.choices = organisation_choices
 
-    organisations = RadioField(
+    organisations = GovukRadiosField(
         'Which NHS Trust or Clinical Commissioning Group do you work for?',
         thing='an NHS Trust or Clinical Commissioning Group'
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2097,14 +2097,14 @@ class BrandingOptions(StripWhitespaceForm):
 
 class ServiceDataRetentionForm(StripWhitespaceForm):
 
-    notification_type = RadioField(
+    notification_type = GovukRadiosField(
         'What notification type?',
         choices=[
             ('email', 'Email'),
             ('sms', 'SMS'),
             ('letter', 'Letter'),
         ],
-        validators=[DataRequired()],
+        thing='notification type',
     )
     days_of_retention = GovukIntegerField(
         label="Days of retention",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1389,7 +1389,7 @@ class LetterTemplateForm(EmailTemplateForm):
 
 
 class LetterTemplatePostageForm(StripWhitespaceForm):
-    postage = RadioField(
+    postage = GovukRadiosField(
         'Choose the postage for this letter template',
         choices=[
             ('first', 'First class'),

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -2,7 +2,6 @@
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -31,7 +30,7 @@
           <div style='margin-top:15px;'>{{form.name}}</div>
           <div style='margin-top:15px;'>{{form.text}}</div>
           {{ form.colour }}
-          {{ radios(form.brand_type) }}
+          {{ form.brand_type }}
           {{ page_footer(
             'Save',
             button_name='operation',

--- a/app/templates/views/organisations/add-nhs-local-organisation.html
+++ b/app/templates/views/organisations/add-nhs-local-organisation.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -21,13 +20,13 @@
       {{ form.organisations.label.text }}
     </p>
     {{ live_search(
-      target_selector='.multiple-choice',
+      target_selector='.govuk-radios__item',
       show=True,
       form=search_form,
       label='Search by name',
       autofocus=True)
     }}
-    {{ radios(form.organisations, hide_legend=True) }}
+    {{ form.organisations }}
     {{ sticky_page_footer('Continue') }}
   {% endcall %}
 {% endblock %}

--- a/app/templates/views/organisations/organisation/settings/edit-agreement.html
+++ b/app/templates/views/organisations/organisation/settings/edit-agreement.html
@@ -17,14 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
       {% call form_wrapper() %}
-        {{ radios(
-          form.agreement_signed,
-          option_hints={
-            'yes': 'Users will be told their organisation has already signed the agreement',
-            'no': 'Users will be prompted to sign the agreement before they can go live',
-            'unknown': 'Users will not be prompted to sign the agreement'
-          }
-        ) }}
+        {{ form.agreement_signed }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/platform-admin/clear-cache.html
+++ b/app/templates/views/platform-admin/clear-cache.html
@@ -1,6 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
@@ -14,7 +13,7 @@
   </h1>
 
   {% call form_wrapper() %}
-    {{ radios(form.model_type) }}
+    {{ form.model_type }}
     {{ page_footer('Clear') }}
   {% endcall %}
 

--- a/app/templates/views/providers/edit-sms-provider-ratio.html
+++ b/app/templates/views/providers/edit-sms-provider-ratio.html
@@ -2,7 +2,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/radios.html" import radios %}
 
 {% block per_page_title %}
   Text message providers
@@ -30,7 +29,7 @@
             </div>
             {% call form_wrapper() %}
               <div class="radio-slider" data-module="radio-slider">
-                {{ radios(form.ratio, inline=True, hide_legend=True) }}
+                {{ form.ratio }}
                 <div class="radio-slider-left-value">
                   —
                 </div>

--- a/app/templates/views/service-settings/data-retention/add.html
+++ b/app/templates/views/service-settings/data-retention/add.html
@@ -2,7 +2,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/radios.html" import radios %}
 
 {% block service_page_title %}
   Data retention
@@ -16,7 +15,7 @@
     ) }}
 
     {% call form_wrapper() %}
-      {{ radios(form.notification_type) }}
+      {{ form.notification_type }}
       {{ form.days_of_retention }}
       {{ page_footer('Add') }}
     {% endcall %}

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -3,7 +3,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 
 {% block service_page_title %}
   Tell us how many messages you expect to send
@@ -39,7 +38,7 @@
             "hint": {"text": "For example, 50,000"},
           }) }}
         </div>
-        {{ radios(form.consent_to_research, hint='You do not have to take part and you can unsubscribe at any time') }}
+        {{ form.consent_to_research }}
         {{ page_footer('Continue') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/link-service-to-organisation.html
+++ b/app/templates/views/service-settings/link-service-to-organisation.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
@@ -18,14 +17,14 @@
     back_link=url_for('.service_settings', service_id=current_service.id)
   ) }}
   {{ live_search(
-    target_selector='.multiple-choice',
+    target_selector='.govuk-radios__item',
     show=True, form=search_form,
     label='Search by name',
     autofocus=True
   ) }}
   {% call form_wrapper() %}
     {% if has_organisations %}
-      {{ radios(form.organisations) }}
+      {{ form.organisations }}
       {{ sticky_page_footer('Save') }}
     {% else %}
       <p class="hint"> No organisations </p>

--- a/app/templates/views/service-settings/set-inbound-number.html
+++ b/app/templates/views/service-settings/set-inbound-number.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
-{% from "components/radios.html" import radios%}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -19,9 +18,9 @@
     <p class="govuk-body"> No available inbound numbers </p>
     {% else %}
     {% call form_wrapper() %}
-	    {{ radios(form.inbound_number) }}
-	    {{ sticky_page_footer('Save') }}
-  	{% endcall %}
+      {{ form.inbound_number }}
+      {{ sticky_page_footer('Save') }}
+    {% endcall %}
 	{% endif %}
 
 {% endblock %}

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -14,12 +13,12 @@
 
   {% call form_wrapper() %}
     {% if current_user.is_authenticated %}
-      {{ radios(form.support_type) }}
+      {{ form.support_type }}
     {% else %}
       <p class="govuk-body">
         What do you need help with?
       </p>
-      {{ radios(form.who, hide_legend=True) }}
+      {{ form.who }}
     {% endif %}
     {{ page_footer('Continue') }}
   {% endcall %}

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
@@ -17,7 +16,7 @@
         back_link=url_for('.support')
       ) }}
       {% call form_wrapper() %}
-        {{ radios(form.severe) }}
+        {{ form.severe }}
         {{ page_footer('Continue') }}
       {% endcall %}
       <h2 class="heading-small">

--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
@@ -17,7 +16,7 @@
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-five-sixths">
-          {{ radios(form.postage) }}
+          {{ form.postage }}
           {{ page_footer('Save') }}
         </div>
         <aside class="govuk-grid-column-three-quarters">

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -2,7 +2,6 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/file-upload.html" import file_upload %}
 
@@ -63,7 +62,17 @@
             file_id=file_id,
           )}}" class='page-footer'>
             {% if form.show_postage %}
-              {{ radios(form.postage, hide_legend=true, inline=True) }}
+              {{ form.postage(param_extensions={
+                "classes": "govuk-radios--inline",
+                "formGroup": {
+                  "classes": "govuk-!-margin-bottom-2"
+                },
+                "fieldset": {
+                  "legend": {
+                    "classes": "govuk-visually-hidden"
+                  }
+                }
+              }) }}
             {% endif %}
             {{ page_footer("Send 1 letter") }}
         </form>

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -704,41 +704,44 @@ def test_organisation_settings_for_platform_admin(
     (
         '.edit_organisation_type',
         (
-            ('central', 'Central government'),
-            ('local', 'Local government'),
-            ('nhs_central', 'NHS – central government agency or public body'),
-            ('nhs_local', 'NHS Trust or Clinical Commissioning Group'),
-            ('nhs_gp', 'GP practice'),
-            ('emergency_service', 'Emergency service'),
-            ('school_or_college', 'School or college'),
-            ('other', 'Other'),
+            {'value': 'central', 'label': 'Central government'},
+            {'value': 'local', 'label': 'Local government'},
+            {'value': 'nhs_central', 'label': 'NHS – central government agency or public body'},
+            {'value': 'nhs_local', 'label': 'NHS Trust or Clinical Commissioning Group'},
+            {'value': 'nhs_gp', 'label': 'GP practice'},
+            {'value': 'emergency_service', 'label': 'Emergency service'},
+            {'value': 'school_or_college', 'label': 'School or college'},
+            {'value': 'other', 'label': 'Other'},
         ),
         'central',
     ),
     (
         '.edit_organisation_crown_status',
         (
-            ('crown', 'Yes'),
-            ('non-crown', 'No'),
-            ('unknown', 'Not sure'),
+            {'value': 'crown', 'label': 'Yes'},
+            {'value': 'non-crown', 'label': 'No'},
+            {'value': 'unknown', 'label': 'Not sure'},
         ),
         'crown',
     ),
     (
         '.edit_organisation_agreement',
         (
-            ('yes', (
-                'Yes '
-                'Users will be told their organisation has already signed the agreement'
-            )),
-            ('no', (
-                'No '
-                'Users will be prompted to sign the agreement before they can go live'
-            )),
-            ('unknown', (
-                'No (but we have some service-specific agreements in place) '
-                'Users will not be prompted to sign the agreement'
-            )),
+            {
+                'value': 'yes',
+                'label': 'Yes',
+                'hint': 'Users will be told their organisation has already signed the agreement'
+            },
+            {
+                'value': 'no',
+                'label': 'No',
+                'hint': 'Users will be prompted to sign the agreement before they can go live'
+            },
+            {
+                'value': 'unknown',
+                'label': 'No (but we have some service-specific agreements in place)',
+                'hint': 'Users will not be prompted to sign the agreement'
+            },
         ),
         'no',
     ),
@@ -769,11 +772,14 @@ def test_view_organisation_settings(
     radios = page.select('input[type=radio]')
 
     for index, option in enumerate(expected_options):
-        label = page.select_one('label[for={}]'.format(radios[index]['id']))
-        assert (
-            radios[index]['value'],
-            normalize_spaces(label.text),
-        ) == option
+        option_values = {
+            'value': radios[index]['value'],
+            'label': normalize_spaces(page.select_one('label[for={}]'.format(radios[index]['id'])).text)
+        }
+        if 'hint' in option:
+            option_values['hint'] = normalize_spaces(
+                page.select_one('label[for={}] + .govuk-hint'.format(radios[index]['id'])).text)
+        assert option_values == option
 
     if expected_selected:
         assert page.select_one('input[checked]')['value'] == expected_selected

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -261,14 +261,14 @@ def test_nhs_local_can_create_own_organisations(
         'Which NHS Trust or Clinical Commissioning Group do you work for?'
     )
     assert page.select_one('[data-module=live-search]')['data-targets'] == (
-        '.multiple-choice'
+        '.govuk-radios__item'
     )
     assert [
         (
             normalize_spaces(radio.select_one('label').text),
             radio.select_one('input')['value']
         )
-        for radio in page.select('.multiple-choice')
+        for radio in page.select('.govuk-radios__item')
     ] == [
         ('Trust 1', 't1'),
         ('Trust 2', 't2'),

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -744,7 +744,7 @@ def test_clear_cache_requires_option(client_request, platform_admin_user, mocker
 
     page = client_request.post('main.clear_cache', _data={}, _expected_status=200)
 
-    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Select an option'
+    assert normalize_spaces(page.find('span', class_='govuk-error-message').text) == 'Error: Select an option'
     assert not redis.delete_cache_keys_by_pattern.called
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4494,10 +4494,10 @@ def test_select_organisation(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
-    assert len(page.select('.multiple-choice')) == 3
+    assert len(page.select('.govuk-radios__item')) == 3
     for i in range(0, 3):
         assert normalize_spaces(
-            page.select('.multiple-choice label')[i].text
+            page.select('.govuk-radios__item label')[i].text
         ) == 'Org {}'.format(i + 1)
 
 


### PR DESCRIPTION
Part 2 of migrating our radio buttons to use the [GOV.UK Frontend radios component](https://design-system.service.gov.uk/components/radios/).

https://www.pivotaltracker.com/story/show/170030262

This pull request pulls together all the basic, atomic updates that just change existing form fields to use the `GovukRadiosField` class. Don't be put off by the number of commits, they all should be very simple changes.

### Notes

The radios on the provider ratio page are configured to render as inline so some CSS that did this is removed as part of these changes.

This also changes `SMSPrefixForm.enabled` to use `OnOffField` for consistency with other forms that just have 'On'/'Off' options.

Part 1 of this work was done in https://github.com/alphagov/notifications-admin/pull/3715.
Pull requests for the other parts are:
- part 3: https://github.com/alphagov/notifications-admin/pull/3728
- part 4: https://github.com/alphagov/notifications-admin/pull/3730
- part 5: https://github.com/alphagov/notifications-admin/pull/3731

Pull requests in this stream of work don't need to be completed in any order.