### PR TITLE
Show only relevant platform admin settings for broadcast service

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -329,17 +329,18 @@
             {% endif %}
           {% endcall %}
 
+          {% if not current_service.has_permission('broadcast') %}
           {% call row() %}
             {{ text_field('Count in list of live services')}}
             {{ text_field('Yes' if current_service.count_as_live else 'No') }}
             {{ edit_field('Change', url_for('.service_switch_count_as_live', service_id=current_service.id), suffix='if service is counted in list of live services') }}
           {% endcall %}
-
           {% call row() %}
             {{ text_field('Billing details')}}
             {{ optional_text_field(current_service.billing_details, default="No billing details yet", wrap=True) }}
             {{ edit_field('Change', url_for('.edit_service_billing_details', service_id=current_service.id), suffix='billing details for service') }}
           {% endcall %}
+          {% endif %}
 
           {% call row() %}
             {{ text_field('Notes')}}
@@ -347,6 +348,7 @@
             {{ edit_field('Change', url_for('.edit_service_notes', service_id=current_service.id), suffix='the notes for the service') }}
           {% endcall %}
 
+          {% if not current_service.has_permission('broadcast') %}
           {% call row() %}
             {{ text_field('Organisation')}}
             {% call field() %}
@@ -365,6 +367,7 @@
             {% endcall %}
             {{ edit_field('Change', url_for('.link_service_to_organisation', service_id=current_service.id), suffix='organisation for service') }}
           {% endcall %}
+
           {% call row() %}
             {{ text_field('Rate limit')}}
             {{ text_field('{:,} per minute'.format(current_service.rate_limit)) }}
@@ -407,6 +410,7 @@
             {% endcall %}
             {{ edit_field('Change', url_for('.data_retention', service_id=current_service.id), suffix='data retention') }}
           {% endcall %}
+          {% endif %}
 
           {% for permission in service_permissions %}
             {% if not service_permissions[permission].requires or current_service.has_permission(service_permissions[permission].requires) %}


### PR DESCRIPTION
Show only relevant platform admin settings for broadcast service

A few of note

Count in list of live services - this should be set to no in the API (to
be implemented) so we never show broadcast services in the list of live
services to reduce security leaks

Organisation - all broadcast services are currently going to be found in
a single organisation so we keep track of them easily. Therefore there
is no need to allow the changing of the organisation

Email authentication - we may in time not allow these services to use
email auth to log in but this hasn't been decided so let's keep it for
the moment

Rate limit - although a service may end up using our API to create
broadcasts, there is currently no rate limit check on this endpoint
and it's also extremely unlikely that any service would ever breach
the default limit

Also note, this isn't intending to be the final look for these service settings as the swapping of cell broadcast permissions and training mode/live mode may be merged into a single setting

## Before

<img width="707" alt="Screenshot 2021-02-04 at 16 45 30" src="https://user-images.githubusercontent.com/7228605/106929845-c823f400-670c-11eb-970d-afe3eb11e44c.png">

## After

<img width="716" alt="Screenshot 2021-02-04 at 17 38 32" src="https://user-images.githubusercontent.com/7228605/106932607-d7587100-670f-11eb-98fe-9e47d228c6f1.png">
