### PR TITLE
Show rejected broadcasts on ‘Previous alerts’ page

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -53,6 +53,7 @@ def broadcast_dashboard_previous(service_id):
             'completed',
             'rejected',
         ),
+        page_title='Previous alerts',
         empty_message='You do not have any previous alerts',
         view_broadcast_endpoint='.view_previous_broadcast',
     )

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -373,35 +373,20 @@ def view_broadcast(service_id, broadcast_message_id):
     if broadcast_message.status == 'draft':
         abort(404)
 
-    if (
-        broadcast_message.status in {'completed', 'cancelled'}
-        and request.endpoint != 'main.view_previous_broadcast'
+    for statuses, endpoint in (
+        ({'completed', 'cancelled'}, 'main.view_previous_broadcast'),
+        ({'broadcasting', 'pending-approval'}, 'main.view_current_broadcast'),
+        ({'rejected'}, 'main.view_rejected_broadcast'),
     ):
-        return redirect(url_for(
-            '.view_previous_broadcast',
-            service_id=current_service.id,
-            broadcast_message_id=broadcast_message.id,
-        ))
-
-    if (
-        broadcast_message.status in {'broadcasting', 'pending-approval'}
-        and request.endpoint != 'main.view_current_broadcast'
-    ):
-        return redirect(url_for(
-            '.view_current_broadcast',
-            service_id=current_service.id,
-            broadcast_message_id=broadcast_message.id,
-        ))
-
-    if (
-        broadcast_message.status in {'rejected'}
-        and request.endpoint != 'main.view_rejected_broadcast'
-    ):
-        return redirect(url_for(
-            '.view_rejected_broadcast',
-            service_id=current_service.id,
-            broadcast_message_id=broadcast_message.id,
-        ))
+        if (
+            broadcast_message.status in statuses
+            and request.endpoint != endpoint
+        ):
+            return redirect(url_for(
+                endpoint,
+                service_id=current_service.id,
+                broadcast_message_id=broadcast_message.id,
+            ))
 
     back_link_endpoint = {
         'main.view_current_broadcast': '.broadcast_dashboard',

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -51,11 +51,25 @@ def broadcast_dashboard_previous(service_id):
         broadcasts=BroadcastMessages(service_id).with_status(
             'cancelled',
             'completed',
-            'rejected',
         ),
         page_title='Previous alerts',
         empty_message='You do not have any previous alerts',
         view_broadcast_endpoint='.view_previous_broadcast',
+    )
+
+
+@main.route('/services/<uuid:service_id>/rejected-alerts')
+@user_has_permissions()
+@service_has_permission('broadcast')
+def broadcast_dashboard_rejected(service_id):
+    return render_template(
+        'views/broadcast/previous-broadcasts.html',
+        broadcasts=BroadcastMessages(service_id).with_status(
+            'rejected',
+        ),
+        page_title='Rejected alerts',
+        empty_message='You do not have any rejected alerts',
+        view_broadcast_endpoint='.view_rejected_broadcast',
     )
 
 
@@ -345,6 +359,10 @@ def preview_broadcast_message(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/previous-alerts/<uuid:broadcast_message_id>',
     endpoint='view_previous_broadcast',
 )
+@main.route(
+    '/services/<uuid:service_id>/rejected-alerts/<uuid:broadcast_message_id>',
+    endpoint='view_rejected_broadcast',
+)
 @user_has_permissions()
 @service_has_permission('broadcast')
 def view_broadcast(service_id, broadcast_message_id):
@@ -356,7 +374,7 @@ def view_broadcast(service_id, broadcast_message_id):
         abort(404)
 
     if (
-        broadcast_message.status in {'completed', 'cancelled', 'rejected'}
+        broadcast_message.status in {'completed', 'cancelled'}
         and request.endpoint != 'main.view_previous_broadcast'
     ):
         return redirect(url_for(
@@ -375,9 +393,20 @@ def view_broadcast(service_id, broadcast_message_id):
             broadcast_message_id=broadcast_message.id,
         ))
 
+    if (
+        broadcast_message.status in {'rejected'}
+        and request.endpoint != 'main.view_rejected_broadcast'
+    ):
+        return redirect(url_for(
+            '.view_rejected_broadcast',
+            service_id=current_service.id,
+            broadcast_message_id=broadcast_message.id,
+        ))
+
     back_link_endpoint = {
         'main.view_current_broadcast': '.broadcast_dashboard',
         'main.view_previous_broadcast': '.broadcast_dashboard_previous',
+        'main.view_rejected_broadcast': '.broadcast_dashboard_rejected',
     }[request.endpoint]
 
     return render_template(

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -48,7 +48,11 @@ def broadcast_dashboard(service_id):
 def broadcast_dashboard_previous(service_id):
     return render_template(
         'views/broadcast/previous-broadcasts.html',
-        broadcasts=BroadcastMessages(service_id).with_status('cancelled', 'completed'),
+        broadcasts=BroadcastMessages(service_id).with_status(
+            'cancelled',
+            'completed',
+            'rejected',
+        ),
         empty_message='You do not have any previous alerts',
         view_broadcast_endpoint='.view_previous_broadcast',
     )

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -158,7 +158,7 @@ class BroadcastMessage(JSONModel):
 
     @cached_property
     def approved_by(self):
-        return User.from_id(self.approved_by_id)
+        return User.from_id(self.approved_by_id) if self.approved_by_id else None
 
     @cached_property
     def cancelled_by(self):

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -147,6 +147,10 @@ class MainNavigation(Navigation):
             'broadcast_dashboard_previous',
             'view_previous_broadcast',
         },
+        'rejected-broadcasts': {
+            'broadcast_dashboard_rejected',
+            'view_rejected_broadcast',
+        },
         'templates': {
             'action_blocked',
             'add_service_template',

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -7,6 +7,7 @@
     {% if current_service.has_permission('broadcast') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Previous alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('rejected-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_rejected', service_id=current_service.id) }}">Rejected alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -18,6 +18,10 @@
             <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
               Waiting for approval
             </p>
+          {% elif item.status == 'rejected' %}
+            <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
+              Rejected {{ item.updated_at|format_datetime_relative }}
+            </p>
           {% elif item.status == 'broadcasting' %}
             <p class="govuk-body govuk-!-margin-bottom-0 live-broadcast">
               Live since {{ item.starts_at|format_datetime_relative }}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -20,7 +20,7 @@
             </p>
           {% elif item.status == 'rejected' %}
             <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
-              Rejected {{ item.updated_at|format_datetime_relative }}
+              {{ item.updated_at|format_date_human|title }} at {{ item.updated_at|format_time }}
             </p>
           {% elif item.status == 'broadcasting' %}
             <p class="govuk-body govuk-!-margin-bottom-0 live-broadcast">
@@ -28,7 +28,7 @@
             </p>
           {% else %}
             <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
-              Broadcast {{ item.starts_at|format_datetime_relative }}
+              {{ item.starts_at|format_date_human|title }} at {{ item.starts_at|format_time }}
             </p>
           {% endif %}
         </div>

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -4,12 +4,12 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  Previous alerts
+  {{ page_title }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-medium">Previous alerts</h1>
+  <h1 class="heading-medium">{{ page_title }}</h1>
 
   {% include('views/broadcast/partials/dashboard-table.html') %}
 

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -116,6 +116,11 @@
           <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcasting</a>
         {% endif %}
       </p>
+    {% elif broadcast_message.status == 'rejected' %}
+      <p class="govuk-body govuk-!-margin-bottom-4">
+        Rejected
+        {{ broadcast_message.updated_at|format_datetime_human }}.
+      </p>
     {% else %}
       <p class="govuk-body govuk-!-margin-bottom-4">
         Broadcast
@@ -150,10 +155,13 @@
     <p class="govuk-body govuk-!-margin-bottom-3">
       {% if broadcast_message.created_by %}
         Prepared by {{ broadcast_message.created_by.name }}
-      {% else %}
+      {%- else %}
         Created from an API call
-      {% endif %}
-      and approved by {{ broadcast_message.approved_by.name }}.
+      {%- endif %}
+      {%- if broadcast_message.approved_by %}
+        and approved by {{ broadcast_message.approved_by.name }}
+      {%- endif %}
+      {{- '.' }}
     </p>
   {% endif %}
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1404,6 +1404,13 @@ def test_start_broadcasting(
         'Prepared by Alice and approved by Bob.',
         'Stopped by Carol yesterday at 9:21pm.',
     ]),
+    ('.view_rejected_broadcast', False, {
+        'status': 'rejected',
+        'updated_at': '2020-02-21T21:21:21.000000',
+    }, [
+        'Rejected yesterday at 9:21pm.',
+        'Prepared by Alice and approved by Bob.',
+    ]),
 ))
 @freeze_time('2020-02-22T22:22:22.000000')
 def test_view_broadcast_message_page(
@@ -1505,6 +1512,7 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
             starts_at='2020-02-20T20:20:20.000000',
             finishes_at='2021-12-21T21:21:21.000000',
             cancelled_at='2021-01-01T01:01:01.000000',
+            updated_at='2021-01-01T01:01:01.000000',
             status=status,
         ),
     )

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -420,8 +420,8 @@ def test_previous_broadcasts_page(
         normalize_spaces(row.text)
         for row in page.select('.ajax-block-container')[0].select('.file-list')
     ] == [
-        'Example template This is a test Broadcast yesterday at 2:20pm England Scotland',
-        'Example template This is a test Broadcast yesterday at 2:20am England Scotland',
+        'Example template This is a test Yesterday at 2:20pm England Scotland',
+        'Example template This is a test Yesterday at 2:20am England Scotland',
     ]
 
     button = page.select_one(
@@ -455,7 +455,7 @@ def test_rejected_broadcasts_page(
         normalize_spaces(row.text)
         for row in page.select('.ajax-block-container')[0].select('.file-list')
     ] == [
-        'Example template This is a test Rejected today at 1:20am England Scotland',
+        'Example template This is a test Today at 1:20am England Scotland',
     ]
 
     button = page.select_one(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -420,6 +420,7 @@ def test_previous_broadcasts_page(
         normalize_spaces(row.text)
         for row in page.select('.ajax-block-container')[0].select('.file-list')
     ] == [
+        'Example template This is a test Rejected today at 1:20am England Scotland',
         'Example template This is a test Broadcast yesterday at 2:20pm England Scotland',
         'Example template This is a test Broadcast yesterday at 2:20am England Scotland',
     ]

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -36,6 +36,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'broadcast',
     'broadcast_dashboard',
     'broadcast_dashboard_previous',
+    'broadcast_dashboard_rejected',
     'broadcast_dashboard_updates',
     'broadcast_tour',
     'callbacks',
@@ -326,6 +327,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'view_previous_broadcast',
     'view_provider',
     'view_providers',
+    'view_rejected_broadcast',
     'view_template',
     'view_template_version',
     'view_template_versions',
@@ -493,6 +495,7 @@ def test_navigation_for_services_with_broadcast_permission(
     ] == [
         '/services/{}/current-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/previous-alerts'.format(SERVICE_ONE_ID),
+        '/services/{}/rejected-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),
         '/services/{}/service-settings'.format(SERVICE_ONE_ID),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4420,6 +4420,13 @@ def mock_get_broadcast_messages(
                     datetime.utcnow() - timedelta(days=10)
                 ).isoformat(),
             ),
+            partial_json(
+                id_=uuid4(),
+                status='rejected',
+                updated_at=(
+                    datetime.utcnow() - timedelta(hours=1)
+                ).isoformat(),
+            ),
         ]
 
     return mocker.patch(


### PR DESCRIPTION
Two reasons to not hide rejected broadcasts:
- if a broadcast was rejected by mistake then it’s useful to have an audit of who did that 
- it means you can still see old broadcasts without having to leave them in `pending-approval`, which is dangerous because they might accidentally be approved

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/114005842-da7af500-9857-11eb-941e-b79c9636c2ae.png) | ![image](https://user-images.githubusercontent.com/355079/114005658-a8699300-9857-11eb-87c8-c927c1d72714.png)
