### PR TITLE
Tweak content for incorrect flash message

### DIFF
--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -57,8 +57,7 @@ def webauthn_complete_register():
     )
 
     flash((
-        'Registration complete. Next time you sign in to Notify '
-        'you’ll be asked to use your security key.'
+        'Registration complete.'
     ), 'default_with_tick')
 
     return cbor.encode('')

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -154,8 +154,7 @@ def test_complete_register_clears_session(
     with platform_admin_client.session_transaction() as session:
         assert 'webauthn_registration_state' not in session
         assert session['_flashes'] == [('default_with_tick', (
-            'Registration complete. Next time you sign in to Notify '
-            'you’ll be asked to use your security key.'
+            'Registration complete.'
         ))]
 
 


### PR DESCRIPTION
Currently someone needs to manually switch a user's account to sign
in with WebAuthn, so this text was misleading.