### PR TITLE
Stop checking for allowed_broadcast_provider being None

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2321,7 +2321,7 @@ class ServiceBroadcastAccountTypeField(GovukRadiosField):
         if broadcast_channel:
             account_type = "live" if live else "training"
             account_type += f"-{broadcast_channel}"
-            if allowed_broadcast_provider and allowed_broadcast_provider != 'all':
+            if allowed_broadcast_provider != 'all':
                 account_type += f"-{allowed_broadcast_provider}"
 
         self.data = account_type

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -435,7 +435,7 @@
               Off
               {% else %}
                 {% if current_service.live and current_service.broadcast_channel == "severe" %}Live{% endif %}
-                {% if current_service.live and current_service.broadcast_channel == "test" %}Test {% if current_service.allowed_broadcast_provider and current_service.allowed_broadcast_provider != "all" %}({{ current_service.allowed_broadcast_provider|format_mobile_network }}){% else %}(All networks){% endif %}{%endif%}
+                {% if current_service.live and current_service.broadcast_channel == "test" %}Test {% if current_service.allowed_broadcast_provider != "all" %}({{ current_service.allowed_broadcast_provider|format_mobile_network }}){% else %}(All networks){% endif %}{%endif%}
                 {% if not current_service.live%}Training {% endif%}
               {% endif %}
             {% endcall %}

--- a/app/templates/withnav_template.html
+++ b/app/templates/withnav_template.html
@@ -25,7 +25,7 @@
             {% else %}
               <span class="navigation-service-type navigation-service-type--live">Live
             {% endif %}
-            {% if current_service.allowed_broadcast_provider and current_service.allowed_broadcast_provider != "all" %}
+            {% if current_service.allowed_broadcast_provider != "all" %}
               ({{ current_service.allowed_broadcast_provider }})
             {% endif %}
             </span>

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -289,20 +289,6 @@ def test_broadcast_tour_page_4_shows_service_name(
 @pytest.mark.parametrize('trial_mode, allowed_broadcast_provider, selector, expected_text, expected_tagged_text', (
     (
         True,
-        None,
-        '.navigation-service-type.navigation-service-type--training',
-        'service one Training Switch service',
-        'Training',
-    ),
-    (
-        False,
-        None,
-        '.navigation-service-type.navigation-service-type--live',
-        'service one Live Switch service',
-        'Live',
-    ),
-    (
-        True,
         "all",
         '.navigation-service-type.navigation-service-type--training',
         'service one Training Switch service',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -198,17 +198,12 @@ def test_platform_admin_sees_only_relevant_settings_for_broadcast_service(
 @pytest.mark.parametrize(
     'has_broadcast_permission,service_mode,broadcast_channel,allowed_broadcast_provider,expected_text',
     [
-        (False, "training", None, None, "Off"),
         (False, "training", None, "all", "Off"),
-        (False, "live", None, None, "Off"),
         (False, "live", None, "all", "Off"),
-        (True, "training", "test", None, "Training"),
         (True, "training", "test", "all", "Training"),
         (True, "live", "test", "ee", "Test (EE)"),
         (True, "live", "test", "three", "Test (Three)"),
-        (True, "live", "test", None, "Test (All networks)"),
         (True, "live", "test", "all", "Test (All networks)"),
-        (True, "live", "severe", None, "Live"),
         (True, "live", "severe", "all", "Live"),
     ]
 )
@@ -5471,13 +5466,6 @@ def test_get_service_set_broadcast_account_type_has_no_radio_selected_for_non_br
         (
             "training",
             "test",
-            None,
-            "Training mode",
-            "training-test",
-        ),
-        (
-            "training",
-            "test",
             "all",
             "Training mode",
             "training-test",
@@ -5488,13 +5476,6 @@ def test_get_service_set_broadcast_account_type_has_no_radio_selected_for_non_br
             "vodafone",
             "Test channel (Vodafone)",
             "live-test-vodafone",
-        ),
-        (
-            "live",
-            "severe",
-            None,
-            "Live (all networks)",
-            "live-severe",
         ),
         (
             "live",


### PR DESCRIPTION
The current_service.allowed_broadcast_provider is now always "all" or one of the four providers, which means we can simply the code by not checking if it is None.

Part four of [Pivotal story](https://www.pivotaltracker.com/story/show/177759863)

Must be merged after
- [x] https://github.com/alphagov/notifications-api/pull/3237