### PR TITLE
Clarify service title included in SMS charges

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -686,10 +686,11 @@ def _get_content_count_error_and_message_for_template(template):
         if template.placeholders:
             return False, (
                 f'Will be charged as {message_count(template.fragment_count, template.template_type)} '
-                f'(not including personalisation)'
+                f'(includes the service name, but not any personalisation)'
             )
         return False, (
             f'Will be charged as {message_count(template.fragment_count, template.template_type)} '
+            f'(includes the service name)'
         )
 
     if template.template_type == 'broadcast':

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -25,6 +25,7 @@
           {{ textbox(
             form.template_content,
             highlight_placeholders=True,
+            hint='All messages will start with your service name',
             width='1-1',
             rows=5,
             extra_form_group_classes='govuk-!-margin-bottom-2'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2629,41 +2629,41 @@ def test_should_not_create_broadcast_template_with_placeholders(
     'template_type, prefix_sms, content, expected_message, expected_class', (
         (
             'sms', False, '',
-            'Will be charged as 1 text message',
+            'Will be charged as 1 text message (includes the service name)',
             None,
         ),
         (
             'sms', False, 'a' * 160,
-            'Will be charged as 1 text message',
+            'Will be charged as 1 text message (includes the service name)',
             None,
         ),
         (
             'sms', False, 'a' * 161,
-            'Will be charged as 2 text messages',
+            'Will be charged as 2 text messages (includes the service name)',
             None,
         ),
         (
             # service name takes 13 characters, 147 + 13 = 160
             'sms', True, 'a' * 147,
-            'Will be charged as 1 text message',
+            'Will be charged as 1 text message (includes the service name)',
             None,
         ),
         (
             # service name takes 13 characters, 148 + 13 = 161
             'sms', True, 'a' * 148,
-            'Will be charged as 2 text messages',
+            'Will be charged as 2 text messages (includes the service name)',
             None,
         ),
         (
             'sms', False, 'a' * 918,
-            'Will be charged as 6 text messages',
+            'Will be charged as 6 text messages (includes the service name)',
             None,
         ),
         (
             # Service name increases fragment count but doesn’t count
             # against total character limit
             'sms', True, 'a' * 918,
-            'Will be charged as 7 text messages',
+            'Will be charged as 7 text messages (includes the service name)',
             None,
         ),
         (
@@ -2688,17 +2688,17 @@ def test_should_not_create_broadcast_template_with_placeholders(
         ),
         (
             'sms', False, 'Ẅ' * 70,
-            'Will be charged as 1 text message',
+            'Will be charged as 1 text message (includes the service name)',
             None,
         ),
         (
             'sms', False, 'Ẅ' * 71,
-            'Will be charged as 2 text messages',
+            'Will be charged as 2 text messages (includes the service name)',
             None,
         ),
         (
             'sms', False, 'Ẅ' * 918,
-            'Will be charged as 14 text messages',
+            'Will be charged as 14 text messages (includes the service name)',
             None,
         ),
         (
@@ -2708,13 +2708,13 @@ def test_should_not_create_broadcast_template_with_placeholders(
         ),
         (
             'sms', False, 'Hello ((name))',
-            'Will be charged as 1 text message (not including personalisation)',
+            'Will be charged as 1 text message (includes the service name, but not any personalisation)',
             None,
         ),
         (
             # Length of placeholder body doesn’t count towards fragment count
             'sms', False, f'Hello (( {"a" * 999} ))',
-            'Will be charged as 1 text message (not including personalisation)',
+            'Will be charged as 1 text message (includes the service name, but not any personalisation)',
             None,
         ),
         (


### PR DESCRIPTION
We've just had a couple of tickets from different users about this
issue, so it's worth explaining it in the UI. The service name is
only shown as part of the message when viewing the preview on the
next page, but we can still explain it in words while they edit.

## Screenshots (without personalisation)

| Before  | After |
| ------------- | ------------- |
| <img width="547" alt="Screenshot 2021-07-02 at 14 19 47" src="https://user-images.githubusercontent.com/9029009/124280490-a48c9a80-db40-11eb-9f46-9bd4e061e5fa.png"> | <img width="614" alt="Screenshot 2021-07-02 at 14 19 25" src="https://user-images.githubusercontent.com/9029009/124280503-a9e9e500-db40-11eb-8ccf-93e77bf9c130.png"> |

## Screenshot (with personalisation)

| Before  | After |
| ------------- | ------------- |
| <img width="619" alt="Screenshot 2021-07-02 at 14 19 58" src="https://user-images.githubusercontent.com/9029009/124280545-ba9a5b00-db40-11eb-892e-69a40e38e6f3.png"> | <img width="706" alt="Screenshot 2021-07-02 at 14 19 34" src="https://user-images.githubusercontent.com/9029009/124280596-c84fe080-db40-11eb-8517-6af8cd121474.png"> |


