### PR TITLE
Reduce impact of bug with performance page caching stale data

### DIFF
--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -103,7 +103,7 @@ class JobApiClient(NotifyAdminAPIClient):
         redis_client.set(
             'has_jobs-{}'.format(service_id),
             b'true',
-            ex=cache.TTL,
+            ex=cache.DEFAULT_TTL,
         )
 
         return job

--- a/app/notify_client/performance_dashboard_api_client.py
+++ b/app/notify_client/performance_dashboard_api_client.py
@@ -3,7 +3,7 @@ from app.notify_client import NotifyAdminAPIClient, cache
 
 class PerformanceDashboardAPIClient(NotifyAdminAPIClient):
 
-    @cache.set('performance-stats-{start_date}-to-{end_date}')
+    @cache.set('performance-stats-{start_date}-to-{end_date}', ttl_in_seconds=3600)
     def get_performance_dashboard_stats(
         self,
         *,

--- a/app/notify_client/status_api_client.py
+++ b/app/notify_client/status_api_client.py
@@ -6,7 +6,7 @@ class StatusApiClient(NotifyAdminAPIClient):
     def get_status(self, *params):
         return self.get(url='/_status', *params)
 
-    @cache.set('live-service-and-organisation-counts')
+    @cache.set('live-service-and-organisation-counts', ttl_in_seconds=3600)
     def get_count_of_live_services_and_organisations(self):
         return self.get(url='/_status/live-service-and-organisation-counts')
 

--- a/requirements.in
+++ b/requirements.in
@@ -30,8 +30,7 @@ pyproj==3.2.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.1.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # cryptography 3.4+ incorporates Rust code, which isn't supported on PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.1.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx

--- a/tests/app/notify_client/test_performance_platform_api_client.py
+++ b/tests/app/notify_client/test_performance_platform_api_client.py
@@ -1,5 +1,4 @@
 from datetime import date
-from unittest.mock import call
 
 from app.notify_client.performance_dashboard_api_client import (
     PerformanceDashboardAPIClient,
@@ -42,21 +41,15 @@ def test_sets_value_in_cache(mocker):
         end_date=date(2022, 2, 2),
     ) == {'data_from': 'api'}
 
-    assert mock_redis_get.call_args_list == [
-        call('performance-stats-2021-01-01-to-2022-02-02'),
-    ]
-    assert mock_api_get.call_args_list == [
-        call('/performance-dashboard', params={
+    mock_redis_get.assert_called_once_with('performance-stats-2021-01-01-to-2022-02-02')
+    mock_api_get.assert_called_once_with('/performance-dashboard', params={
             'start_date': '2021-01-01', 'end_date': '2022-02-02'
-        }),
-    ]
-    assert mock_redis_set.call_args_list == [
-        call(
-            'performance-stats-2021-01-01-to-2022-02-02',
-            '{"data_from": "api"}',
-            ex=3600,
-        ),
-    ]
+        })
+    mock_redis_set.assert_called_once_with(
+        'performance-stats-2021-01-01-to-2022-02-02',
+        '{"data_from": "api"}',
+        ex=3600,
+    )
 
 
 def test_returns_value_from_cache(mocker):
@@ -78,8 +71,6 @@ def test_returns_value_from_cache(mocker):
         end_date=date(2022, 2, 2),
     ) == {'data_from': 'cache'}
 
-    assert mock_redis_get.call_args_list == [
-        call('performance-stats-2021-01-01-to-2022-02-02'),
-    ]
+    mock_redis_get.assert_called_once_with('performance-stats-2021-01-01-to-2022-02-02')
     assert mock_api_get.called is False
     assert mock_redis_set.called is False

--- a/tests/app/notify_client/test_performance_platform_api_client.py
+++ b/tests/app/notify_client/test_performance_platform_api_client.py
@@ -54,7 +54,7 @@ def test_sets_value_in_cache(mocker):
         call(
             'performance-stats-2021-01-01-to-2022-02-02',
             '{"data_from": "api"}',
-            ex=604800,
+            ex=3600,
         ),
     ]
 

--- a/tests/app/notify_client/test_status_api_client.py
+++ b/tests/app/notify_client/test_status_api_client.py
@@ -33,7 +33,7 @@ def test_sets_value_in_cache(mocker):
     mock_redis_set.assert_called_once_with(
         'live-service-and-organisation-counts',
         '{"data_from": "api"}',
-        ex=604800
+        ex=3600
     )
 
 

--- a/tests/app/notify_client/test_status_api_client.py
+++ b/tests/app/notify_client/test_status_api_client.py
@@ -1,0 +1,59 @@
+from app.notify_client.status_api_client import StatusApiClient
+
+
+def test_get_count_of_live_services_and_organisations(mocker):
+    mocker.patch('app.extensions.RedisClient.get', return_value=None)
+    client = StatusApiClient()
+    mock = mocker.patch.object(client, 'get', return_value={})
+
+    client.get_count_of_live_services_and_organisations()
+
+    mock.assert_called_once_with(url='/_status/live-service-and-organisation-counts')
+
+
+def test_sets_value_in_cache(mocker):
+    client = StatusApiClient()
+
+    mock_redis_get = mocker.patch(
+        'app.extensions.RedisClient.get',
+        return_value=None
+    )
+    mock_api_get = mocker.patch(
+        'app.notify_client.NotifyAdminAPIClient.get',
+        return_value={'data_from': 'api'},
+    )
+    mock_redis_set = mocker.patch(
+        'app.extensions.RedisClient.set',
+    )
+
+    assert client.get_count_of_live_services_and_organisations() == {'data_from': 'api'}
+
+    mock_redis_get.assert_called_once_with('live-service-and-organisation-counts')
+    mock_api_get.assert_called_once_with(url='/_status/live-service-and-organisation-counts')
+    mock_redis_set.assert_called_once_with(
+        'live-service-and-organisation-counts',
+        '{"data_from": "api"}',
+        ex=604800
+    )
+
+
+def test_returns_value_from_cache(mocker):
+    client = StatusApiClient()
+
+    mock_redis_get = mocker.patch(
+        'app.extensions.RedisClient.get',
+        return_value=b'{"data_from": "cache"}',
+    )
+    mock_api_get = mocker.patch(
+        'app.notify_client.NotifyAdminAPIClient.get',
+    )
+    mock_redis_set = mocker.patch(
+        'app.extensions.RedisClient.set',
+    )
+
+    assert client.get_count_of_live_services_and_organisations() == {'data_from': 'cache'}
+
+    mock_redis_get.assert_called_once_with('live-service-and-organisation-counts')
+
+    assert mock_api_get.called is False
+    assert mock_redis_set.called is False


### PR DESCRIPTION
Review commit by commit.

Note, the final commit is optional. It seemed sensible to do but I'm very happy to drop it.

Note, tests will fail until https://github.com/alphagov/notifications-admin/pull/3994 is merged and then this PR is rebased on top.

