### PR TITLE
Add GOVUK radios [part 4]

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1168,10 +1168,8 @@ class OrganisationOrganisationTypeForm(StripWhitespaceForm):
 
 
 class OrganisationCrownStatusForm(StripWhitespaceForm):
-    crown_status = RadioField(
-        (
-            'Is this organisation a crown body?'
-        ),
+    crown_status = GovukRadiosField(
+        'Is this organisation a crown body?',
         choices=[
             ('crown', 'Yes'),
             ('non-crown', 'No'),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -426,26 +426,6 @@ class ForgivingIntegerField(GovukTextInputField):
         return super().__call__(value=value, **kwargs)
 
 
-class OrganisationTypeField(RadioField):
-    def __init__(
-        self,
-        *args,
-        include_only=None,
-        validators=None,
-        **kwargs
-    ):
-        super().__init__(
-            *args,
-            choices=[
-                (value, label) for value, label in Organisation.TYPES
-                if not include_only or value in include_only
-            ],
-            thing='the type of organisation',
-            validators=validators or [],
-            **kwargs
-        )
-
-
 class FieldWithNoneOption():
 
     # This is a special value that is specific to our forms. This is
@@ -949,6 +929,26 @@ class OnOffField(GovukRadiosField):
                 label,
                 (self.data in {value, self.coerce(value)})
             )
+
+
+class OrganisationTypeField(GovukRadiosField):
+    def __init__(
+        self,
+        *args,
+        include_only=None,
+        validators=None,
+        **kwargs
+    ):
+        super().__init__(
+            *args,
+            choices=[
+                (value, label) for value, label in Organisation.TYPES
+                if not include_only or value in include_only
+            ],
+            thing='the type of organisation',
+            validators=validators or [],
+            **kwargs
+        )
 
 
 # guard against data entries that aren't a role in permissions

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
@@ -20,7 +19,7 @@
       {{ form.name(param_extensions={"hint": {"text": "You can change this later"}}) }}
 
       {% if not default_organisation_type %}
-        {{ radios(form.organisation_type) }}
+        {{ form.organisation_type }}
       {% endif %}
 
       {{ page_footer('Add service') }}

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block per_page_title %}
@@ -26,8 +25,8 @@
             {{ page_header('New organisation') }}
             {% call form_wrapper() %}
               {{ form.name }}
-              {{ radios(form.organisation_type) }}
-              {{ radios(form.crown_status) }}
+              {{ form.organisation_type }}
+              {{ form.crown_status }}
               {{ page_footer('Save') }}
             {% endcall %}
           {% endblock %}

--- a/app/templates/views/organisations/organisation/settings/edit-crown-status.html
+++ b/app/templates/views/organisations/organisation/settings/edit-crown-status.html
@@ -1,4 +1,3 @@
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
@@ -17,7 +16,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
       {% call form_wrapper() %}
-        {{ radios(form.crown_status) }}
+        {{ form.crown_status }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>

--- a/app/templates/views/organisations/organisation/settings/edit-type.html
+++ b/app/templates/views/organisations/organisation/settings/edit-type.html
@@ -1,4 +1,3 @@
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
@@ -15,7 +14,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   {% call form_wrapper() %}
-    {{ radios(form.organisation_type) }}
+    {{ form.organisation_type }}
     {{ page_footer('Save') }}
   {% endcall %}
 {% endblock %}

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -155,11 +155,11 @@ def test_create_new_organisation_validates(
     )
     assert [
         (error['data-error-label'], normalize_spaces(error.text))
-        for error in page.select('.govuk-error-message, .error-message')
+        for error in page.select('.govuk-error-message')
     ] == [
         ('name', 'Error: Cannot be empty'),
-        ('organisation_type', 'Select the type of organisation'),
-        ('crown_status', 'Select whether this organisation is a crown body'),
+        ('organisation_type', 'Error: Select the type of organisation'),
+        ('crown_status', 'Error: Select whether this organisation is a crown body'),
     ]
     assert mock_create_organisation.called is False
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -37,7 +37,7 @@ def test_get_should_render_add_service_template(
     assert page.select_one('h1').text.strip() == 'About your service'
     assert page.select_one('input[name=name]').get('value') is None
     assert [
-        label.text.strip() for label in page.select('.multiple-choice label')
+        label.text.strip() for label in page.select('.govuk-radios__item label')
     ] == [
         'Central government',
         'Local government',
@@ -49,7 +49,7 @@ def test_get_should_render_add_service_template(
         'Other',
     ]
     assert [
-        radio['value'] for radio in page.select('.multiple-choice input')
+        radio['value'] for radio in page.select('.govuk-radios__item input')
     ] == [
         'central',
         'local',
@@ -193,8 +193,8 @@ def test_add_service_has_to_choose_org_type(
         },
         _expected_status=200,
     )
-    assert normalize_spaces(page.select_one('.error-message').text) == (
-        'Select the type of organisation'
+    assert normalize_spaces(page.select_one('.govuk-error-message').text) == (
+        'Error: Select the type of organisation'
     )
     assert mock_create_service.called is False
     assert mock_create_service_template.called is False
@@ -223,14 +223,14 @@ def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
     assert page.select_one('h1').text.strip() == 'About your service'
     assert page.select_one('input[name=name]').get('value') is None
     assert [
-        label.text.strip() for label in page.select('.multiple-choice label')
+        label.text.strip() for label in page.select('.govuk-radios__item label')
     ] == [
         'NHS – central government agency or public body',
         'NHS Trust or Clinical Commissioning Group',
         'GP practice',
     ]
     assert [
-        radio['value'] for radio in page.select('.multiple-choice input')
+        radio['value'] for radio in page.select('.govuk-radios__item input')
     ] == [
         'nhs_central',
         'nhs_local',


### PR DESCRIPTION
Part 4 of migrating our radio buttons to use the [GOV.UK Frontend radios component](https://design-system.service.gov.uk/components/radios/).

https://www.pivotaltracker.com/story/show/170030262

This pull request makes `OrganisationTypeField` inherit from `GovukRadiosField` and so converts all form fields using `OrganisationTypeField` to use the GOVUK radios component.

It also makes `OrganisationCrownStatusForm.crown_status` use `GovukRadiosField`, with the same effect.

### Notes

Part 1 of this work was done in https://github.com/alphagov/notifications-admin/pull/3715.
Pull requests for the other parts are:
- part 2: https://github.com/alphagov/notifications-admin/pull/3727
- part 3: https://github.com/alphagov/notifications-admin/pull/3728
- part 5: https://github.com/alphagov/notifications-admin/pull/3731

Pull requests in this stream of work don't need to be completed in any order.