### PR TITLE
Let the API handle setting the default free allowance.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,16 +32,7 @@ class Config(object):
     ASSETS_DEBUG = False
     AWS_REGION = 'eu-west-1'
     DEFAULT_SERVICE_LIMIT = 50
-    DEFAULT_FREE_SMS_FRAGMENT_LIMITS = {
-        'central': 150_000,
-        'local': 25_000,
-        'nhs_central': 150_000,
-        'nhs_local': 25_000,
-        'nhs_gp': 10_000,
-        'emergency_service': 25_000,
-        'school_or_college': 10_000,
-        'other': 10_000,
-    }
+
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api
     EMAIL_2FA_EXPIRY_SECONDS = 1800  # 30 Minutes

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -2,7 +2,7 @@ from flask import current_app, redirect, render_template, session, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
-from app import billing_api_client, service_api_client
+from app import service_api_client
 from app.formatters import email_safe
 from app.main import main
 from app.main.forms import CreateNhsServiceForm, CreateServiceForm
@@ -10,11 +10,6 @@ from app.utils import user_is_gov_user, user_is_logged_in
 
 
 def _create_service(service_name, organisation_type, email_from, form):
-    free_sms_fragment_limit = current_app.config[
-        'DEFAULT_FREE_SMS_FRAGMENT_LIMITS'
-    ][
-        organisation_type
-    ]
 
     try:
         service_id = service_api_client.create_service(
@@ -26,8 +21,6 @@ def _create_service(service_name, organisation_type, email_from, form):
             email_from=email_from,
         )
         session['service_id'] = service_id
-
-        billing_api_client.create_or_update_free_sms_fragment_limit(service_id, free_sms_fragment_limit)
 
         return service_id, None
     except HTTPError as e:

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -125,7 +125,6 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
     mock_create_service_template,
     mock_get_services_with_no_services,
     api_user_active,
-    mock_create_or_update_free_sms_fragment_limit,
     mock_get_all_email_branding,
     inherited,
     email_address,
@@ -172,7 +171,6 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
         101,
     )
     assert session['service_id'] == 101
-    mock_create_or_update_free_sms_fragment_limit.assert_called_once_with(101, sms_limit)
 
 
 def test_add_service_has_to_choose_org_type(
@@ -182,7 +180,6 @@ def test_add_service_has_to_choose_org_type(
     mock_create_service_template,
     mock_get_services_with_no_services,
     api_user_active,
-    mock_create_or_update_free_sms_fragment_limit,
     mock_get_all_email_branding,
 ):
     mocker.patch(
@@ -201,7 +198,6 @@ def test_add_service_has_to_choose_org_type(
     )
     assert mock_create_service.called is False
     assert mock_create_service_template.called is False
-    assert mock_create_or_update_free_sms_fragment_limit.called is False
 
 
 @pytest.mark.parametrize('email_address', (
@@ -262,7 +258,6 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     api_user_active,
     organisation_type,
     free_allowance,
-    mock_create_or_update_free_sms_fragment_limit,
     mock_get_all_email_branding,
 ):
     client_request.post(
@@ -287,7 +282,6 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
         user_id=api_user_active['id'],
         email_from='testing.the.post',
     )
-    mock_create_or_update_free_sms_fragment_limit.assert_called_once_with(101, free_allowance)
     assert len(mock_create_service_template.call_args_list) == 0
     assert session['service_id'] == 101
 


### PR DESCRIPTION
The API has a method to handle setting the default SMS free allowance. This will save a call to the API and remove some code duplication between the two apps.

Needs to be merged after https://github.com/alphagov/notifications-api/pull/3197