### PR TITLE
Get webauthn login to honour next queryparam url

### DIFF
--- a/app/assets/javascripts/authenticateSecurityKey.js
+++ b/app/assets/javascripts/authenticateSecurityKey.js
@@ -21,7 +21,21 @@
               return window.navigator.credentials.get(options);
             })
             .then(credential => {
-              return fetch('/webauthn/authenticate', {
+              const currentURL = new URL(window.location.href);
+
+              // create authenticateURL from admin hostname plus /webauthn/authenticate path
+              const authenticateURL = new URL('/webauthn/authenticate', window.location.href);
+
+              const nextUrl = currentURL.searchParams.get('next');
+              if (nextUrl) {
+                // takes nextUrl from the query string on the current browser URL
+                // (which should be /two-factor-webauthn) and pass it through to
+                // the POST. put it in a query string so it's consistent with how
+                // the other login flows manage it
+                authenticateURL.searchParams.set('next', nextUrl);
+              }
+
+              return fetch(authenticateURL, {
                 method: 'POST',
                 headers: { 'X-CSRFToken': component.data('csrfToken') },
                 body: window.CBOR.encode({

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -60,8 +60,8 @@ def two_factor_email(token):
     return log_in_user(user_id)
 
 
-@main.route('/two-factor-sms', methods=['GET', 'POST'])
 @main.route('/two-factor', methods=['GET', 'POST'])
+@main.route('/two-factor-sms', methods=['GET', 'POST'])
 @redirect_to_sign_in
 def two_factor_sms():
     user_id = session['user_details']['id']

--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -49,6 +49,7 @@ def webauthn_complete_register():
             cbor.decode(request.get_data()),
         )
     except RegistrationError as e:
+        current_app.logger.info(f'User {current_user.id} could not register a new webauthn token - {e}')
         return cbor.encode(str(e)), 400
 
     user_api_client.create_webauthn_credential_for_user(

--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -86,7 +86,7 @@ def webauthn_begin_authentication():
 
     authentication_data, state = current_app.webauthn_server.authenticate_begin(
         credentials=user_to_login.webauthn_credentials_as_cbor,
-        user_verification=None,  # required, preferred, discouraged. sets whether to ask for PIN
+        user_verification="discouraged",  # don't ask for PIN
     )
     session["webauthn_authentication_state"] = state
     return cbor.encode(authentication_data)

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -128,8 +128,7 @@ class UserApiClient(NotifyAdminAPIClient):
     @cache.delete('user-{user_id}')
     def complete_webauthn_login_attempt(self, user_id, is_successful):
         data = {'successful': is_successful}
-        # TODO: Change this to `/complete/webauthn-login`
-        endpoint = f'/user/{user_id}/verify/webauthn-login'
+        endpoint = f'/user/{user_id}/complete/webauthn-login'
         try:
             self.post(endpoint, data=data)
             return True, ''

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -130,8 +130,6 @@ def test_process_sms_auth_sign_in_return_2fa_template(
             'email_address': email_address,
             'password': password})
     assert response.status_code == 302
-    # TODO: remove this assert once we start defaulting to returning two_factor_sms first
-    assert '/two-factor-sms' not in response.location
     assert response.location == url_for('.two_factor_sms', next=redirect_url, _external=True)
     mock_verify_password.assert_called_with(api_user_active['id'], password)
     mock_get_user_by_email.assert_called_with('valid@example.gov.uk')

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -273,7 +273,7 @@ def test_complete_webauthn_login_attempt_returns_true_and_no_message_normally(fa
     resp = user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True)
 
     expected_data = {'successful': True}
-    mock_post.assert_called_once_with(f'/user/{fake_uuid}/verify/webauthn-login', data=expected_data)
+    mock_post.assert_called_once_with(f'/user/{fake_uuid}/complete/webauthn-login', data=expected_data)
     assert resp == (True, '')
 
 
@@ -293,7 +293,7 @@ def test_complete_webauthn_login_attempt_returns_false_and_message_on_403(fake_u
     resp = user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True)
 
     expected_data = {'successful': True}
-    mock_post.assert_called_once_with(f'/user/{fake_uuid}/verify/webauthn-login', data=expected_data)
+    mock_post.assert_called_once_with(f'/user/{fake_uuid}/complete/webauthn-login', data=expected_data)
 
     assert resp == (False, 'forbidden')
 

--- a/tests/javascripts/jest.config.js
+++ b/tests/javascripts/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   setupFiles: ['./support/setup.js'],
-  testURL: 'https://www.notifications.service.gov.uk'
+  testURL: 'https://www.notifications.service.gov.uk/?next=%2Ffoo%3Fbar%3Dbaz'
 }


### PR DESCRIPTION
unfortunately i couldn't get mocking location for a single js test to work, but by changing the global config i was able to add some query params that i can expect to be passed through. Don't love this at all but not quite sure of a good way round this. I think we're not practicing very good hygiene and best practices with our mocking (i'm sure that the assigning an empty lambda and then deleting it later isn't the proper way to do things, plus doing that ) and it's really confounding me here.


A few other changes snuck in here so I suggest reviewing commit by commit, and also reviewing the following:

- [x] alphagov/notifications-api#3260