### PR TITLE
Add service history for platform admins

### DIFF
--- a/app/navigation.py
+++ b/app/navigation.py
@@ -532,6 +532,9 @@ class MainNavigation(Navigation):
             'guest_list',
             'old_guest_list',
         },
+        'history': {
+            'history',
+        },
     }
 
     exclude = {
@@ -610,7 +613,6 @@ class MainNavigation(Navigation):
         'send_files_by_email',
         'upload_a_letter',
         'letter_specification',
-        'history',
         'how_to_pay',
         'inbound_sms_admin',
         'inbox_download',

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -31,6 +31,9 @@
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
+  {% if current_user.platform_admin %}
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('history') }}" href="{{ url_for('.history', service_id=current_service.id) }}">Service history</a></li>
+  {% endif %}
   </ul>
 </nav>
 {% endif %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -196,6 +196,29 @@ def test_navigation_for_services_with_broadcast_permission(
     ]
 
 
+def test_navigation_for_platform_admin_user(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    platform_admin_user
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
+    assert [
+        a['href'] for a in page.select('.navigation a')
+    ] == [
+        '/services/{}'.format(SERVICE_ONE_ID),
+        '/services/{}/templates'.format(SERVICE_ONE_ID),
+        '/services/{}/uploads'.format(SERVICE_ONE_ID),
+        '/services/{}/users'.format(SERVICE_ONE_ID),
+        '/services/{}/usage'.format(SERVICE_ONE_ID),
+        '/services/{}/service-settings'.format(SERVICE_ONE_ID),
+        '/services/{}/api'.format(SERVICE_ONE_ID),
+        '/services/{}/history'.format(SERVICE_ONE_ID),
+    ]
+
+
 def test_caseworkers_get_caseworking_navigation(
     client_request,
     mocker,


### PR DESCRIPTION
We have a service history page that exists but people may not know
about. The only way to get to it is by knowing the URL as we don't
appear to link to it anywhere in the admin app.

This adds an easy link just for platform admins as this page may be of
some use I believe. There is a chance that the service history is not
super up to date and could see further improvements but it might still
be helpful when doing support type things.

@quis I imagine you might have opinions on whether this is a good addition to the admin app for us?

![image](https://user-images.githubusercontent.com/7228605/106634298-90d00e80-6577-11eb-8077-e7709553662b.png)
