### PR TITLE
Update utils to version 43.8.

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1362,7 +1362,7 @@ class LetterAddressForm(StripWhitespaceForm):
 
         if address.has_invalid_characters:
             raise ValidationError(
-                'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
+                'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >'
             )
 
 

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -85,7 +85,7 @@
                     Last line of the address must be a real UK postcode
                   {% endif %}
                 {% elif item.as_postal_address.has_invalid_characters %}
-                  Address lines must not start with any of the following characters: @ ( ) = [ ] ” \ / ,
+                  Address lines must not start with any of the following characters: @ ( ) = [ ] ” \ / , < >
                 {% endif %}
               </span>
             {% endcall %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -557,11 +557,11 @@ LETTER_VALIDATION_MESSAGES = {
     'invalid-char-in-address': {
         'title': 'There’s a problem with the address for this letter',
         'detail': (
-            "Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,"
+            "Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >"
         ),
         'summary': (
             "Validation failed because address lines must not start with any of the "
-            "following characters: @ ( ) = [ ] ” \\ / ,"
+            "following characters: @ ( ) = [ ] ” \\ / , < >"
         ),
     },
     'notify-tag-found-in-content': {

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@43.7.0#egg=notifications-utils==43.7.0
+git+https://github.com/alphagov/notifications-utils.git@43.8.3#egg=notifications-utils==43.8.3
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ awscli==1.18.211
     # via
     #   awscli-cwlogs
     #   notifications-utils
-bleach==3.2.1
+bleach==3.3.0
     # via notifications-utils
 blinker==1.4
     # via
@@ -111,12 +111,10 @@ markupsafe==1.1.1
 mistune==0.8.4
     # via notifications-utils
 monotonic==1.5
-    # via
-    #   notifications-python-client
-    #   notifications-utils
+    # via notifications-python-client
 notifications-python-client==5.7.1
     # via -r requirements.in
-git+https://github.com/alphagov/notifications-utils.git@43.7.0#egg=notifications-utils==43.7.0
+git+https://github.com/alphagov/notifications-utils.git@43.8.3#egg=notifications-utils==43.8.3
     # via -r requirements.in
 openpyxl==3.0.5
     # via pyexcel-xlsx
@@ -184,7 +182,9 @@ s3transfer==0.3.3
     #   awscli
     #   boto3
 shapely==1.7.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   notifications-utils
 six==1.15.0
     # via
     #   awscli-cwlogs

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -21,7 +21,7 @@ awscli==1.18.211
     #   notifications-utils
 beautifulsoup4==4.8.1
     # via -r requirements_for_test.in
-bleach==3.2.1
+bleach==3.3.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -191,12 +191,11 @@ monotonic==1.5
     # via
     #   -r requirements.txt
     #   notifications-python-client
-    #   notifications-utils
 more-itertools==8.6.0
     # via pytest
 notifications-python-client==5.7.1
     # via -r requirements.txt
-git+https://github.com/alphagov/notifications-utils.git@43.7.0#egg=notifications-utils==43.7.0
+git+https://github.com/alphagov/notifications-utils.git@43.8.3#egg=notifications-utils==43.8.3
     # via -r requirements.txt
 openpyxl==3.0.5
     # via
@@ -325,7 +324,9 @@ s3transfer==0.3.3
     #   awscli
     #   boto3
 shapely==1.7.1
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   notifications-utils
 six==1.15.0
     # via
     #   -r requirements.txt

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -688,7 +688,7 @@ def test_upload_csv_file_with_bad_postal_address_shows_check_page_with_errors(
         '6 Address must be no more than 7 lines long',
         '1 2 3 4 5 6 7 8',
 
-        '7 Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,',
+        '7 Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >',
         '=Firstname Lastname 123 Example St. SW1A 1AA',
     ]
 
@@ -2324,7 +2324,7 @@ def test_send_one_off_letter_address_populates_address_fields_in_session(
     (
         'a\n(b\nSW1A 1AA',
         [],
-        'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,',
+        'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >',
     ),
 ])
 def test_send_one_off_letter_address_rejects_bad_addresses(

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -562,11 +562,11 @@ def test_get_letter_validation_error_for_unknown_error():
         None,
         'There’s a problem with the address for this letter',
         (
-            'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / ,'
+            'Address lines must not start with any of the following characters: @ ( ) = [ ] ” \\ / , < >'
         ),
         (
             'Validation failed because address lines must not start with any of the following '
-            'characters: @ ( ) = [ ] ” \\ / ,'
+            'characters: @ ( ) = [ ] ” \\ / , < >'
         ),
     ),
 ])


### PR DESCRIPTION
Invalid characters for the first line of a postal address now include < >