### PR TITLE
Show flash instead of inline upload errors

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -175,6 +175,11 @@ def send_messages(service_id, template_id):
             ).format(
                 form.file.data.filename
             ))
+    elif form.errors:
+        # just show the first error, as we don't expect the form to have more
+        # than one, since it only has one field
+        first_field_errors = list(form.errors.values())[0]
+        flash(first_field_errors[0])
 
     column_headings = get_spreadsheet_column_headings_from_template(template)
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -417,6 +417,11 @@ def upload_contact_list(service_id):
             ).format(
                 form.file.data.filename
             ))
+    elif form.errors:
+        # just show the first error, as we don't expect the form to have more
+        # than one, since it only has one field
+        first_field_errors = list(form.errors.values())[0]
+        flash(first_field_errors[0])
 
     return render_template(
         'views/uploads/contact-list/upload.html',

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -22,7 +22,8 @@
     {{file_upload(
       form.file,
       allowed_file_extensions=allowed_file_extensions,
-      button_text='Choose a file'
+      button_text='Choose a file',
+      show_errors=False
     )}}
   </div>
 

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -41,6 +41,7 @@
     form.file,
     allowed_file_extensions=allowed_file_extensions,
     button_text='Choose file',
+    show_errors=False,
   )}}
 </div>
 

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -279,7 +279,6 @@ def test_upload_csv_file_shows_error_banner_for_too_many_rows(
 def test_upload_csv_shows_error_with_invalid_extension(
     client_request,
 ):
-
     page = client_request.post(
         'main.upload_contact_list',
         service_id=SERVICE_ONE_ID,
@@ -287,7 +286,7 @@ def test_upload_csv_shows_error_with_invalid_extension(
         _follow_redirects=True,
     )
 
-    assert normalize_spaces(page.select_one('.file-upload-label .error-message').text) == (
+    assert normalize_spaces(page.select_one('.banner-dangerous').text) == (
         "invalid.txt is not a spreadsheet that Notify can read"
     )
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177535141

This has several advantages:

- It gives us more room to explain the error and actions. This will
be useful for upcoming work we want to do, which will add yet more
validations for CSV uploads.

- We already use a flash to show certain kinds of errors on these
pages (just above). This is more consistent.

- It's potentially more accessible. Previously the error and the
button text used to be read out as a single sentence. Now the page
reloads and reads the flash error alone.

In theory we should show an error in both places, but this can be
confusing on pages where there's only a single form control, and
especially if the error is long.

## Screenshots

| Before  | After |
| ------------- | ------------- |
| <img width="733" alt="Screenshot 2021-12-06 at 17 13 14" src="https://user-images.githubusercontent.com/9029009/144891015-698daf4d-cb2b-4de4-bc7f-99f195d802ea.png"> | <img width="768" alt="Screenshot 2021-12-06 at 17 13 01" src="https://user-images.githubusercontent.com/9029009/144891040-58c1d655-eb6a-462d-adfa-8c95489e98be.png"> |
| <img width="747" alt="Screenshot 2021-12-06 at 17 13 23" src="https://user-images.githubusercontent.com/9029009/144891065-b01e8a41-645c-4530-a993-3708975ced93.png"> | <img width="755" alt="Screenshot 2021-12-06 at 17 10 17" src="https://user-images.githubusercontent.com/9029009/144891089-16ad8c64-c7bd-4e6f-91d2-83c834932141.png"> |



