### PR TITLE
Require the newest version of itsdangerous

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ pyproj==3.2.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
-itsdangerous==1.1.0  # pyup: <2
+itsdangerous==2.0.1
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@50.0.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ idna==2.10
     # via requests
 importlib-metadata==4.2.0
     # via -r requirements.in
-itsdangerous==1.1.0
+itsdangerous==2.0.1
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
Flask version 2 requires itsdangerous version 2. However rather than bumping both at once it feels safer to do this incrementally, so we can isolate anything which breaks.