### PR TITLE
Use optional text field for send files setting

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -104,7 +104,7 @@
 
           {% call settings_row(if_has_permission='email') %}
             {{ text_field('Send files by email') }}
-            {{ text_field(current_service.contact_link if current_service.contact_link else "Not set up", truncate=true) }}
+            {{ optional_text_field(current_service.contact_link, default="Not set up", truncate=true) }}
             {{ edit_field(
               'Manage',
               url_for('.send_files_by_email_contact_details', service_id=current_service.id),


### PR DESCRIPTION
This follows the convention for if you have an empty setting, it is greyed-out.

# Before

![image](https://user-images.githubusercontent.com/355079/119957625-231e7700-bf9a-11eb-8164-ec1d4d8302ca.png)

# After 

![image](https://user-images.githubusercontent.com/355079/119957554-113cd400-bf9a-11eb-8893-83f3b2a291a4.png)
