### PR TITLE
Set window location for individual test

### DIFF
--- a/tests/javascripts/authenticateSecurityKey.test.js
+++ b/tests/javascripts/authenticateSecurityKey.test.js
@@ -99,6 +99,9 @@ describe('Authenticate with security key', () => {
   });
 
   test('authenticates and passes a redirect url through to the authenticate admin endpoint', (done) => {
+    // https://github.com/facebook/jest/issues/890#issuecomment-415202799
+    window.history.pushState({}, 'Test Title', '/?next=%2Ffoo%3Fbar%3Dbaz');
+
     jest.spyOn(window, 'fetch')
       .mockImplementationOnce((_url) => {
         // initial fetch of options from the server

--- a/tests/javascripts/jest.config.js
+++ b/tests/javascripts/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   setupFiles: ['./support/setup.js'],
-  testURL: 'https://www.notifications.service.gov.uk/?next=%2Ffoo%3Fbar%3Dbaz'
+  testURL: 'https://www.notifications.service.gov.uk',
 }


### PR DESCRIPTION
This is less surprising and means we don't end up in a situation
where a future test needs to change the global config to something
else.