### PR TITLE
Add support for the operator channel

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -40,7 +40,7 @@
       box-shadow: 0 -3px 0 0 $grey-3;
     }
 
-    &--live, &--test {
+    &--live, &--test, &--operator {
       // This uses new Design System colours to match .govuk-tag--red
       background: #F6D7D2;
       color: #942514;

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1312,10 +1312,10 @@ class ConfirmBroadcastForm(StripWhitespaceForm):
 
     @staticmethod
     def generate_label(channel, max_phones):
-        if channel == 'test':
+        if channel in {'test', 'operator'}:
             return (
-                'I understand this will alert anyone who has switched '
-                'on the test channel'
+                f'I understand this will alert anyone who has switched '
+                f'on the {channel} channel'
             )
         if channel == 'severe':
             return (
@@ -2382,6 +2382,7 @@ class ServiceBroadcastChannelForm(StripWhitespaceForm):
         thing='mode or channel',
         choices=[
             ("training", "Training mode"),
+            ("operator", "Operator channel"),
             ("test", "Test channel"),
             ("severe", "Live channel"),
             ("government", "Government channel"),
@@ -2435,7 +2436,7 @@ class ServiceBroadcastAccountTypeForm(StripWhitespaceForm):
         ] +
         [
             (f"live-{broadcast_channel}-{provider}", "")
-            for broadcast_channel in ["test", "severe", "government"]
+            for broadcast_channel in ["test", "operator", "severe", "government"]
             for provider in ["all", "ee", "o2", "three", "vodafone"]
         ],
         validators=[DataRequired()]

--- a/app/templates/views/service-settings/service-confirm-broadcast-account-type.html
+++ b/app/templates/views/service-settings/service-confirm-broadcast-account-type.html
@@ -31,8 +31,8 @@
       {% else %}
         <p class="govuk-body">
           Members of the public
-          {% if form.account_type.broadcast_channel == 'test' %}
-            who have switched on the test channel on their phones
+          {% if form.account_type.broadcast_channel in ['test', 'operator'] %}
+            who have switched on the {{ form.account_type.broadcast_channel }} channel on their phones
           {% endif %}
           will receive alerts sent from this service
           {%- if form.account_type.broadcast_channel == 'government' -%}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -323,6 +323,22 @@ def test_some_broadcast_tour_pages_show_service_name(
         ),
         (
             False,
+            'operator',
+            'all',
+            '.navigation-service-type.navigation-service-type--operator',
+            'service one Operator Switch service',
+            'Operator',
+        ),
+        (
+            False,
+            'operator',
+            'vodafone',
+            '.navigation-service-type.navigation-service-type--operator',
+            'service one Operator (Vodafone) Switch service',
+            'Operator (Vodafone)',
+        ),
+        (
+            False,
             'test',
             'all',
             '.navigation-service-type.navigation-service-type--test',
@@ -1854,6 +1870,9 @@ def test_view_pending_broadcast_from_api_call(
 @pytest.mark.parametrize('channel, expected_label_text', (
     ('test', (
         'I understand this will alert anyone who has switched on the test channel'
+    )),
+    ('operator', (
+        'I understand this will alert anyone who has switched on the operator channel'
     )),
     ('severe', (
         'I understand this will alert millions of people'

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -5501,6 +5501,7 @@ def test_service_set_broadcast_channel(
 
     expected_labels = [
         "Training mode",
+        "Operator channel",
         "Test channel",
         "Live channel",
         "Government channel",
@@ -5590,6 +5591,11 @@ def test_service_set_broadcast_channel_has_radio_selected_for_broadcast_service(
             'training',
             '.service_confirm_broadcast_account_type',
             {'account_type': 'training-test-all'},
+        ),
+        (
+            'operator',
+            '.service_set_broadcast_network',
+            {'broadcast_channel': 'operator'},
         ),
         (
             'test',
@@ -5693,6 +5699,7 @@ def test_service_set_broadcast_network_has_radio_selected(
     (
         ('severe', {'all_networks': True}, 'live-severe-all'),
         ('government', {'all_networks': True}, 'live-government-all'),
+        ('operator', {'all_networks': True}, 'live-operator-all'),
         ('test', {'all_networks': True}, 'live-test-all'),
         ('test', {'all_networks': False, 'network': 'o2'}, 'live-test-o2'),
         ('test', {'all_networks': False, 'network': 'ee'}, 'live-test-ee'),
@@ -5732,7 +5739,7 @@ def test_service_set_broadcast_network(
         {'all_networks': ''},  # Missing choice of MNO
     ),
 )
-@pytest.mark.parametrize('broadcast_channel', ['government', 'severe', 'test'])
+@pytest.mark.parametrize('broadcast_channel', ['government', 'severe', 'test', 'operator'])
 def test_service_set_broadcast_network_makes_you_choose(
     client_request,
     platform_admin_user,
@@ -5759,6 +5766,12 @@ def test_service_set_broadcast_network_makes_you_choose(
         ('training-test-all', [
             'Training',
             'No phones will receive alerts sent from this service.',
+        ]),
+        ('live-operator-all', [
+            'Operator',
+            'Members of the public who have switched on the operator '
+            'channel on their phones will receive alerts sent from '
+            'this service.',
         ]),
         ('live-test-ee', [
             'Test (EE)',
@@ -5833,6 +5846,7 @@ def test_service_confirm_broadcast_account_type_confirmation_page(
     'value,service_mode,broadcast_channel,allowed_broadcast_provider',
     [
         ("training-test-all", "training", "test", "all"),
+        ("live-operator-o2", "live", "operator", "o2"),
         ("live-test-vodafone", "live", "test", "vodafone"),
         ("live-severe-all", "live", "severe", "all"),
         ("live-government-all", "live", "government", "all"),


### PR DESCRIPTION
Was just in one of those meetings where it felt like writing this would take less time than I’d already spent talking about its relative priority…

---

In the admin app you can already set the broadcast channel as 'test', 'severe' or 'government'.

Aim:
- Add the 'operator' channel to the list of channels you can pick for the admin app broadcast services

Note:
- The API already supports this - https://github.com/alphagov/notifications-api/pull/3262
- The CBC proxy does not yet support the operator channel and this will need a separate card. That card has not yet been written because the interface has not been agreed between us and the MNOs yet.
- Will need to have the ability to select the operator channel for just a single MNO like we do for the other channels
- If we add this, we shouldn't actually start using it until the MNO in question gives us the go ahead.

---

https://www.pivotaltracker.com/story/show/178485177

---

![image](https://user-images.githubusercontent.com/355079/121678939-b6ce6800-caaf-11eb-8c1d-77924e3fcd16.png)
![image](https://user-images.githubusercontent.com/355079/121678964-be8e0c80-caaf-11eb-8cc6-62812e522399.png)
![image](https://user-images.githubusercontent.com/355079/121678988-c483ed80-caaf-11eb-800d-7ffca7141469.png)
![image](https://user-images.githubusercontent.com/355079/121679116-e67d7000-caaf-11eb-9b82-f871cbd24eec.png)
![image](https://user-images.githubusercontent.com/355079/121679236-0745c580-cab0-11eb-97eb-290331bfc2f4.png)
![image](https://user-images.githubusercontent.com/355079/121679272-0f056a00-cab0-11eb-81ac-cbb26aa10a29.png)
