### PR TITLE
Fix not showing errors for invalid contact uploads

### DIFF
--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -40,8 +40,7 @@
   {{ file_upload(
     form.file,
     allowed_file_extensions=allowed_file_extensions,
-    button_text='Upload your file again' if error else 'Choose file',
-    show_errors=False
+    button_text='Choose file',
   )}}
 </div>
 

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -276,6 +276,22 @@ def test_upload_csv_file_shows_error_banner_for_too_many_rows(
     )
 
 
+def test_upload_csv_shows_error_with_invalid_extension(
+    client_request,
+):
+
+    page = client_request.post(
+        'main.upload_contact_list',
+        service_id=SERVICE_ONE_ID,
+        _data={'file': (BytesIO(''.encode('utf-8')), 'invalid.txt')},
+        _follow_redirects=True,
+    )
+
+    assert normalize_spaces(page.select_one('.file-upload-label .error-message').text) == (
+        "invalid.txt is not a spreadsheet that Notify can read"
+    )
+
+
 def test_upload_csv_file_sanitises_and_truncates_file_name_in_metadata(
     client_request,
     mocker,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177535141

This code should behave the same way as other CSV uploads [1],
but we had to write it in a hurry [2] and the way we show an
error with the upload field was based off that for PDF uploads,
where we show custom button text instead of an error [3].

# Screenshots

| Before (broken, no error)  | After |
| ------------- | ------------- |
| <img width="170" alt="Screenshot 2021-12-01 at 17 07 31" src="https://user-images.githubusercontent.com/9029009/144280373-71cdfc04-0293-4983-800f-817dfd358f96.png"> | <img width="739" alt="Screenshot 2021-12-01 at 17 06 55" src="https://user-images.githubusercontent.com/9029009/144280402-c198dc6a-ca9c-441b-9755-ad47dff22a20.png"> |

This fixes the inconsistency, so that we see the same errors
for CSV uploads here as in other parts of the app.

[1]: https://github.com/alphagov/notifications-admin/blob/6b52735dac02e2284de667676a672d01047995b8/app/templates/views/send.html#L25
[2]: https://github.com/alphagov/notifications-admin/commit/1c02476ee7b3d66cf4db4f9b8616918084caeeda#diff-aedd12af78c9737f1c3344d2afbb9c00878eccbcc754b2b3d9e6864c2ad2f7c3R32
[3]: https://github.com/alphagov/notifications-admin/commit/3b3f74bbf08e7abda58886f3f05537e1192a2a4f