### PR TITLE
Update Security page content

### DIFF
--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -66,7 +66,7 @@
   <h2 class="heading-medium">How we manage risks on Notify</h2>
   <p class="govuk-body">Things we do to manage risks on Notify include:</p>
   <ul class="list list-bullet">
-    <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 2700:2011</a> and National Cyber Security Centre guidance</li>
+    <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 27005:2011</a> and National Cyber Security Centre guidance</li>
     <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.cesg.gov.uk/articles/check-fundamental-principles">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
     <li>residual risk statement preparation and active management of the risk treatment plan</li>
     <li>regular updates to the Privacy Impact Assessment</li>
@@ -79,6 +79,7 @@
 
   <h2 class="heading-medium">Classifications and security vetting</h2>
   <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
+  <p class="govuk-body">Notify does not process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
   <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/organisations/united-kingdom-security-vetting">United Kingdom Security Vetting</a> (UKSV).</p>
 
 {% endblock %}


### PR DESCRIPTION
This PR updates the content on the Security page:

1. Fix a typo in the 'ISO 27005' link text
2. Add a line to make clear that Notify does not process SECRET or TOP SECRET data 

These changes were discussed and agreed with @leohemsted 