### PR TITLE
Use `CustomBroadcastArea` to estimate number of phones in bleed area

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -144,6 +144,10 @@ class CustomBroadcastArea(BaseBroadcastArea):
         self.name = name
         self._polygons = polygons or []
 
+    @classmethod
+    def from_polygon_objects(cls, polygon_objects):
+        return cls(name=None, polygons=polygon_objects.as_coordinate_pairs_lat_long)
+
     @property
     def polygons(self):
         return Polygons(

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -184,10 +184,17 @@ class BroadcastMessage(JSONModel):
         estimated_area = self.simple_polygons.estimated_area
 
         if estimated_area > ESTIMATED_AREA_OF_LARGEST_UK_COUNTY:
+            # For large areas, use a naïve but computationally less
+            # expensive way of counting the number of phones in the
+            # bleed area
             count = self.count_of_phones * (
                 self.simple_polygons_with_bleed.estimated_area / estimated_area
             )
         else:
+            # For smaller areas, where the computation can be done in
+            # a second or less (approximately) calculate the number of
+            # phones based on the ammount of overlap with areas for
+            # which we have population data
             count = CustomBroadcastArea.from_polygon_objects(
                 self.simple_polygons_with_bleed
             ).count_of_phones

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -830,7 +830,7 @@ def test_broadcast_page(
     ], [
         'An area of 6.3 square miles Will get the alert',
         'An extra area of 22.6 square miles is Likely to get the alert',
-        '9,000 to 40,000 phones',
+        '9,000 to 10,000 phones',
     ]),
     ([
         'lad20-E09000019',
@@ -839,7 +839,26 @@ def test_broadcast_page(
     ], [
         'An area of 9.7 square miles Will get the alert',
         'An extra area of 4.7 square miles is Likely to get the alert',
-        '200,000 to 300,000 phones',
+        '200,000 to 500,000 phones',
+    ]),
+    ([
+        'ctyua19-E10000019',
+    ], [
+        'Lincolnshire remove',
+    ], [
+        'An area of 3,986.6 square miles Will get the alert',
+        'An extra area of 599.4 square miles is Likely to get the alert',
+        '500,000 to 600,000 phones',
+    ]),
+    ([
+        'ctyua19-E10000019',
+        'ctyua19-E10000023'
+    ], [
+        'Lincolnshire remove', 'North Yorkshire remove',
+    ], [
+        'An area of 9,776.2 square miles Will get the alert',
+        'An extra area of 1,654.6 square miles is Likely to get the alert',
+        '1,000,000 phones estimated',
     ]),
 ))
 def test_preview_broadcast_areas_page(
@@ -907,7 +926,7 @@ def test_preview_broadcast_areas_page(
         [
             'An area of 3,205.0 square miles Will get the alert',
             'An extra area of 763.4 square miles is Likely to get the alert',
-            '4,000 to 5,000 phones',
+            '4,000 phones estimated',
         ]
     ),
 ))


### PR DESCRIPTION
Our current assumption is that the bleed area has the same population density as the broadcast area.

This is particularly naïve when:
- the bleed area overlaps the sea – no-one lives in the sea
- the broadcast area is a village or town and the bleed area is the surrounding countryside
- the broadcast area is adjacent to a densely populated area like a city

We can be smarter about this now that we have a way of determining the number of phones in an arbitrary area based on the known areas that we have population data about (see https://github.com/alphagov/notifications-admin/pull/3844).

Calculating the population in an overlap is a slightly more intensive calculation. So we only do it for areas which are small enough that it doesn’t slow things down too much. For larger areas (bigger than any single county) we still use the more naïve algorithm.


Before | After
---|---
<img width="744" alt="Screenshot 2021-07-02 at 14 08 38" src="https://user-images.githubusercontent.com/355079/124281287-7cea0200-db41-11eb-98f6-204f7f08f986.png"> | <img width="753" alt="Screenshot 2021-07-02 at 14 06 59" src="https://user-images.githubusercontent.com/355079/124281275-79ef1180-db41-11eb-8f78-6529764f78ff.png">
<img width="742" alt="Screenshot 2021-07-02 at 14 10 34" src="https://user-images.githubusercontent.com/355079/124281293-7e1b2f00-db41-11eb-9c8d-63fb7cd934da.png"> | <img width="746" alt="Screenshot 2021-07-02 at 14 10 58" src="https://user-images.githubusercontent.com/355079/124281301-7f4c5c00-db41-11eb-94cd-e440a853fb35.png">
<img width="748" alt="Screenshot 2021-07-02 at 14 13 02" src="https://user-images.githubusercontent.com/355079/124281303-7fe4f280-db41-11eb-93ef-6b1a72c0a028.png"> | <img width="745" alt="Screenshot 2021-07-02 at 14 13 31" src="https://user-images.githubusercontent.com/355079/124281304-807d8900-db41-11eb-9ff6-1d8f51133d7f.png">
<img width="747" alt="Screenshot 2021-07-02 at 14 17 25" src="https://user-images.githubusercontent.com/355079/124281309-81aeb600-db41-11eb-95a2-7c6c781da466.png"> | <img width="752" alt="Screenshot 2021-07-02 at 14 17 39" src="https://user-images.githubusercontent.com/355079/124281314-82dfe300-db41-11eb-817d-9ad59f8609ed.png">


***

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3943
