### PR TITLE
Reduce default broadcast expiry time

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -220,7 +220,7 @@ class BroadcastMessage(JSONModel):
         self._update(
             starts_at=datetime.utcnow().isoformat(),
             finishes_at=(
-                datetime.utcnow() + timedelta(hours=23, minutes=59)
+                datetime.utcnow() + timedelta(hours=4, minutes=0)
             ).isoformat(),
         )
         self._set_status_to('broadcasting')

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1873,7 +1873,7 @@ def test_request_approval(
             broadcast_message_id=fake_uuid,
             data={
                 'starts_at': '2020-02-22T22:22:22',
-                'finishes_at': '2020-02-23T22:21:22',
+                'finishes_at': '2020-02-23T02:22:22',
             },
         )
         mock_update_broadcast_message_status.assert_called_once_with(


### PR DESCRIPTION
We don’t think we need to broadcast longer than 4 hours to validate that the system is working.