### PR TITLE
Add link to user page to go live tickets

### DIFF
--- a/app/templates/support-tickets/go-live-request.txt
+++ b/app/templates/support-tickets/go-live-request.txt
@@ -30,4 +30,5 @@ Other live services for that user: {{ user.live_services|format_yes_no }}
 Service reply-to address: {{ service.default_email_reply_to_address or "not set" }}
 
 ---
-Request sent by {{ current_user.email_address }}
+Request sent by {{ user.email_address }}
+Requester’s user page: {{ url_for('main.user_information', user_id=user.id, _external=True) }}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1665,9 +1665,11 @@ def test_should_redirect_after_request_to_go_live(
         '\n'
         '---\n'
         'Request sent by test@user.gov.uk\n'
+        'Requester’s user page: http://localhost/users/{user_id}\n'
     ).format(
         service_id=SERVICE_ONE_ID,
         formatted_displayed_volumes=formatted_displayed_volumes,
+        user_id=active_user_with_permissions['id'],
     )
     mock_create_ticket.assert_called_once_with(
         ANY,
@@ -1750,9 +1752,11 @@ def test_request_to_go_live_displays_go_live_notes_in_zendesk_ticket(
         '\n'
         '---\n'
         'Request sent by test@user.gov.uk\n'
+        'Requester’s user page: http://localhost/users/{user_id}\n'
     ).format(
         service_id=SERVICE_ONE_ID,
-        go_live_note=go_live_note
+        go_live_note=go_live_note,
+        user_id=active_user_with_permissions['id'],
     )
 
     mock_create_ticket.assert_called_once_with(


### PR DESCRIPTION
This adds a link to the user profile of the person who requested to go
live for "Request to go live" Zendesk tickets. Viewing a user's profile
page helps us to check for duplicate organisations and services from
that user.

[Pivotal story](https://www.pivotaltracker.com/story/show/180521177)