### PR TITLE
Add Makefile command to watch for frontend changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ bootstrap: generate-version-file ## Set up everything to run the app
 	npm install
 	. environment.sh; npm run build
 
+.PHONY: watch-frontend
+watch-frontend:  ## Build frontend and watch for changes
+	. environment.sh; npm run watch
+
 .PHONY: run-flask
 run-flask:  ## Run flask
 	. environment.sh && flask run -p 6012


### PR DESCRIPTION
When editing CSS, Javascript or other assets it’s useful to not have to run `gulp` manually to rebuild things after making changes.

This is why we have the `npm watch` script.

However for the paths to fonts to resolve properly when running locally it needs the `NOTIFY_ENVIRONMENT` variable set to `development`. Having to remember to do both of these steps every time is awkward.

For a one-off build of the frontend we added a command to set `NOTIFY_ENVIRONMENT` to the appropriate value in https://github.com/alphagov/notifications-admin/pull/4049

This commit does the same thing for the watch task, by encapsulating both steps in one `make` command.

Happy to take alternative suggestions on command naming.