### PR TITLE
Replace 'x' psuedo element with SVG

### DIFF
--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -40,6 +40,11 @@
         color: $light-blue-25;
       }
 
+      // set styles so they don't get overriden by govuk-button styles
+      &:active {
+        top: -2px;
+      }
+
       // The box-shadow that separates the remove link from the list item is hidden in
       // high contrast mode. Remake using a border instead
       // Also sets text colour to match govuk-button

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -19,51 +19,58 @@
       right: -2px; // cover list-item border-right
       bottom: -2px; // cover list-item border-bottom
       width: 35px;
-      background: $govuk-blue;
-      color: $white;
-      box-shadow: -2px 0 0 0 $black, inset 1px 0 0 0 rgba($white, 0.1);
       padding: (govuk-spacing(1) + 1px) 0 govuk-spacing(1); 
       border: 2px solid $govuk-blue;
       border-left: none;
       text-align: center;
       text-decoration: none;
+      font-size: inherit; // counter govuk-button styles
+      line-height: inherit; // counter govuk-button styles
 
-      // The box-shadow that separates the remove link from the list item is hidden in
-      // high contrast mode. Remake using a border instead
-      @media (-ms-high-contrast: active), (forced-colors: active) {
-        & {
-          border-left: 2px solid $govuk-blue;
-        }
+      // set styles so they don't get overriden by govuk-button styles
+      &,
+      &:hover {
+        background: $govuk-blue;
       }
 
-      &:hover,
-      &:focus {
+      &:hover {
         color: $light-blue-25;
       }
 
+      // The box-shadow that separates the remove link from the list item is hidden in
+      // high contrast mode. Remake using a border instead
+      // Also sets text colour to match govuk-button
       @media (-ms-high-contrast: active), (forced-colors: active) {
-        &,
+
+        &:link,
+        &:active,
         &:hover,
-        &:focus {
-          color: CanvasText;
+        &:focus:not(:active):not(:hover) {
+          border-left: 2px solid $govuk-blue;
+          color: LinkText;
         }
+
       }
 
-      &:focus {
+      // set styles so they don't get overriden by govuk-button styles
+      &,
+      &:focus:not(:active):not(:hover) {
+        box-shadow: -2px 0 0 0 $black, inset 1px 0 0 0 rgba($white, 0.1);
+      }
 
-        outline: none;
-        background: $govuk-focus-colour;
-        color: $black;
+      // set styles so they don't get overriden by govuk-button styles
+      &:focus:not(:active):not(:hover) {
         border-color: $black;
-
       }
 
-      // counter background colours being overridden
+      // show outline to make focus visible when background colours are overridden
       @media (-ms-high-contrast: active), (forced-colors: active) {
-        &:focus {
+
+        // set styles so they don't get overriden by govuk-button styles
+        &:focus:not(:active):not(:hover) {
           outline: 3px solid transparent;
-          color: CanvasText;
         }
+
       }
     }
 
@@ -86,7 +93,7 @@
 
   }
 
-  .govuk-button {
+  .govuk-button--secondary {
     margin-left: 3px;
   }
 

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -7,25 +7,28 @@
     display: inline-block;
     border: 2px solid $black;
     // Create space for the remove link on the right of the list item (including borders)
-    padding: (govuk-spacing(1) + 1px) (govuk-spacing(2) + 35px + (2 * 2px)) govuk-spacing(1) govuk-spacing(2);
+    padding: (govuk-spacing(1) + 1px) (govuk-spacing(2) + 37px) govuk-spacing(1) govuk-spacing(2);
     margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
     position: relative;
 
     &-remove {
 
-      display: block;
+      display: block; // fallback for browsers that don't support flexbox
+      display: flex;
+      // center SVG vertically and horizontally
+      align-items: center;
+      justify-content: center;
       position: absolute;
       top: -2px; // cover list-item border-top
       right: -2px; // cover list-item border-right
       bottom: -2px; // cover list-item border-bottom
-      width: 35px;
-      padding: (govuk-spacing(1) + 1px) 0 govuk-spacing(1); 
+      width: 37px;
+      padding: 0;
       border: 2px solid $govuk-blue;
       border-left: none;
       text-align: center;
-      text-decoration: none;
       font-size: inherit; // counter govuk-button styles
-      line-height: inherit; // counter govuk-button styles
+      line-height: 36px; // match area-list-item for browsers that don't support flexbox
 
       // set styles so they don't get overriden by govuk-button styles
       &,
@@ -54,13 +57,20 @@
 
       // set styles so they don't get overriden by govuk-button styles
       &,
+      &:focus,
       &:focus:not(:active):not(:hover) {
         box-shadow: -2px 0 0 0 $black, inset 1px 0 0 0 rgba($white, 0.1);
       }
 
       // set styles so they don't get overriden by govuk-button styles
+      &:focus,
       &:focus:not(:active):not(:hover) {
         border-color: $black;
+      }
+
+      &:focus:hover {
+        background-color: $govuk-focus-colour;
+        color: $black;
       }
 
       // show outline to make focus visible when background colours are overridden
@@ -69,6 +79,14 @@
         // set styles so they don't get overriden by govuk-button styles
         &:focus:not(:active):not(:hover) {
           outline: 3px solid transparent;
+        }
+
+        // override hover styles when focused, to preserve dimensions and outline
+        &:focus:hover {
+          top: -2px;
+          right: -2px;
+          bottom: -2px;
+          width: 37px;
         }
 
       }

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -6,55 +6,65 @@
 
     display: inline-block;
     border: 2px solid $black;
-    padding: (govuk-spacing(1) + 1px) (govuk-spacing(2) + 35px) govuk-spacing(1) govuk-spacing(2);
+    // Create space for the remove link on the right of the list item (including borders)
+    padding: (govuk-spacing(1) + 1px) (govuk-spacing(2) + 35px + (2 * 2px)) govuk-spacing(1) govuk-spacing(2);
     margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
     position: relative;
 
     &-remove {
 
-      font-size: 0;
+      display: block;
+      position: absolute;
+      top: -2px; // cover list-item border-top
+      right: -2px; // cover list-item border-right
+      bottom: -2px; // cover list-item border-bottom
+      width: 35px;
+      background: $govuk-blue;
+      color: $white;
+      box-shadow: -2px 0 0 0 $black, inset 1px 0 0 0 rgba($white, 0.1);
+      padding: (govuk-spacing(1) + 1px) 0 govuk-spacing(1); 
+      border: 2px solid $govuk-blue;
+      border-left: none;
+      text-align: center;
+      text-decoration: none;
 
-      &:before {
-        content: "×";
-        display: block;
-        position: absolute;
-        top: -2px;
-        right: -2px;
-        bottom: -2px;
-        width: 35px;
-        background: $govuk-blue;
-        color: $white;
-        box-shadow: -2px 0 0 0 $black, inset 1px 0 0 0 rgba($white, 0.1);
-        border: 2px solid $govuk-blue;
-        border-left: none;
-        font-size: 24px;
-        font-weight: normal;
-        line-height: 40px;
-        text-align: center;
-        text-decoration: none;
+      // The box-shadow that separates the remove link from the list item is hidden in
+      // high contrast mode. Remake using a border instead
+      @media (-ms-high-contrast: active), (forced-colors: active) {
+        & {
+          border-left: 2px solid $govuk-blue;
+        }
       }
 
       &:hover,
       &:focus {
+        color: $light-blue-25;
+      }
 
-        &:before {
-          color: $light-blue-25;
+      @media (-ms-high-contrast: active), (forced-colors: active) {
+        &,
+        &:hover,
+        &:focus {
+          color: CanvasText;
         }
-
       }
 
       &:focus {
 
         outline: none;
-
-        &:before {
-          background: $govuk-focus-colour;
-          color: $black;
-          border-color: $black;
-        }
+        background: $govuk-focus-colour;
+        color: $black;
+        border-color: $black;
 
       }
 
+      // counter background colours being overridden
+      @media (-ms-high-contrast: active), (forced-colors: active) {
+        &:focus {
+          outline: 3px solid transparent;
+          color: CanvasText;
+        }
+      }
     }
 
     &:last-child {

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -30,7 +30,16 @@
       <ul class="area-list">
     {% endif %}
         <li class="area-list-item">
-          {{ area.name }} <a class="area-list-item-remove" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">remove</a>
+          {{ area.name }}
+          <a class="area-list-item-remove" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
+            <svg id="area-list-item-remove__icon" width="12" height="12" viewbox="0 0 12 12" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg"> <g>
+              <title id="area__{{ loop.index }}">Remove {{ area.name }}</title>
+              <g transform="rotate(45),translate(1, -7.5)">
+                <line stroke-width="2" id="svg_1" y2="0" x2="7.5" y1="15" x1="7.5" stroke="currentColor" fill="none"/>
+                <line stroke-width="2" id="svg_3" y2="7.5" x2="0" y1="7.5" x1="15" stroke="currentColor" fill="none"/>
+              </g>
+            </svg>
+          </a>
         </li>
     {% if loop.last %}
       </ul>

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -31,7 +31,7 @@
     {% endif %}
         <li class="area-list-item">
           {{ area.name }}
-          <a class="area-list-item-remove" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
+          <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
             <svg id="area-list-item-remove__icon" width="12" height="12" viewbox="0 0 12 12" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg"> <g>
               <title id="area__{{ loop.index }}">Remove {{ area.name }}</title>
               <g transform="rotate(45),translate(1, -7.5)">

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -32,7 +32,7 @@
         <li class="area-list-item">
           {{ area.name }}
           <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
-            <svg id="area-list-item-remove__icon" width="11" height="11" viewbox="0 0 10 10" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg"> <g>
+            <svg id="area-list-item-remove__icon" width="11" height="11" viewbox="0 0 10 10" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg">
               <title id="area__{{ loop.index }}">Remove {{ area.name }}</title>
               <g transform="rotate(45),translate(1, -6)">
                 <line stroke-width="1.75" id="svg_1" y2="0" x2="6" y1="12" x1="6" stroke="currentColor" fill="none"/>

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -32,11 +32,11 @@
         <li class="area-list-item">
           {{ area.name }}
           <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
-            <svg id="area-list-item-remove__icon" width="12" height="12" viewbox="0 0 12 12" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg"> <g>
+            <svg id="area-list-item-remove__icon" width="11" height="11" viewbox="0 0 10 10" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg"> <g>
               <title id="area__{{ loop.index }}">Remove {{ area.name }}</title>
-              <g transform="rotate(45),translate(1, -7.5)">
-                <line stroke-width="2" id="svg_1" y2="0" x2="7.5" y1="15" x1="7.5" stroke="currentColor" fill="none"/>
-                <line stroke-width="2" id="svg_3" y2="7.5" x2="0" y1="7.5" x1="15" stroke="currentColor" fill="none"/>
+              <g transform="rotate(45),translate(1, -6)">
+                <line stroke-width="1.75" id="svg_1" y2="0" x2="6" y1="12" x1="6" stroke="currentColor" fill="none"/>
+                <line stroke-width="1.75" id="svg_3" y2="6" x2="0" y1="6" x1="12" stroke="currentColor" fill="none"/>
               </g>
             </svg>
           </a>

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -832,8 +832,8 @@ def test_broadcast_page(
         'ctry19-E92000001',
         'ctry19-S92000003',
     ], [
-        'England remove',
-        'Scotland remove',
+        'England Remove England',
+        'Scotland Remove Scotland',
     ], [
         'An area of 200,000 square miles Will get the alert',
         'An extra area of 8,000 square miles is Likely to get the alert',
@@ -846,11 +846,11 @@ def test_broadcast_page(
         'wd20-E05003228',
         'wd20-E05003229',
     ], [
-        'Penrith Carleton remove',
-        'Penrith East remove',
-        'Penrith Pategill remove',
-        'Penrith South remove',
-        'Penrith West remove',
+        'Penrith Carleton Remove Penrith Carleton',
+        'Penrith East Remove Penrith East',
+        'Penrith Pategill Remove Penrith Pategill',
+        'Penrith South Remove Penrith South',
+        'Penrith West Remove Penrith West',
     ], [
         'An area of 6 square miles Will get the alert',
         'An extra area of 20 square miles is Likely to get the alert',
@@ -859,7 +859,7 @@ def test_broadcast_page(
     ([
         'lad20-E09000019',
     ], [
-        'Islington remove',
+        'Islington Remove Islington',
     ], [
         'An area of 10 square miles Will get the alert',
         'An extra area of 5 square miles is Likely to get the alert',
@@ -868,7 +868,7 @@ def test_broadcast_page(
     ([
         'ctyua19-E10000019',
     ], [
-        'Lincolnshire remove',
+        'Lincolnshire Remove Lincolnshire',
     ], [
         'An area of 4,000 square miles Will get the alert',
         'An extra area of 700 square miles is Likely to get the alert',
@@ -878,7 +878,7 @@ def test_broadcast_page(
         'ctyua19-E10000019',
         'ctyua19-E10000023'
     ], [
-        'Lincolnshire remove', 'North Yorkshire remove',
+        'Lincolnshire Remove Lincolnshire', 'North Yorkshire Remove North Yorkshire',
     ], [
         'An area of 10,000 square miles Will get the alert',
         'An extra area of 2,000 square miles is Likely to get the alert',
@@ -991,7 +991,7 @@ def test_preview_broadcast_areas_page_with_custom_polygons(
         normalize_spaces(item.text)
         for item in page.select('ul.area-list li.area-list-item')
     ] == [
-        'Area one remove', 'Area two remove', 'Area three remove',
+        'Area one Remove Area one', 'Area two Remove Area two', 'Area three Remove Area three',
     ]
 
     assert len(page.select('#area-list-map')) == 1


### PR DESCRIPTION
Part of these cards:
- [Fix admin broadcast pages in high contrast mode](https://www.pivotaltracker.com/story/show/179852075)
- [Improve accessibility of admin broadcasts content](https://www.pivotaltracker.com/story/show/179850485)

<img width="430" alt="image" src="https://user-images.githubusercontent.com/87140/138474148-a73c5d80-9f7f-4450-ab14-1b0eb923fdf5.png">

Changes the following things with the 'x' link-button that removes an area:
- makes the 'x' an SVG instead of [a ::before pseudo element](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) so we can make screen readers announce "Remove [area]" instead of "x"
- fixes the visual design in high contrast modes
- makes it into a button, instead of a link

The last change is because, unlike the other link-buttons (ie. 'Send' & 'Edit' on template pages), the text isn't underlined so it has no link styling.

## Notes for reviewers

You don't need to follow all this but here are some tips in case useful.

### Testing the 'x' being changed to an SVG

If you're comfortable using a screen reader, try using the button with one. If you aren't, worth knowing I tested with the NVDA, Voiceover and JAWS screen readers and that you can check the accessibility info the new HTML produces in devtools. That'll be the 'Accessibility' tab in Firefox devtools. In Chrome you need to inspect the element and look in the 'Accessibility' tab in the pane to the right of the code view.

### Testing in high contrast mode

I have access to Window High Contrast mode via our testing solution, assistivelabs, and recorded some screengrabs you can see below. High contrast views can also be checked manually using Firefox:

Settings > General > Colours > Override the colours specified by the page with your selections above > Always.

### Testing it being a button

Try the following:
- check the role it has in the 'Accessibility' section of devtools (see guidance above for how to see that)
- tab to it and try pressing space to activate

## Before/after screenshots

In all of these, I tab through the buttons and hover the first one.

### Default display

#### Before

https://user-images.githubusercontent.com/87140/138466178-f7495a11-4905-4bdd-bcd0-2ada875ffc18.mov

#### After

https://user-images.githubusercontent.com/87140/138466250-c22aa2e7-5cb9-478a-b4a4-9cfa7789f698.mov

### High contrast white on black

#### Before

https://user-images.githubusercontent.com/87140/138473571-590e675a-27c9-425e-866a-6f4cd4f424c6.mov

#### After

https://user-images.githubusercontent.com/87140/138466548-9db60810-0171-4de1-b9da-6f163d107722.mov

### High contrast black on white

#### Before

https://user-images.githubusercontent.com/87140/138466618-46f68404-0073-42d9-9916-b98d32891cd2.mov

#### After


https://user-images.githubusercontent.com/87140/138466653-5889017f-dc06-4c22-ace3-fe588dafa7c4.mov

### Firefox high contrast

#### Before

https://user-images.githubusercontent.com/87140/138466723-2ad877b0-1308-4b84-8250-c28ddc278ef2.mov

#### After

https://user-images.githubusercontent.com/87140/138466754-ee79a37a-1bcb-4616-847b-18e977ca0372.mov
