### PR TITLE
Fix map key in high contrast

### DIFF
--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -137,17 +137,10 @@
   padding-left: govuk-spacing(8);
   line-height: govuk-spacing(7);
 
-  &:before {
-    content: "";
-    display: block;
+  &__icon {
     position: absolute;
-    top: 3px;
-    left: govuk-spacing(1);
-    width: govuk-spacing(6);
-    height: govuk-spacing(6);
-    box-sizing: border-box;
-    margin-right: govuk-spacing(1);
-    transform: rotate(45deg);
+    left: -5px;
+    top: -7px;
   }
 
   &--certain {

--- a/app/templates/views/broadcast/macros/area-map.html
+++ b/app/templates/views/broadcast/macros/area-map.html
@@ -1,6 +1,10 @@
 {% macro map(broadcast_message) %}
   <div id="area-list-map"></div>
     <p class="area-list-key area-list-key--certain">
+      <svg class="area-list-key__icon" width="50" height="50" viewbox="0 0 50 50" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+        <rect x="0" y="0" width="100%" height="100%" fill="#FFFFFF" />
+        <polygon points="25 5, 45 25, 25 45, 5 25" stroke="#0B0B0C" stroke-width="2" fill="#96C6E2" />
+      </svg>
       <span class="visually-hidden">
         An area of {{ (broadcast_message.simple_polygons.estimated_area)|round_to_significant_figures(1)|format_thousands }} square miles
       </span>
@@ -9,6 +13,10 @@
       alert
     </p>
     <p class="area-list-key area-list-key--likely">
+      <svg class="area-list-key__icon" width="50" height="50" viewbox="0 0 50 50" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+        <rect x="0" y="0" width="100%" height="100%" fill="#FFFFFF" />
+        <polygon points="25 5, 45 25, 25 45, 5 25" stroke="#005ea5" stroke-opacity="1" stroke-width="2" stroke-linecap="square" stroke-linejoin="round" stroke-dasharray="4,7.5,5,7.5,8,8,5,8,7.5,8,5,8,7,8,5,8,4" fill="#2B8CC4" fill-opacity="0.15" />
+      </svg>
       <span class="visually-hidden">
         An extra area of {{ (broadcast_message.simple_polygons_with_bleed.estimated_area - broadcast_message.simple_polygons.estimated_area)|round_to_significant_figures(1)|format_thousands }} square miles is
       </span>

--- a/app/templates/views/broadcast/macros/area-map.html
+++ b/app/templates/views/broadcast/macros/area-map.html
@@ -5,11 +5,13 @@
         <rect x="0" y="0" width="100%" height="100%" fill="#FFFFFF" />
         <polygon points="25 5, 45 25, 25 45, 5 25" stroke="#0B0B0C" stroke-width="2" fill="#96C6E2" />
       </svg>
-      <span class="visually-hidden">
-        An area of {{ (broadcast_message.simple_polygons.estimated_area)|round_to_significant_figures(1)|format_thousands }} square miles
+      <span class="govuk-visually-hidden">
+        An area of {{ (broadcast_message.simple_polygons.estimated_area)|round_to_significant_figures(1)|format_thousands }} square miles&nbsp;
       </span>
       Will get
-      <span class="visually-hidden">the</span>
+      <span class="govuk-visually-hidden">
+        the
+      </span>
       alert
     </p>
     <p class="area-list-key area-list-key--likely">
@@ -17,11 +19,11 @@
         <rect x="0" y="0" width="100%" height="100%" fill="#FFFFFF" />
         <polygon points="25 5, 45 25, 25 45, 5 25" stroke="#005ea5" stroke-opacity="1" stroke-width="2" stroke-linecap="square" stroke-linejoin="round" stroke-dasharray="4,7.5,5,7.5,8,8,5,8,7.5,8,5,8,7,8,5,8,4" fill="#2B8CC4" fill-opacity="0.15" />
       </svg>
-      <span class="visually-hidden">
-        An extra area of {{ (broadcast_message.simple_polygons_with_bleed.estimated_area - broadcast_message.simple_polygons.estimated_area)|round_to_significant_figures(1)|format_thousands }} square miles is
+      <span class="govuk-visually-hidden">
+        An extra area of {{ (broadcast_message.simple_polygons_with_bleed.estimated_area - broadcast_message.simple_polygons.estimated_area)|round_to_significant_figures(1)|format_thousands }} square miles is&nbsp;
       </span>
       Likely to get
-      <span class="visually-hidden">
+      <span class="govuk-visually-hidden">
         the
       </span>
       alert


### PR DESCRIPTION
Part of this card to fix issues in high contrast modes:

https://www.pivotaltracker.com/story/show/179852075

The key to the map that shows the area an alert will be broadcast to can look different to the bits of the map it represents in high contrast mode. This is because its images are made in CSS so can change in those modes.

This tries to fix that by changing them to be inline SVGs, who's stroke and fill are preserved in high contrast modes. The fix also adds a white background area behind them so they display OK in high contrast modes with dark backgrounds. This is based on the backplates that are added for text on top of images in high contrast modes.

This also contains a fix for an issue I noticed with how the text in the key is announced by screen readers. More info' in commit message.

## Default view

### Before

<img width="743" alt="map_key_default_mode_before" src="https://user-images.githubusercontent.com/87140/141097078-8a52a210-ab8b-4045-9e6a-446d1bd1afec.png">

### After

<img width="741" alt="map_key_default_mode_after" src="https://user-images.githubusercontent.com/87140/141097120-18b6a7f4-d966-4669-ba5b-230cfda59779.png">

## High contrast mode (white text on black background)

### Before

<img width="743" alt="map_key_high_contrast_mode_before" src="https://user-images.githubusercontent.com/87140/141097234-9eeb3b83-7bf2-47ef-bd23-589602b76965.png">

### After

<img width="742" alt="map_key_high_contrast_mode_after" src="https://user-images.githubusercontent.com/87140/141097307-8973aa74-3417-46b3-8e84-b0d5b54913c7.png">

## Testing in high contrast mode

I have access to Window High Contrast mode via our testing solution, assistivelabs, where the screenshots you can see above were taken. High contrast views can also be checked manually using Firefox:

Settings > General > Colours > Override the colours specified by the page with your selections above > Always.

## Notes on implementation

Accoding to [the css color adjust spec'](https://www.w3.org/TR/css-color-adjust-1/#forced-color-adjust-prop) it should be possible to just use `forced-color-adjust: none` to protect the existing images from high contrast mode but [this part of the forced-color feature is currently only supported in Chromium browsers](https://caniuse.com/mdn-css_properties_forced-color-adjust).