### PR TITLE
ensure user details are always in the session after entering password

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -33,24 +33,31 @@ def sign_in():
             form.email_address.data, form.password.data
         )
 
-        if user and user.state == 'pending':
-            return redirect(url_for('main.resend_email_verification', next=redirect_url))
+        if user:
+            # add user to session to mark us as in the process of signing the user in
+            session['user_details'] = {"email": user.email_address, "id": user.id}
 
-        if user and session.get('invited_user_id'):
-            invited_user = InvitedUser.from_session()
-            if user.email_address.lower() != invited_user.email_address.lower():
-                flash("You cannot accept an invite for another person.")
-                session.pop('invited_user_id', None)
-                abort(403)
-            else:
-                invited_user.accept_invite()
-        if user and user.sign_in():
-            if user.sms_auth:
-                return redirect(url_for('.two_factor_sms', next=redirect_url))
-            if user.email_auth:
-                return redirect(url_for('.two_factor_email_sent', next=redirect_url))
-            if user.webauthn_auth:
-                return redirect(url_for('.two_factor_webauthn', next=redirect_url))
+            if user.state == 'pending':
+                return redirect(url_for('main.resend_email_verification', next=redirect_url))
+
+            if user.is_active:
+                if session.get('invited_user_id'):
+                    invited_user = InvitedUser.from_session()
+                    if user.email_address.lower() != invited_user.email_address.lower():
+                        flash("You cannot accept an invite for another person.")
+                        session.pop('invited_user_id', None)
+                        abort(403)
+                    else:
+                        invited_user.accept_invite()
+
+                user.send_login_code()
+
+                if user.sms_auth:
+                    return redirect(url_for('.two_factor_sms', next=redirect_url))
+                if user.email_auth:
+                    return redirect(url_for('.two_factor_email_sent', next=redirect_url))
+                if user.webauthn_auth:
+                    return redirect(url_for('.two_factor_webauthn', next=redirect_url))
 
         # Vague error message for login in case of user not known, locked, inactive or password not verified
         flash(Markup(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -142,19 +142,11 @@ class User(JSONModel, UserMixin):
         login_user(self)
         session['user_id'] = self.id
 
-    def sign_in(self):
-
-        session['user_details'] = {"email": self.email_address, "id": self.id}
-
-        if not self.is_active:
-            return False
-
+    def send_login_code(self):
         if self.email_auth:
             user_api_client.send_verify_code(self.id, 'email', None, request.args.get('next'))
         if self.sms_auth:
             user_api_client.send_verify_code(self.id, 'sms', self.mobile_number)
-
-        return True
 
     def sign_out(self):
         session.clear()


### PR DESCRIPTION
We signal that we're mid-way through the sign-in flow by adding a `user_details` dict to the session.

previously, we'd only put a user's details in the session in `User.sign_in`, just before sending any 2fa prompt and redirecting to the two factor pages.

However, we found a bug where a user with no session (eg, using a fresh browser) tried to log in, but they had never clicked the link to validate their email address when registering. Their user's state was still in "pending", so we redirected to `main.resend_email_verification` as intended - however, they didn't have anything in the session and the resend page expected to get the email address to resend to out of that.

To be safe, as soon as we've confirmed the user has entered their password correctly, lets save the session data at that point. That way any redirects will be fine.