### PR TITLE
Accessibility fixes for interactive map

### DIFF
--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -108,7 +108,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
       height: 2px;
       background: $govuk-focus-text-colour;
 
-      // hide for focus:hover state
+      // hide in forced-color mode, where the normal focus state the divider is part of does not show
       @media (forced-colors: active) {
         display: none;
       }

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -10,15 +10,14 @@ $govuk-focus-colour: #FFDD00;
 $zoom-button-colour: govuk-colour("white");
 $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
-// The focus style is a 2-colour outline, made to match the GOVUK text input focus style, using
+// The map focus style is a 2-colour outline, made to match the GOVUK text input focus style, using
 // box-shadow. When colours are overridden, for example when users have Windows high contrast mode
-// on, box-shadows disappear, so the outline which is left as a single colour (defined by the OS,
-// to replace 'transparent').
+// on, box-shadows disappear, so the outline is left as a single colour (defined by the OS, to
+// replace 'transparent') which we offset from the map to mimic the 2-colour version.
 //
 // Leaflet adds focus styles with JS, through inline styles. Because of their higher precedence
 // we need to mark our overrides with !important.
 //
-// This also uses :focus-visible to stop it showing focus when you click zoom in/out.
 // This approach, taken from MDN, allows it to fall back to :focus for browsers without support:
 // https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#selectively_showing_the_focus_indicator
 .leaflet-container {
@@ -26,8 +25,6 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
   &:focus {
     box-shadow: 0px 0px 0 3px $govuk-focus-text-colour, 0 0 0 6px $govuk-focus-colour;
     outline: solid 3px transparent !important; // sass-lint:disable-line no-important
-    // You only see the outline in forced colour mode which doesn't have enough contrast with the
-    // map so this creates some space between them to mimic the two-colour default styling
     outline-offset: 3px;
   }
 
@@ -43,10 +40,11 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 // https://design-system.service.gov.uk/components/button/
 //
 // GOVUK buttons have an invisible outline, used for high contrast modes. Our buttons are cropped by
-// their container so we use a border instead.
+// their container so we use their border instead.
 //
-// Also introduces a black divider between the buttons, made with a pseudo element, appearing on
-// focus to mimic the 2-colour style GOVUK Frontend buttons and links have
+// Also introduces a thick black divider between the buttons, made with a pseudo element, appearing
+// on focus. Together with the yellow background, this copies the 2-colour style GOVUK Frontend
+// buttons and links have.
 .leaflet-bar {
   border-radius: 0; // Remove rounded corners
   background: #CCCCCC;
@@ -66,7 +64,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
     }
 
     &:last-child {
-      // Allow it to contain the absolutely positioned divider bar we show between buttons
+      // Allow it to contain the absolutely positioned divider we show between buttons
       // when one is focused
       position: relative;
     }
@@ -99,7 +97,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
       background-color: $govuk-focus-colour;
     }
 
-    // 3px divider between buttons as a version of the underline from the GOVUK focus style
+    // Shared styles for the divider between buttons that appears when either are focused
     &:last-child:focus:not(:active):not(:hover):before,
     &:first-child:focus:not(:active):not(:hover) + a:before {
       content: "";

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -32,7 +32,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
   // from other sources (like clicks on child elements).
   &:focus:not(:focus-visible) {
     box-shadow: none;
-    outline: none;
+    outline: none !important; // sass-lint:disable-line no-important
   }
 }
 

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -26,21 +26,16 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
   &:focus {
     box-shadow: 0px 0px 0 3px $govuk-focus-text-colour, 0 0 0 6px $govuk-focus-colour;
     outline: solid 3px transparent !important; // sass-lint:disable-line no-important
-  }
-
-  &:focus:not(:focus-visible) {
-    box-shadow: none;
-  }
-
-  &:focus-visible {
-    box-shadow: 0px 0px 0 3px $govuk-focus-text-colour, 0 0 0 6px $govuk-focus-colour;
-    outline: solid 3px transparent !important; // sass-lint:disable-line no-important
-
     // You only see the outline in forced colour mode which doesn't have enough contrast with the
     // map so this creates some space between them to mimic the two-colour default styling
-    @media (forced-colors: active) {
-      outline-offset: 3px;
-    }
+    outline-offset: 3px;
+  }
+
+  // The map should only recieve focus from being tabbed to. This stops the focus state coming
+  // from other sources (like clicks on child elements).
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+    outline: none;
   }
 }
 

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -83,7 +83,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
       // visible outline so it can be set to a colour by the OS.
       border: solid 2px $govuk-focus-colour;
       box-sizing: border-box; // make sure height includes the border
-      line-height: 26px; // subtract the border from the height (normally 30px)
+      line-height: 22px; // subtract the border from the height (normally 26px)
 
       // The inline display box for the button text overlaps the button edge.
       // This is only visible in high contrast mode because of the background colour being set.
@@ -150,6 +150,11 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
     border-bottom-right-radius: 0;
   }
 
+}
+
+// buttons are 30px for touch-capable devices/browsers
+.leaflet-touch .leaflet-bar a:focus {
+  line-height: 26px; // subtract the border from the height (normally 30px)
 }
 
 // Map attribution links

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -49,6 +49,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 // focus to mimic the 2-colour style GOVUK Frontend buttons and links have
 .leaflet-bar {
   border-radius: 0; // Remove rounded corners
+  background: #CCCCCC;
 
   @media (forced-colors: active) {
     background: canvasText;
@@ -58,6 +59,11 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
     // Outlines don't work because of the buttons being so close together so turn off
     outline: none;
+
+    &:first-child {
+      border-bottom: none;
+      margin-bottom: 1px;
+    }
 
     &:last-child {
       // Allow it to contain the absolutely positioned divider bar we show between buttons
@@ -91,11 +97,6 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
     &:focus:not(:active):not(:hover) {
       color: $govuk-focus-text-colour;
       background-color: $govuk-focus-colour;
-    }
-
-    // Retain the space between buttons now we're using the border in the focus style
-    &:first-child:focus {
-      margin-bottom: 1px;
     }
 
     // 3px divider between buttons as a version of the underline from the GOVUK focus style

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -121,7 +121,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
     &:last-child:focus:not(:active):not(:hover):before {
       left: -2px; // Subtract 2px left border
       top: -3px; // Subtract 2px top border and position so it overlaps space above button
-      width: calc(100% + 4px); // Subtract borders
+      width: calc(100% + 4px); // Compensate for borders
     }
 
     // Styles for the divider, specifc to the first button being focused

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -105,7 +105,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
       height: 2px;
       background: $govuk-focus-text-colour;
 
-      // hide in forced-color mode, where the normal focus state the divider is part of does not show
+      // Hide in forced-color mode, since the button outlines suffice
       @media (forced-colors: active) {
         display: none;
       }

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -1,0 +1,148 @@
+@import 'leaflet/dist/leaflet';
+
+// Styles to make the leaflet map match GOVUK (accessibility-focused) styling
+
+@import "settings/all";
+@import "helpers/all";
+
+// Reset focus colour to latest version, to match the rest of the app
+$govuk-focus-colour: #FFDD00;
+$zoom-button-colour: govuk-colour("white");
+$zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
+
+// The focus style is a 2-colour outline, made to match the GOVUK text input focus style.
+// When colours are overridden, for example when users have a dark mode, box-shadows disappear,
+// so the outline which is left as a single colour (defined by the OS, to replace 'transparent').
+//
+// Leaflet adds focus styles with JS, through inline styles. Because of their higher precedence
+// we need to mark our overrides with !important.
+//
+// This also uses :focus-visible to stop it showing focus when you click zoom in/out.
+// This approach, taken from MDN, allows it to fall back to :focus for browsers without support:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#selectively_showing_the_focus_indicator
+.leaflet-container {
+
+  &:focus {
+    box-shadow: 0px 0px 0 3px $govuk-focus-text-colour, 0 0 0 6px $govuk-focus-colour;
+    outline: solid 3px transparent !important; // sass-lint:disable-line no-important
+  }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    box-shadow: 0px 0px 0 3px $govuk-focus-text-colour, 0 0 0 6px $govuk-focus-colour;
+    outline: solid 3px transparent !important; // sass-lint:disable-line no-important
+
+    // You only see the outline in forced colour mode which doesn't have enough contrast with the
+    // map so this creates some space between them to mimic the two-colour default styling
+    @media (forced-colors: active) {
+      outline-offset: 3px;
+    }
+  }
+}
+
+// Overrides for zoom controls to make them match GOVUK buttons
+// https://design-system.service.gov.uk/components/button/
+//
+// GOVUK buttons have an invisible outline, used for high contrast modes. Our buttons are cropped by
+// their container so we use a border instead.
+//
+// Also introduces a black divider between the buttons, made with a pseudo element, appearing on
+// focus to mimic the 2-colour style GOVUK Frontend buttons and links have
+.leaflet-bar a {
+
+  // Allow it to contain the absolutely positioned divider bar we show between buttons
+  // when one is focused
+  &:last-child {
+    position: relative;
+  }
+
+  // Hover style is darker background
+  &:hover {
+    background-color: $zoom-button-hover-colour;
+  }
+
+  // Styles that apply if focused with or without the :hover or :active state
+  &:focus {
+    // When colours are overridden, for example when users have a dark mode,
+    // backgrounds and box-shadows disappear, so we need to ensure there's a
+    // transparent outline which will be set to a visible colour by the OS.
+    border: solid 2px transparent;
+    box-sizing: border-box; // make sure height includes the border
+    line-height: 26px; // subtract the border from the height (normally 30px)
+
+    // The inline display box for the button text overlaps the button edge.
+    // This is only visible in high contrast mode because of the background colour being set.
+    @media (forced-colors: active) {
+      overflow: hidden;
+    }
+  }
+
+  // Focused style sets the button to the focus colour
+  &:focus:not(:active):not(:hover) {
+    color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
+  }
+
+  // Retain the space between buttons now we're using the border in the focus style
+  &:first-child:focus {
+    margin-bottom: 1px;
+  }
+
+  // 3px divider between buttons as a version of the underline from the GOVUK focus style
+  &:last-child:focus:not(:active):not(:hover):before,
+  &:first-child:focus:not(:active):not(:hover) + a:before {
+    content: "";
+    position: absolute;
+    height: 2px;
+    background: $govuk-focus-text-colour;
+
+    @media (forced-colors: active) {
+      background: canvasText;
+    }
+  }
+
+  // Styles for the divider, specifc to the second button being focused
+  &:last-child:focus:not(:active):not(:hover):before {
+    left: -2px; // Subtract 2px left border
+    top: -3px; // Subtract 2px top border and position so it overlaps space above button
+    width: calc(100% + 4px); // Subtract borders
+  }
+
+  // Styles for the divider, specifc to the first button being focused
+  &:first-child:focus:not(:active):not(:hover) + a:before {
+    left: 0px; // No borders on parent of :before when not focused
+    top: -1px; // No borders so just overlap space above parent button
+    width: 100%;
+  }
+}
+
+// Extra block to override specific LeafletJS rounded-corners when buttons are focused
+.leaflet-touch .leaflet-bar a {
+  &:first-child:focus,
+  &:last-child:focus {
+    border-radius: initial;
+  }
+}
+
+// Map attribution links
+.leaflet-control-attribution {
+  & a {
+    &:focus {
+      // When colours are overridden, for example when users have a dark mode,
+      // backgrounds and box-shadows disappear, so we need to ensure there's a
+      // transparent outline which will be set to a visible colour.
+      outline: $govuk-focus-width solid transparent !important; // sass-lint:disable-line no-important
+      color: $govuk-focus-text-colour;
+      background: $govuk-focus-colour;
+      box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+    }
+
+    // use an extra prefix class to override LeafletJS CSS
+    .leaflet-bottom &:hover {
+      text-decoration: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -61,20 +61,10 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
   a {
 
-    &:first-child {
-      // Remove rounded corners
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-    }
-
     &:last-child {
       // Allow it to contain the absolutely positioned divider bar we show between buttons
       // when one is focused
       position: relative;
-
-      // Remove rounded corners
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
     }
 
     // Hover style is darker background
@@ -142,11 +132,21 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 }
 
 // Extra block to override specific LeafletJS rounded-corners when buttons are focused
+.leaflet-bar a,
 .leaflet-touch .leaflet-bar a {
-  &:first-child:focus,
-  &:last-child:focus {
-    border-radius: initial;
+
+  &:first-child {
+    // Remove rounded corners
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }
+
+  &:last-child {
+    // Remove rounded corners
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
 }
 
 // Map attribution links

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -39,7 +39,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 // Overrides for zoom controls to make them match GOVUK buttons
 // https://design-system.service.gov.uk/components/button/
 //
-// GOVUK buttons have an invisible outline, used for high contrast modes. Our buttons are cropped by
+// GOVUK buttons usually have an outline that shows up in high contrast modes. Our buttons are cropped by
 // their container so we use their border instead.
 //
 // Also introduces a thick black divider between the buttons, made with a pseudo element, appearing
@@ -47,7 +47,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 // buttons and links have.
 .leaflet-bar {
   border-radius: 0; // Remove rounded corners
-  background: #CCCCCC;
+  background: #CCCCCC; // Grey background to give a thin divider between buttons when they're not in focus
 
   @media (forced-colors: active) {
     background: canvasText;
@@ -60,7 +60,7 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
     &:first-child {
       border-bottom: none;
-      margin-bottom: 1px;
+      margin-bottom: 1px; // Thin divider to distinguish buttons
     }
 
     &:last-child {
@@ -114,14 +114,14 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
     // Styles for the divider, specifc to the second button being focused
     &:last-child:focus:not(:active):not(:hover):before {
       left: -2px; // Subtract 2px left border
-      top: -3px; // Subtract 2px top border and position so it overlaps space above button
+      top: -3px; // Shift divider up 1px so it overlaps buttons equally, and another 2px to compensate for the reduced height of the last button (due to the border)
       width: calc(100% + 4px); // Compensate for borders
     }
 
     // Styles for the divider, specifc to the first button being focused
     &:first-child:focus:not(:active):not(:hover) + a:before {
       left: 0px; // No borders on parent of :before when not focused
-      top: -1px; // No borders so just overlap space above parent button
+      top: -1px; // Shift divider up 1px so it overlaps buttons equally
       width: 100%;
     }
   }

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -51,72 +51,92 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 //
 // Also introduces a black divider between the buttons, made with a pseudo element, appearing on
 // focus to mimic the 2-colour style GOVUK Frontend buttons and links have
-.leaflet-bar a {
+.leaflet-bar {
+  border-radius: 0; // Remove rounded corners
 
-  // Allow it to contain the absolutely positioned divider bar we show between buttons
-  // when one is focused
-  &:last-child {
-    position: relative;
+  @media (forced-colors: active) {
+    background: canvasText;
   }
 
-  // Hover style is darker background
-  &:hover {
-    background-color: $zoom-button-hover-colour;
-  }
+  a {
 
-  // Styles that apply if focused with or without the :hover or :active state
-  &:focus {
-    // When colours are overridden, for example when users have a dark mode,
-    // backgrounds and box-shadows disappear, so we need to ensure there's a
-    // transparent outline which will be set to a visible colour by the OS.
-    border: solid 2px transparent;
-    box-sizing: border-box; // make sure height includes the border
-    line-height: 26px; // subtract the border from the height (normally 30px)
+    &:first-child {
+      // Remove rounded corners
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
 
-    // The inline display box for the button text overlaps the button edge.
-    // This is only visible in high contrast mode because of the background colour being set.
-    @media (forced-colors: active) {
-      overflow: hidden;
+    &:last-child {
+      // Allow it to contain the absolutely positioned divider bar we show between buttons
+      // when one is focused
+      position: relative;
+
+      // Remove rounded corners
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    // Hover style is darker background
+    &:hover {
+      background-color: $zoom-button-hover-colour;
+    }
+
+    // Styles that apply if focused with or without the :hover or :active state
+    &:focus {
+      // When colours are overridden, for example when users have a dark mode,
+      // backgrounds and box-shadows disappear, so we need to ensure there's a
+      // outline so it can be set to a visible colour by the OS.
+      border: solid 2px $govuk-focus-colour;
+      box-sizing: border-box; // make sure height includes the border
+      line-height: 26px; // subtract the border from the height (normally 30px)
+
+      // The inline display box for the button text overlaps the button edge.
+      // This is only visible in high contrast mode because of the background colour being set.
+      @media (forced-colors: active) {
+        overflow: hidden;
+      }
+    }
+
+    // Focused style sets the button to the focus colour
+    &:focus:not(:active):not(:hover) {
+      color: $govuk-focus-text-colour;
+      background-color: $govuk-focus-colour;
+    }
+
+    // Retain the space between buttons now we're using the border in the focus style
+    &:first-child:focus {
+      margin-bottom: 1px;
+    }
+
+    // 3px divider between buttons as a version of the underline from the GOVUK focus style
+    &:last-child:focus:not(:active):not(:hover):before,
+    &:first-child:focus:not(:active):not(:hover) + a:before {
+      content: "";
+      position: absolute;
+      height: 2px;
+      background: $govuk-focus-text-colour;
+
+      // hide for focus:hover state
+      @media (forced-colors: active) {
+        display: none;
+      }
+    }
+
+    // Styles for the divider, specifc to the second button being focused
+    &:last-child:focus:not(:active):not(:hover):before {
+      left: -2px; // Subtract 2px left border
+      top: -3px; // Subtract 2px top border and position so it overlaps space above button
+      width: calc(100% + 4px); // Subtract borders
+    }
+
+    // Styles for the divider, specifc to the first button being focused
+    &:first-child:focus:not(:active):not(:hover) + a:before {
+      left: 0px; // No borders on parent of :before when not focused
+      top: -1px; // No borders so just overlap space above parent button
+      width: 100%;
     }
   }
 
-  // Focused style sets the button to the focus colour
-  &:focus:not(:active):not(:hover) {
-    color: $govuk-focus-text-colour;
-    background-color: $govuk-focus-colour;
-  }
-
-  // Retain the space between buttons now we're using the border in the focus style
-  &:first-child:focus {
-    margin-bottom: 1px;
-  }
-
-  // 3px divider between buttons as a version of the underline from the GOVUK focus style
-  &:last-child:focus:not(:active):not(:hover):before,
-  &:first-child:focus:not(:active):not(:hover) + a:before {
-    content: "";
-    position: absolute;
-    height: 2px;
-    background: $govuk-focus-text-colour;
-
-    @media (forced-colors: active) {
-      background: canvasText;
-    }
-  }
-
-  // Styles for the divider, specifc to the second button being focused
-  &:last-child:focus:not(:active):not(:hover):before {
-    left: -2px; // Subtract 2px left border
-    top: -3px; // Subtract 2px top border and position so it overlaps space above button
-    width: calc(100% + 4px); // Subtract borders
-  }
-
-  // Styles for the divider, specifc to the first button being focused
-  &:first-child:focus:not(:active):not(:hover) + a:before {
-    left: 0px; // No borders on parent of :before when not focused
-    top: -1px; // No borders so just overlap space above parent button
-    width: 100%;
-  }
 }
 
 // Extra block to override specific LeafletJS rounded-corners when buttons are focused

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -10,9 +10,10 @@ $govuk-focus-colour: #FFDD00;
 $zoom-button-colour: govuk-colour("white");
 $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
-// The focus style is a 2-colour outline, made to match the GOVUK text input focus style.
-// When colours are overridden, for example when users have a dark mode, box-shadows disappear,
-// so the outline which is left as a single colour (defined by the OS, to replace 'transparent').
+// The focus style is a 2-colour outline, made to match the GOVUK text input focus style, using
+// box-shadow. When colours are overridden, for example when users have Windows high contrast mode
+// on, box-shadows disappear, so the outline which is left as a single colour (defined by the OS,
+// to replace 'transparent').
 //
 // Leaflet adds focus styles with JS, through inline styles. Because of their higher precedence
 // we need to mark our overrides with !important.
@@ -83,9 +84,10 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
     // Styles that apply if focused with or without the :hover or :active state
     &:focus {
-      // When colours are overridden, for example when users have a dark mode,
-      // backgrounds and box-shadows disappear, so we need to ensure there's a
-      // outline so it can be set to a visible colour by the OS.
+      // Button focus is shown by a change in background colour.
+      // When colours are overridden, for example when users have Windows high
+      // contrast mode on, backgrounds disappear, so we need to ensure there's a
+      // visible outline so it can be set to a colour by the OS.
       border: solid 2px $govuk-focus-colour;
       box-sizing: border-box; // make sure height includes the border
       line-height: 26px; // subtract the border from the height (normally 30px)
@@ -151,9 +153,10 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 .leaflet-control-attribution {
   & a {
     &:focus {
-      // When colours are overridden, for example when users have a dark mode,
-      // backgrounds and box-shadows disappear, so we need to ensure there's a
-      // transparent outline which will be set to a visible colour.
+      // Link focus is shown by a change in background colour.
+      // When colours are overridden, for example when users have Windows high
+      // contrast mode on, backgrounds disappear, so we need to ensure there's a
+      // visible outline so it can be set to a colour by the OS.
       outline: $govuk-focus-width solid transparent !important; // sass-lint:disable-line no-important
       color: $govuk-focus-text-colour;
       background: $govuk-focus-colour;

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -61,6 +61,9 @@ $zoom-button-hover-colour: govuk-shade($zoom-button-colour, 10%);
 
   a {
 
+    // Outlines don't work because of the buttons being so close together so turn off
+    outline: none;
+
     &:last-child {
       // Allow it to contain the absolutely positioned divider bar we show between buttons
       // when one is focused

--- a/app/templates/views/broadcast/partials/area-map-javascripts.html
+++ b/app/templates/views/broadcast/partials/area-map-javascripts.html
@@ -29,38 +29,12 @@
 
 
   var mapElement = document.getElementById('area-list-map');
-  var mapContainer = mapElement.parentNode;
-  var grandparent = mapContainer.parentNode;
-  var isInDetails = grandparent.className.indexOf('govuk-details') > -1;
+  var grandparent = mapElement.parentNode.parentNode;
+  var isInDetails = grandparent.className.indexOf('govuk-details') !== -1;
   var areas = document.querySelectorAll('.area-list > .area-list-item');
-  var description = document.createElement('p');
-  var descriptionText = 'Use the arrow keys to move the map. Use the buttons to zoom the map in or out';
-  var labelPrefix = 'Map of the United Kingdom, showing the areas for';
   var trimRegExp = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
   var details;
   var label;
-
-  function getStringFromAreas (areas) {
-    var areasLen = areas.length;
-    var areaStrings = [];
-    var idx;
-
-    if (areasLen === 1) { return areas[0].textContent.replace(trimRegExp, ''); }
-
-    for (idx = 0; idx < areasLen; idx++) {
-      areaStrings.push(areas[idx].textContent.replace(trimRegExp, ''));
-    }
-
-    // always join last 2 areas with 'and', the rest with commas
-    return areaStrings.slice(0, areasLen - 1).join(', ') + ' and ' + areaStrings[areasLen - 1];
-  };
-
-  description.appendChild(
-    document.createTextNode(descriptionText)
-  );
-  description.setAttribute('id', 'area-list-map__description');
-  description.className = 'govuk-visually-hidden';
-  mapContainer.insertBefore(description, mapElement.nextSibling);
 
   // if element is inside a details element then to make the map render correctly we open the details element
   // and set up the map before closing the details map after
@@ -69,11 +43,69 @@
     details.open = true;
   }
 
-  label = labelPrefix + " " + getStringFromAreas(areas);
+  function addAriaLabel (mapElement) {
+
+    function getLabelPrefix (areas) {
+      var labelPrefix = ['Map of the United Kingdom, showing the ', ' for'];
+
+      if (areas.length === 1) {
+        return labelPrefix[0] + 'area' + labelPrefix[1];
+      } else {
+        return labelPrefix[0] + 'areas' + labelPrefix[1];
+      }
+    };
+
+    function getStringOfAreas (areas) {
+      var areasLen = areas.length;
+      var areaStrings = [];
+      var idx;
+
+      function getAreaName (area) {
+        var areaString = '';
+        var childNodesLen = area.childNodes.length;
+        var childNode;
+
+        while (childNodesLen--) {
+          childNode = area.childNodes[childNodesLen];
+          if (childNode.nodeType === 3) { areaString += childNode.nodeValue; } // only use text nodes
+        }
+
+        return areaString.replace(trimRegExp, '')
+      };
+
+      if (areasLen === 1) { return getAreaName(areas[0]); }
+
+      for (idx = 0; idx < areasLen; idx++) {
+        areaStrings.push(getAreaName(areas[idx]));
+      }
+
+      // always join last 2 areas with 'and', the rest with commas
+      return areaStrings.slice(0, areasLen - 1).join(', ') + ' and ' + areaStrings[areasLen - 1];
+    };
+
+    label = getLabelPrefix(areas) + " " + getStringOfAreas(areas);
+    mapElement.setAttribute('aria-label', label);
+  };
+
+  function addAriaDescription (mapElement) {
+
+    var mapContainer = mapElement.parentNode;
+    var description = document.createElement('p');
+    var descriptionText = 'Use the arrow keys to move the map. Use the buttons to zoom the map in or out';
+
+    description.appendChild(
+      document.createTextNode(descriptionText)
+    );
+    description.setAttribute('id', 'area-list-map__description');
+    description.className = 'govuk-visually-hidden';
+    mapContainer.insertBefore(description, mapElement.nextSibling);
+    mapElement.setAttribute('aria-describedby', 'area-list-map__description');
+  };
+
   mapElement.style.height = Math.max(320, window.innerHeight - mapElement.offsetTop - 100) + 'px';
   mapElement.setAttribute('role', 'region');
-  mapElement.setAttribute('aria-label', label);
-  mapElement.setAttribute('aria-describedby', 'area-list-map__description');
+  addAriaLabel(mapElement);
+  addAriaDescription(mapElement);
 
   var mymap = L.map(
     'area-list-map',

--- a/app/templates/views/broadcast/partials/area-map-javascripts.html
+++ b/app/templates/views/broadcast/partials/area-map-javascripts.html
@@ -29,16 +29,51 @@
 
 
   var mapElement = document.getElementById('area-list-map');
+  var mapContainer = mapElement.parentNode;
+  var grandparent = mapContainer.parentNode;
+  var isInDetails = grandparent.className.indexOf('govuk-details') > -1;
+  var areas = document.querySelectorAll('.area-list > .area-list-item');
+  var description = document.createElement('p');
+  var descriptionText = 'Use the arrow keys to move the map. Use the buttons to zoom the map in or out';
+  var labelPrefix = 'Map of the United Kingdom, showing the areas for';
+  var trimRegExp = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
+  var details;
+  var label;
+
+  function getStringFromAreas (areas) {
+    var areasLen = areas.length;
+    var areaStrings = [];
+    var idx;
+
+    if (areasLen === 1) { return areas[0].textContent.replace(trimRegExp, ''); }
+
+    for (idx = 0; idx < areasLen; idx++) {
+      areaStrings.push(areas[idx].textContent.replace(trimRegExp, ''));
+    }
+
+    // always join last 2 areas with 'and', the rest with commas
+    return areaStrings.slice(0, areasLen - 1).join(', ') + ' and ' + areaStrings[areasLen - 1];
+  };
+
+  description.appendChild(
+    document.createTextNode(descriptionText)
+  );
+  description.setAttribute('id', 'area-list-map__description');
+  description.className = 'govuk-visually-hidden';
+  mapContainer.insertBefore(description, mapElement.nextSibling);
 
   // if element is inside a details element then to make the map render correctly we open the details element
   // and set up the map before closing the details map after
-  grandparent = mapElement.parentElement.parentElement;
-  if (grandparent.className.split(/\s+/).indexOf('govuk-details') > -1) {
+  if (isInDetails) {
     details = grandparent;
     details.open = true;
   }
 
+  label = labelPrefix + " " + getStringFromAreas(areas);
   mapElement.style.height = Math.max(320, window.innerHeight - mapElement.offsetTop - 100) + 'px';
+  mapElement.setAttribute('role', 'region');
+  mapElement.setAttribute('aria-label', label);
+  mapElement.setAttribute('aria-describedby', 'area-list-map__description');
 
   var mymap = L.map(
     'area-list-map',
@@ -58,7 +93,7 @@
   );
 
   // if element is inside a details element then close the details element
-  if (details) {
+  if (isInDetails) {
     details.open = false;
   }
 

--- a/app/templates/views/broadcast/partials/area-map-javascripts.html
+++ b/app/templates/views/broadcast/partials/area-map-javascripts.html
@@ -46,13 +46,11 @@
   function addAriaLabel (mapElement) {
 
     function getLabelPrefix (areas) {
-      var labelPrefix = ['Map of the United Kingdom, showing the ', ' for'];
-
-      if (areas.length === 1) {
-        return labelPrefix[0] + 'area' + labelPrefix[1];
-      } else {
-        return labelPrefix[0] + 'areas' + labelPrefix[1];
-      }
+      return [
+        'Map of the United Kingdom, showing the ',
+        (areas.length === 1) ? 'area' : 'areas',
+        ' for'
+      ].join('');
     };
 
     function getStringOfAreas (areas) {
@@ -63,10 +61,11 @@
       function getAreaName (area) {
         var areaString = '';
         var childNodesLen = area.childNodes.length;
+        var idx;
         var childNode;
 
-        while (childNodesLen--) {
-          childNode = area.childNodes[childNodesLen];
+        for (idx = 0; idx < childNodesLen; idx++) {
+          childNode = area.childNodes[idx];
           if (childNode.nodeType === 3) { areaString += childNode.nodeValue; } // only use text nodes
         }
 

--- a/app/templates/views/broadcast/partials/area-map-stylesheets.html
+++ b/app/templates/views/broadcast/partials/area-map-stylesheets.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="{{ asset_url('stylesheets/leaflet.css') }}" />
+<link rel="stylesheet" href="{{ asset_url('stylesheets/map.css') }}" />

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -202,8 +202,8 @@ const javascripts = () => {
 const sass = () => {
   return src([
       paths.src + '/stylesheets/main*.scss',
-      paths.src + '/stylesheets/print.scss',
-      paths.npm + '/leaflet/dist/leaflet.css'
+      paths.src + '/stylesheets/map.scss',
+      paths.src + '/stylesheets/print.scss'
     ])
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass({
@@ -212,6 +212,7 @@ const sass = () => {
         paths.npm + 'govuk-elements-sass/public/sass/',
         paths.toolkit + 'stylesheets/',
         paths.govuk_frontend,
+        paths.npm
       ]
     }))
     .pipe(plugins.cssUrlAdjuster({


### PR DESCRIPTION
Makes the controls and links inside it match GOVUK Frontend styles and:
- gives the map container a focus style matching that for GOVUK Frontend text inputs
- makes it all work in high contrast modes (on Windows and Firefox)

Note: the focus style for the container is applied with [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) so only appears when it gets focus directly, not when it does due to child elements (like the controls or links) getting focused. Browsers without support for [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) get the same styling for all forms of focus.

This doesn't have a story because most of the code is ported over from CSS written for the interactive map we had on gov.uk/alerts pages.

## New styles

I used Firefox's high contrast mode for these screenshots as an easy way to see those styles.

### Map container focus styles

| Normal styles | High contrast mode |
|---|---|
|<img width="665" alt="map_container_focused" src="https://user-images.githubusercontent.com/87140/128892657-e5b29692-ca13-4493-8059-2876d0c120f7.png">|<img width="666" alt="map_container_high_contrast_mode_firefox_focused" src="https://user-images.githubusercontent.com/87140/128892711-ec23dab0-44bf-4378-8ae3-c9e680e5ed0b.png">|

### Map controls with normal styles

| First control hovered | First control focused | Second control focused | First control focused and hovered | Link focused |
|---|---|---|---|---|
|<img width="61" alt="map_controls_first_button_hovered" src="https://user-images.githubusercontent.com/87140/128921215-20d46c82-4cc5-4ccb-99be-331f909ab3c0.png">|<img width="58" alt="map_controls_first_button_focused" src="https://user-images.githubusercontent.com/87140/128921262-04bc2434-230a-450d-bb87-ad0f6da02e4e.png">|<img width="58" alt="map_controls_second_button_focused" src="https://user-images.githubusercontent.com/87140/128921322-249fea98-8a95-4486-851f-276266ed7fca.png">|<img width="56" alt="map_controls_first_button_focused_hovered" src="https://user-images.githubusercontent.com/87140/128921367-6e6d55da-12fd-4f0b-bc03-a3bf299df129.png">|<img width="195" alt="map_links_focused" src="https://user-images.githubusercontent.com/87140/128921398-c081d584-864a-487f-a163-7fb6cbe5c191.png">|

### Map controls and links high contrast

Note: following GOVUK styles, there are no hover states in high contrast mode.

| Controls | Control focused | Link focused |
|---|---|---|
|<img width="53" alt="map_controls_high_contrast_mode_firefox" src="https://user-images.githubusercontent.com/87140/128921877-f45bc54d-723f-44cb-8b8e-3c36e8e47f89.png">|<img width="50" alt="maps_controls_high_contrast_mode_firefox_first_button_focused" src="https://user-images.githubusercontent.com/87140/128921997-b575fb3b-c90a-4803-a3af-10ce2be30f7e.png">|<img width="192" alt="map_links_high_contrast_mode_firefox_focused" src="https://user-images.githubusercontent.com/87140/128922027-9144ce91-a740-489e-8c87-be85f0cbfbae.png">|

## Added accessibility information

This also adds WAI-ARIA attributes and content to the map to make sure it has an accessible name and accessible description. This means assistive tech' can tell users what the map is when they start interacting with it (the accessible name) and give help if they need it (the accessible description).

## Notes for reviewers

I've tested in all our supported browsers ([the GDS browser matrix](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in-from-june-2021) but with IE down to 9).

Reviewers are best to look at it in their browser and Firefox with its high contrast mode turned on:

Settings > General > Colours > Override the colours specified by the page with your selections above > Always

They should try using it with just keyboard as well as mouse/trackpad/touch.
