### PR TITLE
Don’t force users to re-enter their password when renaming a service

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -9,7 +9,6 @@ from flask import (
     redirect,
     render_template,
     request,
-    session,
     url_for,
 )
 from flask_login import current_user
@@ -28,7 +27,6 @@ from app import (
     notification_api_client,
     organisations_client,
     service_api_client,
-    user_api_client,
 )
 from app.event_handlers import (
     create_archive_service_event,
@@ -42,7 +40,6 @@ from app.main import main
 from app.main.forms import (
     BillingDetailsForm,
     BrandingOptions,
-    ConfirmPasswordForm,
     EditNotesForm,
     EstimateUsageForm,
     FreeSMSAllowance,
@@ -95,24 +92,28 @@ def service_settings(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/name", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def service_name_change(service_id):
-    form = RenameServiceForm()
-
-    if request.method == 'GET':
-        form.name.data = current_service.name
+    form = RenameServiceForm(name=current_service.name)
 
     if form.validate_on_submit():
 
         if form.name.data == current_service.name:
             return redirect(url_for('.service_settings', service_id=service_id))
 
-        unique_name = service_api_client.is_service_name_unique(service_id, form.name.data, email_safe(form.name.data))
-
-        if not unique_name:
-            form.name.errors.append("This service name is already in use")
-            return render_template('views/service-settings/name.html', form=form)
-
-        session['service_name_change'] = form.name.data
-        return redirect(url_for('.service_name_change_confirm', service_id=service_id))
+        try:
+            current_service.update(
+                name=form.name.data,
+                email_from=email_safe(form.name.data),
+            )
+        except HTTPError as http_error:
+            if http_error.status_code == 400 and any(
+                name_error_message.startswith('Duplicate service name')
+                for name_error_message in http_error.message['name']
+            ):
+                form.name.errors.append('This service name is already in use')
+            else:
+                raise http_error
+        else:
+            return redirect(url_for('.service_settings', service_id=service_id))
 
     if current_service.organisation_type == 'local':
         return render_template(
@@ -124,42 +125,6 @@ def service_name_change(service_id):
         'views/service-settings/name.html',
         form=form,
     )
-
-
-@main.route("/services/<uuid:service_id>/service-settings/name/confirm", methods=['GET', 'POST'])
-@user_has_permissions('manage_service')
-def service_name_change_confirm(service_id):
-    if 'service_name_change' not in session:
-        flash("The change you made was not saved. Please try again.", 'error')
-        return redirect(url_for('main.service_name_change', service_id=service_id))
-
-    # Validate password for form
-    def _check_password(pwd):
-        return user_api_client.verify_password(current_user.id, pwd)
-
-    form = ConfirmPasswordForm(_check_password)
-
-    if form.validate_on_submit():
-        try:
-            current_service.update(
-                name=session['service_name_change'],
-                email_from=email_safe(session['service_name_change'])
-            )
-        except HTTPError as e:
-            error_msg = "Duplicate service name '{}'".format(session['service_name_change'])
-            if e.status_code == 400 and error_msg in e.message['name']:
-                # Redirect the user back to the change service name screen
-                flash('This service name is already in use', 'error')
-                return redirect(url_for('main.service_name_change', service_id=service_id))
-            else:
-                raise e
-        else:
-            session.pop('service_name_change')
-            return redirect(url_for('.service_settings', service_id=service_id))
-    return render_template(
-        'views/service-settings/confirm.html',
-        heading='Change your service name',
-        form=form)
 
 
 @main.route("/services/<uuid:service_id>/service-settings/request-to-go-live/estimate-usage", methods=['GET', 'POST'])

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -239,7 +239,6 @@ class MainNavigation(Navigation):
             'service_letter_contact_details',
             'service_make_blank_default_letter_contact',
             'service_name_change',
-            'service_name_change_confirm',
             'service_preview_email_branding',
             'service_preview_letter_branding',
             'service_set_auth_type',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -787,7 +787,7 @@ def test_should_not_allow_duplicate_service_names(
     assert 'This service name is already in use' in page.text
 
 
-def test_should_redirect_after_service_name_confirmation(
+def test_should_redirect_after_service_name_change(
     client_request,
     mock_update_service,
 ):

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -244,7 +244,6 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'service_letter_contact_details',
     'service_make_blank_default_letter_contact',
     'service_name_change',
-    'service_name_change_confirm',
     'service_preview_email_branding',
     'service_preview_letter_branding',
     'service_set_auth_type',


### PR DESCRIPTION
The original idea behind this was to always ask users to re-enter their password any time:
- we want them to be sure that they want to do what they’re about to do
- we want to be sure it’s really the user trying to do the thing (and not someone malicious)

In reality we:
- removed this from the initial place it was added<sup>1</sup>
- only ever added it to the ‘rename service’ feature

So in reality it’s not a pattern we have persisted with. Arguably there are several things you can now do in the admin app without re-entering your password which are much more high consequence than changing the service name.

Also, with browser autofill there’s a lot less chance that forcing someone to re-enter a password really gives much defence against an unattended laptop, for example.

I also wonder whether we might get people to give better service names if we make the process of renaming the service less intimidating.

So this commit removes the need to re-enter your password when renaming a service.

Note that re-naming an organisation still has the same check, but I haven’t removed that too for the sake of keeping scope of the PR small.

***

1. An ancestor of the ‘suspend service’ feature https://github.com/alphagov/notifications-admin/pull/51