### PR TITLE
Remove last of the backwards compat invite stuff

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -49,8 +49,7 @@ def old_service_dashboard(service_id):
 @user_has_permissions()
 def service_dashboard(service_id):
 
-    if session.get('invited_user_id') or session.get('invited_user'):
-        session.pop('invited_user', None)
+    if session.get('invited_user_id'):
         session.pop('invited_user_id', None)
         session['service_id'] = service_id
 

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -39,7 +39,6 @@ def accept_invite(token):
                                service_name=service.name)
 
     if invited_user.status == 'accepted':
-        session.pop('invited_user', None)
         session.pop('invited_user_id', None)
         service = Service.from_id(invited_user.service)
         if service.has_permission('broadcast'):
@@ -103,7 +102,6 @@ def accept_org_invite(token):
                                organisation_name=organisation.name)
 
     if invited_org_user.status == 'accepted':
-        session.pop('invited_org_user', None)
         session.pop('invited_org_user_id', None)
         return redirect(url_for('main.organisation_dashboard', org_id=invited_org_user.organisation))
 

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -36,11 +36,10 @@ def sign_in():
         if user and user.state == 'pending':
             return redirect(url_for('main.resend_email_verification', next=redirect_url))
 
-        if user and (session.get('invited_user') or session.get('invited_user_id')):
+        if user and session.get('invited_user_id'):
             invited_user = InvitedUser.from_session()
             if user.email_address.lower() != invited_user.email_address.lower():
                 flash("You cannot accept an invite for another person.")
-                session.pop('invited_user', None)
                 session.pop('invited_user_id', None)
                 abort(403)
             else:

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -178,7 +178,7 @@ def test_accepting_invite_removes_invite_from_session(
     assert normalize_spaces(page.select_one('h1').text) == landing_page_title
 
     with client_request.session_transaction() as session:
-        assert 'invited_user' not in session
+        assert 'invited_user_id' not in session
 
 
 def test_existing_user_of_service_get_redirected_to_signin(
@@ -416,7 +416,6 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     with client.session_transaction() as session:
         assert response.status_code == 302
         assert response.location == expected_redirect_location
-        assert 'invited_user' not in session
         assert session.get('invited_user_id') == USER_ONE_ID
 
     data = {'service': sample_invite['service'],

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -1,6 +1,3 @@
-import uuid
-from unittest.mock import Mock
-
 import pytest
 
 from app.models.user import AnonymousUser, InvitedOrgUser, InvitedUser, User
@@ -121,22 +118,6 @@ def test_invited_user_from_session_uses_id(client, mocker, mock_get_invited_user
     mock_get_invited_user_by_id.assert_called_once_with(USER_ONE_ID)
 
 
-def test_invited_user_from_session_uses_id_even_if_obj_in_session(
-    client,
-    mocker,
-    sample_invite,
-    mock_get_invited_user_by_id
-):
-    mock_session_obj = Mock(spec=dict)
-    session_dict = {'invited_user_id': USER_ONE_ID, 'invited_user': mock_session_obj}
-    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
-
-    assert InvitedUser.from_session().id == USER_ONE_ID
-
-    assert mock_session_obj.mock_calls == []
-    mock_get_invited_user_by_id.assert_called_once_with(USER_ONE_ID)
-
-
 def test_invited_user_from_session_returns_none_if_nothing_present(client, mocker):
     mocker.patch.dict('app.models.user.session', values={}, clear=True)
     assert InvitedUser.from_session() is None
@@ -149,24 +130,6 @@ def test_invited_org_user_from_session_uses_id(client, mocker, mock_get_invited_
     assert InvitedOrgUser.from_session().id == sample_org_invite['id']
 
     mock_get_invited_org_user_by_id.assert_called_once_with(sample_org_invite['id'])
-
-
-def test_invited_org_user_from_session_uses_id_even_if_obj_in_session(
-    client,
-    mocker,
-    sample_org_invite,
-    mock_get_invited_org_user_by_id
-):
-    fake_id = str(uuid.uuid4())
-    mock_org_dict = Mock(spec=dict)
-    session_dict = {'invited_org_user_id': fake_id, 'invited_org_user': mock_org_dict}
-    mocker.patch.dict('app.models.user.session', values=session_dict, clear=True)
-
-    assert InvitedOrgUser.from_session().id == sample_org_invite['id']
-
-    # make sure we didn't access invited_org_user (as org_user_id takes precedence)
-    assert mock_org_dict.mock_calls == []
-    mock_get_invited_org_user_by_id.assert_called_once_with(fake_id)
 
 
 def test_invited_org_user_from_session_returns_none_if_nothing_present(client, mocker):


### PR DESCRIPTION
this pr just contains https://github.com/alphagov/notifications-admin/commit/9ad58bca9a820cbd95950370aaf8d25b24a93d01

After #3841  is merged, we don't need to remove the invited_user obj from the session at all. And we can remove checks that expect it when cleaning up the session. And the unit tests that make sure we ignore it if it's in the session.

So long, session['invited_user'] and session['invited_org_user']!
