### PR TITLE
Allow platform admins to cancel broadcasts.

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -93,7 +93,7 @@ def get_broadcast_dashboard_partials(service_id):
 
 
 @main.route('/services/<uuid:service_id>/new-broadcast', methods=['GET', 'POST'])
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def new_broadcast(service_id):
     form = NewBroadcastForm()
@@ -116,7 +116,7 @@ def new_broadcast(service_id):
 
 
 @main.route('/services/<uuid:service_id>/write-new-broadcast', methods=['GET', 'POST'])
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def write_new_broadcast(service_id):
     form = BroadcastTemplateForm()
@@ -140,7 +140,7 @@ def write_new_broadcast(service_id):
 
 
 @main.route('/services/<uuid:service_id>/new-broadcast/<uuid:template_id>')
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def broadcast(service_id, template_id):
     return redirect(url_for(
@@ -154,7 +154,7 @@ def broadcast(service_id, template_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/areas')
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def preview_broadcast_areas(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
@@ -181,7 +181,7 @@ def preview_broadcast_areas(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries')
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_library(service_id, broadcast_message_id):
     return render_template(
@@ -198,7 +198,7 @@ def choose_broadcast_library(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_area(service_id, broadcast_message_id, library_slug):
     broadcast_message = BroadcastMessage.from_id(
@@ -258,7 +258,7 @@ def _get_broadcast_sub_area_back_link(service_id, broadcast_message_id, library_
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>/<area_slug>',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, area_slug):
     broadcast_message = BroadcastMessage.from_id(
@@ -310,7 +310,7 @@ def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, ar
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/remove/<area_slug>')
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def remove_broadcast_area(service_id, broadcast_message_id, area_slug):
     BroadcastMessage.from_id(
@@ -330,7 +330,7 @@ def remove_broadcast_area(service_id, broadcast_message_id, area_slug):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/preview',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def preview_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
@@ -405,7 +405,7 @@ def view_broadcast(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/current-alerts/<uuid:broadcast_message_id>', methods=['POST'])
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def approve_broadcast_message(service_id, broadcast_message_id):
 
@@ -438,7 +438,7 @@ def approve_broadcast_message(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/reject')
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def reject_broadcast_message(service_id, broadcast_message_id):
 
@@ -466,7 +466,7 @@ def reject_broadcast_message(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/cancel',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages')
+@user_has_permissions('send_messages', restrict_admin_usage=False)
 @service_has_permission('broadcast')
 def cancel_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -17,7 +17,7 @@
     'current_broadcasts'
   ) }}
 
-  {% if current_user.has_permissions('send_messages') %}
+  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -13,7 +13,7 @@
 
   {% include('views/broadcast/partials/dashboard-table.html') %}
 
-  {% if current_user.has_permissions('send_messages') %}
+  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -19,9 +19,9 @@
 
 {% block service_page_title %}
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
+    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
       {{ broadcast_message.template.name }} is waiting for approval
-    {% elif current_user.has_permissions('send_messages') %}
+    {% elif current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
       {% if broadcast_message.created_by %}
         {{ broadcast_message.created_by.name }}
       {% else %}
@@ -42,7 +42,7 @@
   {{ govukBackLink({ "href": back_link }) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages') %}
+    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
           {{ broadcast_message.template.name }} is waiting for approval
@@ -81,7 +81,7 @@
           </details>
         {% endif %}
       </div>
-    {% elif current_user.has_permissions('send_messages') %}
+    {% elif current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <h1 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">
           {% if broadcast_message.created_by %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -142,7 +142,7 @@ def test_broadcast_pages_403_for_user_without_permission(
     user_is_platform_admin
 ):
     """
-    Checks that users without permissions, including admin users, cannot create, approve or reject broadcasts.
+    Checks that users without permissions, including admin users, cannot create or edit broadcasts.
     """
     service_one['permissions'] += ['broadcast']
     if user_is_platform_admin:
@@ -160,6 +160,29 @@ def test_broadcast_pages_403_for_user_without_permission(
         service_id=SERVICE_ONE_ID,
         _expected_status=expected_post_status,
         **extra_args
+    )
+
+
+@pytest.mark.parametrize('user_is_platform_admin', [True, False])
+def test_user_cannot_accept_broadcast_without_permission(
+    mocker,
+    client_request,
+    service_one,
+    active_user_view_permissions,
+    platform_admin_user_no_service_permissions,
+    user_is_platform_admin
+):
+    service_one['permissions'] += ['broadcast']
+    if user_is_platform_admin:
+        client_request.login(platform_admin_user_no_service_permissions)
+    else:
+        client_request.login(active_user_view_permissions)
+
+    client_request.post(
+        '.approve_broadcast_message',
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=sample_uuid,
+        _expected_status=403,
     )
 
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -186,6 +186,29 @@ def test_user_cannot_accept_broadcast_without_permission(
     )
 
 
+@pytest.mark.parametrize('user_is_platform_admin', [True, False])
+def test_user_cannot_reject_broadcast_without_permission(
+    mocker,
+    client_request,
+    service_one,
+    active_user_view_permissions,
+    platform_admin_user_no_service_permissions,
+    user_is_platform_admin
+):
+    service_one['permissions'] += ['broadcast']
+    if user_is_platform_admin:
+        client_request.login(platform_admin_user_no_service_permissions)
+    else:
+        client_request.login(active_user_view_permissions)
+
+    client_request.get(
+        '.reject_broadcast_message',
+        service_id=SERVICE_ONE_ID,
+        broadcast_message_id=sample_uuid,
+        _expected_status=403,
+    )
+
+
 def test_cancel_broadcast_page_403_for_user_without_permission(
     mocker,
     client_request,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -39,7 +39,6 @@ from tests.conftest import (
     create_active_user_with_permissions,
     create_multiple_email_reply_to_addresses,
     create_multiple_sms_senders,
-    create_platform_admin_user,
     create_template,
     mock_get_service_email_template,
     mock_get_service_letter_template,
@@ -1614,13 +1613,14 @@ def test_no_link_to_use_existing_list_for_service_without_lists(
     client_request,
     mock_get_service_template,
     mock_has_jobs,
+    platform_admin_user,
     fake_uuid,
 ):
     mocker.patch(
         'app.models.contact_list.ContactLists.client_method',
         return_value=[],
     )
-    client_request.login(create_platform_admin_user())
+    client_request.login(platform_admin_user)
     page = client_request.get(
         'main.send_one_off',
         service_id=SERVICE_ONE_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1082,30 +1082,16 @@ def api_user_pending(fake_uuid):
 
 @pytest.fixture(scope='function')
 def platform_admin_user(fake_uuid):
-    user_data = {'id': fake_uuid,
-                 'name': 'Platform admin user',
-                 'password': 'somepassword',
-                 'email_address': 'platform@admin.gov.uk',
-                 'mobile_number': '07700 900762',
-                 'state': 'active',
-                 'failed_login_count': 0,
-                 'permissions': {SERVICE_ONE_ID: ['send_texts',
-                                                  'send_emails',
-                                                  'send_letters',
-                                                  'manage_users',
-                                                  'manage_templates',
-                                                  'manage_settings',
-                                                  'manage_api_keys',
-                                                  'view_activity']},
-                 'platform_admin': True,
-                 'auth_type': 'sms_auth',
-                 'password_changed_at': str(datetime.utcnow()),
-                 'services': [],
-                 'organisations': [],
-                 'current_session_id': None,
-                 'logged_in_at': None,
-                 }
-    return user_data
+    return create_platform_admin_user(permissions={SERVICE_ONE_ID: [
+        'send_texts',
+        'send_emails',
+        'send_letters',
+        'manage_users',
+        'manage_templates',
+        'manage_settings',
+        'manage_api_keys',
+        'view_activity'
+    ]})
 
 
 @pytest.fixture(scope='function')
@@ -1114,23 +1100,7 @@ def platform_admin_user_no_service_permissions():
     this fixture is for situations where we want to test that platform admin can access
     an endpoint even though they have no explicit permissions for that service.
     """
-    user_data = {'id': uuid4(),
-                 'name': 'Platform admin user no service permissions',
-                 'password': 'somepassword',
-                 'email_address': 'platform2@admin.gov.uk',
-                 'mobile_number': '07700 900763',
-                 'state': 'active',
-                 'failed_login_count': 0,
-                 'permissions': {},
-                 'platform_admin': True,
-                 'auth_type': 'sms_auth',
-                 'password_changed_at': str(datetime.utcnow()),
-                 'services': [],
-                 'organisations': [],
-                 'current_session_id': None,
-                 'logged_in_at': None,
-                 }
-    return user_data
+    return create_platform_admin_user()
 
 
 @pytest.fixture(scope='function')
@@ -3998,7 +3968,7 @@ def create_active_user_manage_template_permissions(with_unique_id=False):
     }
 
 
-def create_platform_admin_user(with_unique_id=False):
+def create_platform_admin_user(with_unique_id=False, permissions=None):
     return {
         'id': str(uuid4()) if with_unique_id else sample_uuid(),
         'name': 'Platform admin user',
@@ -4007,14 +3977,7 @@ def create_platform_admin_user(with_unique_id=False):
         'mobile_number': '07700 900762',
         'state': 'active',
         'failed_login_count': 0,
-        'permissions': {SERVICE_ONE_ID: ['send_texts',
-                                         'send_emails',
-                                         'send_letters',
-                                         'manage_users',
-                                         'manage_templates',
-                                         'manage_settings',
-                                         'manage_api_keys',
-                                         'view_activity']},
+        'permissions': permissions or {},
         'platform_admin': True,
         'auth_type': 'sms_auth',
         'password_changed_at': str(datetime.utcnow()),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1109,6 +1109,31 @@ def platform_admin_user(fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def platform_admin_user_no_service_permissions():
+    """
+    this fixture is for situations where we want to test that platform admin can access
+    an endpoint even though they have no explicit permissions for that service.
+    """
+    user_data = {'id': uuid4(),
+                 'name': 'Platform admin user no service permissions',
+                 'password': 'somepassword',
+                 'email_address': 'platform2@admin.gov.uk',
+                 'mobile_number': '07700 900763',
+                 'state': 'active',
+                 'failed_login_count': 0,
+                 'permissions': {},
+                 'platform_admin': True,
+                 'auth_type': 'sms_auth',
+                 'password_changed_at': str(datetime.utcnow()),
+                 'services': [],
+                 'organisations': [],
+                 'current_session_id': None,
+                 'logged_in_at': None,
+                 }
+    return user_data
+
+
+@pytest.fixture(scope='function')
 def api_user_active(fake_uuid):
     user_data = {'id': fake_uuid,
                  'name': 'Test User',


### PR DESCRIPTION
Do not allow platform admins to:
- create broadcasts
- approve broadcasts
- reject broadcasts

that is, unless they have a send_messages permission for a given service.

This is so platform admins have the minimum permissions necessary to cancel a broadcast that might have been sent out accidentally.

Pivotal ticket: https://www.pivotaltracker.com/story/show/177482418
API PR: https://github.com/alphagov/notifications-api/pull/3199