### PR TITLE
High contrast issues alerts pages

### DIFF
--- a/app/assets/stylesheets/components/broadcast-message.scss
+++ b/app/assets/stylesheets/components/broadcast-message.scss
@@ -6,6 +6,7 @@
     max-width: 464px;
     box-sizing: border-box;
     padding: govuk-spacing(9) govuk-spacing(3) govuk-spacing(3) govuk-spacing(3);
+    border: solid 1px transparent; // to show it's area in high contrast mode
     background: $panel-colour;
     box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.05);
     border-radius: 5px;
@@ -18,10 +19,11 @@
   &-heading {
     display: block;
     position: absolute;
-    top: 0;
-    left: 0;
+    top: -1px;
+    left: -1px;
     padding: govuk-spacing(2) + 1px govuk-spacing(3) (govuk-spacing(2) - 1px) 46px;
-    width: 100%;
+    border: solid 1px transparent; // to show it's area in high contrast mode
+    width: calc(100% + 2px); // grow to overlap wrapper's border (when combined with top and left)
     box-sizing: border-box;
     font-weight: bold;
     background: $grey-1 file-url('exclamation.svg');

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -122,7 +122,8 @@
 
     display: block;
     text-align: left;
-    padding: 10px govuk-spacing(3);
+    padding: 9px (govuk-spacing(3) - 1);
+    border: 1px solid transparent;
     text-align: center;
 
     &:link,

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -39,6 +39,11 @@
     padding-bottom: govuk-spacing(3);
     z-index: 10;
 
+    // transparent borders become visible in high contrast modes so set to match background
+    @media (-ms-high-contrast: active), (forced-colors: active) {
+      border-color: Canvas;
+    }
+
     .placeholder,
     .placeholder-conditional {
       color: transparent;


### PR DESCRIPTION
Fixes for a few issues on this card:

https://www.pivotaltracker.com/story/show/179852075

Attempts to fix the following issues:
- blue buttons on template page don't have an outline so look like floating text
- the mock up of the alert on 'Preview' and other pages doesn't have an outline so looks wrong
- the message textarea has a line below the text you enter that moves when the lines increase

## Blue buttons on template page don't have an outline so look like floating text

### Before

<img width="739" alt="pill_items_high_contrast_dark_before" src="https://user-images.githubusercontent.com/87140/141131276-e2de0805-41d3-4b5d-9a2c-3880210cde49.png">

### After

<img width="755" alt="pill_items_high_contrast_dark_after" src="https://user-images.githubusercontent.com/87140/141131354-c442d427-76c7-4014-b8ec-d2f0d242cf16.png">

## The mock up of the alert on 'Preview' and other pages doesn't have an outline so looks wrong

### Before

<img width="487" alt="mock_up_high_contrast_mode_dark_before" src="https://user-images.githubusercontent.com/87140/141131393-29d084c7-2f19-4853-88ab-0d7175d37153.png">

### After

<img width="503" alt="mock_up_high_contrast_mode_dark_after" src="https://user-images.githubusercontent.com/87140/141131420-98a64968-3d5c-4a6f-82b6-a9dcde62dd0d.png">

#### Note about the alert icon

The alert icon, to the left of the mock up heading, will need to be made into an inline SVG so it can match the text colour in all modes (including high contrast). This is what it looks like in high contrast light:

<img width="262" alt="image" src="https://user-images.githubusercontent.com/87140/141131754-4abfe428-6659-4dc0-a77e-f431b785830c.png">

The HTML for this is in [notifications-utils](https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/jinja_templates/broadcast_preview_template.jinja2) so I'll update it outside of this pull request.

## The message textarea has a line below the text you enter that moves when the lines increase

### Before

<img width="414" alt="textbox_high_contrast_before" src="https://user-images.githubusercontent.com/87140/141131461-72b15792-2614-4ed5-8323-291a0a85a716.png">

### After

<img width="413" alt="textbox_high_contrast_after" src="https://user-images.githubusercontent.com/87140/141131495-cec05394-0d38-4146-9154-f825947beac8.png">

## Notes for reviewers

The screenshots above are from Windows high contrast mode. You can use [Firefox's color modes](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use) to check this normally but, if you're using v94 and above, it'll look broken. I'm looking into this but it affects design system too worth knowing that the approach used in these changes is at least consistent with them and so would be fixed in tandem with any work they do on this.