### PR TITLE
Add webauthn as an auth type

### DIFF
--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -41,9 +41,11 @@ def new_password(token):
             'id': user.id,
             'email': user.email_address,
             'password': form.new_password.data}
-        if user.auth_type == 'email_auth':
+        if user.email_auth:
             # they've just clicked an email link, so have done an email auth journey anyway. Just log them in.
             return log_in_user(user.id)
+        elif user.webauthn_auth:
+            raise NotImplementedError('webauthn not supported yet')
         else:
             # send user a 2fa sms code
             user.send_verify_code()

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -49,6 +49,8 @@ def sign_in():
                 return redirect(url_for('.two_factor', next=redirect_url))
             if user.email_auth:
                 return redirect(url_for('.two_factor_email_sent', next=redirect_url))
+            if user.webauthn_auth:
+                raise NotImplementedError('webauthn not supported yet')
 
         # Vague error message for login in case of user not known, locked, inactive or password not verified
         flash(Markup(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -169,6 +169,10 @@ class User(JSONModel, UserMixin):
     def email_auth(self):
         return self.auth_type == 'email_auth'
 
+    @property
+    def webauthn_auth(self):
+        return self.auth_type == 'webauthn_auth'
+
     def reset_failed_login_count(self):
         user_api_client.reset_failed_login_count(self.id)
 

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -66,8 +66,10 @@
               <p class="govuk-body tick-cross-list-hint">
                 {% if user.auth_type == 'sms_auth' %}
                   Signs in with a text message code
-                {% else %}
+                {% elif user.auth_type == 'email_auth' %}
                   Signs in with an email link
+                {% elif user.auth_type == 'webauthn_auth' %}
+                  Signs in with a security key
                 {% endif %}
               </p>
             {% endif %}


### PR DESCRIPTION
When showing what auth type user uses to sign in, add a text for users with webauthn.

On password change or sign in, throw not implemented error if user uses webauthn auth.