### PR TITLE
Rerun freeze-requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ago==0.0.93
     # via -r requirements.in
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-awscli==1.19.7
+awscli==1.19.13
     # via
     #   awscli-cwlogs
     #   notifications-utils
@@ -18,9 +18,9 @@ blinker==1.4
     # via
     #   -r requirements.in
     #   gds-metrics
-boto3==1.17.7
+boto3==1.17.13
     # via notifications-utils
-botocore==1.20.7
+botocore==1.20.13
     # via
     #   awscli
     #   boto3
@@ -159,7 +159,7 @@ pytz==2021.1
     # via
     #   -r requirements.in
     #   notifications-utils
-pyyaml==5.3.1
+pyyaml==5.4.1
     # via
     #   awscli
     #   notifications-utils
@@ -171,7 +171,7 @@ requests==2.25.1
     #   govuk-bank-holidays
     #   notifications-python-client
     #   notifications-utils
-rsa==4.5
+rsa==4.7.1
     # via awscli
 s3transfer==0.3.4
     # via


### PR DESCRIPTION
This importantly upgrades pyyaml which has a security bug in 5.3.1

Note, strangely, I had to delete the requirements.txt file and rerun to
get these requirements to upgrade, otherwise it kept them in place
(maybe some piptools caching stuff not calculating things if it doesn't
think it has been asked to change them).