### PR TITLE
Basic accessibility fixes for radio select

### DIFF
--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -5,6 +5,7 @@
   var Modules = global.GOVUK.Modules;
   var Hogan = global.Hogan;
 
+  // Object holding all the states for the component's HTML
   let states = {
     'initial': Hogan.compile(`
       {{#showNowAsDefault}}
@@ -63,11 +64,12 @@
     `)
   };
 
-  let shiftFocus = function(target, component) {
-    if (target === 'now') {
+  let shiftFocus = function(elementToFocus, component) {
+    // The first option is always the default
+    if (elementToFocus === 'default') {
       $('[type=radio]', component).eq(0).focus();
     }
-    if (target === 'time') {
+    if (elementToFocus === 'option') {
       $('[type=radio]', component).eq(1).focus();
     }
   };
@@ -80,6 +82,7 @@
       let render = (state, data) => {
         $component.html(states[state].render(data));
       };
+      // store array of all options in component
       let choices = $('label', $component).toArray().map(function(element) {
         let $element = $(element);
         return {
@@ -95,13 +98,15 @@
         $component.data('show-now-as-default').toString() === 'true' ?
         {'name': name} : false
       );
+
+      // functions for changing the state of the component's HTML
       const reset = () => {
         render('initial', {
           'categories': categories,
           'name': name,
           'showNowAsDefault': showNowAsDefault
         });
-        shiftFocus('now', component);
+        shiftFocus('default', component);
       };
       const selectOption = (value) => {
         render('chosen', {
@@ -111,8 +116,10 @@
           'name': name,
           'showNowAsDefault': showNowAsDefault
         });
-        shiftFocus('time', component);
+        shiftFocus('option', component);
       };
+
+      // use mousedown + mouseup event sequence to confirm option selection
       const trackMouseup = (event) => {
         const parentNode = event.target.parentNode;
 
@@ -127,6 +134,7 @@
         }
       };
 
+      // set events
       $component
         .on('click', '.radio-select__button--category', function(event) {
 
@@ -140,7 +148,7 @@
             'name': name,
             'showNowAsDefault': showNowAsDefault
           });
-          shiftFocus('time', component);
+          shiftFocus('option', component);
 
         })
         .on('mousedown', '.js-option', function(event) {
@@ -175,12 +183,12 @@
               'name': name,
               'showNowAsDefault': showNowAsDefault
             });
-            shiftFocus('time', component);
+            shiftFocus('option', component);
 
           } else {
 
             reset();
-            shiftFocus('now', component);
+            shiftFocus('default', component);
 
           }
 
@@ -189,10 +197,11 @@
 
           event.preventDefault();
           reset();
-          shiftFocus('now', component);
+          shiftFocus('default', component);
 
         });
 
+      // set HTML to initial state
       render('initial', {
         'categories': categories,
         'name': name,

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -63,8 +63,13 @@
     `)
   };
 
-  let focusSelected = function(component) {
-    $('[type=radio]:checked', component).focus();
+  let shiftFocus = function(target, component) {
+    if (target === 'now') {
+      $('[type=radio]', component).eq(0).focus();
+    }
+    if (target === 'time') {
+      $('[type=radio]', component).eq(1).focus();
+    }
   };
 
   Modules.RadioSelect = function() {
@@ -96,6 +101,7 @@
           'name': name,
           'showNowAsDefault': showNowAsDefault
         });
+        shiftFocus('now', component);
       };
       const selectOption = (value) => {
         render('chosen', {
@@ -105,7 +111,7 @@
           'name': name,
           'showNowAsDefault': showNowAsDefault
         });
-        focusSelected(component);
+        shiftFocus('time', component);
       };
       const trackMouseup = (event) => {
         const parentNode = event.target.parentNode;
@@ -134,7 +140,7 @@
             'name': name,
             'showNowAsDefault': showNowAsDefault
           });
-          focusSelected(component);
+          shiftFocus('time', component);
 
         })
         .on('mousedown', '.js-option', function(event) {
@@ -169,20 +175,21 @@
               'name': name,
               'showNowAsDefault': showNowAsDefault
             });
+            shiftFocus('time', component);
 
           } else {
 
             reset();
+            shiftFocus('now', component);
 
           }
-          focusSelected(component);
 
         })
         .on('click', '.radio-select__button--reset', function(event) {
 
           event.preventDefault();
           reset();
-          focusSelected(component);
+          shiftFocus('now', component);
 
         });
 

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -17,7 +17,7 @@
       {{/showNowAsDefault}}
       <div class="radio-select__column">
         {{#categories}}
-          <input type='button' class='govuk-button govuk-button--secondary radio-select__button--category' value='{{.}}' />
+          <input type='button' class='govuk-button govuk-button--secondary radio-select__button--category' aria-expanded="false" value='{{.}}' />
         {{/categories}}
       </div>
     `),
@@ -37,7 +37,7 @@
             <label for="{{id}}">{{label}}</label>
           </div>
         {{/choices}}
-        <input type='button' class='govuk-button govuk-button--secondary radio-select__button--done' value='Done' />
+        <input type='button' class='govuk-button govuk-button--secondary radio-select__button--done' aria-expanded='true' value='Done' />
       </div>
     `),
     'chosen': Hogan.compile(`
@@ -58,7 +58,7 @@
         {{/choices}}
       </div>
       <div class="radio-select__column">
-        <input type='button' class='govuk-button govuk-button--secondary radio-select__button--reset' value='Choose a different time' />
+        <input type='button' class='govuk-button govuk-button--secondary radio-select__button--reset' aria-expanded='false' value='Choose a different time' />
       </div>
     `)
   };

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -228,9 +228,9 @@ describe('RadioSelect', () => {
 
         });
 
-        test("keep focus on the default time slot", () => {
+        test("focus the first time slot", () => {
 
-          expect(document.activeElement).toBe(document.getElementById('scheduled_for-0'));
+          expect(document.activeElement).toBe(document.getElementById('scheduled_for-1'));
 
         });
 
@@ -347,6 +347,14 @@ describe('RadioSelect', () => {
 
       })
 
+      test("focus the selected option", () => {
+
+        selectedOption = document.querySelector('.radio-select__column:nth-child(2) input[checked=checked]');
+
+        expect(document.activeElement).toBe(selectedOption);
+
+      });
+
     });
 
     describe("selecting an option with the enter key should", () => {
@@ -397,6 +405,14 @@ describe('RadioSelect', () => {
         expect(button.getAttribute('value')).toEqual('Choose a different time');
 
       })
+
+      test("focus the selected option", () => {
+
+        selectedOption = document.querySelector('.radio-select__column:nth-child(2) input[checked=checked]');
+
+        expect(document.activeElement).toBe(selectedOption);
+
+      });
 
     });
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -179,6 +179,14 @@ describe('RadioSelect', () => {
 
       });
 
+      test("each button's semantics should show it controls another region and that region is collapsed", () => {
+
+        categoryButtons.forEach(btn => {
+          expect(btn.getAttribute('aria-expanded')).toEqual('false');
+        });
+
+      });
+
     });
 
   });
@@ -241,6 +249,7 @@ describe('RadioSelect', () => {
 
       expect(button).not.toBeNull();
       expect(button.getAttribute('value')).toEqual('Done');
+      expect(button.getAttribute('aria-expanded')).toEqual('true');
 
     });
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -304,7 +304,7 @@ describe('RadioSelect', () => {
 
       test("focus the selected option", () => {
 
-        selectedOption = document.querySelector('.radio-select__column:nth-child(2) input[checked=checked]');
+        selectedOption = document.querySelector('.radio-select__column input[checked=checked]');
 
         expect(document.activeElement).toBe(selectedOption);
 
@@ -349,7 +349,7 @@ describe('RadioSelect', () => {
 
       test("focus the selected option", () => {
 
-        selectedOption = document.querySelector('.radio-select__column:nth-child(2) input[checked=checked]');
+        selectedOption = document.querySelector('.radio-select__column input[checked=checked]');
 
         expect(document.activeElement).toBe(selectedOption);
 
@@ -408,7 +408,7 @@ describe('RadioSelect', () => {
 
       test("focus the selected option", () => {
 
-        selectedOption = document.querySelector('.radio-select__column:nth-child(2) input[checked=checked]');
+        selectedOption = document.querySelector('.radio-select__column input[checked=checked]');
 
         expect(document.activeElement).toBe(selectedOption);
 


### PR DESCRIPTION
The Digital Accessibility Centre (DAC) raised some issues against our component for adding/moving templates and folders:

https://www.pivotaltracker.com/story/show/174440877

The work we did to fix those issues in https://github.com/alphagov/notifications-admin/pull/3664 included problems with:
- the semantics of buttons that open/close parts of the component (for which the DAC audit suggested some fixes)
- what happens to focus when the current buttons are replaced with other content

The radioSelect component also opens/closes parts of its content with buttons so will share these problems:

<img width="599" alt="image" src="https://user-images.githubusercontent.com/87140/105050296-8b49d300-5a65-11eb-9d07-3c2616540ef8.png">

<img width="380" alt="image" src="https://user-images.githubusercontent.com/87140/105050562-d237c880-5a65-11eb-8994-29df040a75ea.png">

We're going to get them tested by DAC next week to check that but, in the meantime, this adds fixes for the button semantics we know work and a small improvement to the focus management.

This is part of this story to improve the accessibility of collapsible components:

https://www.pivotaltracker.com/story/show/175477156

## Notes for reviewers

These changes are best reviewed commit-by-commit.

It is also useful to check the branch out and try the old and new versions of this component beforehand.

### Improvements to focus management

When you select a day to send your message, ie. 'Tomorrow', radios for times in that day replace the buttons for different days:

<img width="380" alt="image" src="https://user-images.githubusercontent.com/87140/105050562-d237c880-5a65-11eb-8994-29df040a75ea.png">

We currently move focus to the default 'Now' radio. This doesn't inform non-visual users that the new radios have been added. Focusing the first one tells them the number and type of radios in the component have changed:

- [before these changes](https://drive.google.com/file/d/1zctkqc_6-x1QgGce8yJOJ-UgH8qEPX7g/view?usp=sharing)
- [after these changes](https://drive.google.com/file/d/16IwsZmVcg_mu-n3rfOXLFBtVR1awMezx/view?usp=sharing)

I think it also makes it better for keyboard-only users. They also benefit from their focus being moved to the first time rather than back to 'now'.

We could add more information but I'd like to get this, simpler version tested first to prevent adding anything unnecessary.