### PR TITLE
Let users create an emergency alert without a template 

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1293,6 +1293,21 @@ class ConfirmPasswordForm(StripWhitespaceForm):
             raise ValidationError('Invalid password')
 
 
+class NewBroadcastForm(StripWhitespaceForm):
+    content = GovukRadiosField(
+        "How to do you want to add content to the alert?",
+        choices=[
+            ('freeform', 'Write your own message'),
+            ('template', 'Use a template'),
+        ],
+        param_extensions={'fieldset': {'legend': {'classes': 'govuk-visually-hidden'}}}
+    )
+
+    @property
+    def use_template(self):
+        return self.content.data == 'template'
+
+
 class BaseTemplateForm(StripWhitespaceForm):
     name = GovukTextInputField(
         "Template name",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1295,7 +1295,7 @@ class ConfirmPasswordForm(StripWhitespaceForm):
 
 class NewBroadcastForm(StripWhitespaceForm):
     content = GovukRadiosField(
-        "How to do you want to add content to the alert?",
+        'New alert',
         choices=[
             ('freeform', 'Write your own message'),
             ('template', 'Use a template'),

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -138,12 +138,26 @@ def broadcast(service_id, template_id):
 @user_has_permissions('send_messages')
 @service_has_permission('broadcast')
 def preview_broadcast_areas(service_id, broadcast_message_id):
+    broadcast_message = BroadcastMessage.from_id(
+        broadcast_message_id,
+        service_id=current_service.id,
+    )
+    if broadcast_message.template_id:
+        back_link = url_for(
+            '.view_template',
+            service_id=current_service.id,
+            template_id=broadcast_message.template_id,
+        )
+    else:
+        back_link = url_for(
+            '.write_new_broadcast',
+            service_id=current_service.id,
+        )
+
     return render_template(
         'views/broadcast/preview-areas.html',
-        broadcast_message=BroadcastMessage.from_id(
-            broadcast_message_id,
-            service_id=current_service.id,
-        ),
+        broadcast_message=broadcast_message,
+        back_link=back_link,
     )
 
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -13,6 +13,8 @@ from app.main import main
 from app.main.forms import (
     BroadcastAreaForm,
     BroadcastAreaFormWithSelectAll,
+    BroadcastTemplateForm,
+    NewBroadcastForm,
     SearchByNameForm,
 )
 from app.models.broadcast_message import BroadcastMessage, BroadcastMessages
@@ -68,6 +70,53 @@ def get_broadcast_dashboard_partials(service_id):
             empty_message='You do not have any current alerts',
             view_broadcast_endpoint='.view_current_broadcast',
         ),
+    )
+
+
+@main.route('/services/<uuid:service_id>/new-broadcast', methods=['GET', 'POST'])
+@user_has_permissions('send_messages')
+@service_has_permission('broadcast')
+def new_broadcast(service_id):
+    form = NewBroadcastForm()
+
+    if form.validate_on_submit():
+        if form.use_template:
+            return redirect(url_for(
+                '.choose_template',
+                service_id=current_service.id,
+            ))
+        return redirect(url_for(
+            '.write_new_broadcast',
+            service_id=current_service.id,
+        ))
+
+    return render_template(
+        'views/broadcast/new-broadcast.html',
+        form=form,
+    )
+
+
+@main.route('/services/<uuid:service_id>/write-new-broadcast', methods=['GET', 'POST'])
+@user_has_permissions('send_messages')
+@service_has_permission('broadcast')
+def write_new_broadcast(service_id):
+    form = BroadcastTemplateForm()
+
+    if form.validate_on_submit():
+        broadcast_message = BroadcastMessage.create_from_content(
+            service_id=current_service.id,
+            content=form.template_content.data,
+            reference=form.name.data,
+        )
+        return redirect(url_for(
+            '.preview_broadcast_areas',
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
+        ))
+
+    return render_template(
+        'views/broadcast/write-new-broadcast.html',
+        form=form,
     )
 
 

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -55,6 +55,17 @@ class BroadcastMessage(JSONModel):
         return cls(broadcast_message_api_client.create_broadcast_message(
             service_id=service_id,
             template_id=template_id,
+            content=None,
+            reference=None,
+        ))
+
+    @classmethod
+    def create_from_content(cls, *, service_id, content, reference):
+        return cls(broadcast_message_api_client.create_broadcast_message(
+            service_id=service_id,
+            template_id=None,
+            content=content,
+            reference=reference,
         ))
 
     @classmethod

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -13,7 +13,6 @@ from app.models.user import User
 from app.notify_client.broadcast_message_api_client import (
     broadcast_message_api_client,
 )
-from app.notify_client.service_api_client import service_api_client
 
 
 class BroadcastMessage(JSONModel):
@@ -22,8 +21,6 @@ class BroadcastMessage(JSONModel):
         'id',
         'service_id',
         'template_id',
-        'template_name',
-        'template_version',
         'content',
         'service_id',
         'created_by',
@@ -102,13 +99,18 @@ class BroadcastMessage(JSONModel):
         return self.get_simple_polygons(areas=self.areas)
 
     @property
+    def reference(self):
+        if self.template_id:
+            return self._dict['template_name']
+        return self._dict['reference']
+
+    @property
     def template(self):
-        response = service_api_client.get_service_template(
-            self.service_id,
-            self.template_id,
-            version=self.template_version,
-        )
-        return BroadcastPreviewTemplate(response['data'])
+        return BroadcastPreviewTemplate({
+            'template_type': BroadcastPreviewTemplate.template_type,
+            'name': self.reference,
+            'content': self.content,
+        })
 
     @property
     def status(self):

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -374,6 +374,8 @@ class HeaderNavigation(Navigation):
         'approve_broadcast_message',
         'reject_broadcast_message',
         'cancel_broadcast_message',
+        'new_broadcast',
+        'write_new_broadcast',
     }
 
     # header HTML now comes from GOVUK Frontend so requires a boolean, not an attribute
@@ -400,6 +402,8 @@ class MainNavigation(Navigation):
             'broadcast_dashboard',
             'broadcast_dashboard_updates',
             'view_current_broadcast',
+            'new_broadcast',
+            'write_new_broadcast',
         },
         'previous-broadcasts': {
             'broadcast_dashboard_previous',
@@ -1053,6 +1057,8 @@ class CaseworkNavigation(Navigation):
         'approve_broadcast_message',
         'reject_broadcast_message',
         'cancel_broadcast_message',
+        'new_broadcast',
+        'write_new_broadcast',
     }
 
 
@@ -1386,4 +1392,6 @@ class OrgNavigation(Navigation):
         'approve_broadcast_message',
         'reject_broadcast_message',
         'cancel_broadcast_message',
+        'new_broadcast',
+        'write_new_broadcast',
     }

--- a/app/notify_client/broadcast_message_api_client.py
+++ b/app/notify_client/broadcast_message_api_client.py
@@ -8,12 +8,19 @@ class BroadcastMessageAPIClient(NotifyAdminAPIClient):
         *,
         service_id,
         template_id,
+        content,
+        reference,
     ):
         data = {
             "service_id": service_id,
-            "template_id": template_id,
             "personalisation": {},
         }
+        if template_id:
+            data.update(template_id=template_id)
+        if content:
+            data.update(content=content)
+        if reference:
+            data.update(reference=reference)
 
         data = _attach_current_user(data)
 

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -9,14 +9,6 @@
 
 {% block maincolumn_content %}
 
-  {% if current_user.has_permissions('manage_templates') and not current_service.all_templates %}
-    <nav class="govuk-!-margin-top-2 govuk-!-margin-bottom-6">
-      <a class="govuk-link govuk-link--no-visited-state pill-separate-item govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-font-weight-bold" href="{{ url_for('.choose_template', service_id=current_service.id) }}">
-        Start by creating a template
-      </a>
-    </nav>
-  {% endif %}
-
   <h1 class="heading-medium">Current alerts</h1>
 
   {{ ajax_block(

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -1,4 +1,5 @@
 {% from 'components/ajax-block.html' import ajax_block %}
+{% from "components/button/macro.njk" import govukButton %}
 
 {% extends "withnav_template.html" %}
 
@@ -23,5 +24,16 @@
     url_for('.broadcast_dashboard_updates', service_id=current_service.id),
     'current_broadcasts'
   ) }}
+
+  {% if current_user.has_permissions('send_messages') %}
+    <div class="js-stick-at-bottom-when-scrolling">
+      {{ govukButton({
+        "element": "a",
+        "text": "New alert",
+        "href": url_for('.new_broadcast', service_id=current_service.id),
+        "classes": "govuk-button--secondary"
+      }) }}
+    </div>
+  {% endif %}
 
 {% endblock %}

--- a/app/templates/views/broadcast/new-broadcast.html
+++ b/app/templates/views/broadcast/new-broadcast.html
@@ -1,0 +1,23 @@
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% extends "withnav_template.html" %}
+
+{% block service_page_title %}
+  New alert
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(
+    'New alert',
+    back_link=url_for('.broadcast_dashboard', service_id=current_service.id),
+  )}}
+
+  {% call form_wrapper() %}
+    {{ form.content }}
+    {{ page_footer('Continue') }}
+  {% endcall %}
+
+{% endblock %}

--- a/app/templates/views/broadcast/new-broadcast.html
+++ b/app/templates/views/broadcast/new-broadcast.html
@@ -1,4 +1,4 @@
-{% from "components/page-header.html" import page_header %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -10,13 +10,19 @@
 
 {% block maincolumn_content %}
 
-  {{ page_header(
-    'New alert',
-    back_link=url_for('.broadcast_dashboard', service_id=current_service.id),
-  )}}
+  {{ govukBackLink({ "href": url_for('.broadcast_dashboard', service_id=current_service.id) }) }}
 
   {% call form_wrapper() %}
-    {{ form.content }}
+    {{ form.content(
+      param_extensions={
+        'fieldset': {
+          'legend': {
+            'isPageHeading': True,
+            'classes': 'govuk-fieldset__legend--l'
+          }
+        }
+      }
+    ) }}
     {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/app/templates/views/broadcast/new-broadcast.html
+++ b/app/templates/views/broadcast/new-broadcast.html
@@ -12,7 +12,7 @@
 
   {{ govukBackLink({ "href": url_for('.broadcast_dashboard', service_id=current_service.id) }) }}
 
-  {% call form_wrapper() %}
+  {% call form_wrapper(class="govuk-!-margin-top-3") %}
     {{ form.content(
       param_extensions={
         'fieldset': {

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -5,7 +5,7 @@
   <div class="keyline-block">
     <div class="file-list govuk-!-margin-bottom-2">
       <h2>
-        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template_name }}</a>
+        <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template.name }}</a>
       </h2>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -21,7 +21,7 @@
 
   {{ page_header(
     "Choose where to broadcast to",
-    back_link=url_for('.view_template', service_id=current_service.id, template_id=broadcast_message.template_id)
+    back_link=back_link
   ) }}
 
   {% for area in broadcast_message.areas %}

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -1,4 +1,5 @@
 {% from 'components/ajax-block.html' import ajax_block %}
+{% from "components/button/macro.njk" import govukButton %}
 
 {% extends "withnav_template.html" %}
 
@@ -11,5 +12,16 @@
   <h1 class="heading-medium">Previous alerts</h1>
 
   {% include('views/broadcast/partials/dashboard-table.html') %}
+
+  {% if current_user.has_permissions('send_messages') %}
+    <div class="js-stick-at-bottom-when-scrolling">
+      {{ govukButton({
+        "element": "a",
+        "text": "New alert",
+        "href": url_for('.new_broadcast', service_id=current_service.id),
+        "classes": "govuk-button--secondary"
+      }) }}
+    </div>
+  {% endif %}
 
 {% endblock %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -20,15 +20,15 @@
 {% block service_page_title %}
   {% if broadcast_message.status == 'pending-approval' %}
     {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
-      {{ broadcast_message.template_name }} is waiting for approval
+      {{ broadcast_message.template.name }} is waiting for approval
     {% elif current_user.has_permissions('send_messages') %}
       {{ broadcast_message.created_by.name }} wants to broadcast
-      {{ broadcast_message.template_name }}
+      {{ broadcast_message.template.name }}
     {% else %}
       This alert is waiting for approval
     {% endif %}
   {% else %}
-    {{ broadcast_message.template_name }}
+    {{ broadcast_message.template.name }}
   {% endif %}
 {% endblock %}
 
@@ -40,7 +40,7 @@
     {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
-          {{ broadcast_message.template_name }} is waiting for approval
+          {{ broadcast_message.template.name }} is waiting for approval
         </h1>
         {% if current_service.live %}
           <p class="govuk-body">
@@ -80,7 +80,7 @@
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <h1 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">
           {{ broadcast_message.created_by.name }} wants to broadcast
-          {{ broadcast_message.template_name }}
+          {{ broadcast_message.template.name }}
         </h1>
         {{ page_footer(
           "Start broadcasting now",
@@ -97,7 +97,7 @@
       </div>
     {% endif %}
   {% else %}
-    {{ page_header(broadcast_message.template_name) }}
+    {{ page_header(broadcast_message.template.name) }}
 
     {% if broadcast_message.status == 'broadcasting' %}
       <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">

--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -1,0 +1,49 @@
+{% from "components/form.html" import form_wrapper %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/textbox.html" import textbox %}
+
+{% extends "withnav_template.html" %}
+
+{% block service_page_title %}
+  New alert
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(
+    'New alert',
+    back_link=url_for('.new_broadcast', service_id=current_service.id),
+  )}}
+
+  {% call form_wrapper() %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ form.name(param_extensions={
+          "classes": "govuk-!-width-full",
+          "hint": {"text": "Your recipients will not see this"},
+          "label": {"text": "Title"}
+        }) }}
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        {{ textbox(
+          form.template_content,
+          highlight_placeholders=False,
+          autosize=True,
+          width='1-1',
+          rows=5,
+          extra_form_group_classes='govuk-!-margin-bottom-2'
+        ) }}
+      </div>
+      <div class="govuk-grid-column-full">
+        <div class="template-content-count">
+          <div data-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='broadcast') }}" aria-live="polite">
+            &nbsp;
+          </div>
+        </div>
+        {{ page_footer('Continue') }}
+      </div>
+    </div>
+  {% endcall %}
+
+{% endblock %}

--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -24,8 +24,6 @@
           "hint": {"text": "Your recipients will not see this"},
           "label": {"text": "Title"}
         }) }}
-      </div>
-      <div class="govuk-grid-column-two-thirds">
         {{ textbox(
           form.template_content,
           highlight_placeholders=False,

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -20,16 +20,16 @@
      {{ page_header(page_title, size='medium') }}
 
      <p class="govuk-body">
-       {% if current_user.has_permissions('manage_templates') %}
-         You need a template before you can
-       {% else %}
-         You need to ask your service manager to add templates before you can
-       {% endif %}
        {% if current_service.has_permission('broadcast') %}
-          prepare a broadcast
-       {%- else %}
-          send emails, text messages or letters
-       {%- endif %}.
+          You haven’t added any templates yet.
+       {% else %}
+         {% if current_user.has_permissions('manage_templates') %}
+           You need a template before you can
+         {% else %}
+           You need to ask your service manager to add templates before you can
+         {% endif %}
+         send emails, text messages or letters.
+       {% endif %}
      </p>
 
   {% else %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -656,6 +656,7 @@ def broadcast_message_json(
     cancelled_by_id=None,
     areas=None,
     content=None,
+    reference=None,
     template_name='Example template',
 ):
     return {
@@ -667,6 +668,7 @@ def broadcast_message_json(
         'template_version': 123,
         'template_name': template_name,
         'content': content or 'This is a test',
+        'reference': reference,
 
         'personalisation': {},
         'areas': areas or [

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -357,16 +357,20 @@ def test_broadcast_dashboard(
     )
 
 
+@pytest.mark.parametrize('endpoint', (
+    '.broadcast_dashboard', '.broadcast_dashboard_previous',
+))
 def test_broadcast_dashboard_does_not_have_button_for_view_only_user(
     client_request,
     service_one,
     active_user_view_permissions,
     mock_get_broadcast_messages,
+    endpoint,
 ):
     service_one['permissions'] += ['broadcast']
     client_request.login(active_user_view_permissions)
     page = client_request.get(
-        '.broadcast_dashboard',
+        endpoint,
         service_id=SERVICE_ONE_ID,
     )
     assert not page.select('a.govuk-button')
@@ -419,6 +423,15 @@ def test_previous_broadcasts_page(
         'Example template This is a test Broadcast yesterday at 2:20pm England Scotland',
         'Example template This is a test Broadcast yesterday at 2:20am England Scotland',
     ]
+
+    button = page.select_one(
+        '.js-stick-at-bottom-when-scrolling a.govuk-button.govuk-button--secondary'
+    )
+    assert normalize_spaces(button.text) == 'New alert'
+    assert button['href'] == url_for(
+        'main.new_broadcast',
+        service_id=SERVICE_ONE_ID,
+    )
 
 
 def test_new_broadcast_page(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -27,6 +27,14 @@ sample_uuid = sample_uuid()
         403, 405,
     ),
     (
+        '.new_broadcast', {},
+        403, 403,
+    ),
+    (
+        '.write_new_broadcast', {},
+        403, 403,
+    ),
+    (
         '.broadcast',
         {'template_id': sample_uuid},
         403, 405,
@@ -86,6 +94,14 @@ def test_broadcast_pages_403_without_permission(
 
 
 @pytest.mark.parametrize('endpoint, extra_args, expected_get_status, expected_post_status', (
+    (
+        '.new_broadcast', {},
+        403, 403,
+    ),
+    (
+        '.write_new_broadcast', {},
+        403, 403,
+    ),
     (
         '.broadcast',
         {'template_id': sample_uuid},
@@ -331,6 +347,30 @@ def test_broadcast_dashboard(
         'Example template This is a test Live since today at 1:20am England Scotland',
     ]
 
+    button = page.select_one(
+        '.js-stick-at-bottom-when-scrolling a.govuk-button.govuk-button--secondary'
+    )
+    assert normalize_spaces(button.text) == 'New alert'
+    assert button['href'] == url_for(
+        'main.new_broadcast',
+        service_id=SERVICE_ONE_ID,
+    )
+
+
+def test_broadcast_dashboard_does_not_have_button_for_view_only_user(
+    client_request,
+    service_one,
+    active_user_view_permissions,
+    mock_get_broadcast_messages,
+):
+    service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_view_permissions)
+    page = client_request.get(
+        '.broadcast_dashboard',
+        service_id=SERVICE_ONE_ID,
+    )
+    assert not page.select('a.govuk-button')
+
 
 @freeze_time('2020-02-20 02:20')
 def test_broadcast_dashboard_json(
@@ -379,6 +419,166 @@ def test_previous_broadcasts_page(
         'Example template This is a test Broadcast yesterday at 2:20pm England Scotland',
         'Example template This is a test Broadcast yesterday at 2:20am England Scotland',
     ]
+
+
+def test_new_broadcast_page(
+    client_request,
+    service_one,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get(
+        '.new_broadcast',
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert normalize_spaces(page.select_one('h1').text) == 'New alert'
+
+    form = page.select_one('form')
+    assert form['method'] == 'post'
+    assert 'action' not in form
+
+    assert [
+        (
+            choice.select_one('input')['name'],
+            choice.select_one('input')['value'],
+            normalize_spaces(choice.select_one('label').text),
+        )
+        for choice in form.select('.govuk-radios__item')
+    ] == [
+        ('content', 'freeform', 'Write your own message'),
+        ('content', 'template', 'Use a template'),
+    ]
+
+
+@pytest.mark.parametrize('value, expected_redirect_endpoint', (
+    ('freeform', 'main.write_new_broadcast'),
+    ('template', 'main.choose_template'),
+))
+def test_new_broadcast_page_redirects(
+    client_request,
+    service_one,
+    value,
+    expected_redirect_endpoint,
+):
+    service_one['permissions'] += ['broadcast']
+    client_request.post(
+        '.new_broadcast',
+        service_id=SERVICE_ONE_ID,
+        _data={
+            'content': value,
+        },
+        _expected_redirect=url_for(
+            expected_redirect_endpoint,
+            service_id=SERVICE_ONE_ID,
+            _external=True,
+        )
+    )
+
+
+def test_write_new_broadcast_page(
+    client_request,
+    service_one,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get(
+        '.write_new_broadcast',
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert normalize_spaces(page.select_one('h1').text) == 'New alert'
+
+    form = page.select_one('form')
+    assert form['method'] == 'post'
+    assert 'action' not in form
+
+    assert page.select_one('input[type=text]')['name'] == 'name'
+
+    assert page.select_one('textarea')['name'] == 'template_content'
+    assert page.select_one('textarea')['data-module'] == 'enhanced-textbox'
+    assert page.select_one('textarea')['data-highlight-placeholders'] == 'false'
+
+    assert (
+        page.select_one('[data-module=update-status]')['data-updates-url']
+    ) == url_for(
+        '.count_content_length',
+        service_id=SERVICE_ONE_ID,
+        template_type='broadcast',
+    )
+
+    assert (
+        page.select_one('[data-module=update-status]')['data-target']
+    ) == (
+        page.select_one('textarea')['id']
+    ) == (
+        'template_content'
+    )
+
+    assert (
+        page.select_one('[data-module=update-status]')['aria-live']
+    ) == (
+        'polite'
+    )
+
+
+def test_write_new_broadcast_posts(
+    client_request,
+    service_one,
+    mock_create_broadcast_message,
+    fake_uuid,
+):
+    service_one['permissions'] += ['broadcast']
+    client_request.post(
+        '.write_new_broadcast',
+        service_id=SERVICE_ONE_ID,
+        _data={
+            'name': 'My new alert',
+            'template_content': 'This is a test',
+        },
+        _expected_redirect=url_for(
+            '.preview_broadcast_areas',
+            service_id=SERVICE_ONE_ID,
+            broadcast_message_id=fake_uuid,
+            _external=True,
+        ),
+    )
+    mock_create_broadcast_message.assert_called_once_with(
+        service_id=SERVICE_ONE_ID,
+        reference='My new alert',
+        content='This is a test',
+        template_id=None,
+    )
+
+
+@pytest.mark.parametrize('content, expected_error_message', (
+    ('', 'Cannot be empty'),
+    ('ŵ' * 616, 'Content must be 615 characters or fewer because it contains ŵ'),
+    ('w' * 1_396, 'Content must be 1,395 characters or fewer'),
+    ('hello ((name))', 'You can’t use ((double brackets)) to personalise this message'),
+))
+def test_write_new_broadcast_bad_content(
+    client_request,
+    service_one,
+    mock_create_broadcast_message,
+    fake_uuid,
+    content,
+    expected_error_message,
+):
+    service_one['permissions'] += ['broadcast']
+    page = client_request.post(
+        '.write_new_broadcast',
+        service_id=SERVICE_ONE_ID,
+        _data={
+            'name': 'My new alert',
+            'template_content': content,
+        },
+        _expected_status=200,
+    )
+    assert normalize_spaces(
+        page.select_one('.error-message').text
+    ) == (
+        expected_error_message
+    )
+    assert mock_create_broadcast_message.called is False
 
 
 def test_broadcast_page(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -43,7 +43,7 @@ from tests.conftest import (
         'You need a template before you can send emails, text messages or letters.'
     )),
     (['broadcast'], (
-        'You need a template before you can prepare a broadcast.'
+        'You haven’t added any templates yet.'
     )),
 ))
 def test_should_show_empty_page_when_no_templates(

--- a/tests/app/notify_client/test_broadcast_message_client.py
+++ b/tests/app/notify_client/test_broadcast_message_client.py
@@ -12,6 +12,8 @@ def test_create_broadcast_message(mocker):
     client.create_broadcast_message(
         service_id='12345',
         template_id='67890',
+        content=None,
+        reference=None,
     )
     mock_post.assert_called_once_with(
         '/service/12345/broadcast-message',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4272,8 +4272,11 @@ def mock_create_broadcast_message(
     fake_uuid,
 ):
     def _create(
+        *,
         service_id,
         template_id,
+        content,
+        reference,
     ):
         return {
             'id': fake_uuid,


### PR DESCRIPTION
We think that in some cases alerts will be composed in the moment, and therefore making people first create a template is:
- not a good use of their time
- adding some conceptual complexity which they don’t need to take onboard

This commit makes it possible to type some words and have them go straight into the `content` field in the database.

In the future we might want to progressively enhance the radio buttons so they show on the same page (like we do with the grey buttons on the templates page).

***

![image](https://user-images.githubusercontent.com/355079/104940328-7d367c80-59a9-11eb-9a1e-4e2937939015.png)

![image](https://user-images.githubusercontent.com/355079/104940350-858eb780-59a9-11eb-91a9-775fd71e097e.png)

![image](https://user-images.githubusercontent.com/355079/104940397-94756a00-59a9-11eb-91fd-2e7c9ca8955c.png)

![image](https://user-images.githubusercontent.com/355079/104941083-84aa5580-59aa-11eb-8a91-a39e8c541dd1.png)

![image](https://user-images.githubusercontent.com/355079/104941374-e4a0fc00-59aa-11eb-8deb-e66b9a7f95cf.png)


***

Depends on:
- [x] https://www.pivotaltracker.com/story/show/176186142
- [x] https://github.com/alphagov/notifications-api/pull/3095