### PR TITLE
If the job is for letters do not add the sender_id.

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -742,7 +742,8 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
         'original_file_name': data.get('original_file_name', ''),
     }
 
-    if session.get('sender_id'):
+    if session.get('sender_id') and data['template'].template_type != 'letter':
+        # sender_id is not an option for sending letters.
         metadata_kwargs['sender_id'] = session['sender_id']
 
     set_metadata_on_csv_upload(service_id, upload_id, **metadata_kwargs)


### PR DESCRIPTION
How this happens: a user starts to send a letter job, then in another tab starts a SMS
or email job, the sender_id is set in the session. Then the user goes
back to the letter job tab and creates the job. The sender_id is set in
the metadata of the csv file, and causes an exception when trying to persist
the letter notification.

This PR adds a check to ensure the sender_id is not set for letter jobs.

This will catch a small use case where the user has multiple tabs open
and has started sending an SMS or email job, then tries to send a letter
job.