### PR TITLE
Make space for link in a sticky page footer

### DIFF
--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -76,6 +76,10 @@
         {{ govukButton({ "text": button_text }) }}
       {% endif %}
       {% if template.template_type == 'letter' %}
+        {% if error %}
+          {# no continue button so need to pad the space #}
+          <div>&nbsp;</div>
+        {% endif %}
         <a href="{{ url_for('no_cookie.check_notification_preview', service_id=current_service.id, template_id=template.id, filetype='pdf') }}" download class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link{% if error %}-without-button{% endif %}">Download as a PDF</a>
       {% endif %}
     </form>

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -129,7 +129,9 @@
 
   <div class="js-stick-at-bottom-when-scrolling">
     <div class="page-footer">
-      {% if not confirm_delete_banner %}
+      {% if confirm_delete_banner %}
+        <div>&nbsp;</div>
+      {% else %}
         <span class="page-footer-delete-link page-footer-delete-link-without-button">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.delete_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Delete this contact list</a>
         </span>


### PR DESCRIPTION
If there’s a sticky page footer which only has a right aligned link it needs another element to give the container its height. This is because the link itself is absolutely positioned so takes up no height.

On the _notification_ page we do this with a non-breaking space:
https://github.com/alphagov/notifications-admin/blob/1c2b65356f4b048ddea65cb5084417b2d6b68436/app/templates/views/notifications/notification.html#L101

This commit applies that same approach in the other places where we have right-aligned links in a sticky page footer elsewhere.

# Before 

![image](https://user-images.githubusercontent.com/355079/140312298-5233d79c-5c71-4164-9728-fc5d67810e5d.png)

# After 

![image](https://user-images.githubusercontent.com/355079/140312362-452cce57-82d2-431c-9ecc-5591cb8c87e8.png)


