### PR TITLE
Add GOVUK radios [part 6]

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -46,3 +46,9 @@
 .govuk-button {
   margin-bottom: 0px;
 }
+
+// Allow legends that contain the h1 to go full width
+.govuk-fieldset__legend.govuk-grid-column-full {
+  // $class parameter is deprecated but needed for v2 of GOVUK Frontend. Remove for v3 & above
+  @include govuk-grid-column(full, $class: false);
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1523,7 +1523,7 @@ class CreateKeyForm(StripWhitespaceForm):
         ]
         super().__init__(*args, **kwargs)
 
-    key_type = RadioField(
+    key_type = GovukRadiosField(
         'Type of key',
         thing='the type of key',
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2011,7 +2011,7 @@ class SetSenderForm(StripWhitespaceForm):
         self.sender.choices = kwargs['sender_choices']
         self.sender.label.text = kwargs['sender_label']
 
-    sender = RadioField()
+    sender = GovukRadiosField()
 
 
 class SetTemplateSenderForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2021,7 +2021,7 @@ class SetTemplateSenderForm(StripWhitespaceForm):
         self.sender.choices = kwargs['sender_choices']
         self.sender.label.text = 'Select your sender'
 
-    sender = RadioField()
+    sender = GovukRadiosField()
 
 
 class LinkOrganisationsForm(StripWhitespaceForm):

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -234,6 +234,15 @@ def set_sender(service_id, template_id):
     if sender_context.get('default_and_receives', None):
         option_hints = {sender_context['default_and_receives']: '(Default and receives replies)'}
 
+    # extend all radios that need hint text
+    form.sender.param_extensions = {'items': []}
+    for item_id, _item_value in form.sender.choices:
+        if item_id in option_hints:
+            extensions = {'hint': {'text': option_hints[item_id]}}
+        else:
+            extensions = {}  # if no extensions needed, send an empty dict to preserve order of items
+        form.sender.param_extensions['items'].append(extensions)
+
     if form.validate_on_submit():
         session['sender_id'] = form.sender.data
         return redirect(url_for('.send_one_off',

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -829,7 +829,14 @@ def set_template_sender(service_id, template_id):
         sender=sender_details['current_choice'],
         sender_choices=sender_details['value_and_label'],
     )
-    option_hints = {sender_details['default_sender']: '(Default)'}
+    form.sender.param_extensions = {'items': []}
+    for item_value, _item_label in sender_details['value_and_label']:
+        if item_value == sender_details['default_sender']:
+            extensions = {'hint': {'text': '(Default)'}}
+        else:
+            extensions = {}  # if no extensions needed, send an empty dict to preserve order of items
+
+        form.sender.param_extensions['items'].append(extensions)
 
     if form.validate_on_submit():
         service_api_client.update_service_template_sender(
@@ -843,8 +850,7 @@ def set_template_sender(service_id, template_id):
         'views/templates/set-template-sender.html',
         form=form,
         template_id=template_id,
-        no_senders=no_senders,
-        option_hints=option_hints
+        no_senders=no_senders
     )
 
 

--- a/app/templates/views/add-service-local.html
+++ b/app/templates/views/add-service-local.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/radios.html" import radios %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 
@@ -18,7 +17,7 @@
 
   {% call form_wrapper() %}
     {{ form.key_name }}
-    {{ radios(form.key_type, disable=disabled_options, option_hints=option_hints) }}
+    {{ form.key_type }}
     {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -2,7 +2,6 @@
 {% from "components/textbox.html" import textbox %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
-{% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}

--- a/app/templates/views/organisations/organisation/settings/edit-agreement.html
+++ b/app/templates/views/organisations/organisation/settings/edit-agreement.html
@@ -1,4 +1,3 @@
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -1,4 +1,3 @@
-{% from "components/radios.html" import radios %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/list-entry.html" import list_entry %}

--- a/app/templates/views/service-settings/data-retention/edit.html
+++ b/app/templates/views/service-settings/data-retention/edit.html
@@ -2,7 +2,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/radios.html" import radios %}
 
 {% block service_page_title %}
   Data retention

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -3,28 +3,32 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
 
 {% block service_page_title %}
-  {{sender_context['title']}}
+  {{ sender_context.title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  {{ page_header(
-    sender_context.title,
-    back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
-  ) }}
+  {{ govukBackLink({ "href": url_for('.view_template', service_id=current_service.id, template_id=template_id) }) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      {% call form_wrapper() %}
-        {{ radios(
-          form.sender,
-          option_hints=option_hints,
-          hide_legend=True
-        ) }}
+  <div class="govuk-grid-row govuk-!-margin-top-3">
+    {% call form_wrapper() %}
+      {{ form.sender(param_extensions={
+        'fieldset': {
+          'legend': {
+            'isPageHeading': True,
+            'text': sender_context.title,
+            'classes': 'govuk-fieldset__legend--l govuk-grid-column-full'
+          }
+        },
+        'classes': 'govuk-grid-column-three-quarters'
+      }) }}
+      <div class="govuk-grid-column-three-quarters">
         {{ page_footer('Continue') }}
-      {% endcall %}
+      </div>
+    {% endcall %}
     </div>
   </div>
 

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -1,31 +1,35 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radios %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
+{% set page_title = 'Set letter contact block' %}
 
 {% block service_page_title %}
-  Set letter contact block
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  {{ page_header(
-    'Set letter contact block',
-    back_link=url_for('.view_template', service_id=current_service.id, template_id=template_id)
-  ) }}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      {% call form_wrapper() %}
-        {{ radios(
-          form.sender,
-          option_hints=option_hints,
-          hide_legend=True
-        ) }}
+  {{ govukBackLink({ "href": url_for('.view_template', service_id=current_service.id, template_id=template_id) }) }}
+
+  <div class="govuk-grid-row govuk-!-margin-top-3">
+    {% call form_wrapper() %}
+      {{ form.sender(param_extensions={
+        'fieldset': {
+          'legend': {
+            'isPageHeading': True,
+            'text': page_title,
+            'classes': 'govuk-fieldset__legend--l govuk-grid-column-full'
+          }
+        },
+        'classes': 'govuk-grid-column-three-quarters'
+      }) }}
+      <div class="govuk-grid-column-three-quarters">
         {{ page_footer('Continue') }}
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.service_add_letter_contact', service_id=current_service.id, from_template=template_id) }}">Add new sender</a>
-      {% endcall %}
     </div>
+    {% endcall %}
   </div>
 
 {% endblock %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -205,7 +205,7 @@ def test_should_show_api_keys_page(
 @pytest.mark.parametrize('restricted, can_send_letters, expected_options', [
     (True, False, [
         (
-            'Live – sends to anyone '
+            'Live – sends to anyone',
             'Not available because your service is in trial mode'
         ),
         'Team and guest list – limits who you can send to',
@@ -219,7 +219,7 @@ def test_should_show_api_keys_page(
     (False, True, [
         'Live – sends to anyone',
         (
-            'Team and guest list – limits who you can send to '
+            'Team and guest list – limits who you can send to',
             'Cannot be used to send letters'
         ),
         'Test – pretends to send messages',
@@ -244,7 +244,12 @@ def test_should_show_create_api_key_page(
     page = client_request.get('main.create_api_key', service_id=SERVICE_ONE_ID)
 
     for index, option in enumerate(expected_options):
-        assert normalize_spaces(page.select('.block-label')[index].text) == option
+        item = page.select('.govuk-radios__item')[index]
+        if type(option) is tuple:
+            assert normalize_spaces(item.select_one('.govuk-label').text) == option[0]
+            assert normalize_spaces(item.select_one('.govuk-hint').text) == option[1]
+        else:
+            assert normalize_spaces(item.select_one('.govuk-label').text) == option
 
 
 def test_should_create_api_key_with_type_normal(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -68,10 +68,7 @@ def test_show_correct_title_and_description_for_email_sender_type(
         template_id=fake_uuid
     )
 
-    assert page.select_one('h1').text == 'Where should replies come back to?'
-
-    for element in ('legend', 'legend .govuk-visually-hidden'):
-        assert normalize_spaces(page.select_one(element).text) == 'Where should replies come back to?'
+    assert page.select_one('.govuk-fieldset__legend h1').text.strip() == 'Where should replies come back to?'
 
 
 def test_show_correct_title_and_description_for_sms_sender_type(
@@ -86,10 +83,7 @@ def test_show_correct_title_and_description_for_sms_sender_type(
         template_id=fake_uuid
     )
 
-    assert page.select_one('h1').text == 'Who should the message come from?'
-
-    for element in ('legend', 'legend .govuk-visually-hidden'):
-        assert normalize_spaces(page.select_one(element).text) == 'Who should the message come from?'
+    assert page.select_one('.govuk-fieldset__legend h1').text.strip() == 'Who should the message come from?'
 
 
 def test_default_email_sender_is_checked_and_has_hint(
@@ -104,9 +98,9 @@ def test_default_email_sender_is_checked_and_has_hint(
         template_id=fake_uuid
     )
 
-    assert page.select('.multiple-choice input')[0].has_attr('checked')
-    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "(Default)"
-    assert not page.select('.multiple-choice input')[1].has_attr('checked')
+    assert page.select('.govuk-radios input')[0].has_attr('checked')
+    assert normalize_spaces(page.select_one('.govuk-radios .govuk-hint').text) == "(Default)"
+    assert not page.select('.govuk-radios input')[1].has_attr('checked')
 
 
 def test_default_sms_sender_is_checked_and_has_hint(
@@ -121,9 +115,9 @@ def test_default_sms_sender_is_checked_and_has_hint(
         template_id=fake_uuid
     )
 
-    assert page.select('.multiple-choice input')[0].has_attr('checked')
-    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "(Default)"
-    assert not page.select('.multiple-choice input')[1].has_attr('checked')
+    assert page.select('.govuk-radios input')[0].has_attr('checked')
+    assert normalize_spaces(page.select_one('.govuk-radios .govuk-hint').text) == "(Default)"
+    assert not page.select('.govuk-radios input')[1].has_attr('checked')
 
 
 def test_default_sms_sender_is_checked_and_has_hint_when_there_are_no_inbound_numbers(
@@ -138,9 +132,9 @@ def test_default_sms_sender_is_checked_and_has_hint_when_there_are_no_inbound_nu
         template_id=fake_uuid
     )
 
-    assert page.select('.multiple-choice input')[0].has_attr('checked')
-    assert normalize_spaces(page.select_one('.multiple-choice label .block-label-hint').text) == "(Default)"
-    assert not page.select('.multiple-choice input')[1].has_attr('checked')
+    assert page.select('.govuk-radios input')[0].has_attr('checked')
+    assert normalize_spaces(page.select_one('.govuk-radios .govuk-hint').text) == "(Default)"
+    assert not page.select('.govuk-radios input')[1].has_attr('checked')
 
 
 def test_default_inbound_sender_is_checked_and_has_hint_with_default_and_receives_text(
@@ -156,11 +150,11 @@ def test_default_inbound_sender_is_checked_and_has_hint_with_default_and_receive
         template_id=fake_uuid
     )
 
-    assert page.select('.multiple-choice input')[0].has_attr('checked')
+    assert page.select('.govuk-radios input')[0].has_attr('checked')
     assert normalize_spaces(
-        page.select_one('.multiple-choice label .block-label-hint').text) == "(Default and receives replies)"
-    assert not page.select('.multiple-choice input')[1].has_attr('checked')
-    assert not page.select('.multiple-choice input')[2].has_attr('checked')
+        page.select_one('.govuk-radios .govuk-hint').text) == "(Default and receives replies)"
+    assert not page.select('.govuk-radios input')[1].has_attr('checked')
+    assert not page.select('.govuk-radios input')[2].has_attr('checked')
 
 
 def test_sms_sender_has_receives_replies_hint(
@@ -176,11 +170,11 @@ def test_sms_sender_has_receives_replies_hint(
         template_id=fake_uuid
     )
 
-    assert page.select('.multiple-choice input')[0].has_attr('checked')
+    assert page.select('.govuk-radios input')[0].has_attr('checked')
     assert normalize_spaces(
-        page.select_one('.multiple-choice label .block-label-hint').text) == "(Default and receives replies)"
-    assert not page.select('.multiple-choice input')[1].has_attr('checked')
-    assert not page.select('.multiple-choice input')[2].has_attr('checked')
+        page.select_one('.govuk-radios .govuk-hint').text) == "(Default and receives replies)"
+    assert not page.select('.govuk-radios input')[1].has_attr('checked')
+    assert not page.select('.govuk-radios input')[2].has_attr('checked')
 
 
 @pytest.mark.parametrize('template_type, sender_data', [

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2527,7 +2527,7 @@ def test_add_sender_link_only_appears_on_services_with_no_senders(
         template_id=fake_uuid,
     )
 
-    assert page.select_one('.govuk-grid-column-three-quarters form > a')['href'] == url_for(
+    assert page.select_one('form .page-footer + a')['href'] == url_for(
         'main.service_add_letter_contact',
         service_id=SERVICE_ONE_ID,
         from_template=fake_uuid,


### PR DESCRIPTION
Part 6 of migrating our radio buttons to use the [GOV.UK Frontend radios component](https://design-system.service.gov.uk/components/radios/).

https://www.pivotaltracker.com/story/show/170030262

This pull request converts all radios left from the other parts, except those used to select a folder to move a template/folder to on /templates.

## Notes for reviewers

This pull request is better reviewed commit-by-commit as each one, except the last, convert a single form and field.

### Added CSS

Converting the `SetSenderForm` required adding some new CSS to let the `h1`, now in a `legend`, have the whole width of the main column while the radios below have less space. This can be tested by changing the `h1` to be a string long enough that it fills the main column.

### More on this sequence of work

Part 1 of this work was done in https://github.com/alphagov/notifications-admin/pull/3715.
Pull requests for the other parts are:
- part 2: https://github.com/alphagov/notifications-admin/pull/3727
- part 3: https://github.com/alphagov/notifications-admin/pull/3728
- part 4: https://github.com/alphagov/notifications-admin/pull/3730
- part 5: https://github.com/alphagov/notifications-admin/pull/3731