### PR TITLE
Update the How to pay page

### DIFF
--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -9,12 +9,16 @@
 
     {{ page_header('How to pay') }}
 
+    <p class="govuk-body">
+      If you use GOV.UK Notify to send text messages or letters, you may need to send us a <a class="govuk-link govuk-link--no-visited-state" href="#purchase-orders">purchase order</a>.
+    </p>
+
     <h2 class="heading-medium" id="invoices">
       Invoices
     </h2>
 
     <p class="govuk-body">
-      GOV.UK Notify is run by the Government Digital Service (GDS), part of the Cabinet Office.
+      Notify is run by the Government Digital Service (GDS), part of the Cabinet Office.
     </p>
 
     <p class="govuk-body">

--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -62,8 +62,4 @@
       Your organisation may need to <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.billing_details') }}">add the Cabinet Office as a supplier</a> before you can raise a <abbr title="purchase order">PO</abbr>.
     </p>
 
-    <p class="govuk-body">
-       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact us</a> if you need help raising a purchase order.
-    </p>
-
 {% endblock %}


### PR DESCRIPTION
As part of the work we’re doing for _Better messages_ and the Notify onboarding journey, this PR updates the ‘How to pay’ page to:

* add an introduction
* front-load the fact that users might need to raise a purchase order
* remove the link to contact support because we’ve added a ‘Billing details’ page to deal with most enquiries