### PR TITLE
fix contact list bst bug

### DIFF
--- a/app/models/contact_list.py
+++ b/app/models/contact_list.py
@@ -4,7 +4,6 @@ from os import path
 from flask import abort, current_app
 from notifications_utils.formatters import strip_whitespace
 from notifications_utils.recipients import RecipientCSV
-from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList
@@ -23,6 +22,7 @@ class ContactList(JSONModel):
 
     ALLOWED_PROPERTIES = {
         'id',
+        'created_at',
         'created_by',
         'has_jobs',
         'recent_job_count',
@@ -114,10 +114,6 @@ class ContactList(JSONModel):
             service_id=self.service_id,
             contact_list_id=self.id,
         )
-
-    @property
-    def created_at(self):
-        return utc_string_to_aware_gmt_datetime(self._dict['created_at'])
 
     @property
     def contents(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -716,3 +716,28 @@ def broadcast_message_json(
         'approved_by_id': approved_by_id,
         'cancelled_by_id': cancelled_by_id,
     }
+
+
+def contact_list_json(
+    *,
+    id_=None,
+    created_at='2020-06-13T09:59:56.000000Z',
+    created_by='Test User',
+    service_id,
+    original_file_name='EmergencyContactList.xls',
+    row_count=100,
+    recent_job_count=0,
+    has_jobs=True,
+    template_type='email',
+):
+    return {
+        'id': id_ or sample_uuid(),
+        'created_at': created_at,
+        'created_by': created_by,
+        'service_id': service_id,
+        'original_file_name': original_file_name,
+        'row_count': row_count,
+        'recent_job_count': recent_job_count,
+        'has_jobs': has_jobs,
+        'template_type': template_type,
+    }

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -4285,7 +4285,7 @@ def test_redirects_to_template_if_job_exists_already(
         '123 phone numbers',
     ),
 ))
-@freeze_time('2020-03-13 13:00')
+@freeze_time('2020-06-13 13:00')
 def test_choose_from_contact_list(
     mocker,
     client_request,

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -7,6 +7,7 @@ from flask import url_for
 from freezegun import freeze_time
 
 from app.formatters import normalize_spaces
+from tests import contact_list_json
 from tests.conftest import SERVICE_ONE_ID
 
 
@@ -471,17 +472,11 @@ def test_view_contact_list(
 ):
     mocker.patch(
         'app.models.contact_list.contact_list_api_client.get_contact_list',
-        return_value={
-            'created_at': '2020-03-03 12:12:12',
-            'created_by': 'Test User',
-            'id': fake_uuid,
-            'original_file_name': 'EmergencyContactList.xls',
-            'row_count': 100,
-            'recent_job_count': 0,
-            'has_jobs': has_jobs,
-            'service_id': SERVICE_ONE_ID,
-            'template_type': 'email',
-        },
+        return_value=contact_list_json(
+            created_at='2020-03-03T12:12:12.000000Z',
+            service_id=SERVICE_ONE_ID,
+            has_jobs=has_jobs
+        )
     )
     mocker.patch('app.models.contact_list.s3download', return_value='\n'.join(
         ['email address'] + [

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -458,7 +458,7 @@ def test_cant_save_bad_contact_list(
     (False, 'Not used yet.'),
     (True, 'Not used in the last 7 days.'),
 ])
-@freeze_time('2020-03-13 16:51:56')
+@freeze_time('2020-06-13 16:51:56')
 def test_view_contact_list(
     mocker,
     client_request,

--- a/tests/app/models/test_contact_list.py
+++ b/tests/app/models/test_contact_list.py
@@ -1,13 +1,5 @@
-from datetime import datetime
-
 from app.models.contact_list import ContactList
 from app.models.job import PaginatedJobs
-
-
-def test_created_at():
-    created_at = ContactList({'created_at': '2016-05-06T07:08:09.061258'}).created_at
-    assert isinstance(created_at, datetime)
-    assert created_at.isoformat() == '2016-05-06T08:08:09.061258+01:00'
 
 
 def test_get_jobs(mock_get_jobs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1852,7 +1852,7 @@ def mock_create_contact_list(mocker, api_user_active):
 def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
     def _get(service_id, template_type=None):
         return [{
-            'created_at': '2020-03-13 10:59:56',
+            'created_at': '2020-06-13T09:59:56.000000Z',
             'created_by': 'Test User',
             'id': fake_uuid,
             'original_file_name': 'EmergencyContactList.xls',
@@ -1862,7 +1862,7 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
             'service_id': service_id,
             'template_type': 'email',
         }, {
-            'created_at': '2020-03-13 13:00:00',
+            'created_at': '2020-06-13T12:00:00.000000Z',
             'created_by': 'Test User',
             'id': 'd7b0bd1a-d1c7-4621-be5c-3c1b4278a2ad',
             'original_file_name': 'phone number list.csv',
@@ -1872,7 +1872,7 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
             'service_id': service_id,
             'template_type': 'sms',
         }, {
-            'created_at': '2020-02-02 02:00:00',
+            'created_at': '2020-05-02T01:00:00.000000Z',
             'created_by': 'Test User',
             'id': fake_uuid,
             'original_file_name': 'UnusedList.tsv',
@@ -1893,7 +1893,7 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
 def mock_get_contact_list(mocker, api_user_active, fake_uuid):
     def _get(*, service_id, contact_list_id):
         return {
-            'created_at': '2020-03-13 10:59:56',
+            'created_at': '2020-06-13T09:59:56.000000Z',
             'created_by': 'Test User',
             'id': fake_uuid,
             'original_file_name': 'EmergencyContactList.xls',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from . import (
     api_key_json,
     assert_url_expected,
     broadcast_message_json,
+    contact_list_json,
     generate_uuid,
     invite_json,
     job_json,
@@ -1851,37 +1852,31 @@ def mock_create_contact_list(mocker, api_user_active):
 @pytest.fixture(scope='function')
 def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
     def _get(service_id, template_type=None):
-        return [{
-            'created_at': '2020-06-13T09:59:56.000000Z',
-            'created_by': 'Test User',
-            'id': fake_uuid,
-            'original_file_name': 'EmergencyContactList.xls',
-            'row_count': 100,
-            'recent_job_count': 0,
-            'has_jobs': True,
-            'service_id': service_id,
-            'template_type': 'email',
-        }, {
-            'created_at': '2020-06-13T12:00:00.000000Z',
-            'created_by': 'Test User',
-            'id': 'd7b0bd1a-d1c7-4621-be5c-3c1b4278a2ad',
-            'original_file_name': 'phone number list.csv',
-            'row_count': 123,
-            'recent_job_count': 2,
-            'has_jobs': True,
-            'service_id': service_id,
-            'template_type': 'sms',
-        }, {
-            'created_at': '2020-05-02T01:00:00.000000Z',
-            'created_by': 'Test User',
-            'id': fake_uuid,
-            'original_file_name': 'UnusedList.tsv',
-            'row_count': 1,
-            'recent_job_count': 0,
-            'has_jobs': False,
-            'service_id': service_id,
-            'template_type': 'sms',
-        }]
+        return [
+            contact_list_json(
+                id_=fake_uuid,
+                created_at='2020-06-13T09:59:56.000000Z',
+                service_id=service_id,
+            ),
+            contact_list_json(
+                id_='d7b0bd1a-d1c7-4621-be5c-3c1b4278a2ad',
+                created_at='2020-06-13T12:00:00.000000Z',
+                service_id=service_id,
+                original_file_name='phone number list.csv',
+                row_count=123,
+                recent_job_count=2,
+                template_type='sms',
+            ),
+            contact_list_json(
+                id_=fake_uuid,
+                created_at='2020-05-02T01:00:00.000000Z',
+                original_file_name='UnusedList.tsv',
+                row_count=1,
+                has_jobs=False,
+                service_id=service_id,
+                template_type='sms',
+            )
+        ]
 
     return mocker.patch(
         'app.models.contact_list.ContactLists.client_method',
@@ -1892,17 +1887,11 @@ def mock_get_contact_lists(mocker, api_user_active, fake_uuid):
 @pytest.fixture(scope='function')
 def mock_get_contact_list(mocker, api_user_active, fake_uuid):
     def _get(*, service_id, contact_list_id):
-        return {
-            'created_at': '2020-06-13T09:59:56.000000Z',
-            'created_by': 'Test User',
-            'id': fake_uuid,
-            'original_file_name': 'EmergencyContactList.xls',
-            'row_count': 100,
-            'recent_job_count': 0,
-            'has_jobs': True,
-            'service_id': service_id,
-            'template_type': 'email',
-        }
+        return contact_list_json(
+            id_=fake_uuid,
+            created_at='2020-06-13T09:59:56.000000Z',
+            service_id=service_id,
+        )
 
     return mocker.patch(
         'app.models.contact_list.contact_list_api_client.get_contact_list',


### PR DESCRIPTION
the api returns UTC timestamps, we should keep them as UTC timestamps until the very last moment, and only convert them into BST when we know we want to return to a user (ie: in contact-list.html and other places like that)

see also

- [ ] https://github.com/alphagov/notifications-api/pull/3329