### PR TITLE
Bump utils to 46.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ fido2==0.9.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
 
-git+https://github.com/alphagov/notifications-utils.git@44.5.0#egg=notifications-utils==44.5.0
+git+https://github.com/alphagov/notifications-utils.git@46.0.0#egg=notifications-utils==46.0.0
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
 
 # cryptography 3.4+ incorporates Rust code, which isn't supported on PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.2.1
     # via -r requirements.in
-git+https://github.com/alphagov/notifications-utils.git@44.5.0#egg=notifications-utils==44.5.0
+git+https://github.com/alphagov/notifications-utils.git@46.0.0#egg=notifications-utils==46.0.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx

--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -44,7 +44,7 @@ def test_simple_polygons():
         # Because the areas are close to each other, the simplification
         # and unioning process results in a single polygon with fewer
         # total coordinates
-        [54],
+        [55],
     ]
 
 


### PR DESCRIPTION
This brings in some new polygon simplication code [1] so we need to
tweak any tests that rely on the exact number of polygons after this
operation.

[1]: https://github.com/alphagov/notifications-utils/pull/890