### PR TITLE
Remove caching of performance page data to fix caching bug

### DIFF
--- a/app/notify_client/performance_dashboard_api_client.py
+++ b/app/notify_client/performance_dashboard_api_client.py
@@ -1,9 +1,8 @@
-from app.notify_client import NotifyAdminAPIClient, cache
+from app.notify_client import NotifyAdminAPIClient
 
 
 class PerformanceDashboardAPIClient(NotifyAdminAPIClient):
 
-    @cache.set('performance-stats-{start_date}-to-{end_date}')
     def get_performance_dashboard_stats(
         self,
         *,

--- a/tests/app/notify_client/test_performance_platform_api_client.py
+++ b/tests/app/notify_client/test_performance_platform_api_client.py
@@ -1,5 +1,4 @@
 from datetime import date
-from unittest.mock import call
 
 from app.notify_client.performance_dashboard_api_client import (
     PerformanceDashboardAPIClient,
@@ -7,7 +6,6 @@ from app.notify_client.performance_dashboard_api_client import (
 
 
 def test_get_aggregate_platform_stats(mocker):
-    mocker.patch('app.extensions.RedisClient.get', return_value=None)
     client = PerformanceDashboardAPIClient()
     mock = mocker.patch.object(client, 'get', return_value={})
 
@@ -20,66 +18,3 @@ def test_get_aggregate_platform_stats(mocker):
         'start_date': '2021-03-01',
         'end_date': '2021-03-31'
     })
-
-
-def test_sets_value_in_cache(mocker):
-    client = PerformanceDashboardAPIClient()
-
-    mock_redis_get = mocker.patch(
-        'app.extensions.RedisClient.get',
-        return_value=None,
-    )
-    mock_api_get = mocker.patch(
-        'app.notify_client.NotifyAdminAPIClient.get',
-        return_value={'data_from': 'api'},
-    )
-    mock_redis_set = mocker.patch(
-        'app.extensions.RedisClient.set',
-    )
-
-    assert client.get_performance_dashboard_stats(
-        start_date=date(2021, 1, 1),
-        end_date=date(2022, 2, 2),
-    ) == {'data_from': 'api'}
-
-    assert mock_redis_get.call_args_list == [
-        call('performance-stats-2021-01-01-to-2022-02-02'),
-    ]
-    assert mock_api_get.call_args_list == [
-        call('/performance-dashboard', params={
-            'start_date': '2021-01-01', 'end_date': '2022-02-02'
-        }),
-    ]
-    assert mock_redis_set.call_args_list == [
-        call(
-            'performance-stats-2021-01-01-to-2022-02-02',
-            '{"data_from": "api"}',
-            ex=604800,
-        ),
-    ]
-
-
-def test_returns_value_from_cache(mocker):
-    client = PerformanceDashboardAPIClient()
-
-    mock_redis_get = mocker.patch(
-        'app.extensions.RedisClient.get',
-        return_value=b'{"data_from": "cache"}',
-    )
-    mock_api_get = mocker.patch(
-        'app.notify_client.NotifyAdminAPIClient.get',
-    )
-    mock_redis_set = mocker.patch(
-        'app.extensions.RedisClient.set',
-    )
-
-    assert client.get_performance_dashboard_stats(
-        start_date=date(2021, 1, 1),
-        end_date=date(2022, 2, 2),
-    ) == {'data_from': 'cache'}
-
-    assert mock_redis_get.call_args_list == [
-        call('performance-stats-2021-01-01-to-2022-02-02'),
-    ]
-    assert mock_api_get.called is False
-    assert mock_redis_set.called is False


### PR DESCRIPTION
I came across a bug where the performance page might be visited
on say the 22nd and we expect it to show data for yesterday and
the past 7 days (so the 21st and back 7 days) but instead it
only shows it for the 20th and then back 6 days.

The cause is that we have nightly tasks that run to
- calculate the number of notifications sent per service (the
  `ft_notification_status` table)
- calculate the number of notifications sent within 10 seconds
  (the `ft_processing_time` table)

Both of these tables get filled between the hours of midnight and
2:30am. The first seems to be filled by about 12:30 every night
whereas the processing stats seems to be filled about 2am every
night.

The admin app currently caches the results of the call to the API
(https://github.com/alphagov/notifications-api/blob/master/app/performance_dashboard/rest.py#L24)
to get this data with the key
`performance-stats-{start_date}-to-{end_date}`.

Now the issue here is that if the performance page is visited at
00:01 on the 23rd, it will call the API for data on the 22nd and
backwards 7 days. The data it gets at 00:01 will not yet have the
data for the 22nd, it will only go as far as the 21st, because
the overnight jobs to put data in the tables have not run yet. The
admin app then caches this data, meaning that for the rest of the
day the page will be missing data for the 22nd, even though it
becomes available after approx 2am. We have seen it a few times
in production where the performance page has indeed been visited
before say 2 am, leaving the page with missing data.

In terms of solutions, there are several potential options.

1. Remove the caching that we do in redis. The downside of this is
that we will hit the API more (currently once a day for the first
visitor to the performance page). We have had 255 requests
to the performance page in the last week and when there is no value
in redis, the call to the API takes approximately 1-2 seconds.

2. Make the admin app only set the cache value if it is after
2:30am. This one feels a bit gross and snowflakey.

3. The API flushes the redis cache after it has finished its nightly
tasks. We don't have that much precedent of the API interacting
with redis, it is mostly the admin app that does but this is still
a valid option.

4. Cache in redis the data for 2 days ago to 7 days ago and then
get the data for yesterday freshly every time. This would mean
some things are still cached but the smallest bit that we can't rely
on can be gathered fresh.

5. Remove the caching we do in redis but then try and optimise the
API endpoint to return results even faster and with less
interaction with the DB. My hypothesis is that the slowest part
is where the API has to calculate how many notifications Notify
has ever sent
(https://github.com/alphagov/notifications-api/blob/master/app/performance_dashboard/rest.py#L36)
and so we could potentially try and store these totals in the DB
every night and update them nightly rather than having to query all
the data in the table to figure them out every time.

In the end, I've gone for option 1 here. I think the performance hit
is very very small, (like 40 requests per day that take a second),
and this is the quickest way to fix the bug and also the least
complex. If this page was being visited thousands of times a day
or the API request timing took 10 seconds I'd likely pick a different
solution.