### PR TITLE
Let people ‘add’ templates separately from ‘creating’ alerts

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1031,7 +1031,7 @@ class BroadcastPermissionsForm(BasePermissionsForm):
         ],
         filters=[filter_by_broadcast_permissions],
         param_extensions={
-            "hint": {"text": "Team members with permission to add alerts or approve alerts can also reject them."}
+            "hint": {"text": "Team members who can create or approve alerts can also reject them."}
         }
     )
 

--- a/app/models/roles_and_permissions.py
+++ b/app/models/roles_and_permissions.py
@@ -23,7 +23,7 @@ permissions = (
 
 broadcast_permissions = (
     ('manage_templates', 'Add and edit templates'),
-    ('create_broadcasts', 'Add new alerts'),
+    ('create_broadcasts', 'Create new alerts'),
     ('approve_broadcasts', 'Approve alerts'),
 )
 

--- a/app/models/roles_and_permissions.py
+++ b/app/models/roles_and_permissions.py
@@ -6,7 +6,7 @@ roles = {
     'manage_service': ['manage_users', 'manage_settings'],
     'manage_api_keys': ['manage_api_keys'],
     'view_activity': ['view_activity'],
-    'create_broadcasts': ['manage_templates', 'create_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
+    'create_broadcasts': ['create_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
     'approve_broadcasts': ['approve_broadcasts', 'reject_broadcasts', 'cancel_broadcasts'],
 }
 
@@ -22,7 +22,8 @@ permissions = (
 )
 
 broadcast_permissions = (
-    ('create_broadcasts', 'Add new alerts and templates'),
+    ('manage_templates', 'Add and edit templates'),
+    ('create_broadcasts', 'Add new alerts'),
     ('approve_broadcasts', 'Approve alerts'),
 )
 

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -193,7 +193,7 @@
   {% if broadcast_message.status != 'pending-approval' %}
     <p class="govuk-body govuk-!-margin-bottom-3">
       {% if broadcast_message.created_by %}
-        Sent by {{ broadcast_message.created_by.name }}
+        Created by {{ broadcast_message.created_by.name }}
       {%- else %}
         Created from an API call
       {%- endif %}

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -37,17 +37,16 @@
       </a>
     </p>
   {% endif %}
-  <div class="govuk-grid-row">
-    {% call form_wrapper(class="govuk-grid-column-three-quarters") %}
+  {% call form_wrapper() %}
 
-      {% include 'views/manage-users/permissions.html' %}
+    {% include 'views/manage-users/permissions.html' %}
 
-        {{ page_footer(
-          'Save',
-          delete_link=url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id, delete='yes'),
-          delete_link_text='Remove this team member'
-        ) }}
+    {{ page_footer(
+      'Save',
+      delete_link=url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id, delete='yes'),
+      delete_link_text='Remove this team member'
+    ) }}
 
-    {% endcall %}
-  </div>
+  {% endcall %}
+
 {% endblock %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1656,7 +1656,7 @@ def test_start_broadcasting(
         'finishes_at': '2020-02-23T23:23:23.000000',
     }, [
         'Live since 20 February at 8:20pm Stop sending',
-        'Sent by Alice and approved by Bob.',
+        'Created by Alice and approved by Bob.',
         'Broadcasting stops tomorrow at 11:23pm.'
     ]),
     ('.view_current_broadcast', True, {
@@ -1672,7 +1672,7 @@ def test_start_broadcasting(
         'finishes_at': '2020-02-22T22:20:20.000000',  # 2 mins before now()
     }, [
         'Sent on 20 February at 8:20pm.',
-        'Sent by Alice and approved by Bob.',
+        'Created by Alice and approved by Bob.',
         'Finished broadcasting today at 10:20pm.'
     ]),
     ('.view_previous_broadcast', True, {
@@ -1688,7 +1688,7 @@ def test_start_broadcasting(
         'finishes_at': '2020-02-21T21:21:21.000000',
     }, [
         'Sent on 20 February at 8:20pm.',
-        'Sent by Alice and approved by Bob.',
+        'Created by Alice and approved by Bob.',
         'Finished broadcasting yesterday at 9:21pm.',
     ]),
     ('.view_previous_broadcast', False, {
@@ -1697,7 +1697,7 @@ def test_start_broadcasting(
         'cancelled_at': '2020-02-21T21:21:21.000000',
     }, [
         'Sent on 20 February at 8:20pm.',
-        'Sent by Alice and approved by Bob.',
+        'Created by Alice and approved by Bob.',
         'Stopped by Carol yesterday at 9:21pm.',
     ]),
     ('.view_rejected_broadcast', False, {
@@ -1705,7 +1705,7 @@ def test_start_broadcasting(
         'updated_at': '2020-02-21T21:21:21.000000',
     }, [
         'Rejected yesterday at 9:21pm.',
-        'Sent by Alice and approved by Bob.',
+        'Created by Alice and approved by Bob.',
     ]),
 ))
 @freeze_time('2020-02-22T22:22:22.000000')

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -212,12 +212,14 @@ def test_should_show_overview_page_for_broadcast_service(
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User (you) '
-        'Can Add new alerts and templates '
+        'Can Add and edit templates '
+        'Can Add new alerts '
         'Can Approve alerts'
     )
     assert normalize_spaces(page.select('.user-list-item')[1].text) == (
         'Test User With Permissions (you) '
-        'Cannot Add new alerts and templates '
+        'Cannot Add and edit templates '
+        'Cannot Add new alerts '
         'Cannot Approve alerts'
     )
 
@@ -326,6 +328,7 @@ def test_broadcast_service_only_shows_relevant_permissions(
     assert [
         (field['name'], field['value']) for field in page.select('input[type=checkbox]')
     ] == [
+        ('permissions_field', 'manage_templates'),
         ('permissions_field', 'create_broadcasts'),
         ('permissions_field', 'approve_broadcasts'),
     ]

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -213,13 +213,13 @@ def test_should_show_overview_page_for_broadcast_service(
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
         'Test User (you) '
         'Can Add and edit templates '
-        'Can Add new alerts '
+        'Can Create new alerts '
         'Can Approve alerts'
     )
     assert normalize_spaces(page.select('.user-list-item')[1].text) == (
         'Test User With Permissions (you) '
         'Cannot Add and edit templates '
-        'Cannot Add new alerts '
+        'Cannot Create new alerts '
         'Cannot Approve alerts'
     )
 


### PR DESCRIPTION
At the moment we say you either ‘add’ an alert or ‘send’ it.

This is confusing because:
- it’s two terms for the same thing
- an alert isn’t received on people’s phones until it’s approved, so this is really when it is ‘sent’ conceptually
- an alert can be rejected before anyone receives it, so the UI can say an alert that no-one ever received was sent
- adding templates and adding alerts feel conceptually quite different things (what are you adding the alert to?).

This pull request renames ‘adding‘ or ‘sending’ an alert to ‘creating’ it.

To do this in a way that doesn’t feel clunky I’ve split out the template permission to be a separate thing again, which makes all the permissions nice and distinct from each other. 

Before | After
---|---
<img width="400" alt="Screenshot 2021-07-23 at 08 54 21" src="https://user-images.githubusercontent.com/355079/126752919-8e5bc0d6-b7fa-4a14-af12-c5df5bac3c1a.png"> | <img width="401" alt="Screenshot 2021-07-23 at 08 54 43" src="https://user-images.githubusercontent.com/355079/126752952-bd7e76e2-c7b3-4d17-b118-4aa51d3200f2.png">
![image](https://user-images.githubusercontent.com/355079/126753201-30a19f49-558f-4e3f-b680-9f31bc45a7ba.png) | ![image](https://user-images.githubusercontent.com/355079/126753140-e1dd9aef-7f31-49b3-909c-ba2c19a21967.png)
