### PR TITLE
stop putting invite user objects in the session

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -46,7 +46,6 @@ def accept_invite(token):
             return redirect(url_for('main.broadcast_tour', service_id=service.id, step_index=1))
         return redirect(url_for('main.service_dashboard', service_id=invited_user.service))
 
-    session['invited_user'] = invited_user.serialize()
     session['invited_user_id'] = invited_user.id
 
     existing_user = User.from_email_address_or_none(invited_user.email_address)
@@ -108,7 +107,6 @@ def accept_org_invite(token):
         session.pop('invited_org_user_id', None)
         return redirect(url_for('main.organisation_dashboard', org_id=invited_org_user.organisation))
 
-    session['invited_org_user'] = invited_org_user.serialize()
     session['invited_org_user_id'] = invited_org_user.id
 
     existing_user = User.from_email_address_or_none(invited_org_user.email_address)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -522,11 +522,7 @@ class InvitedUser(JSONModel):
     @classmethod
     def from_session(cls):
         invited_user_id = session.get('invited_user_id')
-        if invited_user_id:
-            return cls.by_id(invited_user_id)
-
-        invited_user = session.get('invited_user')
-        return cls(invited_user) if invited_user else None
+        return cls.by_id(invited_user_id) if invited_user_id else None
 
     def has_permissions(self, *permissions):
         if self.status == 'cancelled':
@@ -606,11 +602,7 @@ class InvitedOrgUser(JSONModel):
     @classmethod
     def from_session(cls):
         invited_org_user_id = session.get('invited_org_user_id')
-        if invited_org_user_id:
-            return cls.by_id(invited_org_user_id)
-
-        invited_org_user = session.get('invited_org_user')
-        return cls(invited_org_user) if invited_org_user else None
+        return cls.by_id(invited_org_user_id) if invited_org_user_id else None
 
     @classmethod
     def by_id_and_org_id(cls, org_id, invited_user_id):

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -133,7 +133,7 @@ def test_invite_goes_in_session(
     )
 
     with client_request.session_transaction() as session:
-        assert session['invited_user']['email_address'] == 'test@user.gov.uk'
+        assert session['invited_user_id'] == sample_invite['id']
 
 
 @pytest.mark.parametrize('user, landing_page_title', [
@@ -410,25 +410,18 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     mock_get_service,
     mocker,
 ):
-    expected_service = service_one['id']
-    expected_email = sample_invite['email_address']
-    expected_from_user = service_one['users'][0]
     expected_redirect_location = 'http://localhost/register-from-invite'
 
     response = client.get(url_for('main.accept_invite', token='thisisnotarealtoken'))
     with client.session_transaction() as session:
         assert response.status_code == 302
         assert response.location == expected_redirect_location
-        invited_user = session.get('invited_user')
-        assert invited_user
+        assert 'invited_user' not in session
         assert session.get('invited_user_id') == USER_ONE_ID
-        assert expected_service == invited_user['service']
-        assert expected_email == invited_user['email_address']
-        assert expected_from_user == invited_user['from_user']
 
-    data = {'service': invited_user['service'],
-            'email_address': invited_user['email_address'],
-            'from_user': invited_user['from_user'],
+    data = {'service': sample_invite['service'],
+            'email_address': sample_invite['email_address'],
+            'from_user': sample_invite['from_user'],
             'password': 'longpassword',
             'mobile_number': '+447890123456',
             'name': 'Invited User',

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -224,7 +224,8 @@ def test_email_address_is_treated_case_insensitively_when_signing_in_as_invited_
     api_user_active,
     sample_invite,
     mock_accept_invite,
-    mock_send_verify_code
+    mock_send_verify_code,
+    mock_get_invited_user_by_id,
 ):
     sample_invite['email_address'] = 'TEST@user.gov.uk'
 
@@ -234,7 +235,7 @@ def test_email_address_is_treated_case_insensitively_when_signing_in_as_invited_
     )
 
     with client.session_transaction() as session:
-        session['invited_user'] = sample_invite
+        session['invited_user_id'] = sample_invite['id']
 
     response = client.post(
         url_for('main.sign_in'), data={
@@ -244,3 +245,4 @@ def test_email_address_is_treated_case_insensitively_when_signing_in_as_invited_
     assert mock_accept_invite.called
     assert response.status_code == 302
     assert mock_send_verify_code.called
+    mock_get_invited_user_by_id.assert_called_once_with(sample_invite['id'])

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -176,6 +176,7 @@ def test_activate_user_redirects_to_service_dashboard_if_user_already_belongs_to
     api_user_active,
     mock_login,
     mock_get_service,
+    mock_get_invited_user_by_id,
 ):
     mocker.patch('app.user_api_client.add_user_to_service', side_effect=HTTPError(
         response=Mock(
@@ -189,10 +190,10 @@ def test_activate_user_redirects_to_service_dashboard_if_user_already_belongs_to
     ))
 
     # Can't use `with client.session_transaction()...` here since activate_session is not a view function
-    flask_session['invited_user'] = sample_invite
+    flask_session['invited_user_id'] = sample_invite['id']
 
     response = activate_user(api_user_active['id'])
 
     assert response.location == url_for('main.service_dashboard', service_id=service_one['id'])
 
-    flask_session.pop('invited_user')
+    flask_session.pop('invited_user_id')

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -137,13 +137,6 @@ def test_invited_user_from_session_uses_id_even_if_obj_in_session(
     mock_get_invited_user_by_id.assert_called_once_with(USER_ONE_ID)
 
 
-def test_invited_user_from_session_uses_obj_if_id_not_present(client, mocker, sample_invite):
-    session_dict = {'invited_user': sample_invite}
-    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
-
-    assert InvitedUser.from_session().id == USER_ONE_ID
-
-
 def test_invited_user_from_session_returns_none_if_nothing_present(client, mocker):
     mocker.patch.dict('app.models.user.session', values={}, clear=True)
     assert InvitedUser.from_session() is None
@@ -174,13 +167,6 @@ def test_invited_org_user_from_session_uses_id_even_if_obj_in_session(
     # make sure we didn't access invited_org_user (as org_user_id takes precedence)
     assert mock_org_dict.mock_calls == []
     mock_get_invited_org_user_by_id.assert_called_once_with(fake_id)
-
-
-def test_invited_org_user_from_session_uses_obj_if_id_not_present(client, mocker, sample_org_invite):
-    session_dict = {'invited_org_user': sample_org_invite}
-    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
-
-    assert InvitedOrgUser.from_session().id == sample_org_invite['id']
 
 
 def test_invited_org_user_from_session_returns_none_if_nothing_present(client, mocker):


### PR DESCRIPTION
the invited_user objects can be arbitrarily large, and when we put them in the session we risk going over the session cookie's 4kb size limit. since https://github.com/alphagov/notifications-admin/pull/3827 was merged, we store the user id in the session. Now that's been live for a day or two we can safely stop putting the rich object in the session.

Needed to change a bunch of tests for this to make sure appropriate mocks were set. Also some tests were accidentally re-using fake_uuid.

Still pop the object when cleaning up sessions. We'll need to remove that in a future PR.