### PR TITLE
Update pricing information on the features page

### DIFF
--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -31,12 +31,7 @@
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='text-message-sender') }}">how to change the text message sender</a>.</p>
 
   <h2 class="heading heading-medium">Pricing<h2>
-    <p class="govuk-body">Each service you add has an annual allowance of free text messages. When you’ve used your allowance, it costs 1.6 pence (plus VAT) for each additional text message you send to a UK number.</p>
-    <p class="govuk-body">The free allowance is:</p>
-    <ul class="list list-bullet">
-      <li>150,000 free text messages for national services</li>
-      <li>25,000 free text messages for regional services</li>
-      <li>10,000 free text messages for state-funded schools and GP practices</li></ul>
-    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
+    <p class="govuk-body">Each service you add has an annual allowance of free text messages.</p>
+    <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing', _anchor='text-messages') }}">See pricing</a> for more details.</p>
 
 {% endblock %}

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -31,11 +31,12 @@
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.branding_and_customisation', _anchor='text-message-sender') }}">how to change the text message sender</a>.</p>
 
   <h2 class="heading heading-medium">Pricing<h2>
-    <p class="govuk-body">Each service you add has a free annual allowance. After that it costs 1.58 pence (plus VAT) to send a text to a UK number.</p>
+    <p class="govuk-body">Each service you add has an annual allowance of free text messages. When you’ve used your allowance, it costs 1.6 pence (plus VAT) for each additional text message you send to a UK number.</p>
     <p class="govuk-body">The free allowance is:</p>
     <ul class="list list-bullet">
-      <li>250,000 free text messages for central government services</li>
-      <li>25,000 free text messages for other public sector services</li></ul>
+      <li>150,000 free text messages for national services</li>
+      <li>25,000 free text messages for regional services</li>
+      <li>10,000 free text messages for state-funded schools and GP practices</li></ul>
     <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing') }}">See pricing</a> for more details.</p>
 
 {% endblock %}


### PR DESCRIPTION
When I updated the Pricing page and landing page I forgot to update the pricing information on the Features page.

Duplicating information across different pages of Notify increases complexity, makes more work for us each time we introduce a change and increases the risk of inconsistencies.

This PR removes the duplicate/out-of-date pricing information from the Features page.