### PR TITLE
Add security policy page

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -33,6 +33,7 @@ from app.main.views import (  # noqa isort:skip
     providers,
     register,
     returned_letters,
+    security_policy,
     send,
     service_settings,
     sign_in,

--- a/app/main/views/security_policy.py
+++ b/app/main/views/security_policy.py
@@ -1,0 +1,11 @@
+from flask import redirect
+
+from app.main import main
+
+
+@main.route('/.well-known/security.txt', methods=['GET'])
+@main.route('/security.txt', methods=['GET'])
+def security_policy():
+    # See GDS Way security policy which this implements
+    # https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html#vulnerability-disclosure-and-security-txt
+    return redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")

--- a/tests/app/main/views/test_security_policy.py
+++ b/tests/app/main/views/test_security_policy.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.mark.parametrize('url', [
+    '/security.txt',
+    '/.well-known/security.txt',
+])
+def test_security_policy_redirects_to_policy(client_request, url):
+    client_request.get_url(
+        url,
+        _expected_status=302,
+        _expected_redirect="https://vdp.cabinetoffice.gov.uk/.well-known/security.txt",
+    )

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -212,6 +212,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'roadmap',
     'save_contact_list',
     'security',
+    'security_policy',
     'send_files_by_email',
     'send_files_by_email_contact_details',
     'send_from_contact_list',


### PR DESCRIPTION
This follows the guidance in
https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html#vulnerability-disclosure-and-security-txt

Note, I plan on just adding this for www.notifications.service.gov.uk and documents.service.gov.uk.

I think we can get away with not adding it to the tech-docs or the API but happy to be challenged on that