### PR TITLE
Revert "Merge pull request #3738 from alphagov/test-pre-compressed-as…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,9 +18,7 @@ plugins.base64 = require('gulp-base64-inline');
 plugins.cleanCSS = require('gulp-clean-css');
 plugins.concat = require('gulp-concat');
 plugins.cssUrlAdjuster = require('gulp-css-url-adjuster');
-plugins.gzip = require('gulp-gzip');
 plugins.jshint = require('gulp-jshint');
-plugins.md5 = require('gulp-md5');
 plugins.prettyerror = require('gulp-prettyerror');
 plugins.rollup = require('gulp-better-rollup')
 plugins.sass = require('gulp-sass');
@@ -109,14 +107,6 @@ const copy = {
     js: () => {
       return src(paths.npm + 'leaflet/dist/leaflet.js')
         .pipe(dest(paths.dist + 'javascripts/'))
-    }
-  },
-  tests: {
-    css: () => { 
-      return src(paths.dist + 'stylesheets/main.css')
-        .pipe(plugins.md5({ separator: '-' }))
-        .pipe(plugins.gzip({ gzipOptions: { level: 9 }, preExtension: 'gz' }))
-        .pipe(dest(paths.dist + 'test/'))
     }
   }
 };
@@ -300,8 +290,7 @@ const defaultTask = parallel(
     series(
       javascripts
     ),
-    sass,
-    copy.tests.css
+    sass
   )
 );
 

--- a/package.json
+++ b/package.json
@@ -47,9 +47,7 @@
   },
   "devDependencies": {
     "gulp-css-url-adjuster": "0.2.3",
-    "gulp-gzip": "1.4.2",
     "gulp-jshint": "2.1.0",
-    "gulp-md5": "0.1.3",
     "gulp-prettyerror": "1.2.1",
     "gulp-sass-lint": "1.4.0",
     "jest": "24.7.1",


### PR DESCRIPTION
Reverts out the code that added a test file to the frontend build to test the effect of gzipping our assets before upload.

See [the pull request it reverts](https://github.com/alphagov/notifications-admin/pull/3738) for more details.