### PR TITLE
Remove March to June section from roadmap page

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -17,10 +17,9 @@
 
   <ul class="list list-bullet">
     
-    <li>Add multilingual letter templates so teams can provide information in several languages</li>
-    <li>Add large-print letter templates</li>
+    <li>Help teams to write better messages (private alpha)</li>
+    <li>Investigate additional letter formats</li>
     <li>Start sending emails from nhs.uk, gov.scot and parliament.uk email addresses</li>
-    <li>Help teams to write better messages (private beta)</li>
     
   </ul>
 

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -13,17 +13,6 @@
   <p class="govuk-body">The roadmap is a guide to what we have planned, but some things might change.</p>
   <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
-  <h2 class="heading-medium">March to June 2021</h2>
-
-  <ul class="list list-bullet">
-
-    <li>Let teams see who else in their organisation is using Notify</li>
-    <li>Help teams to write better messages (alpha)</li>
-    <!--<li>Protect recipients from phishing by improving the quality of text message sender names</li>-->
-    <li>Support more file types when sharing documents by email</li>
-
-  </ul>
-
   <h2 class="heading-medium">July to December 2021</h2>
 
   <ul class="list list-bullet">


### PR DESCRIPTION
While we work on what our roadmap should look like in the future, we need to:

* remove the March to June section
* check that the rest of the roadmap is accurate

This content has been sense checked by Katie M.