### PR TITLE
Refactor failed login count

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -71,7 +71,6 @@ class Config(object):
     EMAIL_2FA_EXPIRY_SECONDS = 1800  # 30 Minutes
     HEADER_COLOUR = '#81878b'  # mix(govuk-colour("dark-grey"), govuk-colour("mid-grey"))
     HTTP_PROTOCOL = 'http'
-    MAX_FAILED_LOGIN_COUNT = 10
     NOTIFY_APP_NAME = 'admin'
     NOTIFY_LOG_LEVEL = 'DEBUG'
     PERMANENT_SESSION_LIFETIME = 20 * 60 * 60  # 20 hours

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,4 @@
-from flask import abort, current_app, request, session
+from flask import abort, request, session
 from flask_login import AnonymousUserMixin, UserMixin, login_user, logout_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
@@ -27,6 +27,8 @@ def _get_org_id_from_view_args():
 
 class User(JSONModel, UserMixin):
 
+    MAX_FAILED_LOGIN_COUNT = 10
+
     ALLOWED_PROPERTIES = {
         'id',
         'name',
@@ -45,7 +47,6 @@ class User(JSONModel, UserMixin):
     def __init__(self, _dict):
         super().__init__(_dict)
         self.permissions = _dict.get('permissions', {})
-        self.max_failed_login_count = current_app.config['MAX_FAILED_LOGIN_COUNT']
         self._platform_admin = _dict['platform_admin']
 
     @classmethod
@@ -261,7 +262,7 @@ class User(JSONModel, UserMixin):
 
     @property
     def locked(self):
-        return self.failed_login_count >= self.max_failed_login_count
+        return self.failed_login_count >= self.MAX_FAILED_LOGIN_COUNT
 
     @property
     def email_domain(self):

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -33,12 +33,12 @@ def test_user(app_):
     assert user.state == 'pending'
 
     # user has ten failed logins before being locked
-    assert user.max_failed_login_count == app_.config['MAX_FAILED_LOGIN_COUNT'] == 10
+    assert user.MAX_FAILED_LOGIN_COUNT == 10
     assert user.failed_login_count == 0
     assert user.locked is False
 
     # set failed logins to threshold
-    user.failed_login_count = app_.config['MAX_FAILED_LOGIN_COUNT']
+    user.failed_login_count = 10
     assert user.locked is True
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
We don’t vary this between different environments so it doesn’t need to be in the config.

I was trying to look up what this value was and found it a bit confusing that it was spread across multiple places.