### PR TITLE
Don’t show future financial years on organisation usage page

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -148,8 +148,8 @@ def organisation_dashboard(org_id):
         services=services,
         years=get_tuples_of_financial_years(
             partial(url_for, '.organisation_dashboard', org_id=current_organisation.id),
-            start=current_financial_year - 1,
-            end=current_financial_year + 1,
+            start=current_financial_year - 2,
+            end=current_financial_year,
         ),
         selected_year=year,
         search_form=SearchByNameForm() if len(services) > 7 else None,

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -511,9 +511,9 @@ def test_organisation_services_shows_live_services_and_usage_with_count_of_1(
 
 @freeze_time("2020-02-20 20:20")
 @pytest.mark.parametrize('financial_year, expected_selected', (
+    (2017, '2017 to 2018 financial year'),
     (2018, '2018 to 2019 financial year'),
     (2019, '2019 to 2020 financial year'),
-    (2020, '2020 to 2021 financial year'),
 ))
 def test_organisation_services_filters_by_financial_year(
     client_request,
@@ -535,9 +535,9 @@ def test_organisation_services_filters_by_financial_year(
     )
     mock.assert_called_once_with(ORGANISATION_ID, financial_year)
     assert normalize_spaces(page.select_one('.pill').text) == (
-        '2020 to 2021 financial year '
         '2019 to 2020 financial year '
-        '2018 to 2019 financial year'
+        '2018 to 2019 financial year '
+        '2017 to 2018 financial year'
     )
     assert normalize_spaces(page.select_one('.pill-item--selected').text) == (
         expected_selected


### PR DESCRIPTION
There’s no useful information in the page for the future financial year because there’s no way for any of the services to have yet used anything.

Changing this matches the change we made to the service usage page in https://github.com/alphagov/notifications-admin/pull/3439