### PR TITLE
Use the GOVUK Frontend inset text component instead of <aside>

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -34,6 +34,7 @@ $govuk-assets-path: "/static/";
 @import "components/radios/_radios";
 @import "components/checkboxes/_checkboxes";
 @import "components/input/_input";
+@import "components/inset-text/_inset-text";
 
 // update to focus styles, remove when upgrading to GOVUK Frontend 3.x.x
 @import "./focus/components";

--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -4,33 +4,27 @@
 <p class="govuk-body">
   To put a heading in your template, use a hash:
 </p>
-<div>
-  {{ govukInsetText({
-    "text": "# This is a heading",
-    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
-  }}
-</div>
+{{ govukInsetText({
+  "text": "# This is a heading",
+  "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+}}
 <p class="govuk-body">
   To make bullet points, use asterisks:
 </p>
-<div>
-  {{ govukInsetText({
-    "html": "* point 1<br/>
-             * point 2<br/>
-             * point 3<br/>",
-    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
-  }}
-</div>
+{{ govukInsetText({
+  "html": "* point 1<br/>
+            * point 2<br/>
+            * point 3<br/>",
+  "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+}}
 <p class="govuk-body">
   To insert a page break, use three asterisks:
 </p>
-<div>
-  {{ govukInsetText({
-    "html": "Content on page 1<br/>
-             <br/>
-             ***<br/>
-             <br/>
-             Content on page 2<br/>",
-    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
-  }}
-</div>
+{{ govukInsetText({
+  "html": "Content on page 1<br/>
+            <br/>
+            ***<br/>
+            <br/>
+            Content on page 2<br/>",
+  "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+}}

--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -1,31 +1,36 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
 <h2 class="heading-medium">Formatting</h2>
 <p class="govuk-body">
   To put a heading in your template, use a hash:
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    # This is a heading
-  </p>
+<div>
+  {{ govukInsetText({
+    "text": "# This is a heading",
+    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+  }}
 </div>
 <p class="govuk-body">
   To make bullet points, use asterisks:
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    * point 1<br/>
-    * point 2<br/>
-    * point 3<br/>
-  </p>
+<div>
+  {{ govukInsetText({
+    "html": "* point 1<br/>
+             * point 2<br/>
+             * point 3<br/>",
+    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+  }}
 </div>
 <p class="govuk-body">
   To insert a page break, use three asterisks:
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    Content on page 1<br/>
-    <br/>
-    ***<br/>
-    <br/>
-    Content on page 2<br/>
-  </p>
+<div>
+  {{ govukInsetText({
+    "html": "Content on page 1<br/>
+             <br/>
+             ***<br/>
+             <br/>
+             Content on page 2<br/>",
+    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+  }}
 </div>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,41 +1,37 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
 <h2 class="heading-medium">Formatting</h2>
 <p class="bottom-gutter-1-3">
   To put a title in your template, use a hash:
 </p>
-<div class="panel panel-border-wide bottom-gutter">
-  <p class="govuk-body">
-    # This is a title
-  </p>
+<div class="bottom-gutter">
+  {{ govukInsetText({"text": "# This is a title", "classes": "govuk-!-margin-top-0"})}}
 </div>
 <p class="bottom-gutter-1-3">
   To make bullet points, use asterisks:
 </p>
-<div class="panel panel-border-wide bottom-gutter">
-  <p class="govuk-body">
-    * point 1<br/>
-    * point 2<br/>
-    * point 3<br/>
-  </p>
+<div class="bottom-gutter">
+  {{ govukInsetText({
+    "html": "* point 1<br/>
+             * point 2<br/>
+             * point 3<br/>",
+    "classes": "govuk-!-margin-top-0"})
+  }}
 </div>
 <p class="bottom-gutter-1-3">
   To add inset text, use a caret:
 </p>
-<div class="panel panel-border-wide bottom-gutter">
-  <p class="govuk-body">
-    ^ You must tell us if your circumstances change
-  </p>
+<div class="bottom-gutter">
+  {{ govukInsetText({"text": "^ You must tell us if your circumstances change", "classes": "govuk-!-margin-top-0"})}}
 </div>
 <p class="bottom-gutter-1-3">
   To add a horizontal line, use three dashes:
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    First paragraph
-  </p>
-  <p style="letter-spacing: 1px;">
-    ---
-  </p>
-  <p class="govuk-body">
-    Second paragraph
-  </p>
+<div>
+  {{ govukInsetText({
+    "html": '<p class="govuk-body">First paragraph</p>
+             <p class="govuk-body" style="letter-spacing: 1px;">---</p>
+             <p class="govuk-body">Second paragraph</p>',
+    "classes": "govuk-!-margin-top-0"})
+  }}
 </div>

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -4,13 +4,13 @@
 <p class="bottom-gutter-1-3">
   To put a title in your template, use a hash:
 </p>
-<div class="bottom-gutter">
+<div class="govuk-!-margin-bottom-6">
   {{ govukInsetText({"text": "# This is a title", "classes": "govuk-!-margin-top-0"})}}
 </div>
 <p class="bottom-gutter-1-3">
   To make bullet points, use asterisks:
 </p>
-<div class="bottom-gutter">
+<div class="govuk-!-margin-bottom-6">
   {{ govukInsetText({
     "html": "* point 1<br/>
              * point 2<br/>
@@ -21,17 +21,15 @@
 <p class="bottom-gutter-1-3">
   To add inset text, use a caret:
 </p>
-<div class="bottom-gutter">
+<div class="govuk-!-margin-bottom-6">
   {{ govukInsetText({"text": "^ You must tell us if your circumstances change", "classes": "govuk-!-margin-top-0"})}}
 </div>
 <p class="bottom-gutter-1-3">
   To add a horizontal line, use three dashes:
 </p>
-<div>
-  {{ govukInsetText({
-    "html": '<p class="govuk-body">First paragraph</p>
-             <p class="govuk-body" style="letter-spacing: 1px;">---</p>
-             <p class="govuk-body">Second paragraph</p>',
-    "classes": "govuk-!-margin-top-0"})
-  }}
-</div>
+{{ govukInsetText({
+  "html": '<p class="govuk-body">First paragraph</p>
+            <p class="govuk-body" style="letter-spacing: 1px;">---</p>
+            <p class="govuk-body">Second paragraph</p>',
+  "classes": "govuk-!-margin-top-0"})
+}}

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -1,9 +1,12 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
 <h2 class="heading-medium">Links and URLs</h2>
 <p class="bottom-gutter-1-3">
   Always use full URLs, starting with https://
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    Apply now at https://www.gov.uk/example
-  </p>
+<div>
+  {{ govukInsetText({
+    "text": "Apply now at https://www.gov.uk/example",
+    "classes": "govuk-!-margin-top-0"})
+  }}
 </div>

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -4,9 +4,7 @@
 <p class="bottom-gutter-1-3">
   Always use full URLs, starting with https://
 </p>
-<div>
-  {{ govukInsetText({
-    "text": "Apply now at https://www.gov.uk/example",
-    "classes": "govuk-!-margin-top-0"})
-  }}
-</div>
+{{ govukInsetText({
+  "text": "Apply now at https://www.gov.uk/example",
+  "classes": "govuk-!-margin-top-0"})
+}}

--- a/app/templates/partials/templates/guidance-optional-content.html
+++ b/app/templates/partials/templates/guidance-optional-content.html
@@ -10,13 +10,11 @@
   For example if you only want to show something to people who are under
   18:
 </p>
-<div>
-  {{ govukInsetText({
-    "text": "((under18??Please get your application signed by a parent or
-    guardian.))",
-    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
-  }}
-</div>
+{{ govukInsetText({
+  "text": "((under18??Please get your application signed by a parent or
+  guardian.))",
+  "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+}}
 <p class="govuk-body">
   For each person you send this message to, specify ‘yes’ or ‘no’ to
   show or hide this content.

--- a/app/templates/partials/templates/guidance-optional-content.html
+++ b/app/templates/partials/templates/guidance-optional-content.html
@@ -1,3 +1,5 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
 <h2 class="heading-medium">
   Optional content
 </h2>
@@ -8,11 +10,12 @@
   For example if you only want to show something to people who are under
   18:
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    ((under18??Please get your application signed by a parent or
-    guardian.))
-  </p>
+<div>
+  {{ govukInsetText({
+    "text": "((under18??Please get your application signed by a parent or
+    guardian.))",
+    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+  }}
 </div>
 <p class="govuk-body">
   For each person you send this message to, specify ‘yes’ or ‘no’ to

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -1,11 +1,14 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
 <h2 class="heading-medium">
   Personalisation
 </h2>
 <p class="bottom-gutter-1-3">
   Use double brackets to personalise your message:
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    Hello ((first name)), your reference is ((ref number))
-  </p>
+<div>
+  {{ govukInsetText({
+    "text": "Hello ((first name)), your reference is ((ref number))",
+    "classes": "govuk-!-margin-top-0"})
+  }}
 </div>

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -6,9 +6,7 @@
 <p class="bottom-gutter-1-3">
   Use double brackets to personalise your message:
 </p>
-<div>
-  {{ govukInsetText({
-    "text": "Hello ((first name)), your reference is ((ref number))",
-    "classes": "govuk-!-margin-top-0"})
-  }}
-</div>
+{{ govukInsetText({
+  "text": "Hello ((first name)), your reference is ((ref number))",
+  "classes": "govuk-!-margin-top-0"})
+}}

--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -1,12 +1,15 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+
 <h2 class="heading-medium">
   Send a document by email
 </h2>
 <p class="govuk-body">
   Use double brackets to add a placeholder field to your template. This will contain a secure link to download the document.
 </p>
-<div class="panel panel-border-wide">
-  <p class="govuk-body">
-    Download your document at: ((link_to_file))
-  </p>
+<div>
+  {{ govukInsetText({
+    "text": "Download your document at: ((link_to_file))",
+    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+  }}
 </div>
   Next, use the API to upload your document. Follow the instructions to send a document by email in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a>.

--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -6,10 +6,9 @@
 <p class="govuk-body">
   Use double brackets to add a placeholder field to your template. This will contain a secure link to download the document.
 </p>
-<div>
-  {{ govukInsetText({
-    "text": "Download your document at: ((link_to_file))",
-    "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
-  }}
-</div>
-  Next, use the API to upload your document. Follow the instructions to send a document by email in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a>.
+{{ govukInsetText({
+  "text": "Download your document at: ((link_to_file))",
+  "classes": "govuk-!-margin-top-0 govuk-!-margin-bottom-3"})
+}}
+
+Next, use the API to upload your document. Follow the instructions to send a document by email in the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">API documentation</a>.

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -31,7 +31,7 @@
             'Save'
           ) }}
         </div>
-        <aside class="govuk-grid-column-full">
+        <div class="govuk-grid-column-full">
           {% include "partials/templates/guidance-formatting.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}
@@ -39,7 +39,7 @@
           {% if current_service.has_permission('upload_document') %}
             {% include "partials/templates/guidance-send-a-document.html" %}
           {% endif %}
-        </aside>
+        </div>
       </div>
     {% endcall %}
 

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -28,11 +28,11 @@
             'Save'
           ) }}
         </div>
-        <aside class="govuk-grid-column-three-quarters">
+        <div class="govuk-grid-column-three-quarters">
           {% include "partials/templates/guidance-formatting-letters.html" %}
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}
-        </aside>
+        </div>
       </div>
     {% endcall %}
 

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -41,12 +41,12 @@
           </div>
           {{ page_footer('Save') }}
         </div>
-        <aside class="govuk-grid-column-full">
+        <div class="govuk-grid-column-full">
           {% include "partials/templates/guidance-personalisation.html" %}
           {% include "partials/templates/guidance-optional-content.html" %}
           {% include "partials/templates/guidance-links.html" %}
           {% include "partials/templates/guidance-character-count.html" %}
-        </aside>
+        </div>
       </div>
     {% endcall %}
 

--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -19,9 +19,9 @@
           {{ form.postage }}
           {{ page_footer('Save') }}
         </div>
-        <aside class="govuk-grid-column-three-quarters">
+        <div class="govuk-grid-column-three-quarters">
           {% include "partials/templates/guidance-postage.html" %}
-        </aside>
+        </div>
       </div>
     {% endcall %}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,8 @@ const copy = {
         'label',
         'checkboxes',
         'radios',
-        'input'
+        'input',
+        'inset-text'
       ];
       let done = 0;
 


### PR DESCRIPTION
We use the `<aside>` tag to wrap our indented text in the 'formatting' guidance you see when creating a template. This is invalid HTML. We should use the GOVUK Frontend inset text component instead.

Note, there are more places that will need to be updated to use the inset-text macro - this PR only changes the template formatting pages since these were flagged by the accessibility audit.

[Pivotal story](https://www.pivotaltracker.com/story/show/176905338)