### PR TITLE
Allow broadcasts which have no created_at to be compared

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -49,6 +49,8 @@ class BroadcastMessage(JSONModel):
             return self.updated_at < other.created_at
         if not self.updated_at and other.updated_at:
             return self.created_at < other.updated_at
+        if not self.updated_at and not other.updated_at:
+            return self.created_at < other.created_at
         return self.updated_at < other.updated_at
 
     @classmethod


### PR DESCRIPTION
This adds to the `__le__` method on the `BroadcastMessage` class to
allow two BroadcastMessages with no `updated_at` to be compared.
Previously, the method expected at least one message to have
`updated_at` set, but this is not necessarily the case.