### PR TITLE
Generate asset to test CDN compression config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,9 @@ plugins.base64 = require('gulp-base64-inline');
 plugins.cleanCSS = require('gulp-clean-css');
 plugins.concat = require('gulp-concat');
 plugins.cssUrlAdjuster = require('gulp-css-url-adjuster');
+plugins.gzip = require('gulp-gzip');
 plugins.jshint = require('gulp-jshint');
+plugins.md5 = require('gulp-md5');
 plugins.prettyerror = require('gulp-prettyerror');
 plugins.rollup = require('gulp-better-rollup')
 plugins.sass = require('gulp-sass');
@@ -107,6 +109,14 @@ const copy = {
     js: () => {
       return src(paths.npm + 'leaflet/dist/leaflet.js')
         .pipe(dest(paths.dist + 'javascripts/'))
+    }
+  },
+  tests: {
+    css: () => { 
+      return src(paths.dist + 'stylesheets/main.css')
+        .pipe(plugins.md5({ separator: '-' }))
+        .pipe(plugins.gzip({ gzipOptions: { level: 9 }, preExtension: 'gz' }))
+        .pipe(dest(paths.dist + 'test/'))
     }
   }
 };
@@ -290,7 +300,8 @@ const defaultTask = parallel(
     series(
       javascripts
     ),
-    sass
+    sass,
+    copy.tests.css
   )
 );
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "devDependencies": {
     "gulp-css-url-adjuster": "0.2.3",
+    "gulp-gzip": "1.4.2",
     "gulp-jshint": "2.1.0",
+    "gulp-md5": "0.1.3",
     "gulp-prettyerror": "1.2.1",
     "gulp-sass-lint": "1.4.0",
     "jest": "24.7.1",


### PR DESCRIPTION
Cloudfront, our CDN, sometimes decides not to gzip assets. Because of this, we're going to gzip them ourselves prior to upload instead.

This will involve:
1. adding gzipping to the make task that uploads
   them
2. turning compression off in Cloudfront

There is already a pull request up for number 1:

https://github.com/alphagov/notifications-admin/pull/3733

Because deploying all this will, at some point, create a state where Cloudfront is set to compress assets that are already compressed, we need to test that it doesn't re-compress them.

This adds a frontend build task that generates a test asset which is:
- a copy of app/static/stylesheets/main.css
- renamed to include a MD5 SHA of its contents
- already gzipped

Once deployed, the test will be to:
1. download the asset from the live environment
2. unzip it
3. diff it against app/static/stylesheets/main.css

Something like:
```bash
curl -o ~/Downloads/test-main.css https://static.notifications.service.gov.uk/test/main-110c571859be1151126352d4798dd2a4.gz.css
curl -o ~/Downloads/current-main.css https://static.notifications.service.gov.uk/stylesheets/main.css?110c571859be1151126352d4798dd2a4
gzip -d -c ~/Downloads/test-main.css > ~/Downloads/test-main-unzipped.css
if diff ~/Downloads/test-main.css ~/Downloads/current-main.css > /dev/null; then echo "Test file has differences"; else echo "Test file matches main.css"; fi
```
This snippet will need all paths checking beforehand to ensure the latest `main.css` is referenced.