### PR TITLE
Show service suspension in breadcrumb

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -34,6 +34,12 @@
       box-shadow: 0 -3px 0 0 $grey-3;
     }
 
+    &--suspended {
+      background: $grey-3;
+      color: mix($grey-1, $text-colour);
+      box-shadow: 0 -3px 0 0 $grey-3;
+    }
+
     &--live {
       // This uses new Design System colours to match .govuk-tag--red
       background: #F6D7D2;

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -17,16 +17,18 @@
       {% endif %}
       <div class="navigation-service-name govuk-!-font-weight-bold">
         {{ current_service.name }}
-        {% if current_service.has_permission('broadcast') %}
-          {% if current_service.trial_mode %}
-            <span class="navigation-service-type navigation-service-type--training">Training
-          {% else %}
-            <span class="navigation-service-type navigation-service-type--live">Live
-          {% endif %}
-          {% if current_service.allowed_broadcast_provider %}
-            ({{ current_service.allowed_broadcast_provider }})
-          {% endif %}
-          </span>
+          {% if not current_service.active %}
+            <span class="navigation-service-type navigation-service-type--suspended">Suspended</span>
+          {% elif current_service.has_permission('broadcast') %}
+            {% if current_service.trial_mode %}
+              <span class="navigation-service-type navigation-service-type--training">Training
+            {% else %}
+              <span class="navigation-service-type navigation-service-type--live">Live
+            {% endif %}
+            {% if current_service.allowed_broadcast_provider %}
+              ({{ current_service.allowed_broadcast_provider }})
+            {% endif %}
+            </span>
         {% endif %}
       </div>
       <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1713,6 +1713,29 @@ def test_org_breadcrumbs_show_if_user_is_platform_admin(
     )
 
 
+def test_breadcrumb_shows_if_service_is_suspended(
+    mocker,
+    mock_get_template_statistics,
+    mock_get_service_templates_when_no_templates_exist,
+    mock_has_no_jobs,
+    mock_get_usage,
+    mock_get_free_sms_fragment_limit,
+    mock_get_returned_letter_statistics_with_no_returned_letters,
+    active_user_with_permissions,
+    client_request,
+):
+    service_one_json = service_json(
+        SERVICE_ONE_ID,
+        active=False,
+        users=[active_user_with_permissions['id']],
+    )
+
+    mocker.patch('app.service_api_client.get_service', return_value={'data': service_one_json})
+    page = client_request.get('main.service_dashboard', service_id=SERVICE_ONE_ID)
+
+    assert 'Suspended' in page.select_one('.navigation-service-name').text
+
+
 @pytest.mark.parametrize('permissions', (
     ['email', 'sms'],
     ['email', 'sms', 'letter'],


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177758598

Previously there was no indication that a service was suspended.
While this could also be shown for archived/deleted services, the
meaning is similar enough that it makes sense there too - the name
of the archived service should distinguish it as being archived.

## Screenshots

| Before | After |
| ------- | ----- |
| <img width="403" alt="Screenshot 2021-04-27 at 10 56 38" src="https://user-images.githubusercontent.com/9029009/116223278-48278c00-a747-11eb-9346-c01f42f72bd9.png"> | <img width="347" alt="Screenshot 2021-04-27 at 10 52 00" src="https://user-images.githubusercontent.com/9029009/116222819-d3545200-a746-11eb-9f1c-2be91a6f5dcd.png"> |
| <img width="585" alt="Screenshot 2021-04-27 at 10 56 24" src="https://user-images.githubusercontent.com/9029009/116223326-55447b00-a747-11eb-91af-5dbb41add986.png"> | <img width="547" alt="Screenshot 2021-04-27 at 10 52 49" src="https://user-images.githubusercontent.com/9029009/116222823-d3ece880-a746-11eb-942c-86f8350bf267.png"> |



