### PR TITLE
Fix sign in link on 401 page

### DIFF
--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -4,6 +4,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
     <h1>You’re not authorised to see this page</h1>
-      <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
+      <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.sign_in' )}}">Sign in</a> to GOV.UK Notify and try again.</p>
   </div>
 {% endblock %}


### PR DESCRIPTION
We've seen someone getting a `500` when trying to visit the `/metrics`
endpoint. This is because the metrics endpoint is not in the `main`
blueprint, so we can't use `url_for` with a relative endpoint.

Although only bots visit '/metrics' without authorisation, this stops
the odd `500`.