### PR TITLE
Hide details of go live request ticket from the user 

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -243,6 +243,7 @@ def submit_request_to_go_live(service_id):
         user_email=current_user.email_address,
         user_name=current_user.name,
         tags=current_service.request_to_go_live_tags,
+        requester_sees_message_content=False,
     )
 
     current_service.update(go_live_user=current_user.id)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1737,6 +1737,7 @@ def test_should_redirect_after_request_to_go_live(
             'notify_go_live_incomplete_mou',
             'notify_go_live_incomplete_team_member',
         ],
+        requester_sees_message_content=False,
     )
     assert mock_post.call_args[1]['message'] == (
         'Service: service one\n'


### PR DESCRIPTION
We put some content in the go live ticket which is for our benefit, for example notes about the organisation.

It’s hard for us to be able to say what we want here if we know that the person making a go live request is going to see those notes.

This commit changes go live requests so that the initial content of the ticket is hidden from the person raising it (in Zendesk it will appear as an ‘internal note’, rather than a ‘public reply’).

---

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/877