### PR TITLE
Add total_letters to the billing report

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -282,7 +282,7 @@ def get_billing_report():
         end_date = form.end_date.data
         headers = [
             "organisation_id", "organisation_name", "service_id", "service_name",
-            "sms_cost", "sms_fragments", "letter_cost", "letter_breakdown", "purchase_order_number",
+            "sms_cost", "sms_fragments", "total_letters", "letter_cost", "letter_breakdown", "purchase_order_number",
             "contact_names", "contact_email_addresses", "billing_reference"
         ]
         try:
@@ -297,7 +297,7 @@ def get_billing_report():
         rows = [
             [
                 r["organisation_id"], r["organisation_name"], r["service_id"], r["service_name"],
-                r["sms_cost"], r["sms_fragments"], r["letter_cost"], r["letter_breakdown"].strip(),
+                r["sms_cost"], r["sms_fragments"], r["total_letters"], r["letter_cost"], r["letter_breakdown"].strip(),
                 r.get("purchase_order_number"), r.get("contact_names"), r.get("contact_email_addresses"),
                 r.get("billing_reference")
             ]

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -851,6 +851,7 @@ def test_get_billing_report_when_calls_api_and_download_data(platform_admin_clie
         "app.main.views.platform_admin.billing_api_client.get_data_for_billing_report",
         return_value=[{
             'letter_breakdown': '6 second class letters at 45p\n2 first class letters at 35p\n',
+            'total_letters': 8,
             'letter_cost': 3.4,
             'organisation_id': '7832a1be-a1f0-4f2a-982f-05adfd3d6354',
             'organisation_name': 'Org for a - with sms and letter',
@@ -875,7 +876,7 @@ def test_get_billing_report_when_calls_api_and_download_data(platform_admin_clie
     )
 
     assert response.get_data(as_text=True) == (
-        'organisation_id,organisation_name,service_id,service_name,sms_cost,sms_fragments,letter_cost' +
+        'organisation_id,organisation_name,service_id,service_name,sms_cost,sms_fragments,total_letters,letter_cost' +
         ',letter_breakdown,purchase_order_number,contact_names,contact_email_addresses,billing_reference' +
 
         '\r\n' +
@@ -886,6 +887,7 @@ def test_get_billing_report_when_calls_api_and_download_data(platform_admin_clie
         'a - with sms and letter,' +
         '0,' +
         '0,' +
+        '8,' +
         '3.4,' +
         '"6 second class letters at 45p' +
         '\n' +


### PR DESCRIPTION
This adds an extra column to the report that can be downloaded from `platform-admin/reports/usage-for-all-services`.

[Pivotal story](https://www.pivotaltracker.com/story/show/177558710)

**Depends on**
- [x] https://github.com/alphagov/notifications-api/pull/3264