### PR TITLE
Remove logging of session size

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1,5 +1,4 @@
 import itertools
-import json
 from string import ascii_uppercase
 from zipfile import BadZipFile
 
@@ -109,14 +108,6 @@ def get_example_letter_address(key):
 @main.route("/services/<uuid:service_id>/send/<uuid:template_id>/csv", methods=['GET', 'POST'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def send_messages(service_id, template_id):
-    # if there's lots of data in the session, lets log it for debugging purposes
-    # TODO: Remove this once we're confident we have session size under control
-    if len(session.get('file_uploads', {}).keys()) > 2:
-        current_app.logger.info('session contains large file_uploads - json_len {}, keys: {}'.format(
-            len(json.dumps(session['file_uploads'])),
-            session['file_uploads'].keys())
-        )
-
     db_template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
     email_reply_to = None


### PR DESCRIPTION
There’s no record of this warning in our logs at the moment, and we haven’t seen any users report problems recently.

This logging was added 3 years ago: https://github.com/alphagov/notifications-admin/pull/2004
