### PR TITLE
Give WebAuthn illustration a fixed size

### DIFF
--- a/app/assets/stylesheets/views/webauthn.scss
+++ b/app/assets/stylesheets/views/webauthn.scss
@@ -26,15 +26,15 @@
 
 .webauthn-illustration {
 
-  @include govuk-media-query($from: tablet) {
-    margin: govuk-spacing(9) auto 0 auto;
-    padding: 0;
-  }
-
   box-sizing: border-box;
   width: 100%;
   height: 100%;
   margin: govuk-spacing(6) auto 0 auto;
   padding: 0 govuk-spacing(9) 0 govuk-spacing(9);
+
+  @include govuk-media-query($from: tablet) {
+    margin: govuk-spacing(9) auto 0 auto;
+    padding: 0;
+  }
 
 }

--- a/app/assets/stylesheets/views/webauthn.scss
+++ b/app/assets/stylesheets/views/webauthn.scss
@@ -26,13 +26,15 @@
 
 .webauthn-illustration {
 
-  @include media-down(mobile) {
-    box-sizing: border-box;
-    margin: govuk-spacing(6) auto 0 auto;
-    padding: 0 govuk-spacing(9) 0 govuk-spacing(9);
+  @include govuk-media-query($from: tablet) {
+    margin: govuk-spacing(9) auto 0 auto;
+    padding: 0;
   }
 
+  box-sizing: border-box;
   width: 100%;
-  margin: govuk-spacing(9) auto 0 auto;
+  height: 100%;
+  margin: govuk-spacing(6) auto 0 auto;
+  padding: 0 govuk-spacing(9) 0 govuk-spacing(9);
 
 }

--- a/app/assets/stylesheets/views/webauthn.scss
+++ b/app/assets/stylesheets/views/webauthn.scss
@@ -27,9 +27,12 @@
 .webauthn-illustration {
 
   @include media-down(mobile) {
-    margin: govuk-spacing(6) govuk-spacing(9) 0 govuk-spacing(9);
+    box-sizing: border-box;
+    margin: govuk-spacing(6) auto 0 auto;
+    padding: 0 govuk-spacing(9) 0 govuk-spacing(9);
   }
 
+  width: 100%;
   margin: govuk-spacing(9) auto 0 auto;
 
 }

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -65,7 +65,7 @@
       }) }}
     </div>
     <div class="govuk-grid-column-one-quarter">
-      <img src="{{ asset_url('images/security-key.svg') }}" alt="" class="webauthn-illustration">
+      <img src="{{ asset_url('images/security-key.svg') }}" alt="" class="webauthn-illustration" width="149" height="150">
     </div>
   </div>
 {% endblock %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -99,7 +99,7 @@
         {{ webauthn_button }}
       </div>
       <div class="govuk-grid-column-one-quarter">
-        <img src="{{ asset_url('images/security-key.svg') }}" alt="" class="webauthn-illustration">
+        <img src="{{ asset_url('images/security-key.svg') }}" alt="" class="webauthn-illustration" width="149" height="150">>
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
The browser uses the `width` and `height` attributes of the `<img>` tag to allocate space on the page for the image.

If these aren’t provided then the browser will assume the image takes up no space, until it downloads it and has a look at what the file’s dimensions are. This causes the layout of the page to jump once the image downloads. We can stop this jump from happening by providing the `width` and `height` attributes.

149 × 150 pixels is the native size of the image. But we don’t want it to display at that size, so this commit also adds some extra CSS which keeps it looking the same, namely:
- the full width (100%) of the 1/4 page column on desktop
- the full width (100%) of the column minus a 40 pixel gutter either side on mobile (by using `box-sizing: border-box` the 40 pixels of padding is subtracted from the 100% width, rather than added to it)