### PR TITLE
Update text message pricing content

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -45,7 +45,7 @@
   <p class="govuk-body">From 1 April 2021, the new allowance will be:</p>
   <ul class="list list-bullet">
     <li>150,000 free text messages for national services</li>
-    <li>25,000 free text messages for local services</li>
+    <li>25,000 free text messages for regional services</li>
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
   <p class="govuk-body">Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_can_use_notify') }}">whether your organisation can use Notify</a>.</p>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -51,7 +51,7 @@
   <p class="govuk-body">See who can use Notify.</p>
   <p class="govuk-body">We’re making this change so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.</p>
   <h3 class="heading-small" id="paying-for-additional-text-messages">Paying for additional text messages</h3>
-  <p class="govuk-body">When you’ve used your free allowance, it costs 1.58 pence (plus VAT) for each additional text message you send.</p>
+  <p class="govuk-body">When you’ve used your annual allowance of free text messages, it costs 1.58 pence (plus VAT) for each additional text message you send.</p>
   <p class="govuk-body">From 1 April 2021, the cost will increase to 1.6 pence (plus VAT). This is because some mobile networks are changing their rates.</p>
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -32,14 +32,27 @@
   <p class="govuk-body">It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
+  <p class="govuk-body">From 1 April 2021, we’re changing the free text message allowance for some services. We’re also increasing the cost of sending additional text messages.</p>
+  <h3 class="heading-small" id="free-text-message-allowance">Free text message allowance</h3>
   <p class="govuk-body">Every service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
-  <p class="govuk-body">The allowance is:</p>
+  <p class="govuk-body">You will only start paying for text messages when a service has used its free allowance.</p>
+  <p class="govuk-body">The current allowance is:</p>
   <ul class="list list-bullet">
     <li>250,000 free text messages for central government services</li>
     <li>25,000 free text messages for other public sector services</li>
   </ul>
-  <p class="govuk-body">It costs 1.58 pence (plus VAT) for each text message you send after you've used your free allowance.</p>
+  <p class="govuk-body">From 1 April 2021, the new allowance will be:</p>
+  <ul class="list list-bullet">
+    <li>150,000 free text messages for national services</li>
+    <li>25,000 free text messages for local services</li>
+    <li>10,000 free text messages for state-funded schools and GP practices</li>
+  </ul>
+  <p class="govuk-body">See who can use Notify.</p>
+  <p class="govuk-body">We’re making this change so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.</p>
+  <h3 class="heading-small" id="paying-for-additional-text-messages">Paying for additional text messages</h3>
+  <p class="govuk-body">When you’ve used your free allowance, it costs 1.58 pence (plus VAT) for each additional text message you send.</p>
+  <p class="govuk-body">From 1 April 2021, the cost will increase to 1.6 pence (plus VAT). This is because some mobile networks are changing their rates.</p>
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -48,7 +48,6 @@
     <li>25,000 free text messages for regional services</li>
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
-  <p class="govuk-body">Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_can_use_notify') }}">whether your organisation can use Notify</a>.</p>
   <p class="govuk-body">We’re making this change so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.</p>
   <h3 class="heading-small" id="paying-for-additional-text-messages">Paying for additional text messages</h3>
   <p class="govuk-body">When you’ve used your annual allowance of free text messages, it costs 1.58 pence (plus VAT) for each additional text message you send.</p>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -36,7 +36,7 @@
   <h3 class="heading-small" id="free-text-message-allowance">Free text message allowance</h3>
   <p class="govuk-body">Every service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
-  <p class="govuk-body">You will only start paying for text messages when a service has used its free allowance.</p>
+  <p class="govuk-body">You will only start paying for text messages when a service has used its free allowance for the year.</p>
   <p class="govuk-body">The current allowance is:</p>
   <ul class="list list-bullet">
     <li>250,000 free text messages for central government services</li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -48,7 +48,7 @@
     <li>25,000 free text messages for local services</li>
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
-  <p class="govuk-body">See who can use Notify.</p>
+  <p class="govuk-body">Check <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_can_use_notify') }}">whether your organisation can use Notify</a>.</p>
   <p class="govuk-body">We’re making this change so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.</p>
   <h3 class="heading-small" id="paying-for-additional-text-messages">Paying for additional text messages</h3>
   <p class="govuk-body">When you’ve used your annual allowance of free text messages, it costs 1.58 pence (plus VAT) for each additional text message you send.</p>


### PR DESCRIPTION
This PR adds information about the 1 April text message allowance and rate changes.

We’ll update the page again after the changes come into effect.

# Why we need to do this

We’re changing the free allowance so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.

We’re also increasing the cost of sending additional text messages. This is because some mobile networks are changing their rates in 2021.