### PR TITLE
Clear user cache when broadcast service settings form is submitted

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -396,11 +396,14 @@ def service_confirm_broadcast_account_type(service_id, account_type):
         abort(404)
 
     if form.validate_on_submit():
+        cached_service_user_ids = [user.id for user in current_service.active_users]
+
         service_api_client.set_service_broadcast_settings(
             current_service.id,
             service_mode=form.account_type.service_mode,
             broadcast_channel=form.account_type.broadcast_channel,
-            provider_restriction=form.account_type.provider_restriction
+            provider_restriction=form.account_type.provider_restriction,
+            cached_service_user_ids=cached_service_user_ids
         )
         create_broadcast_account_type_change_event(
             service_id=current_service.id,

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -618,13 +618,16 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete('service-{service_id}')
     def set_service_broadcast_settings(
-        self, service_id, service_mode, broadcast_channel, provider_restriction
+        self, service_id, service_mode, broadcast_channel, provider_restriction, cached_service_user_ids
     ):
         """
         service_mode is one of "training" or "live"
-        broadcast channel is one of "test" or "severe"
+        broadcast channel is one of "operator", "test", "severe", "government"
         provider_restriction is one of "all", "three", "o2", "vodafone", "ee"
         """
+        if cached_service_user_ids:
+            redis_client.delete(*map('user-{}'.format, cached_service_user_ids))
+
         data = {
             "service_mode": service_mode,
             "broadcast_channel": broadcast_channel,

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -5883,6 +5883,7 @@ def test_service_confirm_broadcast_account_type_posts_data_to_api_and_redirects(
     broadcast_channel,
     allowed_broadcast_provider,
     fake_uuid,
+    mock_get_users_by_service,
 ):
     set_service_broadcast_settings_mock = mocker.patch('app.service_api_client.set_service_broadcast_settings')
     mock_event_handler = mocker.patch('app.main.views.service_settings.create_broadcast_account_type_change_event')
@@ -5901,6 +5902,7 @@ def test_service_confirm_broadcast_account_type_posts_data_to_api_and_redirects(
         service_mode=service_mode,
         broadcast_channel=broadcast_channel,
         provider_restriction=allowed_broadcast_provider,
+        cached_service_user_ids=[fake_uuid]
     )
     mock_event_handler.assert_called_once_with(
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
When the broadcast service settings form is submitted it now [removes all permissions for users](https://github.com/alphagov/notifications-api/pull/3277) in notifications-api. This means we need to clear the user cache.