### PR TITLE
Add a success message when security key registered

### DIFF
--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -55,6 +55,11 @@ def webauthn_complete_register():
         current_user.id, credential
     )
 
+    flash((
+        'Registration complete. Next time you sign in to Notify '
+        'you’ll be asked to use your security key.'
+    ), 'default_with_tick')
+
     return cbor.encode('')
 
 

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -153,6 +153,10 @@ def test_complete_register_clears_session(
 
     with platform_admin_client.session_transaction() as session:
         assert 'webauthn_registration_state' not in session
+        assert session['_flashes'] == [('default_with_tick', (
+            'Registration complete. Next time you sign in to Notify '
+            'you’ll be asked to use your security key.'
+        ))]
 
 
 def test_complete_register_handles_library_errors(


### PR DESCRIPTION
This makes it clear that there’s nothing more the user needs to do, until the next time they sign in.

![image](https://user-images.githubusercontent.com/355079/120356370-3021ca00-c2fc-11eb-9046-e4b455aba93c.png)
