### PR TITLE
Stop accidental markdown in go live ticket

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -217,6 +217,7 @@ def submit_request_to_go_live(service_id):
             '\nOther live services: {existing_live}'
             '\n'
             '\nService reply-to address: {email_reply_to}'
+            '\n'
             '\n---'
             '\nRequest sent by {email_address}'
             '\n'

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1668,6 +1668,7 @@ def test_should_redirect_after_request_to_go_live(
         'Other live services: No\n'
         '\n'
         'Service reply-to address: test@example.com\n'
+        '\n'
         '---\n'
         'Request sent by test@user.gov.uk\n'
     ).format(
@@ -1736,6 +1737,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         'Other live services: No\n'
         '\n'
         'Service reply-to address: test@example.com\n'
+        '\n'
         '---\n'
         'Request sent by test@user.gov.uk\n'
     ).format(


### PR DESCRIPTION
In Markdown this is interpreted as a H1:
```
Text
---
```

We can prevent this by adding an extra linebreak, like this:
```
Text

---
```