### PR TITLE
Check the daily limit get the daily notification_count from redis.

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -272,7 +272,6 @@ def get_notifications(service_id, message_type, status_override=None):
                 message_type,
                 service_api_client.get_service_statistics(
                     service_id,
-                    today_only=False,
                     limit_days=service_data_retention_days
                 )
             )

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -612,8 +612,8 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         if e.status_code != 404:
             raise
 
-    statistics = service_api_client.get_service_statistics(service_id, today_only=True)
-    remaining_messages = (current_service.message_limit - sum(stat['requested'] for stat in statistics.values()))
+    notification_count = service_api_client.get_notification_count(service_id)
+    remaining_messages = (current_service.message_limit - notification_count)
 
     contents = s3download(service_id, upload_id)
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -43,10 +43,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         return self.get('/service/{0}'.format(service_id))
 
-    def get_service_statistics(self, service_id, today_only, limit_days=None):
-        return self.get('/service/{0}/statistics'.format(service_id), params={
-                'today_only': today_only, 'limit_days': limit_days
-            })['data']
+    def get_service_statistics(self, service_id, limit_days=None):
+        return self.get('/service/{0}/statistics'.format(service_id), params={'limit_days': limit_days})['data']
 
     def get_services(self, params_dict=None):
         """

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -40,7 +40,6 @@ def test_client_gets_service(mocker):
 @pytest.mark.parametrize('today_only, limit_days', [
     (False, None),
     (False, 30),
-    pytest.param(True, None, marks=pytest.mark.xfail(raises=AssertionError)),
 ])
 def test_client_gets_service_statistics(mocker, today_only, limit_days):
     client = ServiceAPIClient()

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -37,20 +37,15 @@ def test_client_gets_service(mocker):
     mock_get.assert_called_once_with('/service/foo')
 
 
-@pytest.mark.parametrize('today_only, limit_days', [
-    (False, None),
-    (False, 30),
-])
-def test_client_gets_service_statistics(mocker, today_only, limit_days):
+@pytest.mark.parametrize('limit_days', [None, 30])
+def test_client_gets_service_statistics(mocker, limit_days):
     client = ServiceAPIClient()
     mock_get = mocker.patch.object(client, 'get', return_value={'data': {'a': 'b'}})
 
-    ret = client.get_service_statistics('foo', today_only, limit_days)
+    ret = client.get_service_statistics('foo', limit_days)
 
     assert ret == {'a': 'b'}
-    mock_get.assert_called_once_with('/service/foo/statistics', params={
-        'today_only': today_only, 'limit_days': limit_days
-    })
+    mock_get.assert_called_once_with('/service/foo/statistics', params={'limit_days': limit_days})
 
 
 def test_client_only_updates_allowed_attributes(mocker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,7 +502,7 @@ def mock_get_service(mocker, api_user_active):
 
 @pytest.fixture(scope='function')
 def mock_get_service_statistics(mocker, api_user_active):
-    def _get(service_id, today_only, limit_days=None):
+    def _get(service_id, limit_days=None):
         return {
             'email': {'requested': 0, 'delivered': 0, 'failed': 0},
             'sms': {'requested': 0, 'delivered': 0, 'failed': 0},


### PR DESCRIPTION
The daily limit cache is set by the api when a notification is created. There is one cache key per service per day and it expires after 24 hours.