### PR TITLE
Add Pyup comment to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ docutils==0.15.2
     # via awscli
 et-xmlfile==1.1.0
     # via openpyxl
-eventlet==0.30.2
+eventlet==0.30.2 # pyup: ignore
     # via -r requirements.in
 fido2==0.9.1
     # via -r requirements.in


### PR DESCRIPTION
This matches what’s in requirements.in, but the Pyup comments don’t automatically get copied when generating requirements.txt. This causes Pyup’s safety CI to complain we’re using a version with a known vulnerability (a vulnerability which doesn’t affect us since we don’t use websockets).