### PR TITLE
Fix backend permissions for stopping services

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -421,7 +421,7 @@ def service_confirm_broadcast_account_type(service_id, account_type):
 @main.route("/services/<uuid:service_id>/service-settings/archive", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def archive_service(service_id):
-    if not current_service.active and (
+    if not current_service.active or not (
         current_service.trial_mode or current_user.platform_admin
     ):
         abort(403)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -447,7 +447,7 @@ def archive_service(service_id):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/suspend", methods=["GET", "POST"])
-@user_has_permissions('manage_service')
+@user_is_platform_admin
 def suspend_service(service_id):
     if request.method == 'POST':
         service_api_client.suspend_service(service_id)
@@ -460,7 +460,7 @@ def suspend_service(service_id):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/resume", methods=["GET", "POST"])
-@user_has_permissions('manage_service')
+@user_is_platform_admin
 def resume_service(service_id):
     if request.method == 'POST':
         service_api_client.resume_service(service_id)

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4111,10 +4111,12 @@ def test_switch_service_enable_international_sms_and_letters(
     assert mocked_fn.call_args[0][0] == service_one['id']
 
 
-@pytest.mark.parametrize('user', (
-    create_platform_admin_user(),
-    create_active_user_with_permissions(),
-    pytest.param(create_active_user_no_settings_permission(), marks=pytest.mark.xfail),
+@pytest.mark.parametrize('user, is_trial_service', (
+    [create_platform_admin_user(), True],
+    [create_platform_admin_user(), False],
+    [create_active_user_with_permissions(), True],
+    pytest.param(create_active_user_with_permissions(), False, marks=pytest.mark.xfail),
+    pytest.param(create_active_user_no_settings_permission(), True, marks=pytest.mark.xfail),
 ))
 def test_archive_service_after_confirm(
     client_request,
@@ -4124,8 +4126,11 @@ def test_archive_service_after_confirm(
     mock_get_organisations_and_services_for_user,
     mock_get_users_by_service,
     mock_get_service_templates,
+    service_one,
     user,
+    is_trial_service,
 ):
+    service_one['restricted'] = is_trial_service
     mock_api = mocker.patch('app.service_api_client.post')
     mock_event = mocker.patch('app.main.views.service_settings.create_archive_service_event')
     redis_delete_mock = mocker.patch('app.notify_client.service_api_client.redis_client.delete')
@@ -4149,21 +4154,26 @@ def test_archive_service_after_confirm(
     assert call(f"user-{sample_uuid()}") in redis_delete_mock.call_args_list
 
 
-@pytest.mark.parametrize('user', (
-    create_platform_admin_user(),
-    create_active_user_with_permissions(),
-    pytest.param(create_active_user_no_settings_permission(), marks=pytest.mark.xfail),
+@pytest.mark.parametrize('user, is_trial_service', (
+    [create_platform_admin_user(), True],
+    [create_platform_admin_user(), False],
+    [create_active_user_with_permissions(), True],
+    pytest.param(create_active_user_with_permissions(), False, marks=pytest.mark.xfail),
+    pytest.param(create_active_user_no_settings_permission(), True, marks=pytest.mark.xfail),
 ))
 def test_archive_service_prompts_user(
     client_request,
     mocker,
     single_reply_to_email_address,
     single_letter_contact_block,
+    service_one,
     single_sms_sender,
     mock_get_service_settings_page_common,
     user,
+    is_trial_service,
 ):
-    mocked_fn = mocker.patch('app.service_api_client.post')
+    mock_api = mocker.patch('app.service_api_client.post')
+    service_one['restricted'] = is_trial_service
     client_request.login(user)
 
     settings_page = client_request.get(
@@ -4186,7 +4196,7 @@ def test_archive_service_prompts_user(
         'There’s no way to undo this. '
         'Yes, delete'
     )
-    assert mocked_fn.called is False
+    assert mock_api.called is False
 
 
 def test_cant_archive_inactive_service(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4208,8 +4208,7 @@ def test_cant_archive_inactive_service(
 
 @pytest.mark.parametrize('user', (
     create_platform_admin_user(),
-    create_active_user_with_permissions(),
-    pytest.param(create_active_user_no_settings_permission(), marks=pytest.mark.xfail),
+    pytest.param(create_active_user_with_permissions(), marks=pytest.mark.xfail),
 ))
 def test_suspend_service_after_confirm(
     client_request,
@@ -4236,8 +4235,7 @@ def test_suspend_service_after_confirm(
 
 @pytest.mark.parametrize('user', (
     create_platform_admin_user(),
-    create_active_user_with_permissions(),
-    pytest.param(create_active_user_no_settings_permission(), marks=pytest.mark.xfail),
+    pytest.param(create_active_user_with_permissions(), marks=pytest.mark.xfail),
 ))
 def test_suspend_service_prompts_user(
     client_request,
@@ -4278,8 +4276,7 @@ def test_cant_suspend_inactive_service(
 
 @pytest.mark.parametrize('user', (
     create_platform_admin_user(),
-    create_active_user_with_permissions(),
-    pytest.param(create_active_user_no_settings_permission(), marks=pytest.mark.xfail),
+    pytest.param(create_active_user_with_permissions(), marks=pytest.mark.xfail),
 ))
 def test_resume_service_after_confirm(
     mocker,
@@ -4308,8 +4305,7 @@ def test_resume_service_after_confirm(
 
 @pytest.mark.parametrize('user', (
     create_platform_admin_user(),
-    create_active_user_with_permissions(),
-    pytest.param(create_active_user_no_settings_permission(), marks=pytest.mark.xfail),
+    pytest.param(create_active_user_with_permissions(), marks=pytest.mark.xfail),
 ))
 def test_resume_service_prompts_user(
     client_request,


### PR DESCRIPTION
In response to: [1]

I noticed we don't have backend tests / checks for the service being (in)active
when it's suspended / resumed. However, since we've fixed it so only a Platform
Admin can do these actions, I don't think we need too protective in the backend.

[1]: https://github.com/alphagov/notifications-admin/pull/3959#pullrequestreview-704091492