### PR TITLE
Add downloadable report for org usage

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -156,8 +156,18 @@ def organisation_dashboard(org_id):
         **{
             f'total_{key}': sum(service[key] for service in services)
             for key in ('emails_sent', 'sms_cost', 'letter_cost')
-        }
+        },
+        download_link=url_for(
+            '.download_services_report_for_org',
+            org_id=org_id,
+        )
     )
+
+
+@main.route("/organisations/<uuid:org_id>", methods=['GET'])
+@user_has_permissions()
+def download_services_report_for_org(org_id):
+    pass
 
 
 @main.route("/organisations/<uuid:org_id>/trial-services", methods=['GET'])

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -112,4 +112,10 @@
     <div class="keyline-block govuk-!-margin-top-2"></div>
   {% endif %}
 
+  <div class="js-stick-at-bottom-when-scrolling">
+    <p class="bottom-gutter">
+      <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
+    </p>
+  </div>
+
 {% endblock %}

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -113,7 +113,7 @@
   {% endif %}
 
   <div class="js-stick-at-bottom-when-scrolling">
-    <p class="bottom-gutter">
+    <p class="govuk-!-margin-bottom-1">
       <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
     </p>
   </div>

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -624,6 +624,7 @@ def test_organisation_services_hides_search_bar_for_7_or_fewer_services(
     assert not page.select_one('.live-search')
 
 
+@freeze_time("2021-11-12 11:09:00.061258")
 def test_organisation_services_links_to_downloadable_report(
     client_request,
     mock_get_organisation,
@@ -651,7 +652,62 @@ def test_organisation_services_links_to_downloadable_report(
     page = client_request.get('.organisation_dashboard', org_id=ORGANISATION_ID)
 
     link_to_report = page.find('a', text="Download this report")
-    assert link_to_report.attrs["href"] == url_for('.download_services_report_for_org', org_id=ORGANISATION_ID)
+    assert link_to_report.attrs["href"] == url_for(
+        '.download_organisation_usage_report',
+        org_id=ORGANISATION_ID,
+        selected_year=2021
+    )
+
+
+@freeze_time("2021-11-12 11:09:00.061258")
+def test_download_organisation_usage_report(
+    client_request,
+    mock_get_organisation,
+    mocker,
+    active_user_with_permissions,
+    fake_uuid,
+):
+    mocker.patch(
+        'app.organisations_client.get_services_and_usage',
+        return_value={"services": [
+            {
+                'service_id': SERVICE_ONE_ID,
+                'service_name': 'Service 1',
+                'chargeable_billable_sms': 22,
+                'emails_sent': 13000,
+                'free_sms_limit': 100,
+                'letter_cost': 30.50,
+                'sms_billable_units': 122,
+                'sms_cost': 1.93,
+                'sms_remainder': None
+            },
+            {
+                'service_id': SERVICE_TWO_ID,
+                'service_name': 'Service 1',
+                'chargeable_billable_sms': 222,
+                'emails_sent': 23000,
+                'free_sms_limit': 250000,
+                'letter_cost': 60.50,
+                'sms_billable_units': 322,
+                'sms_cost': 3.93,
+                'sms_remainder': None
+            },
+        ]}
+    )
+    client_request.login(active_user_with_permissions)
+    csv_report = client_request.get(
+        '.download_organisation_usage_report',
+        org_id=ORGANISATION_ID,
+        selected_year=2021,
+        _test_page_title=False
+    )
+
+    assert csv_report.string == (
+        "Service ID,Service Name,Emails sent,Free text message allowance remaining,"
+        "Spent on text messages (£),Spent on letters (£)"
+        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,,1.93,30.5"
+        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,,3.93,60.5\r\n"
+    )
 
 
 def test_organisation_trial_mode_services_shows_all_non_live_services(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -624,6 +624,36 @@ def test_organisation_services_hides_search_bar_for_7_or_fewer_services(
     assert not page.select_one('.live-search')
 
 
+def test_organisation_services_links_to_downloadable_report(
+    client_request,
+    mock_get_organisation,
+    mocker,
+    active_user_with_permissions,
+    fake_uuid,
+):
+    mocker.patch(
+        'app.organisations_client.get_services_and_usage',
+        return_value={"services": [
+            {
+                'service_id': SERVICE_ONE_ID,
+                'service_name': 'Service 1',
+                'chargeable_billable_sms': 250122,
+                'emails_sent': 13000,
+                'free_sms_limit': 250000,
+                'letter_cost': 30.50,
+                'sms_billable_units': 122,
+                'sms_cost': 1.93,
+                'sms_remainder': None
+            },
+        ] * 2}
+    )
+    client_request.login(active_user_with_permissions)
+    page = client_request.get('.organisation_dashboard', org_id=ORGANISATION_ID)
+
+    link_to_report = page.find('a', text="Download this report")
+    assert link_to_report.attrs["href"] == url_for('.download_services_report_for_org', org_id=ORGANISATION_ID)
+
+
 def test_organisation_trial_mode_services_shows_all_non_live_services(
     client_request,
     platform_admin_user,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -89,6 +89,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'documentation',
     'download_contact_list',
     'download_notifications_csv',
+    'download_organisation_usage_report',
     'edit_and_format_messages',
     'edit_data_retention',
     'edit_organisation_agreement',


### PR DESCRIPTION
In this PR we took the info that org level users see for each service on the org dashboard, and put it into a downloadable report.

This is so org level users can use this data easier for things like determining spending per service.

Pivotal ticket: https://www.pivotaltracker.com/story/show/180276865

Next steps: think / research if we could add anything to this report to make it even more useful.

Org dashboard with a link to download the report:
<img width="1122" alt="Screenshot 2021-11-17 at 17 56 51" src="https://user-images.githubusercontent.com/20957548/142256185-1f494c7d-48e8-4a21-a928-16f31c2324d6.png">
