### PR TITLE
Format 1000s properly on returned letters pages

### DIFF
--- a/app/templates/views/returned-letter-summary.html
+++ b/app/templates/views/returned-letter-summary.html
@@ -37,7 +37,7 @@
       <a class="govuk-link govuk-link--no-visited-state file-list-filename"
          href="{{url_for('.returned_letters', service_id=current_service.id, reported_at=item.reported_at)}}">{{ item.reported_at | format_date_normal }}</a>
        <p class="file-list-hint">
-         {{ item.returned_letter_count}} {{ item.returned_letter_count|message_count_label('letter', suffix='')}}
+         {{ item.returned_letter_count|format_thousands }} {{ item.returned_letter_count|message_count_label('letter', suffix='')}}
        </p>
     {% endcall %}
   {% endcall %}

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -51,7 +51,7 @@
   {% endcall %}
   {% if more_than_one_page %}
     <p class="table-show-more-link">
-      Only showing the first {{ page_size }} of {{ count_of_returned_letters }} rows
+      Only showing the first {{ page_size }} of {{ count_of_returned_letters|format_thousands }} rows
     </p>
   {% endif %}
 </div>


### PR DESCRIPTION
Our style is to comma-separate numbers in the 1000s for easier reading.