### PR TITLE
Always show form to choose / copy template

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -187,19 +187,12 @@
       return changed;
     };
 
-    this.$singleNotificationChannel = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-channel");
-    this.$singleChannelService = (document.querySelector('div[id=add_new_template_form]')).getAttribute("data-service");
-
     this.actionButtonClicked = function(event) {
       event.preventDefault();
       this.currentState = $(event.currentTarget).val();
 
-      if (event.currentTarget.value === 'add-new-template' && this.$singleNotificationChannel) {
-        window.location = "/services/" + this.$singleChannelService + "/templates/add-" + this.$singleNotificationChannel;
-      } else {
-        if (this.stateChanged()) {
-          this.render();
-        }
+      if (this.stateChanged()) {
+        this.render();
       }
     };
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -39,7 +39,7 @@ from app.main.views.send import get_sender_details
 from app.models.service import Service
 from app.models.template_list import TemplateList, TemplateLists
 from app.template_previews import TemplatePreview, get_page_count_for_letter
-from app.utils import NOTIFICATION_TYPES, should_skip_template_page
+from app.utils import should_skip_template_page
 from app.utils.templates import get_template
 from app.utils.user import user_has_permissions, user_is_platform_admin
 
@@ -115,11 +115,6 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
     )
     option_hints = {template_folder_id: 'current folder'}
 
-    single_notification_channel = None
-    notification_channels = list(set(current_service.permissions).intersection(NOTIFICATION_TYPES))
-    if len(notification_channels) == 1:
-        single_notification_channel = notification_channels[0]
-
     if request.method == 'POST' and templates_and_folders_form.validate_on_submit():
         if not current_user.has_permissions('manage_templates'):
             abort(403)
@@ -158,7 +153,6 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         templates_and_folders_form=templates_and_folders_form,
         move_to_children=templates_and_folders_form.move_to.children(),
         user_has_template_folder_permission=user_has_template_folder_permission,
-        single_notification_channel=single_notification_channel,
         option_hints=option_hints
     )
 

--- a/app/templates/views/templates/_move_to.html
+++ b/app/templates/views/templates/_move_to.html
@@ -26,7 +26,7 @@
       {{ page_footer('Add new folder', button_name='operation', button_value='add-new-folder') }}
     </div>
   </div>
-  <div id="add_new_template_form" class="sticky-template-form" role="region" aria-label="Choose template type" {% if single_notification_channel %}data-channel="{{single_notification_channel}}" data-service="{{current_service.id}}"{% endif %}>
+  <div id="add_new_template_form" class="sticky-template-form" role="region" aria-label="Choose template type">
     <div class="js-will-stick-at-bottom-when-scrolling">
     {{ radios(templates_and_folders_form.add_template_by_template_type) }}
     </div>

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -443,40 +443,6 @@ def test_should_show_new_template_choices_if_service_has_folder_permission(
     ] == expected_labels
 
 
-@pytest.mark.parametrize("permissions,are_data_attrs_added", [
-    (['sms'], True),
-    (['email'], True),
-    (['letter'], True),
-    (['broadcast'], True),
-    (['sms', 'email'], False),
-])
-def test_should_add_data_attributes_for_services_that_only_allow_one_type_of_notifications(
-    client_request,
-    service_one,
-    mock_get_service_templates,
-    mock_get_template_folders,
-    mock_get_no_api_keys,
-    permissions,
-    are_data_attrs_added
-):
-    service_one['permissions'] = permissions
-
-    page = client_request.get(
-        'main.choose_template',
-        service_id=SERVICE_ONE_ID,
-    )
-
-    if not page.select('#add_new_template_form'):
-        raise ElementNotFound()
-
-    if are_data_attrs_added:
-        assert page.find(id='add_new_template_form').attrs['data-channel'] == permissions[0]
-        assert page.find(id='add_new_template_form').attrs['data-service'] == SERVICE_ONE_ID
-    else:
-        assert page.find(id='add_new_template_form').attrs.get('data-channel') is None
-        assert page.find(id='add_new_template_form').attrs.get('data-service') is None
-
-
 def test_should_show_page_for_one_template(
     client_request,
     mock_get_service_template,

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -315,37 +315,6 @@ describe('TemplateFolderForm', () => {
 
   });
 
-  describe("Click 'New template' for single channel service", () => {
-    test("should redirect to new template page", () => {
-      setFixtures(hierarchy, "data-channel='sms' data-service='123'")
-      templateFolderForm = document.querySelector('form[data-module=template-folder-form]');
-
-      // start module
-      window.GOVUK.modules.start();
-
-      formControls = templateFolderForm.querySelector('#sticky_template_forms');
-
-      // reset sticky JS mocks called when the module starts
-      resetStickyMocks();
-      // add listener for url change
-      const descriptor1 = Object.getOwnPropertyDescriptor(window, 'location');
-      delete window.location
-
-      const mockCallback = jest.fn(x => {});
-
-      Object.defineProperty(window, 'location', {
-        set: mockCallback
-      });
-      // click
-      helpers.triggerEvent(formControls.querySelector('[value=add-new-template]'), 'click');
-      // expect url to change
-      expect(mockCallback).toHaveBeenCalledWith("/services/123/templates/add-sms")
-
-      setFixtures(hierarchy)
-      resetStickyMocks()
-    });
-  })
-
   describe("Clicking 'New template'", () => {
 
     beforeEach(() => {


### PR DESCRIPTION
Previously a user couldn't copy an existing template if their service
only had a single notification channel enabled. While we could amend
the conditional to also show the radio buttons if the service has more
than one template, it's easier to always show it.

The only downside to always showing the form is that a user will see a
single radio button in the rare case they are adding the first template
and only one channel is enabled (for some reason).

Note that the form is currently broken if all notification channels are
disabled for a service. We don't fix that here.