### PR TITLE
Remove empty state step before choosing areas

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -150,7 +150,7 @@ def write_new_broadcast(service_id):
             reference=form.name.data,
         )
         return redirect(url_for(
-            '.preview_broadcast_areas',
+            '.choose_broadcast_library',
             service_id=current_service.id,
             broadcast_message_id=broadcast_message.id,
         ))
@@ -166,7 +166,7 @@ def write_new_broadcast(service_id):
 @service_has_permission('broadcast')
 def broadcast(service_id, template_id):
     return redirect(url_for(
-        '.preview_broadcast_areas',
+        '.choose_broadcast_library',
         service_id=current_service.id,
         broadcast_message_id=BroadcastMessage.create(
             service_id=service_id,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -737,7 +737,7 @@ def test_write_new_broadcast_posts(
             'template_content': 'This is a test',
         },
         _expected_redirect=url_for(
-            '.preview_broadcast_areas',
+            '.choose_broadcast_library',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
             _external=True,
@@ -795,7 +795,7 @@ def test_broadcast_page(
         service_id=SERVICE_ONE_ID,
         template_id=fake_uuid,
         _expected_redirect=url_for(
-            '.preview_broadcast_areas',
+            '.choose_broadcast_library',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
             _external=True,


### PR DESCRIPTION
We had some kind of idea that having this empty page would introduce the idea of choosing areas and reinforce that you are building up a list of areas.

But since the journey is now so simple with the button to create an alert directly on the dashboard page, maybe people don’t need this extra orientation.