### PR TITLE
Explain about text message prefixes when editing

### DIFF
--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -16,7 +16,7 @@
     ) }}
 
     {% if current_service.prefix_sms %}
-      {% set content_hint = 'All messages will start with your service name' %}
+      {% set content_hint = 'Your message will start with your service name' %}
     {% endif %}
 
     {% call form_wrapper() %}

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -15,6 +15,10 @@
       back_link=url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
     ) }}
 
+    {% if current_service.prefix_sms %}
+      {% set content_hint = 'All messages will start with your service name' %}
+    {% endif %}
+
     {% call form_wrapper() %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -26,6 +30,7 @@
             form.template_content,
             highlight_placeholders=True,
             width='1-1',
+            hint=content_hint,
             rows=5,
             extra_form_group_classes='govuk-!-margin-bottom-2'
           ) }}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1045,7 +1045,7 @@ def test_should_show_message_with_prefix_hint_if_enabled_for_service(
         template_id=fake_uuid,
     )
 
-    assert 'All messages will start with your service name' in page.text
+    assert 'Your message will start with your service name' in page.text
 
 
 def test_should_show_page_template_with_priority_select_if_platform_admin(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1024,6 +1024,30 @@ def test_should_let_letter_contact_block_be_changed_for_the_template(
     )['href'] == expected_partial_url(service_id=SERVICE_ONE_ID)
 
 
+@pytest.mark.parametrize('prefix_sms', [
+    True,
+    pytest.param(False, marks=pytest.mark.xfail())
+])
+def test_should_show_message_with_prefix_hint_if_enabled_for_service(
+    client_request,
+    mocker,
+    mock_get_service_template,
+    mock_get_users_by_service,
+    service_one,
+    fake_uuid,
+    prefix_sms
+):
+    service_one['prefix_sms'] = prefix_sms
+
+    page = client_request.get(
+        '.edit_service_template',
+        service_id=service_one['id'],
+        template_id=fake_uuid,
+    )
+
+    assert 'All messages will start with your service name' in page.text
+
+
 def test_should_show_page_template_with_priority_select_if_platform_admin(
     platform_admin_client,
     platform_admin_user,


### PR DESCRIPTION
Supersedes: https://github.com/alphagov/notifications-admin/pull/3949

Previously this lead to 2 support tickets because the user didn't
understand why their messages was being split into 2 fragments. We
tried modifying the message about charges, but that made it more
complicated. Adding a hint should hopefully be enough.

## Screenshots (with SMS prefix turned on)

| Before  | After |
| ------------- | ------------- |
| <img width="520" alt="Screenshot 2021-07-02 at 16 30 35" src="https://user-images.githubusercontent.com/9029009/124297327-dd356f80-db52-11eb-8bfb-dea8b4524c15.png"> | <img width="535" alt="Screenshot 2021-07-02 at 16 30 17" src="https://user-images.githubusercontent.com/9029009/124297348-e292ba00-db52-11eb-83f2-3b6d7d6cef1b.png"> |

