### PR TITLE
Refactor User.webauthn_credentials into a ModelList

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -243,10 +243,6 @@ def user_profile_security_keys():
     )
 
 
-def get_key_from_list_of_keys(key_id, list_of_keys):
-    return next((key for key in list_of_keys if key.id == key_id), None)
-
-
 @main.route(
     "/user-profile/security-keys/<uuid:key_id>/manage",
     methods=['GET', 'POST'],
@@ -259,8 +255,7 @@ def get_key_from_list_of_keys(key_id, list_of_keys):
 )
 @user_is_platform_admin
 def user_profile_manage_security_key(key_id):
-    security_keys = current_user.webauthn_credentials
-    security_key = get_key_from_list_of_keys(key_id, security_keys)
+    security_key = current_user.webauthn_credentials.by_id(key_id)
 
     if not security_key:
         abort(404)

--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -28,7 +28,7 @@ def webauthn_begin_register():
             "name": current_user.email_address,
             "displayName": current_user.name,
         },
-        credentials=current_user.webauthn_credentials_as_cbor,
+        credentials=current_user.webauthn_credentials.as_cbor,
         user_verification="discouraged",  # don't ask for PIN
         authenticator_attachment="cross-platform",
     )
@@ -85,7 +85,7 @@ def webauthn_begin_authentication():
         abort(403)
 
     authentication_data, state = current_app.webauthn_server.authenticate_begin(
-        credentials=user_to_login.webauthn_credentials_as_cbor,
+        credentials=user_to_login.webauthn_credentials.as_cbor,
         user_verification="discouraged",  # don't ask for PIN
     )
     session["webauthn_authentication_state"] = state
@@ -144,7 +144,7 @@ def _verify_webauthn_authentication(user):
     try:
         current_app.webauthn_server.authenticate_complete(
             state=state,
-            credentials=user.webauthn_credentials_as_cbor,
+            credentials=user.webauthn_credentials.as_cbor,
             credential_id=request_data['credentialId'],
             client_data=ClientData(request_data['clientDataJSON']),
             auth_data=AuthenticatorData(request_data['authenticatorData']),

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -10,7 +10,7 @@ from app.models.roles_and_permissions import (
     all_permissions,
     translate_permissions_from_db_to_admin_roles,
 )
-from app.models.webauthn_credential import WebAuthnCredential
+from app.models.webauthn_credential import WebAuthnCredentials
 from app.notify_client import InviteTokenError
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.org_invite_api_client import org_invite_api_client
@@ -350,15 +350,7 @@ class User(JSONModel, UserMixin):
 
     @property
     def webauthn_credentials(self):
-        return [WebAuthnCredential(json) for json in
-                user_api_client.get_webauthn_credentials_for_user(self.id)]
-
-    @property
-    def webauthn_credentials_as_cbor(self):
-        return [
-            credential.to_credential_data()
-            for credential in self.webauthn_credentials
-        ]
+        return WebAuthnCredentials(self.id)
 
     def create_webauthn_credential(self, credential):
         user_api_client.create_webauthn_credential_for_user(

--- a/app/models/webauthn_credential.py
+++ b/app/models/webauthn_credential.py
@@ -6,7 +6,8 @@ from fido2.cose import UnsupportedKey
 from fido2.ctap2 import AttestationObject, AttestedCredentialData
 from flask import current_app
 
-from app.models import JSONModel
+from app.models import JSONModel, ModelList
+from app.notify_client.user_api_client import user_api_client
 
 
 class RegistrationError(Exception):
@@ -60,3 +61,16 @@ class WebAuthnCredential(JSONModel):
             'credential_data': self.credential_data,
             'registration_response': self.registration_response,
         }
+
+
+class WebAuthnCredentials(ModelList):
+
+    model = WebAuthnCredential
+    client_method = user_api_client.get_webauthn_credentials_for_user
+
+    @property
+    def as_cbor(self):
+        return [credential.to_credential_data() for credential in self]
+
+    def by_id(self, key_id):
+        return next((key for key in self if key.id == key_id), None)

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -50,7 +50,7 @@ def test_begin_register_returns_encoded_options(
     platform_admin_client,
     webauthn_dev_server,
 ):
-    mocker.patch('app.user_api_client.get_webauthn_credentials_for_user', return_value=[])
+    mocker.patch('app.models.webauthn_credential.WebAuthnCredentials.client_method', return_value=[])
 
     response = platform_admin_client.get(url_for('main.webauthn_begin_register'))
 
@@ -79,7 +79,7 @@ def test_begin_register_includes_existing_credentials(
     mocker,
 ):
     mocker.patch(
-        'app.user_api_client.get_webauthn_credentials_for_user',
+        'app.models.webauthn_credential.WebAuthnCredentials.client_method',
         return_value=[webauthn_credential, webauthn_credential]
     )
 
@@ -96,7 +96,7 @@ def test_begin_register_stores_state_in_session(
     mocker,
 ):
     mocker.patch(
-        'app.user_api_client.get_webauthn_credentials_for_user',
+        'app.models.webauthn_credential.WebAuthnCredentials.client_method',
         return_value=[])
 
     response = platform_admin_client.get(
@@ -227,7 +227,7 @@ def test_begin_authentication_returns_encoded_options(client, mocker, webauthn_c
         session['user_details'] = {'id': platform_admin_user['id']}
 
     get_creds_mock = mocker.patch(
-        'app.user_api_client.get_webauthn_credentials_for_user',
+        'app.models.webauthn_credential.WebAuthnCredentials.client_method',
         return_value=[webauthn_credential]
     )
     response = client.get(url_for('main.webauthn_begin_authentication'))
@@ -248,7 +248,7 @@ def test_begin_authentication_stores_state_in_session(client, mocker, webauthn_c
         session['user_details'] = {'id': platform_admin_user['id']}
 
     mocker.patch(
-        'app.user_api_client.get_webauthn_credentials_for_user',
+        'app.models.webauthn_credential.WebAuthnCredentials.client_method',
         return_value=[webauthn_credential]
     )
     client.get(url_for('main.webauthn_begin_authentication'))
@@ -268,7 +268,7 @@ def test_complete_authentication_checks_credentials(
 ):
     platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
-    mocker.patch('app.user_api_client.get_webauthn_credentials_for_user', return_value=[webauthn_credential])
+    mocker.patch('app.models.webauthn_credential.WebAuthnCredentials.client_method', return_value=[webauthn_credential])
     mocker.patch(
         'app.main.views.webauthn_credentials._complete_webauthn_login_attempt',
         return_value=Mock(location='/foo')
@@ -291,7 +291,7 @@ def test_complete_authentication_403s_if_key_isnt_in_users_credentials(
     platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     # user has no keys in the database
-    mocker.patch('app.user_api_client.get_webauthn_credentials_for_user', return_value=[])
+    mocker.patch('app.models.webauthn_credential.WebAuthnCredentials.client_method', return_value=[])
     mock_verify_webauthn_login = mocker.patch('app.main.views.webauthn_credentials._complete_webauthn_login_attempt')
     mock_unsuccesful_login_api_call = mocker.patch('app.user_api_client.complete_webauthn_login_attempt')
 


### PR DESCRIPTION
This saves a bit of repetition, and lets us attach other methods to the collection, rather than having multiple methods on the user object prefixed with the same name, or random functions floating about.