### PR TITLE
Update service name advice

### DIFF
--- a/app/templates/views/add-service-local.html
+++ b/app/templates/views/add-service-local.html
@@ -20,7 +20,7 @@
           <li>Electoral services – {{ current_user.default_organisation.name }}</li>
           <li>Blue Badge – {{ current_user.default_organisation.name }}</li>
         </ul>
-        <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
+        <p class="govuk-body">You should only use an acronym or initialism if your users are already familiar with it.</p>
 
     {% call form_wrapper() %}
 

--- a/app/templates/views/service-settings/name-local.html
+++ b/app/templates/views/service-settings/name-local.html
@@ -23,7 +23,7 @@
       <li>Blue Badge - {{ current_service.organisation.name or current_user.default_organisation.name }}</li>
     </ul>
 
-  <p class="govuk-body">You should only use an acronym if your users are already familiar with it.</p>
+  <p class="govuk-body">You should only use an acronym or initialism if your users are already familiar with it.</p>
 
   <div class="form-group">
     {% if current_service.prefix_sms %}


### PR DESCRIPTION
This PR adds 'or initialism' to the advice about avoiding acronyms in service names.

As acronyms **and** initialisms are both problematic, it's probably worth calling them out as separate things.