### PR TITLE
Add GOVUK radios [part 3]

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1942,13 +1942,7 @@ class CallbackForm(StripWhitespaceForm):
 
 
 class SMSPrefixForm(StripWhitespaceForm):
-    enabled = RadioField(
-        '',
-        choices=[
-            ('on', 'On'),
-            ('off', 'Off'),
-        ],
-    )
+    enabled = OnOffField('')  # label is assigned on instantiation
 
 
 def get_placeholder_form_instance(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -593,38 +593,6 @@ class PostalAddressField(TextAreaField):
             self.data = PostalAddress(valuelist[0]).normalised
 
 
-class OnOffField(RadioField):
-
-    def __init__(self, label, choices=None, *args, **kwargs):
-        choices = choices or [
-            (True, 'On'),
-            (False, 'Off'),
-        ]
-        super().__init__(
-            label,
-            choices=choices,
-            thing=f'{choices[0][1].lower()} or {choices[1][1].lower()}',
-            *args,
-            **kwargs,
-        )
-
-    def process_formdata(self, valuelist):
-        if valuelist:
-            value = valuelist[0]
-            self.data = (value == 'True') if value in ['True', 'False'] else value
-
-    def iter_choices(self):
-        for value, label in self.choices:
-            # This overrides WTForms default behaviour which is to check
-            # self.coerce(value) == self.data
-            # where self.coerce returns a string for a boolean input
-            yield (
-                value,
-                label,
-                (self.data in {value, self.coerce(value)})
-            )
-
-
 class LoginForm(StripWhitespaceForm):
     email_address = GovukEmailField('Email address', validators=[
         Length(min=5, max=255),
@@ -949,6 +917,38 @@ class GovukRadiosField(RadioField):
     # this bypasses that by making self.widget a method with the same interface as widget.__call__
     def widget(self, field, param_extensions=None, **kwargs):
         return govuk_radios_field_widget(self, field, param_extensions=param_extensions, **kwargs)
+
+
+class OnOffField(GovukRadiosField):
+
+    def __init__(self, label, choices=None, *args, **kwargs):
+        choices = choices or [
+            (True, 'On'),
+            (False, 'Off'),
+        ]
+        super().__init__(
+            label,
+            choices=choices,
+            thing=f'{choices[0][1].lower()} or {choices[1][1].lower()}',
+            *args,
+            **kwargs,
+        )
+
+    def process_formdata(self, valuelist):
+        if valuelist:
+            value = valuelist[0]
+            self.data = (value == 'True') if value in ['True', 'False'] else value
+
+    def iter_choices(self):
+        for value, label in self.choices:
+            # This overrides WTForms default behaviour which is to check
+            # self.coerce(value) == self.data
+            # where self.coerce returns a string for a boolean input
+            yield (
+                value,
+                label,
+                (self.data in {value, self.coerce(value)})
+            )
 
 
 # guard against data entries that aren't a role in permissions

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -630,15 +630,13 @@ def service_set_inbound_number(service_id):
 @user_has_permissions('manage_service')
 def service_set_sms_prefix(service_id):
 
-    form = SMSPrefixForm(enabled=(
-        'on' if current_service.prefix_sms else 'off'
-    ))
+    form = SMSPrefixForm(enabled=current_service.prefix_sms)
 
     form.enabled.label.text = 'Start all text messages with ‘{}:’'.format(current_service.name)
 
     if form.validate_on_submit():
         current_service.update(
-            prefix_sms=(form.enabled.data == 'on')
+            prefix_sms=form.enabled.data
         )
         return redirect(url_for('.service_settings', service_id=service_id))
 

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 
 {% block service_page_title %}
   Send emails
@@ -20,7 +19,7 @@
         It’s free to send emails through GOV.UK Notify.
       </p>
       {% call form_wrapper() %}
-        {{ radios(form.enabled) }}
+        {{ form.enabled }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/set-international-letters.html
+++ b/app/templates/views/service-settings/set-international-letters.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -24,7 +23,7 @@
         of rates.
       </p>
       {% call form_wrapper() %}
-        {{ radios(form.enabled) }}
+        {{ form.enabled }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -24,7 +23,7 @@
         of rates.
       </p>
       {% call form_wrapper() %}
-        {{ radios(form.enabled) }}
+        {{ form.enabled }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -24,7 +23,7 @@
         of rates.
       </p>
       {% call form_wrapper() %}
-        {{ radios(form.enabled) }}
+        {{ form.enabled }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/set-service-setting.html
+++ b/app/templates/views/service-settings/set-service-setting.html
@@ -1,8 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
 
 {% block service_page_title %}
   {{ title }}
@@ -12,12 +11,20 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-      {{ page_header(
-        title,
-        back_link=url_for('.service_settings', service_id=current_service.id)
-      ) }}
+      {{ govukBackLink({
+        "text": "Back",
+        "href": url_for('.service_settings', service_id=current_service.id)
+      }) }}
       {% call form_wrapper() %}
-        {{ radios(form.enabled, hide_legend=True) }}
+        {{ form.enabled(param_extensions={
+          "fieldset": {
+            "classes": "govuk-!-margin-top-3",
+            "legend": {
+              "isPageHeading": True,
+              "classes": "govuk-fieldset__legend--l"
+            }
+          }
+        }) }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 
 {% block service_page_title %}
   Send text messages
@@ -29,7 +28,7 @@
         See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(".pricing", _anchor="letters") }}">pricing</a> for more details.
       </p>
       {% call form_wrapper() %}
-        {{ radios(form.enabled) }}
+        {{ form.enabled }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/service-settings/sms-prefix.html
+++ b/app/templates/views/service-settings/sms-prefix.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -16,7 +15,7 @@
   ) }}
 
   {% call form_wrapper() %}
-    {{ radios(form.enabled) }}
+    {{ form.enabled }}
     {{ page_footer('Save') }}
   {% endcall %}
 

--- a/app/templates/views/user-profile/disable-platform-admin-view.html
+++ b/app/templates/views/user-profile/disable-platform-admin-view.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/radios.html" import radios %}
 
 {% block per_page_title %}
   Use platform admin view
@@ -18,7 +17,7 @@
       ) }}
 
       {% call form_wrapper() %}
-        {{ radios(form.enabled) }}
+        {{ form.enabled }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3907,7 +3907,7 @@ def test_show_international_sms_and_letters_as_radio_button(
         f'main.service_set_{permission}',
         service_id=service_one['id'],
     ).select(
-        '.multiple-choice input[checked]'
+        '.govuk-radios__item input[checked]'
     )
 
     assert len(checked_radios) == 1

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4450,22 +4450,21 @@ def test_show_sms_prefixing_setting_page(
     )
     radios = page.select('input[type=radio]')
     assert len(radios) == 2
-    assert radios[0]['value'] == 'on'
+    assert radios[0]['value'] == 'True'
     assert radios[0]['checked'] == ''
-    assert radios[1]['value'] == 'off'
+    assert radios[1]['value'] == 'False'
     with pytest.raises(KeyError):
         assert radios[1]['checked']
 
 
-@pytest.mark.parametrize('post_value, expected_api_argument', [
-    ('on', True),
-    ('off', False),
+@pytest.mark.parametrize('post_value', [
+    True,
+    False,
 ])
 def test_updates_sms_prefixing(
     client_request,
     mock_update_service,
     post_value,
-    expected_api_argument,
 ):
     client_request.post(
         'main.service_set_sms_prefix', service_id=SERVICE_ONE_ID,
@@ -4477,7 +4476,7 @@ def test_updates_sms_prefixing(
     )
     mock_update_service.assert_called_once_with(
         SERVICE_ONE_ID,
-        prefix_sms=expected_api_argument,
+        prefix_sms=post_value,
     )
 
 


### PR DESCRIPTION
Part 3 of migrating our radio buttons to use the [GOV.UK Frontend radios component](https://design-system.service.gov.uk/components/radios/).

https://www.pivotaltracker.com/story/show/170030262

This pull request changes the `OnOffField` class to inherit from `GovukRadiosField` and updates all the pages that use it so they no longer use the existing `radios` macro.

### Notes

This also changes `SMSPrefixForm.enabled` to use `OnOffField` for consistency with other forms that just have 'On'/'Off' options.

Part 1 of this work was done in https://github.com/alphagov/notifications-admin/pull/3715.
Pull requests for the other parts are:
- part 2: https://github.com/alphagov/notifications-admin/pull/3727
- part 4: https://github.com/alphagov/notifications-admin/pull/3730
- part 5: https://github.com/alphagov/notifications-admin/pull/3731

Pull requests in this stream of work don't need to be completed in any order.