### PR TITLE
Add an audit event when a service's broadcast permissions change

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -41,6 +41,23 @@ def create_archive_user_event(user_id, archived_by_id):
         archived_by_id=archived_by_id)
 
 
+def create_broadcast_account_type_change_event(
+    service_id,
+    changed_by_id,
+    service_mode,
+    broadcast_channel,
+    provider_restriction,
+):
+    _send_event(
+        'change_broadcast_account_type',
+        service_id=service_id,
+        changed_by_id=changed_by_id,
+        service_mode=service_mode,
+        broadcast_channel=broadcast_channel,
+        provider_restriction=provider_restriction
+    )
+
+
 def _send_event(event_type, **kwargs):
     event_data = _construct_event_data(request)
     event_data.update(kwargs)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -28,6 +28,7 @@ from app import (
     service_api_client,
     user_api_client,
 )
+from app.event_handlers import create_broadcast_account_type_change_event
 from app.extensions import zendesk_client
 from app.formatters import email_safe
 from app.main import main
@@ -332,6 +333,13 @@ def service_set_broadcast_account_type(service_id):
             service_mode=form.account_type.service_mode,
             broadcast_channel=form.account_type.broadcast_channel,
             provider_restriction=form.account_type.provider_restriction
+        )
+        create_broadcast_account_type_change_event(
+            service_id=current_service.id,
+            changed_by_id=current_user.id,
+            service_mode=form.account_type.service_mode,
+            broadcast_channel=form.account_type.broadcast_channel,
+            provider_restriction=form.account_type.provider_restriction,
         )
 
         return redirect(url_for(".service_settings", service_id=service_id))

--- a/tests/app/test_event_handlers.py
+++ b/tests/app/test_event_handlers.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY
 
 from app.event_handlers import (
     create_archive_user_event,
+    create_broadcast_account_type_change_event,
     create_email_change_event,
     create_mobile_number_change_event,
     create_remove_user_from_service_event,
@@ -88,3 +89,26 @@ def test_create_archive_user_event_calls_events_api(app_, mock_events):
                                         'ip_address': ANY,
                                         'user_id': user_id,
                                         'archived_by_id': archived_by_id})
+
+
+def test_create_broadcast_account_type_change_event(app_, mock_events):
+    service_id = str(uuid.uuid4())
+    changed_by_id = str(uuid.uuid4())
+
+    with app_.test_request_context():
+        create_broadcast_account_type_change_event(
+            service_id,
+            changed_by_id,
+            'training',
+            'severe',
+            None)
+
+        mock_events.assert_called_with('change_broadcast_account_type',
+                                       {'browser_fingerprint':
+                                        {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
+                                        'ip_address': ANY,
+                                        'service_id': service_id,
+                                        'changed_by_id': changed_by_id,
+                                        'service_mode': 'training',
+                                        'broadcast_channel': 'severe',
+                                        'provider_restriction': None})


### PR DESCRIPTION
This adds an audit event to the `events` table when the broadcast
permissions for a service (the service mode, channel or provider
restriction) changes.