### PR TITLE
Backup original precompiled uploads to S3

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,7 @@ class Development(Config):
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-tools'
     MOU_BUCKET_NAME = 'notify.tools-mou'
     TRANSIENT_UPLOADED_LETTERS = 'development-transient-uploaded-letters'
+    PRECOMPILED_ORIGINALS_BACKUP_LETTERS = 'development-letters-precompiled-originals-backup'
 
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
     API_HOST_NAME = 'http://localhost:6011'
@@ -112,6 +113,7 @@ class Test(Development):
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-test'
     MOU_BUCKET_NAME = 'test-mou'
     TRANSIENT_UPLOADED_LETTERS = 'test-transient-uploaded-letters'
+    PRECOMPILED_ORIGINALS_BACKUP_LETTERS = 'test-letters-precompiled-originals-backup'
     NOTIFY_ENVIRONMENT = 'test'
     API_HOST_NAME = 'http://you-forgot-to-mock-an-api-call-to'
     TEMPLATE_PREVIEW_API_HOST = 'http://localhost:9999'
@@ -131,6 +133,7 @@ class Preview(Config):
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-preview'
     MOU_BUCKET_NAME = 'notify.works-mou'
     TRANSIENT_UPLOADED_LETTERS = 'preview-transient-uploaded-letters'
+    PRECOMPILED_ORIGINALS_BACKUP_LETTERS = 'preview-letters-precompiled-originals-backup'
     NOTIFY_ENVIRONMENT = 'preview'
     CHECK_PROXY_HEADER = False
     ASSET_DOMAIN = 'static.notify.works'
@@ -148,6 +151,7 @@ class Staging(Config):
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-staging'
     MOU_BUCKET_NAME = 'staging-notify.works-mou'
     TRANSIENT_UPLOADED_LETTERS = 'staging-transient-uploaded-letters'
+    PRECOMPILED_ORIGINALS_BACKUP_LETTERS = 'staging-letters-precompiled-originals-backup'
     NOTIFY_ENVIRONMENT = 'staging'
     CHECK_PROXY_HEADER = False
     ASSET_DOMAIN = 'static.staging-notify.works'
@@ -162,6 +166,7 @@ class Live(Config):
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-production'
     MOU_BUCKET_NAME = 'notifications.service.gov.uk-mou'
     TRANSIENT_UPLOADED_LETTERS = 'production-transient-uploaded-letters'
+    PRECOMPILED_ORIGINALS_BACKUP_LETTERS = 'production-letters-precompiled-originals-backup'
     NOTIFY_ENVIRONMENT = 'live'
     CHECK_PROXY_HEADER = False
     ASSET_DOMAIN = 'static.notifications.service.gov.uk'

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -39,6 +39,7 @@ from app.main import main
 from app.main.forms import CsvUploadForm, LetterUploadPostageForm, PDFUploadForm
 from app.models.contact_list import ContactList
 from app.s3_client.s3_letter_upload_client import (
+    backup_original_letter_to_s3,
     get_letter_metadata,
     get_letter_pdf_and_metadata,
     get_transient_letter_file_location,
@@ -215,6 +216,11 @@ def upload_letter(service_id):
                 page_count=page_count,
                 filename=original_filename,
                 recipient=recipient)
+
+            backup_original_letter_to_s3(
+                pdf_file_bytes,
+                upload_id=upload_id,
+            )
 
         return redirect(
             url_for(

--- a/app/s3_client/s3_letter_upload_client.py
+++ b/app/s3_client/s3_letter_upload_client.py
@@ -10,6 +10,18 @@ def get_transient_letter_file_location(service_id, upload_id):
     return 'service-{}/{}.pdf'.format(service_id, upload_id)
 
 
+def backup_original_letter_to_s3(
+    data,
+    upload_id,
+):
+    utils_s3upload(
+        filedata=data,
+        region=current_app.config['AWS_REGION'],
+        bucket_name=current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTERS'],
+        file_location=f'{upload_id}.pdf',
+    )
+
+
 def upload_letter_to_s3(
     data,
     *,

--- a/tests/app/s3_client/test_s3_letter_upload_client.py
+++ b/tests/app/s3_client/test_s3_letter_upload_client.py
@@ -1,11 +1,30 @@
 import urllib
+import uuid
 
 from flask import current_app
 
 from app.s3_client.s3_letter_upload_client import (
     LetterMetadata,
+    backup_original_letter_to_s3,
     upload_letter_to_s3,
 )
+
+
+def test_backup_original_letter_to_s3(mocker, notify_admin):
+    s3_mock = mocker.patch('app.s3_client.s3_letter_upload_client.utils_s3upload')
+    upload_id = uuid.uuid4()
+
+    backup_original_letter_to_s3(
+        'pdf_data',
+        upload_id=upload_id,
+    )
+
+    s3_mock.assert_called_once_with(
+        bucket_name=current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTERS'],
+        file_location=f'{str(upload_id)}.pdf',
+        filedata='pdf_data',
+        region=current_app.config['AWS_REGION']
+    )
 
 
 def test_upload_letter_to_s3(mocker):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178542772

This continues the work from Template Preview [1], so that we have
a complete store of original PDFs to use for testing changes to it.

Previously we did store some originals, but these were only invalid
PDFs that had failed sanitisation; for valid PDFs, the "transient"
bucket only contains the sanitised versions, which the API deletes
/ moves when the notification is sent [2].

Since the notification is only created at a later stage [3], there's
no easy way to get the final name of the PDF we send to DVLA. Instead,
we use the "upload_id", which eventually becomes the notification ID
[4]. This should be enough to trace the file for specific debugging.

Note that we only want to store original PDFs if they're valid (and
virus free!), since there's no point testing changes with bad data.

[1]: https://github.com/alphagov/notifications-template-preview/pull/545
[2]: https://github.com/alphagov/notifications-api/blob/c44ec57c1784084d92ab54903034241c9612253d/app/service/send_notification.py#L212
[3]: https://github.com/alphagov/notifications-admin/blob/7930a53a58bd86f6fe4f979db5253b889fd10c06/app/main/views/uploads.py#L362
[4]: https://github.com/alphagov/notifications-admin/blob/7930a53a58bd86f6fe4f979db5253b889fd10c06/app/main/views/uploads.py#L373