### PR TITLE
Don't show user as unknown for service history

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -652,6 +652,12 @@ class Users(ModelList):
         for user in self:
             if user.id == id:
                 return user.name
+        # The user may not exist in the list of users for this service if they are
+        # a platform admin or if they have since left the team. In this case, we fall
+        # back to getting the user from the API (or Redis if it is in the cache)
+        user = User.from_id(id)
+        if user and user.name:
+            return user.name
         return 'Unknown'
 
 

--- a/tests/app/main/views/test_history.py
+++ b/tests/app/main/views/test_history.py
@@ -36,7 +36,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
                 'Created an API key called ‘Good key’ '
                 'Test User 10:09am '
                 'Created an API key called ‘Key event returned in non-chronological order’ '
-                'Unknown 2:01am '
+                'Test User 2:01am '
                 'Created this service and called it ‘Example service’'
             ),
         ),
@@ -79,7 +79,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
         (
             '10 October 2010',
             (
-                'Unknown 2:01am '
+                'Test User 2:01am '
                 'Created this service and called it ‘Example service’'
             ),
         ),


### PR DESCRIPTION
A commit was added:
https://github.com/alphagov/notifications-admin/commit/600e3affc12947d5a7b957b71e3d2864467d6bc2

In it, it falls back to the string 'Unknown' for actions done by those
not belonging to the service.

This commit changes the behaviour such that if the user is not in the
list of active users for a service, it will go get the user from the DB
(or redis). This should be fine to do as redis will protect us from most
calls as most of these cases are for platform admins.

This will mean we can now see which user platform admin put a service
live rather than seeing 'Unknown'.

Note, tests are a bit hacky, I couldn't quite get the mocking figured out as I would have liked

Before:
![image](https://user-images.githubusercontent.com/7228605/113698807-bd65eb00-96cc-11eb-9e02-2f10191b8179.png)

After:
![image](https://user-images.githubusercontent.com/7228605/113698849-c951ad00-96cc-11eb-89b5-86ee6f02a3b3.png)
