### PR TITLE
Fix broken CSS links to assets in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$V
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
-	npm install && npm run build
+	npm install && NOTIFY_ENVIRONMENT=development npm run build
 
 .PHONY: run-flask
 run-flask:  ## Run flask


### PR DESCRIPTION
This depends on an environment variable being set when the assets
are built in a development context [1]. Otherwise, the assets get
their '/static' prefix stripped like they do for production, which
isn't compatible with serving them under '/static' in development.

[1]: https://github.com/alphagov/notifications-admin/blob/66e50221983eb1a12bae4009d3cba1fc07c2ed6a/gulpfile.js#L37-L41