### PR TITLE
post to get user by email

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -40,7 +40,7 @@ class UserApiClient(NotifyAdminAPIClient):
         return self.get("/user/{}".format(user_id))
 
     def get_user_by_email(self, email_address):
-        user_data = self.get('/user/email', params={'email': email_address})
+        user_data = self.post('/user/email', params={'email': email_address})
         return user_data['data']
 
     def get_user_by_email_or_none(self, email_address):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -36,11 +36,11 @@ def test_client_uses_correct_find_by_email(mocker, api_user_active):
     expected_params = {'email': api_user_active['email_address']}
 
     user_api_client.max_failed_login_count = 1  # doesn't matter for this test
-    mock_get = mocker.patch('app.notify_client.user_api_client.UserApiClient.get')
+    mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
 
     user_api_client.get_user_by_email(api_user_active['email_address'])
 
-    mock_get.assert_called_once_with(expected_url, params=expected_params)
+    mock_post.assert_called_once_with(expected_url, params=expected_params)
 
 
 def test_client_only_updates_allowed_attributes(mocker):


### PR DESCRIPTION
rather than get. this endpoint is used every time a user signs in, accepts an invite, resets their password, etc.

- [x] requires new API endpoint https://github.com/alphagov/notifications-api/pull/3169