### PR TITLE
Remove ‘manage settings’ permission for alerts

### DIFF
--- a/app/models/roles_and_permissions.py
+++ b/app/models/roles_and_permissions.py
@@ -28,7 +28,6 @@ permissions = (
 broadcast_permissions = (
     ('send_messages', 'Prepare and approve broadcasts'),
     ('manage_templates', 'Add and edit templates'),
-    ('manage_service', 'Manage settings and team'),
 )
 
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -213,14 +213,12 @@ def test_should_show_overview_page_for_broadcast_service(
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User (you) '
         'Can Prepare and approve broadcasts '
-        'Can Add and edit templates '
-        'Can Manage settings and team'
+        'Can Add and edit templates'
     )
     assert normalize_spaces(page.select('.user-list-item')[1].text) == (
         'Test User With Permissions (you) '
         'Cannot Prepare and approve broadcasts '
-        'Cannot Add and edit templates '
-        'Cannot Manage settings and team'
+        'Cannot Add and edit templates'
     )
 
 
@@ -330,7 +328,6 @@ def test_broadcast_service_only_shows_relevant_permissions(
     ] == [
         ('permissions_field', 'send_messages'),
         ('permissions_field', 'manage_templates'),
-        ('permissions_field', 'manage_service'),
     ]
 
 
@@ -564,7 +561,6 @@ def test_edit_user_permissions(
         {
             'view_activity',
             'send_messages',
-            'manage_service',
             'manage_templates',
         }
     ),
@@ -1190,7 +1186,6 @@ def test_invite_user_with_email_auth_service(
             'view_activity',
             'send_messages',
             'manage_templates',
-            'manage_service',
         },
     ),
     (


### PR DESCRIPTION
We shouldn’t have any real users on emergency alert services inviting other users or renaming the service.

If we need to do these things then we can do them as platform admins.

This reduce a potential risk of people having permissions they shouldn’t on production, while we are rolling out the service.