### PR TITLE
Remove deprecated command line flag to `isort`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: ## Run tests
 
 .PHONY: fix-imports
 fix-imports: ## Fix imports using isort
-	isort -rc ./app ./tests
+	isort ./app ./tests
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt


### PR DESCRIPTION
> Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

— https://github.com/PyCQA/isort/blob/main/docs/upgrade_guides/5.0.0.md#--recursive-or--rc

***

We moved to version `> 5.0.0` of isort in March 2021: https://github.com/alphagov/notifications-admin/pull/3828/files