### PR TITLE
Start changing broadcast_provider value from None to "all"

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2334,7 +2334,7 @@ class ServiceBroadcastAccountTypeField(GovukRadiosField):
             split_values = self.data.split("-")
             self.service_mode = split_values[0]
             self.broadcast_channel = split_values[1]
-            self.provider_restriction = split_values[2] if len(split_values) == 3 else None
+            self.provider_restriction = split_values[2] if len(split_values) == 3 else 'all'
 
 
 class ServiceBroadcastAccountTypeForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2321,7 +2321,7 @@ class ServiceBroadcastAccountTypeField(GovukRadiosField):
         if broadcast_channel:
             account_type = "live" if live else "training"
             account_type += f"-{broadcast_channel}"
-            if allowed_broadcast_provider:
+            if allowed_broadcast_provider and allowed_broadcast_provider != 'all':
                 account_type += f"-{allowed_broadcast_provider}"
 
         self.data = account_type

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -623,7 +623,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         service_mode is one of "training" or "live"
         broadcast channel is one of "test" or "severe"
-        provider_restriction is one of None, "three", "o2", "vodafone", "ee"
+        provider_restriction is one of "all", "three", "o2", "vodafone", "ee"
         """
         data = {
             "service_mode": service_mode,

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -435,7 +435,7 @@
               Off
               {% else %}
                 {% if current_service.live and current_service.broadcast_channel == "severe" %}Live{% endif %}
-                {% if current_service.live and current_service.broadcast_channel == "test" %}Test {% if current_service.allowed_broadcast_provider %}({{ current_service.allowed_broadcast_provider|format_mobile_network }}){% else %}(All networks){% endif %}{%endif%}
+                {% if current_service.live and current_service.broadcast_channel == "test" %}Test {% if current_service.allowed_broadcast_provider and current_service.allowed_broadcast_provider != "all" %}({{ current_service.allowed_broadcast_provider|format_mobile_network }}){% else %}(All networks){% endif %}{%endif%}
                 {% if not current_service.live%}Training {% endif%}
               {% endif %}
             {% endcall %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -25,7 +25,7 @@
             {% else %}
               <span class="navigation-service-type navigation-service-type--live">Live
             {% endif %}
-            {% if current_service.allowed_broadcast_provider %}
+            {% if current_service.allowed_broadcast_provider and current_service.allowed_broadcast_provider != "all" %}
               ({{ current_service.allowed_broadcast_provider }})
             {% endif %}
             </span>

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -301,6 +301,20 @@ def test_broadcast_tour_page_4_shows_service_name(
         'service one Live Switch service',
         'Live',
     ),
+    (
+        True,
+        "all",
+        '.navigation-service-type.navigation-service-type--training',
+        'service one Training Switch service',
+        'Training',
+    ),
+    (
+        False,
+        "all",
+        '.navigation-service-type.navigation-service-type--live',
+        'service one Live Switch service',
+        'Live',
+    ),
 
     (
         True,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -199,12 +199,17 @@ def test_platform_admin_sees_only_relevant_settings_for_broadcast_service(
     'has_broadcast_permission,service_mode,broadcast_channel,allowed_broadcast_provider,expected_text',
     [
         (False, "training", None, None, "Off"),
+        (False, "training", None, "all", "Off"),
         (False, "live", None, None, "Off"),
+        (False, "live", None, "all", "Off"),
         (True, "training", "test", None, "Training"),
+        (True, "training", "test", "all", "Training"),
         (True, "live", "test", "ee", "Test (EE)"),
         (True, "live", "test", "three", "Test (Three)"),
         (True, "live", "test", None, "Test (All networks)"),
+        (True, "live", "test", "all", "Test (All networks)"),
         (True, "live", "severe", None, "Live"),
+        (True, "live", "severe", "all", "Live"),
     ]
 )
 def test_platform_admin_sees_correct_description_of_broadcast_service_setting(
@@ -5471,6 +5476,13 @@ def test_get_service_set_broadcast_account_type_has_no_radio_selected_for_non_br
             "training-test",
         ),
         (
+            "training",
+            "test",
+            "all",
+            "Training mode",
+            "training-test",
+        ),
+        (
             "live",
             "test",
             "vodafone",
@@ -5481,6 +5493,13 @@ def test_get_service_set_broadcast_account_type_has_no_radio_selected_for_non_br
             "live",
             "severe",
             None,
+            "Live (all networks)",
+            "live-severe",
+        ),
+        (
+            "live",
+            "severe",
+            "all",
             "Live (all networks)",
             "live-severe",
         ),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -5524,9 +5524,9 @@ def test_get_service_set_broadcast_account_type_has_radio_selected_for_broadcast
 @pytest.mark.parametrize(
     'value,service_mode,broadcast_channel,allowed_broadcast_provider',
     [
-        ("training-test", "training", "test", None),
+        ("training-test", "training", "test", "all"),
         ("live-test-vodafone", "live", "test", "vodafone"),
-        ("live-severe", "live", "severe", None),
+        ("live-severe", "live", "severe", "all"),
     ]
 )
 def test_post_service_set_broadcast_account_type_posts_data_to_api_and_redirects(


### PR DESCRIPTION
We're replacing the value of `None` in the broadcast_provider_settings table with the value of `"all"`. 

This change 
* Starts sending api the broadcast provider restriction of 'all', not 'None' (API has already been updated to accept both values (alphagov/notifications-api@1767535)
* Checks for both values of `"all"` and `None` when displaying the broadcast provider (this is a temporary step until we've stopped using the value of `None`)

Step two of [Pivotal story](https://www.pivotaltracker.com/story/show/177759863)