### PR TITLE
Fix incorrect log message for dodgy broadcasts

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -102,7 +102,7 @@ class BroadcastMessage(JSONModel):
                 # which isn't great as our code doesn't support editing its
                 # areas, but we don't expect this to happen often
                 current_app.logger.warn(
-                    f'BroadcastMessage has {len(self._dict["areas"])} areas '
+                    f'BroadcastMessage has {len(self.area_ids)} area IDs '
                     f'but {len(library_areas)} found in the library. Treating '
                     f'{self.id} as a custom broadcast.'
                 )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178986763

This was logging the number of keys in the whole JSON blob, rather
than the number of IDs specified within it.