### PR TITLE
Prevent switching auth type for Platform Admins

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -57,15 +57,16 @@ def accept_invite(token):
             return redirect(url_for('main.service_dashboard', service_id=invited_user.service))
         else:
             service = Service.from_id(invited_user.service)
-            # if the service you're being added to can modify auth type, then check if this is relevant
-            if service.has_permission('email_auth') and (
-                # they have a phone number, we want them to start using it. if they dont have a mobile we just
-                # ignore that option of the invite
-                (existing_user.mobile_number and invited_user.auth_type == 'sms_auth') or
-                # we want them to start sending emails. it's always valid, so lets always update
-                invited_user.auth_type == 'email_auth'
-            ):
-                existing_user.update(auth_type=invited_user.auth_type)
+            # if the service you're being added to can modify auth type, then check if we can do this;
+            # if the user is a Platform Admin, we silently leave this unchanged to prevent a security
+            # issue where someone could switch their auth type to something less secure
+            if service.has_permission('email_auth') and not existing_user.platform_admin:
+                if invited_user.auth_type == 'email_auth' or (
+                    # they have a phone number, we want them to start using it.
+                    # if they dont have a mobile we just ignore that option of the invite
+                    existing_user.mobile_number and invited_user.auth_type == 'sms_auth'
+                ):
+                    existing_user.update(auth_type=invited_user.auth_type)
             existing_user.add_to_service(
                 service_id=invited_user.service,
                 permissions=invited_user.permissions,

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -142,7 +142,9 @@ def edit_user_permissions(service_id, user_id):
             permissions=form.permissions,
             folder_permissions=form.folder_permissions.data,
         )
-        if service_has_email_auth:
+        # only change the auth type if this is supported for a service; for Platform Admin users,
+        # we avoid changing the auth type to prevent it being switched to something less secure
+        if service_has_email_auth and not user.platform_admin:
             user.update(auth_type=form.login_authentication.data)
         return redirect(url_for('.manage_users', service_id=service_id))
 

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -11,7 +11,11 @@
 {% endif %}
 
 {% if service_has_email_auth %}
-  {% if not mobile_number %}
+  {% if user.platform_admin %}
+    <p class="bottom-gutter">
+      Platform admin users will login with a security key.
+    </p>
+  {% elif not mobile_number %}
     {{ radios(
       form.login_authentication,
       disable=['sms_auth'],

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -25,6 +25,11 @@ def mock_get_existing_user_by_email(mocker, api_user_active):
     return mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_active)
 
 
+@pytest.fixture(scope='function')
+def mock_check_invite_token(mocker, sample_invite):
+    return mocker.patch('app.invite_api_client.check_token', return_value=sample_invite)
+
+
 def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     client,
     service_one,

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -1,5 +1,4 @@
 from unittest.mock import ANY, Mock
-from uuid import uuid4
 
 import pytest
 from bs4 import BeautifulSoup
@@ -18,13 +17,18 @@ from tests.conftest import (
 )
 
 
+@pytest.fixture()
+def mock_no_users_for_service(mocker):
+    mocker.patch('app.models.user.Users.client_method', return_value=[])
+
+
 def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     client,
     service_one,
     api_user_active,
     mock_check_invite_token,
     mock_get_unknown_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_accept_invite,
     mock_add_user_to_service,
     mock_get_service,
@@ -66,7 +70,7 @@ def test_broadcast_service_shows_tour(
     service_one,
     mock_check_invite_token,
     mock_get_unknown_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_accept_invite,
     mock_add_user_to_service,
     mocker,
@@ -103,7 +107,7 @@ def test_existing_user_with_no_permissions_or_folder_permissions_accept_invite(
     sample_invite,
     mock_check_invite_token,
     mock_get_unknown_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_add_user_to_service,
     mock_get_service,
     mock_events,
@@ -153,7 +157,7 @@ def test_invite_goes_in_session(
     api_user_active,
     mock_check_invite_token,
     mock_get_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_add_user_to_service,
     mock_accept_invite,
 ):
@@ -188,7 +192,7 @@ def test_accepting_invite_removes_invite_from_session(
     service_one,
     mock_check_invite_token,
     mock_get_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_add_user_to_service,
     mock_accept_invite,
     mock_get_service_templates,
@@ -255,7 +259,7 @@ def test_accept_invite_redirects_if_api_raises_an_error_that_they_are_already_pa
     sample_invite,
     mock_accept_invite,
     mock_get_service,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_get_user,
 ):
     sample_invite['email_address'] = api_user_active['email_address']
@@ -289,7 +293,7 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
     sample_invite,
     mock_check_invite_token,
     mock_get_unknown_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_add_user_to_service,
     mock_accept_invite,
     mock_get_service,
@@ -327,7 +331,7 @@ def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
     mock_check_invite_token,
     mock_dont_get_user_by_email,
     mock_add_user_to_service,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_get_service,
     mocker,
 ):
@@ -349,7 +353,7 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(
     mock_dont_get_user_by_email,
     mock_get_invited_user_by_id,
     mock_add_user_to_service,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_get_service,
     mocker,
 ):
@@ -446,7 +450,7 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     mock_send_verify_code,
     mock_get_invited_user_by_id,
     mock_accept_invite,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_add_user_to_service,
     mock_get_service,
     mocker,
@@ -559,7 +563,7 @@ def test_new_invited_user_verifies_and_added_to_service(
     mock_get_template_statistics,
     mock_has_no_jobs,
     mock_has_permissions,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_get_service_statistics,
     mock_get_usage,
     mock_get_free_sms_fragment_limit,
@@ -667,7 +671,7 @@ def test_existing_user_accepts_and_sets_email_auth(
     service_one,
     sample_invite,
     mock_get_unknown_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_accept_invite,
     mock_update_user_attribute,
     mock_add_user_to_service,
@@ -696,7 +700,7 @@ def test_platform_admin_user_accepts_and_preserves_auth(
     platform_admin_user,
     service_one,
     sample_invite,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_accept_invite,
     mock_update_user_attribute,
     mock_add_user_to_service,
@@ -705,10 +709,6 @@ def test_platform_admin_user_accepts_and_preserves_auth(
     sample_invite['email_address'] = platform_admin_user['email_address']
     sample_invite['auth_type'] = 'email_auth'
     service_one['permissions'].append('email_auth')
-
-    # mock_get_users_by_service uses the same global UUID as the platform admin user,
-    # so we need to reset it to pretend this user isn't a member of the service
-    platform_admin_user['id'] = uuid4()
     platform_admin_user['auth_type'] = 'webauthn_auth'
 
     # mock_get_unknown_user_by_email returns the active_api_user, which we don't want
@@ -734,7 +734,7 @@ def test_existing_user_doesnt_get_auth_changed_by_service_without_permission(
     service_one,
     sample_invite,
     mock_get_user_by_email,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_accept_invite,
     mock_update_user_attribute,
     mock_add_user_to_service,
@@ -762,7 +762,7 @@ def test_existing_email_auth_user_without_phone_cannot_set_sms_auth(
     api_user_active,
     service_one,
     sample_invite,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_accept_invite,
     mock_update_user_attribute,
     mock_add_user_to_service,
@@ -794,7 +794,7 @@ def test_existing_email_auth_user_with_phone_can_set_sms_auth(
     api_user_active,
     service_one,
     sample_invite,
-    mock_get_users_by_service,
+    mock_no_users_for_service,
     mock_get_unknown_user_by_email,
     mock_accept_invite,
     mock_update_user_attribute,

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -22,6 +22,17 @@ def mock_no_users_for_service(mocker):
     mocker.patch('app.models.user.Users.client_method', return_value=[])
 
 
+@pytest.fixture(scope='function')
+def mock_get_unknown_user_by_email(mocker, api_user_active):
+    api_user_active['id'] = USER_ONE_ID
+
+    def _get_user(email_address):
+        api_user_active['email_address'] = email_address
+        return api_user_active
+
+    return mocker.patch('app.user_api_client.get_user_by_email', side_effect=_get_user)
+
+
 def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     client,
     service_one,

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -11,7 +11,6 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     create_active_caseworking_user,
     create_active_user_with_permissions,
-    create_api_user_active,
     normalize_spaces,
 )
 
@@ -261,16 +260,12 @@ def test_accept_invite_redirects_if_api_raises_an_error_that_they_are_already_pa
     mocker,
     api_user_active,
     sample_invite,
+    mock_get_existing_user_by_email,
     mock_accept_invite,
     mock_get_service,
     mock_no_users_for_service,
     mock_get_user,
 ):
-    sample_invite['email_address'] = api_user_active['email_address']
-
-    # This mock needs to return a user with a different ID to the invited user so that
-    # `existing_user in Users(invited_user.service)` returns False and the right code path is tested
-    mocker.patch('app.user_api_client.get_user_by_email', return_value=create_api_user_active(with_unique_id=True))
     mocker.patch('app.invite_api_client.check_token', return_value=sample_invite)
     mock_audit_event = mocker.patch('app.event_handlers.create_add_user_to_service_event')
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -795,6 +795,42 @@ def test_edit_user_permissions_including_authentication_with_email_auth_service(
     )
 
 
+@pytest.mark.parametrize('auth_type', ['email_auth', 'sms_auth'])
+def test_edit_user_permissions_preserves_auth_type_for_platform_admin(
+    client_request,
+    service_one,
+    platform_admin_user,
+    mock_get_users_by_service,
+    mock_get_invites_for_service,
+    mock_set_user_permissions,
+    mock_update_user_attribute,
+    auth_type,
+    mock_get_template_folders
+):
+    service_one['permissions'].append('email_auth')
+    client_request.login(platform_admin_user)
+
+    client_request.post(
+        'main.edit_user_permissions',
+        service_id=SERVICE_ONE_ID,
+        user_id=platform_admin_user['id'],
+        _data={
+            'email_address': platform_admin_user['email_address'],
+            'permissions_field': [],
+            'login_authentication': auth_type,
+        },
+        _expected_status=302,
+    )
+
+    mock_set_user_permissions.assert_called_with(
+        str(platform_admin_user['id']),
+        SERVICE_ONE_ID,
+        permissions=set(),
+        folder_permissions=[],
+    )
+    mock_update_user_attribute.assert_not_called()
+
+
 def test_should_show_page_for_inviting_user(
     client_request,
     mock_get_template_folders,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2483,14 +2483,6 @@ def mock_get_invites_without_manage_permission(mocker, service_one, sample_invit
 
 
 @pytest.fixture(scope='function')
-def mock_check_invite_token(mocker, sample_invite):
-    def _check_token(token):
-        return sample_invite
-
-    return mocker.patch('app.invite_api_client.check_token', side_effect=_check_token)
-
-
-@pytest.fixture(scope='function')
 def mock_accept_invite(mocker, sample_invite):
     def _accept(service_id, invite_id):
         return sample_invite

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1501,17 +1501,6 @@ def mock_get_user_by_email(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
-def mock_get_unknown_user_by_email(mocker, api_user_active):
-    api_user_active['id'] = USER_ONE_ID
-
-    def _get_user(email_address):
-        api_user_active['email_address'] = email_address
-        return api_user_active
-
-    return mocker.patch('app.user_api_client.get_user_by_email', side_effect=_get_user)
-
-
-@pytest.fixture(scope='function')
 def mock_dont_get_user_by_email(mocker):
     def _get_user(email_address):
         return None


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178213469

This also has a few extra commits to refactor the tests,
which I found quite hard to write for the invite flow.

## Screenshots (editing platform admin team member)

| Before | After |
| ------------- | ------------- |
| <img width="651" alt="Screenshot 2021-05-25 at 17 57 47" src="https://user-images.githubusercontent.com/9029009/119538238-d01ea700-bd82-11eb-8c79-f80669f39be8.png"> | <img width="611" alt="Screenshot 2021-05-25 at 17 57 36" src="https://user-images.githubusercontent.com/9029009/119538233-cf861080-bd82-11eb-861c-645b10be1671.png"> |

