### PR TITLE
Fix the ‘revoke’ links on the API keys page

### DIFF
--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -46,7 +46,7 @@
         {% endcall %}
       {% else %}
         {% call field(align='right', status='error') %}
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>
+          <a class="govuk-link govuk-link--destructive" href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>
             Revoke<span class="govuk-visually-hidden"> {{ item.name }}</span>
           </a>
         {% endcall %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -191,13 +191,22 @@ def test_should_show_empty_api_keys_page(
 def test_should_show_api_keys_page(
     client_request,
     mock_get_api_keys,
+    fake_uuid,
 ):
     page = client_request.get('main.api_keys', service_id=SERVICE_ONE_ID)
     rows = [normalize_spaces(row.text) for row in page.select('main tr')]
+    revoke_link = page.select_one('main tr a.govuk-link.govuk-link--destructive')
 
     assert rows[0] == 'API keys Action'
     assert rows[1] == 'another key name Revoked 1 January at 1:00am'
     assert rows[2] == 'some key name Revoke some key name'
+
+    assert normalize_spaces(revoke_link.text) == 'Revoke some key name'
+    assert revoke_link['href'] == url_for(
+        'main.revoke_api_key',
+        service_id=SERVICE_ONE_ID,
+        key_id=fake_uuid,
+    )
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 


### PR DESCRIPTION
They were missing the `govuk-link--destructive` class which turns them red, consistent with other links we use for deleting or suspending things.

Before | After 
---|---
![image](https://user-images.githubusercontent.com/355079/108512338-f7b03000-72b8-11eb-9a7e-c32990e8db31.png) | ![image](https://user-images.githubusercontent.com/355079/108512281-e404c980-72b8-11eb-870f-562dbf621373.png) 

