### PR TITLE
Improve handling of large CSVs / spreadsheets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,7 +28,10 @@ from notifications_utils.formatters import (
     formatted_list,
     get_lines_with_normalised_whitespace,
 )
-from notifications_utils.recipients import format_phone_number_human_readable
+from notifications_utils.recipients import (
+    CSVTooBigError,
+    format_phone_number_human_readable,
+)
 from notifications_utils.sanitise_text import SanitiseASCII
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 from werkzeug.exceptions import abort
@@ -441,6 +444,10 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
     @application.errorhandler(401)
     def handle_no_permissions(error):
         return _error_response(401)
+
+    @application.errorhandler(CSVTooBigError)
+    def handle_csv_too_big(error):
+        return _error_response(413)
 
     @application.errorhandler(BadSignature)
     def handle_bad_token(error):

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -652,7 +652,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         template=template,
         max_initial_rows_shown=50,
         max_errors_shown=50,
-        whitelist=itertools.chain.from_iterable(
+        guestlist=itertools.chain.from_iterable(
             [user.name, user.mobile_number, user.email_address] for user in Users(service_id)
         ) if current_service.trial_mode else None,
         remaining_messages=remaining_messages,

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -451,7 +451,7 @@ def check_contact_list(service_id, upload_id):
     recipients = RecipientCSV(
         contents,
         template=get_sample_template(template_type or 'sms'),
-        whitelist=itertools.chain.from_iterable(
+        guestlist=itertools.chain.from_iterable(
             [user.name, user.mobile_number, user.email_address]
             for user in current_service.active_users
         ) if current_service.trial_mode else None,

--- a/app/templates/error/413.html
+++ b/app/templates/error/413.html
@@ -9,7 +9,7 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <p class="govuk-body">
-              Files must be smaller than 5 MB.
+              Try splitting your file into smaller files.
             </p>
             <p class="govuk-body">
               <a class="govuk-link govuk-link--no-visited-state" href="javascript: history.go(-1)">Go back and try again.</a>

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ pyproj==3.2.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@50.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # cryptography 3.4+ incorporates Rust code, which isn't supported on PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@50.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177535141

This pulls in a bunch of performance improvements from utils, which
include raising a CSVTooBigError if a CSV takes too long to process.

I want to get these improvements out quickly so we can monitor their
impact. To that end, I've reused an old error page to handle the new
"too big" error, until we have some more time to iterate the content
and overall error handling for large CSVs, as it's...complicated.

## Screenshot

<img width="654" alt="Screenshot 2021-12-09 at 17 23 25" src="https://user-images.githubusercontent.com/9029009/145447282-ffcec2ed-9294-4509-ae51-8079f0d2ac0e.png">
