### PR TITLE
Bump due dates on accessiblity statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -115,7 +115,7 @@
   </ul>
 
   <p class="govuk-body">
-    We expect to fix these issues by the end of October 2021.
+    We expect to fix these issues by the end of December 2021.
   </p>
 
   <h3 class="heading-small">Problems with using the interface</h3>
@@ -143,7 +143,7 @@
   </ul>
 
   <p class="govuk-body">
-    We hope to fix these issues by the end of December 2021.
+    We hope to fix these issues by the end of January 2022.
   </p>
 
   <h3 class="heading-small">
@@ -206,6 +206,6 @@
   </p>
 
   <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 13 August 2021.
+    This statement was prepared on 23 September 2020. It was last reviewed on 27 October 2021.
   </p>
 {% endblock %}


### PR DESCRIPTION
Work prepping the interface that will be used for
emergency alerts for its accessibility audit has
taken priority so the issues in this statement
will need to be worked on later than we expected
when we originally set the dates for them to be
fixed.

This moves the work forward to be started after
the emergency alerts work is complete.