### PR TITLE
Fix areas not showing for custom broadcasts

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -203,8 +203,8 @@ class CustomBroadcastArea(BaseBroadcastArea):
 class CustomBroadcastAreas(SerialisedModelCollection):
     model = CustomBroadcastArea
 
-    def __init__(self, *, area_ids, polygons):
-        self.items = area_ids
+    def __init__(self, *, names, polygons):
+        self.items = names
         self._polygons = polygons
 
     def __getitem__(self, index):

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -89,10 +89,9 @@ class BroadcastMessage(JSONModel):
 
     @property
     def areas(self):
-        polygons = self._dict['areas']['simple_polygons']
-        library_areas = self.get_areas(self.area_ids)
+        if 'ids' in self._dict['areas']:
+            library_areas = self.get_areas(self.area_ids)
 
-        if library_areas:
             if len(library_areas) != len(self.area_ids):
                 raise RuntimeError(
                     f'BroadcastMessage has {len(self.area_ids)} areas '
@@ -101,8 +100,8 @@ class BroadcastMessage(JSONModel):
             return library_areas
 
         return CustomBroadcastAreas(
-            area_ids=self.area_ids,
-            polygons=polygons,
+            names=self._dict['areas']['names'],
+            polygons=self._dict['areas']['simple_polygons'],
         )
 
     @property

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -111,7 +111,7 @@ class BroadcastMessage(JSONModel):
 
     @property
     def area_ids(self):
-        return self._dict['areas']['ids']
+        return self._dict['areas'].get('ids', [])
 
     @area_ids.setter
     def area_ids(self, value):

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -99,10 +99,15 @@ class BroadcastMessage(JSONModel):
                 )
             return library_areas
 
-        return CustomBroadcastAreas(
-            names=self._dict['areas']['names'],
-            polygons=self._dict['areas']['simple_polygons'],
-        )
+        polygons = self._dict['areas'].get('simple_polygons', [])
+
+        if polygons:
+            return CustomBroadcastAreas(
+                names=self._dict['areas']['names'],
+                polygons=polygons,
+            )
+
+        return []
 
     @property
     def area_ids(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -678,6 +678,7 @@ def broadcast_message_json(
     updated_at=None,
     approved_by_id=None,
     cancelled_by_id=None,
+    areas=None,
     area_ids=None,
     simple_polygons=None,
     content=None,
@@ -696,7 +697,7 @@ def broadcast_message_json(
         'reference': reference,
 
         'personalisation': {},
-        'areas': {
+        'areas': areas or {
             'ids': area_ids or ['ctry19-E92000001', 'ctry19-S92000003'],
             'simple_polygons': simple_polygons or [],
         },

--- a/tests/app/broadcast_areas/test_utils.py
+++ b/tests/app/broadcast_areas/test_utils.py
@@ -175,8 +175,10 @@ def test_aggregate_areas_for_custom_polygons(
 ):
     broadcast_message = BroadcastMessage(
         broadcast_message_json(
-            area_ids=['derived from polygons'],
-            simple_polygons=simple_polygons
+            areas={
+                'names': [f'polygon {i}' for i, _ in enumerate(simple_polygons)],
+                'simple_polygons': simple_polygons
+            }
         )
     )
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -974,8 +974,10 @@ def test_preview_broadcast_areas_page_with_custom_polygons(
             created_by_id=fake_uuid,
             service_id=SERVICE_ONE_ID,
             status='draft',
-            area_ids=['Area one', 'Area two', 'Area three'],
-            simple_polygons=polygons,
+            areas={
+                'names': ['Area one', 'Area two', 'Area three'],
+                'simple_polygons': polygons,
+            }
         ),
     )
     client_request.login(active_user_create_broadcasts_permission)

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -4,6 +4,21 @@ from app.models.broadcast_message import BroadcastMessage
 from tests import broadcast_message_json
 
 
+@pytest.mark.parametrize('areas, expected_area_ids', [
+    ({'simple_polygons': []}, []),
+    ({'ids': ['123'], 'simple_polygons': []}, ['123'])
+])
+def test_area_ids(
+    areas,
+    expected_area_ids,
+):
+    broadcast_message = BroadcastMessage(broadcast_message_json(
+        areas=areas
+    ))
+
+    assert broadcast_message.area_ids == expected_area_ids
+
+
 def test_simple_polygons():
     broadcast_message = BroadcastMessage(broadcast_message_json(
         area_ids=[

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -4,13 +4,8 @@ from app.models.broadcast_message import BroadcastMessage
 from tests import broadcast_message_json
 
 
-def test_simple_polygons(fake_uuid):
+def test_simple_polygons():
     broadcast_message = BroadcastMessage(broadcast_message_json(
-        id_=fake_uuid,
-        service_id=fake_uuid,
-        template_id=fake_uuid,
-        status='draft',
-        created_by_id=fake_uuid,
         area_ids=[
             # Hackney Central
             'wd20-E05009372',
@@ -38,24 +33,13 @@ def test_simple_polygons(fake_uuid):
     ]
 
 
-def test_content_comes_from_attribute_not_template(fake_uuid):
-    broadcast_message = BroadcastMessage(broadcast_message_json(
-        id_=fake_uuid,
-        service_id=fake_uuid,
-        template_id=fake_uuid,
-        status='draft',
-        created_by_id=fake_uuid,
-    ))
+def test_content_comes_from_attribute_not_template():
+    broadcast_message = BroadcastMessage(broadcast_message_json())
     assert broadcast_message.content == 'This is a test'
 
 
-def test_areas_raises_for_missing_areas(fake_uuid):
+def test_areas_raises_for_missing_areas():
     broadcast_message = BroadcastMessage(broadcast_message_json(
-        id_=fake_uuid,
-        service_id=fake_uuid,
-        template_id=fake_uuid,
-        status='draft',
-        created_by_id=fake_uuid,
         area_ids=[
             'wd20-E05009372',
             'something else',

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -38,6 +38,22 @@ def test_content_comes_from_attribute_not_template():
     assert broadcast_message.content == 'This is a test'
 
 
+@pytest.mark.parametrize(('areas', 'expected_length'), [
+    ({'ids': []}, 0),
+    ({'ids': ['wd20-E05009372']}, 1),
+    ({'names': ['somewhere'], 'simple_polygons': [[[3.5, 1.5]]]}, 1)
+])
+def test_areas(
+    areas,
+    expected_length
+):
+    broadcast_message = BroadcastMessage(broadcast_message_json(
+        areas=areas
+    ))
+
+    assert len(list(broadcast_message.areas)) == expected_length
+
+
 def test_areas_raises_for_missing_areas():
     broadcast_message = BroadcastMessage(broadcast_message_json(
         area_ids=[

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -49,7 +49,7 @@ def test_content_comes_from_attribute_not_template(fake_uuid):
     assert broadcast_message.content == 'This is a test'
 
 
-def test_raises_for_missing_areas(fake_uuid):
+def test_areas_raises_for_missing_areas(fake_uuid):
     broadcast_message = BroadcastMessage(broadcast_message_json(
         id_=fake_uuid,
         service_id=fake_uuid,

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -41,6 +41,7 @@ def test_content_comes_from_attribute_not_template():
 @pytest.mark.parametrize(('areas', 'expected_length'), [
     ({'ids': []}, 0),
     ({'ids': ['wd20-E05009372']}, 1),
+    ({'no data': 'just created'}, 0),
     ({'names': ['somewhere'], 'simple_polygons': [[[3.5, 1.5]]]}, 1)
 ])
 def test_areas(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

This also reduces the reliance we have on the API defaulting
fields to empty arrays. Since "areas" is just an arbitrary JSON
blob, this app should be more resilient to what it contains or
doesn't contain. Best reviewed commit by commit.