### PR TITLE
Remove id from table used for the row numbers

### DIFF
--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -51,6 +51,9 @@
             .removeClass('fullscreen-scrollable-table')
             .removeAttr(attributesForFocus)
             .attr('aria-hidden', true)
+            .find('caption')
+            .removeAttr('id')
+            .closest('.fullscreen-fixed-table')
         )
         .append(
           '<div class="fullscreen-right-shadow" />'


### PR DESCRIPTION
A recent audit by the Digital Accessibility Centre (DAC) showed that our fullscreenTable component had 2 of the same id in its HTML. This makes its HTML invalid as ids should be unique.

This removes one of the ids. More detail on how is in the commit.