### PR TITLE
Webauthn bug fixes and permission tightening

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -66,7 +66,6 @@ def two_factor_email(token):
     return log_in_user(user_id)
 
 
-@main.route('/two-factor', methods=['GET', 'POST'])
 @main.route('/two-factor-sms', methods=['GET', 'POST'])
 @redirect_to_sign_in
 def two_factor_sms():

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -1,6 +1,7 @@
 import json
 
 from flask import (
+    abort,
     current_app,
     redirect,
     render_template,
@@ -91,9 +92,14 @@ def two_factor_sms():
 @main.route('/two-factor-webauthn', methods=['GET'])
 @redirect_to_sign_in
 def two_factor_webauthn():
-    # TODO: Return a sensible error page if the user isn't platform admin or doesn't have webauthn
-    redirect_url = request.args.get('next')
-    return render_template('views/two-factor-webauthn.html', redirect_url=redirect_url)
+    user_id = session['user_details']['id']
+    user = User.from_id(user_id)
+    if not user.platform_admin:
+        abort(403)
+    if not user.webauthn_auth:
+        abort(403)
+
+    return render_template('views/two-factor-webauthn.html')
 
 
 @main.route('/re-validate-email', methods=['GET'])

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -713,7 +713,6 @@ def test_platform_admin_user_accepts_and_preserves_auth(
     sample_invite['email_address'] = platform_admin_user['email_address']
     sample_invite['auth_type'] = 'email_auth'
     service_one['permissions'].append('email_auth')
-    platform_admin_user['auth_type'] = 'webauthn_auth'
 
     mocker.patch('app.user_api_client.get_user_by_email', return_value=platform_admin_user)
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -277,6 +277,57 @@ def test_two_factor_get_should_redirect_to_sign_in_if_user_not_in_session(
     )
 
 
+def test_two_factor_webauthn_should_have_auth_signin_button(
+    client,
+    platform_admin_user,
+    mocker,
+):
+    platform_admin_user['auth_type'] = 'webauthn_auth'
+    mock_get_user = mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
+    with client.session_transaction() as session:
+        session['user_details'] = {'id': platform_admin_user['id'], 'email': platform_admin_user['email_address']}
+
+    response = client.get(url_for('main.two_factor_webauthn'))
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    button = page.select_one("button[data-module=authenticate-security-key]")
+
+    assert button.text.strip() == 'Check security key'
+
+    assert button.name == 'button'
+    mock_get_user.assert_called_once_with(platform_admin_user['id'])
+
+
+def test_two_factor_webauthn_should_reject_non_platform_admins(
+    client,
+    api_user_active,
+    mock_get_user,
+):
+    api_user_active['auth_type'] = 'webauthn_auth'
+    with client.session_transaction() as session:
+        session['user_details'] = {'id': api_user_active['id'], 'email': api_user_active['email_address']}
+
+    response = client.get(url_for('main.two_factor_webauthn'))
+
+    assert response.status_code == 403
+
+
+def test_two_factor_webauthn_should_reject_non_webauthn_auth_users(
+    client,
+    platform_admin_user,
+    mocker,
+):
+    platform_admin_user['auth_type'] = 'sms_auth'
+    mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
+    with client.session_transaction() as session:
+        session['user_details'] = {'id': platform_admin_user['id'], 'email': platform_admin_user['email_address']}
+
+    response = client.get(url_for('main.two_factor_webauthn'))
+
+    assert response.status_code == 403
+
+
 def test_two_factor_should_activate_pending_user(
     client,
     mocker,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -282,7 +282,6 @@ def test_two_factor_webauthn_should_have_auth_signin_button(
     platform_admin_user,
     mocker,
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     mock_get_user = mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     with client.session_transaction() as session:
         session['user_details'] = {'id': platform_admin_user['id'], 'email': platform_admin_user['email_address']}

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -212,7 +212,7 @@ def test_should_login_user_when_multiple_valid_codes_exist(
     assert response.status_code == 302
 
 
-def test_two_factor_should_set_password_when_new_password_exists_in_session(
+def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
     client,
     api_user_active,
     mock_get_user,
@@ -238,7 +238,7 @@ def test_two_factor_should_set_password_when_new_password_exists_in_session(
     )
 
 
-def test_two_factor_returns_error_when_user_is_locked(
+def test_two_factor_sms_returns_error_when_user_is_locked(
     client,
     api_user_locked,
     mock_get_locked_user,
@@ -256,7 +256,7 @@ def test_two_factor_returns_error_when_user_is_locked(
     assert 'Code not found' in response.get_data(as_text=True)
 
 
-def test_two_factor_post_should_redirect_to_sign_in_if_user_not_in_session(
+def test_two_factor_sms_post_should_redirect_to_sign_in_if_user_not_in_session(
     client_request,
 ):
     client_request.post(
@@ -267,7 +267,7 @@ def test_two_factor_post_should_redirect_to_sign_in_if_user_not_in_session(
 
 
 @pytest.mark.parametrize('endpoint', ['main.two_factor_webauthn', 'main.two_factor_sms'])
-def test_two_factor_get_should_redirect_to_sign_in_if_user_not_in_session(
+def test_two_factor_endpoints_get_should_redirect_to_sign_in_if_user_not_in_session(
     client_request,
     endpoint,
 ):
@@ -327,7 +327,7 @@ def test_two_factor_webauthn_should_reject_non_webauthn_auth_users(
     assert response.status_code == 403
 
 
-def test_two_factor_should_activate_pending_user(
+def test_two_factor_sms_should_activate_pending_user(
     client,
     mocker,
     api_user_pending,

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -209,6 +209,7 @@ def test_begin_authentication_forbidden_for_non_platform_admins(client, api_user
 
 
 def test_begin_authentication_forbidden_for_users_without_webauthn(client, mocker, platform_admin_user):
+    platform_admin_user['auth_type'] = 'sms_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
 
     with client.session_transaction() as session:
@@ -219,7 +220,6 @@ def test_begin_authentication_forbidden_for_users_without_webauthn(client, mocke
 
 
 def test_begin_authentication_returns_encoded_options(client, mocker, webauthn_credential, platform_admin_user):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
 
     with client.session_transaction() as session:
@@ -240,7 +240,6 @@ def test_begin_authentication_returns_encoded_options(client, mocker, webauthn_c
 
 
 def test_begin_authentication_stores_state_in_session(client, mocker, webauthn_credential, platform_admin_user):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
 
     with client.session_transaction() as session:
@@ -265,7 +264,6 @@ def test_complete_authentication_checks_credentials(
     webauthn_authentication_post_data,
     platform_admin_user
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     mocker.patch('app.models.webauthn_credential.WebAuthnCredentials.client_method', return_value=[webauthn_credential])
     mocker.patch(
@@ -287,7 +285,6 @@ def test_complete_authentication_403s_if_key_isnt_in_users_credentials(
     webauthn_authentication_post_data,
     platform_admin_user
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     # user has no keys in the database
     mocker.patch('app.models.webauthn_credential.WebAuthnCredentials.client_method', return_value=[])
@@ -320,7 +317,6 @@ def test_complete_authentication_clears_session(
     mock_create_event,
     platform_admin_user
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     mocker.patch('app.user_api_client.get_user', return_value=platform_admin_user)
     mocker.patch('app.user_api_client.get_webauthn_credentials_for_user', return_value=[webauthn_credential])
     mocker.patch(
@@ -347,8 +343,6 @@ def test_verify_webauthn_login_signs_user_in(
     url_kwargs,
     expected_redirect,
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
-
     with client.session_transaction() as session:
         session['user_details'] = {
             'id': platform_admin_user['id'],
@@ -375,7 +369,6 @@ def test_verify_webauthn_login_signs_user_in_doesnt_sign_user_in_if_api_rejects(
     mocker,
     platform_admin_user,
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
 
     with client.session_transaction() as session:
         session['user_details'] = {
@@ -401,7 +394,6 @@ def test_verify_webauthn_login_signs_user_in_sends_revalidation_email_if_needed(
     mock_send_verify_code,
     platform_admin_user,
 ):
-    platform_admin_user['auth_type'] = 'webauthn_auth'
     user_details = {
         'id': platform_admin_user['id'],
         'email': platform_admin_user['email_address']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3628,7 +3628,7 @@ def create_active_user_manage_template_permissions(with_unique_id=False):
     )
 
 
-def create_platform_admin_user(with_unique_id=False, auth_type='sms_auth', permissions=None):
+def create_platform_admin_user(with_unique_id=False, auth_type='webauthn_auth', permissions=None):
     return create_user(
         id=str(uuid4()) if with_unique_id else sample_uuid(),
         name='Platform admin user',


### PR DESCRIPTION
Take a good look at that second commit, it's a horror show. (But right now, you cannot edit any platform admin's permissions on production for any service, as it silently errors when trying to validate their existing webauthn_auth type against the radio choices of sms or email