### PR TITLE
Allow users of the API to search templates by ID

### DIFF
--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -52,3 +52,9 @@
   // $class parameter is deprecated but needed for v2 of GOVUK Frontend. Remove for v3 & above
   @include govuk-grid-column(full, $class: false);
 }
+
+// Add override from future version of GOV.UK Frontend
+// Todo: remove this once we’ve upgraded past v3.11.0
+.govuk-\!-display-none {
+  display: none !important;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1924,6 +1924,17 @@ class SearchNotificationsForm(StripWhitespaceForm):
         )
 
 
+class SearchTemplatesForm(StripWhitespaceForm):
+
+    search = GovukSearchField()
+
+    def __init__(self, api_keys, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.search.label.text = (
+            'Search by name or ID' if api_keys else 'Search by name'
+        )
+
+
 class PlaceholderForm(StripWhitespaceForm):
 
     pass

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -29,7 +29,7 @@ from app.main.forms import (
     EmailTemplateForm,
     LetterTemplateForm,
     LetterTemplatePostageForm,
-    SearchByNameForm,
+    SearchTemplatesForm,
     SetTemplateSenderForm,
     SMSTemplateForm,
     TemplateAndFoldersSelectionForm,
@@ -159,7 +159,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         ),
         template_nav_items=get_template_nav_items(template_folder_id),
         template_type=template_type,
-        search_form=SearchByNameForm(),
+        search_form=SearchTemplatesForm(current_service.api_keys),
         templates_and_folders_form=templates_and_folders_form,
         move_to_children=templates_and_folders_form.move_to.children(),
         user_has_template_folder_permission=user_has_template_folder_permission,
@@ -352,14 +352,14 @@ def choose_template_to_copy(
             ),
             template_folder_path=service.get_template_folder_path(from_folder),
             from_service=service,
-            search_form=SearchByNameForm(),
+            search_form=SearchTemplatesForm(current_service.api_keys),
         )
 
     else:
         return render_template(
             'views/templates/copy.html',
             services_templates_and_folders=TemplateLists(current_user),
-            search_form=SearchByNameForm(),
+            search_form=SearchTemplatesForm(current_service.api_keys),
         )
 
 

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -42,7 +42,12 @@
           </a>
         {% else %}
           <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" class="govuk-link govuk-link--no-visited-state template-list-template">
-            <span class="live-search-relevant">{{- format_item_name(item.name) -}}</span>
+            <span class="live-search-relevant">
+              {%- if current_service.api_keys -%}
+                <span class="govuk-!-display-none">{{ item.id }} </span>
+              {%- endif -%}
+              {{- format_item_name(item.name) -}}
+            </span>
           </a>
         {% endif %}
       {% endset %}

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -415,6 +415,7 @@ def test_service_user_without_manage_service_permission_can_see_usage_page_when_
     mock_get_organisation,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
     user_organisations,
     expected_status,
     expected_menu_items,

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -161,6 +161,7 @@ def test_accepting_invite_removes_invite_from_session(
     mock_get_free_sms_fragment_limit,
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mock_get_api_keys,
     fake_uuid,
     user,
     landing_page_title,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1613,6 +1613,7 @@ def test_org_breadcrumbs_do_not_show_if_user_is_not_an_org_member(
     client_request,
     mock_get_template_folders,
     mock_get_returned_letter_statistics_with_no_returned_letters,
+    mock_get_api_keys,
 ):
     # active_caseworking_user is not an org member
 

--- a/tests/app/main/views/test_letters.py
+++ b/tests/app/main/views/test_letters.py
@@ -70,6 +70,7 @@ def test_given_option_to_add_letters_if_allowed(
     mock_get_service_templates,
     mock_get_template_folders,
     mock_get_organisations_and_services_for_user,
+    mock_get_api_keys,
     permissions,
     choices,
 ):

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -375,6 +375,7 @@ def test_should_show_templates_folder_page(
     client_request,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     service_one,
     mocker,
     expected_title_tag,
@@ -475,6 +476,71 @@ def test_should_show_templates_folder_page(
         assert not page.select('.template-list-empty')
 
     mock_get_service_templates.assert_called_once_with(SERVICE_ONE_ID)
+
+
+def test_template_id_is_searchable_for_services_with_api_keys(
+    client_request,
+    mock_get_template_folders,
+    mock_has_no_jobs,
+    mock_get_api_keys,
+    service_one,
+    mocker,
+
+):
+    mock_get_template_folders.return_value = [
+        _folder('folder one', PARENT_FOLDER_ID),
+    ]
+    template_1 = _template('sms', 'template one')
+    template_2 = _template('sms', 'template two', parent=PARENT_FOLDER_ID)
+    mocker.patch(
+        'app.service_api_client.get_service_templates',
+        return_value={'data': [
+            template_1,
+            template_2,
+        ]}
+    )
+
+    page = client_request.get(
+        'main.choose_template',
+        service_id=SERVICE_ONE_ID,
+        _test_page_title=False,
+    )
+
+    assert [
+        normalize_spaces(item.text)
+        for item in page.select(
+            # Elements which the live search will filter by
+            '.template-list-item .live-search-relevant'
+        )
+    ] == [
+        'folder one',
+        f'{template_2["id"]} template two',
+        f'{template_1["id"]} template one',
+    ]
+
+    assert [
+        normalize_spaces(item.text)
+        for item in page.select(
+            # Elements the user will see when first loading the page
+            '.template-list-item:not(.template-list-item-hidden-by-default)'
+        )
+    ] == [
+        'folder one folder one 1 template',
+        f'template one {template_1["id"]} template one Text message template',
+    ]
+
+    assert [
+        normalize_spaces(item.text)
+        for item in page.select(
+            # Text which should be hidden from all users
+            r'#template-list .govuk-\!-display-none'
+        )
+    ] == [
+        template_2["id"],
+        template_1["id"],
+    ]
+
+    mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 
 
 def test_can_create_email_template_with_parent_folder(
@@ -968,6 +1034,7 @@ def test_should_show_checkboxes_for_selecting_templates(
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     user,
 ):
     client_request.login(user)
@@ -1003,6 +1070,7 @@ def test_should_not_show_radios_and_buttons_for_move_destination_if_incorrect_pe
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     user,
 ):
     client_request.login(user)
@@ -1027,6 +1095,7 @@ def test_should_show_radios_and_buttons_for_move_destination_if_correct_permissi
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     fake_uuid,
     active_user_with_permissions
 ):
@@ -1070,6 +1139,7 @@ def test_move_to_shouldnt_select_a_folder_by_default(
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     fake_uuid,
     active_user_with_permissions
 ):
@@ -1168,6 +1238,7 @@ def test_move_folder_form_shows_current_folder_hint_when_in_a_folder(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_no_api_keys,
 ):
     mock_get_template_folders.return_value = [
         _folder('parent_folder', PARENT_FOLDER_ID, None),
@@ -1195,6 +1266,7 @@ def test_move_folder_form_does_not_show_current_folder_hint_at_the_top_level(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_no_api_keys,
 ):
     mock_get_template_folders.return_value = [
         _folder('parent_folder', PARENT_FOLDER_ID, None),
@@ -1306,6 +1378,7 @@ def test_no_action_if_user_fills_in_ambiguous_fields(
     mock_get_template_folders,
     mock_move_to_template_folder,
     mock_create_template_folder,
+    mock_get_no_api_keys,
     data,
 ):
     service_one['permissions'] += ['letter']
@@ -1434,6 +1507,7 @@ def test_radio_button_with_no_value_shows_custom_error_message(
     mock_get_template_folders,
     mock_move_to_template_folder,
     mock_create_template_folder,
+    mock_get_no_api_keys,
 ):
     page = client_request.post(
         'main.choose_template',
@@ -1473,6 +1547,7 @@ def test_show_custom_error_message(
         mock_get_template_folders,
         mock_move_to_template_folder,
         mock_create_template_folder,
+        mock_get_no_api_keys,
         data,
         error_msg,
 ):
@@ -1604,6 +1679,7 @@ def test_should_filter_templates_folder_page_based_on_user_permissions(
     client_request,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     service_one,
     mocker,
     active_user_with_permissions,

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -533,7 +533,7 @@ def test_template_id_is_searchable_for_services_with_api_keys(
         normalize_spaces(item.text)
         for item in page.select(
             # Text which should be hidden from all users
-            r'#template-list .govuk-\!-display-none'
+            r'.template-list-item .govuk-\!-display-none'
         )
     ] == [
         template_2["id"],

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -51,6 +51,7 @@ def test_should_show_empty_page_when_no_templates(
     service_one,
     mock_get_service_templates_when_no_templates_exist,
     mock_get_template_folders,
+    mock_get_no_api_keys,
     permissions,
     expected_message,
 ):
@@ -77,6 +78,7 @@ def test_should_show_add_template_form_if_service_has_folder_permission(
     service_one,
     mock_get_service_templates_when_no_templates_exist,
     mock_get_template_folders,
+    mock_get_no_api_keys,
 ):
     page = client_request.get(
         'main.choose_template',
@@ -164,6 +166,7 @@ def test_should_show_page_for_choosing_a_template(
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_no_jobs,
+    mock_get_no_api_keys,
     extra_args,
     expected_nav_links,
     expected_templates,
@@ -207,6 +210,7 @@ def test_should_show_page_of_broadcast_templates(
     service_one,
     fake_uuid,
     mock_get_template_folders,
+    mock_get_no_api_keys,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -274,6 +278,7 @@ def test_choose_template_can_pass_through_an_initial_state_to_templates_and_fold
     client_request,
     mock_get_template_folders,
     mock_get_service_templates,
+    mock_get_no_api_keys,
 ):
     page = client_request.get(
         'main.choose_template',
@@ -289,6 +294,7 @@ def test_should_not_show_template_nav_if_only_one_type_of_template(
     client_request,
     mock_get_template_folders,
     mock_get_service_templates_with_only_one_template,
+    mock_get_no_api_keys,
 ):
 
     page = client_request.get(
@@ -302,7 +308,8 @@ def test_should_not_show_template_nav_if_only_one_type_of_template(
 def test_should_not_show_live_search_if_list_of_templates_fits_onscreen(
     client_request,
     mock_get_template_folders,
-    mock_get_service_templates
+    mock_get_service_templates,
+    mock_get_no_api_keys,
 ):
 
     page = client_request.get(
@@ -316,7 +323,8 @@ def test_should_not_show_live_search_if_list_of_templates_fits_onscreen(
 def test_should_show_live_search_if_list_of_templates_taller_than_screen(
     client_request,
     mock_get_template_folders,
-    mock_get_more_service_templates_than_can_fit_onscreen
+    mock_get_more_service_templates_than_can_fit_onscreen,
+    mock_get_no_api_keys,
 ):
 
     page = client_request.get(
@@ -327,14 +335,33 @@ def test_should_show_live_search_if_list_of_templates_taller_than_screen(
 
     assert search['data-module'] == 'live-search'
     assert search['data-targets'] == '#template-list .template-list-item'
+    assert normalize_spaces(search.select_one('label').text) == (
+        'Search by name'
+    )
 
     assert len(page.select(search['data-targets'])) == len(page.select('#template-list .govuk-label')) == 14
+
+
+def test_should_label_search_by_id_for_services_with_api_keys(
+    client_request,
+    mock_get_template_folders,
+    mock_get_more_service_templates_than_can_fit_onscreen,
+    mock_get_api_keys,
+):
+    page = client_request.get(
+        'main.choose_template',
+        service_id=SERVICE_ONE_ID,
+    )
+    assert normalize_spaces(page.select_one('.live-search label').text) == (
+        'Search by name or ID'
+    )
 
 
 def test_should_show_live_search_if_service_has_lots_of_folders(
     client_request,
     mock_get_template_folders,
     mock_get_service_templates,  # returns 4 templates
+    mock_get_no_api_keys,
 ):
 
     mock_get_template_folders.return_value = [
@@ -390,6 +417,7 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_no_api_keys,
     service_permissions,
     expected_values,
     expected_labels,
@@ -427,6 +455,7 @@ def test_should_add_data_attributes_for_services_that_only_allow_one_type_of_not
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_no_api_keys,
     permissions,
     are_data_attrs_added
 ):
@@ -1129,6 +1158,7 @@ def test_choose_a_template_to_copy(
     client_request,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_no_api_keys,
     mock_get_just_services_for_user,
 ):
     page = client_request.get(
@@ -1226,6 +1256,7 @@ def test_choose_a_template_to_copy_when_user_has_one_service(
     client_request,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_no_api_keys,
     mock_get_empty_organisations_and_one_service_for_user,
 ):
     page = client_request.get(
@@ -1281,6 +1312,7 @@ def test_choose_a_template_to_copy_from_folder_within_service(
     client_request,
     mock_get_template_folders,
     mock_get_non_empty_organisations_and_services_for_user,
+    mock_get_no_api_keys,
 ):
     mock_get_template_folders.return_value = [
         _folder('Parent folder', PARENT_FOLDER_ID),
@@ -2169,7 +2201,8 @@ def test_route_permissions_for_choose_template(
     api_user_active,
     mock_get_template_folders,
     service_one,
-    mock_get_service_templates
+    mock_get_service_templates,
+    mock_get_no_api_keys,
 ):
     mocker.patch('app.job_api_client.get_job')
     validate_route_permission(

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -417,6 +417,7 @@ def test_a_page_should_nave_selected_navigation_item(
     mock_get_users_by_service,
     mock_get_invites_for_service,
     mock_get_template_folders,
+    mock_get_api_keys,
     endpoint,
     selected_nav_item,
 ):
@@ -467,6 +468,7 @@ def test_navigation_urls(
     client_request,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
 ):
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert [
@@ -487,6 +489,7 @@ def test_navigation_for_services_with_broadcast_permission(
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
+    mock_get_api_keys,
 ):
     service_one['permissions'] += ['broadcast']
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
@@ -508,6 +511,7 @@ def test_caseworkers_get_caseworking_navigation(
     mock_get_template_folders,
     mock_get_service_templates,
     mock_has_no_jobs,
+    mock_get_api_keys,
     active_caseworking_user,
 ):
     mocker.patch(
@@ -527,6 +531,7 @@ def test_caseworkers_see_jobs_nav_if_jobs_exist(
     mock_get_template_folders,
     mock_has_jobs,
     active_caseworking_user,
+    mock_get_api_keys,
 ):
     mocker.patch(
         'app.user_api_client.get_user',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/355079/114572146-26baa080-9c6f-11eb-9d88-7ced7f1e1558.png)

***

For someone who has retrieved a template ID from their system the only way to find it in Notify is:
- hack the URL
- click through every template, visually inspecting the ID shown on the page until you find the right one

Neither of these is ideal.

This commit adds searching by ID, for those services who have an API integration. This means we don’t need to confuse teams who aren’t using the API by talking about IDs.

This is similar to how we let these teams [search for notifications by reference](https://github.com/alphagov/notifications-admin/pull/3223).