### PR TITLE
Update `email_access_validated_at` as soon as a you click a fresh link

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -52,6 +52,7 @@ def accept_invite(token):
     existing_user = User.from_email_address_or_none(invited_user.email_address)
 
     if existing_user:
+        existing_user.update_email_access_validated_at()
         invited_user.accept_invite()
         if existing_user in Users(invited_user.service):
             return redirect(url_for('main.service_dashboard', service_id=invited_user.service))
@@ -117,6 +118,7 @@ def accept_org_invite(token):
     organisation_users = OrganisationUsers(invited_org_user.organisation)
 
     if existing_user:
+        existing_user.update_email_access_validated_at()
         invited_org_user.accept_invite()
         if existing_user not in organisation_users:
             existing_user.add_to_organisation(organisation_id=invited_org_user.organisation)

--- a/app/main/views/new_password.py
+++ b/app/main/views/new_password.py
@@ -33,6 +33,9 @@ def new_password(token):
         flash('The link in the email has already been used')
         return redirect(url_for('main.index'))
 
+    if request.method == 'GET':
+        user.update_email_access_validated_at()
+
     form = NewPasswordForm()
 
     if form.validate_on_submit():

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -114,8 +114,8 @@ class User(JSONModel, UserMixin):
         response = user_api_client.update_user_attribute(self.id, **kwargs)
         self.__init__(response)
 
-    def update_password(self, password, validated_email_access=False):
-        response = user_api_client.update_password(self.id, password, validated_email_access=validated_email_access)
+    def update_password(self, password):
+        response = user_api_client.update_password(self.id, password)
         self.__init__(response)
 
     def update_email_access_validated_at(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import abort, request, session
 from flask_login import AnonymousUserMixin, UserMixin, login_user, logout_user
 from notifications_python_client.errors import HTTPError
@@ -115,6 +117,11 @@ class User(JSONModel, UserMixin):
     def update_password(self, password, validated_email_access=False):
         response = user_api_client.update_password(self.id, password, validated_email_access=validated_email_access)
         self.__init__(response)
+
+    def update_email_access_validated_at(self):
+        self.update(
+            email_access_validated_at=datetime.utcnow().isoformat()
+        )
 
     def password_changed_more_recently_than(self, datetime_string):
         if not self.password_changed_at:

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -74,10 +74,8 @@ class UserApiClient(NotifyAdminAPIClient):
         return user_data['data']
 
     @cache.delete('user-{user_id}')
-    def update_password(self, user_id, password, validated_email_access=False):
+    def update_password(self, user_id, password):
         data = {"_password": password}
-        if validated_email_access:
-            data["validated_email_access"] = validated_email_access
         url = "/user/{}/update-password".format(user_id)
         user_data = self.post(url, data=data)
         return user_data['data']

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -9,7 +9,8 @@ ALLOWED_ATTRIBUTES = {
     'mobile_number',
     'auth_type',
     'updated_by',
-    'current_session_id'
+    'current_session_id',
+    'email_access_validated_at',
 }
 
 

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -23,7 +23,7 @@ def log_in_user(user_id):
         session['current_session_id'] = user.current_session_id
         # Check if coming from new password page
         if 'password' in session.get('user_details', {}):
-            user.update_password(session['user_details']['password'], validated_email_access=True)
+            user.update_password(session['user_details']['password'])
         user.activate()
         user.login()
     finally:

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -156,6 +156,6 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
 
     # the log-in flow makes a couple of calls
     mock_get_user.assert_called_once_with(user['id'])
-    mock_update_user_password.assert_called_once_with(user['id'], 'a-new_password', validated_email_access=True)
+    mock_update_user_password.assert_called_once_with(user['id'], 'a-new_password')
 
     assert not mock_send_verify_code.called

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -234,7 +234,7 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
     assert response.location == url_for('main.show_accounts_or_dashboard', _external=True)
 
     mock_update_user_password.assert_called_once_with(
-        api_user_active['id'], 'changedpassword', validated_email_access=True
+        api_user_active['id'], 'changedpassword',
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1353,7 +1353,7 @@ def mock_verify_password(mocker):
 
 @pytest.fixture(scope='function')
 def mock_update_user_password(mocker, api_user_active):
-    def _update(user_id, password, validated_email_access=False):
+    def _update(user_id, password):
         api_user_active['id'] = user_id
         return api_user_active
 


### PR DESCRIPTION
When someone uses a fresh password reset or invite link they have proved that they have access to their inbox.

At the moment, when resetting a user’s email address we wait until after they’ve put in the 2FA code before updating the timestamp which records when they last validated their email address<sup>1</sup>.

We can’t think of a good reason that we need the extra assurance of a valid 2FA code to assert that the user has access to their email – they’ve done that just by clicking the link. When the user clicks the link we already update their failed login count before they 2fa. Think it makes sense to handle `email_access_validated_at` then too.

As a bonus, the functional tests never go as far as getting a 2FA code after a password reset<sup>2</sup>, so the functional test user never gets its timestamp updated. This causes the functional tests start failing after 90 days. By moving the update to this point we ensure that the functional tests will keep passing indefinitely.

1. [This code in the API](https://github.com/alphagov/notifications-api/blob/91542ad33eb995c9b3e617cde30a9714846dd37b/app/dao/users_dao.py#L131) which is called by this code in the admin app: https://github.com/alphagov/notifications-admin/blob/9ba37249a47f08b1396e63a34bc591c781739686/app/utils/login.py#L26)
2. https://github.com/alphagov/notifications-functional-tests/blob/5837eb01dc5c9b5bb255d2d1c54e64f778ff4f4e/tests/functional/preview_and_dev/test_email_auth.py#L43-L46

***

https://www.pivotaltracker.com/story/show/172893003