### PR TITLE
Validate length of broadcast content

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -40,6 +40,7 @@ from wtforms.validators import URL, DataRequired, Length, Optional, Regexp
 
 from app import format_thousands
 from app.main.validators import (
+    BroadcastLength,
     CommonlyUsedPassword,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
@@ -1324,6 +1325,7 @@ class BroadcastTemplateForm(SMSTemplateForm):
     def validate_template_content(self, field):
         OnlySMSCharacters(template_type='broadcast')(None, field)
         NoPlaceholders()(None, field)
+        BroadcastLength()(None, field)
 
 
 class LetterAddressForm(StripWhitespaceForm):

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -24,7 +24,7 @@
         }) }}
       </div>
       <div class="govuk-grid-column-two-thirds">
-        {{ textbox(form.template_content, highlight_placeholders=False, width='1-1', rows=5) }}
+        {{ textbox(form.template_content, highlight_placeholders=False, autosize=True, width='1-1', rows=5) }}
         {{ sticky_page_footer('Save') }}
       </div>
     </div>

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.8#egg=notifications-utils==43.5.8
+git+https://github.com/alphagov/notifications-utils.git@43.6.0#egg=notifications-utils==43.6.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.8#egg=notifications-utils==43.5.8
+git+https://github.com/alphagov/notifications-utils.git@43.6.0#egg=notifications-utils==43.6.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1865,6 +1865,37 @@ def test_should_not_update_too_big_template(
     assert "Content has a character count greater than the limit of 459" in page.text
 
 
+@pytest.mark.parametrize('content, expected_error', (
+    (("ŴŶ" * 308), (
+        'Content must be 615 characters or fewer because it contains Ŵ and Ŷ'
+    )),
+    (("ab" * 698), (
+        'Content must be 1,395 characters or fewer'
+    )),
+))
+def test_should_not_create_too_big_template_for_broadcasts(
+    client_request,
+    service_one,
+    content,
+    expected_error,
+):
+    service_one['permissions'] = ['broadcast']
+    page = client_request.post(
+        '.add_service_template',
+        service_id=SERVICE_ONE_ID,
+        template_type='broadcast',
+        _data={
+            'name': 'New name',
+            'template_content': content,
+            'template_type': 'broadcast',
+            'service': SERVICE_ONE_ID,
+            'process_type': 'normal'
+        },
+        _expected_status=200,
+    )
+    assert normalize_spaces(page.select_one('.error-message').text) == expected_error
+
+
 def test_should_redirect_when_saving_a_template_email(
     client_request,
     mock_get_service_email_template,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -480,6 +480,7 @@ def test_broadcast_template_doesnt_highlight_placeholders(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
     )
+    assert page.select_one('textarea')['data-module'] == 'enhanced-textbox'
     assert page.select_one('textarea')['data-highlight-placeholders'] == 'false'
 
 


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/826

Adds error messages for when the content of a broadcast template is too long:

***

![image](https://user-images.githubusercontent.com/355079/103092889-a9e8b580-45f0-11eb-89e8-1c2a03ba14f1.png)

***

The error message is explicit when the limit is reduced by non-GSM characters. We may not want to expose this complexity to our users, but it’s useful for now while we’re testing things out.

![image](https://user-images.githubusercontent.com/355079/103092869-950c2200-45f0-11eb-8892-f69dc39a9029.png)

***

https://www.pivotaltracker.com/story/show/176094622