### PR TITLE
pin prometheus-client to 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ fix-imports:
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install pip-tools
+	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip-tools
 	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
 
 .PHONY: clean

--- a/requirements.in
+++ b/requirements.in
@@ -28,5 +28,6 @@ git+https://github.com/alphagov/notifications-utils.git@44.1.0#egg=notifications
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
-prometheus-client==0.10.0
+# version 0.10.0 introduced exceptions when workers crashed due to deprecating lower case `prometheus_multiproc_dir`.
+prometheus-client>=0.9.0,!=0.10.0
 gds-metrics==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ packaging==20.9
     # via bleach
 phonenumbers==8.12.20
     # via notifications-utils
-prometheus-client==0.10.0
+prometheus-client==0.9.0
     # via
     #   -r requirements.in
     #   gds-metrics


### PR DESCRIPTION
we saw exceptions on prod that I think might have caused a worker that is being terminated to die ungracefully. While I'm not sure if this is an actual problem that changed behaviour (app instances crashing and restarting), at the very least it definitely polluted the logs and obscured any actual issues we were having.

https://github.com/prometheus/client_python/releases/tag/v0.10.0

see the pending fix for this problem here: prometheus/client_python#644