### PR TITLE
Remove free text allowance remaining column from organisation report

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -179,7 +179,8 @@ def download_organisation_usage_report(org_id):
         ('service_id', 'Service ID'),
         ('service_name', 'Service Name'),
         ('emails_sent', 'Emails sent'),
-        ('sms_remainder', 'Free text message allowance remaining'),
+        # TODO: reinstate this once the API is returning correct data
+        # ('sms_remainder', 'Free text message allowance remaining'),
     ])
 
     monetary_column_names = OrderedDict([

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -719,10 +719,10 @@ def test_download_organisation_usage_report(
     )
 
     assert csv_report.string == (
-        "Service ID,Service Name,Emails sent,Free text message allowance remaining,"
+        "Service ID,Service Name,Emails sent,"
         "Spent on text messages (£),Spent on letters (£)"
-        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,,1.93,30.50"
-        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,,3.94,60.50\r\n"
+        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,1.93,30.50"
+        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,3.94,60.50\r\n"
     )
 
 


### PR DESCRIPTION
We think that the API is returning incorrect data for this column.

It’s going to take a while to figure out what’s going on with the queries in the API, so this pull request temporarily removes the column so we’ve not giving people incorrect data.