### PR TITLE
Require the newest version of Jinja2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ Flask==1.1.2  # pyup: <2
 Flask-WTF==0.15.1
 Flask-Login==0.5.0
 werkzeug==2.0.2
+jinja2==3.0.2
 
 blinker==1.4
 pyexcel==0.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,8 +95,9 @@ itsdangerous==1.1.0
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==2.11.3
+jinja2==3.0.2
     # via
+    #   -r requirements.in
     #   flask
     #   govuk-frontend-jinja
     #   notifications-utils


### PR DESCRIPTION
Flask version 2 requires Jinja2 version 3. However rather than bumping both at once it feels safer to do this incrementally, so we can isolate anything which breaks.