### PR TITLE
Update data format for platform admin report

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -260,9 +260,6 @@ def notifications_sent_by_service():
         ]
         result = notification_api_client.get_notification_status_by_service(start_date, end_date)
 
-        for row in result:
-            row[0] = datetime.strptime(row[0], '%a, %d %b %Y %X %Z').strftime('%Y-%m-%d')
-
         return Spreadsheet.from_rows([headers] + result).as_csv_data, 200, {
             'Content-Type': 'text/csv; charset=utf-8',
             'Content-Disposition': 'attachment; filename="{} to {} notification status per service report.csv"'.format(

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -905,9 +905,9 @@ def test_get_notifications_sent_by_service_calls_api_and_downloads_data(
     service_two,
 ):
     api_data = [
-        ['Tue, 01 Jan 2019 00:00:00 GMT', SERVICE_ONE_ID, service_one['name'], 'email', 191, 0, 0, 14, 0, 0],
-        ['Tue, 01 Jan 2019 00:00:00 GMT', SERVICE_ONE_ID, service_one['name'], 'sms', 42, 0, 0, 8, 0, 0],
-        ['Tue, 01 Jan 2019 00:00:00 GMT', SERVICE_TWO_ID, service_two['name'], 'email', 3, 1, 0, 2, 0, 0],
+        ['2019-01-01', SERVICE_ONE_ID, service_one['name'], 'email', 191, 0, 0, 14, 0, 0],
+        ['2019-01-01', SERVICE_ONE_ID, service_one['name'], 'sms', 42, 0, 0, 8, 0, 0],
+        ['2019-01-01', SERVICE_TWO_ID, service_two['name'], 'email', 3, 1, 0, 2, 0, 0],
     ]
     mocker.patch('app.main.views.platform_admin.notification_api_client.get_notification_status_by_service',
                  return_value=api_data)


### PR DESCRIPTION
The format of dates returned from API for the "Monthly notification statuses for live services" report has changed, so we no longer need to format the dates here.

https://github.com/alphagov/notifications-api/pull/3279