### PR TITLE
Remove code to migrate cookie names

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -552,12 +552,6 @@ def make_session_permanent():
     when you first log in/sign up/get invited/etc, but we do it just to be safe. For more reading, check here:
     https://stackoverflow.com/questions/34118093/flask-permanent-session-where-to-define-them
     """
-
-    # TODO: Remove this loop after a weekend, when all cookies have either run through this code or expired
-    for val in ['user_id', 'remember', 'remember_seconds']:
-        if val in session:
-            session[f'_{val}'] = session[val]
-
     session.permanent = True
 
 


### PR DESCRIPTION
We added this code in https://github.com/alphagov/notifications-admin/pull/3371 to account for Flask Login renaming its cookies. We wanted our apps to be compatible with the old and new names, so people didn’t get logged out when we rolled out the change.

Now that all the cookies with the old names will have expired (some weekends have passed since March) we can remove this loop.