### PR TITLE
Fix bug when live services have no organisation

### DIFF
--- a/app/main/views/performance.py
+++ b/app/main/views/performance.py
@@ -18,7 +18,7 @@ def performance():
     stats['organisations_using_notify'] = sorted(
         [
             {
-                'organisation_name': organisation_name,
+                'organisation_name': organisation_name or 'No organisation',
                 'count_of_live_services': len(list(group)),
             }
             for organisation_name, group in groupby(

--- a/tests/app/main/views/test_performance.py
+++ b/tests/app/main/views/test_performance.py
@@ -93,6 +93,15 @@ def _get_example_performance_data():
           "service_id": uuid.uuid4(),
           "service_name": "Example service 3"
         },
+        {
+          # On production there should be no live services without an
+          # organisation, but this isn’t always true in people’s local
+          # environments
+          "organisation_id": None,
+          "organisation_name": None,
+          "service_id": uuid.uuid4(),
+          "service_name": "Example service 4"
+        },
       ],
     }
 
@@ -150,5 +159,6 @@ def test_should_render_performance_page(
         'Organisations using Notify '
         'Organisation Number of live services '
         'Department of Examples and Patterns 2 '
-        'Department of One Service 1'
+        'Department of One Service 1 '
+        'No organisation 1'
     )


### PR DESCRIPTION
The performance page expects all live services to have an organisation. This should be true on production, but it isn’t always the case in other environments.

When the organisation name is `None`, the frontend can’t sort the list of organisations alphabetically and so raises an exception.