### PR TITLE
Fix static assets in development (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$V
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
-	npm install && NOTIFY_ENVIRONMENT=development npm run build
+	npm install
+	. environment.sh; npm run build
 
 .PHONY: run-flask
 run-flask:  ## Run flask


### PR DESCRIPTION
Previous attempt: https://github.com/alphagov/notifications-admin/pull/4048

The problem with the previous attempt is that the assets built on
CI become part of the build artefact used for production [1]. This
switches back to my original approach of using environment.sh, but
with a technique to cope with it being absent on CI. I've tested it
works with and without an environment.sh file.

Note that "npm install" is fine to be on a separate line, since a
non-zero exit code will always cause "make" to stop.

[1]: https://github.com/alphagov/notifications-aws/blob/master/concourse/templates/admin.yml.j2#L47