### PR TITLE
Support service IDs in ‘find services by name’

### DIFF
--- a/app/main/views/find_services.py
+++ b/app/main/views/find_services.py
@@ -1,4 +1,7 @@
-from flask import render_template
+import uuid
+from contextlib import suppress
+
+from flask import redirect, render_template, url_for
 
 from app import service_api_client
 from app.main import main
@@ -12,6 +15,11 @@ def find_services_by_name():
     form = SearchByNameForm()
     services_found = None
     if form.validate_on_submit():
+        with suppress(ValueError):
+            return redirect(url_for(
+                'main.service_dashboard',
+                service_id=uuid.UUID(form.search.data)
+            ))
         services_found = service_api_client.find_services_by_name(service_name=form.search.data)['data']
     return render_template(
         'views/find-services/find-services-by-name.html',

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -20,7 +20,7 @@
   ) %}
     <div class="govuk-grid-column-three-quarters">
       {{ form.search(param_extensions={
-        "label": {"text": "Find services by name, or by partial name"}
+        "label": {"text": "Find services by name, partial name, or service ID"}
       }) }}
     </div>
     <div class="govuk-grid-column-one-quarter">

--- a/tests/app/main/views/test_find_services.py
+++ b/tests/app/main/views/test_find_services.py
@@ -1,3 +1,5 @@
+from flask import url_for
+
 from tests import service_json
 
 
@@ -71,3 +73,21 @@ def test_find_services_by_name_validates_against_empty_search_submission(
 
     expected_message = "Error: You need to enter full or partial name to search by."
     assert document.find('span', {'class': 'govuk-error-message'}).text.strip() == expected_message
+
+
+def test_find_services_by_name_redirects_for_uuid(
+    client_request,
+    platform_admin_user,
+    mocker,
+    fake_uuid
+):
+    client_request.login(platform_admin_user)
+    client_request.post(
+        'main.find_services_by_name',
+        _data={"search": fake_uuid},
+        _expected_redirect=url_for(
+            'main.service_dashboard',
+            service_id=fake_uuid,
+            _external=True,
+        ),
+    )


### PR DESCRIPTION
Sometimes we get a service ID from a support ticket or a Slack discussion. Rather than having to hack the URL, this PR augments the ‘Find services by name’ page to support service IDs. If a UUID is entered, it assumes that it’s been given a service ID, and redirects straight to the dashboard for that service, without showing any search results (a complete UUID would never match multiple services). If the UUID is not a service ID, the user will get a 404.