### PR TITLE
Remove inlining of images in CSS

### DIFF
--- a/app/assets/stylesheets/_url-helpers.scss
+++ b/app/assets/stylesheets/_url-helpers.scss
@@ -1,14 +1,12 @@
 // Copy of _url-helpers.scss in govuk_frontend_toolkit
-// to allow us to use gulp-base64-inline on all our images
-// gulp-base64-inline requires you to specify which of your
-// images you want encoded by using the `inline()` function
-// see https://github.com/goschevski/gulp-base64-inline
+// to prepend the path to where we store images
+
 @function file-url($file) {
   $url: '';
   @if $path {
-    $url: inline($path + $file);
+    $url: url($path + $file);
   } @else {
-    $url: image-url($file);
+    $url: url($file);
   }
   @return $url;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,6 @@ const stylish = require('jshint-stylish');
 const plugins = {};
 plugins.addSrc = require('gulp-add-src');
 plugins.babel = require('gulp-babel');
-plugins.base64 = require('gulp-base64-inline');
 plugins.cleanCSS = require('gulp-clean-css');
 plugins.concat = require('gulp-concat');
 plugins.cssUrlAdjuster = require('gulp-css-url-adjuster');
@@ -209,7 +208,6 @@ const sass = () => {
         paths.govuk_frontend,
       ]
     }))
-    .pipe(plugins.base64('../..'))
     .pipe(plugins.cssUrlAdjuster({
       replace: [staticPathMatcher, '/']
     }))

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gulp": "4.0.0",
     "gulp-add-src": "1.0.0",
     "gulp-babel": "8.0.0",
-    "gulp-base64-inline": "1.0.4",
     "gulp-better-rollup": "4.0.1",
     "gulp-clean-css": "4.2.0",
     "gulp-concat": "2.6.1",


### PR DESCRIPTION
In very old browsers (like IE6) it used to be that you could only make 2 concurrent requests from the same origin. This limit was defined the HTTP specification.

So base64 encoding of images into CSS was an optimisation that became popular because it reduced the number of separate requests. The Yahoo! developer network used to be the go-to place for guidance on this kind of stuff, and their first rule for high performance websites was [Make Fewer HTTP requests](http://web.archive.org/web/20070602032626/http://developer.yahoo.net/blog/archives/2007/04/rule_1_make_few.html).

When we added this optimisation back in 2016 we said that [combining requests was better ‘up to a point’](https://github.com/alphagov/notifications-admin/pull/187/commits/fd54eeaeb7552f547d3e20a5c8650cab04e6b6b2). At that point we only had [4 very small images](https://github.com/alphagov/notifications-admin/tree/fd54eeaeb7552f547d3e20a5c8650cab04e6b6b2/app/assets/images).

However base64 encoding images has a few disadvantages:
- it increases the size of the image by about 30%
- it increases the size of the CSS file, which is a [render blocking resource](https://web.dev/render-blocking-resources/)
  so makes the page appear to load more slowly for the sake of some images which, on most pages, never get used
- GZipping things that are already compressed (for example PNG data) is very CPU intensive, and might be why Cloudfront sometimes gives up

Removing the inlining of images reduces the size of the CSS we’re sending to the browser considerably:

Compression | Before | After | Saving
---|---|---|---
None | 198kb | 164kb | 17%
Gzip | 38kb | 23kb | 39%

Browsers started ignoring the 2-concurrent-connections limit in the HTTP spec, and [in 2014 it was removed](https://tools.ietf.org/html/rfc7230#section-6.4). Each browsers sets its own limit now, Chrome uses 6, for example. This, plus lower network latency, mean it’s a lot more efficient to request many small assets than it used to be. So the thing to optimise for now is reducing the number and size of render-blocking resources, like CSS.