### PR TITLE
Add splunk service

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -32,6 +32,7 @@ applications:
     services:
       - logit-ssl-syslog-drain
       - notify-prometheus
+      - notify-splunk
 
     env:
       NOTIFY_APP_NAME: admin


### PR DESCRIPTION
This will allow shipping app and router logs to splunk[1]

1: https://github.com/alphagov/paas-csls-splunk-broker/blob/main/docs/user-guide.md

---- 

I created the service on all 3 environments by running `cf create-service splunk unlimited notify-splunk`