### PR TITLE
Fix headings on choose account page

### DIFF
--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -7,7 +7,7 @@
   organisations=[],
   services=[]
 ) %}
-  {% if show_heading %}
+  {% if show_heading and (services or organisations) %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
         <h2>
@@ -33,7 +33,7 @@
       <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="govuk-link govuk-link--no-visited-state">{{ service.name }}</a>
     </li>
   {% endfor %}
-  {% if show_heading %}
+  {% if show_heading and (services or organisations) %}
         </ul>
       </div>
     </div>
@@ -77,14 +77,14 @@
     {% if current_user.organisations %}
       {{ service_list(
         heading='Live services',
-        show_heading=current_user.trial_mode_services,
+        show_heading=current_user.trial_mode_services or current_user.platform_admin,
         organisations=current_user.organisations,
         services=current_user.live_services
       ) }}
     {% else %}
       {{ service_list(
         heading='Live services',
-        show_heading=(current_user.trial_mode_services and current_user.live_services),
+        show_heading=(current_user.trial_mode_services and current_user.live_services) or current_user.platform_admin,
         services=current_user.live_services
       ) }}
     {% endif %}
@@ -92,7 +92,7 @@
     {% if current_user.trial_mode_services %}
       {{ service_list(
         heading='Trial mode services',
-        show_heading=(current_user.organisations or current_user.live_services),
+        show_heading=(current_user.organisations or current_user.live_services or current_user.platform_admin),
         services=current_user.trial_mode_services
       ) }}
     {% endif %}


### PR DESCRIPTION
You’re supposed to see the two column layout on this page if you have multiple categories of things to show.

We weren’t counting the ‘platform admin’ section as one of these categories so platform admin users with only live services or only trial mode services were inadvertently seeing a mixture of the one column and two column layout.

Also this logic around the headings wasn’t tested before – now it is.

Screenshot of the problem:

<img width="1027" alt="Screenshot 2021-10-26 at 14 38 36" src="https://user-images.githubusercontent.com/355079/138896431-10812db6-041b-41d4-bdde-8b7fa1f76d72.png">

How the page looks with the non-broken two-column layout:

![Screenshot 2021-10-26 at 14 48 25](https://user-images.githubusercontent.com/355079/138896506-794fc405-61d8-4d56-9365-b247b3c14deb.png)


