### PR TITLE
Only show the alternative product image on desktop

### DIFF
--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -29,8 +29,10 @@ $button-shadow-size: $govuk-border-width-form-element;
       }
 
       &--alternative {
-        background-image: file-url('product/proposition-alternative.svg');
-        background-position: right 10px bottom 0;
+        @include media(desktop) {
+          background-image: file-url('product/proposition-alternative.svg');
+          background-position: right 10px bottom 0;
+        }
       }
 
     }


### PR DESCRIPTION
This matches what we do with the regular product image, to make sure the text doesn’t overlap it.