### PR TITLE
Fix minor accessibility bugs from recent audit

### DIFF
--- a/app/assets/javascripts/collapsibleCheckboxes.js
+++ b/app/assets/javascripts/collapsibleCheckboxes.js
@@ -20,12 +20,14 @@
     }[field] || `No ${field}s`)
   };
   Summary.prototype.addContent = function() {
+    const $hint = this.module.$formGroup.find('.govuk-hint');
     this.$text = $(`<p class="selection-summary__text" />`);
 
     if (this.fieldLabel === 'folder') { this.$text.addClass('selection-summary__text--folders'); }
 
+    this.$el.attr('id', $hint.attr('id'));
     this.$el.append(this.$text);
-    this.module.$formGroup.find('.govuk-hint').remove();
+    $hint.remove();
   };
   Summary.prototype.update = function(selection) {
     let template;

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -555,6 +555,10 @@ class StripWhitespaceForm(Form):
             bound.get_form = weakref.ref(form)  # GC won't collect the form if we don't use a weakref
             return bound
 
+        def render_field(self, field, render_kw):
+            render_kw.setdefault('required', False)
+            return super().render_field(field, render_kw)
+
 
 class StripWhitespaceStringField(GovukTextInputField):
     def __init__(self, label=None, param_extensions=None, **kwargs):

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -351,7 +351,7 @@ def _get_job_counts(job):
         ) for label, query_param, count in [
             [
                 f'''total<span class="govuk-visually-hidden">
-                 {message_count_noun(job.notification_count, job_type)}</span>''',
+                 {"text message" if job_type == "sms" else job_type}s</span>''',
                 '',
                 job.notification_count
             ],

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -29,7 +29,7 @@ from app import (
     notification_api_client,
     service_api_client,
 )
-from app.formatters import get_time_left
+from app.formatters import get_time_left, message_count_noun
 from app.main import main
 from app.main.forms import SearchNotificationsForm
 from app.models.job import Job
@@ -336,6 +336,7 @@ def get_status_filters(service, message_type, statistics):
 
 
 def _get_job_counts(job):
+    job_type = job.template_type
     return [
         (
             label,
@@ -349,19 +350,27 @@ def _get_job_counts(job):
             count
         ) for label, query_param, count in [
             [
-                'total', '',
+                f'''total<span class="govuk-visually-hidden">
+                 {message_count_noun(job.notification_count, job_type)}</span>''',
+                '',
                 job.notification_count
             ],
             [
-                'sending', 'sending',
+                f'''sending<span class="govuk-visually-hidden">
+                 {message_count_noun(job.notifications_sending, job_type)}</span>''',
+                'sending',
                 job.notifications_sending
             ],
             [
-                'delivered', 'delivered',
+                f'''delivered<span class="govuk-visually-hidden">
+                 {message_count_noun(job.notifications_delivered, job_type)}</span>''',
+                'delivered',
                 job.notifications_delivered
             ],
             [
-                'failed', 'failed',
+                f'''failed<span class="govuk-visually-hidden">
+                 {message_count_noun(job.notifications_failed, job_type)}</span>''',
+                'failed',
                 job.notifications_failed
             ]
         ]

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -18,7 +18,7 @@
           {% if show_count %}
             {{ big_number(count, **big_number_args) }}
           {% endif %}
-            <div class="pill-item__label{% if not show_count %} pill-item--centered{% endif %}">{{ label }}</div>
+            <div class="pill-item__label{% if not show_count %} pill-item--centered{% endif %}">{{ label | safe }}</div>
           </a>
         </li>
       {% endfor %}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -46,7 +46,9 @@
         {% endcall %}
       {% else %}
         {% call field(align='right', status='error') %}
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>Revoke</a>
+          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>
+            Revoke<span class="govuk-visually-hidden"> {{ item.name }}</span>
+          </a>
         {% endcall %}
       {% endif %}
     {% endcall %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -35,7 +35,9 @@
           </div>
           <div class="govuk-grid-column-one-quarter">
             {% if current_user.has_permissions('manage_service') %}
-              <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">Change</a>
+              <a class="govuk-link govuk-link--no-visited-state user-list-edit-link"href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">
+                Change<span class="govuk-visually-hidden"> {{ item.email_address }}</span>
+              </a>
             {% endif %}
           </div>
         </div>

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -49,7 +49,9 @@
           </div>
           <div class="govuk-grid-column-one-quarter">
             {% if current_user.has_permissions('manage_service') %}
-            <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">Change</a>
+            <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_letter_contact', service_id =current_service.id, letter_contact_id = item.id) }}">
+              Change<span class="govuk-visually-hidden"> {{ item.contact_block }}</span>
+            </a>
             {% endif %}
           </div>
         </div>

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -37,7 +37,9 @@
           </div>
           <div class="govuk-grid-column-one-quarter">
             {% if current_user.has_permissions('manage_service') %}
-              <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">Change</a>
+              <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_sms_sender', service_id=current_service.id, sms_sender_id = item.id) }}">
+               Change<span class="govuk-visually-hidden"> {{ item.sms_sender }}</span>
+              </a>
             {% endif %}
           </div>
         </div>

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -197,7 +197,7 @@ def test_should_show_api_keys_page(
 
     assert rows[0] == 'API keys Action'
     assert rows[1] == 'another key name Revoked 1 January at 1:00am'
-    assert rows[2] == 'some key name Revoke'
+    assert rows[2] == 'some key name Revoke some key name'
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -190,7 +190,7 @@ def test_should_show_job_in_progress(
         normalize_spaces(link.text)
         for link in page.select('.pill a:not(.pill-item--selected)')
     ] == [
-        '10 sending', '0 delivered', '0 failed'
+        '10 sending text messages', '0 delivered text messages', '0 failed text messages'
     ]
     assert page.select_one('p.hint').text.strip() == 'Report is 50% complete…'
 
@@ -215,7 +215,7 @@ def test_should_show_job_without_notifications(
         normalize_spaces(link.text)
         for link in page.select('.pill a:not(.pill-item--selected)')
     ] == [
-        '10 sending', '0 delivered', '0 failed'
+        '10 sending text messages', '0 delivered text messages', '0 failed text messages'
     ]
     assert page.select_one('p.hint').text.strip() == 'Report is 50% complete…'
     assert page.select_one('tbody').text.strip() == 'No messages to show yet…'

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2191,7 +2191,7 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
 
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [
     ('main.service_email_reply_to', 0, 'test@example.com (default) Change test@example.com'),
-    ('main.service_letter_contact_details', 1, '1 Example Street (default) Change'),
+    ('main.service_letter_contact_details', 1, '1 Example Street (default) Change 1 Example Street'),
     ('main.service_sms_senders', 0, 'GOVUK (default) Change GOVUK')
 ])
 def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
@@ -2237,9 +2237,9 @@ def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
         create_multiple_letter_contact_blocks(),
         [
             'Blank Make default',
-            '1 Example Street (default) Change ID: 1234',
-            '2 Example Street Change ID: 5678',
-            'foo<bar>baz Change ID: 9457',
+            '1 Example Street (default) Change 1 Example Street ID: 1234',
+            '2 Example Street Change 2 Example Street ID: 5678',
+            'foo<bar>baz Change foo <bar> baz ID: 9457',
         ],
     ), (
         'main.service_sms_senders',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2192,7 +2192,7 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [
     ('main.service_email_reply_to', 0, 'test@example.com (default) Change test@example.com'),
     ('main.service_letter_contact_details', 1, '1 Example Street (default) Change'),
-    ('main.service_sms_senders', 0, 'GOVUK (default) Change')
+    ('main.service_sms_senders', 0, 'GOVUK (default) Change GOVUK')
 ])
 def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
     client_request,
@@ -2246,9 +2246,9 @@ def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
         'app.service_api_client.get_sms_senders',
         create_multiple_sms_senders(),
         [
-            'Example (default and receives replies) Change ID: 1234',
-            'Example 2 Change ID: 5678',
-            'Example 3 Change ID: 9457',
+            'Example (default and receives replies) Change Example ID: 1234',
+            'Example 2 Change Example 2 ID: 5678',
+            'Example 3 Change Example 3 ID: 9457',
         ],
     ),
     ]

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2190,7 +2190,7 @@ def test_and_more_hint_appears_on_settings_with_more_than_just_a_single_sender(
 
 
 @pytest.mark.parametrize('sender_list_page, index, expected_output', [
-    ('main.service_email_reply_to', 0, 'test@example.com (default) Change'),
+    ('main.service_email_reply_to', 0, 'test@example.com (default) Change test@example.com'),
     ('main.service_letter_contact_details', 1, '1 Example Street (default) Change'),
     ('main.service_sms_senders', 0, 'GOVUK (default) Change')
 ])
@@ -2227,9 +2227,9 @@ def test_api_ids_dont_show_on_option_pages_with_a_single_sender(
         'app.service_api_client.get_reply_to_email_addresses',
         create_multiple_email_reply_to_addresses(),
         [
-            'test@example.com (default) Change ID: 1234',
-            'test2@example.com Change ID: 5678',
-            'test3@example.com Change ID: 9457',
+            'test@example.com (default) Change test@example.com ID: 1234',
+            'test2@example.com Change test2@example.com ID: 5678',
+            'test3@example.com Change test3@example.com ID: 9457',
         ],
     ), (
         'main.service_letter_contact_details',

--- a/tests/javascripts/collapsibleCheckboxes.test.js
+++ b/tests/javascripts/collapsibleCheckboxes.test.js
@@ -42,10 +42,10 @@ describe('Collapsible fieldset', () => {
     document.body.innerHTML =
       `<div class="selection-wrapper" data-module="collapsible-checkboxes" data-field-label="folder">
         <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" id="folder_permissions">
+          <fieldset class="govuk-fieldset" id="folder_permissions" aria-describedby="users_with_permission-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
               Folders this team member can see
-              <span class="govuk-hint">
+              <span class="govuk-hint" id="users_with_permission-hint">
                 <div class="selection-summary" role="region" aria-live="polite"></div>
               </span>
             </legend>
@@ -144,9 +144,26 @@ describe('Collapsible fieldset', () => {
 
     });
 
-    test("removes the hint", () => {
+    test("the hint is removed", () => {
 
       expect(document.querySelector('.govuk-hint')).toBeNull();
+
+    });
+
+    describe("the live region that was inside the hint", () => {
+
+      test("is moved above the fieldset", () => {
+
+        expect(fieldset.previousElementSibling.matches('.selection-summary')).toBe(true);
+
+      });
+
+      test("has an id matching the aria-describedby on the fieldset", () => {
+
+        const fieldsetDescribedby = fieldset.getAttribute('aria-describedby');
+        expect(fieldset.previousElementSibling.getAttribute('id')).toEqual(fieldsetDescribedby);
+
+      });
 
     });
 


### PR DESCRIPTION
This fixes the incorrect use of aria, non-descriptive links and mandatory fields issues that were identified by the recent Digital Accessibility Centre Audit.

See individual commits and [Pivotal story](https://www.pivotaltracker.com/story/show/176905338) for details.