### PR TITLE
Revert "Reduce default broadcast expiry time"

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -252,7 +252,7 @@ class BroadcastMessage(JSONModel):
         self._update(
             starts_at=datetime.utcnow().isoformat(),
             finishes_at=(
-                datetime.utcnow() + timedelta(hours=4, minutes=0)
+                datetime.utcnow() + timedelta(hours=23, minutes=59)
             ).isoformat(),
         )
         self._set_status_to('broadcasting')

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -2457,7 +2457,7 @@ def test_confirm_approve_broadcast(
             broadcast_message_id=fake_uuid,
             data={
                 'starts_at': '2020-02-22T22:22:22',
-                'finishes_at': '2020-02-23T02:22:22',
+                'finishes_at': '2020-02-23T22:21:22',
             },
         )
         mock_update_broadcast_message_status.assert_called_once_with(


### PR DESCRIPTION
Reverts alphagov/notifications-admin#3800

We set it to 4 hours for the first Reading demo, so we could test expiry within the working day. Now we should change it back to the maximum possible for flexibility in real emergencies. 

We can’t go longer than 24 hours because there is a risk that phones will forget they’ve received the alert and display it again.