### PR TITLE
Show status when job has exceeded the daily sending limit

### DIFF
--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -21,8 +21,11 @@
     {% endif %}
   </p>
   {% if job.status == 'sending limits exceeded'%}
-    <p class="govuk-error-message" >
-    You have exceeded your daily sending limits. You can upload your CSV tomorrow or <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a>
+    <p class="govuk-error-message">
+        Notify cannot send these messages because you have reached your daily limit. You can only send {{ current_service.message_limit|format_thousands }} messages per day.
+    </p>
+    <p class="govuk-error-message govuk-!-margin-bottom-6">
+        Upload this spreadsheet again tomorrow or <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a> to raise the limit.
     </p>
     {% endif %}
 </div>

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -11,7 +11,7 @@
       {% else %}
         Uploaded by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
       {% endif %}
-    {% else %}
+   {% else %}
       Sent by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
       {% if job.template.template_type == "letter" %}
         <p class="govuk-body" id="printing-info">
@@ -20,4 +20,9 @@
       {% endif %}
     {% endif %}
   </p>
+  {% if job.status == 'sending limits exceeded'%}
+    <p class="govuk-error-message" >
+    You have exceeded your daily sending limits. You can upload your CSV tomorrow or <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a>
+    </p>
+    {% endif %}
 </div>

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -236,8 +236,12 @@ def test_should_show_job_with_sending_limit_exceeded_status(
         service_id=service_one['id'],
         job_id=fake_uuid,
     )
+
     assert normalize_spaces(page.select('main p')[1].text) == (
-       "You have exceeded your daily sending limits. You can upload your CSV tomorrow or contact the GOV.UK Notify team"
+        "Notify cannot send these messages because you have reached your daily limit. You can only send 1,000 messages per day." # noqa
+    )
+    assert normalize_spaces(page.select('main p')[2].text) == (
+        "Upload this spreadsheet again tomorrow or contact the GOV.UK Notify team to raise the limit."
     )
 
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -221,6 +221,26 @@ def test_should_show_job_without_notifications(
     assert page.select_one('tbody').text.strip() == 'No messages to show yet…'
 
 
+def test_should_show_job_with_sending_limit_exceeded_status(
+    client_request,
+    service_one,
+    active_user_with_permissions,
+    mock_get_service_template,
+    mock_get_job_with_sending_limits_exceeded,
+    mock_get_notifications_with_no_notifications,
+    mock_get_service_data_retention,
+    fake_uuid,
+):
+    page = client_request.get(
+        'main.view_job',
+        service_id=service_one['id'],
+        job_id=fake_uuid,
+    )
+    assert normalize_spaces(page.select('main p')[1].text) == (
+       "You have exceeded your daily sending limits. You can upload your CSV tomorrow or contact the GOV.UK Notify team"
+    )
+
+
 @freeze_time("2020-01-10 1:0:0")
 @pytest.mark.parametrize('created_at, processing_started, expected_message', (
     # Recently created, not yet started

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1542,6 +1542,19 @@ def mock_get_job_in_progress(mocker, api_user_active):
 
 
 @pytest.fixture(scope='function')
+def mock_get_job_with_sending_limits_exceeded(mocker, api_user_active):
+    def _get_job(service_id, job_id):
+        return {"data": job_json(
+            service_id, api_user_active, job_id=job_id,
+            notification_count=10,
+            notifications_requested=5,
+            job_status='sending limits exceeded',
+        )}
+
+    return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)
+
+
+@pytest.fixture(scope='function')
 def mock_get_letter_job_in_progress(mocker, api_user_active):
     def _get_job(service_id, job_id):
         return {"data": job_json(


### PR DESCRIPTION
If a job exceeds the daily sending limit, show that on the job page. The job is only created if the sending limit has been reached when the delivery app is processing the job, usually this error is caught at the time the CSV is uploaded and the job is not created.
![exceeded_daily_limit](https://user-images.githubusercontent.com/4282990/124476977-6212ca00-dd9b-11eb-868d-15bb3a88b9c1.png)
