### PR TITLE
Move the '- archived' label for organisations to be next to the org name

### DIFF
--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -17,13 +17,13 @@
       {% for org in organisations %}
         <li class="browse-list-item">
           <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="govuk-link govuk-link--no-visited-state">{{ org.name }}</a>
+          {% if not org.active %}
+            <span class="table-field-status-default heading-medium">- archived</span>
+          {% endif %}
           <p class="browse-list-hint">
             {{ org.count_of_live_services }}
             live service{% if org.count_of_live_services != 1 %}s{% endif %}
           </p>
-          {% if not org.active %}
-            <span class="table-field-status-default heading-medium">- archived</span>
-          {% endif %}
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Before:
<img width="408" alt="Screenshot 2021-06-14 at 12 18 50" src="https://user-images.githubusercontent.com/12881990/121886828-d2cf4500-cd0d-11eb-9750-f9f940d84d0f.png">

After:
<img width="328" alt="Screenshot 2021-06-14 at 12 33 26" src="https://user-images.githubusercontent.com/12881990/121886843-d95dbc80-cd0d-11eb-92d6-eb0e21743244.png">
