### PR TITLE
Stop checking for `send_messages` permission for broadcast pages

### DIFF
--- a/app/main/views/broadcast.py
+++ b/app/main/views/broadcast.py
@@ -115,7 +115,7 @@ def get_broadcast_dashboard_partials(service_id):
 
 
 @main.route('/services/<uuid:service_id>/new-broadcast', methods=['GET', 'POST'])
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def new_broadcast(service_id):
     form = NewBroadcastForm()
@@ -138,7 +138,7 @@ def new_broadcast(service_id):
 
 
 @main.route('/services/<uuid:service_id>/write-new-broadcast', methods=['GET', 'POST'])
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def write_new_broadcast(service_id):
     form = BroadcastTemplateForm()
@@ -162,7 +162,7 @@ def write_new_broadcast(service_id):
 
 
 @main.route('/services/<uuid:service_id>/new-broadcast/<uuid:template_id>')
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def broadcast(service_id, template_id):
     return redirect(url_for(
@@ -176,7 +176,7 @@ def broadcast(service_id, template_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/areas')
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def preview_broadcast_areas(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
@@ -203,7 +203,7 @@ def preview_broadcast_areas(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries')
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_library(service_id, broadcast_message_id):
     return render_template(
@@ -220,7 +220,7 @@ def choose_broadcast_library(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_area(service_id, broadcast_message_id, library_slug):
     broadcast_message = BroadcastMessage.from_id(
@@ -280,7 +280,7 @@ def _get_broadcast_sub_area_back_link(service_id, broadcast_message_id, library_
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/libraries/<library_slug>/<area_slug>',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, area_slug):
     broadcast_message = BroadcastMessage.from_id(
@@ -332,7 +332,7 @@ def choose_broadcast_sub_area(service_id, broadcast_message_id, library_slug, ar
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/remove/<area_slug>')
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def remove_broadcast_area(service_id, broadcast_message_id, area_slug):
     BroadcastMessage.from_id(
@@ -352,7 +352,7 @@ def remove_broadcast_area(service_id, broadcast_message_id, area_slug):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/preview',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def preview_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(
@@ -426,7 +426,7 @@ def view_broadcast(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/current-alerts/<uuid:broadcast_message_id>', methods=['POST'])
-@user_has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('approve_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def approve_broadcast_message(service_id, broadcast_message_id):
 
@@ -476,7 +476,7 @@ def approve_broadcast_message(service_id, broadcast_message_id):
 
 
 @main.route('/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/reject')
-@user_has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True)
+@user_has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True)
 @service_has_permission('broadcast')
 def reject_broadcast_message(service_id, broadcast_message_id):
 
@@ -504,7 +504,7 @@ def reject_broadcast_message(service_id, broadcast_message_id):
     '/services/<uuid:service_id>/broadcast/<uuid:broadcast_message_id>/cancel',
     methods=['GET', 'POST'],
 )
-@user_has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=False)
+@user_has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=False)
 @service_has_permission('broadcast')
 def cancel_broadcast_message(service_id, broadcast_message_id):
     broadcast_message = BroadcastMessage.from_id(

--- a/app/templates/views/broadcast/dashboard.html
+++ b/app/templates/views/broadcast/dashboard.html
@@ -17,7 +17,7 @@
     'current_broadcasts'
   ) }}
 
-  {% if current_user.has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True) %}
+  {% if current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -13,7 +13,7 @@
 
   {% include('views/broadcast/partials/dashboard-table.html') %}
 
-  {% if current_user.has_permissions('send_messages', 'create_broadcasts', restrict_admin_usage=True) %}
+  {% if current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
     <div class="js-stick-at-bottom-when-scrolling">
       {{ govukButton({
         "element": "a",

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -19,9 +19,9 @@
 {% block service_page_title %}
   {% if broadcast_message.status == 'pending-approval' %}
     {% if broadcast_message.created_by and broadcast_message.created_by == current_user
-      and current_user.has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
+      and current_user.has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
       {{ broadcast_message.template.name }} is waiting for approval
-    {% elif current_user.has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True) %}
+    {% elif current_user.has_permissions('approve_broadcasts', restrict_admin_usage=True) %}
       {% if broadcast_message.created_by %}
         {{ broadcast_message.created_by.name }}
       {% else %}
@@ -43,7 +43,7 @@
 
   {% if broadcast_message.status == 'pending-approval' %}
     {% if broadcast_message.created_by and broadcast_message.created_by == current_user
-      and current_user.has_permissions('send_messages', 'create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
+      and current_user.has_permissions('create_broadcasts', 'approve_broadcasts', restrict_admin_usage=True) %}
       <div class="banner govuk-!-margin-bottom-6">
         <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
           {{ broadcast_message.template.name }} is waiting for approval
@@ -56,7 +56,7 @@
             delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
             delete_link_text='Discard this alert'
           ) }}
-        {% elif current_user.has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True) %}
+        {% elif current_user.has_permissions('approve_broadcasts', restrict_admin_usage=True) %}
           <p class="govuk-body govuk-!-margin-bottom-3">
             When you use a live account you’ll need another member of
             your team to approve your alert.
@@ -93,7 +93,7 @@
           ) }}
         {% endif %}
       </div>
-    {% elif current_user.has_permissions('send_messages', 'approve_broadcasts', restrict_admin_usage=True) %}
+    {% elif current_user.has_permissions('approve_broadcasts', restrict_admin_usage=True) %}
       {% call form_wrapper(class="banner govuk-!-margin-bottom-6") %}
         <h1 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">
           {% if broadcast_message.created_by %}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -28,7 +28,7 @@
             </div>
           {% endif %}
         {% elif template.template_type == 'broadcast' %}
-          {% if current_user.has_permissions('send_messages', 'create_broadcasts') %}
+          {% if current_user.has_permissions('create_broadcasts') %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".broadcast", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
                 Get ready to send

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2018,7 +2018,7 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
 
     client_request.login(active_user_approve_broadcasts_permission)
     page = client_request.post(
-        '.view_current_broadcast',
+        '.approve_broadcast_message',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _data={},
@@ -2441,7 +2441,7 @@ def test_confirm_approve_broadcast(
 
     client_request.login(active_user_approve_broadcasts_permission)
     client_request.post(
-        '.view_current_broadcast',
+        '.approve_broadcast_message',
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         _expected_redirect=expected_redirect(

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -14,7 +14,6 @@ from tests.conftest import (
     create_active_user_approve_broadcasts_permissions,
     create_active_user_create_broadcasts_permissions,
     create_active_user_view_permissions,
-    create_active_user_with_permissions,
     create_platform_admin_user,
     normalize_spaces,
 )
@@ -477,19 +476,15 @@ def test_empty_broadcast_dashboard(
 
 
 @freeze_time('2020-02-20 02:20')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-])
 def test_broadcast_dashboard(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_service_templates,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
@@ -566,19 +561,15 @@ def test_broadcast_dashboard_json(
 
 
 @freeze_time('2020-02-20 02:20')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-])
 def test_previous_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_service_templates,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.broadcast_dashboard_previous',
         service_id=SERVICE_ONE_ID,
@@ -607,19 +598,15 @@ def test_previous_broadcasts_page(
 
 
 @freeze_time('2020-02-20 02:20')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-])
 def test_rejected_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
     mock_get_service_templates,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.broadcast_dashboard_rejected',
         service_id=SERVICE_ONE_ID,
@@ -646,17 +633,13 @@ def test_rejected_broadcasts_page(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_new_broadcast_page(
     client_request,
     service_one,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -688,10 +671,12 @@ def test_new_broadcast_page(
 def test_new_broadcast_page_redirects(
     client_request,
     service_one,
+    active_user_create_broadcasts_permission,
     value,
     expected_redirect_endpoint,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.post(
         '.new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -706,17 +691,13 @@ def test_new_broadcast_page_redirects(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_write_new_broadcast_page(
     client_request,
     service_one,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.write_new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -762,8 +743,10 @@ def test_write_new_broadcast_posts(
     service_one,
     mock_create_broadcast_message,
     fake_uuid,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.post(
         '.write_new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -797,10 +780,12 @@ def test_write_new_broadcast_bad_content(
     service_one,
     mock_create_broadcast_message,
     fake_uuid,
+    active_user_create_broadcasts_permission,
     content,
     expected_error_message,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.post(
         '.write_new_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -818,19 +803,15 @@ def test_write_new_broadcast_bad_content(
     assert mock_create_broadcast_message.called is False
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_broadcast_page(
     client_request,
     service_one,
     fake_uuid,
     mock_create_broadcast_message,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.get(
         '.broadcast',
         service_id=SERVICE_ONE_ID,
@@ -844,10 +825,6 @@ def test_broadcast_page(
     ),
 
 
-@pytest.mark.parametrize('current_user', [
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-])
 @pytest.mark.parametrize('areas_selected, areas_listed, estimates', (
     ([
         'ctry19-E92000001',
@@ -914,7 +891,7 @@ def test_preview_broadcast_areas_page(
     areas_selected,
     areas_listed,
     estimates,
-    current_user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -928,7 +905,7 @@ def test_preview_broadcast_areas_page(
             areas=areas_selected,
         ),
     )
-    client_request.login(current_user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.preview_broadcast_areas',
         service_id=SERVICE_ONE_ID,
@@ -948,10 +925,6 @@ def test_preview_broadcast_areas_page(
     ] == estimates
 
 
-@pytest.mark.parametrize('current_user', [
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-])
 @pytest.mark.parametrize('polygons, expected_list_items', (
     (
         [
@@ -988,7 +961,7 @@ def test_preview_broadcast_areas_page_with_custom_polygons(
     fake_uuid,
     polygons,
     expected_list_items,
-    current_user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -1003,7 +976,7 @@ def test_preview_broadcast_areas_page_with_custom_polygons(
             simple_polygons=polygons,
         ),
     )
-    client_request.login(current_user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.preview_broadcast_areas',
         service_id=SERVICE_ONE_ID,
@@ -1077,6 +1050,7 @@ def test_choose_broadcast_library_page(
     client_request,
     service_one,
     fake_uuid,
+    active_user_create_broadcasts_permission,
     areas,
     expected_list,
 ):
@@ -1092,6 +1066,7 @@ def test_choose_broadcast_library_page(
             areas=areas,
         ),
     )
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.choose_broadcast_library',
         service_id=SERVICE_ONE_ID,
@@ -1115,16 +1090,12 @@ def test_choose_broadcast_library_page(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_suggested_area_has_correct_link(
     mocker,
     client_request,
     service_one,
     fake_uuid,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     mocker.patch(
@@ -1140,7 +1111,7 @@ def test_suggested_area_has_correct_link(
             ],
         ),
     )
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.choose_broadcast_library',
         service_id=SERVICE_ONE_ID,
@@ -1158,19 +1129,15 @@ def test_suggested_area_has_correct_link(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_choose_broadcast_area_page(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1194,19 +1161,15 @@ def test_choose_broadcast_area_page(
     ]
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_choose_broadcast_area_page_for_area_with_sub_areas(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1242,19 +1205,15 @@ def test_choose_broadcast_area_page_for_area_with_sub_areas(
     assert choices[-1] == (partial_url_for(area_slug='lad20-E06000014'), 'York',)
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_choose_broadcast_sub_area_page_for_district_shows_checkboxes_for_wards(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         'main.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
@@ -1316,11 +1275,13 @@ def test_choose_broadcast_sub_area_page_for_district_has_back_link(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
+    active_user_create_broadcasts_permission,
     prev_area_slug,
     expected_back_link_url,
     expected_back_link_extra_kwargs
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         'main.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
@@ -1347,8 +1308,11 @@ def test_choose_broadcast_sub_area_page_for_county_shows_links_for_districts(
     service_one,
     mock_get_draft_broadcast_message,
     fake_uuid,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
+
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         'main.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
@@ -1400,10 +1364,6 @@ def test_choose_broadcast_sub_area_page_for_county_shows_links_for_districts(
     assert districts[-1][1] == 'Tunbridge Wells'
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_add_broadcast_area(
     client_request,
     service_one,
@@ -1411,7 +1371,7 @@ def test_add_broadcast_area(
     mock_update_broadcast_message,
     fake_uuid,
     mocker,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
@@ -1419,7 +1379,7 @@ def test_add_broadcast_area(
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mocker.patch('app.models.broadcast_message.BroadcastMessage.get_simple_polygons', return_value=polygons)
 
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.post(
         '.choose_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1466,7 +1426,8 @@ def test_add_broadcast_sub_area_district_view(
     fake_uuid,
     post_data,
     expected_selected,
-    mocker
+    mocker,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
@@ -1474,6 +1435,7 @@ def test_add_broadcast_sub_area_district_view(
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mocker.patch('app.models.broadcast_message.BroadcastMessage.get_simple_polygons', return_value=polygons)
 
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.post(
         '.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
@@ -1503,6 +1465,7 @@ def test_add_broadcast_sub_area_county_view(
     mock_update_broadcast_message,
     fake_uuid,
     mocker,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
@@ -1510,6 +1473,7 @@ def test_add_broadcast_sub_area_county_view(
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mocker.patch('app.models.broadcast_message.BroadcastMessage.get_simple_polygons', return_value=polygons)
 
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.post(
         '.choose_broadcast_sub_area',
         service_id=SERVICE_ONE_ID,
@@ -1534,10 +1498,6 @@ def test_add_broadcast_sub_area_county_view(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_remove_broadcast_area_page(
     client_request,
     service_one,
@@ -1545,7 +1505,7 @@ def test_remove_broadcast_area_page(
     mock_update_broadcast_message,
     fake_uuid,
     mocker,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
     polygon_class = namedtuple("polygon_class", ["as_coordinate_pairs_lat_long"])
@@ -1553,7 +1513,7 @@ def test_remove_broadcast_area_page(
     polygons = polygon_class(as_coordinate_pairs_lat_long=coordinates)
     mocker.patch('app.models.broadcast_message.BroadcastMessage.get_simple_polygons', return_value=polygons)
 
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.get(
         '.remove_broadcast_area',
         service_id=SERVICE_ONE_ID,
@@ -1576,20 +1536,16 @@ def test_remove_broadcast_area_page(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_preview_broadcast_message_page(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
     mock_get_broadcast_template,
     fake_uuid,
-    user,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         '.preview_broadcast_message',
         service_id=SERVICE_ONE_ID,
@@ -1630,8 +1586,10 @@ def test_start_broadcasting(
     mock_get_broadcast_template,
     mock_update_broadcast_message_status,
     fake_uuid,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_create_broadcasts_permission)
     client_request.post(
         '.preview_broadcast_message',
         service_id=SERVICE_ONE_ID,
@@ -1713,7 +1671,7 @@ def test_view_broadcast_message_page(
     mocker,
     client_request,
     service_one,
-    active_user_with_permissions,
+    active_user_view_permissions,
     mock_get_broadcast_template,
     fake_uuid,
     endpoint,
@@ -1734,7 +1692,7 @@ def test_view_broadcast_message_page(
         ),
     )
     mocker.patch('app.user_api_client.get_user', side_effect=[
-        active_user_with_permissions,
+        active_user_view_permissions,
         user_json(name='Alice'),
         user_json(name='Bob'),
         user_json(name='Carol'),
@@ -1789,7 +1747,7 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
     mocker,
     client_request,
     service_one,
-    active_user_with_permissions,
+    active_user_approve_broadcasts_permission,
     mock_get_broadcast_template,
     fake_uuid,
     endpoint,
@@ -1814,6 +1772,7 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
     )
     service_one['permissions'] += ['broadcast']
 
+    client_request.login(active_user_approve_broadcasts_permission)
     page = client_request.get(
         endpoint,
         service_id=SERVICE_ONE_ID,
@@ -1834,17 +1793,13 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
 
 
 @freeze_time('2020-02-22T22:22:22.000000')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-])
 def test_view_pending_broadcast(
     mocker,
     client_request,
     service_one,
     mock_get_broadcast_template,
     fake_uuid,
-    user,
+    active_user_approve_broadcasts_permission,
 ):
     broadcast_creator = create_active_user_create_broadcasts_permissions(with_unique_id=True)
     mocker.patch(
@@ -1858,9 +1813,9 @@ def test_view_pending_broadcast(
             status='pending-approval',
         ),
     )
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     mocker.patch('app.user_api_client.get_user', side_effect=[
-        user,  # Current user
+        active_user_approve_broadcasts_permission,  # Current user
         broadcast_creator,  # User who created broadcast
     ])
     service_one['permissions'] += ['broadcast']
@@ -1895,16 +1850,12 @@ def test_view_pending_broadcast(
 
 
 @freeze_time('2020-02-22T22:22:22.000000')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-])
 def test_view_pending_broadcast_without_template(
     mocker,
     client_request,
     service_one,
     fake_uuid,
-    user,
+    active_user_approve_broadcasts_permission,
 ):
     broadcast_creator = create_active_user_create_broadcasts_permissions(with_unique_id=True)
     mocker.patch(
@@ -1920,9 +1871,9 @@ def test_view_pending_broadcast_without_template(
             content='Uh-oh',
         ),
     )
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     mocker.patch('app.user_api_client.get_user', side_effect=[
-        user,  # Current user
+        active_user_approve_broadcasts_permission,  # Current user
         broadcast_creator,  # User who created broadcast
     ])
     service_one['permissions'] += ['broadcast']
@@ -1949,16 +1900,12 @@ def test_view_pending_broadcast_without_template(
 
 
 @freeze_time('2020-02-22T22:22:22.000000')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-])
 def test_view_pending_broadcast_from_api_call(
     mocker,
     client_request,
     service_one,
     fake_uuid,
-    user,
+    active_user_approve_broadcasts_permission,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -1975,7 +1922,7 @@ def test_view_pending_broadcast_from_api_call(
     )
     service_one['permissions'] += ['broadcast']
 
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     page = client_request.get(
         '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -1997,10 +1944,6 @@ def test_view_pending_broadcast_from_api_call(
     )
 
 
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-])
 @pytest.mark.parametrize('channel, expected_label_text', (
     ('test', (
         'I understand this will alert anyone who has switched on the test channel'
@@ -2021,7 +1964,7 @@ def test_checkbox_to_confirm_non_training_broadcasts(
     client_request,
     service_one,
     fake_uuid,
-    user,
+    active_user_approve_broadcasts_permission,
     channel,
     expected_label_text,
 ):
@@ -2040,7 +1983,7 @@ def test_checkbox_to_confirm_non_training_broadcasts(
     service_one['allowed_broadcast_provider'] = 'all'
     service_one['broadcast_channel'] = channel
 
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     page = client_request.get(
         '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -2058,10 +2001,6 @@ def test_checkbox_to_confirm_non_training_broadcasts(
 
 
 @freeze_time('2020-02-22T22:22:22.000000')
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-])
 def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     mocker,
     client_request,
@@ -2069,7 +2008,7 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
-    user,
+    active_user_approve_broadcasts_permission,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -2086,7 +2025,7 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     service_one['allowed_broadcast_provider'] = 'all'
     service_one['broadcast_channel'] = 'severe'
 
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     page = client_request.post(
         '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -2106,17 +2045,13 @@ def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
 
 
 @freeze_time('2020-02-22T22:22:22.000000')
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-))
 def test_can_approve_own_broadcast_in_training_mode(
     mocker,
     client_request,
     service_one,
     mock_get_broadcast_template,
     fake_uuid,
-    user,
+    active_user_approve_broadcasts_permission,
 ):
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
@@ -2129,10 +2064,10 @@ def test_can_approve_own_broadcast_in_training_mode(
             status='pending-approval',
         ),
     )
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     mocker.patch('app.user_api_client.get_user', side_effect=[
-        user,  # Current user
-        user,  # User who created broadcast (the same)
+        active_user_approve_broadcasts_permission,  # Current user
+        active_user_approve_broadcasts_permission,  # User who created broadcast (the same)
     ])
     service_one['permissions'] += ['broadcast']
 
@@ -2187,7 +2122,6 @@ def test_can_approve_own_broadcast_in_training_mode(
 
 @freeze_time('2020-02-22T22:22:22.000000')
 @pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
     create_active_user_approve_broadcasts_permissions(),
     create_active_user_create_broadcasts_permissions(),
 ])
@@ -2251,7 +2185,7 @@ def test_view_only_user_cant_approve_broadcast_created_by_someone_else(
     mocker,
     client_request,
     service_one,
-    active_user_with_permissions,
+    active_user_create_broadcasts_permission,
     active_user_view_permissions,
     platform_admin_user_no_service_permissions,
     mock_get_broadcast_template,
@@ -2275,7 +2209,7 @@ def test_view_only_user_cant_approve_broadcast_created_by_someone_else(
         current_user = active_user_view_permissions
     mocker.patch('app.user_api_client.get_user', side_effect=[
         current_user,  # Current user
-        active_user_with_permissions,  # User who created broadcast
+        active_user_create_broadcasts_permission,  # User who created broadcast
     ])
     service_one['permissions'] += ['broadcast']
 
@@ -2409,23 +2343,23 @@ def test_user_without_approve_permission_cant_approve_broadcast_they_created(
     client_request,
     service_one,
     fake_uuid,
+    active_user_create_broadcasts_permission,
 ):
-    current_user = create_active_user_create_broadcasts_permissions()
     mocker.patch(
         'app.broadcast_message_api_client.get_broadcast_message',
         return_value=broadcast_message_json(
             id_=fake_uuid,
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            created_by_id=current_user['id'],
+            created_by_id=active_user_create_broadcasts_permission['id'],
             finishes_at=None,
             status='pending-approval',
         ),
     )
-    client_request.login(current_user)
+    client_request.login(active_user_create_broadcasts_permission)
     mocker.patch('app.user_api_client.get_user', side_effect=[
-        current_user,  # Current user
-        current_user,  # Same created the broadcast
+        active_user_create_broadcasts_permission,  # Current user
+        active_user_create_broadcasts_permission,  # Same created the broadcast
     ])
     service_one['permissions'] += ['broadcast']
 
@@ -2454,10 +2388,6 @@ def test_user_without_approve_permission_cant_approve_broadcast_they_created(
     )
 
 
-@pytest.mark.parametrize('user', [
-    create_active_user_with_permissions(),
-    create_active_user_approve_broadcasts_permissions(),
-])
 @pytest.mark.parametrize(
     'trial_mode, initial_status, post_data, expected_approval, expected_redirect',
     (
@@ -2502,7 +2432,7 @@ def test_confirm_approve_broadcast(
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
-    user,
+    active_user_approve_broadcasts_permission,
     initial_status,
     post_data,
     expected_approval,
@@ -2523,7 +2453,7 @@ def test_confirm_approve_broadcast(
     service_one['restricted'] = trial_mode
     service_one['permissions'] += ['broadcast']
 
-    client_request.login(user)
+    client_request.login(active_user_approve_broadcasts_permission)
     client_request.post(
         '.view_current_broadcast',
         service_id=SERVICE_ONE_ID,
@@ -2555,7 +2485,6 @@ def test_confirm_approve_broadcast(
 
 
 @pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
     create_active_user_create_broadcasts_permissions(),
     create_active_user_approve_broadcasts_permissions(),
 ))
@@ -2604,6 +2533,10 @@ def test_reject_broadcast(
     )
 
 
+@pytest.mark.parametrize('user', [
+    create_active_user_create_broadcasts_permissions(),
+    create_active_user_approve_broadcasts_permissions(),
+])
 @pytest.mark.parametrize('initial_status', (
     'draft',
     'rejected',
@@ -2619,6 +2552,7 @@ def test_cant_reject_broadcast_in_wrong_state(
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
+    user,
     initial_status,
 ):
     mocker.patch(
@@ -2634,6 +2568,7 @@ def test_cant_reject_broadcast_in_wrong_state(
     )
     service_one['permissions'] += ['broadcast']
 
+    client_request.login(user)
     client_request.get(
         '.reject_broadcast_message',
         service_id=SERVICE_ONE_ID,
@@ -2671,7 +2606,6 @@ def test_no_view_page_for_draft(
 
 
 @pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
     create_active_user_create_broadcasts_permissions(),
     create_active_user_approve_broadcasts_permissions(),
     create_platform_admin_user(),
@@ -2682,7 +2616,6 @@ def test_cancel_broadcast(
     mock_get_live_broadcast_message,
     mock_get_broadcast_template,
     mock_update_broadcast_message_status,
-    platform_admin_user_no_service_permissions,
     fake_uuid,
     user,
 ):
@@ -2717,7 +2650,6 @@ def test_cancel_broadcast(
 
 @pytest.mark.parametrize('user', [
     create_platform_admin_user(),
-    create_active_user_with_permissions(),
     create_active_user_create_broadcasts_permissions(),
     create_active_user_approve_broadcasts_permissions(),
 ])
@@ -2762,9 +2694,11 @@ def test_cant_cancel_broadcast_in_a_different_state(
     mock_get_draft_broadcast_message,
     mock_update_broadcast_message_status,
     fake_uuid,
+    active_user_create_broadcasts_permission,
     method,
 ):
     service_one['permissions'] += ['broadcast']
+    client_request.login(active_user_create_broadcasts_permission)
     getattr(client_request, method)(
         '.cancel_broadcast_message',
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -138,7 +138,6 @@ def test_broadcast_pages_403_without_permission(
     ),
 ))
 def test_broadcast_pages_403_for_user_without_permission(
-    mocker,
     client_request,
     service_one,
     active_user_view_permissions,
@@ -194,7 +193,6 @@ def test_user_cannot_accept_broadcast_without_permission(
 
 @pytest.mark.parametrize('user_is_platform_admin', [True, False])
 def test_user_cannot_reject_broadcast_without_permission(
-    mocker,
     client_request,
     service_one,
     active_user_view_permissions,
@@ -388,7 +386,6 @@ def test_broadcast_service_shows_channel_settings(
     client_request,
     service_one,
     mock_get_no_broadcast_messages,
-    mock_get_service_templates_when_no_templates_exist,
     trial_mode,
     allowed_broadcast_provider,
     channel,
@@ -456,9 +453,7 @@ def test_dashboard_redirects_to_broadcast_dashboard(
 def test_empty_broadcast_dashboard(
     client_request,
     service_one,
-    active_user_view_permissions,
     mock_get_no_broadcast_messages,
-    mock_get_service_templates_when_no_templates_exist,
 ):
     service_one['permissions'] += ['broadcast']
     page = client_request.get(
@@ -480,7 +475,6 @@ def test_broadcast_dashboard(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    mock_get_service_templates,
     active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
@@ -541,7 +535,6 @@ def test_broadcast_dashboard_does_not_have_button_if_user_does_not_have_permissi
 def test_broadcast_dashboard_json(
     logged_in_client,
     service_one,
-    active_user_view_permissions,
     mock_get_broadcast_messages,
 ):
     service_one['permissions'] += ['broadcast']
@@ -565,7 +558,6 @@ def test_previous_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    mock_get_service_templates,
     active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
@@ -602,7 +594,6 @@ def test_rejected_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    mock_get_service_templates,
     active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
@@ -779,7 +770,6 @@ def test_write_new_broadcast_bad_content(
     client_request,
     service_one,
     mock_create_broadcast_message,
-    fake_uuid,
     active_user_create_broadcasts_permission,
     content,
     expected_error_message,
@@ -1540,7 +1530,6 @@ def test_preview_broadcast_message_page(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
-    mock_get_broadcast_template,
     fake_uuid,
     active_user_create_broadcasts_permission,
 ):
@@ -1578,12 +1567,10 @@ def test_preview_broadcast_message_page(
     assert 'action' not in form
 
 
-@freeze_time('2020-02-02 02:02:02')
 def test_start_broadcasting(
     client_request,
     service_one,
     mock_get_draft_broadcast_message,
-    mock_get_broadcast_template,
     mock_update_broadcast_message_status,
     fake_uuid,
     active_user_create_broadcasts_permission,
@@ -1672,7 +1659,6 @@ def test_view_broadcast_message_page(
     client_request,
     service_one,
     active_user_view_permissions,
-    mock_get_broadcast_template,
     fake_uuid,
     endpoint,
     created_by_api,
@@ -1748,7 +1734,6 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
     client_request,
     service_one,
     active_user_approve_broadcasts_permission,
-    mock_get_broadcast_template,
     fake_uuid,
     endpoint,
     status,
@@ -1792,12 +1777,10 @@ def test_view_broadcast_message_shows_correct_highlighted_navigation(
     )
 
 
-@freeze_time('2020-02-22T22:22:22.000000')
 def test_view_pending_broadcast(
     mocker,
     client_request,
     service_one,
-    mock_get_broadcast_template,
     fake_uuid,
     active_user_approve_broadcasts_permission,
 ):
@@ -1849,7 +1832,6 @@ def test_view_pending_broadcast(
     )
 
 
-@freeze_time('2020-02-22T22:22:22.000000')
 def test_view_pending_broadcast_without_template(
     mocker,
     client_request,
@@ -1899,7 +1881,6 @@ def test_view_pending_broadcast_without_template(
     )
 
 
-@freeze_time('2020-02-22T22:22:22.000000')
 def test_view_pending_broadcast_from_api_call(
     mocker,
     client_request,
@@ -1958,7 +1939,6 @@ def test_view_pending_broadcast_from_api_call(
         'I understand this will alert millions of people, even if they’ve opted out'
     )),
 ))
-@freeze_time('2020-02-22T22:22:22.000000')
 def test_checkbox_to_confirm_non_training_broadcasts(
     mocker,
     client_request,
@@ -2000,7 +1980,6 @@ def test_checkbox_to_confirm_non_training_broadcasts(
     assert page.select_one('form.banner input[type=checkbox]')['value'] == 'y'
 
 
-@freeze_time('2020-02-22T22:22:22.000000')
 def test_confirm_approve_non_training_broadcasts_errors_if_not_ticked(
     mocker,
     client_request,
@@ -2049,7 +2028,6 @@ def test_can_approve_own_broadcast_in_training_mode(
     mocker,
     client_request,
     service_one,
-    mock_get_broadcast_template,
     fake_uuid,
     active_user_approve_broadcasts_permission,
 ):
@@ -2129,7 +2107,6 @@ def test_cant_approve_own_broadcast_if_service_is_live(
     mocker,
     client_request,
     service_one,
-    mock_get_broadcast_template,
     fake_uuid,
     user,
 ):
@@ -2188,7 +2165,6 @@ def test_view_only_user_cant_approve_broadcast_created_by_someone_else(
     active_user_create_broadcasts_permission,
     active_user_view_permissions,
     platform_admin_user_no_service_permissions,
-    mock_get_broadcast_template,
     fake_uuid,
     user_is_platform_admin
 ):
@@ -2297,7 +2273,6 @@ def test_user_without_approve_permission_cant_approve_broadcast_created_by_someo
     client_request,
     service_one,
     active_user_create_broadcasts_permission,
-    mock_get_broadcast_template,
     fake_uuid,
     is_service_training_mode,
     banner_text,
@@ -2428,7 +2403,6 @@ def test_confirm_approve_broadcast(
     mocker,
     client_request,
     service_one,
-    mock_get_broadcast_template,
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
@@ -2493,7 +2467,6 @@ def test_reject_broadcast(
     mocker,
     client_request,
     service_one,
-    mock_get_broadcast_template,
     fake_uuid,
     mock_update_broadcast_message,
     mock_update_broadcast_message_status,
@@ -2614,7 +2587,6 @@ def test_cancel_broadcast(
     client_request,
     service_one,
     mock_get_live_broadcast_message,
-    mock_get_broadcast_template,
     mock_update_broadcast_message_status,
     fake_uuid,
     user,
@@ -2657,7 +2629,6 @@ def test_confirm_cancel_broadcast(
     client_request,
     service_one,
     mock_get_live_broadcast_message,
-    mock_get_broadcast_template,
     mock_update_broadcast_message_status,
     fake_uuid,
     user,

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2235,7 +2235,7 @@ def test_view_only_user_cant_approve_broadcasts_they_created(
     client_request,
     service_one,
     fake_uuid,
-    active_user_broadcast_permissions,
+    active_user_create_broadcasts_permission,
     active_user_view_permissions,
 ):
     mocker.patch(
@@ -2251,11 +2251,11 @@ def test_view_only_user_cant_approve_broadcasts_they_created(
     )
     client_request.login(active_user_view_permissions)
 
-    # active_user_view_permissions and active_user_broadcast_permissions have the same
+    # active_user_view_permissions and active_user_create_broadcasts_permission have the same
     # id. This mocks the same user being returned, but with different permissions each time.
     mocker.patch('app.user_api_client.get_user', side_effect=[
         active_user_view_permissions,  # Current user
-        active_user_broadcast_permissions,  # User who created broadcast
+        active_user_create_broadcasts_permission,  # User who created broadcast
     ])
     service_one['permissions'] += ['broadcast']
     service_one['restriced'] = False
@@ -2296,7 +2296,7 @@ def test_user_without_approve_permission_cant_approve_broadcast_created_by_someo
     mocker,
     client_request,
     service_one,
-    active_user_broadcast_permissions,
+    active_user_create_broadcasts_permission,
     mock_get_broadcast_template,
     fake_uuid,
     is_service_training_mode,
@@ -2317,7 +2317,7 @@ def test_user_without_approve_permission_cant_approve_broadcast_created_by_someo
     client_request.login(current_user)
     mocker.patch('app.user_api_client.get_user', side_effect=[
         current_user,  # Current user
-        active_user_broadcast_permissions,  # User who created broadcast
+        active_user_create_broadcasts_permission,  # User who created broadcast
     ])
     service_one['permissions'] += ['broadcast']
     service_one['restricted'] = is_service_training_mode

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -470,15 +470,19 @@ def test_empty_broadcast_dashboard(
     ]
 
 
+@pytest.mark.parametrize('user', [
+    create_active_user_approve_broadcasts_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 @freeze_time('2020-02-20 02:20')
 def test_broadcast_dashboard(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    active_user_create_broadcasts_permission,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(active_user_create_broadcasts_permission)
+    client_request.login(user)
     page = client_request.get(
         '.broadcast_dashboard',
         service_id=SERVICE_ONE_ID,
@@ -495,15 +499,6 @@ def test_broadcast_dashboard(
         'Example template This is a test Live since today at 2:20am England Scotland',
         'Example template This is a test Live since today at 1:20am England Scotland',
     ]
-
-    button = page.select_one(
-        '.js-stick-at-bottom-when-scrolling a.govuk-button.govuk-button--secondary'
-    )
-    assert normalize_spaces(button.text) == 'New alert'
-    assert button['href'] == url_for(
-        'main.new_broadcast',
-        service_id=SERVICE_ONE_ID,
-    )
 
 
 @pytest.mark.parametrize('user', [
@@ -531,6 +526,33 @@ def test_broadcast_dashboard_does_not_have_button_if_user_does_not_have_permissi
     assert not page.select('a.govuk-button')
 
 
+@pytest.mark.parametrize('endpoint', (
+    '.broadcast_dashboard', '.broadcast_dashboard_previous', '.broadcast_dashboard_rejected',
+))
+def test_broadcast_dashboard_has_new_alert_button_if_user_has_permission_to_create_broadcasts(
+    client_request,
+    service_one,
+    mock_get_broadcast_messages,
+    active_user_create_broadcasts_permission,
+    endpoint,
+):
+    client_request.login(active_user_create_broadcasts_permission)
+
+    service_one['permissions'] += ['broadcast']
+    page = client_request.get(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+    )
+    button = page.select_one(
+        '.js-stick-at-bottom-when-scrolling a.govuk-button.govuk-button--secondary'
+    )
+    assert normalize_spaces(button.text) == 'New alert'
+    assert button['href'] == url_for(
+        'main.new_broadcast',
+        service_id=SERVICE_ONE_ID,
+    )
+
+
 @freeze_time('2020-02-20 02:20')
 def test_broadcast_dashboard_json(
     logged_in_client,
@@ -553,15 +575,19 @@ def test_broadcast_dashboard_json(
     assert 'Live since today at 2:20am' in json_response['current_broadcasts']
 
 
+@pytest.mark.parametrize('user', [
+    create_active_user_approve_broadcasts_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 @freeze_time('2020-02-20 02:20')
 def test_previous_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    active_user_create_broadcasts_permission,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(active_user_create_broadcasts_permission)
+    client_request.login(user)
     page = client_request.get(
         '.broadcast_dashboard_previous',
         service_id=SERVICE_ONE_ID,
@@ -579,25 +605,20 @@ def test_previous_broadcasts_page(
         'Example template This is a test Yesterday at 2:20am England Scotland',
     ]
 
-    button = page.select_one(
-        '.js-stick-at-bottom-when-scrolling a.govuk-button.govuk-button--secondary'
-    )
-    assert normalize_spaces(button.text) == 'New alert'
-    assert button['href'] == url_for(
-        'main.new_broadcast',
-        service_id=SERVICE_ONE_ID,
-    )
 
-
+@pytest.mark.parametrize('user', [
+    create_active_user_approve_broadcasts_permissions(),
+    create_active_user_create_broadcasts_permissions(),
+])
 @freeze_time('2020-02-20 02:20')
 def test_rejected_broadcasts_page(
     client_request,
     service_one,
     mock_get_broadcast_messages,
-    active_user_create_broadcasts_permission,
+    user,
 ):
     service_one['permissions'] += ['broadcast']
-    client_request.login(active_user_create_broadcasts_permission)
+    client_request.login(user)
     page = client_request.get(
         '.broadcast_dashboard_rejected',
         service_id=SERVICE_ONE_ID,
@@ -613,15 +634,6 @@ def test_rejected_broadcasts_page(
     ] == [
         'Example template This is a test Today at 1:20am England Scotland',
     ]
-
-    button = page.select_one(
-        '.js-stick-at-bottom-when-scrolling a.govuk-button.govuk-button--secondary'
-    )
-    assert normalize_spaces(button.text) == 'New alert'
-    assert button['href'] == url_for(
-        'main.new_broadcast',
-        service_id=SERVICE_ONE_ID,
-    )
 
 
 def test_new_broadcast_page(

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -202,21 +202,29 @@ def test_should_show_overview_page_for_broadcast_service(
     mock_get_template_folders,
     service_one,
     active_user_view_permissions,
-    active_user_broadcast_permissions,
+    active_user_create_broadcasts_permission,
+    active_user_approve_broadcasts_permission,
 ):
     service_one['permissions'].append('broadcast')
     mocker.patch('app.models.user.Users.client_method', return_value=[
-        active_user_broadcast_permissions,
+        active_user_create_broadcasts_permission,
+        active_user_approve_broadcasts_permission,
         active_user_view_permissions,
     ])
     page = client_request.get('main.manage_users', service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select('.user-list-item')[0].text) == (
-        'Test User (you) '
-        'Can Add and edit templates '
+        'Test User Create Broadcasts Permission (you) '
+        'Cannot Add and edit templates '
         'Can Create new alerts '
-        'Can Approve alerts'
+        'Cannot Approve alerts'
     )
     assert normalize_spaces(page.select('.user-list-item')[1].text) == (
+        'Test User Approve Broadcasts Permission (you) '
+        'Cannot Add and edit templates '
+        'Cannot Create new alerts '
+        'Can Approve alerts'
+    )
+    assert normalize_spaces(page.select('.user-list-item')[2].text) == (
         'Test User With Permissions (you) '
         'Cannot Add and edit templates '
         'Cannot Create new alerts '

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -22,9 +22,7 @@ from tests.conftest import (
     TEMPLATE_ONE_ID,
     ElementNotFound,
     create_active_caseworking_user,
-    create_active_user_create_broadcasts_permissions,
     create_active_user_view_permissions,
-    create_active_user_with_permissions,
     create_letter_contact_block,
     create_template,
     normalize_spaces,
@@ -922,19 +920,16 @@ def test_should_be_able_to_view_a_template_with_links(
     )
 
 
-@pytest.mark.parametrize('user', (
-    create_active_user_with_permissions(),
-    create_active_user_create_broadcasts_permissions(),
-))
 def test_view_broadcast_template(
     client_request,
     service_one,
     mock_get_broadcast_template,
     mock_get_template_folders,
     fake_uuid,
-    user,
+    active_user_create_broadcasts_permission,
 ):
-    client_request.login(user)
+    client_request.login(active_user_create_broadcasts_permission)
+    active_user_create_broadcasts_permission['permissions'][SERVICE_ONE_ID].append('manage_templates')
     page = client_request.get(
         '.view_template',
         service_id=SERVICE_ONE_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1128,6 +1128,16 @@ def active_user_with_permissions(fake_uuid):
 
 
 @pytest.fixture(scope='function')
+def active_user_create_broadcasts_permission():
+    return create_active_user_create_broadcasts_permissions()
+
+
+@pytest.fixture(scope='function')
+def active_user_approve_broadcasts_permission():
+    return create_active_user_approve_broadcasts_permissions()
+
+
+@pytest.fixture(scope='function')
 def active_user_broadcast_permissions(fake_uuid):
     return create_service_one_user(
         id=fake_uuid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1138,22 +1138,6 @@ def active_user_approve_broadcasts_permission():
 
 
 @pytest.fixture(scope='function')
-def active_user_broadcast_permissions(fake_uuid):
-    return create_service_one_user(
-        id=fake_uuid,
-        permissions={SERVICE_ONE_ID: [
-            'view_activity',
-            'manage_templates',
-            'create_broadcasts',
-            'reject_broadcasts',
-            'cancel_broadcasts',
-            'approve_broadcasts',
-        ]},
-        auth_type='webauthn_auth',
-    )
-
-
-@pytest.fixture(scope='function')
 def active_user_with_session(fake_uuid):
     return create_service_one_admin(
         id=fake_uuid,
@@ -3624,7 +3608,6 @@ def create_active_user_create_broadcasts_permissions(with_unique_id=False):
         id=str(uuid4()) if with_unique_id else sample_uuid(),
         name='Test User Create Broadcasts Permission',
         permissions={SERVICE_ONE_ID: [
-            'manage_templates',
             'create_broadcasts',
             'reject_broadcasts',
             'cancel_broadcasts',


### PR DESCRIPTION
The `send_messages` permission has been deprecated for use with broadcast services, so we can drop support for it in the code. We were supporting both the old permissions and new permissions (`create_broadcasts` and `approve_broadcasts`) while we switched people over.

This also tidies up a few tests (see individual commits for details) but nothing in this PR should affect how things currently work.