### PR TITLE
Remove hack for bug in Chrome autocomplete

### DIFF
--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -27,7 +27,6 @@ Create an account
           "classes": "govuk-!-width-three-quarters"
         }) }}
       </div>
-      <input class="govuk-visually-hidden" aria-hidden="true" tabindex="-1" id="defeat-chrome-autocomplete">
       {{ form.password(param_extensions={"hint": {"text": "At least 8 characters"}, "classes": "govuk-!-width-three-quarters", "autocomplete": "new-password"}) }}
       {{form.auth_type}}
       {{ page_footer("Continue") }}


### PR DESCRIPTION
We added an extra, hidden, <input> to our /sign-in and /register forms to stop Chrome's form heuristics filling the fields in wrong.

See the commit that added it:

https://github.com/alphagov/notifications-admin/commit/33b15cdec6ce4eb4ad70a5e0701a2e49466cf825

This was raised as being a potential (very minor) issue in the accessibility audit that was part of our service assessment.

This proposes removing it, based on testing with the following Chrome/OS combinations without the hack, all of which worked:

- Chrome 87, OSX Mojave (10.14.6)
- Chrome 87, Windows 7
- Chrome 86, Windows 8.1
- Chrome 86, Windows 7
- Chrome 86, Windows 10
- Chrome 85, Windows 7
- Chrome 81, Windows 7
- Chrome 80, Windows 10
- Chrome 78, Windows 8.1
- Chrome 68, Windows 7
- Chrome 52, Windows 7

These combinations were based on the most-used versions from in our analytics for the last 3 months.

For each, I set up a saved address with:
- name
- email address
- phone number
...and tried entering my details on /sign-in and /register.