### PR TITLE
Update support page content

### DIFF
--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -9,7 +9,7 @@
 {% block maincolumn_content %}
 
   <h1 class="heading-large">Support</h1>
-  <p class="govuk-body">We provide 24-hour online support for teams with a live service on GOV.UK&nbsp;Notify.</p>
+  <p class="govuk-body">GOV.UK Notify provides 24-hour online support.</p>
 
   {% call form_wrapper() %}
     {% if current_user.is_authenticated %}
@@ -35,7 +35,7 @@
     <p class="govuk-body">Outside office hours, response times depend on whether you’re reporting an emergency.</p>
     <p class="govuk-body">If it’s an emergency, we’ll reply within 30 minutes and update you every hour until the problem’s fixed.</p>
     <p class="govuk-body">If your problem is not an emergency, we’ll reply within one working day.</p>
-    <p class="govuk-body">A problem is only classed as an emergency if:</p>
+    <p class="govuk-body">A problem is only classed as an emergency if you have a live service and:</p>
     <ul class="list list-bullet">
       <li>nobody on your team can sign in</li>
       <li>a ‘technical difficulties’ error appears when you try to upload a file</li>


### PR DESCRIPTION
This PR updates the content of the support page to make the terms of our support clearer.

The current content says:
> We provide 24-hour online support for teams with a live service on GOV.UK Notify.

This was interpreted to mean that teams with a trial service should email the team instead.

The support form already gives non-live teams an expected response time, so we can improve the Support page content by simplifying the introduction and updating the _Out-of-hours_ section.

## Introduction
![Screenshot 2021-01-11 at 13 00 10](https://user-images.githubusercontent.com/28294225/104186390-3d522100-540e-11eb-873d-96744c1dbc56.png)

## Out-of-hours section
![Screenshot 2021-01-11 at 13 10 39](https://user-images.githubusercontent.com/28294225/104186514-6d99bf80-540e-11eb-95de-e5ec30c424b7.png)
