### PR TITLE
Handle exception is org name already exists

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -62,10 +62,17 @@ def add_organisation():
     form = NewOrganisationForm()
 
     if form.validate_on_submit():
-        return redirect(url_for(
-            '.organisation_settings',
-            org_id=Organisation.create_from_form(form).id,
-        ))
+        try:
+            return redirect(url_for(
+                '.organisation_settings',
+                org_id=Organisation.create_from_form(form).id,
+            ))
+        except HTTPError as e:
+            msg = 'Organisation name already exists'
+            if e.status_code == 400 and msg in e.message:
+                form.name.errors.append("This organisation name is already in use")
+            else:
+                raise e
 
     return render_template(
         'views/organisations/add-organisation.html',

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1,5 +1,3 @@
-from unittest.mock import ANY, Mock
-
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
@@ -102,7 +100,7 @@ def test_page_to_create_new_organisation(
         ('radio', 'organisation_type', 'other'),
         ('radio', 'crown_status', 'crown'),
         ('radio', 'crown_status', 'non-crown'),
-        ('hidden', 'csrf_token', ANY),
+        ('hidden', 'csrf_token', mocker.ANY),
     ]
 
 
@@ -200,8 +198,8 @@ def test_create_new_organisation_fails_with_duplicate_name(
     mocker,
 ):
     def _create(**_kwargs):
-        json_mock = Mock(return_value={'message': 'Organisation name already exists'})
-        resp_mock = Mock(status_code=400, json=json_mock)
+        json_mock = mocker.Mock(return_value={'message': 'Organisation name already exists'})
+        resp_mock = mocker.Mock(status_code=400, json=json_mock)
         http_error = HTTPError(response=resp_mock, message="Default message")
         raise http_error
 
@@ -1079,7 +1077,7 @@ def test_update_organisation_domains_when_domain_already_exists(
     client_request.login(user)
 
     mocker.patch('app.organisations_client.update_organisation', side_effect=HTTPError(
-        response=Mock(
+        response=mocker.Mock(
             status_code=400,
             json={'result': 'error', 'message': 'Domain already exists'}
         ),
@@ -1229,7 +1227,7 @@ def test_confirm_update_organisation_with_name_already_in_use(
     mocker.patch(
         'app.organisations_client.update_organisation_name',
         side_effect=HTTPError(
-            response=Mock(
+            response=mocker.Mock(
                 status_code=400,
                 json={'result': 'error', 'message': 'Organisation name already exists'}
             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -588,25 +588,6 @@ def mock_create_service(mocker):
 
 
 @pytest.fixture(scope='function')
-def mock_create_duplicate_service(mocker):
-    def _create(
-        service_name,
-        organisation_type,
-        message_limit,
-        restricted,
-        user_id,
-        email_from,
-    ):
-        json_mock = Mock(return_value={'message': {'name': ["Duplicate service name '{}'".format(service_name)]}})
-        resp_mock = Mock(status_code=400, json=json_mock)
-        http_error = HTTPError(response=resp_mock, message="Default message")
-        raise http_error
-
-    return mocker.patch(
-        'app.service_api_client.create_service', side_effect=_create)
-
-
-@pytest.fixture(scope='function')
 def mock_update_service(mocker):
     def _update(service_id, **kwargs):
         service = service_json(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176804067

Please see the commit for more details on the approach. Note 
the message matches that shown when changing the name of 
an existing organisation.

## After

<img width="625" alt="Screenshot 2021-02-11 at 12 17 49" src="https://user-images.githubusercontent.com/9029009/107635515-2ef06280-6c63-11eb-8cac-139a5f1c40b4.png">