### PR TITLE
Create additional non-UK broadcast test polygons

### DIFF
--- a/app/broadcast_areas/source_files/Test.geojson
+++ b/app/broadcast_areas/source_files/Test.geojson
@@ -1,20 +1,73 @@
 {
-  "type":"FeatureCollection",
-  "features":[{
-    "type": "Feature",
-    "properties": {
-      "id": "santa-claus-village-rovaniemi",
-      "name": "Santa Claus Village, Rovaniemi"
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "santa-claus-village-rovaniemi-a",
+        "name": "Santa Claus Village, Rovaniemi A"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [25.8890, 66.5500],
+          [25.8890, 66.551],
+          [25.8910, 66.551],
+          [25.8910, 66.5500],
+          [25.889, 66.55000]
+        ]]
+      }
     },
-    "geometry": {
-      "type":"Polygon",
-      "coordinates": [[
-        [25.8890, 66.5500],
-        [25.8890, 66.551],
-        [25.8910, 66.551],
-        [25.8910, 66.5500],
-        [25.889, 66.55000]
-      ]]
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "santa-claus-village-rovaniemi-b",
+        "name": "Santa Claus Village, Rovaniemi B"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [25.895, 66.577],
+          [25.897, 66.577],
+          [25.897, 66.578],
+          [25.895, 66.578],
+          [25.895, 66.577]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+      "id": "santa-claus-village-rovaniemi-c",
+        "name": "Santa Claus Village, Rovaniemi C"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [25.952, 66.572],
+          [25.954, 66.572],
+          [25.954, 66.573],
+          [25.952, 66.573],
+          [25.952, 66.572]  
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+      "id": "santa-claus-village-rovaniemi-d",
+        "name": "Santa Claus Village, Rovaniemi D"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [25.944, 66.586],
+          [25.947, 66.586],
+          [25.947, 66.587],
+          [25.944, 66.587],
+          [25.944, 66.586]
+        ]]
+      }
     }
-  }]
+  ]
 }

--- a/tests/app/broadcast_areas/test_broadcast_area.py
+++ b/tests/app/broadcast_areas/test_broadcast_area.py
@@ -336,7 +336,7 @@ def test_phone_density(
     ),
     (
         # No population data available
-        'test-santa-claus-village-rovaniemi', 1_500, 0.01347
+        'test-santa-claus-village-rovaniemi-a', 1_500, 0.01347
     )
 ))
 def test_estimated_bleed(


### PR DESCRIPTION
This allows MNOs to test delivery to multiple non-adjacent cells without risk of sending a broadcast on the public network.

Additional polygons will also support the testing of multiple polygon geometries in a single message.

Test polygons are all non-UK (northern Finland).

<img width="1008" alt="Screenshot 2021-03-31 at 09 41 04" src="https://user-images.githubusercontent.com/783245/113116342-411f6380-9205-11eb-9fb2-84be320fe8b9.png">
