### PR TITLE
Remove content for October to December 2020

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -13,18 +13,13 @@
   <p class="govuk-body">The roadmap is a guide to what we have planned, but some things might change.</p>
   <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
-  <h2 class="heading-medium">October to December 2020</h2>
-
-  <ul class="list list-bullet">
-    <li>Increase our capacity to meet the needs of NHS Test and Trace, and other COVID-19 services</li>
-    <li>Explore ways to help teams send effective messages</li>
-  </ul>
-
   <h2 class="heading-medium">January 2021 onwards</h2>
 
   <ul class="list list-bullet">
 
     <li>Use two-factor authentication to protect files sent by email</li>
+    <!--<li>Increase our capacity to meet the needs of NHS Test and Trace, and other COVID-19 services</li>-->
+    <li>Explore ways to help teams send effective messages</li>
     <li>Add a link shortening service</li>
     <li>Let services attach forms to letter templates</li>
     <li>Add large print letter templates</li>


### PR DESCRIPTION
This PR removes 2020 content from the road map page.

We’ll update 2021 to reflect the priorities for each quarter just as soon as we have them.