### PR TITLE
Be strict about similar email addresses when inviting a user to an emergency alerts service

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1044,10 +1044,12 @@ class BaseInviteUserForm():
 
     def __init__(self, invalid_email_address, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.invalid_email_address = invalid_email_address.lower()
+        self.invalid_email_address = invalid_email_address
 
     def validate_email_address(self, field):
-        if field.data.lower() == self.invalid_email_address and not current_user.platform_admin:
+        if current_user.platform_admin:
+            return
+        if field.data.lower() == self.invalid_email_address.lower():
             raise ValidationError("You cannot send an invitation to yourself")
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1043,14 +1043,14 @@ class BroadcastPermissionsForm(BasePermissionsForm):
 class BaseInviteUserForm():
     email_address = email_address(gov_user=False)
 
-    def __init__(self, invalid_email_address, *args, **kwargs):
+    def __init__(self, inviter_email_address, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.invalid_email_address = invalid_email_address
+        self.inviter_email_address = inviter_email_address
 
     def validate_email_address(self, field):
         if current_user.platform_admin:
             return
-        if field.data.lower() == self.invalid_email_address.lower():
+        if field.data.lower() == self.inviter_email_address.lower():
             raise ValidationError("You cannot send an invitation to yourself")
 
 
@@ -1062,19 +1062,19 @@ class BroadcastInviteUserForm(BaseInviteUserForm, BroadcastPermissionsForm):
     email_address = email_address(gov_user=True)
 
     def validate_email_address(self, field):
-        if not distinct_email_addresses(field.data, self.invalid_email_address):
+        if not distinct_email_addresses(field.data, self.inviter_email_address):
             raise ValidationError("You cannot send an invitation to yourself")
 
 
 class InviteOrgUserForm(StripWhitespaceForm):
     email_address = email_address(gov_user=False)
 
-    def __init__(self, invalid_email_address, *args, **kwargs):
+    def __init__(self, inviter_email_address, *args, **kwargs):
         super(InviteOrgUserForm, self).__init__(*args, **kwargs)
-        self.invalid_email_address = invalid_email_address.lower()
+        self.inviter_email_address = inviter_email_address.lower()
 
     def validate_email_address(self, field):
-        if field.data.lower() == self.invalid_email_address and not current_user.platform_admin:
+        if field.data.lower() == self.inviter_email_address and not current_user.platform_admin:
             raise ValidationError("You cannot send an invitation to yourself")
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -62,6 +62,7 @@ from app.models.roles_and_permissions import (
     roles,
 )
 from app.utils import merge_jsonlike
+from app.utils.user import distinct_email_addresses
 
 
 def get_time_value_and_label(future_time):
@@ -1059,6 +1060,10 @@ class InviteUserForm(BaseInviteUserForm, PermissionsForm):
 
 class BroadcastInviteUserForm(BaseInviteUserForm, BroadcastPermissionsForm):
     email_address = email_address(gov_user=True)
+
+    def validate_email_address(self, field):
+        if not distinct_email_addresses(field.data, self.invalid_email_address):
+            raise ValidationError("You cannot send an invitation to yourself")
 
 
 class InviteOrgUserForm(StripWhitespaceForm):

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -59,7 +59,7 @@ def invite_user(service_id, user_id=None):
         form_class = InviteUserForm
 
     form = form_class(
-        invalid_email_address=current_user.email_address,
+        inviter_email_address=current_user.email_address,
         all_template_folders=current_service.all_template_folders,
         folder_permissions=[f['id'] for f in current_service.all_template_folders]
     )

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -184,7 +184,7 @@ def manage_org_users(org_id):
 @user_has_permissions()
 def invite_org_user(org_id):
     form = InviteOrgUserForm(
-        invalid_email_address=current_user.email_address
+        inviter_email_address=current_user.email_address
     )
     if form.validate_on_submit():
         email_address = form.email_address.data

--- a/app/utils/user.py
+++ b/app/utils/user.py
@@ -66,3 +66,14 @@ def _email_address_ends_with(email_address, known_domains):
         ))
         for known in known_domains
     )
+
+
+def normalise_email_address_aliases(email_address):
+    local_part, domain = email_address.split('@')
+    local_part = local_part.split('+')[0].replace('.', '')
+
+    return f'{local_part}@{domain}'.lower()
+
+
+def distinct_email_addresses(*args):
+    return len(args) == len(set(map(normalise_email_address_aliases, args)))


### PR DESCRIPTION
We don’t want a single person to have two accounts on an emergency alerts service because it would let them circumvent the two eyes approval process.

We can go some way towards mitigating against this by stopping people using common methods of aliasing email addresses that email providers offer. These are:
- being case insensitive
- being insensitive to the position or number of dots in the local part
  of an email address
- using ‘plus addressing’

We already prevent the first one, this pull request adds normalisation which strips out the second two before doing the comparison with the current user’s email address.

***

https://www.pivotaltracker.com/story/show/178863068