### PR TITLE
Use the singular for Royal Mail

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -236,7 +236,7 @@
       <li>first class postage will increase by 8 pence, plus VAT</li>
       <li>international postage will increase by 5 pence, plus VAT</li>
     </ul>
-    <p class="govuk-body">This is because Royal Mail has increased their rates.</p>
+    <p class="govuk-body">This is because Royal Mail has increased its rates.</p>
 
   </div>
 


### PR DESCRIPTION
We should use the singular verb form when referring to organisations by name. 

As described in the GOV.UK style guide: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#organisations