### PR TITLE
Update pricing information for text messages

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -35,7 +35,7 @@
   <p class="govuk-body">Every service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
   <p class="govuk-body">You will only start paying for text messages when a service has used its free allowance for the year.</p>
-  <p class="govuk-body">From 1 April 2021, the allowance is:</p>
+  <p class="govuk-body">The current allowance is:</p>
   <ul class="list list-bullet">
     <li>150,000 free text messages for national services</li>
     <li>25,000 free text messages for regional services</li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -32,26 +32,17 @@
   <p class="govuk-body">It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
-  <p class="govuk-body">From 1 April 2021, we’re changing the free text message allowance for some services. We’re also increasing the cost of sending additional text messages.</p>
-  <h3 class="heading-small" id="free-text-message-allowance">Free text message allowance</h3>
   <p class="govuk-body">Every service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
   <p class="govuk-body">You will only start paying for text messages when a service has used its free allowance for the year.</p>
-  <p class="govuk-body">The current allowance is:</p>
-  <ul class="list list-bullet">
-    <li>250,000 free text messages for central government services</li>
-    <li>25,000 free text messages for other public sector services</li>
-  </ul>
-  <p class="govuk-body">From 1 April 2021, the new allowance will be:</p>
+  <p class="govuk-body">From 1 April 2021, the allowance is:</p>
   <ul class="list list-bullet">
     <li>150,000 free text messages for national services</li>
     <li>25,000 free text messages for regional services</li>
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
-  <p class="govuk-body">We’re making this change so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.</p>
   <h3 class="heading-small" id="paying-for-additional-text-messages">Paying for additional text messages</h3>
-  <p class="govuk-body">When you’ve used your annual allowance of free text messages, it costs 1.58 pence (plus VAT) for each additional text message you send.</p>
-  <p class="govuk-body">From 1 April 2021, the cost will increase to 1.6 pence (plus VAT). This is because some mobile networks are changing their rates.</p>
+  <p class="govuk-body">When you’ve used your annual allowance of free text messages, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -151,9 +151,9 @@
         </div>
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Text messages</h3>
-          <div class="product-page-big-number">Up to 250,000</div>
+          <div class="product-page-big-number">Up to 150,000</div>
           free text messages a year,<br>
-          then 1.58 pence per message
+          then 1.6 pence per message
         </div>
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Letters</h3>


### PR DESCRIPTION
This PR updates the information about the 1 April text message allowance and rate changes.

## Why we need to do this

We’ve changed the free allowance so we can continue to support all the teams that use Notify. The new allowance means over 90% of teams can still send all the text messages they need to without paying.

We’ve also increasing the cost of sending additional text messages. This is because some mobile networks are changing their rates in 2021.