### PR TITLE
Fix showing service type radios on error

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -53,7 +53,6 @@ def add_service():
         form = CreateServiceForm(
             organisation_type=default_organisation_type
         )
-    heading = 'About your service'
 
     if form.validate_on_submit():
         email_from = email_safe(form.name.data)
@@ -66,7 +65,7 @@ def add_service():
             form,
         )
         if error:
-            return render_template('views/add-service.html', form=form, heading=heading)
+            return _render_add_service_page(form, default_organisation_type)
         if len(service_api_client.get_active_services({'user_id': session['user_id']}).get('data', [])) > 1:
             return redirect(url_for('main.service_dashboard', service_id=service_id))
 
@@ -78,17 +77,23 @@ def add_service():
             template_id=example_sms_template['data']['id']
         ))
     else:
-        if default_organisation_type == 'local':
-            return render_template(
-                'views/add-service-local.html',
-                form=form,
-                heading=heading,
-                default_organisation_type=default_organisation_type,
-            )
+        return _render_add_service_page(form, default_organisation_type)
 
+
+def _render_add_service_page(form, default_organisation_type):
+    heading = 'About your service'
+
+    if default_organisation_type == 'local':
         return render_template(
-            'views/add-service.html',
+            'views/add-service-local.html',
             form=form,
             heading=heading,
             default_organisation_type=default_organisation_type,
         )
+
+    return render_template(
+        'views/add-service.html',
+        form=form,
+        heading=heading,
+        default_organisation_type=default_organisation_type,
+    )


### PR DESCRIPTION
The radio buttons to select the type of service - central, etc. -
are only shown if we can't infer the type based on the user's email
/ default organisation. However, the code to render the page in the
error case didn't accommodate this, nor did it show the version of
the page for adding a local government service.

This fixes the bug by DRYing-up the logic to render the pages. I've
not added a test for this for a couple of reasons:

- It's not a critical bug: no one has complained about it and it
doesn't block the user from adding service.

- It's unlikely to reoccur because the bug involved writing _more_
code than was necessary.

- It's not trivial to test this due to the 3 versions of the page
involved - these are tested for the happy path.

## Screenshots

| Before  | After |
| ------------- | ------------- |
| <img width="470" alt="Screenshot 2021-09-16 at 12 14 49" src="https://user-images.githubusercontent.com/9029009/133602568-408a75c2-c59d-408e-b2d3-39ac9f442845.png"> | <img width="527" alt="Screenshot 2021-09-16 at 12 15 08" src="https://user-images.githubusercontent.com/9029009/133602595-704a9e60-2e04-49ec-a89e-de6e912fa74d.png"> |

