### PR TITLE
Fix spacing on send one-off SMS

### DIFF
--- a/app/assets/stylesheets/views/send.scss
+++ b/app/assets/stylesheets/views/send.scss
@@ -1,6 +1,7 @@
 .send-one-off-form {
 
-  .form-group {
+  .form-group,
+  .govuk-form-group {
     margin-bottom: 20px;
   }
 


### PR DESCRIPTION
Previous the text input on the send one off SMS page was wrapped in an element with a class of `form-group`. We overrode the spacing on this element to make the links under the textbox move closer to the textbox, so that visually they group together.

This was broken when we moved to GOV.UK frontend, which uses a class of `govuk-form-group`. This commit changes the CSS to account for both possibilities, because the send-a-one-off-letter page is still using a textbox, not a text input, and textboxes haven’t moved to GOV.UK Frontend yet.

— | Before | After
---|---|---
**Text message** | ![image](https://user-images.githubusercontent.com/355079/140310572-e0dddc08-b55b-478b-aa8a-dc9de9d6d1ee.png) | ![image](https://user-images.githubusercontent.com/355079/140310612-5417e875-b6fe-4eb9-9600-41820311e029.png)
**Letter** | ![image](https://user-images.githubusercontent.com/355079/140310530-1275bc6a-f10b-4daf-aa5c-ff06e9055c59.png) | ![image](https://user-images.githubusercontent.com/355079/140310542-82091212-ca53-4338-b565-8f038676961d.png)
  