### PR TITLE
Fix autofocus in places where it wasn’t working

### DIFF
--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -10,7 +10,16 @@
       // is still where users intend to start
       if (($(window).scrollTop() > 0) && !forceFocus) { return; }
 
-      $component.filter('input, textarea, select').eq(0).trigger('focus');
+      // See if the component itself is something we want to send focus to
+      var target = $component.filter('input, textarea, select');
+
+      // Otherwise look inside the component to see if there are any elements
+      // we want to send focus to
+      if (target.length === 0) {
+        target = $('input, textarea, select', $component);
+      }
+
+      target.eq(0).trigger('focus');
 
     };
   };

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -17,7 +17,7 @@ showHideContent.init();
 
 $(() => GOVUK.modules.start());
 
-$(() => $('.error-message').eq(0).parent('label').next('input').trigger('focus'));
+$(() => $('.error-message, .govuk-error-message').eq(0).parent('label').next('input').trigger('focus'));
 
 $(() => $('.banner-dangerous').eq(0).trigger('focus'));
 

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -33,6 +33,51 @@ def test_view_team_members(
     ) == 'Cancel invitation'
 
 
+@pytest.mark.parametrize('number_of_users', (
+    pytest.param(7, marks=pytest.mark.xfail),
+    pytest.param(8),
+))
+def test_should_show_live_search_if_more_than_7_users(
+    client_request,
+    mocker,
+    mock_get_organisation,
+    active_user_with_permissions,
+    number_of_users,
+):
+    mocker.patch(
+        'app.models.user.OrganisationInvitedUsers.client_method',
+        return_value=[],
+    )
+    mocker.patch(
+        'app.models.user.OrganisationUsers.client_method',
+        return_value=[active_user_with_permissions] * number_of_users,
+    )
+
+    page = client_request.get(
+        '.manage_org_users',
+        org_id=ORGANISATION_ID,
+    )
+
+    assert page.select_one('div[data-module=live-search]')['data-targets'] == (
+        ".user-list-item"
+    )
+    assert len(page.select('.user-list-item')) == number_of_users
+
+    textbox = page.select_one('[data-module=autofocus] .govuk-input')
+    assert 'value' not in textbox
+    assert textbox['name'] == 'search'
+    # data-module=autofocus is set on a containing element so it
+    # shouldn’t also be set on the textbox itself
+    assert 'data-module' not in textbox
+    assert not page.select_one('[data-force-focus]')
+    assert textbox['class'] == [
+        'govuk-input', 'govuk-!-width-full',
+    ]
+    assert normalize_spaces(
+        page.select_one('label[for=search]').text
+    ) == 'Search by name or email address'
+
+
 def test_invite_org_user(
     client_request,
     mocker,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -2253,8 +2253,14 @@ def test_send_one_off_letter_address_shows_form(
 
     form = page.select_one('form')
 
+    assert form['data-module'] == 'autofocus'
+    assert form['data-force-focus'] == 'True'
+
     assert form.select_one('label').text.strip() == 'Address'
-    assert form.select_one('textarea').attrs['name'] == 'address'
+    assert form.select_one('textarea')['name'] == 'address'
+    assert form.select_one('textarea')['data-module'] == 'enhanced-textbox'
+    assert form.select_one('textarea')['data-highlight-placeholders'] == 'false'
+    assert form.select_one('textarea')['rows'] == '4'
 
     upload_link = form.select_one('a')
 

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -164,6 +164,36 @@ def test_should_200_for_get_tour_step(
     )
 
 
+def test_should_show_empty_text_box(
+    client_request,
+    mock_get_service_template_with_multiple_placeholders,
+    service_one,
+    fake_uuid,
+):
+    with client_request.session_transaction() as session:
+        session['placeholders'] = {'phone number': '07700 900762'}
+
+    page = client_request.get(
+        'main.tour_step',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        step_index=1
+    )
+
+    textbox = page.select_one('[data-module=autofocus][data-force-focus=True] .govuk-input')
+    assert 'value' not in textbox
+    assert textbox['name'] == 'placeholder_value'
+    assert textbox['class'] == [
+        'govuk-input', 'govuk-!-width-full',
+    ]
+    # data-module=autofocus is set on a containing element so it
+    # shouldn’t also be set on the textbox itself
+    assert 'data-module' not in textbox
+    assert normalize_spaces(
+        page.select_one('label[for=placeholder_value]').text
+    ) == 'one'
+
+
 def test_should_prefill_answers_for_get_tour_step(
     client_request,
     mock_get_service_template_with_multiple_placeholders,

--- a/tests/javascripts/autofocus.test.js
+++ b/tests/javascripts/autofocus.test.js
@@ -20,7 +20,7 @@ describe('Autofocus', () => {
 
     // set up DOM
     document.body.innerHTML =
-      `<div>
+      `<div id="wrapper">
         <label class="form-label" for="search">
           ${labelText}
         </label>
@@ -42,6 +42,18 @@ describe('Autofocus', () => {
   });
 
   test('is focused when modules start', () => {
+
+    // start module
+    window.GOVUK.modules.start();
+
+    expect(focusHandler).toHaveBeenCalled();
+
+  });
+
+  test('is focused when attribute is set on outer element', () => {
+
+    document.getElementById('search').removeAttribute('data-module');
+    document.getElementById('wrapper').setAttribute('data-module', 'autofocus');
 
     // start module
     window.GOVUK.modules.start();


### PR DESCRIPTION
There are quite a few places where autofocusing text entry elements wasn’t working because the HTML is using a mixture of GOV.UK-Elements-style HTML and class names and new GOV.UK Frontend components.

This PR makes the Javascript work with both types, until such a time as we’ve moved entirely to GOV.UK Frontend.

Best reviewed commit-by-commit.