### PR TITLE
Show an error if user cannot login with WebAuthn

### DIFF
--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -2,8 +2,14 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/webauthn-api-check.html" import webauthn_api_check %}
+{% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% set page_title = 'Get your security key' %}
+
+{% block extra_javascripts_before_body %}
+  {{ webauthn_api_check() }}
+{% endblock %}
 
 {% block per_page_title %}
   {{ page_title }}
@@ -15,17 +21,29 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       {{ page_header(page_title) }}
+
       <p class="govuk-body">
         You need to have your security key to sign in.
       </p>
+
       {{ govukButton({
         "element": "button",
         "text": "Check security key",
-        "classes": "govuk-button--secondary",
+        "classes": "govuk-button--secondary webauthn__api-required",
         "attributes": {
           "data-module": "authenticate-security-key",
           "data-csrf-token": csrf_token(),
         }
+      }) }}
+
+      {{ govukErrorMessage({
+        "classes": "webauthn__api-missing",
+        "text": "Your browser does not support security keys. Try signing in to Notify using a different browser."
+      }) }}
+
+      {{ govukErrorMessage({
+        "classes": "webauthn__no-js",
+        "text": "JavaScript is not available for this page. Security keys need JavaScript to work."
       }) }}
     </div>
     <div class="govuk-grid-column-one-quarter">


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1443052

This follows the same approach as for registration [1]. None of
this code is tested, as:

- We don't have a way to test inline JS.
- The risk of this code not working is low.
- We might change the approach in future [2].

[1]: https://github.com/alphagov/notifications-admin/pull/3886
[2]: https://github.com/alphagov/notifications-admin/pull/3886#issuecomment-841128380

## Screenshots

| Error (no JS)  | Error (JS, but no WebAuthn) |
| ------------- | ------------- |
| <img width="809" alt="Screenshot 2021-06-15 at 14 03 42" src="https://user-images.githubusercontent.com/9029009/122057483-9588b700-cde2-11eb-9424-f7f1f2258f74.png"> | <img width="832" alt="Screenshot 2021-06-15 at 14 04 13" src="https://user-images.githubusercontent.com/9029009/122057503-9ae60180-cde2-11eb-8a0a-059e92277cee.png"> |



[1]: https://github.com/alphagov/notifications-admin/pull/3886