### PR TITLE
Add a confirmation checkbox for live broadcasts

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1297,7 +1297,9 @@ class ConfirmBroadcastForm(StripWhitespaceForm):
         self.confirm.label.text = self.generate_label(channel, max_phones)
 
         if service_is_live:
-            self.confirm.validators += (DataRequired(),)
+            self.confirm.validators += (
+                DataRequired('You need to confirm that you understand'),
+            )
 
     confirm = GovukCheckboxField("Confirm")
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,3 +1,4 @@
+import math
 import weakref
 from datetime import datetime, timedelta
 from itertools import chain
@@ -1286,6 +1287,50 @@ class NewBroadcastForm(StripWhitespaceForm):
     @property
     def use_template(self):
         return self.content.data == 'template'
+
+
+class ConfirmBroadcastForm(StripWhitespaceForm):
+
+    def __init__(self, *args, service_is_live, channel, max_phones, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.confirm.label.text = self.generate_label(channel, max_phones)
+
+        if service_is_live:
+            self.confirm.validators += (DataRequired(),)
+
+    confirm = GovukCheckboxField("Confirm")
+
+    @staticmethod
+    def generate_label(channel, max_phones):
+        if channel == 'test':
+            return (
+                'I understand this will alert anyone who has switched '
+                'on the test channel'
+            )
+        if channel == 'severe':
+            return (
+                f'I understand this will alert {ConfirmBroadcastForm.format_number_generic(max_phones)} '
+                'of people'
+            )
+        if channel == 'government':
+            return (
+                f'I understand this will alert {ConfirmBroadcastForm.format_number_generic(max_phones)} '
+                'of people, even if they’ve opted out'
+            )
+
+    @staticmethod
+    def format_number_generic(count):
+        for threshold, message in (
+            (1_000_000, 'millions'),
+            (100_000, 'hundreds of thousands'),
+            (10_000, 'tens of thousands'),
+            (1_000, 'thousands'),
+            (100, 'hundreds'),
+            (-math.inf, 'an unknown number')
+        ):
+            if count >= threshold:
+                return message
 
 
 class BaseTemplateForm(StripWhitespaceForm):

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -22,6 +22,15 @@ from app.models.broadcast_message import BroadcastMessage, BroadcastMessages
 from app.utils import service_has_permission, user_has_permissions
 
 
+def get_back_link_endpoint():
+    return {
+        'main.view_current_broadcast': '.broadcast_dashboard',
+        'main.view_previous_broadcast': '.broadcast_dashboard_previous',
+        'main.view_rejected_broadcast': '.broadcast_dashboard_rejected',
+        'main.approve_broadcast_message': '.broadcast_dashboard',
+    }[request.endpoint]
+
+
 @main.route('/services/<uuid:service_id>/broadcast-tour/<int:step_index>')
 @user_has_permissions()
 @service_has_permission('broadcast')
@@ -389,17 +398,11 @@ def view_broadcast(service_id, broadcast_message_id):
                 broadcast_message_id=broadcast_message.id,
             ))
 
-    back_link_endpoint = {
-        'main.view_current_broadcast': '.broadcast_dashboard',
-        'main.view_previous_broadcast': '.broadcast_dashboard_previous',
-        'main.view_rejected_broadcast': '.broadcast_dashboard_rejected',
-    }[request.endpoint]
-
     return render_template(
         'views/broadcast/view-message.html',
         broadcast_message=broadcast_message,
         back_link=url_for(
-            back_link_endpoint,
+            get_back_link_endpoint(),
             service_id=current_service.id,
         ),
         form=ConfirmBroadcastForm(
@@ -442,6 +445,16 @@ def approve_broadcast_message(service_id, broadcast_message_id):
         ))
     elif form.validate_on_submit():
         broadcast_message.approve_broadcast()
+    else:
+        return render_template(
+            'views/broadcast/view-message.html',
+            broadcast_message=broadcast_message,
+            back_link=url_for(
+                get_back_link_endpoint(),
+                service_id=current_service.id,
+            ),
+            form=form,
+        )
 
     return redirect(url_for(
         '.view_current_broadcast',

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -22,7 +22,7 @@ from app.models.broadcast_message import BroadcastMessage, BroadcastMessages
 from app.utils import service_has_permission, user_has_permissions
 
 
-def get_back_link_endpoint():
+def _get_back_link_from_view_broadcast_endpoint():
     return {
         'main.view_current_broadcast': '.broadcast_dashboard',
         'main.view_previous_broadcast': '.broadcast_dashboard_previous',
@@ -402,7 +402,7 @@ def view_broadcast(service_id, broadcast_message_id):
         'views/broadcast/view-message.html',
         broadcast_message=broadcast_message,
         back_link=url_for(
-            get_back_link_endpoint(),
+            _get_back_link_from_view_broadcast_endpoint(),
             service_id=current_service.id,
         ),
         form=ConfirmBroadcastForm(
@@ -450,7 +450,7 @@ def approve_broadcast_message(service_id, broadcast_message_id):
             'views/broadcast/view-message.html',
             broadcast_message=broadcast_message,
             back_link=url_for(
-                get_back_link_endpoint(),
+                _get_back_link_from_view_broadcast_endpoint(),
                 service_id=current_service.id,
             ),
             form=form,

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -14,6 +14,7 @@ from app.main.forms import (
     BroadcastAreaForm,
     BroadcastAreaFormWithSelectAll,
     BroadcastTemplateForm,
+    ConfirmBroadcastForm,
     NewBroadcastForm,
     SearchByNameForm,
 )
@@ -401,6 +402,11 @@ def view_broadcast(service_id, broadcast_message_id):
             back_link_endpoint,
             service_id=current_service.id,
         ),
+        form=ConfirmBroadcastForm(
+            service_is_live=current_service.live,
+            channel=current_service.broadcast_channel,
+            max_phones=broadcast_message.count_of_phones_likely,
+        ),
     )
 
 
@@ -414,6 +420,12 @@ def approve_broadcast_message(service_id, broadcast_message_id):
         service_id=current_service.id,
     )
 
+    form = ConfirmBroadcastForm(
+        service_is_live=current_service.live,
+        channel=current_service.broadcast_channel,
+        max_phones=broadcast_message.count_of_phones_likely,
+    )
+
     if broadcast_message.status != 'pending-approval':
         return redirect(url_for(
             '.view_current_broadcast',
@@ -421,14 +433,15 @@ def approve_broadcast_message(service_id, broadcast_message_id):
             broadcast_message_id=broadcast_message.id,
         ))
 
-    broadcast_message.approve_broadcast()
-
     if current_service.trial_mode:
+        broadcast_message.approve_broadcast()
         return redirect(url_for(
             '.broadcast_tour',
             service_id=current_service.id,
             step_index=6,
         ))
+    elif form.validate_on_submit():
+        broadcast_message.approve_broadcast()
 
     return redirect(url_for(
         '.view_current_broadcast',

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -92,6 +92,17 @@
           wants to broadcast
           {{ broadcast_message.template.name }}
         </h1>
+        {% if current_service.live %}
+          {{ form.confirm(param_extensions={
+            'formGroup': {
+              'classes': 'govuk-!-margin-bottom-4'
+            }
+          }) }}
+        {% else %}
+          <p class="govuk-body govuk-!-margin-bottom-3">
+            No phones will get this alert.
+          </p>
+        {% endif %}
         {{ page_footer(
           "Start broadcasting now",
           delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2159,41 +2159,38 @@ def test_view_only_user_cant_approve_broadcast(
 
 
 @pytest.mark.parametrize(
-    'trial_mode, initial_status, post_data, expected_approval, expected_redirect, expected_status',
+    'trial_mode, initial_status, post_data, expected_approval, expected_redirect',
     (
         (True, 'draft', {}, False, partial(
             url_for,
             '.view_current_broadcast',
             broadcast_message_id=sample_uuid,
-        ), 302),
+        )),
         (True, 'pending-approval', {}, True, partial(
             url_for,
             '.broadcast_tour',
             step_index=6,
-        ), 302),
-        (False, 'pending-approval', {}, False, (
-            lambda service_id, _external: None
-        ), 200),
+        )),
         (False, 'pending-approval', {'confirm': 'y'}, True, partial(
             url_for,
             '.view_current_broadcast',
             broadcast_message_id=sample_uuid,
-        ), 302),
+        )),
         (True, 'rejected', {}, False, partial(
             url_for,
             '.view_current_broadcast',
             broadcast_message_id=sample_uuid,
-        ), 302),
+        )),
         (True, 'broadcasting', {}, False, partial(
             url_for,
             '.view_current_broadcast',
             broadcast_message_id=sample_uuid,
-        ), 302),
+        )),
         (True, 'cancelled', {}, False, partial(
             url_for,
             '.view_current_broadcast',
             broadcast_message_id=sample_uuid,
-        ), 302),
+        )),
     )
 )
 @freeze_time('2020-02-22T22:22:22.000000')
@@ -2210,7 +2207,6 @@ def test_request_approval(
     expected_approval,
     trial_mode,
     expected_redirect,
-    expected_status,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -2234,7 +2230,6 @@ def test_request_approval(
             service_id=SERVICE_ONE_ID,
             _external=True,
         ),
-        _expected_status=expected_status,
         _data=post_data,
     )
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1970,9 +1970,6 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     assert normalize_spaces(error_message.text) == (
         'Error: You need to confirm that you understand'
     )
-    assert page.select_one('form.banner input#confirm')['aria-describedby'] == (
-        error_message['id']
-    )
 
     assert mock_update_broadcast_message.called is False
     assert mock_update_broadcast_message_status.called is False

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1873,59 +1873,6 @@ def test_checkbox_to_confirm_non_training_broadcasts(
     assert page.select_one('form.banner input[type=checkbox]')['value'] == 'y'
 
 
-@pytest.mark.parametrize('channel', (
-    'test',
-    'severe',
-    'government',
-))
-@freeze_time('2020-02-22T22:22:22.000000')
-def test_confirm_approve_non_training_broadcasts(
-    mocker,
-    client_request,
-    service_one,
-    active_user_with_permissions,
-    fake_uuid,
-    mock_update_broadcast_message,
-    mock_update_broadcast_message_status,
-    channel,
-):
-    mocker.patch(
-        'app.broadcast_message_api_client.get_broadcast_message',
-        return_value=broadcast_message_json(
-            id_=fake_uuid,
-            service_id=SERVICE_ONE_ID,
-            template_id=None,
-            created_by_id=None,
-            status='pending-approval',
-        ),
-    )
-    service_one['permissions'] += ['broadcast']
-    service_one['restricted'] = False
-    service_one['allowed_broadcast_provider'] = 'all'
-    service_one['broadcast_channel'] = channel
-
-    client_request.post(
-        '.view_current_broadcast',
-        service_id=SERVICE_ONE_ID,
-        broadcast_message_id=fake_uuid,
-        _data={'confirm': 'y'}
-    )
-
-    mock_update_broadcast_message.assert_called_once_with(
-        service_id=SERVICE_ONE_ID,
-        broadcast_message_id=fake_uuid,
-        data={
-            'starts_at': '2020-02-22T22:22:22',
-            'finishes_at': '2020-02-23T02:22:22',
-        },
-    )
-    mock_update_broadcast_message_status.assert_called_once_with(
-        'broadcasting',
-        service_id=SERVICE_ONE_ID,
-        broadcast_message_id=fake_uuid,
-    )
-
-
 @freeze_time('2020-02-22T22:22:22.000000')
 def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     mocker,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1926,11 +1926,6 @@ def test_confirm_approve_non_training_broadcasts(
     )
 
 
-@pytest.mark.parametrize('channel', (
-    'test',
-    'severe',
-    'government',
-))
 @freeze_time('2020-02-22T22:22:22.000000')
 def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     mocker,
@@ -1940,7 +1935,6 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
-    channel,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -1955,7 +1949,7 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     service_one['permissions'] += ['broadcast']
     service_one['restricted'] = False
     service_one['allowed_broadcast_provider'] = 'all'
-    service_one['broadcast_channel'] = channel
+    service_one['broadcast_channel'] = 'severe'
 
     page = client_request.post(
         '.view_current_broadcast',


### PR DESCRIPTION
We want people to be really sure before sending a live broadcast, not just clicking through the green buttons.

This commit adds a checkbox which explains exactly the consequences of what they’re about to do, tailored to:
- the channel they’re on
- the area chosen by the person creating the alert.

***

![image](https://user-images.githubusercontent.com/355079/117985336-840a4600-b330-11eb-94fb-6597b60a9ce5.png)

***

![image](https://user-images.githubusercontent.com/355079/117985185-63da8700-b330-11eb-86fe-0a713fca257e.png)

***

![image](https://user-images.githubusercontent.com/355079/117985019-41e10480-b330-11eb-9455-6c638d0257c7.png)

***

![image](https://user-images.githubusercontent.com/355079/117984905-27a72680-b330-11eb-98fd-a902f81c268e.png)


