### PR TITLE
Don’t put version number in requirements twice

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -30,8 +30,8 @@ pyproj==3.2.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
 
-git+https://github.com/alphagov/notifications-utils.git@48.0.0#egg=notifications-utils==48.0.0
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha#egg=govuk-frontend-jinja==0.5.8-alpha
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@48.0.0
+govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # cryptography 3.4+ incorporates Rust code, which isn't supported on PaaS
 # e.g. https://github.com/alphagov/notifications-api/pull/3126


### PR DESCRIPTION
It’s a pain having to remember to update both of them. Looks like `pip` now supports a different syntax without the `egg` bit which means a git dependency only needs the version number changing in one place.