### PR TITLE
Use the new broadcast permissions

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1031,7 +1031,7 @@ class BroadcastPermissionsForm(BasePermissionsForm):
         ],
         filters=[filter_by_broadcast_permissions],
         param_extensions={
-            "hint": {"text": "All team members can see sent messages."}
+            "hint": {"text": "Team members with permission to add alerts or approve alerts can also reject them."}
         }
     )
 

--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -115,7 +115,7 @@ def get_broadcast_dashboard_partials(service_id):
 
 
 @main.route('/services/<uuid:service_id>/new-broadcast', methods=['GET', 'POST'])
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def new_broadcast(service_id):
     form = NewBroadcastForm()
@@ -138,7 +138,7 @@ def new_broadcast(service_id):
 
 
 @main.route('/services/<uuid:service_id>/write-new-broadcast', methods=['GET', 'POST'])
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def write_new_broadcast(service_id):
     form = BroadcastTemplateForm()
@@ -162,7 +162,7 @@ def write_new_broadcast(service_id):
 
 
 @main.route('/services/<uuid:service_id>/new-broadcast/<uuid:template_id>')
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def broadcast(service_id, template_id):
     return redirect(url_for(
@@ -176,7 +176,7 @@ def broadcast(service_id, template_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/areas')
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def preview_broadcast_areas(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
@@ -203,7 +203,7 @@ def preview_broadcast_areas(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries')
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_library(service_id, broadcast_message_id):
     return render_template(
@@ -220,7 +220,7 @@ def choose_broadcast_library(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_area(service_id, broadcast_message_id, library_slug):
     broadcast_message = BroadcastMessage.from_id(
@@ -280,7 +280,7 @@ def _get_broadcast_sub_area_back_link(service_id, broadcast_message_id, library_
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>/<area_slug>',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, area_slug):
     broadcast_message = BroadcastMessage.from_id(
@@ -332,7 +332,7 @@ def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, ar
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/remove/<area_slug>')
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def remove_broadcast_area(service_id, broadcast_message_id, area_slug):
     BroadcastMessage.from_id(
@@ -352,7 +352,7 @@ def remove_broadcast_area(service_id, broadcast_message_id, area_slug):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/preview',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def preview_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
@@ -426,7 +426,7 @@ def view_broadcast(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/current-alerts/<uuid:broadcast_message_id>', methods=['POST'])
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def approve_broadcast_message(service_id, broadcast_message_id):
 
@@ -476,7 +476,7 @@ def approve_broadcast_message(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/reject')
-@user_has_permissions('send_messages', restrict_admin_usage=True)
+@user_has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def reject_broadcast_message(service_id, broadcast_message_id):
 
@@ -504,7 +504,7 @@ def reject_broadcast_message(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/cancel',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', restrict_admin_usage=False)
+@user_has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=False)
 @service_has_permission('broadcast')
 def cancel_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(

--- a/app/models/roles_and_permissions.py
+++ b/app/models/roles_and_permissions.py
@@ -6,6 +6,8 @@ roles = {
     'manage_service': ['manage_users', 'manage_settings'],
     'manage_api_keys': ['manage_api_keys'],
     'view_activity': ['view_activity'],
+    'create_broadcasts': ['manage_templates', 'create_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
+    'approve_broadcasts': ['approve_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
 }
 
 # same dict as above, but flipped round

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -17,7 +17,7 @@
     'current_broadcasts'
   ) }}
 
-  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+  {% if current_user.has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True) %}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -13,7 +13,7 @@
 
   {% include('views/broadcast/partials/dashboard-table.html') %}
 
-  {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+  {% if current_user.has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True) %}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,5 +1,4 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
-{% from "components/button/macro.njk" import govukButton %}
 {% from "components/details/macro.njk" import govukDetails %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
@@ -19,9 +18,10 @@
 
 {% block service_page_title %}
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+    {% if broadcast_message.created_by and broadcast_message.created_by == current_user
+      and current_user.has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
       {{ broadcast_message.template.name }} is waiting for approval
-    {% elif current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+    {% elif current_user.has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True) %}
       {% if broadcast_message.created_by %}
         {{ broadcast_message.created_by.name }}
       {% else %}
@@ -42,7 +42,8 @@
   {{ govukBackLink({ "href": back_link }) }}
 
   {% if broadcast_message.status == 'pending-approval' %}
-    {% if broadcast_message.created_by and broadcast_message.created_by == current_user and current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+    {% if broadcast_message.created_by and broadcast_message.created_by == current_user
+      and current_user.has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
           {{ broadcast_message.template.name }} is waiting for approval
@@ -55,7 +56,7 @@
             delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
             delete_link_text='Discard this alert'
           ) }}
-        {% else %}
+        {% elif current_user.has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True) %}
           <p class="govuk-body govuk-!-margin-bottom-3">
             When you use a live account you’ll need another member of
             your team to approve your alert.
@@ -79,9 +80,20 @@
               ) }}
             {% endcall %}
           </details>
+        {% elif current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
+          <p class="govuk-body">
+            You need another member of your team to approve this alert.
+          </p>
+          <p class="govuk-body">
+            This service is in training mode. No real alerts will be sent.
+          </p>
+          {{ page_footer(
+            delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+            delete_link_text='Discard this alert'
+          ) }}
         {% endif %}
       </div>
-    {% elif current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+    {% elif current_user.has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True) %}
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <h1 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">
           {% if broadcast_message.created_by %}
@@ -109,6 +121,22 @@
           delete_link_text='Reject this alert'
         ) }}
       {% endcall %}
+    {% elif current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
+      <div class="banner govuk-!-margin-bottom-6">
+        <h1 class="govuk-heading-m govuk-!-margin-bottom-3">This alert is waiting for approval</h1>
+        <p class="govuk-body">
+          Another member of your team needs to approve this alert.
+        </p>
+        {% if not current_service.live %}
+          <p class="govuk-body">
+            This service is in training mode. No real alerts will be sent.
+          </p>
+        {% endif %}
+        {{ page_footer(
+          delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+          delete_link_text='Reject this alert'
+          ) }}
+      </div>
     {% else %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">This alert is waiting for approval</h1>

--- a/app/templates/views/service-settings/service-confirm-broadcast-account-type.html
+++ b/app/templates/views/service-settings/service-confirm-broadcast-account-type.html
@@ -41,6 +41,10 @@
         </p>
       {% endif %}
 
+      <p class="govuk-body">
+        All team member permissions will be removed.
+      </p>
+
       {% call form_wrapper() %}
         {{ page_footer('Confirm') }}
       {% endcall %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -28,7 +28,7 @@
             </div>
           {% endif %}
         {% elif template.template_type == 'broadcast' %}
-          {% if current_user.has_permissions('send_messages') %}
+          {% if current_user.has_permissions('send_messages', 'create_broadcasts') %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".broadcast", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Get ready to send

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -18,10 +18,34 @@ from tests.conftest import (
 )
 
 
-def test_translate_permissions_from_db_to_admin_roles():
-    db_perms = ['send_texts', 'send_emails', 'send_letters', 'manage_templates', 'some_unknown_permission']
-    roles = translate_permissions_from_db_to_admin_roles(db_perms)
-    assert roles == {'send_messages', 'manage_templates', 'some_unknown_permission'}
+@pytest.mark.parametrize('db_roles,admin_roles', [
+    (
+        ['approve_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
+        {'approve_broadcasts'},
+    ),
+    (
+        ['manage_templates', 'create_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
+        {'create_broadcasts', 'manage_templates'},
+    ),
+    (
+        ['manage_templates'],
+        {'manage_templates'},
+    ),
+    (
+        ['create_broadcasts'],
+        set(),
+    ),
+    (
+        ['send_texts', 'send_emails', 'send_letters', 'manage_templates', 'some_unknown_permission'],
+        {'send_messages', 'manage_templates', 'some_unknown_permission'},
+    ),
+])
+def test_translate_permissions_from_db_to_admin_roles(
+    db_roles,
+    admin_roles,
+):
+    roles = translate_permissions_from_db_to_admin_roles(db_roles)
+    assert roles == admin_roles
 
 
 def test_translate_permissions_from_admin_roles_to_db():
@@ -66,7 +90,7 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     api_user_active['services'] = user_services
     api_user_active['organisations'] = user_organisations
     api_user_active['permissions'] = {
-        service_id: ['manage_service']
+        service_id: ['manage_users', 'manage_settings']
         for service_id in user_services
     }
     service = service_json(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -13,7 +13,9 @@ from tests.conftest import (
     SERVICE_ONE_ID,
     create_active_user_approve_broadcasts_permissions,
     create_active_user_create_broadcasts_permissions,
+    create_active_user_view_permissions,
     create_active_user_with_permissions,
+    create_platform_admin_user,
     normalize_spaces,
 )
 
@@ -477,13 +479,19 @@ def test_empty_broadcast_dashboard(
 
 
 @freeze_time('2020-02-20 02:20')
+@pytest.mark.parametrize('user', [
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 def test_broadcast_dashboard(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_service_templates,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
@@ -511,23 +519,22 @@ def test_broadcast_dashboard(
     )
 
 
-@pytest.mark.parametrize("user_is_platform_admin", [True, False])
+@pytest.mark.parametrize('user', [
+    create_platform_admin_user(),
+    create_active_user_view_permissions(),
+    create_active_user_approve_broadcasts_permissions(),
+])
 @pytest.mark.parametrize('endpoint', (
     '.broadcast_dashboard', '.broadcast_dashboard_previous', '.broadcast_dashboard_rejected',
 ))
-def test_broadcast_dashboard_does_not_have_button_for_view_only_user(
+def test_broadcast_dashboard_does_not_have_button_if_user_does_not_have_permission_to_create_broadcast(
     client_request,
     service_one,
-    active_user_view_permissions,
-    platform_admin_user_no_service_permissions,
     mock_get_broadcast_messages,
     endpoint,
-    user_is_platform_admin
+    user,
 ):
-    if user_is_platform_admin:
-        client_request.login(platform_admin_user_no_service_permissions)
-    else:
-        client_request.login(active_user_view_permissions)
+    client_request.login(user)
 
     service_one['permissions'] += ['broadcast']
     page = client_request.get(
@@ -561,13 +568,19 @@ def test_broadcast_dashboard_json(
 
 
 @freeze_time('2020-02-20 02:20')
+@pytest.mark.parametrize('user', [
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 def test_previous_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_service_templates,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.broadcast_dashboard_previous',
         service_id=SERVICE_ONE_ID,
@@ -596,13 +609,19 @@ def test_previous_broadcasts_page(
 
 
 @freeze_time('2020-02-20 02:20')
+@pytest.mark.parametrize('user', [
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 def test_rejected_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_service_templates,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.broadcast_dashboard_rejected',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -9,7 +9,13 @@ from freezegun import freeze_time
 
 from tests import broadcast_message_json, sample_uuid, user_json
 from tests.app.broadcast_areas.custom_polygons import BRISTOL, SKYE
-from tests.conftest import SERVICE_ONE_ID, normalize_spaces
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    create_active_user_approve_broadcasts_permissions,
+    create_active_user_create_broadcasts_permissions,
+    create_active_user_with_permissions,
+    normalize_spaces,
+)
 
 sample_uuid = sample_uuid()
 
@@ -623,11 +629,17 @@ def test_rejected_broadcasts_page(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_new_broadcast_page(
     client_request,
     service_one,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -677,11 +689,17 @@ def test_new_broadcast_page_redirects(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_write_new_broadcast_page(
     client_request,
     service_one,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.write_new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -783,13 +801,19 @@ def test_write_new_broadcast_bad_content(
     assert mock_create_broadcast_message.called is False
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_broadcast_page(
     client_request,
     service_one,
     fake_uuid,
     mock_create_broadcast_message,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     client_request.get(
         '.broadcast',
         service_id=SERVICE_ONE_ID,
@@ -803,6 +827,10 @@ def test_broadcast_page(
     ),
 
 
+@pytest.mark.parametrize('current_user', [
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 @pytest.mark.parametrize('areas_selected, areas_listed, estimates', (
     ([
         'ctry19-E92000001',
@@ -869,6 +897,7 @@ def test_preview_broadcast_areas_page(
     areas_selected,
     areas_listed,
     estimates,
+    current_user,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -882,6 +911,7 @@ def test_preview_broadcast_areas_page(
             areas=areas_selected,
         ),
     )
+    client_request.login(current_user)
     page = client_request.get(
         '.preview_broadcast_areas',
         service_id=SERVICE_ONE_ID,
@@ -901,6 +931,10 @@ def test_preview_broadcast_areas_page(
     ] == estimates
 
 
+@pytest.mark.parametrize('current_user', [
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 @pytest.mark.parametrize('polygons, expected_list_items', (
     (
         [
@@ -937,6 +971,7 @@ def test_preview_broadcast_areas_page_with_custom_polygons(
     fake_uuid,
     polygons,
     expected_list_items,
+    current_user,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -951,6 +986,7 @@ def test_preview_broadcast_areas_page_with_custom_polygons(
             simple_polygons=polygons,
         ),
     )
+    client_request.login(current_user)
     page = client_request.get(
         '.preview_broadcast_areas',
         service_id=SERVICE_ONE_ID,
@@ -1062,11 +1098,16 @@ def test_choose_broadcast_library_page(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_suggested_area_has_correct_link(
     mocker,
     client_request,
     service_one,
     fake_uuid,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -1082,6 +1123,7 @@ def test_suggested_area_has_correct_link(
             ],
         ),
     )
+    client_request.login(user)
     page = client_request.get(
         '.choose_broadcast_library',
         service_id=SERVICE_ONE_ID,
@@ -1099,13 +1141,19 @@ def test_suggested_area_has_correct_link(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_choose_broadcast_area_page(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1129,13 +1177,19 @@ def test_choose_broadcast_area_page(
     ]
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_choose_broadcast_area_page_for_area_with_sub_areas(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1171,13 +1225,19 @@ def test_choose_broadcast_area_page_for_area_with_sub_areas(
     assert choices[-1] == (partial_url_for(area_slug='lad20-E06000014'), 'York',)
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_choose_broadcast_sub_area_page_for_district_shows_checkboxes_for_wards(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(user)
     page = client_request.get(
         'main.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
@@ -1323,13 +1383,18 @@ def test_choose_broadcast_sub_area_page_for_county_shows_links_for_districts(
     assert districts[-1][1] == 'Tunbridge Wells'
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_add_broadcast_area(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     mock_update_broadcast_message,
     fake_uuid,
-    mocker
+    mocker,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
@@ -1337,6 +1402,7 @@ def test_add_broadcast_area(
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mocker.patch('app.models.broadcast_message.BroadcastMessage.get_simple_polygons', return_value=polygons)
 
+    client_request.login(user)
     client_request.post(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1451,6 +1517,10 @@ def test_add_broadcast_sub_area_county_view(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_remove_broadcast_area_page(
     client_request,
     service_one,
@@ -1458,6 +1528,7 @@ def test_remove_broadcast_area_page(
     mock_update_broadcast_message,
     fake_uuid,
     mocker,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
@@ -1465,6 +1536,7 @@ def test_remove_broadcast_area_page(
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mocker.patch('app.models.broadcast_message.BroadcastMessage.get_simple_polygons', return_value=polygons)
 
+    client_request.login(user)
     client_request.get(
         '.remove_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1487,15 +1559,20 @@ def test_remove_broadcast_area_page(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_preview_broadcast_message_page(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     mock_get_broadcast_template,
     fake_uuid,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
-
+    client_request.login(user)
     page = client_request.get(
         '.preview_broadcast_message',
         service_id=SERVICE_ONE_ID,
@@ -2258,6 +2335,11 @@ def test_request_approval(
         assert mock_update_broadcast_message_status.called is False
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+    create_active_user_approve_broadcasts_permissions(),
+))
 @freeze_time('2020-02-22T22:22:22.000000')
 def test_reject_broadcast(
     mocker,
@@ -2267,6 +2349,7 @@ def test_reject_broadcast(
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
+    user,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -2281,6 +2364,7 @@ def test_reject_broadcast(
     )
     service_one['permissions'] += ['broadcast']
 
+    client_request.login(user)
     client_request.get(
         '.reject_broadcast_message',
         service_id=SERVICE_ONE_ID,
@@ -2367,6 +2451,11 @@ def test_no_view_page_for_draft(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+    create_active_user_approve_broadcasts_permissions(),
+))
 @pytest.mark.parametrize("user_is_platform_admin", [True, False])
 def test_cancel_broadcast(
     client_request,
@@ -2376,7 +2465,8 @@ def test_cancel_broadcast(
     mock_update_broadcast_message_status,
     platform_admin_user_no_service_permissions,
     fake_uuid,
-    user_is_platform_admin
+    user_is_platform_admin,
+    user,
 ):
     """
     users with 'send_messages' permissions and platform admins should be able to cancel broadcasts.
@@ -2386,6 +2476,7 @@ def test_cancel_broadcast(
     if user_is_platform_admin:
         client_request.login(platform_admin_user_no_service_permissions)
 
+    client_request.login(user)
     page = client_request.get(
         '.cancel_broadcast_message',
         service_id=SERVICE_ONE_ID,
@@ -2409,24 +2500,27 @@ def test_cancel_broadcast(
     ) not in page
 
 
-@pytest.mark.parametrize("user_is_platform_admin", [True, False])
+@pytest.mark.parametrize('user', [
+    create_platform_admin_user(),
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+    create_active_user_approve_broadcasts_permissions(),
+])
 def test_confirm_cancel_broadcast(
     client_request,
     service_one,
     mock_get_live_broadcast_message,
     mock_get_broadcast_template,
     mock_update_broadcast_message_status,
-    platform_admin_user_no_service_permissions,
     fake_uuid,
-    user_is_platform_admin
+    user,
 ):
     """
-    users with 'send_messages' permissions and platform admins should be able to cancel broadcasts.
+    Platform admins and users with any of the broadcast permissions can cancel broadcasts.
     """
     service_one['permissions'] += ['broadcast']
 
-    if user_is_platform_admin:
-        client_request.login(platform_admin_user_no_service_permissions)
+    client_request.login(user)
 
     client_request.post(
         '.cancel_broadcast_message',

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1214,7 +1214,7 @@ def test_menu_send_messages(
             notify_admin,
             api_user_active,
             service_one,
-            ['view_activity', 'send_messages'])
+            ['view_activity', 'send_texts', 'send_emails', 'send_letters'])
         page = resp.get_data(as_text=True)
         assert url_for(
             'main.choose_template',
@@ -1248,7 +1248,7 @@ def test_menu_send_messages_when_service_does_not_have_upload_letters_permission
             notify_admin,
             api_user_active,
             service_one,
-            ['view_activity', 'send_messages'])
+            ['view_activity', 'send_texts', 'send_emails', 'send_letters'])
         page = BeautifulSoup(resp.data.decode('utf-8'), 'html.parser')
         assert page.select_one('.navigation')
         assert url_for('main.uploads', service_id=service_one['id']) not in page.select_one('.navigation')
@@ -1274,7 +1274,7 @@ def test_menu_manage_service(
             notify_admin,
             api_user_active,
             service_one,
-            ['view_activity', 'manage_templates', 'manage_service'])
+            ['view_activity', 'manage_templates', 'manage_users', 'manage_settings'])
         page = resp.get_data(as_text=True)
         assert url_for(
             'main.choose_template',

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -202,25 +202,23 @@ def test_should_show_overview_page_for_broadcast_service(
     mock_get_template_folders,
     service_one,
     active_user_view_permissions,
-    active_user_with_permissions,
+    active_user_broadcast_permissions,
 ):
     service_one['permissions'].append('broadcast')
     mocker.patch('app.models.user.Users.client_method', return_value=[
-        active_user_with_permissions,
+        active_user_broadcast_permissions,
         active_user_view_permissions,
     ])
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User (you) '
-        'Can Prepare and approve broadcasts '
-        'Can Add and edit templates '
-        'Can Manage settings and team'
+        'Can Add new alerts and templates '
+        'Can Approve alerts'
     )
     assert normalize_spaces(page.select('.user-list-item')[1].text) == (
         'Test User With Permissions (you) '
-        'Cannot Prepare and approve broadcasts '
-        'Cannot Add and edit templates '
-        'Cannot Manage settings and team'
+        'Cannot Add new alerts and templates '
+        'Cannot Approve alerts'
     )
 
 
@@ -328,9 +326,8 @@ def test_broadcast_service_only_shows_relevant_permissions(
     assert [
         (field['name'], field['value']) for field in page.select('input[type=checkbox]')
     ] == [
-        ('permissions_field', 'send_messages'),
-        ('permissions_field', 'manage_templates'),
-        ('permissions_field', 'manage_service'),
+        ('permissions_field', 'create_broadcasts'),
+        ('permissions_field', 'approve_broadcasts'),
     ]
 
 
@@ -558,28 +555,36 @@ def test_edit_user_permissions(
     (
         {
             'permissions_field': [
-                'send_messages',
-                'manage_templates',
-                'manage_service',
-                'manage_api_keys',
+                'create_broadcasts',
             ]
         },
         {
             'view_activity',
-            'send_messages',
-            'manage_service',
-            'manage_templates',
+            'create_broadcasts',
         }
     ),
     (
         {
             'permissions_field': [
-                'send_messages',
+                'approve_broadcasts',
             ]
         },
         {
             'view_activity',
-            'send_messages',
+            'approve_broadcasts',
+        }
+    ),
+    (
+        {
+            'permissions_field': [
+                'create_broadcasts',
+                'approve_broadcasts',
+            ]
+        },
+        {
+            'view_activity',
+            'create_broadcasts',
+            'approve_broadcasts',
         }
     ),
     (
@@ -1225,16 +1230,12 @@ def test_invite_user_with_email_auth_service(
     (
         {
             'permissions_field': [
-                'send_messages',
-                'manage_templates',
-                'manage_service',
+                'create_broadcasts',
             ]
         },
         {
             'view_activity',
-            'send_messages',
-            'manage_templates',
-            'manage_service',
+            'create_broadcasts',
         },
     ),
     (

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -5884,7 +5884,7 @@ def test_service_confirm_broadcast_account_type_confirmation_page(
     )
     assert [
         normalize_spaces(p.text) for p in page.select('main p')
-    ] == expected_paragraphs
+    ] == expected_paragraphs + ['All team member permissions will be removed.']
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -22,7 +22,9 @@ from tests.conftest import (
     TEMPLATE_ONE_ID,
     ElementNotFound,
     create_active_caseworking_user,
+    create_active_user_create_broadcasts_permissions,
     create_active_user_view_permissions,
+    create_active_user_with_permissions,
     create_letter_contact_block,
     create_template,
     normalize_spaces,
@@ -894,14 +896,19 @@ def test_should_be_able_to_view_a_template_with_links(
     )
 
 
+@pytest.mark.parametrize('user', (
+    create_active_user_with_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+))
 def test_view_broadcast_template(
     client_request,
     service_one,
     mock_get_broadcast_template,
     mock_get_template_folders,
-    active_user_with_permissions,
     fake_uuid,
+    user,
 ):
+    client_request.login(user)
     page = client_request.get(
         '.view_template',
         service_id=SERVICE_ONE_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3593,6 +3593,33 @@ def create_active_user_view_permissions(with_unique_id=False):
     )
 
 
+def create_active_user_create_broadcasts_permissions(with_unique_id=False):
+    return create_service_one_user(
+        id=str(uuid4()) if with_unique_id else sample_uuid(),
+        name='Test User Create Broadcasts Permission',
+        permissions={SERVICE_ONE_ID: [
+            'manage_templates',
+            'create_broadcasts',
+            'reject_broadcasts',
+            'cancel_broadcasts',
+        ]},
+        auth_type='webauthn_auth',
+    )
+
+
+def create_active_user_approve_broadcasts_permissions(with_unique_id=False):
+    return create_service_one_user(
+        id=str(uuid4()) if with_unique_id else sample_uuid(),
+        name='Test User Approve Broadcasts Permission',
+        permissions={SERVICE_ONE_ID: [
+            'approve_broadcasts',
+            'reject_broadcasts',
+            'cancel_broadcasts',
+        ]},
+        auth_type='webauthn_auth',
+    )
+
+
 def create_active_caseworking_user(with_unique_id=False):
     return create_user(
         id=str(uuid4()) if with_unique_id else sample_uuid(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1128,6 +1128,22 @@ def active_user_with_permissions(fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def active_user_broadcast_permissions(fake_uuid):
+    return create_service_one_user(
+        id=fake_uuid,
+        permissions={SERVICE_ONE_ID: [
+            'view_activity',
+            'manage_templates',
+            'create_broadcasts',
+            'reject_broadcasts',
+            'cancel_broadcasts',
+            'approve_broadcasts',
+        ]},
+        auth_type='webauthn_auth',
+    )
+
+
+@pytest.fixture(scope='function')
 def active_user_with_session(fake_uuid):
     return create_service_one_admin(
         id=fake_uuid,
@@ -2205,7 +2221,7 @@ def sample_invite(mocker, service_one):
     from_user = service_one['users'][0]
     email_address = 'invited_user@test.gov.uk'
     service_id = service_one['id']
-    permissions = 'view_activity,send_messages,manage_service,manage_api_keys'
+    permissions = 'view_activity,send_emails,send_letters,send_texts,manage_settings,manage_users,manage_api_keys'
     created_at = str(datetime.utcnow())
     auth_type = 'sms_auth'
     folder_permissions = []
@@ -3640,6 +3656,7 @@ def create_active_user_no_api_key_permission(with_unique_id=False):
         permissions={SERVICE_ONE_ID: [
             'manage_templates',
             'manage_settings',
+            'manage_users',
             'view_activity',
         ]},
     )


### PR DESCRIPTION
See the commit messages for full details, but this does a few things:
1. Makes the broadcast endpoints and the links to them work with the existing broadcast permissions and the [new ones that will be added](https://github.com/alphagov/notifications-api/pull/3274)
2. Updates the broadcast user form (and also rewrites some of the roles and permissions code which no longer works with the way we know have our admin roles and database permissions mapped to each other)
3. Adds a paragraph to the broadcast setting form to warn that [all user permissions will be removed when it is submitted](https://github.com/alphagov/notifications-api/pull/3277)

[Pivotal story](https://www.pivotaltracker.com/story/show/178482657)

### Merge after
- [x] https://github.com/alphagov/notifications-api/pull/3274
- [x] https://github.com/alphagov/notifications-api/pull/3277

### Next steps
The plan for deploying this is to remove people's permissions in the database immediately after this is deployed, then to re-add them manually. The routes will work with no changes throughout, but there will be a brief period (between deploying this code and updating the data) where viewing a user's permissions on the "manage users" page will not show the right thing.

### Screenshots for the new options for the single broadcast page
**Looking at a pending broadcast you have created when the service is in trial mode and you only have `create_broadcasts` permission**
<img width="500" alt="scenario_3" src="https://user-images.githubusercontent.com/12881990/124601695-0b22f880-de60-11eb-82b2-361ec1db6b53.png">

**Looking at a pending broadcast someone else has created when the service is in training mode and you only have `create_broadcasts` permission**
<img width="500" alt="scenario_8_training" src="https://user-images.githubusercontent.com/12881990/124601729-16762400-de60-11eb-935b-02ce0776a16c.png">

**Looking at a pending broadcast someone else has created when the service is live and you only have `create_broadcasts` permission**
<img width="500" alt="scenario-8_live" src="https://user-images.githubusercontent.com/12881990/124601755-1d049b80-de60-11eb-8177-22642c1d9cab.png">