### PR TITLE
Update text message pricing description

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -54,7 +54,6 @@
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
   <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
-  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_can_use_notify') }}">who can use Notify</a>.</p>
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -54,7 +54,7 @@
     <li>25,000 free text messages for regional services</li>
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
-  <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
+  <p class="govuk-body">Each unique service you add has a separate allowance.</p>
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
   <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -37,7 +37,7 @@
   <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
   <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you:</p>
   <ul class="list list-bullet">
-    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">long messages</a></li>
+    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">messages longer than 160 characters</a></li>
     <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>
     <li>use <a class="govuk-link govuk-link--no-visited-state" href="#accents">accents and accented letters</a></li>
     <li>send text messages to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">international numbers</a></li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -21,9 +21,9 @@
 
   <p class="govuk-body">
     {% if not current_user.is_authenticated %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many different services as you need to.</p>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many unique services as you need to.</p>
     {% else %}
-      You can add as many different services as you need to.
+      You can add as many unique services as you need to.
     {% endif %}
   </p>
 
@@ -33,25 +33,31 @@
   <p class="govuk-body">It’s free to send emails through Notify.</p>
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
-  <p class="govuk-body">Every service you add has an annual allowance of free text messages.</p>
-  <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
-  <p class="govuk-body">You will only start paying for text messages when a service has used its free allowance for the year.</p>
+  <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
+  <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
+  <p class="govuk-body">The actual number of text messages we charge you for will depend on whether you:</p>
+  <ul class="list list-bullet">
+    <li>send long messages</li>
+    <li>use certain signs and symbols</li>
+    <li>use accents and accented letters</li>
+    <li>send text messages to international numbers</li>
+  </ul>
+
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
+
+  <h3 class="heading-small" id="free-text-message-allowance">Free text message allowance</h3>
+
   <p class="govuk-body">The current allowance is:</p>
   <ul class="list list-bullet">
     <li>150,000 free text messages for national services</li>
     <li>25,000 free text messages for regional services</li>
     <li>10,000 free text messages for state-funded schools and GP practices</li>
   </ul>
-  <h3 class="heading-small" id="paying-for-additional-text-messages">Paying for additional text messages</h3>
-  <p class="govuk-body">When you’ve used your annual allowance of free text messages, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
-  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
+  <p class="govuk-body">If your organisation has more than one service on Notify, they each have a separate allowance.</p>
+  <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.who_can_use_notify') }}">who can use Notify</a>.</p>
 
   <h3 class="heading-small" id="long-text-messages">Long text messages</h3>
-  <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it’ll be charged as more than one message.</p>
-  <p class="govuk-body">
-    The following characters are charged as 2 characters each:<br />
-    <span class="extended-gsm-characters">[]{}^\|~€</span>
-  </p>
+  <p class="govuk-body">If a text message is longer than 160 characters (including spaces), it counts as more than one message.</p>
 
   <div class="bottom-gutter-3-2">
     {% call mapping_table(
@@ -75,9 +81,19 @@
       {% endfor %}
     {% endcall %}
   </div>
+
+  <h3 class="heading-small" id="symbols">Signs and symbols</h3>
+
+  <p class="govuk-body">
+    The following signs and symbols count as 2 characters each:<br />
+    <span class="extended-gsm-characters">[]{}^\|~€</span>
+  </p>
+
+  <p class="govuk-body">Using them can increase the cost of sending text messages.</p>
+
   <h3 class="heading-small" id="accents">Accents and accented characters</h3>
   <p class="govuk-body">Some languages, such as Welsh, use accented characters.</p>
-  <p class="govuk-body">Text messages containing the following accented characters are charged at the normal rate: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>
+  <p class="govuk-body">The following accented characters do not affect the cost of sending text messages: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>
   <p class="govuk-body">Using other accented characters can increase the cost of sending text messages.<p class="govuk-body">
   {% set accentedChars %}
     <div class="bottom-gutter-3-2">

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -35,7 +35,7 @@
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
-  <p class="govuk-body">The actual number of text messages we charge you for will depend on whether you:</p>
+  <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you:</p>
   <ul class="list list-bullet">
     <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">long messages</a></li>
     <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -35,9 +35,10 @@
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each text message you send.</p>
-  <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you:</p>
+  <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">text messages longer than 160 characters</a>.</p>
+  <p class="govuk-body">You may also use more free messages, or pay more for each message, if you:</p>
   <ul class="list list-bullet">
-    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">messages longer than 160 characters</a></li>
+    <li></li>
     <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>
     <li>use <a class="govuk-link govuk-link--no-visited-state" href="#accents">accents and accented letters</a></li>
     <li>send text messages to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">international numbers</a></li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -37,10 +37,10 @@
   <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
   <p class="govuk-body">The actual number of text messages we charge you for will depend on whether you:</p>
   <ul class="list list-bullet">
-    <li>send long messages</li>
-    <li>use certain signs and symbols</li>
-    <li>use accents and accented letters</li>
-    <li>send text messages to international numbers</li>
+    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">long messages</a></li>
+    <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>
+    <li>use <a class="govuk-link govuk-link--no-visited-state" href="#accents">accents and accented letters</a></li>
+    <li>send text messages to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">international numbers</a></li>
   </ul>
 
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -34,7 +34,7 @@
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
-  <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each additional text message you send.</p>
+  <p class="govuk-body">When a service has used its annual allowance, it costs 1.6 pence (plus VAT) for each text message you send.</p>
   <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you:</p>
   <ul class="list list-bullet">
     <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">messages longer than 160 characters</a></li>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -35,7 +35,6 @@
   <h2 class="heading-medium" id="before-you-request-to-go-live">Before you request to go live</h2>
   <p class="govuk-body">You must:</p>
   <ul class="list list-bullet">
-    <li>check that your service is unique</li>
     <li>add examples of the messages you want to send</li>
     <li>update your settings so you’re ready to send and receive messages</li>
     <li>accept our data sharing and financial agreement</li>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -35,6 +35,7 @@
   <h2 class="heading-medium" id="before-you-request-to-go-live">Before you request to go live</h2>
   <p class="govuk-body">You must:</p>
   <ul class="list list-bullet">
+    <li>check that your service is unique</li>
     <li>add examples of the messages you want to send</li>
     <li>update your settings so you’re ready to send and receive messages</li>
     <li>accept our data sharing and financial agreement</li>


### PR DESCRIPTION
This PR makes some changes to the Text messages section of the Pricing page.

The aim is to help users understand how and why they might use up their free allowance more quickly than they expect. We’ve been contacted by services who did not know that sending messages longer than 160 characters would count as more than 1 text message.

This first iteration of changes is fairly subtle – we’re mostly reordering and clarifying existing information. I haven’t introduced new language (like ‘fragments’, ‘parts’, ‘segments’) yet. 

This work will eventually tie in to the changes we’re making elsewhere (like the usage page).