### PR TITLE
Permanent failure message for letters

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -220,7 +220,7 @@ def format_notification_status(status, template_type):
             'failed': '',
             'technical-failure': 'Technical failure',
             'temporary-failure': '',
-            'permanent-failure': '',
+            'permanent-failure': 'Permanent failure',
             'delivered': '',
             'received': '',
             'accepted': '',

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -80,6 +80,7 @@
         ('Printed', 'The provider has printed the letter. Letters are printed at 5:30pm and dispatched the next working day.'), 
         ('Cancelled', 'Sending cancelled. Your letter will not be printed or dispatched.'),
         ('Technical failure', 'Notify had an unexpected error while sending the letter to our printing provider.'),
+        ('Permenent failure', 'The provider cannot print the letter. Your letter will not be dispatched.')
       ] %}
         {% call row() %}
           {{ text_field(message_length) }}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -41,7 +41,7 @@
     </p>
 
     {% if template.template_type == 'letter' %}
-      {% if notification_status in ('permanent-failure', 'cancelled') %}
+      {% if notification_status == 'cancelled' %}
         <p class="notification-status-cancelled">
           Cancelled {{ updated_at|format_datetime_short }}
         </p>
@@ -49,6 +49,10 @@
         <p class="notification-status-cancelled">
           {{ message.summary | safe }}
         </p>
+      {% elif notification_status == 'permanent-failure' %}
+         <p class="notification-status-cancelled">
+          Permanent failure – The postal provider is unable to print the letter. Your letter has not been sent.
+         </p>
       {% elif notification_status == 'technical-failure' %}
         <p class="notification-status-cancelled">
           Technical failure – Notify will resend once the team have

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -51,7 +51,7 @@
         </p>
       {% elif notification_status == 'permanent-failure' %}
          <p class="notification-status-cancelled">
-          Permanent failure – The postal provider is unable to print the letter. Your letter has not been sent.
+          Permanent failure – The provider cannot print the letter. Your letter will not be dispatched.
          </p>
       {% elif notification_status == 'technical-failure' %}
         <p class="notification-status-cancelled">

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -741,7 +741,7 @@ def test_big_numbers_dont_show_for_letters(
         ('letter', 'received', '27 September at 5:30pm', True),
         ('letter', 'accepted', '27 September at 5:30pm', True),
         ('letter', 'cancelled', '27 September at 5:30pm', False),  # The API won’t return cancelled letters
-        ('letter', 'permanent-failure', '27 September at 5:31pm', False),  # Deprecated for ‘cancelled’
+        ('letter', 'permanent-failure', 'Permanent failure 27 September at 5:31pm', False),
         ('letter', 'temporary-failure', '27 September at 5:30pm', False),  # Not currently a real letter status
         ('letter', 'virus-scan-failed', 'Virus detected 27 September at 5:30pm', False),
         ('letter', 'validation-failed', 'Validation failed 27 September at 5:30pm', False),

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -442,7 +442,7 @@ def test_notification_page_shows_validation_failed_precompiled_letter(
 @pytest.mark.parametrize('notification_status, expected_message', (
     (
         'permanent-failure',
-        'Permanent failure – The postal provider is unable to print the letter. Your letter has not been sent.',
+        'Permanent failure – The provider cannot print the letter. Your letter will not be dispatched.',
     ),
     (
         'cancelled',

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -442,7 +442,7 @@ def test_notification_page_shows_validation_failed_precompiled_letter(
 @pytest.mark.parametrize('notification_status, expected_message', (
     (
         'permanent-failure',
-        'Cancelled 1 January at 1:02am',
+        'Permanent failure – The postal provider is unable to print the letter. Your letter has not been sent.',
     ),
     (
         'cancelled',


### PR DESCRIPTION
When a letter has passed our validation but the postal provider is unable to print the letter we need to mark the letter as failed.

If we mark the letter as a technical-failure, we say that we will fix the issue, which is wrong because we cannot fix the issue.

If we mark the letter as validation-failed, the letter is in the wrong bucket, so the letter is not viewable/downloadable by the client.

This PR updates the message for a letter marked as permanent-failure to better reflect what has actually happened.