### PR TITLE
Complete migration to new "areas" API format

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -88,7 +88,7 @@ class BroadcastMessage(JSONModel):
 
     @property
     def areas(self):
-        polygons = self._dict['areas_2']['simple_polygons']
+        polygons = self._dict['areas']['simple_polygons']
         library_areas = self.get_areas(self.area_ids)
 
         if library_areas:
@@ -106,11 +106,11 @@ class BroadcastMessage(JSONModel):
 
     @property
     def area_ids(self):
-        return self._dict['areas_2']['ids']
+        return self._dict['areas']['ids']
 
     @area_ids.setter
     def area_ids(self, value):
-        self._dict['areas_2']['ids'] = value
+        self._dict['areas']['ids'] = value
 
     @property
     def ancestor_areas(self):
@@ -230,7 +230,7 @@ class BroadcastMessage(JSONModel):
         self._update_areas()
 
     def remove_area(self, area_id):
-        self.area_ids = list(set(self._dict['areas_2']['ids']) - {area_id})
+        self.area_ids = list(set(self._dict['areas']['ids']) - {area_id})
         self._update_areas()
 
     def _set_status_to(self, status):
@@ -241,13 +241,13 @@ class BroadcastMessage(JSONModel):
         )
 
     def _update_areas(self, force_override=False):
-        areas_2 = {
+        areas = {
             'ids': self.area_ids,
             'names': [area.name for area in self.areas],
             'simple_polygons': self.simple_polygons.as_coordinate_pairs_lat_long
         }
 
-        data = {'areas_2': areas_2}
+        data = {'areas': areas}
 
         # TEMPORARY: while we migrate to a new format for "areas"
         if force_override:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -696,7 +696,7 @@ def broadcast_message_json(
         'reference': reference,
 
         'personalisation': {},
-        'areas_2': {
+        'areas': {
             'ids': area_ids or ['ctry19-E92000001', 'ctry19-S92000003'],
             'simple_polygons': simple_polygons or [],
         },

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1395,7 +1395,7 @@ def test_add_broadcast_area(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'areas_2': {
+            'areas': {
                 'ids': ['ctry19-E92000001', 'ctry19-S92000003', 'ctry19-W92000004'],
                 'names': ['England', 'Scotland', 'Wales'],
                 'simple_polygons': coordinates
@@ -1459,7 +1459,7 @@ def test_add_broadcast_sub_area_district_view(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'areas_2': {
+            'areas': {
                 'simple_polygons': coordinates,
                 **expected_data,
             }
@@ -1495,7 +1495,7 @@ def test_add_broadcast_sub_area_county_view(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'areas_2': {
+            'areas': {
                 'simple_polygons': coordinates,
                 'ids': [
                     # These two areas are on the broadcast already
@@ -1542,7 +1542,7 @@ def test_remove_broadcast_area_page(
         service_id=SERVICE_ONE_ID,
         broadcast_message_id=fake_uuid,
         data={
-            'areas_2': {
+            'areas': {
                 'simple_polygons': coordinates,
                 'names': ['Scotland'],
                 'ids': ['ctry19-S92000003']


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

Depends on: https://github.com/alphagov/notifications-api/pull/3314

Previously:

- We introduced a new "areas_2" API field that's can
populate the "areas" column in the same way.

- We updated the Admin app to use the new field, so that
the old "areas" and "simple_polygons" API fields are unused.

- We repurposed the unused "areas" API field to use
the new "areas_2" format.

This PR:

- We can switch the Admin app back to the "areas" field,
but in the new format.

Future PRs:

- Remove support for the unused "areas_2" field (migration complete)