### PR TITLE
Fix bug with extend_params function

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -649,16 +649,19 @@ def extend_params(params, extensions):
     # merge dicts
     merge_jsonlike(params, extensions)
 
+    # tidy up
+    extensions['items'] = items
+
     # merge items
     if items:
         if 'items' not in params:
-            params['items'] = items
+            params['items'] = extensions['items']
         else:
-            for idx, _item in enumerate(items):
+            for idx, _item in enumerate(extensions['items']):
                 if idx >= param_items:
-                    params['items'].append(items[idx])
+                    params['items'].append(extensions['items'][idx])
                 else:
-                    params['items'][idx].update(items[idx])
+                    params['items'][idx].update(extensions['items'][idx])
 
 
 def govuk_checkbox_field_widget(self, field, param_extensions=None, **kwargs):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -637,33 +637,6 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
     auth_type = HiddenField('auth_type', validators=[DataRequired()])
 
 
-def extend_params(params, extensions):
-    items = None
-    param_items = len(params['items']) if 'items' in params else 0
-
-    # split items off from params to make it a pure dict
-    if 'items' in extensions:
-        items = extensions['items']
-        del extensions['items']
-
-    # merge dicts
-    merge_jsonlike(params, extensions)
-
-    # tidy up
-    extensions['items'] = items
-
-    # merge items
-    if items:
-        if 'items' not in params:
-            params['items'] = extensions['items']
-        else:
-            for idx, _item in enumerate(extensions['items']):
-                if idx >= param_items:
-                    params['items'].append(extensions['items'][idx])
-                else:
-                    params['items'][idx].update(extensions['items'][idx])
-
-
 def govuk_checkbox_field_widget(self, field, param_extensions=None, **kwargs):
 
     # error messages
@@ -695,11 +668,11 @@ def govuk_checkbox_field_widget(self, field, param_extensions=None, **kwargs):
 
     # extend default params with any sent in during instantiation
     if self.param_extensions:
-        extend_params(params, self.param_extensions)
+        merge_jsonlike(params, self.param_extensions)
 
     # add any sent in though use in templates
     if param_extensions:
-        extend_params(params, param_extensions)
+        merge_jsonlike(params, param_extensions)
 
     return Markup(
         render_template('forms/fields/checkboxes/macro.njk', params=params))
@@ -751,11 +724,11 @@ def govuk_checkboxes_field_widget(self, field, wrap_in_collapsible=False, param_
 
     # extend default params with any sent in during instantiation
     if self.param_extensions:
-        extend_params(params, self.param_extensions)
+        merge_jsonlike(params, self.param_extensions)
 
     # add any sent in though use in templates
     if param_extensions:
-        extend_params(params, param_extensions)
+        merge_jsonlike(params, param_extensions)
 
     if wrap_in_collapsible:
 
@@ -805,11 +778,11 @@ def govuk_radios_field_widget(self, field, param_extensions=None, **kwargs):
 
     # extend default params with any sent in during instantiation
     if self.param_extensions:
-        extend_params(params, self.param_extensions)
+        merge_jsonlike(params, self.param_extensions)
 
     # add any sent in though use in templates
     if param_extensions:
-        extend_params(params, param_extensions)
+        merge_jsonlike(params, param_extensions)
 
     return Markup(
         render_template('components/radios/template.njk', params=params))

--- a/app/utils.py
+++ b/app/utils.py
@@ -651,9 +651,9 @@ def merge_jsonlike(source, destination):
         return True
 
     def merge_lists(source, destination):
-        last_dest_idx = len(destination) - 1
+        last_src_idx = len(source) - 1
         for idx, item in enumerate(destination):
-            if idx <= last_dest_idx:
+            if idx <= last_src_idx:
                 # assign destination value if can't be merged into source
                 if merge_items(source[idx], destination[idx]) is False:
                     source[idx] = destination[idx]

--- a/app/utils.py
+++ b/app/utils.py
@@ -651,8 +651,13 @@ def merge_jsonlike(source, destination):
         return True
 
     def merge_lists(source, destination):
-        for item in destination:
-            if item not in source:
+        last_dest_idx = len(destination) - 1
+        for idx, item in enumerate(destination):
+            if idx <= last_dest_idx:
+                # assign destination value if can't be merged into source
+                if merge_items(source[idx], destination[idx]) is False:
+                    source[idx] = destination[idx]
+            else:
                 source.append(item)
 
     def merge_dicts(source, destination):

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -616,6 +616,8 @@ def test_get_sample_template_returns_template(template_type):
     ({"a": {"b": "c"}}, {"a": {"e": "f"}}, {"a": {"b": "c", "e": "f"}}),
     # same key in both dicts, value is a string, destination supercedes source:
     ({"a": "b"}, {"a": "c"}, {"a": "c"}),
+    # nested dict added to new key of dict, additive behaviour:
+    ({"a": "b"}, {"c": {"d": "e"}}, {"a": "b", "c": {"d": "e"}}),
     # lists with same length but different items, destination supercedes source:
     (["b", "c", "d"], ["b", "e", "f"], ["b", "e", "f"]),
     # lists in dicts behave as top level lists
@@ -626,8 +628,14 @@ def test_get_sample_template_returns_template(template_type):
     ([{"b": "c"}], [{"b": "c"}], [{"b": "c"}]),
     # if dicts in lists have different values, they are not merged
     ([{"b": "c"}], [{"b": "e"}], [{"b": "e"}]),
+    # if nested dicts in lists have different keys, additive behaviour
+    ([{"b": "c"}], [{"d": {"e": "f"}}], [{"b": "c", "d": {"e": "f"}}]),
     # merge a dict with a null object returns that dict (does not work the other way round)
-    ({"a": {"b": "c"}}, None, {"a": {"b": "c"}})
+    ({"a": {"b": "c"}}, None, {"a": {"b": "c"}}),
+    # double nested dicts, new adds new Boolean key: value, additive behaviour
+    ({"a": {"b": {"c": "d"}}}, {"a": {"b": {"e": True}}}, {"a": {"b": {"c": "d", "e": True}}}),
+    # double nested dicts, both have same key, different values, destination supercedes source
+    ({"a": {"b": {"c": "d"}}}, {"a": {"b": {"c": "e"}}}, {"a": {"b": {"c": "e"}}})
 ])
 def test_merge_jsonlike_merges_jsonlike_objects_correctly(source_object, destination_object, expected_result):
     merge_jsonlike(source_object, destination_object)

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -614,18 +614,20 @@ def test_get_sample_template_returns_template(template_type):
     ({"a": "b"}, {"c": "d"}, {"a": "b", "c": "d"}),
     # dicts with nested dict, both under same key, additive behaviour:
     ({"a": {"b": "c"}}, {"a": {"e": "f"}}, {"a": {"b": "c", "e": "f"}}),
-    # same key in both dicts, value is a string, destination supersedes source:
+    # same key in both dicts, value is a string, destination supercedes source:
     ({"a": "b"}, {"a": "c"}, {"a": "c"}),
+    # lists with same length but different items, destination supercedes source:
+    (["b", "c", "d"], ["b", "e", "f"], ["b", "e", "f"]),
     # lists in dicts behave as top level lists
-    ({"a": ["b", "c", "d"]}, {"a": ["b", "e", "f"]}, {"a": ["b",  "c", "d", "e", "f"]}),
-    # lists with same string in both result in a list of unique values
-    (["a", "b", "c", "d"], ["d", "e", "f"], ["a", "b", "c", "d", "e", "f"]),
+    ({"a": ["b", "c", "d"]}, {"a": ["b", "e", "f"]}, {"a": ["b", "e", "f"]}),
+    # lists with same string in both, at different positions, result in duplicates keeping their positions
+    (["a", "b", "c", "d"], ["d", "e", "f"], ["d", "e", "f", "d"]),
     # lists with same dict in both result in a list with one instance of that dict
     ([{"b": "c"}], [{"b": "c"}], [{"b": "c"}]),
     # if dicts in lists have different values, they are not merged
-    ([{"b": "c"}], [{"b": "e"}], [{"b": "c"}, {"b": "e"}]),
+    ([{"b": "c"}], [{"b": "e"}], [{"b": "e"}]),
     # merge a dict with a null object returns that dict (does not work the other way round)
-    ({"a": {"b": "c"}}, None, {"a": {"b": "c"}}),
+    ({"a": {"b": "c"}}, None, {"a": {"b": "c"}})
 ])
 def test_merge_jsonlike_merges_jsonlike_objects_correctly(source_object, destination_object, expected_result):
     merge_jsonlike(source_object, destination_object)

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -630,6 +630,8 @@ def test_get_sample_template_returns_template(template_type):
     ([{"b": "c"}], [{"b": "e"}], [{"b": "e"}]),
     # if nested dicts in lists have different keys, additive behaviour
     ([{"b": "c"}], [{"d": {"e": "f"}}], [{"b": "c", "d": {"e": "f"}}]),
+    # if dicts in destination list but not source, they just get added to end of source
+    ([{"a": "b"}], [{"a": "b"}, {"a": "b"}, {"c": "d"}], [{"a": "b"}, {"a": "b"}, {"c": "d"}]),
     # merge a dict with a null object returns that dict (does not work the other way round)
     ({"a": {"b": "c"}}, None, {"a": {"b": "c"}}),
     # double nested dicts, new adds new Boolean key: value, additive behaviour


### PR DESCRIPTION
The /organisations/<org_id>/settings/edit-agreement page has a bug where the hints appear on load:

<img width="981" alt="edit-agreement_on_load" src="https://user-images.githubusercontent.com/87140/104710237-c53e7080-5717-11eb-8bb9-8764ff71114e.png">

but then disappear when the page refreshes.

<img width="983" alt="edit-agreement_on_refresh" src="https://user-images.githubusercontent.com/87140/104710261-ca9bbb00-5717-11eb-9a4a-b91001756fdb.png">

I'm pretty sure this is because of a side effect in the `extend_params` function in `app/main/forms.py`.

## Detail of the fix

The radios in this page are `OrganisationAgreementSignedForm.agreement_signed`which inherits from the [RadioField from the WTF library](https://wtforms.readthedocs.io/en/2.3.x/fields/#wtforms.fields.RadioField) but with its rendering rewritten to use [the Radios component from the design system](https://design-system.service.gov.uk/components/radios/) to render HTML.

When `OrganisationAgreementSignedForm.agreement_signed` renders its HTML, it passes a `dict` called `params` to the design system radios component: https://github.com/alphagov/notifications-admin/blob/master/app/main/forms.py#L812

`params` has default contents but `OrganisationAgreementSignedForm.agreement_signed` also has a `param_extensions` attribute for any updates you want to make to `params`. A function called `extend_params` is used to apply any updates from `param_extensions` to `params`, before rendering happens: https://github.com/alphagov/notifications-admin/blob/master/app/main/forms.py#L803

As part of its work, `extend_params` deletes the `'items'` property of `param_extensions`. I believe this is the cause of the bug: https://github.com/alphagov/notifications-admin/blob/master/app/main/forms.py#L647

 I think what is happening is:
1. the page is requested for the first time
2. `OrganisationAgreementSignedForm.agreement_signed.param_extensions['items']` is deleted by `extend_params`
3. `OrganisationAgreementSignedForm.agreement_signed.param_extensions is cached in memory
4. the second request (from a page refresh) happens
5. the hints, which are added to `param_extensions['items']`, don't appear