### PR TITLE
Rename "app_" fixture to "notify_admin"

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -559,7 +559,7 @@ def single_notification_json(
 
 
 def validate_route_permission(mocker,
-                              app_,
+                              notify_admin,
                               method,
                               response_code,
                               route,
@@ -582,8 +582,8 @@ def validate_route_permission(mocker,
     mocker.patch('app.service_api_client.get_service', return_value={'data': service})
     mocker.patch('app.models.user.Users.client_method', return_value=[usr])
     mocker.patch('app.job_api_client.has_jobs', return_value=False)
-    with app_.test_request_context():
-        with app_.test_client() as client:
+    with notify_admin.test_request_context():
+        with notify_admin.test_client() as client:
             client.login(usr)
             if session:
                 with client.session_transaction() as session_:

--- a/tests/app/main/test_choose_time_form.py
+++ b/tests/app/main/test_choose_time_form.py
@@ -5,7 +5,7 @@ from app.main.forms import ChooseTimeForm
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_contains_next_24h(app_):
+def test_form_contains_next_24h(notify_admin):
 
     choices = ChooseTimeForm().scheduled_for.choices
 
@@ -34,12 +34,12 @@ def test_form_contains_next_24h(app_):
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_defaults_to_now(app_):
+def test_form_defaults_to_now(notify_admin):
     assert ChooseTimeForm().scheduled_for.data == ''
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
-def test_form_contains_next_three_days(app_):
+def test_form_contains_next_three_days(notify_admin):
     assert ChooseTimeForm().scheduled_for.categories == [
         'Later today', 'Tomorrow', 'Sunday', 'Monday'
     ]

--- a/tests/app/main/test_placeholder_form.py
+++ b/tests/app/main/test_placeholder_form.py
@@ -3,9 +3,9 @@ import pytest
 from app.main.forms import get_placeholder_form_instance
 
 
-def test_form_class_not_mutated(app_):
+def test_form_class_not_mutated(notify_admin):
 
-    with app_.test_request_context(
+    with notify_admin.test_request_context(
         method='POST',
         data={'placeholder_value': ''}
     ):
@@ -46,14 +46,14 @@ def test_form_class_not_mutated(app_):
 
 ])
 def test_validates_recipients(
-    app_,
+    notify_admin,
     placeholder_name,
     template_type,
     value,
     service_can_send_international_sms,
     expected_error,
 ):
-    with app_.test_request_context(
+    with notify_admin.test_request_context(
         method='POST',
         data={'placeholder_value': value}
     ):

--- a/tests/app/main/test_request_header.py
+++ b/tests/app/main/test_request_header.py
@@ -9,14 +9,14 @@ from tests.conftest import set_config_values
     (False, 'wrong_key', 200),
     (False, 'key_1', 200),
 ])
-def test_route_correct_secret_key(app_, check_proxy_header, header_value, expected_code):
-    with set_config_values(app_, {
+def test_route_correct_secret_key(notify_admin, check_proxy_header, header_value, expected_code):
+    with set_config_values(notify_admin, {
         'ROUTE_SECRET_KEY_1': 'key_1',
         'ROUTE_SECRET_KEY_2': '',
         'CHECK_PROXY_HEADER': check_proxy_header,
     }):
 
-        with app_.test_client() as client:
+        with notify_admin.test_client() as client:
             response = client.get(
                 path='/_status?elb=True',
                 headers=[

--- a/tests/app/main/test_service_contact_details_form.py
+++ b/tests/app/main/test_service_contact_details_form.py
@@ -3,8 +3,8 @@ import pytest
 from app.main.forms import ServiceContactDetailsForm
 
 
-def test_form_fails_validation_with_no_radio_buttons_selected(app_):
-    with app_.test_request_context(method='POST', data={}):
+def test_form_fails_validation_with_no_radio_buttons_selected(notify_admin):
+    with notify_admin.test_request_context(method='POST', data={}):
         form = ServiceContactDetailsForm()
 
         assert not form.validate_on_submit()
@@ -21,14 +21,14 @@ def test_form_fails_validation_with_no_radio_buttons_selected(app_):
     ('email_address', 'phone_number', '0207 123 4567'),
 ])
 def test_form_fails_validation_when_radio_button_selected_and_text_box_filled_in_do_not_match(
-    app_,
+    notify_admin,
     selected_radio_button,
     selected_text_box,
     text_box_data
 ):
     data = {'contact_details_type': selected_radio_button, selected_text_box: text_box_data}
 
-    with app_.test_request_context(method='POST', data=data):
+    with notify_admin.test_request_context(method='POST', data=data):
         form = ServiceContactDetailsForm()
 
         assert not form.validate_on_submit()
@@ -42,7 +42,7 @@ def test_form_fails_validation_when_radio_button_selected_and_text_box_filled_in
     ('phone_number', 'www.invalid-url.com', 'invalid-email.com', '0207 123 4567'),
 ])
 def test_form_only_validates_the_field_which_matches_the_selected_radio_button(
-    app_,
+    notify_admin,
     selected_field,
     url,
     email_address,
@@ -53,16 +53,16 @@ def test_form_only_validates_the_field_which_matches_the_selected_radio_button(
             'email_address': email_address,
             'phone_number': phone_number}
 
-    with app_.test_request_context(method='POST', data=data):
+    with notify_admin.test_request_context(method='POST', data=data):
         form = ServiceContactDetailsForm()
 
         assert form.validate_on_submit()
 
 
-def test_form_url_validation_fails_with_invalid_url_field(app_):
+def test_form_url_validation_fails_with_invalid_url_field(notify_admin):
     data = {'contact_details_type': 'url', 'url': 'www.example.com'}
 
-    with app_.test_request_context(method='POST', data=data):
+    with notify_admin.test_request_context(method='POST', data=data):
         form = ServiceContactDetailsForm()
 
         assert not form.validate_on_submit()
@@ -70,10 +70,10 @@ def test_form_url_validation_fails_with_invalid_url_field(app_):
         assert len(form.errors['url']) == 1
 
 
-def test_form_email_validation_fails_with_invalid_email_address_field(app_):
+def test_form_email_validation_fails_with_invalid_email_address_field(notify_admin):
     data = {'contact_details_type': 'email_address', 'email_address': '1@co'}
 
-    with app_.test_request_context(method='POST', data=data):
+    with notify_admin.test_request_context(method='POST', data=data):
         form = ServiceContactDetailsForm()
 
         assert not form.validate_on_submit()
@@ -81,10 +81,10 @@ def test_form_email_validation_fails_with_invalid_email_address_field(app_):
         assert len(form.errors['email_address']) == 2
 
 
-def test_form_phone_number_validation_fails_with_invalid_phone_number_field(app_):
+def test_form_phone_number_validation_fails_with_invalid_phone_number_field(notify_admin):
     data = {'contact_details_type': 'phone_number', 'phone_number': '1235 A'}
 
-    with app_.test_request_context(method='POST', data=data):
+    with notify_admin.test_request_context(method='POST', data=data):
         form = ServiceContactDetailsForm()
 
         assert not form.validate_on_submit()

--- a/tests/app/main/test_strip_whitespace_form.py
+++ b/tests/app/main/test_strip_whitespace_form.py
@@ -25,7 +25,7 @@ class ExampleFormSpecialField(Form):
     ExampleFormSpecialField,
 ])
 def test_form_strips_all_whitespace(
-    app_,
+    notify_admin,
     form,
     submitted_data,
 ):

--- a/tests/app/main/test_two_factor_form.py
+++ b/tests/app/main/test_two_factor_form.py
@@ -15,11 +15,11 @@ def _check_code(code):
     {'sms_code': '1-23-45'},
 ])
 def test_form_is_valid_returns_no_errors(
-    app_,
+    notify_admin,
     mock_check_verify_code,
     post_data,
 ):
-    with app_.test_request_context(method='POST', data=post_data):
+    with notify_admin.test_request_context(method='POST', data=post_data):
         form = TwoFactorForm(_check_code)
         assert form.validate() is True
         assert form.errors == {}
@@ -49,32 +49,32 @@ def test_form_is_valid_returns_no_errors(
     ),
 ))
 def test_check_verify_code_returns_errors(
-    app_,
+    notify_admin,
     post_data,
     expected_error,
     mock_check_verify_code,
 ):
-    with app_.test_request_context(method='POST', data=post_data):
+    with notify_admin.test_request_context(method='POST', data=post_data):
         form = TwoFactorForm(_check_code)
         assert form.validate() is False
         assert form.errors == {'sms_code': [expected_error]}
 
 
 def test_check_verify_code_returns_error_when_code_has_expired(
-    app_,
+    notify_admin,
     mock_check_verify_code_code_expired,
 ):
-    with app_.test_request_context(method='POST', data={'sms_code': '99999'}):
+    with notify_admin.test_request_context(method='POST', data={'sms_code': '99999'}):
         form = TwoFactorForm(_check_code)
         assert form.validate() is False
         assert form.errors == {'sms_code': ['Code has expired']}
 
 
 def test_check_verify_code_returns_error_when_code_was_not_found(
-    app_,
+    notify_admin,
     mock_check_verify_code_code_not_found,
 ):
-    with app_.test_request_context(method='POST', data={'sms_code': '99999'}):
+    with notify_admin.test_request_context(method='POST', data={'sms_code': '99999'}):
         form = TwoFactorForm(_check_code)
         assert form.validate() is False
         assert form.errors == {'sms_code': ['Code not found']}

--- a/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
+++ b/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
@@ -110,7 +110,7 @@ def test_show_accounts_or_dashboard_doesnt_redirect_to_org_dashboard_if_user_not
 
 def test_show_accounts_or_dashboard_redirects_if_not_logged_in(
     client,
-    app_
+    notify_admin,
 ):
     response = client.get(url_for('main.show_accounts_or_dashboard'))
     assert response.status_code == 302

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -248,7 +248,7 @@ def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
     ('other', 10_000),
 ])
 def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
-    app_,
+    notify_admin,
     mocker,
     client_request,
     mock_create_service,
@@ -277,7 +277,7 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     mock_create_service.assert_called_once_with(
         service_name='testing the post',
         organisation_type=organisation_type,
-        message_limit=app_.config['DEFAULT_SERVICE_LIMIT'],
+        message_limit=notify_admin.config['DEFAULT_SERVICE_LIMIT'],
         restricted=True,
         user_id=api_user_active['id'],
         email_from='testing.the.post',

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -381,17 +381,17 @@ def test_should_redirect_after_revoking_api_key(
 ])
 def test_route_permissions(
     mocker,
-    app_,
+    notify_admin,
     fake_uuid,
     api_user_active,
     service_one,
     mock_get_api_keys,
     route,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         validate_route_permission(
             mocker,
-            app_,
+            notify_admin,
             "GET",
             200,
             url_for(route, service_id=service_one['id'], key_id=fake_uuid),
@@ -407,17 +407,17 @@ def test_route_permissions(
 ])
 def test_route_invalid_permissions(
     mocker,
-    app_,
+    notify_admin,
     fake_uuid,
     api_user_active,
     service_one,
     mock_get_api_keys,
     route,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         validate_route_permission(
             mocker,
-            app_,
+            notify_admin,
             "GET",
             403,
             url_for(route, service_id=service_one['id'], key_id=fake_uuid),

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1178,9 +1178,9 @@ def test_future_usage_page(
     mock_get_free_sms_fragment_limit.assert_called_with(SERVICE_ONE_ID, 2014)
 
 
-def _test_dashboard_menu(mocker, app_, usr, service, permissions):
-    with app_.test_request_context():
-        with app_.test_client() as client:
+def _test_dashboard_menu(mocker, notify_admin, usr, service, permissions):
+    with notify_admin.test_request_context():
+        with notify_admin.test_client() as client:
             usr['permissions'][str(service['id'])] = permissions
             usr['services'] = [service['id']]
             mocker.patch('app.user_api_client.check_verify_code', return_value=(True, ''))
@@ -1194,7 +1194,7 @@ def _test_dashboard_menu(mocker, app_, usr, service, permissions):
 
 def test_menu_send_messages(
     mocker,
-    app_,
+    notify_admin,
     api_user_active,
     service_one,
     mock_get_service_templates,
@@ -1208,10 +1208,10 @@ def test_menu_send_messages(
 ):
     service_one['permissions'] = ['email', 'sms', 'letter', 'upload_letters']
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
-            app_,
+            notify_admin,
             api_user_active,
             service_one,
             ['view_activity', 'send_messages'])
@@ -1230,7 +1230,7 @@ def test_menu_send_messages(
 
 def test_menu_send_messages_when_service_does_not_have_upload_letters_permission(
     mocker,
-    app_,
+    notify_admin,
     api_user_active,
     service_one,
     mock_get_service_templates,
@@ -1242,10 +1242,10 @@ def test_menu_send_messages_when_service_does_not_have_upload_letters_permission
     mock_get_free_sms_fragment_limit,
     mock_get_returned_letter_statistics_with_no_returned_letters,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
-            app_,
+            notify_admin,
             api_user_active,
             service_one,
             ['view_activity', 'send_messages'])
@@ -1256,7 +1256,7 @@ def test_menu_send_messages_when_service_does_not_have_upload_letters_permission
 
 def test_menu_manage_service(
     mocker,
-    app_,
+    notify_admin,
     api_user_active,
     service_one,
     mock_get_service_templates,
@@ -1268,10 +1268,10 @@ def test_menu_manage_service(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     mock_get_free_sms_fragment_limit,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
-            app_,
+            notify_admin,
             api_user_active,
             service_one,
             ['view_activity', 'manage_templates', 'manage_service'])
@@ -1288,7 +1288,7 @@ def test_menu_manage_service(
 
 def test_menu_manage_api_keys(
     mocker,
-    app_,
+    notify_admin,
     api_user_active,
     service_one,
     mock_get_service_templates,
@@ -1300,10 +1300,10 @@ def test_menu_manage_api_keys(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     mock_get_free_sms_fragment_limit,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
-            app_,
+            notify_admin,
             api_user_active,
             service_one,
             ['view_activity', 'manage_api_keys'])
@@ -1318,7 +1318,7 @@ def test_menu_manage_api_keys(
 
 def test_menu_all_services_for_platform_admin_user(
     mocker,
-    app_,
+    notify_admin,
     platform_admin_user,
     service_one,
     mock_get_service_templates,
@@ -1330,10 +1330,10 @@ def test_menu_all_services_for_platform_admin_user(
     mock_get_returned_letter_statistics_with_no_returned_letters,
     mock_get_free_sms_fragment_limit,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         resp = _test_dashboard_menu(
             mocker,
-            app_,
+            notify_admin,
             platform_admin_user,
             service_one,
             [])
@@ -1348,7 +1348,7 @@ def test_menu_all_services_for_platform_admin_user(
 
 def test_route_for_service_permissions(
     mocker,
-    app_,
+    notify_admin,
     api_user_active,
     service_one,
     mock_get_service,
@@ -1362,10 +1362,10 @@ def test_route_for_service_permissions(
     mock_get_inbound_sms_summary,
     mock_get_returned_letter_statistics_with_no_returned_letters,
 ):
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         validate_route_permission(
             mocker,
-            app_,
+            notify_admin,
             "GET",
             200,
             url_for('main.service_dashboard', service_id=service_one['id']),

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -10,7 +10,7 @@ from tests.conftest import SERVICE_ONE_ID, url_for_endpoint_with_token
 
 
 def test_should_render_new_password_template(
-    app_,
+    notify_admin,
     client,
     api_user_active,
     mock_login,
@@ -18,8 +18,8 @@ def test_should_render_new_password_template(
     mock_get_user_by_email_request_password_reset,
 ):
     data = json.dumps({'email': api_user_active['email_address'], 'created_at': str(datetime.utcnow())})
-    token = generate_token(data, app_.config['SECRET_KEY'],
-                           app_.config['DANGEROUS_SALT'])
+    token = generate_token(data, notify_admin.config['SECRET_KEY'],
+                           notify_admin.config['DANGEROUS_SALT'])
 
     response = client.get(url_for_endpoint_with_token('.new_password', token=token))
     assert response.status_code == 200
@@ -27,12 +27,12 @@ def test_should_render_new_password_template(
 
 
 def test_should_return_404_when_email_address_does_not_exist(
-    app_,
+    notify_admin,
     client,
     mock_get_user_by_email_not_found,
 ):
     data = json.dumps({'email': 'no_user@d.gov.uk', 'created_at': str(datetime.utcnow())})
-    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    token = generate_token(data, notify_admin.config['SECRET_KEY'], notify_admin.config['DANGEROUS_SALT'])
     response = client.get(url_for_endpoint_with_token('.new_password', token=token))
     assert response.status_code == 404
 
@@ -42,7 +42,7 @@ def test_should_return_404_when_email_address_does_not_exist(
     f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_should_redirect_to_two_factor_when_password_reset_is_successful(
-    app_,
+    notify_admin,
     client,
     mock_get_user_by_email_request_password_reset,
     mock_login,
@@ -52,7 +52,7 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(
 ):
     user = mock_get_user_by_email_request_password_reset.return_value
     data = json.dumps({'email': user['email_address'], 'created_at': str(datetime.utcnow())})
-    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    token = generate_token(data, notify_admin.config['SECRET_KEY'], notify_admin.config['DANGEROUS_SALT'])
     response = client.post(url_for_endpoint_with_token('.new_password', token=token, next=redirect_url),
                            data={'new_password': 'a-new_password'})
     assert response.status_code == 302
@@ -61,7 +61,7 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(
 
 
 def test_should_redirect_index_if_user_has_already_changed_password(
-    app_,
+    notify_admin,
     client,
     mock_get_user_by_email_user_changed_password,
     mock_login,
@@ -70,7 +70,7 @@ def test_should_redirect_index_if_user_has_already_changed_password(
 ):
     user = mock_get_user_by_email_user_changed_password.return_value
     data = json.dumps({'email': user['email_address'], 'created_at': str(datetime.utcnow())})
-    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    token = generate_token(data, notify_admin.config['SECRET_KEY'], notify_admin.config['DANGEROUS_SALT'])
     response = client.post(url_for_endpoint_with_token('.new_password', token=token),
                            data={'new_password': 'a-new_password'})
     assert response.status_code == 302
@@ -79,13 +79,13 @@ def test_should_redirect_index_if_user_has_already_changed_password(
 
 
 def test_should_redirect_to_forgot_password_with_flash_message_when_token_is_expired(
-    app_,
+    notify_admin,
     client,
     mock_login,
     mocker
 ):
     mocker.patch('app.main.views.new_password.check_token', side_effect=SignatureExpired('expired'))
-    token = generate_token('foo@bar.com', app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    token = generate_token('foo@bar.com', notify_admin.config['SECRET_KEY'], notify_admin.config['DANGEROUS_SALT'])
 
     response = client.get(url_for_endpoint_with_token('.new_password', token=token))
 
@@ -94,7 +94,7 @@ def test_should_redirect_to_forgot_password_with_flash_message_when_token_is_exp
 
 
 def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
-    app_,
+    notify_admin,
     client,
     mock_get_user,
     mock_get_user_by_email_request_password_reset,
@@ -106,7 +106,7 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
     user = mock_get_user_by_email_request_password_reset.return_value
     user['auth_type'] = 'email_auth'
     data = json.dumps({'email': user['email_address'], 'created_at': str(datetime.utcnow())})
-    token = generate_token(data, app_.config['SECRET_KEY'], app_.config['DANGEROUS_SALT'])
+    token = generate_token(data, notify_admin.config['SECRET_KEY'], notify_admin.config['DANGEROUS_SALT'])
 
     response = client.post(url_for_endpoint_with_token('.new_password', token=token),
                            data={'new_password': 'a-new_password'})

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2880,7 +2880,7 @@ def test_dont_show_preview_letter_templates_for_bad_filetype(
 ])
 def test_route_permissions(
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     service_one,
@@ -2896,7 +2896,7 @@ def test_route_permissions(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         response_code,
         url_for(
@@ -2915,7 +2915,7 @@ def test_route_permissions(
 ])
 def test_route_permissions_send_check_notifications(
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     service_one,
@@ -2952,7 +2952,7 @@ def test_route_permissions_send_check_notifications(
 ])
 def test_route_permissions_sending(
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     service_one,
@@ -2967,7 +2967,7 @@ def test_route_permissions_sending(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         expected_status,
         url_for(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2071,7 +2071,7 @@ def test_ready_to_go_live(
 ])
 def test_route_permissions(
         mocker,
-        app_,
+        notify_admin,
         client,
         api_user_active,
         service_one,
@@ -2085,7 +2085,7 @@ def test_route_permissions(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         200,
         url_for(route, service_id=service_one['id']),
@@ -2107,7 +2107,7 @@ def test_route_permissions(
 ])
 def test_route_invalid_permissions(
         mocker,
-        app_,
+        notify_admin,
         client,
         api_user_active,
         service_one,
@@ -2117,7 +2117,7 @@ def test_route_invalid_permissions(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         403,
         url_for(route, service_id=service_one['id']),
@@ -2135,7 +2135,7 @@ def test_route_invalid_permissions(
 ])
 def test_route_for_platform_admin(
         mocker,
-        app_,
+        notify_admin,
         client,
         platform_admin_user,
         service_one,
@@ -2149,7 +2149,7 @@ def test_route_for_platform_admin(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         200,
         url_for(route, service_id=service_one['id']),

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2169,7 +2169,7 @@ def test_should_show_page_for_a_deleted_template(
 def test_route_permissions(
     route,
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     service_one,
@@ -2181,7 +2181,7 @@ def test_route_permissions(
                  return_value='2012-01-01 12:00:00')
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         200,
         url_for(
@@ -2196,7 +2196,7 @@ def test_route_permissions(
 
 def test_route_permissions_for_choose_template(
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     mock_get_template_folders,
@@ -2207,7 +2207,7 @@ def test_route_permissions_for_choose_template(
     mocker.patch('app.job_api_client.get_job')
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         200,
         url_for(
@@ -2227,7 +2227,7 @@ def test_route_permissions_for_choose_template(
 def test_route_invalid_permissions(
     route,
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     service_one,
@@ -2236,7 +2236,7 @@ def test_route_invalid_permissions(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         403,
         url_for(

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -102,7 +102,7 @@ def test_should_404_if_no_mobile_number_for_tour_start(
 
 def test_should_403_if_user_does_not_have_send_permissions_for_tour_start(
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     mock_get_service_template_with_multiple_placeholders,
@@ -111,7 +111,7 @@ def test_should_403_if_user_does_not_have_send_permissions_for_tour_start(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         "GET",
         403,
         url_for(
@@ -227,7 +227,7 @@ def test_should_404_for_get_tour_step_0(
 @pytest.mark.parametrize('method', ['GET', 'POST'])
 def test_should_403_if_user_does_not_have_send_permissions_for_tour_step(
     mocker,
-    app_,
+    notify_admin,
     client,
     api_user_active,
     mock_get_service_template_with_multiple_placeholders,
@@ -237,7 +237,7 @@ def test_should_403_if_user_does_not_have_send_permissions_for_tour_step(
 ):
     validate_route_permission(
         mocker,
-        app_,
+        notify_admin,
         method,
         403,
         url_for(

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -356,7 +356,7 @@ def test_valid_two_factor_email_link_logs_in_user(
     f'/services/{SERVICE_ONE_ID}/templates',
 ])
 def test_two_factor_email_link_has_expired(
-    app_,
+    notify_admin,
     valid_token,
     client,
     mock_send_verify_code,
@@ -364,7 +364,7 @@ def test_two_factor_email_link_has_expired(
     redirect_url
 ):
 
-    with set_config(app_, 'EMAIL_2FA_EXPIRY_SECONDS', -1):
+    with set_config(notify_admin, 'EMAIL_2FA_EXPIRY_SECONDS', -1):
         response = client.post(
             url_for_endpoint_with_token('main.two_factor_email', token=valid_token, next=redirect_url),
             follow_redirects=True,

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -120,14 +120,14 @@ def test_should_render_change_email_continue_after_authenticate_email(
 
 
 def test_should_redirect_to_user_profile_when_user_confirms_email_link(
-    app_,
+    notify_admin,
     logged_in_client,
     api_user_active,
     mock_update_user_attribute,
 ):
 
     token = generate_token(payload=json.dumps({'user_id': api_user_active['id'], 'email': 'new_email@gov.uk'}),
-                           secret=app_.config['SECRET_KEY'], salt=app_.config['DANGEROUS_SALT'])
+                           secret=notify_admin.config['SECRET_KEY'], salt=notify_admin.config['DANGEROUS_SALT'])
     response = logged_in_client.get(url_for_endpoint_with_token('main.user_profile_email_confirm',
                                                                 token=token))
 

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -16,7 +16,6 @@ def test_register_forbidden_for_non_platform_admins(
 
 
 def test_begin_register_returns_encoded_options(
-    app_,
     mocker,
     platform_admin_user,
     platform_admin_client,

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -74,7 +74,7 @@ def _get_all_folders(active_user_with_permissions):
 
 
 def test_get_user_template_folders_only_returns_folders_visible_to_user(
-    app_,
+    notify_admin,
     mock_get_template_folders,
     service_one,
     active_user_with_permissions,
@@ -118,7 +118,7 @@ def test_get_user_template_folders_only_returns_folders_visible_to_user(
 
 
 def test_get_template_folders_shows_user_folders_when_user_id_passed_in(
-    app_,
+    notify_admin,
     mock_get_template_folders,
     service_one,
     active_user_with_permissions,

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -4,7 +4,7 @@ from app.models.user import AnonymousUser, InvitedOrgUser, InvitedUser, User
 from tests.conftest import USER_ONE_ID
 
 
-def test_anonymous_user(app_):
+def test_anonymous_user(notify_admin):
     assert AnonymousUser().is_authenticated is False
     assert AnonymousUser().logged_in_elsewhere() is False
     assert AnonymousUser().default_organisation.name is None
@@ -15,7 +15,7 @@ def test_anonymous_user(app_):
     assert AnonymousUser().default_organisation.request_to_go_live_notes is None
 
 
-def test_user(app_):
+def test_user(notify_admin):
     user_data = {'id': 1,
                  'name': 'Test User',
                  'email_address': 'test@user.gov.uk',
@@ -45,12 +45,12 @@ def test_user(app_):
         user.has_permissions('to_do_bad_things')
 
 
-def test_activate_user(app_, api_user_pending, mock_activate_user):
+def test_activate_user(notify_admin, api_user_pending, mock_activate_user):
     assert User(api_user_pending).activate() == User(api_user_pending)
     mock_activate_user.assert_called_once_with(api_user_pending['id'])
 
 
-def test_activate_user_already_active(app_, api_user_active, mock_activate_user):
+def test_activate_user_already_active(notify_admin, api_user_active, mock_activate_user):
     assert User(api_user_active).activate() == User(api_user_active)
     assert mock_activate_user.called is False
 

--- a/tests/app/models/test_webauthn_credential.py
+++ b/tests/app/models/test_webauthn_credential.py
@@ -47,7 +47,7 @@ def test_from_registration_encodes_as_unicode(webauthn_dev_server):
     assert type(serialized_credential['registration_response']) == str
 
 
-def test_from_registration_handles_library_errors(app_):
+def test_from_registration_handles_library_errors():
     registration_response = {
        'clientDataJSON': CLIENT_DATA_JSON,
        'attestationObject': ATTESTATION_OBJECT,

--- a/tests/app/notify_client/test_invite_client.py
+++ b/tests/app/notify_client/test_invite_client.py
@@ -4,7 +4,7 @@ from app import invite_api_client
 
 
 def test_client_creates_invite(
-    app_,
+    notify_admin,
     mocker,
     fake_uuid,
     sample_invite,

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -28,10 +28,10 @@ from tests.conftest import (
     service_json(active=True),
     None
 ], ids=['active_service', 'no_service'])
-def test_active_service_can_be_modified(app_, method, user, service):
+def test_active_service_can_be_modified(notify_admin, method, user, service):
     api_client = NotifyAdminAPIClient()
 
-    with app_.test_request_context() as request_context, app_.test_client() as client:
+    with notify_admin.test_request_context() as request_context, notify_admin.test_client() as client:
         client.login(user)
         request_context.service = Service(service)
 
@@ -47,10 +47,10 @@ def test_active_service_can_be_modified(app_, method, user, service):
     'post',
     'delete'
 ])
-def test_inactive_service_cannot_be_modified_by_normal_user(app_, api_user_active, method):
+def test_inactive_service_cannot_be_modified_by_normal_user(notify_admin, api_user_active, method):
     api_client = NotifyAdminAPIClient()
 
-    with app_.test_request_context() as request_context, app_.test_client() as client:
+    with notify_admin.test_request_context() as request_context, notify_admin.test_client() as client:
         client.login(api_user_active)
         request_context.service = Service(service_json(active=False))
 
@@ -66,10 +66,10 @@ def test_inactive_service_cannot_be_modified_by_normal_user(app_, api_user_activ
     'post',
     'delete'
 ])
-def test_inactive_service_can_be_modified_by_platform_admin(app_, platform_admin_user, method):
+def test_inactive_service_can_be_modified_by_platform_admin(notify_admin, platform_admin_user, method):
     api_client = NotifyAdminAPIClient()
 
-    with app_.test_request_context() as request_context, app_.test_client() as client:
+    with notify_admin.test_request_context() as request_context, notify_admin.test_client() as client:
         client.login(platform_admin_user)
         request_context.service = Service(service_json(active=False))
 
@@ -80,10 +80,10 @@ def test_inactive_service_can_be_modified_by_platform_admin(app_, platform_admin
     assert ret == request.return_value
 
 
-def test_generate_headers_sets_standard_headers(app_):
+def test_generate_headers_sets_standard_headers(notify_admin):
     api_client = NotifyAdminAPIClient()
-    with set_config(app_, 'ROUTE_SECRET_KEY_1', 'proxy-secret'):
-        api_client.init_app(app_)
+    with set_config(notify_admin, 'ROUTE_SECRET_KEY_1', 'proxy-secret'):
+        api_client.init_app(notify_admin)
 
     # with patch('app.notify_client.has_request_context', return_value=False):
     headers = api_client.generate_headers('api_token')
@@ -95,11 +95,11 @@ def test_generate_headers_sets_standard_headers(app_):
     assert headers['X-Custom-Forwarder'] == 'proxy-secret'
 
 
-def test_generate_headers_sets_request_id_if_in_request_context(app_):
+def test_generate_headers_sets_request_id_if_in_request_context(notify_admin):
     api_client = NotifyAdminAPIClient()
-    api_client.init_app(app_)
+    api_client.init_app(notify_admin)
 
-    with app_.test_request_context() as request_context:
+    with notify_admin.test_request_context() as request_context:
         headers = api_client.generate_headers('api_token')
 
     assert set(headers.keys()) == {

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -93,7 +93,7 @@ from app import organisations_client
     ]
 )
 def test_returns_value_from_cache(
-    app_,
+    notify_admin,
     mocker,
     client_method,
     expected_cache_get_calls,
@@ -125,7 +125,7 @@ def test_returns_value_from_cache(
 
 
 def test_deletes_domain_cache(
-    app_,
+    notify_admin,
     mock_get_user,
     mocker,
     fake_uuid,

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -141,7 +141,7 @@ def test_get_precompiled_template(mocker):
     ),
 ))
 def test_client_returns_count_of_service_templates(
-    app_,
+    notify_admin,
     mocker,
     template_data,
     extra_args,
@@ -415,7 +415,7 @@ def test_returns_value_from_cache(
     (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, uuid4()], {}),
 ])
 def test_deletes_service_cache(
-    app_,
+    notify_admin,
     mock_get_user,
     mock_get_service_templates,
     mocker,
@@ -464,7 +464,7 @@ def test_deletes_service_cache(
     ]),
 ])
 def test_deletes_caches_when_modifying_templates(
-    app_,
+    notify_admin,
     mock_get_user,
     mocker,
     method,
@@ -523,7 +523,7 @@ def test_client_updates_guest_list(mocker):
 
 
 def test_client_doesnt_delete_service_template_cache_when_none_exist(
-    app_,
+    notify_admin,
     mock_get_user,
     mock_get_service_templates_when_no_templates_exist,
     mocker
@@ -542,7 +542,7 @@ def test_client_doesnt_delete_service_template_cache_when_none_exist(
 
 
 def test_client_deletes_service_template_cache_when_service_is_updated(
-    app_,
+    notify_admin,
     mock_get_user,
     mocker
 ):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -71,7 +71,7 @@ def test_client_activates_if_pending(mocker, api_user_pending):
 
 
 def test_client_passes_admin_url_when_sending_email_auth(
-    app_,
+    notify_admin,
     mocker,
     fake_uuid,
 ):
@@ -88,7 +88,7 @@ def test_client_passes_admin_url_when_sending_email_auth(
     )
 
 
-def test_client_converts_admin_permissions_to_db_permissions_on_edit(app_, mocker):
+def test_client_converts_admin_permissions_to_db_permissions_on_edit(notify_admin, mocker):
     mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
 
     user_api_client.set_user_permissions('user_id', 'service_id', permissions={'send_messages', 'view_activity'})
@@ -101,7 +101,7 @@ def test_client_converts_admin_permissions_to_db_permissions_on_edit(app_, mocke
     ], key=lambda x: x['permission'])
 
 
-def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(app_, mocker):
+def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(notify_admin, mocker):
     mock_post = mocker.patch('app.notify_client.user_api_client.UserApiClient.post', return_value={'data': {}})
 
     user_api_client.add_user_to_service('service_id',
@@ -155,7 +155,7 @@ def test_client_converts_admin_permissions_to_db_permissions_on_add_to_service(a
     ]
 )
 def test_returns_value_from_cache(
-    app_,
+    notify_admin,
     mocker,
     expected_cache_get_calls,
     cache_value,
@@ -201,7 +201,7 @@ def test_returns_value_from_cache(
     (invite_api_client, 'accept_invite', [SERVICE_ONE_ID, user_id], {}),
 ])
 def test_deletes_user_cache(
-    app_,
+    notify_admin,
     mock_get_user,
     mocker,
     client,

--- a/tests/app/test_event_handlers.py
+++ b/tests/app/test_event_handlers.py
@@ -13,21 +13,21 @@ from app.event_handlers import (
 from app.models.user import User
 
 
-def test_on_user_logged_in_calls_events_api(app_, api_user_active, mock_events):
+def test_on_user_logged_in_calls_events_api(notify_admin, api_user_active, mock_events):
 
-    with app_.test_request_context():
-        on_user_logged_in(app_, User(api_user_active))
+    with notify_admin.test_request_context():
+        on_user_logged_in(notify_admin, User(api_user_active))
         mock_events.assert_called_with('sucessful_login',
                                        {'browser_fingerprint':
                                         {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
                                         'ip_address': ANY, 'user_id': str(api_user_active['id'])})
 
 
-def test_create_email_change_event_calls_events_api(app_, mock_events):
+def test_create_email_change_event_calls_events_api(notify_admin, mock_events):
     user_id = str(uuid.uuid4())
     updated_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         create_email_change_event(user_id, updated_by_id, 'original@example.com', 'new@example.com')
 
         mock_events.assert_called_with('update_user_email',
@@ -40,12 +40,12 @@ def test_create_email_change_event_calls_events_api(app_, mock_events):
                                         'new_email_address': 'new@example.com'})
 
 
-def test_create_add_user_to_service_event_calls_events_api(app_, mock_events):
+def test_create_add_user_to_service_event_calls_events_api(notify_admin, mock_events):
     user_id = str(uuid.uuid4())
     invited_by_id = str(uuid.uuid4())
     service_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         create_add_user_to_service_event(user_id, invited_by_id, service_id)
 
         mock_events.assert_called_with(
@@ -60,12 +60,12 @@ def test_create_add_user_to_service_event_calls_events_api(app_, mock_events):
         )
 
 
-def test_create_remove_user_from_service_event_calls_events_api(app_, mock_events):
+def test_create_remove_user_from_service_event_calls_events_api(notify_admin, mock_events):
     user_id = str(uuid.uuid4())
     removed_by_id = str(uuid.uuid4())
     service_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         create_remove_user_from_service_event(user_id, removed_by_id, service_id)
 
         mock_events.assert_called_with(
@@ -80,11 +80,11 @@ def test_create_remove_user_from_service_event_calls_events_api(app_, mock_event
         )
 
 
-def test_create_mobile_number_change_event_calls_events_api(app_, mock_events):
+def test_create_mobile_number_change_event_calls_events_api(notify_admin, mock_events):
     user_id = str(uuid.uuid4())
     updated_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         create_mobile_number_change_event(user_id, updated_by_id, '07700900000', '07700900999')
 
         mock_events.assert_called_with('update_user_mobile_number',
@@ -97,11 +97,11 @@ def test_create_mobile_number_change_event_calls_events_api(app_, mock_events):
                                         'new_mobile_number': '07700900999'})
 
 
-def test_create_archive_user_event_calls_events_api(app_, mock_events):
+def test_create_archive_user_event_calls_events_api(notify_admin, mock_events):
     user_id = str(uuid.uuid4())
     archived_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         create_archive_user_event(user_id, archived_by_id)
 
         mock_events.assert_called_with('archive_user',
@@ -112,11 +112,11 @@ def test_create_archive_user_event_calls_events_api(app_, mock_events):
                                         'archived_by_id': archived_by_id})
 
 
-def test_create_broadcast_account_type_change_event(app_, mock_events):
+def test_create_broadcast_account_type_change_event(notify_admin, mock_events):
     service_id = str(uuid.uuid4())
     changed_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with notify_admin.test_request_context():
         create_broadcast_account_type_change_event(
             service_id,
             changed_by_id,

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -180,7 +180,7 @@ def test_spreadsheet_checks_for_bad_arguments(args, kwargs):
     ),
 ])
 def test_generate_notifications_csv_without_job(
-    app_,
+    notify_admin,
     mocker,
     created_by_name,
     expected_content,
@@ -224,7 +224,7 @@ def test_generate_notifications_csv_without_job(
     ),
 ])
 def test_generate_notifications_csv_returns_correct_csv_file(
-    app_,
+    notify_admin,
     mocker,
     _get_notifications_csv_mock,
     original_file_contents,
@@ -242,7 +242,7 @@ def test_generate_notifications_csv_returns_correct_csv_file(
 
 
 def test_generate_notifications_csv_only_calls_once_if_no_next_link(
-    app_,
+    notify_admin,
     _get_notifications_csv_mock,
 ):
     list(generate_notifications_csv(service_id='1234'))
@@ -252,7 +252,7 @@ def test_generate_notifications_csv_only_calls_once_if_no_next_link(
 
 @pytest.mark.parametrize("job_id", ["some", None])
 def test_generate_notifications_csv_calls_twice_if_next_link(
-    app_,
+    notify_admin,
     mocker,
     job_id,
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ class ElementNotFound(Exception):
 
 
 @pytest.fixture(scope='session')
-def app_():
+def notify_admin():
     app = Flask('app')
     create_app(app)
 
@@ -2998,8 +2998,8 @@ def mock_send_notification(mocker, fake_uuid):
 
 
 @pytest.fixture(scope='function')
-def client(app_):
-    with app_.test_request_context(), app_.test_client() as client:
+def client(notify_admin):
+    with notify_admin.test_request_context(), notify_admin.test_client() as client:
         yield client
 
 
@@ -3246,25 +3246,25 @@ def set_config_values(app, dict):
 
 
 @pytest.fixture
-def webauthn_dev_server(app_, mocker):
+def webauthn_dev_server(notify_admin, mocker):
     overrides = {
         'NOTIFY_ENVIRONMENT': 'development',
         'ADMIN_BASE_URL': 'https://webauthn.io',
     }
 
-    with set_config_values(app_, overrides):
-        webauthn_server.init_app(app_)
+    with set_config_values(notify_admin, overrides):
+        webauthn_server.init_app(notify_admin)
         yield
 
-    webauthn_server.init_app(app_)
+    webauthn_server.init_app(notify_admin)
 
 
 @pytest.fixture(scope='function')
-def valid_token(app_, fake_uuid):
+def valid_token(notify_admin, fake_uuid):
     return generate_token(
         json.dumps({'user_id': fake_uuid, 'secret_code': 'my secret'}),
-        app_.config['SECRET_KEY'],
-        app_.config['DANGEROUS_SALT']
+        notify_admin.config['SECRET_KEY'],
+        notify_admin.config['DANGEROUS_SALT']
     )
 
 


### PR DESCRIPTION
This naming was introduced in 2016 without explanation [1]. I find it
confusing because:

- It's reminiscent of "_app", which is a Python convention indicating
the variable is internal, so maybe avoid using it.

- It suggests there's some other "app" fixture I should be using (there
isn't, though).

The Python style guide describes using an underscore suffix to avoid 
clashes with inbuilt names [1], which is sort of applicable if we need 
to import the "app" module [2]. However, we can also avoid clashes by 
choosing a different name, without the strange underscore.