### PR TITLE
Remove text about service is live or in trial mode

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -266,43 +266,41 @@
       {% endif %}
     </div>
 
-    {% if current_service.trial_mode %}
-      <h2 class="heading-medium top-gutter-0">Your service is in trial mode</h2>
+    {% if not current_service.has_permission('broadcast')%}
+      {% if current_service.trial_mode %}
+        <h2 class="heading-medium top-gutter-0">Your service is in trial mode</h2>
 
-      {% if not current_service.has_permission('broadcast') %}
-        <p class="govuk-body">You can only:</p>
+          <p class="govuk-body">You can only:</p>
 
-        <ul class='list list-bullet'>
-          <li>send {{ current_service.message_limit }} text messages and emails per day</li>
-          <li>send messages to yourself and other people in your team</li>
-          <li>create letter templates, but not send them</li>
-        </ul>
-      {% endif %}
+          <ul class='list list-bullet'>
+            <li>send {{ current_service.message_limit }} text messages and emails per day</li>
+            <li>send messages to yourself and other people in your team</li>
+            <li>create letter templates, but not send them</li>
+          </ul>
 
-      <p class="govuk-body">
-        {% if current_user.has_permissions('manage_service') %}
-          To remove these restrictions, you can send us a
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
-        {% else %}
-          Your service manager can ask to have these restrictions removed.
-        {% endif %}
-      </p>
+        <p class="govuk-body">
+          {% if current_user.has_permissions('manage_service') %}
+            To remove these restrictions, you can send us a
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.request_to_go_live', service_id=current_service.id) }}">request to go live</a>.
+          {% else %}
+            Your service manager can ask to have these restrictions removed.
+          {% endif %}
+        </p>
 
-    {% else %}
-      <h2 class="heading-medium top-gutter-0">Your service is live</h2>
+      {% else %}
+        <h2 class="heading-medium top-gutter-0">Your service is live</h2>
 
-      {% if not current_service.has_permission('broadcast') %}
         <p class="govuk-body">
           You can send up to
           {{ "{:,}".format(current_service.message_limit) }} messages
           per day.
         </p>
-      {% endif %}
-      <p class="govuk-body">
-        Problems or comments?
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Give feedback</a>.
-      </p>
+        <p class="govuk-body">
+          Problems or comments?
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Give feedback</a>.
+        </p>
 
+      {% endif %}
     {% endif %}
 
     {% if current_user.platform_admin %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -613,14 +613,8 @@ def test_show_restricted_broadcast_service(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert page.select('main h2')[0].text == 'Your service is in trial mode'
-
-    request_to_live = page.select_one('main p')
-    request_to_live_link = request_to_live.select_one('a')
-    assert normalize_spaces(page.select_one('main p').text) == (
-        'To remove these restrictions, you can send us a request to go live.'
-    )
-    assert request_to_live_link['href'] == url_for('main.request_to_go_live', service_id=SERVICE_ONE_ID)
+    assert 'Your service is in trial mode' not in page.select('main')[0].text
+    assert 'To remove these restrictions, you can send us a request to go live' not in page.select('main')[0].text
     assert not page.select_one('main ul')
 
 


### PR DESCRIPTION
This is not relevant for broadcast services. This information is
given in the heading bar next to the service name. There is no process
to request to go live and it is not necessary to tell you again that the
service is live

## Before

![Screenshot 2021-02-10 at 15 34 41](https://user-images.githubusercontent.com/7228605/107532539-e9c22700-6bb5-11eb-97ae-1693dd1a7ae2.png)

## After

![Screenshot 2021-02-10 at 15 35 07](https://user-images.githubusercontent.com/7228605/107532567-f181cb80-6bb5-11eb-8aef-f2f291ae4432.png)
