### PR TITLE
Fix HTML showing on old job page

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -350,26 +350,34 @@ def _get_job_counts(job):
             count
         ) for label, query_param, count in [
             [
-                f'''total<span class="govuk-visually-hidden">
-                 {"text message" if job_type == "sms" else job_type}s</span>''',
+                Markup(
+                    f'''total<span class="govuk-visually-hidden">
+                    {"text message" if job_type == "sms" else job_type}s</span>'''
+                ),
                 '',
                 job.notification_count
             ],
             [
-                f'''sending<span class="govuk-visually-hidden">
-                 {message_count_noun(job.notifications_sending, job_type)}</span>''',
+                Markup(
+                    f'''sending<span class="govuk-visually-hidden">
+                    {message_count_noun(job.notifications_sending, job_type)}</span>'''
+                ),
                 'sending',
                 job.notifications_sending
             ],
             [
-                f'''delivered<span class="govuk-visually-hidden">
-                 {message_count_noun(job.notifications_delivered, job_type)}</span>''',
+                Markup(
+                    f'''delivered<span class="govuk-visually-hidden">
+                    {message_count_noun(job.notifications_delivered, job_type)}</span>'''
+                ),
                 'delivered',
                 job.notifications_delivered
             ],
             [
-                f'''failed<span class="govuk-visually-hidden">
-                 {message_count_noun(job.notifications_failed, job_type)}</span>''',
+                Markup(
+                    f'''failed<span class="govuk-visually-hidden">
+                    {message_count_noun(job.notifications_failed, job_type)}</span>'''
+                ),
                 'failed',
                 job.notifications_failed
             ]

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -283,6 +283,15 @@ def test_should_show_old_job(
     assert not page.select('p.hint')
     assert not page.select('a[download]')
     assert page.select_one('tbody').text.strip() == expected_message
+    assert [
+        normalize_spaces(column.text)
+        for column in page.select('main .govuk-grid-column-one-quarter')
+    ] == [
+        '1 total text messages',
+        '1 sending text message',
+        '0 delivered text messages',
+        '0 failed text messages',
+    ]
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
Using the `Markup` class tells Jinja that the content is safe to render without any escaping.