### PR TITLE
Give user profile change links more context

### DIFF
--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -20,14 +20,24 @@
       {% call row() %}
         {{ text_field('Name') }}
         {{ text_field(current_user.name) }}
-        {{ edit_field('Change', url_for('.user_profile_name')) }}
+        {{ edit_field(
+            'Change',
+            url_for('.user_profile_name'),
+            suffix='name'
+          )
+        }}
       {% endcall %}
 
       {% call row() %}
         {{ text_field('Email address') }}
         {{ text_field(current_user.email_address) }}
         {% if can_see_edit %}
-          {{ edit_field('Change', url_for('.user_profile_email')) }}
+          {{ edit_field(
+              'Change',
+              url_for('.user_profile_email'),
+              suffix='email address'
+            )
+          }}
         {% else %}
           {{ text_field('') }}
         {% endif %}
@@ -36,13 +46,23 @@
       {% call row() %}
         {{ text_field('Mobile number') }}
         {{ optional_text_field(current_user.mobile_number) }}
-        {{ edit_field('Change', url_for('.user_profile_mobile_number')) }}
+        {{ edit_field(
+            'Change',
+            url_for('.user_profile_mobile_number'),
+            suffix='mobile number'
+          )
+        }}
       {% endcall %}
 
       {% call row() %}
         {{ text_field('Password') }}
         {{ text_field('Last changed ' + current_user.password_changed_at|format_delta) }}
-        {{ edit_field('Change', url_for('.user_profile_password')) }}
+        {{ edit_field(
+            'Change',
+            url_for('.user_profile_password'),
+            suffix='password'
+          )
+        }}
       {% endcall %}
 
       {% if current_user.can_use_webauthn %}
@@ -52,7 +72,12 @@
             ('{} registered'.format(current_user.webauthn_credentials|length)) if current_user.webauthn_credentials else None,
             default='None registered'
           ) }}
-          {{ edit_field('Change', url_for('.user_profile_security_keys')) }}
+          {{ edit_field(
+              'Change',
+              url_for('.user_profile_security_keys'),
+              suffix='security keys'
+            )
+          }}
         {% endcall %}
       {% endif %}
 
@@ -60,7 +85,12 @@
         {% call row(id='disable-platform-admin') %}
           {{ text_field('Use platform admin view') }}
           {{ text_field('Yes' if not session.get('disable_platform_admin_view') else 'No') }}
-          {{ edit_field('Change', url_for('.user_profile_disable_platform_admin_view')) }}
+          {{ edit_field(
+              'Change',
+              url_for('.user_profile_disable_platform_admin_view'),
+              suffix='whether to use platform admin view'
+            )
+          }}
         {% endcall %}
       {% endif %}
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -36,13 +36,14 @@ def test_overview_page_shows_disable_for_platform_admin(
     page = client_request.get('main.user_profile')
     assert page.select_one('h1').text.strip() == 'Your profile'
     disable_platform_admin_row = page.select_one('#disable-platform-admin')
-    assert ' '.join(disable_platform_admin_row.text.split()) == 'Use platform admin view Yes Change'
+    assert ' '.join(disable_platform_admin_row.text.split()) == \
+        'Use platform admin view Yes Change whether to use platform admin view'
 
 
 @pytest.mark.parametrize('key_count, expected_row_text', [
-    (0, 'Security keys None registered Change'),
-    (1, 'Security keys 1 registered Change'),
-    (2, 'Security keys 2 registered Change'),
+    (0, 'Security keys None registered Change security keys'),
+    (1, 'Security keys 1 registered Change security keys'),
+    (2, 'Security keys 2 registered Change security keys'),
 ])
 def test_overview_page_shows_security_keys_if_user_they_can_use_webauthn(
     mocker,


### PR DESCRIPTION
They all currently say 'Change' which makes it confusing when they are viewed out of their context (ie. when all the links in the page are listed out by a screen reader).

This gives them a suffix relating to the thing they will change, like [the links on the service settings page](https://github.com/alphagov/notifications-admin/blob/master/app/templates/views/service-settings.html#L23).

## Before

<img width="1094" alt="profile_before_changes" src="https://user-images.githubusercontent.com/87140/128354556-cf077028-bcdd-4cb4-9962-c0b495bc077b.png">

## After

<img width="1088" alt="profile_after_changes" src="https://user-images.githubusercontent.com/87140/128354607-a7e5730b-edc3-48bd-9b66-736b393a6bf4.png">
