### PR TITLE
Tell users that postage prices will increase

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -230,7 +230,10 @@
     {% endcall %}
   </div>
   <div class="panel panel-border-wide">
-    <p class="govuk-body">These prices will increase by X pence plus VAT on 1 February 2021.</p>
+    <p class="govuk-body">Second class postage will increase by 4 pence plus VAT on 1 February 2021.</p>
+    <p class="govuk-body">First class postage will increase by 8 pence plus VAT on 1 February 2021.</p>
+    <p class="govuk-body">International postage will increase by 5 pence plus VAT on 1 February 2021.</p>
+
   </div>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -229,11 +229,14 @@
       {% endfor %}
     {% endcall %}
   </div>
-  <div class="panel panel-border-wide">
-    <p class="govuk-body">Second class postage will increase by 4 pence plus VAT on 1 February 2021.</p>
-    <p class="govuk-body">First class postage will increase by 8 pence plus VAT on 1 February 2021.</p>
-    <p class="govuk-body">International postage will increase by 5 pence plus VAT on 1 February 2021.</p>
-
+  <div class="panel panel-border-wide">  
+    <p class="govuk-body">We’re changing the cost of sending letters through Notify. This is because Royal Mail has increased their rates.</p>
+    <p class="govuk-body">From 1 February 2021:</p>
+    <ul class="list list-bullet">
+      <li>second class postage will increase by 4 pence, plus VAT</li>
+      <li>first class postage will increase by 8 pence, plus VAT</li>
+      <li>international postage will increase by 5 pence, plus VAT</li>
+    </ul>
   </div>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -230,13 +230,14 @@
     {% endcall %}
   </div>
   <div class="panel panel-border-wide">  
-    <p class="govuk-body">We’re changing the cost of sending letters through Notify. This is because Royal Mail has increased their rates.</p>
     <p class="govuk-body">From 1 February 2021:</p>
     <ul class="list list-bullet">
       <li>second class postage will increase by 4 pence, plus VAT</li>
       <li>first class postage will increase by 8 pence, plus VAT</li>
       <li>international postage will increase by 5 pence, plus VAT</li>
     </ul>
+    <p class="govuk-body">This is because Royal Mail has increased their rates.</p>
+
   </div>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -230,7 +230,7 @@
     {% endcall %}
   </div>
   <div class="panel panel-border-wide">
-    <p class="govuk-body">These prices were updated on 7 September 2020.</p>
+    <p class="govuk-body">These prices will increase by X pence plus VAT on 1 February 2021.</p>
   </div>
 
 {% endblock %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -156,7 +156,7 @@
         </div>
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Letters</h3>
-          <div class="product-page-big-number">35 pence</div>
+          <div class="product-page-big-number">XX pence</div>
           to print and post a one page letter
         </div>
         <div class="govuk-grid-column-one-half">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -156,7 +156,7 @@
         </div>
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Letters</h3>
-          <div class="product-page-big-number">XX pence</div>
+          <div class="product-page-big-number">35 pence</div>
           to print and post a one page letter
         </div>
         <div class="govuk-grid-column-one-half">


### PR DESCRIPTION
This PR follows the pattern we used for the October 2019 increases:

1. Announce the date (and value) of the rate increase in advance, using the call-out pattern.
2. Temporarily replace the ‘These prices were updated on 7 September 2020’ (we’ll reinstate this message once the new prices come into effect, and the table is updated)

## Why we’re doing this

We’re changing the cost of sending letters through Notify. This is because Royal Mail (and DVLA) are increasing their rates in 2021.

We understand that prices will change from 1 February 2021, so we need to give users a month’s notice.

## Price increases
![Screenshot 2020-12-23 at 09 49 22](https://user-images.githubusercontent.com/28294225/102991329-e80ea800-4510-11eb-97d5-1efb4a5c2e5b.png)
