### PR TITLE
Pre-compress static files 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ generate-manifest:
 
 .PHONY: upload-static ## Upload the static files to be served from S3
 upload-static:
+	gzip -9 ./app/static/stylesheets/*.css
+	for file in app/static/stylesheets/*.gz; do mv "$file" "${file%%.gz}"; done;
+	gzip -9 ./app/static/javascripts/*.js
+	for file in app/static/javascripts/*.gz; do mv "$file" "${file%%.gz}"; done;
 	aws s3 cp --region eu-west-1 --recursive --cache-control max-age=315360000,immutable ./app/static s3://${DNS_NAME}-static
 
 .PHONY: cf-deploy


### PR DESCRIPTION
At the moment we store uncompressed files in S3 and ask Cloudfront to compress them before caching and serving them.

This works great, except sometimes when Cloudfront is busy it just decides not to apply any compression<sup>1 2</sup>. As a bonus it caches this uncompressed response. So we serve uncompressed assets until we deploy a change that modifies one of the assets. This is totally the behaviour of a well-designed service that’s been built with developer ergonomics in mind, and is exactly the kind of technical decision you’d expect from a company with such clear and readable documentation as AWS.

This commit applies some blunt bash scripting to compress the files (preserving the original file name) before uploading them to S3, so that we always serve compressed assets. Using gzip with `-9` (the highest) level of compression will save us a few bytes, since Cloudfront seems to use a lower level of compression to save CPU time on their servers<sup>3</sup>.

All browsers down to Netscape 4 and Internet Explorer 4 support gzip-compressed content<sup>4</sup>.

We only need to compress CSS and Javascript, since fonts and images are already compressed.

1. https://www.debugbear.com/blog/intermittent-compression
2. https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html
3. Try entering `https://static.notifications.service.gov.uk/stylesheets/main.css` at https://tools.paulcalvano.com/compression.php
4. http://schroepl.net/projekte/mod_gzip/browser.htm