### PR TITLE
Change performance stats to be 2 decimal places

### DIFF
--- a/app/templates/views/performance.html
+++ b/app/templates/views/performance.html
@@ -88,7 +88,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       {{ big_number(
-        '{:.1f}%'.format(average_percentage_under_10_seconds),
+        '{:.2f}%'.format(average_percentage_under_10_seconds),
         label='on average',
       ) }}
     </div>
@@ -107,7 +107,7 @@
         {{ item.date | format_date_normal }}
       {% endcall %}
       {% call field() %}
-        {{ item.percentage_under_10_seconds }}%
+        {{ '{:.2f}%'.format(item.percentage_under_10_seconds) }}
       {% endcall %}
     {% endcall %}
     <p class="table-show-more-link">

--- a/tests/app/main/views/test_performance.py
+++ b/tests/app/main/views/test_performance.py
@@ -47,31 +47,31 @@ def _get_example_performance_data():
       "processing_time": [
         {
           "date": "2021-02-21",
-          "percentage_under_10_seconds": 99.2
+          "percentage_under_10_seconds": 99.25
         },
         {
           "date": "2021-02-22",
-          "percentage_under_10_seconds": 95.3
+          "percentage_under_10_seconds": 95.30
         },
         {
           "date": "2021-02-23",
-          "percentage_under_10_seconds": 95.6
+          "percentage_under_10_seconds": 95.0
         },
         {
           "date": "2021-02-24",
-          "percentage_under_10_seconds": 96.7
+          "percentage_under_10_seconds": 100.0
         },
         {
           "date": "2021-02-25",
-          "percentage_under_10_seconds": 95.7
+          "percentage_under_10_seconds": 99.99
         },
         {
           "date": "2021-02-26",
-          "percentage_under_10_seconds": 96.5
+          "percentage_under_10_seconds": 100.0
         },
         {
           "date": "2021-02-27",
-          "percentage_under_10_seconds": 98.6
+          "percentage_under_10_seconds": 98.60
         },
       ],
       "services_using_notify": [
@@ -144,16 +144,16 @@ def test_should_render_performance_page(
         'Only showing the last 7 days '
         ''
         'Messages sent within 10 seconds '
-        '96.8% on average '
+        '98.31% on average '
         'Messages sent within 10 seconds '
         'Date Percentage '
-        '27 February 2021 98.6% '
-        '26 February 2021 96.5% '
-        '25 February 2021 95.7% '
-        '24 February 2021 96.7% '
-        '23 February 2021 95.6% '
-        '22 February 2021 95.3% '
-        '21 February 2021 99.2% '
+        '27 February 2021 98.60% '
+        '26 February 2021 100.00% '
+        '25 February 2021 99.99% '
+        '24 February 2021 100.00% '
+        '23 February 2021 95.00% '
+        '22 February 2021 95.30% '
+        '21 February 2021 99.25% '
         'Only showing the last 7 days '
         ''
         'Organisations using Notify '


### PR DESCRIPTION
We are starting to see lots of 100.0%s in the current table
and we think this looks suspiciously too good so think it is
beneficial to change it to be 2dp such that we get a few more
non 100.0% values.

This will put all the values in to having 2dp, however it will
also require the API to have a change to
https://github.com/alphagov/notifications-api/blob/master/app/performance_dashboard/rest.py#L81
in https://github.com/alphagov/notifications-api/pull/3382
where it is currently losing the granularity down to a single
decimal place (meaning that if we were really at 99.894% then that
would be shown on the page as 99.90% rather than 99.89%).

## Before
![image](https://user-images.githubusercontent.com/7228605/143462752-b2c3e08f-dcab-4f4f-b749-fc72eb58900e.png)

## After (dummy data)
![image](https://user-images.githubusercontent.com/7228605/143462787-272267bd-8ec5-4e3b-b5f8-a9723af6b6e1.png)
