### PR TITLE
Format monetary values to two decimal places in organisation usage report 

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -175,14 +175,21 @@ def download_organisation_usage_report(org_id):
         financial_year=selected_year
     )['services']
 
-    column_names = OrderedDict([
+    unit_column_names = OrderedDict([
         ('service_id', 'Service ID'),
         ('service_name', 'Service Name'),
         ('emails_sent', 'Emails sent'),
         ('sms_remainder', 'Free text message allowance remaining'),
+    ])
+
+    monetary_column_names = OrderedDict([
         ('sms_cost', 'Spent on text messages (£)'),
         ('letter_cost', 'Spent on letters (£)')
     ])
+
+    column_names = OrderedDict(
+        list(unit_column_names.items()) + list(monetary_column_names.items())
+    )
 
     org_usage_data = [[x for x in column_names.values()]]
 

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -187,15 +187,13 @@ def download_organisation_usage_report(org_id):
         ('letter_cost', 'Spent on letters (£)')
     ])
 
-    column_names = OrderedDict(
-        list(unit_column_names.items()) + list(monetary_column_names.items())
-    )
-
     org_usage_data = [
-        list(column_names.values())
+        list(unit_column_names.values()) + list(monetary_column_names.values())
     ] + [
         [
-            service[attribute] for attribute in column_names.keys()
+            service[attribute] for attribute in unit_column_names.keys()
+        ] + [
+            '{:,.2f}'.format(service[attribute]) for attribute in monetary_column_names.keys()
         ]
         for service in services_usage
     ]

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -191,10 +191,14 @@ def download_organisation_usage_report(org_id):
         list(unit_column_names.items()) + list(monetary_column_names.items())
     )
 
-    org_usage_data = [[x for x in column_names.values()]]
-
-    for service in services_usage:
-        org_usage_data.append([service[attribute] for attribute in column_names.keys()])
+    org_usage_data = [
+        list(column_names.values())
+    ] + [
+        [
+            service[attribute] for attribute in column_names.keys()
+        ]
+        for service in services_usage
+    ]
 
     return Spreadsheet.from_rows(org_usage_data).as_csv_data, 200, {
         'Content-Type': 'text/csv; charset=utf-8',

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -692,9 +692,9 @@ def test_download_organisation_usage_report(
                 'chargeable_billable_sms': 22,
                 'emails_sent': 13000,
                 'free_sms_limit': 100,
-                'letter_cost': 30.50,
+                'letter_cost': 30.5,
                 'sms_billable_units': 122,
-                'sms_cost': 1.93,
+                'sms_cost': 1.934,
                 'sms_remainder': None
             },
             {
@@ -703,9 +703,9 @@ def test_download_organisation_usage_report(
                 'chargeable_billable_sms': 222,
                 'emails_sent': 23000,
                 'free_sms_limit': 250000,
-                'letter_cost': 60.50,
+                'letter_cost': 60.5,
                 'sms_billable_units': 322,
-                'sms_cost': 3.93,
+                'sms_cost': 3.935,
                 'sms_remainder': None
             },
         ]}
@@ -721,8 +721,8 @@ def test_download_organisation_usage_report(
     assert csv_report.string == (
         "Service ID,Service Name,Emails sent,Free text message allowance remaining,"
         "Spent on text messages (£),Spent on letters (£)"
-        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,,1.93,30.5"
-        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,,3.93,60.5\r\n"
+        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,,1.93,30.50"
+        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,,3.94,60.50\r\n"
     )
 
 


### PR DESCRIPTION
Because our text messages cost 1.6p per message we don’t usually get a round number of pennies in a service’s total text message usage. But when we play the information back on the page we round it to the nearest penny, because people aren’t used to being charged in fractions of a penny.

The organisation report doesn’t do any rounding so the numbers don’t match what on the page.

This pull request adds the same string formatting to round the numbers as the `big_number` component does, so it should round the numbers in the same way.