### PR TITLE
Rename demo area to match govuk-alerts

### DIFF
--- a/app/broadcast_areas/source_files/Demo.geojson
+++ b/app/broadcast_areas/source_files/Demo.geojson
@@ -5,7 +5,7 @@
       "type": "Feature",
       "properties": {
         "id": "sizewell",
-        "name": "Sizewell",
+        "name": "East Suffolk",
         "count_of_phones": 700
       },
       "geometry": {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178774818

Relates to: https://github.com/alphagov/notifications-govuk-alerts/pull/152

I ran the "create-broadcast-areas-db.py" script to regenerate the
Sqlite DB. Existing alerts with the old naming still appear correctly,
and since we don't (yet) store this text in the DB, there's nothing
more to update.