### PR TITLE
Put underlines back on footer links

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/focus/components.scss
+++ b/app/assets/stylesheets/govuk-frontend/focus/components.scss
@@ -28,13 +28,6 @@
 
 // Updates to footer component
 .govuk-footer__link {
-  text-decoration: none;
-
-  &:hover,
-  &:active {
-    text-decoration: underline;
-  }
-
   @include govuk-focusable-text-link;
 }
 


### PR DESCRIPTION
The links in the footer are only identified as links by the underline that appears when you hover/focus. This isn't a problem in other navigation blocks that only contain links but the footer is a mix of text and links.

This fails the Web Content Accessibility Guidelines (WCAG) success criteria 1.4.1 (see https://www.w3.org/TR/WCAG20-TECHS/F73.html).

This issue was raised in the service assessment accessibility review and is part of https://www.pivotaltracker.com/story/show/175994911

Note: this change was also made to GOVUK Frontend in https://github.com/alphagov/govuk-frontend/pull/1672