### PR TITLE
Invited user

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -49,8 +49,9 @@ def old_service_dashboard(service_id):
 @user_has_permissions()
 def service_dashboard(service_id):
 
-    if session.get('invited_user'):
+    if session.get('invited_user_id') or session.get('invited_user'):
         session.pop('invited_user', None)
+        session.pop('invited_user_id', None)
         session['service_id'] = service_id
 
     if current_service.has_permission('broadcast'):

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -103,9 +103,11 @@ def accept_org_invite(token):
 
     if invited_org_user.status == 'accepted':
         session.pop('invited_org_user', None)
+        session.pop('invited_org_user_id', None)
         return redirect(url_for('main.organisation_dashboard', org_id=invited_org_user.organisation))
 
     session['invited_org_user'] = invited_org_user.serialize()
+    session['invited_org_user_id'] = invited_org_user.id
 
     existing_user = User.from_email_address_or_none(invited_org_user.email_address)
     organisation_users = OrganisationUsers(invited_org_user.organisation)

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -40,12 +40,14 @@ def accept_invite(token):
 
     if invited_user.status == 'accepted':
         session.pop('invited_user', None)
+        session.pop('invited_user_id', None)
         service = Service.from_id(invited_user.service)
         if service.has_permission('broadcast'):
             return redirect(url_for('main.broadcast_tour', service_id=service.id, step_index=1))
         return redirect(url_for('main.service_dashboard', service_id=invited_user.service))
 
     session['invited_user'] = invited_user.serialize()
+    session['invited_user_id'] = invited_user.id
 
     existing_user = User.from_email_address_or_none(invited_user.email_address)
 

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -36,11 +36,12 @@ def sign_in():
         if user and user.state == 'pending':
             return redirect(url_for('main.resend_email_verification', next=redirect_url))
 
-        if user and session.get('invited_user'):
+        if user and (session.get('invited_user') or session.get('invited_user_id')):
             invited_user = InvitedUser.from_session()
             if user.email_address.lower() != invited_user.email_address.lower():
                 flash("You cannot accept an invite for another person.")
                 session.pop('invited_user', None)
+                session.pop('invited_user_id', None)
                 abort(403)
             else:
                 invited_user.accept_invite()

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -75,7 +75,7 @@ def activate_user(user_id):
     activated_user = user.activate()
     activated_user.login()
 
-    invited_user = session.get('invited_user')
+    invited_user = InvitedUser.from_session()
     if invited_user:
         service_id = _add_invited_user_to_service(invited_user)
         service = Service.from_id(service_id)
@@ -93,10 +93,9 @@ def activate_user(user_id):
         return redirect(url_for('main.add_service', first='first'))
 
 
-def _add_invited_user_to_service(invited_user):
-    invitation = InvitedUser(invited_user)
+def _add_invited_user_to_service(invitation):
     user = User.from_id(session['user_id'])
-    service_id = invited_user['service']
+    service_id = invitation.service
     user.add_to_service(
         service_id,
         invitation.permissions,

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -16,7 +16,7 @@ from app import user_api_client
 from app.main import main
 from app.main.forms import TwoFactorForm
 from app.models.service import Service
-from app.models.user import InvitedUser, User
+from app.models.user import InvitedOrgUser, InvitedUser, User
 from app.utils import redirect_to_sign_in
 
 
@@ -83,9 +83,9 @@ def activate_user(user_id):
             return redirect(url_for('main.broadcast_tour', service_id=service.id, step_index=1))
         return redirect(url_for('main.service_dashboard', service_id=service_id))
 
-    invited_org_user = session.get('invited_org_user')
+    invited_org_user = InvitedOrgUser.from_session()
     if invited_org_user:
-        user_api_client.add_user_to_organisation(invited_org_user['organisation'], session['user_details']['id'])
+        user_api_client.add_user_to_organisation(invited_org_user.organisation, session['user_details']['id'])
 
     if organisation_id:
         return redirect(url_for('main.organisation_dashboard', org_id=organisation_id))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -473,7 +473,7 @@ class InvitedUser(JSONModel):
     @classmethod
     def by_id_and_service_id(cls, service_id, invited_user_id):
         return cls(
-            invite_api_client.get_invited_user(service_id, invited_user_id)
+            invite_api_client.get_invited_user_for_service(service_id, invited_user_id)
         )
 
     def accept_invite(self):
@@ -601,7 +601,7 @@ class InvitedOrgUser(JSONModel):
     @classmethod
     def by_id_and_org_id(cls, org_id, invited_user_id):
         return cls(
-            org_invite_api_client.get_invited_user(org_id, invited_user_id)
+            org_invite_api_client.get_invited_user_for_org(org_id, invited_user_id)
         )
 
     def serialize(self, permissions_as_string=False):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -595,6 +595,10 @@ class InvitedOrgUser(JSONModel):
 
     @classmethod
     def from_session(cls):
+        invited_org_user_id = session.get('invited_org_user_id')
+        if invited_org_user_id:
+            return cls.by_id(invited_org_user_id)
+
         invited_org_user = session.get('invited_org_user')
         return cls(invited_org_user) if invited_org_user else None
 
@@ -602,6 +606,12 @@ class InvitedOrgUser(JSONModel):
     def by_id_and_org_id(cls, org_id, invited_user_id):
         return cls(
             org_invite_api_client.get_invited_user_for_org(org_id, invited_user_id)
+        )
+
+    @classmethod
+    def by_id(cls, invited_user_id):
+        return cls(
+            org_invite_api_client.get_invited_user(invited_user_id)
         )
 
     def serialize(self, permissions_as_string=False):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -476,6 +476,12 @@ class InvitedUser(JSONModel):
             invite_api_client.get_invited_user_for_service(service_id, invited_user_id)
         )
 
+    @classmethod
+    def by_id(cls, invited_user_id):
+        return cls(
+            invite_api_client.get_invited_user(invited_user_id)
+        )
+
     def accept_invite(self):
         invite_api_client.accept_invite(self.service, self.id)
 
@@ -515,6 +521,10 @@ class InvitedUser(JSONModel):
 
     @classmethod
     def from_session(cls):
+        invited_user_id = session.get('invited_user_id')
+        if invited_user_id:
+            return cls.by_id(invited_user_id)
+
         invited_user = session.get('invited_user')
         return cls(invited_user) if invited_user else None
 

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -37,6 +37,11 @@ class InviteApiClient(NotifyAdminAPIClient):
             '/service/{}/invite'.format(service_id)
         )['data']
 
+    def get_invited_user(self, invited_user_id):
+        return self.get(
+            f'/invite/service/{invited_user_id}'
+        )['data']
+
     def get_invited_user_for_service(self, service_id, invited_user_id):
         return self.get(
             f'/service/{service_id}/invite/{invited_user_id}'

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -37,7 +37,7 @@ class InviteApiClient(NotifyAdminAPIClient):
             '/service/{}/invite'.format(service_id)
         )['data']
 
-    def get_invited_user(self, service_id, invited_user_id):
+    def get_invited_user_for_service(self, service_id, invited_user_id):
         return self.get(
             f'/service/{service_id}/invite/{invited_user_id}'
         )['data']

--- a/app/notify_client/invite_api_client.py
+++ b/app/notify_client/invite_api_client.py
@@ -56,7 +56,7 @@ class InviteApiClient(NotifyAdminAPIClient):
         ])
 
     def check_token(self, token):
-        return self.get(url='/invite/service/{}'.format(token))['data']
+        return self.get(url='/invite/service/check/{}'.format(token))['data']
 
     def cancel_invited_user(self, service_id, invited_user_id):
         data = {'status': 'cancelled'}

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -34,7 +34,7 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
         )['data']
 
     def check_token(self, token):
-        resp = self.get(url='/invite/organisation/{}'.format(token))
+        resp = self.get(url='/invite/organisation/check/{}'.format(token))
         return resp['data']
 
     def cancel_invited_user(self, org_id, invited_user_id):

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -23,7 +23,7 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
         resp = self.get(endpoint)
         return resp['data']
 
-    def get_invited_user(self, org_id, invited_org_user_id):
+    def get_invited_user_for_org(self, org_id, invited_org_user_id):
         return self.get(
             f'/organisation/{org_id}/invite/{invited_org_user_id}'
         )['data']

--- a/app/notify_client/org_invite_api_client.py
+++ b/app/notify_client/org_invite_api_client.py
@@ -28,6 +28,11 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
             f'/organisation/{org_id}/invite/{invited_org_user_id}'
         )['data']
 
+    def get_invited_user(self, invited_user_id):
+        return self.get(
+            f'/invite/organisation/{invited_user_id}'
+        )['data']
+
     def check_token(self, token):
         resp = self.get(url='/invite/organisation/{}'.format(token))
         return resp['data']

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -676,7 +676,7 @@ def test_cancel_invited_org_user_cancels_user_invitations(
     mocker,
 ):
     mock_cancel = mocker.patch('app.org_invite_api_client.cancel_invited_user')
-    mocker.patch('app.org_invite_api_client.get_invited_user', return_value=sample_org_invite)
+    mocker.patch('app.org_invite_api_client.get_invited_user_for_org', return_value=sample_org_invite)
 
     page = client_request.get(
         'main.cancel_invited_org_user',

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1242,7 +1242,7 @@ def test_cancel_invited_user_cancels_user_invitations(
     mocker,
 ):
     mock_cancel = mocker.patch('app.invite_api_client.cancel_invited_user')
-    mocker.patch('app.invite_api_client.get_invited_user', return_value=sample_invite)
+    mocker.patch('app.invite_api_client.get_invited_user_for_service', return_value=sample_invite)
 
     page = client_request.get(
         'main.cancel_invited_user',

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -113,13 +113,12 @@ def test_has_live_services_when_service_is_not_live(
 
 
 def test_invited_user_from_session_uses_id(client, mocker, mock_get_invited_user_by_id):
-    fake_id = str(uuid.uuid4())
-    session_dict = {'invited_user_id': fake_id}
+    session_dict = {'invited_user_id': USER_ONE_ID}
     mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
 
     assert InvitedUser.from_session().id == USER_ONE_ID
 
-    mock_get_invited_user_by_id.assert_called_once_with(fake_id)
+    mock_get_invited_user_by_id.assert_called_once_with(USER_ONE_ID)
 
 
 def test_invited_user_from_session_uses_id_even_if_obj_in_session(

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -1,6 +1,9 @@
+import uuid
+from unittest.mock import Mock
+
 import pytest
 
-from app.models.user import AnonymousUser, User
+from app.models.user import AnonymousUser, InvitedOrgUser, User
 
 
 def test_anonymous_user(app_):
@@ -106,3 +109,42 @@ def test_has_live_services_when_service_is_not_live(
         'id': fake_uuid,
         'platform_admin': False,
     }).live_services == []
+
+
+def test_invited_org_user_from_session_uses_id(client, mocker, mock_get_invited_org_user_by_id, sample_org_invite):
+    session_dict = {'invited_org_user_id': sample_org_invite['id']}
+    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
+
+    assert InvitedOrgUser.from_session().id == sample_org_invite['id']
+
+    mock_get_invited_org_user_by_id.assert_called_once_with(sample_org_invite['id'])
+
+
+def test_invited_org_user_from_session_uses_id_even_if_obj_in_session(
+    client,
+    mocker,
+    sample_org_invite,
+    mock_get_invited_org_user_by_id
+):
+    fake_id = str(uuid.uuid4())
+    mock_org_dict = Mock(spec=dict)
+    session_dict = {'invited_org_user_id': fake_id, 'invited_org_user': mock_org_dict}
+    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
+
+    assert InvitedOrgUser.from_session().id == sample_org_invite['id']
+
+    # make sure we didn't access invited_org_user (as org_user_id takes precedence)
+    assert mock_org_dict.mock_calls == []
+    mock_get_invited_org_user_by_id.assert_called_once_with(fake_id)
+
+
+def test_invited_org_user_from_session_uses_obj_if_id_not_present(client, mocker, sample_org_invite):
+    session_dict = {'invited_org_user': sample_org_invite}
+    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
+
+    assert InvitedOrgUser.from_session().id == sample_org_invite['id']
+
+
+def test_invited_org_user_from_session_returns_none_if_nothing_present(client, mocker):
+    mocker.patch.dict('app.models.user.session', values={}, clear=True)
+    assert InvitedOrgUser.from_session() is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4462,3 +4462,16 @@ def mock_update_broadcast_message_status(
         'app.broadcast_message_api_client.update_broadcast_message_status',
         side_effect=_update,
     )
+
+
+@pytest.fixture
+def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
+    def _get(
+        invited_org_user_id
+    ):
+        return sample_org_invite
+
+    return mocker.patch(
+        'app.org_invite_api_client.get_invited_user',
+        side_effect=_get,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4465,6 +4465,19 @@ def mock_update_broadcast_message_status(
 
 
 @pytest.fixture
+def mock_get_invited_user_by_id(mocker, sample_invite):
+    def _get(
+        invited_user_id
+    ):
+        return sample_invite
+
+    return mocker.patch(
+        'app.invite_api_client.get_invited_user',
+        side_effect=_get,
+    )
+
+
+@pytest.fixture
 def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
     def _get(
         invited_org_user_id


### PR DESCRIPTION
store invited user ids in session

first of a two step process to remove invited user objects from the session. we're removing them because they're of variable size, and with a lot of folder permissions they can cause the session to exceed the 4kb cookie size limit and not save properly.

in this step, start saving the invited user (or org user)'s id to the session alongside the session object. Then, if the invited_user_id is present in the next step of the invite flow, fetch the user object from the API instead of from the session. If it's not present (due to a session set by an older instance of the admin app), then just use the old code to get the entire object out of the session.

For invites where the user is small enough to persist to the cookie, this will still save both the old and the new way, but will always make an extra check to the API, I think this minor performance hit is totally fine. For invites where the user is too big to persist, they'll still fail for now, and will need to wait until the next PR comes along and stops saving the large invited user object to the session entirely.