### PR TITLE
Fix "flask shell" not working on PaaS instances

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -36,6 +36,7 @@ applications:
 
     env:
       NOTIFY_APP_NAME: admin
+      FLASK_APP: application.py
 
       # Credentials variables
       ADMIN_CLIENT_SECRET: '{{ ADMIN_CLIENT_SECRET }}'


### PR DESCRIPTION
This is consistent with API [1]. Other apps don't need this as they
follow the Flask convention of it being the "app" module or package.

[1]: https://github.com/alphagov/notifications-api/blob/master/manifest.yml.j2#L112