### PR TITLE
Fix all radios forms with duplicate legends

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1928,7 +1928,7 @@ class ServiceInboundNumberForm(StripWhitespaceForm):
         self.inbound_number.choices = kwargs['inbound_number_choices']
 
     inbound_number = GovukRadiosField(
-        "Select your inbound number",
+        "Set inbound number",
         thing='an inbound number',
     )
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -209,11 +209,13 @@ def user_profile_disable_platform_admin_view():
         abort(403)
 
     form = ServiceOnOffSettingForm(
-        name="Signing in again clears this setting",
+        name="Use platform admin view",
         enabled=not session.get('disable_platform_admin_view'),
         truthy='Yes',
         falsey='No',
     )
+
+    form.enabled.param_extensions = {"hint": {"text": "Signing in again clears this setting"}}
 
     if form.validate_on_submit():
         session['disable_platform_admin_view'] = not form.enabled.data

--- a/app/templates/views/service-settings/set-inbound-number.html
+++ b/app/templates/views/service-settings/set-inbound-number.html
@@ -27,7 +27,6 @@
       {{ form.inbound_number(param_extensions={
         'fieldset': {
           'legend': {
-            'text': page_title,
             'isPageHeading': True,
             'classes': 'govuk-fieldset__legend--l'
           }

--- a/app/templates/views/service-settings/set-inbound-number.html
+++ b/app/templates/views/service-settings/set-inbound-number.html
@@ -2,25 +2,39 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
+{% set page_title = 'Set inbound number' %}
 
 {% block service_page_title %}
-  Set inbound number
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
+  {% if current_service.has_inbound_number or no_available_numbers %}
     {{ page_header(
-      'Set inbound number',
+      page_title,
       back_link=url_for('.service_settings', service_id=current_service.id)
     ) }}
-    {% if current_service.has_inbound_number %}
+  {% endif %}
+  {% if current_service.has_inbound_number %}
     <p class="govuk-body"> This service already has an inbound number </p>
-    {% elif no_available_numbers %}
+  {% elif no_available_numbers %}
     <p class="govuk-body"> No available inbound numbers </p>
-    {% else %}
-    {% call form_wrapper() %}
-      {{ form.inbound_number }}
+  {% else %}
+    {{ govukBackLink({ "href": url_for('.service_settings', service_id=current_service.id) }) }}
+    {% call form_wrapper(class="govuk-!-margin-top-3") %}
+      {{ form.inbound_number(param_extensions={
+        'fieldset': {
+          'legend': {
+            'text': page_title,
+            'isPageHeading': True,
+            'classes': 'govuk-fieldset__legend--l'
+          }
+        }
+      }) }}
       {{ sticky_page_footer('Save') }}
     {% endcall %}
-	{% endif %}
+  {% endif %}
 
 {% endblock %}

--- a/app/templates/views/user-profile/disable-platform-admin-view.html
+++ b/app/templates/views/user-profile/disable-platform-admin-view.html
@@ -1,23 +1,32 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/page-header.html" import page_header %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
+{% set page_title = 'Use platform admin view' %}
 
 {% block per_page_title %}
-  Use platform admin view
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-      {{ page_header(
-        'Use platform admin view',
-        back_link=url_for('.user_profile')
-      ) }}
+      {{ govukBackLink({ "href": url_for('.user_profile') }) }}
 
-      {% call form_wrapper() %}
-        {{ form.enabled }}
+      {% call form_wrapper(class="govuk-!-margin-top-3") %}
+        {{ form.enabled(param_extensions={
+          'fieldset': {
+            'legend': {
+              'isPageHeading': True,
+              'classes': 'govuk-fieldset__legend--l'
+            }
+          },
+          'hint': {
+            'text': 'Signing in again clears this setting'
+          }
+        }) }}
         {{ page_footer('Save') }}
       {% endcall %}
     </div>


### PR DESCRIPTION
A few radios converted to GOVUK Frontend had `<legends>` which duplicated the `<h1>` of the page. The design system advice on this is to configure the radios so their `<legend>` contains the `<h1>`:

https://design-system.service.gov.uk/get-started/labels-legends-headings/

This was missed out when the radios were originally converted. This converts all the radios that have this issue.