### PR TITLE
Add label for hidden username field

### DIFF
--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -22,6 +22,7 @@ Create an account
         the view process the input.
       #}
       <div class="govuk-visually-hidden">
+        <label for="username" aria-hidden="true">Email</label>
         <input type="email" name="username" id="username" value="{{ invited_user.email_address }}" disabled="disabled" tabindex="-1" aria-hidden="true" autocomplete="username" />
       </div>
       {{ form.name(param_extensions={"classes": "govuk-!-width-three-quarters"}) }}


### PR DESCRIPTION
The /register page contains a hidden input to help password managers remember your login details (see https://github.com/alphagov/notifications-admin/pull/3559).

This was logged as a problem in an accessibility review we had as part of our service assessment due to it appearing when CSS is disabled. The use case here, from an accessibility auditor, is users who disable styles and use their own stylesheet to make the visual interface work for their disability.

We already hide it from assistive tech' by `aria-hidden="true"`, disable it and remove it from the tab order.  This just leaves the problem that it appears visually without explanation which could be confusing:

<img width="739" alt="register_from_invite_no_css_current" src="https://user-images.githubusercontent.com/87140/103792876-c72f7200-503b-11eb-9a9a-8e9117ac7e9a.png">

This proposes adding a semantically hidden label to explain what it is. I think this combines with the paragraph above it to explain that it is information already entered that doesn't need any interaction from the user.

<img width="733" alt="register_from_invite_no_css_with_label" src="https://user-images.githubusercontent.com/87140/103794034-23929180-503c-11eb-9638-5a30ea4c1e65.png">

Users who cannot access the visual interface won't see either the label or its input but the paragraph above them provides the same information, like users with CSS.

I've tried using the form with Voiceover with the visual interface visible, to simulate this kind of use. It doesn't feel odd that the input isn't interactive as it has the visuals of being disabled and the paragraph above explains that information has already been taken.

