### PR TITLE
Fix edit reply to email bug

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -617,9 +617,13 @@ def get_service_verify_reply_to_address_partials(service_id, notification_id):
 def service_edit_email_reply_to(service_id, reply_to_email_id):
     form = ServiceReplyToEmailForm()
     reply_to_email_address = current_service.get_email_reply_to_address(reply_to_email_id)
+
     if request.method == 'GET':
         form.email_address.data = reply_to_email_address['email_address']
         form.is_default.data = reply_to_email_address['is_default']
+
+    show_choice_of_default_checkbox = not reply_to_email_address['is_default']
+
     if form.validate_on_submit():
         if form.email_address.data == reply_to_email_address["email_address"] or current_user.platform_admin:
             service_api_client.update_reply_to_email_address(
@@ -653,6 +657,7 @@ def service_edit_email_reply_to(service_id, reply_to_email_id):
         'views/service-settings/email-reply-to/edit.html',
         form=form,
         reply_to_email_address_id=reply_to_email_id,
+        show_choice_of_default_checkbox=show_choice_of_default_checkbox
     )
 
 

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -23,7 +23,7 @@
         },
         error_message_with_html=True
     ) }}
-    {% if form.is_default.data %}
+    {% if not show_choice_of_default_checkbox %}
       <p class="form-group">
         This is the default reply-to address for {{ current_service.name }} emails
       </p>

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2881,23 +2881,20 @@ def test_add_edit_reply_to_email_address_goes_straight_to_update_if_address_not_
     assert mock_update_reply_to_email_address.called is False
 
 
-@pytest.mark.parametrize('reply_to_address, expected_link_text, partial_href', [
+@pytest.mark.parametrize('reply_to_address, default_choice_and_delete_link_expected', [
     (
         create_reply_to_email_address(is_default=False),
-        'Delete',
-        partial(url_for, 'main.service_confirm_delete_email_reply_to', reply_to_email_id=sample_uuid()),
+        True,
     ),
     (
         create_reply_to_email_address(is_default=True),
-        None,
-        None,
+        False,
     ),
 ])
 def test_shows_delete_link_for_get_request_for_edit_email_reply_to_address(
     mocker,
     reply_to_address,
-    expected_link_text,
-    partial_href,
+    default_choice_and_delete_link_expected,
     fake_uuid,
     client_request,
 ):
@@ -2915,10 +2912,16 @@ def test_shows_delete_link_for_get_request_for_edit_email_reply_to_address(
         service_id=SERVICE_ONE_ID,
     )
 
-    if expected_link_text:
+    if default_choice_and_delete_link_expected:
         link = page.select_one('.page-footer a')
-        assert normalize_spaces(link.text) == expected_link_text
-        assert link['href'] == partial_href(service_id=SERVICE_ONE_ID)
+        assert normalize_spaces(link.text) == 'Delete'
+        assert link['href'] == url_for(
+            'main.service_confirm_delete_email_reply_to',
+            service_id=SERVICE_ONE_ID,
+            reply_to_email_id=sample_uuid()
+        )
+        assert not page.select_one('input#is_default').has_attr('checked')
+
     else:
         assert not page.select('.page-footer a')
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180026726

Can be reviewed commit by commit (commit 1 fixes the bug, commit 2 is a slight refactor to a related test).

There was a bug where if you enter an invalid email address in
to the edit reply to email address form and click save, the
form you get shown with your error message will always contain
the field to set as default the reply to and also delete. This should
not have been the case. If you make an error on the form when
changing a reply to that is already a default, then you should not
be given the chance to change it to not default, nor should you
be able to delete it.

This PR fixes that bug by making sure the additional form fields
are only shown if the reply to being changed is not the default.

## Default reply to address
### Before
![image](https://user-images.githubusercontent.com/7228605/140306701-33541aee-889e-45b5-aa12-74750470d227.png)

### After
![image](https://user-images.githubusercontent.com/7228605/140306649-4436a6b0-9937-42d3-9bd3-e49a47fa5e0d.png)

## Non default reply to address staying as not the default
### Before
![image](https://user-images.githubusercontent.com/7228605/140306974-5d67a52b-18c4-4d9e-995b-be1fa2cd4013.png)

### After
![image](https://user-images.githubusercontent.com/7228605/140306896-5357be8c-9cfa-4ab6-bd6f-66395e5f0bf3.png)


## Non default reply to address requesting to become the default
### Before
![image](https://user-images.githubusercontent.com/7228605/140307103-ee7d5731-69e8-4ea8-ae62-10cf48f2b840.png)

### After![image](https://user-images.githubusercontent.com/7228605/140307066-50520ae2-f8a1-4fe3-a0c9-47467bad47c7.png)


