### PR TITLE
Don’t combine polygons with different projections

### DIFF
--- a/tests/app/models/test_broadcast_message.py
+++ b/tests/app/models/test_broadcast_message.py
@@ -91,3 +91,43 @@ def test_areas_treats_missing_ids_as_custom_broadcast(notify_admin):
 
     assert len(list(broadcast_message.areas)) == 2
     assert type(broadcast_message.areas) == CustomBroadcastAreas
+
+
+@pytest.mark.parametrize('area_ids, approx_bounds', (
+    ([
+        'ctry19-N92000002',  # Northern Ireland (UTM zone 29N)
+        'ctry19-W92000004',  # Wales (UTM zone 30N)
+    ], [
+        -8.2, 51.5, -2.1, 55.1
+    ]),
+    ([
+        'lad20-E06000031',  # Peterborough (UTM zone 30N)
+        'lad20-E07000146',  # Kings Lyn and West Norfolk (UTM zone 31N)
+    ], [
+        -0.5, 52.5, 0.8, 53.0
+    ]),
+    ([
+        'wd20-E05009372',  # Hackney Central (UTM zone 30N)
+        'wd20-E05009374',  # Hackney Wick (UTM zone 30N)
+    ], [
+        -0.1, 51.5, -0.0, 51.6
+    ]),
+    ([
+        'wd20-E05009372',  # Hackney Central (UTM zone 30N)
+        'test-santa-claus-village-rovaniemi-a',  # (UTM zone 35N)
+    ], [
+        -0.1, 51.5, 25.9, 66.6
+    ]),
+))
+def test_combining_multiple_areas_keeps_same_bounds(area_ids, approx_bounds):
+    broadcast_message = BroadcastMessage(broadcast_message_json(
+        areas={'ids': area_ids}
+    ))
+
+    assert [
+        round(coordinate, 1) for coordinate in broadcast_message.polygons.bounds
+    ] == [
+        round(coordinate, 1) for coordinate in broadcast_message.simple_polygons.bounds
+    ] == (
+        approx_bounds
+    )


### PR DESCRIPTION
When we combine simplified polygons from different areas we try to use the polygons defined in metres (not degrees) as a speed optimisation.

This doesn’t work when those polygons are in several different projections because the distance in metres is relative to the edge of the projection. For the UK and Northern Ireland there are 3 possible Universal Transverse Mercator projections (29N, 30N and 31N):

![Modified_UTM_Zones](https://user-images.githubusercontent.com/355079/145042723-7354f39f-5b97-40b5-80d8-005eabddc698.png)

Just naively choosing one means that some of the polygons will shift position on the earth by 100s of kilometres once they are converted back to degrees.

To avoid this we need to:
- check for situations where we have polygons in multiple different projections
- transforms these polygons back into degrees and let `Polygons` pick a common projection for all of them before doing any merging/smoothing/etc.

# Examples of the problem

Wales has moved to south-west Ireland 

<img width="758" alt="Screenshot 2021-12-07 at 12 50 56" src="https://user-images.githubusercontent.com/355079/145036546-b04d18e6-7641-4d30-bcfe-d4edfc03df64.png">

Kings Lynn and West Norfolk has moved to the middle of the Irish Sea

<img width="747" alt="Screenshot 2021-12-07 at 12 51 40" src="https://user-images.githubusercontent.com/355079/145036619-ac020ee6-9c5f-49ba-a2a5-a42c81caae42.png">





