### PR TITLE
show error banner rather than alert when registering an invalid key

### DIFF
--- a/app/assets/javascripts/authenticateSecurityKey.js
+++ b/app/assets/javascripts/authenticateSecurityKey.js
@@ -50,22 +50,17 @@
               });
             })
             .then(response => {
-              if (response.status === 403) {
-                // flask will have `flash`ed an error message up
-                window.location.reload();
-                return;
+              if (!response.ok) {
+                throw Error(response.statusText);
               }
 
-              return response.arrayBuffer()
-                .then(cbor => {
-                  return Promise.resolve(window.CBOR.decode(cbor));
-                })
-                .catch(() => {
-                  throw Error(response.statusText);
-                })
-                .then(data => {
-                  window.location.assign(data.redirect_url);
-                });
+              return response.arrayBuffer();
+            })
+            .then(cbor => {
+              return Promise.resolve(window.CBOR.decode(cbor));
+            })
+            .then(data => {
+              window.location.assign(data.redirect_url);
             })
             .catch(error => {
               console.error(error);

--- a/app/assets/javascripts/authenticateSecurityKey.js
+++ b/app/assets/javascripts/authenticateSecurityKey.js
@@ -71,7 +71,7 @@
               console.error(error);
               // some browsers will show an error dialogue for some
               // errors; to be safe we always display an error message on the page.
-              window.GOVUK.ErrorBanner.showBanner('Something went wrong');
+              window.GOVUK.ErrorBanner.showBanner();
             });
         });
     };

--- a/app/assets/javascripts/authenticateSecurityKey.js
+++ b/app/assets/javascripts/authenticateSecurityKey.js
@@ -7,6 +7,9 @@
         .on('click', function (event) {
           event.preventDefault();
 
+          // hide any existing error prompt
+          window.GOVUK.ErrorBanner.hideBanner();
+
           fetch('/webauthn/authenticate')
             .then(response => {
               if (!response.ok) {
@@ -67,9 +70,8 @@
             .catch(error => {
               console.error(error);
               // some browsers will show an error dialogue for some
-              // errors; to be safe we always pop up an alert
-              var message = error.message || error;
-              alert('Error during authentication.\n\n' + message);
+              // errors; to be safe we always display an error message on the page.
+              window.GOVUK.ErrorBanner.showBanner('Something went wrong');
             });
         });
     };

--- a/app/assets/javascripts/errorBanner.js
+++ b/app/assets/javascripts/errorBanner.js
@@ -10,8 +10,7 @@
   */
   window.GOVUK.ErrorBanner = {
     hideBanner: () => $('.banner-dangerous').addClass('govuk-!-display-none'),
-    showBanner: (errorMessage) => $('.banner-dangerous')
-      .html(`<span class="govuk-visually-hidden">Error:</span> ${errorMessage}`)
+    showBanner: () => $('.banner-dangerous')
       .removeClass('govuk-!-display-none')
       .trigger('focus'),
   };

--- a/app/assets/javascripts/errorBanner.js
+++ b/app/assets/javascripts/errorBanner.js
@@ -1,0 +1,18 @@
+(function (window) {
+  "use strict";
+
+  /*
+  This module is intended to be used to show and hide an error banner based on a javascript trigger. You should make
+  sure the banner has an appropriate aria-live attribute, and a tabindex of -1 so that screenreaders and keyboard users
+  are alerted to the change respectively.
+
+  This may behave in unexpected ways if you have more than one element with the `banner-dangerous` class on your page.
+  */
+  window.GOVUK.ErrorBanner = {
+    hideBanner: () => $('.banner-dangerous').addClass('govuk-!-display-none'),
+    showBanner: (errorMessage) => $('.banner-dangerous')
+      .html(`<span class="govuk-visually-hidden">Error:</span> ${errorMessage}`)
+      .removeClass('govuk-!-display-none')
+      .trigger('focus'),
+  };
+})(window);

--- a/app/assets/javascripts/registerSecurityKey.js
+++ b/app/assets/javascripts/registerSecurityKey.js
@@ -49,7 +49,7 @@
               // some browsers will show an error dialogue for some
               // errors; to be safe we always display an error message on the page.
               const message = error.message || error;
-              window.GOVUK.ErrorBanner.showBanner('Something went wrong');
+              window.GOVUK.ErrorBanner.showBanner();
             });
         });
     };

--- a/app/assets/javascripts/registerSecurityKey.js
+++ b/app/assets/javascripts/registerSecurityKey.js
@@ -30,16 +30,7 @@
             })
             .then((response) => {
               if (!response.ok) {
-                return response.arrayBuffer()
-                  .then((cbor) => {
-                    return Promise.resolve(window.CBOR.decode(cbor));
-                  })
-                  .catch(() => {
-                    throw Error(response.statusText);
-                  })
-                  .then((text) => {
-                    throw Error(text);
-                  });
+                throw Error(response.statusText);
               }
 
               window.location.reload();
@@ -48,7 +39,6 @@
               console.error(error);
               // some browsers will show an error dialogue for some
               // errors; to be safe we always display an error message on the page.
-              const message = error.message || error;
               window.GOVUK.ErrorBanner.showBanner();
             });
         });

--- a/app/assets/javascripts/registerSecurityKey.js
+++ b/app/assets/javascripts/registerSecurityKey.js
@@ -7,6 +7,9 @@
         .on('click', function(event) {
           event.preventDefault();
 
+          // hide any existing error prompt
+          window.GOVUK.ErrorBanner.hideBanner();
+
           fetch('/webauthn/register')
             .then((response) => {
               if (!response.ok) {
@@ -44,9 +47,9 @@
             .catch((error) => {
               console.error(error);
               // some browsers will show an error dialogue for some
-              // errors; to be safe we always pop up an alert
-              var message = error.message || error;
-              alert('Error during registration.\n\n' + message);
+              // errors; to be safe we always display an error message on the page.
+              const message = error.message || error;
+              window.GOVUK.ErrorBanner.showBanner('Something went wrong');
             });
         });
     };

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -232,6 +232,7 @@ def user_profile_disable_platform_admin_view():
 
 
 @main.route("/user-profile/security-keys", methods=['GET'])
+@user_is_logged_in
 def user_profile_security_keys():
     if not current_user.can_use_webauthn:
         abort(403)
@@ -251,6 +252,7 @@ def user_profile_security_keys():
     methods=['GET'],
     endpoint="user_profile_confirm_delete_security_key"
 )
+@user_is_logged_in
 def user_profile_manage_security_key(key_id):
     if not current_user.can_use_webauthn:
         abort(403)
@@ -282,6 +284,7 @@ def user_profile_manage_security_key(key_id):
 
 
 @main.route("/user-profile/security-keys/<uuid:key_id>/delete", methods=['POST'])
+@user_is_logged_in
 def user_profile_delete_security_key(key_id):
     if not current_user.can_use_webauthn:
         abort(403)

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -21,6 +21,15 @@
 
 {% block maincolumn_content %}
 
+    {{ govukErrorMessage({
+      "classes": "banner-dangerous govuk-!-display-none",
+      "text": "There was a javascript error.",
+      "attributes": {
+        "aria-live": "polite",
+        "tabindex": '-1'
+      }
+    }) }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       {{ page_header(page_title) }}

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -23,7 +23,13 @@
 
     {{ govukErrorMessage({
       "classes": "banner-dangerous govuk-!-display-none",
-      "text": "There was a javascript error.",
+      "html": (
+        'There’s a problem with your security key' +
+        '<p class="govuk-body">Check you have the right key and try again. ' +
+        'If this does not work, ' +
+        '<a class="govuk-link govuk-link--no-visited-state" href=' + url_for('main.support') + ">contact us</a>." +
+        '</p>'
+      ),
       "attributes": {
         "aria-live": "polite",
         "tabindex": '-1'

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -46,6 +46,16 @@
 {% endset %}
 
   <div class="govuk-grid-row">
+
+    {{ govukErrorMessage({
+      "classes": "banner-dangerous govuk-!-display-none",
+      "text": "There was a javascript error.",
+      "attributes": {
+        "aria-live": "polite",
+        "tabindex": '-1'
+      }
+    }) }}
+
     {% if credentials %}
       <div class="govuk-grid-column-five-sixths">
         {{ page_header(page_title) }}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -49,7 +49,13 @@
 
     {{ govukErrorMessage({
       "classes": "banner-dangerous govuk-!-display-none",
-      "text": "There was a javascript error.",
+      "html": (
+        'There’s a problem with your security key' +
+        '<p class="govuk-body">Check you have the right key and try again. ' +
+        'If this does not work, ' +
+        '<a class="govuk-link govuk-link--no-visited-state" href=' + url_for('main.support') + ">contact us</a>." +
+        '</p>'
+      ),
       "attributes": {
         "aria-live": "polite",
         "tabindex": '-1'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,6 +182,7 @@ const javascripts = () => {
     paths.src + 'javascripts/registerSecurityKey.js',
     paths.src + 'javascripts/authenticateSecurityKey.js',
     paths.src + 'javascripts/updateStatus.js',
+    paths.src + 'javascripts/errorBanner.js',
     paths.src + 'javascripts/homepage.js',
     paths.src + 'javascripts/main.js',
   ])

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -181,7 +181,6 @@ def test_complete_register_handles_library_errors(
     )
 
     assert response.status_code == 400
-    assert cbor.decode(response.data) == 'error'
 
 
 def test_complete_register_handles_missing_state(
@@ -289,8 +288,6 @@ def test_complete_authentication_403s_if_key_isnt_in_users_credentials(
         assert 'user_id' not in session
         # webauthn state reset so can't replay
         assert 'webauthn_authentication_state' not in session
-        # make sure there's an error message to show when the page reloads
-        assert '_flashes' in session
 
     assert mock_verify_webauthn_login.called is False
     # make sure we incremented the failed login count
@@ -369,10 +366,6 @@ def test_verify_webauthn_login_signs_user_in_doesnt_sign_user_in_if_api_rejects(
     mocker.patch('app.user_api_client.complete_webauthn_login_attempt', return_value=(False, None))
 
     resp = client.post(url_for('main.webauthn_complete_authentication'))
-
-    with client.session_transaction() as session:
-        # make sure there's an error message to show when the page reloads
-        assert '_flashes' in session
 
     assert resp.status_code == 403
 

--- a/tests/javascripts/authenticateSecurityKey.test.js
+++ b/tests/javascripts/authenticateSecurityKey.test.js
@@ -91,8 +91,8 @@ describe('Authenticate with security key', () => {
     })
 
     // this will make the test fail if the error banner is displayed
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      done(msg)
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
+      done('didnt expect the banner to be shown')
     })
 
     button.click()
@@ -152,8 +152,7 @@ describe('Authenticate with security key', () => {
       }
     })
 
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      expect(msg).toEqual('Something went wrong')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
       done()
     })
 
@@ -174,8 +173,7 @@ describe('Authenticate with security key', () => {
       return Promise.reject(new DOMException('error'))
     })
 
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      expect(msg).toEqual('Something went wrong')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
       done()
     })
 
@@ -222,8 +220,7 @@ describe('Authenticate with security key', () => {
     })
 
 
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      expect(msg).toEqual('Something went wrong')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
       done()
     })
 

--- a/tests/javascripts/authenticateSecurityKey.test.js
+++ b/tests/javascripts/authenticateSecurityKey.test.js
@@ -5,6 +5,10 @@ beforeAll(() => {
   // populate missing values to allow consistent jest.spyOn()
   window.fetch = () => { }
   window.navigator.credentials = { get: () => { } }
+  window.GOVUK.ErrorBanner = {
+    showBanner: () => {},
+    hideBanner: () => {}
+  };
 })
 
 afterAll(() => {
@@ -22,9 +26,6 @@ describe('Authenticate with security key', () => {
     // disable console.error() so we don't see it in test output
     // you might need to comment this out to debug some failures
     jest.spyOn(console, 'error').mockImplementation(() => { })
-
-    // ensure window.alert() is implemented to simplify errors
-    jest.spyOn(window, 'alert').mockImplementation(() => { })
 
     document.body.innerHTML = `
       <button type="submit" data-module="authenticate-security-key" data-csrf-token="abc123"></button>`
@@ -89,8 +90,8 @@ describe('Authenticate with security key', () => {
       done()
     })
 
-    // this will make the test fail if the alert is called
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
+    // this will make the test fail if the error banner is displayed
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
       done(msg)
     })
 
@@ -142,7 +143,7 @@ describe('Authenticate with security key', () => {
   test.each([
     ['network'],
     ['server'],
-  ])('alerts if fetching WebAuthn fails (%s error)', (errorType, done) => {
+  ])('errors if fetching WebAuthn fails (%s error)', (errorType, done) => {
     jest.spyOn(window, 'fetch').mockImplementation((_url) => {
       if (errorType == 'network') {
         return Promise.reject('error')
@@ -151,15 +152,15 @@ describe('Authenticate with security key', () => {
       }
     })
 
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
-      expect(msg).toEqual('Error during authentication.\n\nerror')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
+      expect(msg).toEqual('Something went wrong')
       done()
     })
 
     button.click()
   })
 
-  test('alerts if comms with the authenticator fails', (done) => {
+  test('errors if comms with the authenticator fails', (done) => {
     jest.spyOn(window, 'fetch')
       .mockImplementationOnce((_url) => {
         const webauthnOptions = window.CBOR.encode('someArbitraryOptions')
@@ -173,8 +174,8 @@ describe('Authenticate with security key', () => {
       return Promise.reject(new DOMException('error'))
     })
 
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
-      expect(msg).toEqual('Error during authentication.\n\nerror')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
+      expect(msg).toEqual('Something went wrong')
       done()
     })
 
@@ -184,7 +185,7 @@ describe('Authenticate with security key', () => {
   test.each([
     ['network error'],
     ['internal server error'],
-  ])('alerts if POSTing WebAuthn credentials fails (%s)', (errorType, done) => {
+  ])('errors if POSTing WebAuthn credentials fails (%s)', (errorType, done) => {
     jest.spyOn(window, 'fetch')
       .mockImplementationOnce((_url) => {
         const webauthnOptions = window.CBOR.encode('someArbitraryOptions')
@@ -220,8 +221,9 @@ describe('Authenticate with security key', () => {
       }
     })
 
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
-      expect(msg).toEqual('Error during authentication.\n\nerror')
+
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
+      expect(msg).toEqual('Something went wrong')
       done()
     })
 
@@ -266,8 +268,8 @@ describe('Authenticate with security key', () => {
       done()
     })
 
-    // this will make the test fail if the alert is called
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
+    // this will make the test fail if the error banner is displayed
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
       done(msg)
     })
 

--- a/tests/javascripts/errorBanner.test.js
+++ b/tests/javascripts/errorBanner.test.js
@@ -1,0 +1,41 @@
+beforeAll(() => {
+  require('../../app/assets/javascripts/errorBanner.js')
+});
+
+afterAll(() => {
+    require('./support/teardown.js');
+});
+
+describe("Error Banner", () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe("The `hideBanner` method", () => {
+    test("Will hide the element", () => {
+      document.body.innerHTML = `
+      <span class="govuk-error-message banner-dangerous js-error-visible">
+      </span>`;
+      window.GOVUK.ErrorBanner.hideBanner();
+      expect(document.querySelector('.banner-dangerous').classList).toContain('govuk-!-display-none')
+    });
+  });
+
+  describe("The `showBanner` method", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <span class="govuk-error-message banner-dangerous js-error-visible govuk-!-display-none">
+        </span>`;
+
+      window.GOVUK.ErrorBanner.showBanner('Some Err');
+    });
+
+    test("Will set a specific error message on the element", () => {
+      expect(document.querySelector('.banner-dangerous').textContent).toEqual('Error: Some Err')
+    });
+
+    test("Will show the element", () => {
+      expect(document.querySelector('.banner-dangerous').classList).not.toContain('govuk-!-display-none')
+    });
+  });
+});

--- a/tests/javascripts/errorBanner.test.js
+++ b/tests/javascripts/errorBanner.test.js
@@ -30,10 +30,6 @@ describe("Error Banner", () => {
       window.GOVUK.ErrorBanner.showBanner('Some Err');
     });
 
-    test("Will set a specific error message on the element", () => {
-      expect(document.querySelector('.banner-dangerous').textContent).toEqual('Error: Some Err')
-    });
-
     test("Will show the element", () => {
       expect(document.querySelector('.banner-dangerous').classList).not.toContain('govuk-!-display-none')
     });

--- a/tests/javascripts/registerSecurityKey.test.js
+++ b/tests/javascripts/registerSecurityKey.test.js
@@ -4,7 +4,11 @@ beforeAll(() => {
 
   // populate missing values to allow consistent jest.spyOn()
   window.fetch = () => {}
-  window.navigator.credentials = { create: () => {} }
+  window.navigator.credentials = { create: () => { } }
+  window.GOVUK.ErrorBanner = {
+    showBanner: () => { },
+    hideBanner: () => { }
+  };
 })
 
 afterAll(() => {
@@ -22,9 +26,6 @@ describe('Register security key', () => {
     // disable console.error() so we don't see it in test output
     // you might need to comment this out to debug some failures
     jest.spyOn(console, 'error').mockImplementation(() => {})
-
-    // ensure window.alert() is implemented to simplify errors
-    jest.spyOn(window, 'alert').mockImplementation(() => {})
 
     document.body.innerHTML = `
       <a href="#" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="register-security-key">
@@ -78,8 +79,8 @@ describe('Register security key', () => {
       done()
     })
 
-    // this will make the test fail if the alert is called
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
+    // this will make the test fail if the error banner is displayed
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
       done(msg)
     })
 
@@ -89,7 +90,7 @@ describe('Register security key', () => {
   test.each([
     ['network'],
     ['server'],
-  ])('alerts if fetching WebAuthn options fails (%s error)', (errorType, done) => {
+  ])('errors if fetching WebAuthn options fails (%s error)', (errorType, done) => {
     jest.spyOn(window, 'fetch').mockImplementation((_url) => {
       if (errorType == 'network') {
         return Promise.reject('error')
@@ -98,8 +99,8 @@ describe('Register security key', () => {
       }
     })
 
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
-      expect(msg).toEqual('Error during registration.\n\nerror')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
+      expect(msg).toEqual('Something went wrong')
       done()
     })
 
@@ -110,7 +111,7 @@ describe('Register security key', () => {
     ['network error'],
     ['internal server error'],
     ['bad request'],
-  ])('alerts if sending WebAuthn credentials fails (%s)', (errorType, done) => {
+  ])('errors if sending WebAuthn credentials fails (%s)', (errorType, done) => {
 
     jest.spyOn(window, 'fetch').mockImplementationOnce((_url) => {
       // initial fetch of options from the server
@@ -140,15 +141,15 @@ describe('Register security key', () => {
       }
     })
 
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
-      expect(msg).toEqual('Error during registration.\n\nerror')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
+      expect(msg).toEqual('Something went wrong')
       done()
     })
 
     button.click()
   })
 
-  test('alerts if comms with the authenticator fails', (done) => {
+  test('errors if comms with the authenticator fails', (done) => {
     jest.spyOn(window.navigator.credentials, 'create').mockImplementation(() => {
       return Promise.reject(new DOMException('error'))
     })
@@ -162,8 +163,8 @@ describe('Register security key', () => {
       })
     })
 
-    jest.spyOn(window, 'alert').mockImplementation((msg) => {
-      expect(msg).toEqual('Error during registration.\n\nerror')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
+      expect(msg).toEqual('Something went wrong')
       done()
     })
 

--- a/tests/javascripts/registerSecurityKey.test.js
+++ b/tests/javascripts/registerSecurityKey.test.js
@@ -107,9 +107,8 @@ describe('Register security key', () => {
   })
 
   test.each([
-    ['network error'],
-    ['internal server error'],
-    ['bad request'],
+    ['network'],
+    ['server'],
   ])('errors if sending WebAuthn credentials fails (%s)', (errorType, done) => {
 
     jest.spyOn(window, 'fetch').mockImplementationOnce((_url) => {
@@ -129,14 +128,10 @@ describe('Register security key', () => {
     jest.spyOn(window, 'fetch').mockImplementationOnce((_url) => {
       // subsequent POST of credential data to server
       switch (errorType) {
-        case 'network error':
+        case 'network':
           return Promise.reject('error')
-        case 'bad request':
-          message = Promise.resolve(window.CBOR.encode('error'))
-          return Promise.resolve({ ok: false, arrayBuffer: () => message })
-        case 'internal server error':
-          message = Promise.reject('encoding error')
-          return Promise.resolve({ ok: false, arrayBuffer: () => message, statusText: 'error' })
+        case 'server':
+          return Promise.resolve({ ok: false, statusText: 'FORBIDDEN' })
       }
     })
 

--- a/tests/javascripts/registerSecurityKey.test.js
+++ b/tests/javascripts/registerSecurityKey.test.js
@@ -80,8 +80,8 @@ describe('Register security key', () => {
     })
 
     // this will make the test fail if the error banner is displayed
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      done(msg)
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
+      done('didnt expect the banner to be shown')
     })
 
     button.click()
@@ -99,8 +99,7 @@ describe('Register security key', () => {
       }
     })
 
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      expect(msg).toEqual('Something went wrong')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
       done()
     })
 
@@ -141,8 +140,7 @@ describe('Register security key', () => {
       }
     })
 
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      expect(msg).toEqual('Something went wrong')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
       done()
     })
 
@@ -163,8 +161,7 @@ describe('Register security key', () => {
       })
     })
 
-    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation((msg) => {
-      expect(msg).toEqual('Something went wrong')
+    jest.spyOn(window.GOVUK.ErrorBanner, 'showBanner').mockImplementation(() => {
       done()
     })
 


### PR DESCRIPTION
you can test this by trying to re-register the same key twice, or by letting the prompt timeout without touching your yubikey (30 secs).

Sample what-the-user-sees, a story in three parts:

![image](https://user-images.githubusercontent.com/5020841/129580227-73458b99-0af0-4b44-9a9d-91e03036f435.png)
![image](https://user-images.githubusercontent.com/5020841/129580275-19fbe995-4962-4432-b6b8-927d8ce12e74.png)
![image](https://user-images.githubusercontent.com/5020841/129580292-fbd31435-fa39-42bd-b917-c4a8fc0bc393.png)


Depending on which browser they use, the user may not see that second error panel, that's a chrome implementation detail.
Content will need a sprinkle of @karlchillmaid magic, but I'd rather show a generic message than something that varies from browser to browser but can be as cryptic and unhelpful as something like this.

> The operation either timed out or was not allowed. See: https://www.w3.org/TR/webauthn-2/#sctn-privacy-considerations-client.