### PR TITLE
Add server timing headers to measure backend performance 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,7 @@ from notifications_utils.recipients import (
 from notifications_utils.sanitise_text import SanitiseASCII
 from notifications_utils.take import Take
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
+from server_timing import Timing
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 from werkzeug.exceptions import abort
 from werkzeug.local import LocalProxy
@@ -193,6 +194,8 @@ def create_app(application):
     register_errorhandlers(application)
 
     setup_event_handlers()
+
+    application.server_timing = Timing(application)
 
 
 def init_app(application):

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -3,7 +3,20 @@ from notifications_utils.clients.antivirus.antivirus_client import (
 )
 from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
+from server_timing import Timing
+
+
+class TimingRedisClient(RedisClient):
+
+    def init_app(self, app):
+        self.server_timing = Timing(app)
+        super().init_app(app)
+
+    def get(self, key, raise_exception=False):
+        with self.server_timing.time(f'Redis--{key}'):
+            return super().get(key, raise_exception=raise_exception)
+
 
 antivirus_client = AntivirusClient()
 zendesk_client = ZendeskClient()
-redis_client = RedisClient()
+redis_client = TimingRedisClient()

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -9,6 +9,7 @@ freezegun==0.3.12
 flake8==3.7.9
 flake8-bugbear==19.8.0
 flake8-print==3.1.4
+flask-server-timing==0.1.2
 requests-mock==1.7.0
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.7.0


### PR DESCRIPTION
This is just a little spike into implementing [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) headers. We can decide if this is actually useful.

Lets us use Chrome/Firefox dev tools to see where time is spent on the backend. This is an example for the uploads page:

![image](https://user-images.githubusercontent.com/355079/103350383-b741ec00-4a97-11eb-944f-af953e26d607.png)

