### PR TITLE
Remove a link from using-notify page

### DIFF
--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -30,7 +30,7 @@
   <ul class="list list-bullet">
     <li>headings</li>
     <li>bullets</li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://design-system.service.gov.uk/components/inset-text/">inset text</a></li>
+    <li>inset text</li>
     <li>horizontal rules</li>
   </ul>
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -342,7 +342,7 @@ def test_font_preload(
 
     preload_tags = page.select('link[rel=preload][as=font][type="font/woff2"][crossorigin]')
 
-    assert len(preload_tags) == 4, 'Run `npm build` to copy fonts into app/static/fonts/'
+    assert len(preload_tags) == 4, 'Run `npm run build` to copy fonts into app/static/fonts/'
 
     for element in preload_tags:
         assert element['href'].startswith('https://static.example.com/fonts/')


### PR DESCRIPTION
This stops the 'inset text' linking to the design system on the
'edit-and-format-messages' page. The link has been removed to avoid
confusion - someone thought they needed to use the design system
code in order to create inset text in templates.