### PR TITLE
Add GOVUK radios [part 8]

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -516,7 +516,7 @@ class NestedFieldMixin:
 
             params['items'].append(item)
 
-        return render_template('forms/fields/checkboxes/template.njk', params=params)
+        return render_template(self.template_path, params=params)
 
 
 class NestedRadioField(RadioFieldWithNoneOption, NestedFieldMixin):
@@ -852,6 +852,7 @@ class GovukCollapsibleCheckboxesField(GovukCheckboxesField):
 class GovukCollapsibleNestedCheckboxesField(NestedFieldMixin, GovukCollapsibleCheckboxesField):
     NONE_OPTION_VALUE = None
     render_as_list = True
+    template_path = 'forms/fields/checkboxes/template.njk'
 
 
 class GovukRadiosField(RadioField):
@@ -887,6 +888,7 @@ class GovukRadiosFieldWithNoneOption(FieldWithNoneOption, GovukRadiosField):
 # NestedFieldMixin puts the items into a tree hierarchy, pre-rendering the sub-trees of the top-level items
 class GovukNestedRadiosField(NestedFieldMixin, GovukRadiosFieldWithNoneOption):
     render_as_list = True
+    template_path = 'forms/fields/radios/template.njk'
 
 
 class OnOffField(GovukRadiosField):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -934,6 +934,10 @@ class GovukRadiosFieldWithNoneOption(FieldWithNoneOption, GovukRadiosField):
     pass
 
 
+class GovukRadiosFieldWithRequiredMessage(RadioFieldWithRequiredMessage, GovukRadiosField):
+    pass
+
+
 # NestedFieldMixin puts the items into a tree hierarchy, pre-rendering the sub-trees of the top-level items
 class GovukNestedRadiosField(NestedFieldMixin, GovukRadiosFieldWithNoneOption):
     render_as_list = True
@@ -2347,7 +2351,7 @@ class TemplateAndFoldersSelectionForm(Form):
     add_new_folder_name = GovukTextInputField('Folder name', validators=[required_for_ops('add-new-folder')])
     move_to_new_folder_name = GovukTextInputField('Folder name', validators=[required_for_ops('move-to-new-folder')])
 
-    add_template_by_template_type = RadioFieldWithRequiredMessage('New template', validators=[
+    add_template_by_template_type = GovukRadiosFieldWithRequiredMessage('New template', validators=[
         required_for_ops('add-new-template'),
         Optional(),
     ], required_message='Select the type of template you want to add')

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -894,11 +894,14 @@ class GovukCollapsibleCheckboxesField(GovukCheckboxesField):
 # NestedFieldMixin puts the items into a tree hierarchy, pre-rendering the sub-trees of the top-level items
 class GovukCollapsibleNestedCheckboxesField(NestedFieldMixin, GovukCollapsibleCheckboxesField):
     NONE_OPTION_VALUE = None
+    # renders the top-level items as a list. NestedFieldMixin handles all others and always renders them as lists
     render_as_list = True
     template_path = 'forms/fields/checkboxes/template.njk'
 
 
 class GovukRadiosField(RadioField):
+
+    render_as_list = False
 
     def __init__(self, label='', validators=None, param_extensions=None, **kwargs):
         super(GovukRadiosField, self).__init__(label, validators, **kwargs)
@@ -940,6 +943,7 @@ class GovukRadiosFieldWithRequiredMessage(RadioFieldWithRequiredMessage, GovukRa
 
 # NestedFieldMixin puts the items into a tree hierarchy, pre-rendering the sub-trees of the top-level items
 class GovukNestedRadiosField(NestedFieldMixin, GovukRadiosFieldWithNoneOption):
+    # renders the top-level items as a list. NestedFieldMixin handles all others and always renders them as lists
     render_as_list = True
     template_path = 'forms/fields/radios/template.njk'
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -789,7 +789,7 @@ def govuk_radios_field_widget(self, field, param_extensions=None, **kwargs):
         merge_jsonlike(params, param_extensions)
 
     return Markup(
-        render_template('components/radios/template.njk', params=params))
+        render_template('forms/fields/radios/template.njk', params=params))
 
 
 class GovukCheckboxField(BooleanField):
@@ -880,6 +880,15 @@ class GovukRadiosField(RadioField):
         return govuk_radios_field_widget(self, field, param_extensions=param_extensions, **kwargs)
 
 
+class GovukRadiosFieldWithNoneOption(FieldWithNoneOption, GovukRadiosField):
+    pass
+
+
+# NestedFieldMixin puts the items into a tree hierarchy, pre-rendering the sub-trees of the top-level items
+class GovukNestedRadiosField(NestedFieldMixin, GovukRadiosFieldWithNoneOption):
+    render_as_list = True
+
+
 class OnOffField(GovukRadiosField):
 
     def __init__(self, label, choices=None, *args, **kwargs):
@@ -930,10 +939,6 @@ class OrganisationTypeField(GovukRadiosField):
             validators=validators or [],
             **kwargs
         )
-
-
-class GovukRadiosFieldWithNoneOption(FieldWithNoneOption, GovukRadiosField):
-    pass
 
 
 # guard against data entries that aren't a role in permissions

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -226,7 +226,7 @@ def govuk_text_input_field_widget(self, field, type=None, param_extensions=None,
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            error_message_format: " ".join(field.errors).strip()
+            error_message_format: field.errors[0]
         }
 
     # convert to parameters that govuk understands
@@ -672,7 +672,7 @@ def govuk_checkbox_field_widget(self, field, param_extensions=None, **kwargs):
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            "text": " ".join(field.errors).strip()
+            "text": field.errors[0]
         }
 
     params = {
@@ -732,7 +732,7 @@ def govuk_checkboxes_field_widget(self, field, wrap_in_collapsible=False, param_
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            "text": " ".join(field.errors).strip()
+            "text": field.errors[0]
         }
 
     # returns either a list or a hierarchy of lists, in a tree structure
@@ -797,7 +797,7 @@ def govuk_radios_field_widget(self, field, param_extensions=None, **kwargs):
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            "text": " ".join(field.errors).strip()
+            "text": field.errors[0]
         }
 
     # returns either a list or a hierarchy of lists, in a tree structure

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -118,7 +118,14 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
             current_service.all_templates or len(current_user.service_ids) > 1
         ),
     )
-    option_hints = {template_folder_id: 'current folder'}
+    if template_folder_id is not None:
+        templates_and_folders_form.move_to.param_extensions = {'items': []}
+        for item_id, _item_value in templates_and_folders_form.move_to.choices:
+            if item_id == template_folder_id:
+                extensions = {'hint': {'text': 'current folder'}}
+            else:
+                extensions = {}  # add an empty dict for items we don't want to extend, to preserve the order
+            templates_and_folders_form.move_to.param_extensions['items'].append(extensions)
 
     single_notification_channel = None
     notification_channels = list(set(current_service.permissions).intersection(NOTIFICATION_TYPES))
@@ -161,10 +168,8 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         template_type=template_type,
         search_form=SearchTemplatesForm(current_service.api_keys),
         templates_and_folders_form=templates_and_folders_form,
-        move_to_children=templates_and_folders_form.move_to.children(),
         user_has_template_folder_permission=user_has_template_folder_permission,
-        single_notification_channel=single_notification_channel,
-        option_hints=option_hints
+        single_notification_channel=single_notification_channel
     )
 
 

--- a/app/templates/forms/fields/radios/macro.njk
+++ b/app/templates/forms/fields/radios/macro.njk
@@ -1,0 +1,4 @@
+{%- macro govukRadios(params) %}
+  {%- include "./template.njk" -%}
+{%- endmacro %}
+{{ govukRadios(params) }}

--- a/app/templates/forms/fields/radios/template.njk
+++ b/app/templates/forms/fields/radios/template.njk
@@ -1,0 +1,128 @@
+{% from "components/error-message/macro.njk" import govukErrorMessage -%}
+{% from "components/fieldset/macro.njk" import govukFieldset %}
+{% from "components/hint/macro.njk" import govukHint %}
+{% from "components/label/macro.njk" import govukLabel %}
+
+
+{#- Copied from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/radios/template.njk
+    Changes:
+    - `asList` option added the root `params` object to allow setting of the `.govuk-radios` and `.govuk-radios__item` element types
+    - Nunjucks-to-Jinja language problems fixed (see https://github.com/alphagov/govuk-frontend-jinja/blob/master/govuk_frontend_jinja/templates.py) -#}
+
+{#- If an id 'prefix' is not passed, fall back to using the name attribute
+   instead. We need this for error messages and hints as well -#}
+{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
+{% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
+
+{#- set the types of element used for the checkboxes and their group based on
+   whether asList is set -#}
+{% if params.asList %}
+  {% set groupElement = 'ul' %}
+  {% set groupItemElement = 'li' %}
+{% else %}
+  {% set groupElement = 'div' %}
+  {% set groupItemElement = 'div' %}
+{% endif %}
+
+{% set isConditional = False %}
+{% for item in params['items'] %}
+  {% if item.conditional %}
+    {% set isConditional = True %}
+  {% endif %}
+{% endfor %}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{% set innerHtml %}
+{% if params.hint %}
+  {% set hintId = idPrefix ~ '-hint' %}
+  {% set describedBy = describedBy ~ ' ' ~ hintId if describedBy else hintId %}
+  {{ govukHint({
+    "id": hintId,
+    "classes": params.hint.classes,
+    "attributes": params.hint.attributes,
+    "html": params.hint.html,
+    "text": params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = idPrefix ~ '-error' %}
+  {% set describedBy = describedBy ~ ' ' ~ errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    "id": errorId,
+    "classes": params.errorMessage.classes,
+    "attributes": params.errorMessage.attributes,
+    "html": params.errorMessage.html,
+    "text": params.errorMessage.text,
+    "visuallyHiddenText": params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+  <{{ groupElement }} class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}{%- if isConditional %} govuk-radios--conditional{% endif -%}"
+    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+    {%- if isConditional %} data-module="radios"{% endif -%}>
+    {% for item in params['items'] %}
+    {% set id = item.id if item.id else idPrefix ~ "-" ~ loop.index %}
+    {% set conditionalId = "conditional-" ~ id %}
+    {%- if item.divider %}
+    <div class="govuk-radios__divider">{{ item.divider }}</div>
+    {%- else %}
+    {% set hasHint = True if item.hint.text or item.hint.html %}
+    {% set itemHintId = id ~ '-item-hint' %}
+    <{{ groupItemElement}} class="govuk-radios__item">
+      <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
+      {{-" checked" if item.checked }}
+      {{-" disabled" if item.disabled }}
+      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
+      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+      {{ govukLabel({
+        "html": item.html,
+        "text": item.text,
+        "classes": 'govuk-radios__label' ~ (' ' ~ item.label.classes if item.label.classes),
+        "attributes": item.label.attributes,
+        "for": id
+      }) | indent(6) | trim }}
+      {%- if hasHint %}
+      {{ govukHint({
+        "id": itemHintId,
+        "classes": 'govuk-radios__hint',
+        "attributes": item.hint.attributes,
+        "html": item.hint.html,
+        "text": item.hint.text
+      }) | indent(6) | trim }}
+      {%- endif %}
+      {%- if params.asList and item.conditional %}
+        <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+          {{ item.conditional.html | safe }}
+        </div>
+      {% endif %}
+      {% if item.children %}
+        {{ item.children | safe }}
+      {% endif %}
+    </{{ groupItemElement }}>
+    {%- if not params.asList and item.conditional %}
+      <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+        {{ item.conditional.html | safe }}
+      </div>
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+  </{{ groupElement }}>
+{% endset -%}
+
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+{% if params.fieldset %}
+  {% call govukFieldset({
+    "describedBy": describedBy,
+    "classes": params.fieldset.classes,
+    "attributes": params.fieldset.attributes,
+    "legend": params.fieldset.legend
+  }) %}
+  {{ innerHtml | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
+</div>

--- a/app/templates/forms/fields/radios/template.njk
+++ b/app/templates/forms/fields/radios/template.njk
@@ -6,8 +6,14 @@
 
 {#- Copied from https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/radios/template.njk
     Changes:
-    - `asList` option added the root `params` object to allow setting of the `.govuk-radios` and `.govuk-radios__item` element types
-    - Nunjucks-to-Jinja language problems fixed (see https://github.com/alphagov/govuk-frontend-jinja/blob/master/govuk_frontend_jinja/templates.py) -#}
+    - `asList` option added to the root `params` object to allow setting of the `.govuk-radios` and `.govuk-radios__item` element types
+    - `children` option added to `item` allowing the sending in of prerendered child checkboxes (enabling the creation of tree structures through recursio    n)
+    - `item.conditional` changed so it appears in different places, depending on the radios being wrapped in a list or not (lists need it to go in the <li> whereas by default it sits outside)
+    Nunjucks/JavaScript language features fixed to work with Jinja/Python:
+    - true/false (Nunjucks/JavaScript) changed to True/False (Jinja/Python)
+    - '+' operator (Nunjucks/JavaScript) changed to '~' (Jinja/Python)
+    - optional space for item.children added below each radio to allow insertion of prerendered child radios HTML
+    (see https://github.com/alphagov/govuk-frontend-jinja/blob/master/govuk_frontend_jinja/templates.py for fixes currently handled by the extension) -#}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}
@@ -28,7 +34,7 @@
 {% endif %}
 
 {% set isConditional = False %}
-{% for item in params['items'] %}
+{% for item in params.items %}
   {% if item.conditional %}
     {% set isConditional = True %}
   {% endif %}

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -7,7 +7,7 @@
   {% if templates_and_folders_form.move_to.choices and template_list.templates_to_show %}
     <div id="move_to_folder_radios" class="sticky-template-form" role="region" aria-label="Choose the folder to move selected items to">
       <div class="js-will-stick-at-bottom-when-scrolling">
-      {{ radios_nested(templates_and_folders_form.move_to, move_to_children, option_hints=option_hints) }}
+      {{ templates_and_folders_form.move_to }}
       </div>
       <div class="js-will-stick-at-bottom-when-scrolling">
       {{ page_footer('Move', button_name='operation', button_value='move-to-existing-folder', button_text_hidden_suffix=' selection to folder') }}

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -1,4 +1,3 @@
-{% from "components/radios.html" import radios, radios_nested %}
 {% from "components/page-footer.html" import page_footer %}
 
 <div id="sticky_template_forms">
@@ -28,7 +27,7 @@
   </div>
   <div id="add_new_template_form" class="sticky-template-form" role="region" aria-label="Choose template type" {% if single_notification_channel %}data-channel="{{single_notification_channel}}" data-service="{{current_service.id}}"{% endif %}>
     <div class="js-will-stick-at-bottom-when-scrolling">
-    {{ radios(templates_and_folders_form.add_template_by_template_type) }}
+    {{ templates_and_folders_form.add_template_by_template_type }}
     </div>
     <div class="js-will-stick-at-bottom-when-scrolling">
     {{ page_footer('Continue', button_name='operation', button_value='add-new-template') }}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1257,7 +1257,8 @@ def test_move_folder_form_shows_current_folder_hint_when_in_a_folder(
 
     assert len(move_form_labels) == 3
     assert normalize_spaces(move_form_labels[0].text) == 'Templates'
-    assert normalize_spaces(move_form_labels[1].text) == 'parent_folder current folder'
+    assert normalize_spaces(move_form_labels[1].text) == 'parent_folder'
+    assert normalize_spaces(move_form_labels[1].parent.select_one('.govuk-hint').text) == 'current folder'
     assert normalize_spaces(move_form_labels[2].text) == 'child_folder'
 
 

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1521,7 +1521,8 @@ def test_radio_button_with_no_value_shows_custom_error_message(
     assert mock_move_to_template_folder.called is False
     assert mock_create_template_folder.called is False
 
-    assert page.select_one('span.error-message').text.strip() == 'Select the type of template you want to add'
+    assert page.select_one('span.govuk-error-message').text.strip() == \
+        'Error: Select the type of template you want to add'
 
 
 @pytest.mark.parametrize('data, error_msg', [


### PR DESCRIPTION
Part 8 of migrating our radio buttons to use the [GOV.UK Frontend radios component](https://design-system.service.gov.uk/components/radios/).

https://www.pivotaltracker.com/story/show/170030262

Changes the radios on the /templates page used for adding and moving templates and folders.

Includes some slightly big changes to `NestedFieldMixin`, `GovukRadiosField` and `GovukCheckboxesField` to allow customisation of radios and checkboxes that render in a tree structure.

## Nested radios and checkboxes

It's useful to have some context on how nested fields work before reviewing this pull request.

The nested versions of radios and checkboxes work by:
1. converting `option`s (the WTForms class for a single radio/checkbox) to `item`s ([GOVUK Frontend data for a single radio/checkbox](https://design-system.service.gov.uk/components/radios/#options-inline-radios-example--items))
2. checking each `option` for any child `option`s and doing the same for each of them until no children are found (leaf node)
3. getting the HTML for this level of `option`s by prerendering them as a group of radios
4. doing this for each parent until you get to the root
5. render the root radios/checkboxes

For example, the end `option`s in these radios are 'Folder 13, Folder 16 and Folder 2' and their parent `option` is 'Folder 1':

<img width="310" alt="tree_rendering_1" src="https://user-images.githubusercontent.com/87140/107360526-fc613100-6acd-11eb-8daa-c92a476feaef.png">

...so the `item`s for 'Folder 13, Folder 16 and Folder 2' will be prerendered and the result set as HTML below the 'Folder 1' `option`:

<img width="310" alt="tree_rendering_2" src="https://user-images.githubusercontent.com/87140/107360687-2ca8cf80-6ace-11eb-9330-9d4ac7a351a6.png">

This is then done for each grouping, until we hit the 'Templates' root:

<img width="310" alt="tree_rendering_3" src="https://user-images.githubusercontent.com/87140/107360774-4e09bb80-6ace-11eb-96fb-f7467974743c.png">

