### PR TITLE
Let admin user update and delete their security key

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2506,8 +2506,8 @@ class BroadcastAreaFormWithSelectAll(BroadcastAreaForm):
         return self.areas.data
 
 
-class ChangeNameOfSecurityKey(StripWhitespaceForm):
-    name_of_key = GovukTextInputField(
+class ChangeSecurityKeyNameForm(StripWhitespaceForm):
+    security_key_name = GovukTextInputField(
         'Name of key',
         validators=[
             DataRequired(message='Cannot be empty'),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2504,3 +2504,13 @@ class BroadcastAreaFormWithSelectAll(BroadcastAreaForm):
         if self.select_all.data:
             return [self.select_all.area_slug]
         return self.areas.data
+
+
+class ChangeNameOfSecurityKey(StripWhitespaceForm):
+    name_of_key = GovukTextInputField(
+        'Name of key',
+        validators=[
+            DataRequired(message='Cannot be empty'),
+            MustContainAlphanumericCharacters(),
+            Length(max=255, message='Name of key must be 255 characters or fewer')
+        ])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -237,3 +237,11 @@ def user_profile_security_keys():
     return render_template(
         'views/user-profile/security-keys.html',
     )
+
+
+@main.route("/user-profile/security-keys/<uuid:key_id>/manage", methods=['GET'])
+@user_is_platform_admin
+def user_profile_manage_security_key():
+    return render_template(
+        'views/user-profile/manage-security-key.html',
+    )

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -264,11 +264,12 @@ def user_profile_manage_security_key(key_id):
     form = ChangeNameOfSecurityKey(name_of_key=security_key["name"])
 
     if form.validate_on_submit():
-        user_api_client.update_webauthn_credential_for_user(
-            user_id=current_user.id,
-            credential_id=key_id,
-            new_name_for_credential=form.name_of_key.data
-        )
+        if form.name_of_key.data != security_key["name"]:
+            user_api_client.update_webauthn_credential_for_user(
+                user_id=current_user.id,
+                credential_id=key_id,
+                new_name_for_credential=form.name_of_key.data
+            )
         return redirect(url_for('.user_profile_security_keys'))
 
     if (request.endpoint == "main.user_profile_confirm_delete_security_key"):

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -20,8 +20,8 @@ from app.main.forms import (
     ChangeEmailForm,
     ChangeMobileNumberForm,
     ChangeNameForm,
-    ChangeNameOfSecurityKey,
     ChangePasswordForm,
+    ChangeSecurityKeyNameForm,
     ConfirmPasswordForm,
     ServiceOnOffSettingForm,
     TwoFactorForm,
@@ -261,14 +261,14 @@ def user_profile_manage_security_key(key_id):
     if not security_key:
         abort(404)
 
-    form = ChangeNameOfSecurityKey(name_of_key=security_key["name"])
+    form = ChangeSecurityKeyNameForm(security_key_name=security_key["name"])
 
     if form.validate_on_submit():
-        if form.name_of_key.data != security_key["name"]:
-            user_api_client.update_webauthn_credential_for_user(
+        if form.security_key_name.data != security_key["name"]:
+            user_api_client.update_webauthn_credential_name_for_user(
                 user_id=current_user.id,
                 credential_id=key_id,
-                new_name_for_credential=form.name_of_key.data
+                new_name_for_credential=form.security_key_name.data
             )
         return redirect(url_for('.user_profile_security_keys'))
 

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -243,6 +243,10 @@ def user_profile_security_keys():
     )
 
 
+def get_key_from_list_of_keys(key_id, list_of_keys):
+    return next((key for key in list_of_keys if key.id == key_id), None)
+
+
 @main.route(
     "/user-profile/security-keys/<uuid:key_id>/manage",
     methods=['GET', 'POST'],
@@ -255,16 +259,16 @@ def user_profile_security_keys():
 )
 @user_is_platform_admin
 def user_profile_manage_security_key(key_id):
-    security_keys = user_api_client.get_webauthn_credentials_for_user(current_user.id)
-    security_key = next((key for key in security_keys if key["id"] == key_id), None)
+    security_keys = current_user.webauthn_credentials
+    security_key = get_key_from_list_of_keys(key_id, security_keys)
 
     if not security_key:
         abort(404)
 
-    form = ChangeSecurityKeyNameForm(security_key_name=security_key["name"])
+    form = ChangeSecurityKeyNameForm(security_key_name=security_key.name)
 
     if form.validate_on_submit():
-        if form.security_key_name.data != security_key["name"]:
+        if form.security_key_name.data != security_key.name:
             user_api_client.update_webauthn_credential_name_for_user(
                 user_id=current_user.id,
                 credential_id=key_id,

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -17,6 +17,7 @@ from app.main.forms import (
     ChangeEmailForm,
     ChangeMobileNumberForm,
     ChangeNameForm,
+    ChangeNameOfSecurityKey,
     ChangePasswordForm,
     ConfirmPasswordForm,
     ServiceOnOffSettingForm,
@@ -241,7 +242,17 @@ def user_profile_security_keys():
 
 @main.route("/user-profile/security-keys/<uuid:key_id>/manage", methods=['GET'])
 @user_is_platform_admin
-def user_profile_manage_security_key():
+def user_profile_manage_security_key(key_id):
+    security_keys = user_api_client.get_webauthn_credentials_for_user(current_user.id)
+    security_key = next((key for key in security_keys if key["id"] == key_id), None)
+
+    if not security_key:
+        abort(404)
+
+    form = ChangeNameOfSecurityKey(name_of_key=security_key["name"])
+
     return render_template(
         'views/user-profile/manage-security-key.html',
+        security_key=security_key,
+        form=form
     )

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -240,7 +240,7 @@ def user_profile_security_keys():
     )
 
 
-@main.route("/user-profile/security-keys/<uuid:key_id>/manage", methods=['GET'])
+@main.route("/user-profile/security-keys/<uuid:key_id>/manage", methods=['GET', 'POST'])
 @user_is_platform_admin
 def user_profile_manage_security_key(key_id):
     security_keys = user_api_client.get_webauthn_credentials_for_user(current_user.id)
@@ -250,6 +250,14 @@ def user_profile_manage_security_key(key_id):
         abort(404)
 
     form = ChangeNameOfSecurityKey(name_of_key=security_key["name"])
+
+    if form.validate_on_submit():
+        user_api_client.update_webauthn_credential_for_user(
+            user_id=current_user.id,
+            credential_id=key_id,
+            new_name_for_credential=form.name_of_key.data
+        )
+        return redirect(url_for('.user_profile_security_keys'))
 
     return render_template(
         'views/user-profile/manage-security-key.html',

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -206,5 +206,10 @@ class UserApiClient(NotifyAdminAPIClient):
 
         return self.post(endpoint, data={"name": new_name_for_credential})
 
+    def delete_webauthn_credential_for_user(self, *, user_id, credential_id):
+        endpoint = f'/user/{user_id}/webauthn/{credential_id}'
+
+        return self.delete(endpoint)
+
 
 user_api_client = UserApiClient()

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -201,7 +201,7 @@ class UserApiClient(NotifyAdminAPIClient):
 
         return self.post(endpoint, data=credential.serialize())
 
-    def update_webauthn_credential_for_user(self, *, user_id, credential_id, new_name_for_credential):
+    def update_webauthn_credential_name_for_user(self, *, user_id, credential_id, new_name_for_credential):
         endpoint = f'/user/{user_id}/webauthn/{credential_id}'
 
         return self.post(endpoint, data={"name": new_name_for_credential})

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -201,5 +201,10 @@ class UserApiClient(NotifyAdminAPIClient):
 
         return self.post(endpoint, data=credential.serialize())
 
+    def update_webauthn_credential_for_user(self, *, user_id, credential_id, new_name_for_credential):
+        endpoint = f'/user/{user_id}/webauthn/{credential_id}'
+
+        return self.post(endpoint, data={"name": new_name_for_credential})
+
 
 user_api_client = UserApiClient()

--- a/app/templates/views/user-profile/manage-security-key.html
+++ b/app/templates/views/user-profile/manage-security-key.html
@@ -1,8 +1,10 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
 
 
-{% set page_title = 'Manage security key' %}
+{% set page_title = 'Manage ' + '‘' + security_key.name + '’' %}
 
 {% block per_page_title %}
   {{ page_title }}
@@ -13,5 +15,14 @@
     page_title,
     back_link=url_for('.user_profile_security_keys')
   ) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      {% call form_wrapper(autocomplete=True) %}
+        {{ form.name_of_key }}
+        {{ page_footer('Save') }}
+      {% endcall %}
+    </div>
+  </div>
 
 {% endblock %}

--- a/app/templates/views/user-profile/manage-security-key.html
+++ b/app/templates/views/user-profile/manage-security-key.html
@@ -20,7 +20,12 @@
     <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper(autocomplete=True) %}
         {{ form.name_of_key }}
-        {{ page_footer('Save') }}
+        {{ page_footer(
+          'Save',
+          delete_link=url_for(
+            '.user_profile_confirm_delete_security_key', key_id=security_key.id),
+          delete_link_text='Delete'
+        ) }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/user-profile/manage-security-key.html
+++ b/app/templates/views/user-profile/manage-security-key.html
@@ -19,7 +19,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       {% call form_wrapper(autocomplete=True) %}
-        {{ form.name_of_key }}
+        {{ form.security_key_name }}
         {{ page_footer(
           'Save',
           delete_link=url_for(

--- a/app/templates/views/user-profile/manage-security-key.html
+++ b/app/templates/views/user-profile/manage-security-key.html
@@ -1,0 +1,17 @@
+{% extends "withoutnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+
+
+{% set page_title = 'Manage security key' %}
+
+{% block per_page_title %}
+  {{ page_title }}
+{% endblock %}
+
+{% block maincolumn_content %}
+  {{ page_header(
+    page_title,
+    back_link=url_for('.user_profile_security_keys')
+  ) }}
+
+{% endblock %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
-{% from "components/table.html" import mapping_table, row, field, row_heading %}
+{% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
 
@@ -26,22 +26,24 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
       {% if credentials %}
-
-        {% call mapping_table(
-          caption=page_title,
-          field_headings=['Security key'],
-          field_headings_visible=False,
-          caption_visible=False,
-        ) %}
-          {% for credential in credentials %}
-            {% call row() %}
-              {% call field() %}
-                <div class="govuk-body">{{ credential.name }}</div>
-                <div class="govuk-body hint">Registered {{ credential.created_at|format_delta }}</div>
+        <div class="body-copy-table">
+          {% call mapping_table(
+            caption=page_title,
+            field_headings=['Security key details', 'Action'],
+            field_headings_visible=False,
+            caption_visible=False,
+          ) %}
+            {% for credential in credentials %}
+              {% call row() %}
+                {% call field() %}
+                  <div class="govuk-body">{{ credential.name }}</div>
+                  <div class="govuk-body hint">Registered {{ credential.created_at|format_delta }}</div>
+                {% endcall %}
+                {{ edit_field('Manage', url_for('.user_profile_manage_security_key', key_id=credential.id)) }}
               {% endcall %}
-            {% endcall %}
-          {% endfor %}
-        {% endcall %}
+            {% endfor %}
+          {% endcall %}
+        </div>
 
       {% else %}
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -401,7 +401,7 @@ def test_should_show_manage_security_key_page(
     assert page.select_one('.govuk-back-link').text.strip() == 'Back'
     assert page.select_one('.govuk-back-link')['href'] == url_for('.user_profile_security_keys')
 
-    assert page.select_one('#name_of_key')["value"] == webauthn_credential["name"]
+    assert page.select_one('#security_key_name')["value"] == webauthn_credential["name"]
 
 
 def test_manage_security_key_page_404s_when_key_not_found(
@@ -464,14 +464,14 @@ def test_should_redirect_after_change_of_security_key_name(
     )
 
     mock_update = mocker.patch(
-        'app.user_api_client.update_webauthn_credential_for_user',
+        'app.user_api_client.update_webauthn_credential_name_for_user',
         return_value=[webauthn_credential],
     )
 
     client_request.post(
         'main.user_profile_manage_security_key',
         key_id=webauthn_credential['id'],
-        _data={'name_of_key': "new name"},
+        _data={'security_key_name': "new name"},
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_security_keys',
@@ -501,14 +501,14 @@ def test_user_profile_manage_security_key_should_not_call_api_if_key_name_stays_
     )
 
     mock_update = mocker.patch(
-        'app.user_api_client.update_webauthn_credential_for_user',
+        'app.user_api_client.update_webauthn_credential_name_for_user',
         return_value=[webauthn_credential],
     )
 
     client_request.post(
         'main.user_profile_manage_security_key',
         key_id=webauthn_credential['id'],
-        _data={'name_of_key': webauthn_credential['name']},
+        _data={'security_key_name': webauthn_credential['name']},
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_security_keys',

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -424,12 +424,29 @@ def test_manage_security_key_page_404s_when_key_not_found(
     )
 
 
-def test_non_platform_admin_user_doesnt_see_manage_security_key_page(client_request, webauthn_credential,):
-    client_request.get(
-        '.user_profile_manage_security_key',
-        key_id=webauthn_credential['id'],
-        _expected_status=403,
-    )
+@pytest.mark.parametrize('endpoint,method', [
+    (".user_profile_manage_security_key", "get"),
+    (".user_profile_manage_security_key", "post"),
+    (".user_profile_confirm_delete_security_key", "get"),
+    (".user_profile_confirm_delete_security_key", "post"),
+    (".user_profile_delete_security_key", "post"),
+])
+def test_non_platform_admin_user_cant_manage_security_keys(
+    client_request, webauthn_credential, endpoint, method
+):
+    if method == "get":
+        client_request.get(
+            endpoint,
+            key_id=webauthn_credential['id'],
+            _expected_status=403,
+        )
+
+    else:
+        client_request.post(
+            endpoint,
+            key_id=webauthn_credential['id'],
+            _expected_status=403,
+        )
 
 
 def test_should_redirect_after_change_of_security_key_name(

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -366,6 +366,11 @@ def test_should_show_security_keys_page(
 
     credential_row = page.select('tr')[-1]
     assert 'Test credential' in credential_row.text
+    assert "Manage" in credential_row.find('a').text
+    assert credential_row.find('a')["href"] == url_for(
+        '.user_profile_manage_security_key',
+        key_id=webauthn_credential['id']
+    )
 
     register_button = page.select_one("[data-module='register-security-key']")
     assert register_button.text.strip() == 'Register a key'

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -303,6 +303,8 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'usage',
     'user_information',
     'user_profile',
+    'user_profile_confirm_delete_security_key',
+    'user_profile_delete_security_key',
     'user_profile_disable_platform_admin_view',
     'user_profile_email',
     'user_profile_email_authenticate',

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -307,6 +307,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'user_profile_email',
     'user_profile_email_authenticate',
     'user_profile_email_confirm',
+    'user_profile_manage_security_key',
     'user_profile_mobile_number',
     'user_profile_mobile_number_authenticate',
     'user_profile_mobile_number_confirm',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4484,9 +4484,20 @@ def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
 @pytest.fixture
 def webauthn_credential():
     return {
-        'id': uuid4(),
+        'id': str(uuid4()),
         'name': 'Test credential',
         'credential_data': 'WJ0AAAAAAAAAAAAAAAAAAAAAAECKU1ppjl9gmhHWyDkgHsUvZmhr6oF3/lD3llzLE2SaOSgOGIsIuAQqgp8JQSUu3r/oOaP8RS44dlQjrH+ALfYtpAECAyYhWCAxnqAfESXOYjKUc2WACuXZ3ch0JHxV0VFrrTyjyjIHXCJYIFnx8H87L4bApR4M+hPcV+fHehEOeW+KCyd0H+WGY8s6',  # noqa
         'registration_response': 'anything',
         'created_at': '2017-10-18T16:57:14.154185Z',
+    }
+
+
+@pytest.fixture
+def webauthn_credential_2():
+    return {
+        'id': str(uuid4()),
+        'name': 'Another test credential',
+        'credential_data': 'WJ0AAAAAAAAAAAAAAAAAAAAAAECKU1jppl9mhgHWyDkgHsUvZmhr6oF3/lD3llzLE2SaOSgOGIsIuAQqgp8JQSUu3r/oOaP8RS44dlQjrH+ALfYtpAECAyYhWCAxnqAfESXOYjKUc2WACuXZ3ch0JHxV0VFrrTyjyjIHXCJYIFnx8L4H87bApR4M+hPcV+fHehEOeW+KCyd0H+WGY8s6',  # noqa
+        'registration_response': 'stuff',
+        'created_at': '2021-05-14T16:57:14.154185Z',
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4484,6 +4484,7 @@ def mock_get_invited_org_user_by_id(mocker, sample_org_invite):
 @pytest.fixture
 def webauthn_credential():
     return {
+        'id': uuid4(),
         'name': 'Test credential',
         'credential_data': 'WJ0AAAAAAAAAAAAAAAAAAAAAAECKU1ppjl9gmhHWyDkgHsUvZmhr6oF3/lD3llzLE2SaOSgOGIsIuAQqgp8JQSUu3r/oOaP8RS44dlQjrH+ALfYtpAECAyYhWCAxnqAfESXOYjKUc2WACuXZ3ch0JHxV0VFrrTyjyjIHXCJYIFnx8H87L4bApR4M+hPcV+fHehEOeW+KCyd0H+WGY8s6',  # noqa
         'registration_response': 'anything',


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/178066154

### "Manage" link on the page listing the keys:
![Screenshot 2021-05-18 at 15 34 13](https://user-images.githubusercontent.com/20957548/118670669-b7e0e200-b7ee-11eb-865b-7777706dcc96.png)

### Manage key page
![Screenshot 2021-05-18 at 15 34 31](https://user-images.githubusercontent.com/20957548/118670796-d5ae4700-b7ee-11eb-9d3b-7c20f0a2583b.png)

### Confirm delete key dialog
![Screenshot 2021-05-18 at 15 35 01](https://user-images.githubusercontent.com/20957548/118670859-e3fc6300-b7ee-11eb-9bcf-5350f9f63554.png)

### "Can't delete last credential" message
![Screenshot 2021-05-18 at 15 35 08](https://user-images.githubusercontent.com/20957548/118670880-e8288080-b7ee-11eb-95eb-d5ae3adbec27.png)


