### PR TITLE
Revert "Disable the remaining messages check for uploads"

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -42,20 +42,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get('/service/{0}'.format(service_id))
 
     def get_service_statistics(self, service_id, today_only, limit_days=None):
-        # FIXME: The statistics request is taking more than 30s on some accounts,
-        # so return an empty set of statistics for the upload check page.
-        # We still do the request for when `today_only=False` so that reporting
-        # pages in the admin are still showing the correct values for other services.
-        if today_only:
-            return {
-                'email': {'requested': 0, 'delivered': 0, 'failed': 0},
-                'sms': {'requested': 0, 'delivered': 0, 'failed': 0},
-                'letter': {'requested': 0, 'delivered': 0, 'failed': 0}
-            }
-        else:
-            return self.get('/service/{0}/statistics'.format(service_id), params={
-                'today_only': today_only, 'limit_days': limit_days
-            })['data']
+        return self.get('/service/{0}/statistics'.format(service_id), params={
+            'today_only': today_only, 'limit_days': limit_days
+        })['data']
 
     def get_services(self, params_dict=None):
         """

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -38,9 +38,9 @@ def test_client_gets_service(mocker):
 
 
 @pytest.mark.parametrize('today_only, limit_days', [
+    (True, None),
     (False, None),
     (False, 30),
-    pytest.param(True, None, marks=pytest.mark.xfail(raises=AssertionError)),
 ])
 def test_client_gets_service_statistics(mocker, today_only, limit_days):
     client = ServiceAPIClient()


### PR DESCRIPTION
Reverts alphagov/notifications-admin#3895

We've updated the query in API to use an existing query. The query is still slow for large volume services but I saw a marked difference and show mean that the CSV upload will not time out. However we should revisit how we handle checking for daily limits. 