### PR TITLE
Bump WTForms and Flask-WTF to latest versions

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -22,6 +22,7 @@ from werkzeug.utils import cached_property
 from wtforms import (
     BooleanField,
     DateField,
+    EmailField,
     FieldList,
     FileField,
     HiddenField,
@@ -30,13 +31,14 @@ from wtforms import (
 )
 from wtforms import RadioField as WTFormsRadioField
 from wtforms import (
+    SearchField,
     SelectMultipleField,
     StringField,
+    TelField,
     TextAreaField,
     ValidationError,
     validators,
 )
-from wtforms.fields.html5 import EmailField, SearchField, TelField
 from wtforms.validators import URL, DataRequired, Length, Optional, Regexp
 
 from app.formatters import format_thousands, guess_name_from_email_address
@@ -542,7 +544,7 @@ class RadioFieldWithRequiredMessage(RadioField):
         try:
             return super().pre_validate(form)
         except ValueError:
-            raise ValueError(self.required_message)
+            raise ValidationError(self.required_message)
 
 
 class StripWhitespaceForm(Form):

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -58,7 +58,7 @@ class ValidEmail:
 
     def __call__(self, form, field):
 
-        if field.data == '':
+        if not field.data:
             return
 
         try:

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,8 @@ ago==0.0.93
 govuk-bank-holidays==0.8
 humanize==3.12.0
 Flask==1.1.2  # pyup: <2
-Flask-WTF==0.15.1
+Flask-WTF==1.0.0
+wtforms==3.0.0
 Flask-Login==0.5.0
 werkzeug==2.0.2
 jinja2==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ flask-login==0.5.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-flask-wtf==0.15.1
+flask-wtf==1.0.0
     # via -r requirements.in
 gds-metrics==0.2.4
     # via -r requirements.in
@@ -225,8 +225,10 @@ werkzeug==2.0.2
     # via
     #   -r requirements.in
     #   flask
-wtforms==2.3.3
-    # via flask-wtf
+wtforms==3.0.0
+    # via
+    #   -r requirements.in
+    #   flask-wtf
 xlrd==1.2.0
     # via pyexcel-xls
 xlwt==1.3.0


### PR DESCRIPTION
WTForms versions less than 3.0.0 have a security vulnerability where arbitrary HTML can be inserted into the label of a form, allowing the possibility of a cross-site scripting attack.

See https://github.com/wtforms/wtforms/commit/8529b953a0919300794f95e01a7713162908c8a6 for details.

I don’t know if there’s anywhere we put user-generated content into form labels but it’s possible we are vulnerable somewhere.

This require moving some imports because as of https://github.com/wtforms/wtforms/pull/614 there is no longer a separate module for HTML 5 fields, they are now considered core fields.

As of https://github.com/wtforms/wtforms/issues/445 custom implementations of `pre_validate` or `post_validate` must raise `ValidationError` to trigger a validation message, where we were raising `ValueError` this was no longer being caught.

As of https://github.com/wtforms/wtforms/pull/355 `StringField` returns `None` for empty data, not `''` but our 
 `validate_email_address` function only accepts strings.