### PR TITLE
allow caseworkers to view letter previews

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -197,7 +197,7 @@ def get_preview_error_image():
 
 
 @main.route("/services/<uuid:service_id>/notification/<uuid:notification_id>.<letter_file_extension:filetype>")
-@user_has_permissions('view_activity')
+@user_has_permissions('view_activity', 'send_messages')
 def view_letter_notification_as_preview(
     service_id, notification_id, filetype, with_metadata=False
 ):

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -610,12 +610,19 @@ def test_notification_page_shows_page_for_other_postage_classes(
 @pytest.mark.parametrize('filetype', [
     'pdf', 'png'
 ])
+@pytest.mark.parametrize('user', [
+    create_active_user_with_permissions(),
+    create_active_caseworking_user(),
+])
 def test_should_show_image_of_letter_notification(
     logged_in_client,
     fake_uuid,
     mocker,
     filetype,
+    user,
 ):
+    mocker.patch('app.user_api_client.get_user', return_value=user)
+
     notification = create_notification(template_type='letter')
     mocker.patch('app.notification_api_client.get_notification', return_value=notification)
 


### PR DESCRIPTION
they can already view notifications page, but the png and pdf letter previews just 403 for them currently