### PR TITLE
Fix styles for API key value not being applied

### DIFF
--- a/app/assets/stylesheets/components/copy-to-clipboard.scss
+++ b/app/assets/stylesheets/components/copy-to-clipboard.scss
@@ -10,7 +10,7 @@
   }
 
   &__notice,
-  &__key {
+  &__value {
     font-family: monospace;
     display: block;
     padding: 0 0 10px 0;


### PR DESCRIPTION
When the component was renamed from ‘API key’ to ‘Copy to clipboard’ the class for the thing to be copied changed from `api-key__key` to `copy-to-clipboard__value`. While the CSS was updated to reflect the change from `api-key` to `copy-to-clipboard` the change from `__key` to `__value` was not made.

This can be seen in the [HTML before](https://github.com/alphagov/notifications-admin/blob/4921e6d46e10fe8fde9671e55f43a9583884030e/app/templates/components/api-key.html) and the [HTML after](https://github.com/alphagov/notifications-admin/blob/85f6881a5642d594797cab54c9990d40991f379a/app/templates/components/copy-to-clipboard.html).

This commit changes updates the CSS to reflect the change from `__key` to `__value` , so that the styles get applied properly.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/135107809-bad76eae-96a2-47a5-8210-5b272b25119b.png) | ![image](https://user-images.githubusercontent.com/355079/135107873-c330e38d-d917-4049-ab81-da92ad5fad85.png)

