### PR TITLE
Clear the organisation cache when a service's organisation is changed.

### DIFF
--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -64,6 +64,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
 
     @cache.delete('service-{service_id}')
     @cache.delete('live-service-and-organisation-counts')
+    @cache.delete('organisations')
     def update_service_organisation(self, service_id, org_id):
         data = {
             'service_id': service_id

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import pytest
 
@@ -192,3 +192,23 @@ def test_update_organisation_when_updating_org_type_but_org_has_no_services(mock
         call('organisations'),
         call('domains'),
     ]
+
+
+def test_update_service_organisation_deletes_cache(mocker, fake_uuid):
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')
+
+    organisations_client.update_service_organisation(
+        service_id=fake_uuid,
+        org_id=fake_uuid
+    )
+
+    assert sorted(mock_redis_delete.call_args_list) == [
+        call('live-service-and-organisation-counts'),
+        call('organisations'),
+        call('service-{}'.format(fake_uuid)),
+    ]
+    mock_post.assert_called_with(
+        url='/organisations/{}/service'.format(fake_uuid),
+        data=ANY
+    )


### PR DESCRIPTION
The /organisations page was showing the wrong live services count after a change is made to the service organisation.