### PR TITLE
Fix not showing 'From' / 'Reply to' after sending

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -95,6 +95,8 @@ def view_notification(service_id, notification_id):
         page_count=page_count,
         show_recipient=True,
         redact_missing_personalisation=True,
+        sms_sender=notification['reply_to_text'],
+        email_reply_to=notification['reply_to_text'],
     )
     template.values = personalisation
     if notification['job']:

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -218,6 +218,10 @@ def set_sender(service_id, template_id):
         return redirect_to_one_off
 
     sender_details = get_sender_details(service_id, template['template_type'])
+
+    if len(sender_details) == 1:
+        session['sender_id'] = sender_details[0]['id']
+
     if len(sender_details) <= 1:
         return redirect_to_one_off
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -949,3 +949,22 @@ def test_cancelling_a_letter_calls_the_api(
     )
 
     assert cancel_endpoint.called
+
+
+@pytest.mark.parametrize('notification_type', ['sms', 'email'])
+def test_should_show_reply_to_from_notification(
+    mocker,
+    fake_uuid,
+    notification_type,
+    client_request,
+):
+    notification = create_notification(reply_to_text='reply to info', template_type=notification_type)
+    mocker.patch('app.notification_api_client.get_notification', return_value=notification)
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=SERVICE_ONE_ID,
+        notification_id=fake_uuid,
+    )
+
+    assert 'reply to info' in page.text

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -254,6 +254,52 @@ def test_set_sender_redirects_if_no_sms_senders(
     )
 
 
+def test_set_sender_redirects_if_one_email_sender(
+    client_request,
+    fake_uuid,
+    mock_get_service_email_template,
+    single_reply_to_email_address,
+):
+    client_request.get(
+        '.set_sender',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _expected_status=302,
+        _expected_url=url_for(
+            '.send_one_off',
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _external=True,
+        )
+    )
+
+    with client_request.session_transaction() as session:
+        assert session['sender_id'] == '1234'
+
+
+def test_set_sender_redirects_if_one_sms_sender(
+    client_request,
+    fake_uuid,
+    mock_get_service_template,
+    single_sms_sender,
+):
+    client_request.get(
+        '.set_sender',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _expected_status=302,
+        _expected_url=url_for(
+            '.send_one_off',
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _external=True,
+        )
+    )
+
+    with client_request.session_transaction() as session:
+        assert session['sender_id'] == '1234'
+
+
 def test_that_test_files_exist():
     assert len(test_spreadsheet_files) == 8
     assert len(test_non_spreadsheet_files) == 6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4174,13 +4174,15 @@ def create_notification(
     key_type=None,
     postage=None,
     sent_one_off=True,
+    reply_to_text=None,
 ):
     noti = notification_json(
         service_id,
         rows=1,
         status=notification_status,
         template_type=template_type,
-        postage=postage
+        postage=postage,
+        reply_to_text=reply_to_text,
     )['notifications'][0]
 
     noti['id'] = notifification_id or sample_uuid()


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1443052/stories/176779890
https://www.pivotaltracker.com/n/projects/1443052/stories/176779854

This is one approach to fixing the issue, but has some caveats we may
want to consider in more depth. It was quite hard to trace what happens
during the request - see the first commit for the full story.

| Before | After |
| -------:|:-----|
| <img width="785" alt="Screenshot 2021-02-08 at 17 34 42" src="https://user-images.githubusercontent.com/9029009/107258920-4ac1f180-6a34-11eb-8b51-1d4862440e7b.png"> | <img width="783" alt="Screenshot 2021-02-08 at 17 34 56" src="https://user-images.githubusercontent.com/9029009/107258943-51e8ff80-6a34-11eb-8c4c-6ba440047fd8.png"> |
| <img width="801" alt="Screenshot 2021-02-08 at 17 34 03" src="https://user-images.githubusercontent.com/9029009/107259076-77760900-6a34-11eb-817b-b2a9dd7044e3.png"> | <img width="794" alt="Screenshot 2021-02-08 at 17 33 32" src="https://user-images.githubusercontent.com/9029009/107259256-b1dfa600-6a34-11eb-995c-4993c253b95f.png"> |
| <img width="797" alt="Screenshot 2021-02-08 at 17 35 35" src="https://user-images.githubusercontent.com/9029009/107259109-852b8e80-6a34-11eb-9526-93d346814787.png"> | <img width="797" alt="Screenshot 2021-02-08 at 17 35 25" src="https://user-images.githubusercontent.com/9029009/107259127-89f04280-6a34-11eb-856f-2a95390d1efa.png"> |
| <img width="545" alt="Screenshot 2021-02-08 at 17 35 45" src="https://user-images.githubusercontent.com/9029009/107259153-92e11400-6a34-11eb-819a-4f6001594f0a.png"> | <img width="546" alt="Screenshot 2021-02-08 at 17 35 10" src="https://user-images.githubusercontent.com/9029009/107259180-9a082200-6a34-11eb-9b0a-e9a4085cb470.png"> |







