### PR TITLE
Use new Zendesk form everywhere

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -130,7 +130,7 @@ def feedback(ticket_type):
         ticket = NotifySupportTicket(
             subject='Notify feedback',
             message=feedback_msg,
-            ticket_type=ticket_type,
+            ticket_type=get_zendesk_ticket_type(ticket_type),
             p1=out_of_hours_emergency,
             user_name=user_name,
             user_email=user_email,
@@ -231,3 +231,14 @@ def needs_escalation(ticket_type, severe):
         not current_user.is_authenticated,
         not in_business_hours(),
     ))
+
+
+def get_zendesk_ticket_type(ticket_type):
+    # Zendesk has 4 ticket types - "problem", "incident", "task" and "question".
+    # We don't want to use a Zendesk "problem" ticket type when someone reports a
+    # Notify problem because they are designed to group multiple incident tickets together,
+    # allowing them to be solved as a group.
+    if ticket_type == PROBLEM_TICKET_TYPE:
+        return NotifySupportTicket.TYPE_INCIDENT
+
+    return NotifySupportTicket.TYPE_QUESTION

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1207,8 +1207,8 @@ def branding_request(service_id, branding_type):
     elif branding_type == "letter":
         branding_name = current_service.letter_branding_name
     if form.validate_on_submit():
-        zendesk_client.create_ticket(
-            subject='{} branding request - {}'.format(branding_type.capitalize(), current_service.name),
+        ticket = NotifySupportTicket(
+            subject=f'{branding_type.capitalize()} branding request - {current_service.name}',
             message=(
                 'Organisation: {organisation}\n'
                 'Service: {service_name}\n'
@@ -1228,11 +1228,14 @@ def branding_request(service_id, branding_type):
                 new_paragraph='\n\n' if form.something_else.data else '',
                 detail=form.something_else.data or ''
             ),
-            ticket_type=zendesk_client.TYPE_QUESTION,
-            user_email=current_user.email_address,
+            ticket_type=NotifySupportTicket.TYPE_QUESTION,
             user_name=current_user.name,
-            tags=['notify_action', 'notify_branding'],
+            user_email=current_user.email_address,
+            org_id=current_service.organisation_id,
+            org_type=current_service.organisation_type,
+            service_id=current_service.id
         )
+        zendesk_client.send_ticket_to_zendesk(ticket)
         flash((
             'Thanks for your branding request. We’ll get back to you '
             'within one working day.'

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -12,7 +12,7 @@ from app.models.feedback import (
     PROBLEM_TICKET_TYPE,
     QUESTION_TICKET_TYPE,
 )
-from tests.conftest import normalize_spaces
+from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 def no_redirect():
@@ -138,9 +138,16 @@ def test_get_feedback_page(client, ticket_type, expected_status_code):
 @freeze_time('2016-12-12 12:00:00.000000')
 @pytest.mark.parametrize('ticket_type', [PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE])
 def test_passed_non_logged_in_user_details_through_flow(client, mocker, ticket_type):
-    mock_post = mocker.patch('app.main.views.feedback.zendesk_client.create_ticket')
+    mock_ticket = mocker.patch(
+        'app.main.views.feedback.NotifySupportTicket',
+        return_value='feedback_ticket',
+    )
+    mock_send_ticket_to_zendesk = mocker.patch(
+        'app.main.views.feedback.zendesk_client.send_ticket_to_zendesk',
+        autospec=True,
+    )
 
-    data = {'feedback': 'blah', 'name': 'Steve Irwin', 'email_address': 'rip@gmail.com'}
+    data = {'feedback': 'blah', 'name': 'Anne Example', 'email_address': 'anne@example.com'}
 
     resp = client.post(
         url_for('main.feedback', ticket_type=ticket_type),
@@ -154,14 +161,18 @@ def test_passed_non_logged_in_user_details_through_flow(client, mocker, ticket_t
         email_address_provided=True,
         _external=True,
     )
-    mock_post.assert_called_with(
+    mock_ticket.assert_called_once_with(
         subject='Notify feedback',
         message='blah\n',
-        user_email='rip@gmail.com',
-        user_name='Steve Irwin',
         ticket_type=ticket_type,
-        p1=ANY
+        p1=False,
+        user_name='Anne Example',
+        user_email='anne@example.com',
+        org_id=None,
+        org_type=None,
+        service_id=None
     )
+    mock_send_ticket_to_zendesk.assert_called_once_with('feedback_ticket')
 
 
 @freeze_time("2016-12-12 12:00:00.000000")
@@ -177,7 +188,14 @@ def test_passes_user_details_through_flow(
     ticket_type,
     data
 ):
-    mock_post = mocker.patch('app.main.views.feedback.zendesk_client.create_ticket')
+    mock_ticket = mocker.patch(
+        'app.main.views.feedback.NotifySupportTicket',
+        return_value='feedback_ticket',
+    )
+    mock_send_ticket_to_zendesk = mocker.patch(
+        'app.main.views.feedback.zendesk_client.send_ticket_to_zendesk',
+        autospec=True,
+    )
 
     client_request.post(
         'main.feedback',
@@ -191,25 +209,29 @@ def test_passes_user_details_through_flow(
             _external=True,
         ),
     )
-
-    mock_post.assert_called_with(
+    mock_ticket.assert_called_once_with(
         subject='Notify feedback',
         message=ANY,
-        user_email='test@user.gov.uk',
-        user_name='Test User',
         ticket_type=ticket_type,
-        p1=ANY
+        p1=False,
+        user_name='Test User',
+        user_email='test@user.gov.uk',
+        org_id=None,
+        org_type='central',
+        service_id=SERVICE_ONE_ID
     )
-    assert mock_post.call_args[1]['message'] == '\n'.join([
+
+    assert mock_ticket.call_args[1]['message'] == '\n'.join([
         'blah',
         'Service: "service one"',
         url_for(
             'main.service_dashboard',
-            service_id='596364a0-858e-42c8-9062-a8fe822260eb',
+            service_id=SERVICE_ONE_ID,
             _external=True
         ),
         ''
     ])
+    mock_send_ticket_to_zendesk.assert_called_once_with('feedback_ticket')
 
 
 @freeze_time('2016-12-12 12:00:00.000000')
@@ -289,7 +311,13 @@ def test_urgency(
     is_out_of_hours_emergency,
 ):
     mocker.patch('app.main.views.feedback.in_business_hours', return_value=is_in_business_hours)
-    mock_post = mocker.patch('app.main.views.feedback.zendesk_client.create_ticket')
+
+    mock_ticket = mocker.patch('app.main.views.feedback.NotifySupportTicket')
+    mocker.patch(
+        'app.main.views.feedback.zendesk_client.send_ticket_to_zendesk',
+        autospec=True,
+    )
+
     client_request.post(
         'main.feedback',
         ticket_type=ticket_type,
@@ -303,7 +331,7 @@ def test_urgency(
             _external=True,
         ),
     )
-    assert mock_post.call_args[1]['p1'] == is_out_of_hours_emergency
+    assert mock_ticket.call_args[1]['p1'] == is_out_of_hours_emergency
 
 
 ids, params = zip(*[

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1720,11 +1720,7 @@ def test_should_redirect_after_request_to_go_live(
             new_callable=PropertyMock,
             return_value=volume,
         )
-    mock_ticket = mocker.patch(
-        'app.main.views.service_settings.NotifySupportTicket',
-        return_value='go_live_ticket',
-    )
-    mock_ticket.TYPE_QUESTION = 'question'
+    mock_create_ticket = mocker.spy(NotifySupportTicket, '__init__')
     mock_send_ticket_to_zendesk = mocker.patch(
         'app.main.views.service_settings.zendesk_client.send_ticket_to_zendesk',
         autospec=True,
@@ -1756,7 +1752,8 @@ def test_should_redirect_after_request_to_go_live(
         service_id=SERVICE_ONE_ID,
         formatted_displayed_volumes=formatted_displayed_volumes,
     )
-    mock_ticket.assert_called_once_with(
+    mock_create_ticket.assert_called_once_with(
+        ANY,
         subject='Request to go live - service one',
         message=expected_message,
         ticket_type='question',
@@ -1767,7 +1764,7 @@ def test_should_redirect_after_request_to_go_live(
         org_type='central',
         service_id=SERVICE_ONE_ID,
     )
-    mock_send_ticket_to_zendesk.assert_called_once_with('go_live_ticket')
+    mock_send_ticket_to_zendesk.assert_called_once()
 
     assert normalize_spaces(page.select_one('.banner-default').text) == (
         'Thanks for your request to go live. We’ll get back to you within one working day.'
@@ -1806,11 +1803,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
             request_to_go_live_notes=go_live_note,
         )
     )
-    mock_ticket = mocker.patch(
-        'app.main.views.service_settings.NotifySupportTicket',
-        return_value='go_live_ticket',
-    )
-    mock_ticket.TYPE_QUESTION = 'question'
+    mock_create_ticket = mocker.spy(NotifySupportTicket, '__init__')
     mock_send_ticket_to_zendesk = mocker.patch(
         'app.main.views.service_settings.zendesk_client.send_ticket_to_zendesk',
         autospec=True,
@@ -1845,7 +1838,8 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         go_live_note=go_live_note
     )
 
-    mock_ticket.assert_called_once_with(
+    mock_create_ticket.assert_called_once_with(
+        ANY,
         subject='Request to go live - service one',
         message=expected_message,
         ticket_type='question',
@@ -1856,7 +1850,7 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         org_type='central',
         service_id=SERVICE_ONE_ID
     )
-    mock_send_ticket_to_zendesk.assert_called_once_with('go_live_ticket')
+    mock_send_ticket_to_zendesk.assert_called_once()
 
 
 def test_should_be_able_to_request_to_go_live_with_no_organisation(


### PR DESCRIPTION
We started using the new form for go live tickets in alphagov/notifications-admin#4024.

This change updates the two other ticket types that admin creates (branding requests and general enquiries) to also use the new form.

[Pivotal story](https://www.pivotaltracker.com/story/show/179005041)