### PR TITLE
Tell browser to connect to asset domain earlier

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -630,6 +630,11 @@ def useful_headers_after_request(response):
             logo_domain=get_logo_cdn_domain(),
         )
     ))
+    response.headers.add('Link', (
+        '<{asset_url}>; rel=dns-prefetch, <{asset_url}>; rel=preconnect'.format(
+            asset_url=f'https://{current_app.config["ASSET_DOMAIN"]}'
+        )
+    ))
     if 'Cache-Control' in response.headers:
         del response.headers['Cache-Control']
     response.headers.add(

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -24,6 +24,10 @@ def test_owasp_useful_headers_set(
         " *.notifications.service.gov.uk static-logos.test.com data:;"
         "frame-src 'self' www.youtube-nocookie.com;"
     )
+    assert response.headers['Link'] == (
+        '<https://static.example.com>; rel=dns-prefetch, '
+        '<https://static.example.com>; rel=preconnect'
+    )
 
 
 def test_headers_non_ascii_characters_are_replaced(


### PR DESCRIPTION
When a browser loads a Notify page it does the following:
- DNS and TLS handshake for notifications.service.gov.uk
- download some HTML
- sees that the HTML needs to load some CSS
- DNS and TLS handshake for static.notifications.service.gov.uk
- downloads the CSS

We can speed things up a bit in modern browsers by parallelizing this process a bit. Modern browsers support some HTTP headers<sup>1</sup> that allow them to connect to other origins sooner.

After this change the steps are:
- DNS and TLS handshake for notifications.service.gov.uk
- receive response headers and simultaneously:
  - download some HTML
  - DNS and TLS handshake for static.notifications.service.gov.uk
- sees that the HTML needs to load some CSS
- downloads the CSS

1. https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch