### PR TITLE
Bump utils to 47.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ importlib-metadata==4.2.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
 
-git+https://github.com/alphagov/notifications-utils.git@46.1.0#egg=notifications-utils==46.1.0
+git+https://github.com/alphagov/notifications-utils.git@47.0.1#egg=notifications-utils==47.0.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
 
 # cryptography 3.4+ incorporates Rust code, which isn't supported on PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ awscli==1.19.84
     #   notifications-utils
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-bleach==3.3.0
+bleach==4.1.0
     # via notifications-utils
 blinker==1.4
     # via
@@ -125,7 +125,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@46.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@47.0.1
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx


### PR DESCRIPTION
Changes: https://github.com/alphagov/notifications-utils/compare/46.1.0...47.0.1

The breaking change is due to the removal of ZendeskClient.create_ticket which this app is no longer using.

> Although this is a breaking change to the ZendeskClient, nothing is using the code that was deleted.

— https://github.com/alphagov/notifications-utils/pull/902#discussion_r720095133