### PR TITLE
Update isort config to match that in API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,4 @@ multi_line_output=3
 known_third_party=notifications_utils,notifications_python_client
 known_first_party=app,tests
 include_trailing_comma=True
+use_parentheses=True


### PR DESCRIPTION
As discussed in [1]. This has no effect on the existing imports.

[1]: https://github.com/alphagov/notifications-api/pull/3175#issuecomment-795530323