### PR TITLE
Send upload_id to Template Preview for logging

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -182,6 +182,7 @@ def upload_letter(service_id):
         try:
             response = sanitise_letter(
                 BytesIO(pdf_file_bytes),
+                upload_id=upload_id,
                 allow_international_letters=current_service.has_permission(
                     'international_letters'
                 ),

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -94,11 +94,12 @@ def get_page_count_for_letter(template, values=None):
     return page_count
 
 
-def sanitise_letter(pdf_file, *, allow_international_letters):
+def sanitise_letter(pdf_file, *, upload_id, allow_international_letters):
     return requests.post(
-        '{}/precompiled/sanitise?allow_international_letters={}'.format(
+        '{}/precompiled/sanitise?allow_international_letters={}&upload_id={}'.format(
             current_app.config['TEMPLATE_PREVIEW_API_HOST'],
             'true' if allow_international_letters else 'false',
+            upload_id,
         ),
         data=pdf_file,
         headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -83,6 +83,7 @@ def test_post_upload_letter_redirects_for_valid_file(
     mock_sanitise.assert_called_once_with(
         ANY,
         allow_international_letters=expected_allow_international,
+        upload_id=ANY,
     )
 
     assert 'The Queen' in page.find('div', class_='js-stick-at-bottom-when-scrolling').text

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -164,18 +164,27 @@ def test_from_example_template_makes_request(mocker):
     )
 
 
-@pytest.mark.parametrize('allow_international_letters, expected_url', (
-    (False, 'http://localhost:9999/precompiled/sanitise?allow_international_letters=false'),
-    (True, 'http://localhost:9999/precompiled/sanitise?allow_international_letters=true'),
-))
+@pytest.mark.parametrize('allow_international_letters, query_param_value', [
+    [False, "false"],
+    [True, "true"]
+])
 def test_sanitise_letter_calls_template_preview_sanitise_endoint_with_file(
     mocker,
     allow_international_letters,
-    expected_url,
+    query_param_value,
+    fake_uuid,
 ):
     request_mock = mocker.patch('app.template_previews.requests.post')
 
-    sanitise_letter('pdf_data', allow_international_letters=allow_international_letters)
+    sanitise_letter(
+        'pdf_data',
+        upload_id=fake_uuid,
+        allow_international_letters=allow_international_letters
+    )
+
+    expected_url = f'http://localhost:9999/precompiled/sanitise' \
+                   f'?allow_international_letters={query_param_value}' \
+                   f'&upload_id={fake_uuid}'
 
     request_mock.assert_called_once_with(
         expected_url,


### PR DESCRIPTION
This means we can include the anonymous ID for the file in the log
we have about Type3 fonts [1]. Currently, we have no way of tracing
manually uploaded files with this potential defect.

[1]: https://github.com/alphagov/notifications-template-preview/pull/557