### PR TITLE
Check that PyProj can be installed on PaaS

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,7 @@ Shapely==1.7.1
 rtreelib==0.2.0
 fido2==0.9.1
 importlib-metadata==4.2.0
+pyproj==3.2.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,9 @@ botocore==1.20.84
 cachetools==4.2.2
     # via notifications-utils
 certifi==2021.5.30
-    # via requests
+    # via
+    #   pyproj
+    #   requests
 cffi==1.14.5
     # via cryptography
 chardet==4.0.0
@@ -162,6 +164,8 @@ pyparsing==2.4.7
     # via packaging
 pypdf2==1.26.0
     # via notifications-utils
+pyproj==3.2.1
+    # via -r requirements.in
 python-dateutil==2.8.1
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
Previously when trying to bring in https://github.com/alphagov/notifications-utils/pull/889 we had trouble because there were no wheels available for the version of Pip that we were using. Now that we have upgraded to Python 3.9 we are using a newer buildpack which should have the necessary wheels available.

This commit is just installing the latest version of the package and nothing else, to give us more confidence that we can merge https://github.com/alphagov/notifications-utils/pull/915 without having to subsequently revert it.