### PR TITLE
Update ‘Send’ button content

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -23,7 +23,7 @@
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
-                Send<span class="govuk-visually-hidden"> a message using this template</span>
+                Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
               </a>
             </div>
           {% endif %}
@@ -46,7 +46,7 @@
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
             <div class="govuk-grid-column-one-half">
               <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
-                Send<span class="govuk-visually-hidden"> a message using this template</span>
+                Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
               </a>
             </div>
           {% endif %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -867,12 +867,17 @@ def test_edit_letter_templates_postage_updates_postage(
     ),
     (
         ['manage_templates'],
-        ['.edit_service_template'],
+        [
+            ('.edit_service_template', 'Edit'),
+        ],
         None,
     ),
     (
         ['send_messages', 'manage_templates'],
-        ['.set_sender', '.edit_service_template'],
+        [
+            ('.set_sender', 'Get ready to send a message using this template'),
+            ('.edit_service_template', 'Edit'),
+        ],
         None,
     ),
 ])
@@ -904,16 +909,17 @@ def test_should_be_able_to_view_a_template_with_links(
         'Two week reminder – Templates – service one – GOV.UK Notify'
     )
 
-    links_in_page = page.select('.pill-separate-item')
-
-    assert len(links_in_page) == len(links_to_be_shown)
-
-    for index, link_to_be_shown in enumerate(links_to_be_shown):
-        assert links_in_page[index]['href'] == url_for(
-            link_to_be_shown,
+    assert [
+        (link['href'], normalize_spaces(link.text))
+        for link in page.select('.pill-separate-item')
+    ] == [
+        (url_for(
+            endpoint,
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-        )
+        ), text)
+        for endpoint, text in links_to_be_shown
+    ]
 
     assert normalize_spaces(page.select_one('main p').text) == (
         permissions_warning_to_be_shown or 'To: phone number'


### PR DESCRIPTION
This PR updates the ‘Send’ button content to ‘Get ready to send’.

The aim is to make users feel more confident about using this button.

In research and through user support we’ve heard that users:
* worry that clicking the button will send the message immediately
* cannot find how to add or upload recipients