### PR TITLE
Bump utils to allow double hyphens in email address domain

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ Shapely==1.7.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@44.0.0#egg=notifications-utils==44.0.0
+git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications-utils==44.1.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.0.2
     # via -r requirements.in
-git+https://github.com/alphagov/notifications-utils.git@44.0.0#egg=notifications-utils==44.0.0
+git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications-utils==44.1.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx


### PR DESCRIPTION
It was requested by our user and it is an allowed domain format with Amazon SES, so we started allowing it in our validation.

Utils PR: https://github.com/alphagov/notifications-utils/pull/855 (merged)