### PR TITLE
Fix bug with incorrect redirect to send_one_off

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -65,7 +65,7 @@ def view_template(service_id, template_id):
 
     if should_skip_template_page(template['template_type']):
         return redirect(url_for(
-            '.send_one_off', service_id=service_id, template_id=template_id
+            '.set_sender', service_id=service_id, template_id=template_id
         ))
 
     page_count = get_page_count_for_letter(template)

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -531,7 +531,7 @@ def test_broadcast_template_doesnt_highlight_placeholders_but_does_count_charact
     )
 
 
-def test_caseworker_redirected_to_one_off(
+def test_caseworker_redirected_to_set_sender_for_one_off(
     client_request,
     mock_get_service_templates,
     mock_get_service_template,
@@ -548,7 +548,7 @@ def test_caseworker_redirected_to_one_off(
         template_id=fake_uuid,
         _expected_status=302,
         _expected_redirect=url_for(
-            'main.send_one_off',
+            'main.set_sender',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             _external=True,
@@ -556,7 +556,7 @@ def test_caseworker_redirected_to_one_off(
     )
 
 
-def test_user_with_only_send_and_view_redirected_to_one_off(
+def test_user_with_only_send_and_view_redirected_to_set_sender_for_one_off(
     client_request,
     mock_get_service_templates,
     mock_get_service_template,
@@ -575,7 +575,7 @@ def test_user_with_only_send_and_view_redirected_to_one_off(
         template_id=fake_uuid,
         _expected_status=302,
         _expected_redirect=url_for(
-            'main.send_one_off',
+            'main.set_sender',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             _external=True,


### PR DESCRIPTION
If a user has only send_message permissions, when they click on a
template name they are currently taken to the `send_one_off` page. This
is incorrect as if there is more than one SMS sender or email reply to
address, then they should pick the address they wish to use.

This commit fixes that bug by redirecting them to the `set_sender`
route. Note, if there is only one sender then the `set_sender` will
redirect the user on to the `send_one_off` route.

https://www.pivotaltracker.com/story/show/176541486

How to review:
Spin up the app locally, log in as a user with only the `send_message` permission and click on the name of a template from the list of all templates. If there is more than one sender, then you should be prompted to choose. If there is only one sender, then you will not be prompted to choose. For letters, you will not be prompted to choose regardless.