### PR TITLE
Only check for WebAuthn where it's used

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,7 +1,6 @@
 {% extends "template.njk" %}
 {% from "components/banner.html" import banner %}
 {% from "components/cookie-banner.html" import cookie_banner %}
-{% from "components/webauthn-api-check.html" import webauthn_api_check %}
 
 {% block headIcons %}
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ asset_url('images/favicon.ico') }}" type="image/x-icon" />
@@ -39,8 +38,7 @@
 {% endblock %}
 
 {% block bodyStart %}
-  {% block webauthn_api %}
-    {{ webauthn_api_check() }}
+  {% block extra_javascripts_before_body %}
   {% endblock %}
 
   {% block cookie_message %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -3,10 +3,15 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/table.html" import mapping_table, row, field, row_heading %}
+{% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}
+
+{% block extra_javascripts_before_body %}
+  {{ webauthn_api_check() }}
+{% endblock %}
 
 {% block per_page_title %}
   {{ page_title }}


### PR DESCRIPTION
This scopes the check for WebAuthn API to the page where we need
it, which will slightly reduce load times for other pages. Since
we want this script to execute ASAP, I've added a new block for
extra JS to run at the start of the body.