### PR TITLE
Emergency alerts content review

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -64,7 +64,7 @@ def broadcast_dashboard(service_id):
     )
 
 
-@main.route('/services/<uuid:service_id>/previous-alerts')
+@main.route('/services/<uuid:service_id>/past-alerts')
 @user_has_permissions()
 @service_has_permission('broadcast')
 def broadcast_dashboard_previous(service_id):
@@ -74,8 +74,8 @@ def broadcast_dashboard_previous(service_id):
             'cancelled',
             'completed',
         ),
-        page_title='Previous alerts',
-        empty_message='You do not have any previous alerts',
+        page_title='Past alerts',
+        empty_message='You do not have any past alerts',
         view_broadcast_endpoint='.view_previous_broadcast',
     )
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -6,7 +6,7 @@
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Previous alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Past alerts</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('rejected-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_rejected', service_id=current_service.id) }}">Rejected alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>

--- a/app/templates/views/broadcast/areas.html
+++ b/app/templates/views/broadcast/areas.html
@@ -26,7 +26,7 @@
 
   {% call form_wrapper() %}
     {{ form.areas }}
-    {{ sticky_page_footer('Add to broadcast') }}
+    {{ sticky_page_footer('Continue') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/broadcast/counties.html
+++ b/app/templates/views/broadcast/counties.html
@@ -35,7 +35,7 @@
       </div>
     {% endfor %}
 
-    {{ sticky_page_footer('Add to broadcast') }}
+    {{ sticky_page_footer('Continue') }}
 
   {% endcall %}
 

--- a/app/templates/views/broadcast/libraries.html
+++ b/app/templates/views/broadcast/libraries.html
@@ -3,13 +3,13 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  Choose where to broadcast to
+  Choose where to send this alert
 {% endblock %}
 
 {% block maincolumn_content %}
 
   {{ page_header(
-    "Choose where to broadcast to",
+    "Choose where to send this alert",
     back_link=url_for(".preview_broadcast_areas", service_id=current_service.id, broadcast_message_id=broadcast_message.id)
   ) }}
 

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -54,7 +54,7 @@
   {% if broadcast_message.areas %}
     {{ map(broadcast_message) }}
     <form action="{{ url_for('.preview_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" method="get" class="govuk-!-margin-top-1">
-      {{ page_footer('Continue to preview') }}
+      {{ page_footer('Preview this alert') }}
     </form>
   {% endif %}
 

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -6,7 +6,7 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  Choose where to broadcast to
+  Choose where to send this alert
 {% endblock %}
 
 {% block extra_stylesheets %}
@@ -20,7 +20,7 @@
 {% block maincolumn_content %}
 
   {{ page_header(
-    "Choose where to broadcast to",
+    "Choose where to send this alert",
     back_link=back_link
   ) }}
 

--- a/app/templates/views/broadcast/sub-areas.html
+++ b/app/templates/views/broadcast/sub-areas.html
@@ -28,7 +28,7 @@
       {{ form.areas }}
     </div>
 
-    {{ sticky_page_footer('Add to broadcast') }}
+    {{ sticky_page_footer('Continue') }}
 
   {% endcall %}
 

--- a/app/templates/views/broadcast/tour/2.html
+++ b/app/templates/views/broadcast/tour/2.html
@@ -3,7 +3,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  In an emergency, you can broadcast an alert to every mobile phone in
+  In an emergency, you can send an alert to every mobile phone in
   the affected area at exactly the same time.
 {% endblock %}
 
@@ -15,7 +15,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="heading-medium">
-          In an emergency, you can broadcast an alert to every mobile phone in
+          In an emergency, you can send an alert to every mobile phone in
           the affected area at exactly the same time.
         </h1>
         <p class="govuk-body heading-medium govuk-!-margin-bottom-6">

--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -22,13 +22,13 @@
           You’re in training mode.
         </h1>
         <p class="govuk-body heading-medium">
-          There’s no risk of broadcasting a real alert.
+          There’s no risk of sending a real alert.
         </p>
         <p class="govuk-body heading-medium">
           Get used to the system now, so you know what to do in an&nbsp;emergency.
         </p>
         <p class="govuk-body heading-medium">
-          When you’re ready, you can turn off training mode.
+          When you’re ready, you can ask for access to the live system.
         </p>
         <p class="govuk-body heading-medium">
           <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -3,7 +3,7 @@
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}
-  Notify has not broadcast your alert because you’re in training mode.
+  Notify has not sent your alert because you’re in training mode.
 {% endblock %}
 
 {% set mainClasses = "govuk-!-padding-top-0 govuk-!-padding-bottom-0" %}
@@ -16,7 +16,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h1 class="heading-medium">
-          Notify has not broadcast your alert because you’re in training mode.
+          Notify has not sent your alert because you’re in training mode.
         </h1>
         <p class="govuk-body heading-medium">
           In a real emergency, every mobile phone in the area

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -124,7 +124,7 @@
       <p class="govuk-body govuk-!-margin-bottom-2 live-broadcast live-broadcast--left">
         Live since {{ broadcast_message.starts_at|format_datetime_relative }}&ensp;
         {%- if not hide_stop_link %}
-          <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop broadcasting</a>
+          <a href="{{ url_for('.cancel_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" class="destructive-link destructive-link--no-visited-state">Stop sending</a>
         {% endif %}
       </p>
     {% elif broadcast_message.status == 'rejected' %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -75,7 +75,7 @@
               {{ page_footer(
                 "Start broadcasting now",
                 delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-                delete_link_text='Cancel this alert'
+                delete_link_text='Reject this alert'
               ) }}
             {% endcall %}
           </details>

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -53,7 +53,7 @@
           </p>
           {{ page_footer(
             delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-            delete_link_text='Withdraw this alert'
+            delete_link_text='Discard this alert'
           ) }}
         {% else %}
           <p class="govuk-body govuk-!-margin-bottom-3">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -134,7 +134,7 @@
       </p>
     {% else %}
       <p class="govuk-body govuk-!-margin-bottom-4">
-        Broadcast
+        Sent
         {{ broadcast_message.starts_at|format_datetime_human }}.
       </p>
     {% endif %}
@@ -165,7 +165,7 @@
   {% if broadcast_message.status != 'pending-approval' %}
     <p class="govuk-body govuk-!-margin-bottom-3">
       {% if broadcast_message.created_by %}
-        Prepared by {{ broadcast_message.created_by.name }}
+        Sent by {{ broadcast_message.created_by.name }}
       {%- else %}
         Created from an API call
       {%- endif %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -31,7 +31,7 @@
           {% if current_user.has_permissions('send_messages') %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".broadcast", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
-                Prepare broadcast
+                Get ready to send
               </a>
             </div>
           {% endif %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1542,15 +1542,15 @@ def test_start_broadcasting(
         'status': 'broadcasting',
         'finishes_at': '2020-02-23T23:23:23.000000',
     }, [
-        'Live since 20 February at 8:20pm Stop broadcasting',
-        'Prepared by Alice and approved by Bob.',
+        'Live since 20 February at 8:20pm Stop sending',
+        'Sent by Alice and approved by Bob.',
         'Broadcasting stops tomorrow at 11:23pm.'
     ]),
     ('.view_current_broadcast', True, {
         'status': 'broadcasting',
         'finishes_at': '2020-02-23T23:23:23.000000',
     }, [
-        'Live since 20 February at 8:20pm Stop broadcasting',
+        'Live since 20 February at 8:20pm Stop sending',
         'Created from an API call and approved by Alice.',
         'Broadcasting stops tomorrow at 11:23pm.'
     ]),
@@ -1558,15 +1558,15 @@ def test_start_broadcasting(
         'status': 'broadcasting',
         'finishes_at': '2020-02-22T22:20:20.000000',  # 2 mins before now()
     }, [
-        'Broadcast on 20 February at 8:20pm.',
-        'Prepared by Alice and approved by Bob.',
+        'Sent on 20 February at 8:20pm.',
+        'Sent by Alice and approved by Bob.',
         'Finished broadcasting today at 10:20pm.'
     ]),
     ('.view_previous_broadcast', True, {
         'status': 'broadcasting',
         'finishes_at': '2020-02-22T22:20:20.000000',  # 2 mins before now()
     }, [
-        'Broadcast on 20 February at 8:20pm.',
+        'Sent on 20 February at 8:20pm.',
         'Created from an API call and approved by Alice.',
         'Finished broadcasting today at 10:20pm.'
     ]),
@@ -1574,8 +1574,8 @@ def test_start_broadcasting(
         'status': 'completed',
         'finishes_at': '2020-02-21T21:21:21.000000',
     }, [
-        'Broadcast on 20 February at 8:20pm.',
-        'Prepared by Alice and approved by Bob.',
+        'Sent on 20 February at 8:20pm.',
+        'Sent by Alice and approved by Bob.',
         'Finished broadcasting yesterday at 9:21pm.',
     ]),
     ('.view_previous_broadcast', False, {
@@ -1583,8 +1583,8 @@ def test_start_broadcasting(
         'cancelled_by_id': sample_uuid,
         'cancelled_at': '2020-02-21T21:21:21.000000',
     }, [
-        'Broadcast on 20 February at 8:20pm.',
-        'Prepared by Alice and approved by Bob.',
+        'Sent on 20 February at 8:20pm.',
+        'Sent by Alice and approved by Bob.',
         'Stopped by Carol yesterday at 9:21pm.',
     ]),
     ('.view_rejected_broadcast', False, {
@@ -1592,7 +1592,7 @@ def test_start_broadcasting(
         'updated_at': '2020-02-21T21:21:21.000000',
     }, [
         'Rejected yesterday at 9:21pm.',
-        'Prepared by Alice and approved by Bob.',
+        'Sent by Alice and approved by Bob.',
     ]),
 ))
 @freeze_time('2020-02-22T22:22:22.000000')
@@ -1662,7 +1662,7 @@ def test_view_broadcast_message_page(
     ),
     (
         'cancelled',
-        'Previous alerts',
+        'Past alerts',
         '.broadcast_dashboard_previous',
     ),
     (
@@ -2086,7 +2086,7 @@ def test_can_approve_own_broadcast_in_trial_mode(
     )
 
     link = page.select_one('.banner a.govuk-link.govuk-link--destructive')
-    assert link.text == 'Cancel this alert'
+    assert link.text == 'Reject this alert'
     assert link['href'] == url_for(
         '.reject_broadcast_message',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -568,7 +568,7 @@ def test_previous_broadcasts_page(
     )
 
     assert normalize_spaces(page.select_one('main h1').text) == (
-        'Previous alerts'
+        'Past alerts'
     )
     assert len(page.select('.ajax-block-container')) == 1
     assert [
@@ -1657,7 +1657,7 @@ def test_view_broadcast_message_page(
     ),
     (
         'completed',
-        'Previous alerts',
+        'Past alerts',
         '.broadcast_dashboard_previous',
     ),
     (

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2075,7 +2075,7 @@ def test_can_approve_own_broadcast_in_trial_mode(
         'alerts, to see how it works. '
         'No real alerts will be broadcast to anyone’s phone. '
         'Start broadcasting now '
-        'Cancel this alert'
+        'Reject this alert'
     )
 
     form = page.select_one('.banner details form')

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2011,7 +2011,7 @@ def test_cant_approve_own_broadcast(
     assert not page.select('form')
 
     link = page.select_one('.banner a.govuk-link.govuk-link--destructive')
-    assert link.text == 'Withdraw this alert'
+    assert link.text == 'Discard this alert'
     assert link['href'] == url_for(
         '.reject_broadcast_message',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -913,7 +913,7 @@ def test_view_broadcast_template(
         (link.text.strip(), link['href'])
         for link in page.select('.pill-separate-item')
     ] == [
-        ('Prepare broadcast', url_for(
+        ('Get ready to send', url_for(
             '.broadcast',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -509,7 +509,7 @@ def test_navigation_for_services_with_broadcast_permission(
         a['href'] for a in page.select('.navigation a')
     ] == [
         '/services/{}/current-alerts'.format(SERVICE_ONE_ID),
-        '/services/{}/previous-alerts'.format(SERVICE_ONE_ID),
+        '/services/{}/past-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/rejected-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),


### PR DESCRIPTION
This PR updates some of the UI content for emergency alerts.

Specifically:

- replacing the word 'broadcast' where it makes sense to
- replacing 'previous alerts' with 'past alerts' to be consistent with gov.uk/alerts
- making the 4 destructive actions consistent (discard, reject, stop and delete)
- updating some of the progress/action buttons to make their meaning clearer

## Why we’re doing this
We know that some of the buttons, links, page titles and other content:

- use the term `broadcast` as a noun – we want to move away from this
- ‘broadcast’ as a verb can sound a bit weird in some contexts – we want to make the UI as clear as possible for new users, even if this means using ‘send’ and ‘broadcast’
- are not consistent with the public facing content about emergency alerts
- are not consistent within the emergency alerts sender UI

We want to fix these things before onboarding more users – so any user research we do highlights the things we’ve missed, not the things we (think) we already know about.

## To discuss
Should we be changing the code as part of this PR to remove/reduce the use of 'broadcast' and make page URLs more consistent with page titles?