### PR TITLE
Display areas that aren’t in the library

### DIFF
--- a/app/broadcast_areas/__init__.py
+++ b/app/broadcast_areas/__init__.py
@@ -89,6 +89,41 @@ class BroadcastArea(SortableMixin):
             id = parent_broadcast_area.id
 
 
+class CustomBroadcastArea:
+
+    # We don’t yet have a way to estimate the number of phones in a
+    # user-defined polygon
+    count_of_phones = 0
+
+    def __init__(self, *, name, polygons=None):
+        self.name = name
+        self._polygons = polygons or []
+
+    @property
+    def polygons(self):
+        return Polygons(
+            # Polygons in the DB are stored with the coordinate pair
+            # order flipped – this flips them back again
+            Polygons(self._polygons).as_coordinate_pairs_lat_long
+        )
+
+    simple_polygons = polygons
+
+
+class CustomBroadcastAreas(SerialisedModelCollection):
+    model = CustomBroadcastArea
+
+    def __init__(self, *, areas, polygons):
+        self.items = areas
+        self._polygons = polygons
+
+    def __getitem__(self, index):
+        return self.model(
+            name=self.items[index],
+            polygons=self._polygons if index == 0 else None,
+        )
+
+
 class BroadcastAreaLibrary(SerialisedModelCollection, SortableMixin, GetItemByIdMixin):
 
     model = BroadcastArea

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -45,6 +45,10 @@ class BroadcastMessage(JSONModel):
             return True
         if not self.starts_at and other.starts_at:
             return False
+        if self.updated_at and not other.updated_at:
+            return self.updated_at < other.created_at
+        if not self.updated_at and other.updated_at:
+            return self.created_at < other.updated_at
         return self.updated_at < other.updated_at
 
     @classmethod
@@ -129,7 +133,7 @@ class BroadcastMessage(JSONModel):
 
     @cached_property
     def created_by(self):
-        return User.from_id(self.created_by_id)
+        return User.from_id(self.created_by_id) if self.created_by_id else None
 
     @cached_property
     def approved_by(self):

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -5,7 +5,7 @@ from notifications_utils.template import BroadcastPreviewTemplate
 from orderedset import OrderedSet
 from werkzeug.utils import cached_property
 
-from app.broadcast_areas import broadcast_area_libraries
+from app.broadcast_areas import CustomBroadcastAreas, broadcast_area_libraries
 from app.broadcast_areas.polygons import Polygons
 from app.formatters import round_to_significant_figures
 from app.models import JSONModel, ModelList
@@ -74,7 +74,12 @@ class BroadcastMessage(JSONModel):
 
     @property
     def areas(self):
-        return self.get_areas(areas=self._dict['areas'])
+        return self.get_areas(
+            areas=self._dict['areas']
+        ) or CustomBroadcastAreas(
+            areas=self._dict['areas'],
+            polygons=self._dict['simple_polygons'],
+        )
 
     @property
     def parent_areas(self):

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -78,9 +78,17 @@ class BroadcastMessage(JSONModel):
 
     @property
     def areas(self):
-        return self.get_areas(
-            areas=self._dict['areas']
-        ) or CustomBroadcastAreas(
+        library_areas = self.get_areas(areas=self._dict['areas'])
+
+        if library_areas:
+            if len(library_areas) != len(self._dict['areas']):
+                raise RuntimeError(
+                    f'BroadcastMessage has {len(self._dict["areas"])} areas '
+                    f'but {len(library_areas)} found in the library'
+                )
+            return library_areas
+
+        return CustomBroadcastAreas(
             areas=self._dict['areas'],
             polygons=self._dict['simple_polygons'],
         )

--- a/app/templates/views/broadcast/macros/area-map.html
+++ b/app/templates/views/broadcast/macros/area-map.html
@@ -20,7 +20,9 @@
       alert
     </li>
     <li class="area-list-key area-list-key--phone-estimate">
-      {% if broadcast_message.count_of_phones == broadcast_message.count_of_phones_likely %}
+      {% if broadcast_message.count_of_phones == 0 %}
+        Unknown number of phones
+      {% elif broadcast_message.count_of_phones == broadcast_message.count_of_phones_likely %}
         {{ broadcast_message.count_of_phones|format_thousands }} phones estimated
       {% else %}
         {{ broadcast_message.count_of_phones|format_thousands }} to {{ broadcast_message.count_of_phones_likely|format_thousands }} phones

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -19,10 +19,15 @@
 
 {% block service_page_title %}
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
+    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
       {{ broadcast_message.template.name }} is waiting for approval
     {% elif current_user.has_permissions('send_messages') %}
-      {{ broadcast_message.created_by.name }} wants to broadcast
+      {% if broadcast_message.created_by %}
+        {{ broadcast_message.created_by.name }}
+      {% else %}
+        An API call
+      {% endif %}
+      wants to broadcast
       {{ broadcast_message.template.name }}
     {% else %}
       This alert is waiting for approval
@@ -37,7 +42,7 @@
   {{ govukBackLink({ "href": back_link }) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
+    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
           {{ broadcast_message.template.name }} is waiting for approval
@@ -79,7 +84,12 @@
     {% elif current_user.has_permissions('send_messages') %}
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <h1 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-          {{ broadcast_message.created_by.name }} wants to broadcast
+          {% if broadcast_message.created_by %}
+            {{ broadcast_message.created_by.name }}
+          {% else %}
+            An API call
+          {% endif %}
+          wants to broadcast
           {{ broadcast_message.template.name }}
         </h1>
         {{ page_footer(
@@ -138,8 +148,12 @@
 
   {% if broadcast_message.status != 'pending-approval' %}
     <p class="govuk-body govuk-!-margin-bottom-3">
-      Prepared by {{ broadcast_message.created_by.name }} and approved by
-      {{ broadcast_message.approved_by.name }}.
+      {% if broadcast_message.created_by %}
+        Prepared by {{ broadcast_message.created_by.name }}
+      {% else %}
+        Created from an API call
+      {% endif %}
+      and approved by {{ broadcast_message.approved_by.name }}.
     </p>
   {% endif %}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -657,6 +657,7 @@ def broadcast_message_json(
     approved_by_id=None,
     cancelled_by_id=None,
     areas=None,
+    simple_polygons=None,
     content=None,
     reference=None,
     template_name='Example template',
@@ -676,6 +677,7 @@ def broadcast_message_json(
         'areas': areas or [
             'ctry19-E92000001', 'ctry19-S92000003',
         ],
+        'simple_polygons': simple_polygons or [],
 
         'status': status,
 

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.models.broadcast_message import BroadcastMessage
 from tests import broadcast_message_json
 
@@ -45,3 +47,24 @@ def test_content_comes_from_attribute_not_template(fake_uuid):
         created_by_id=fake_uuid,
     ))
     assert broadcast_message.content == 'This is a test'
+
+
+def test_raises_for_missing_areas(fake_uuid):
+    broadcast_message = BroadcastMessage(broadcast_message_json(
+        id_=fake_uuid,
+        service_id=fake_uuid,
+        template_id=fake_uuid,
+        status='draft',
+        created_by_id=fake_uuid,
+        areas=[
+            'wd20-E05009372',
+            'something else',
+        ],
+    ))
+
+    with pytest.raises(RuntimeError) as exception:
+        broadcast_message.areas
+
+    assert str(exception.value) == (
+        'BroadcastMessage has 2 areas but 1 found in the library'
+    )


### PR DESCRIPTION
For broadcasts that aren’t using our library of data we can get the names of the areas and the simplified polygon from the `BroadcastMessage` instead.

![image](https://user-images.githubusercontent.com/355079/105831947-3fe07900-5fbf-11eb-9a7c-54c7c96a4ea7.png)
