### PR TITLE
Fix two small bugs with forms

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -657,7 +657,7 @@ def govuk_checkbox_field_widget(self, field, param_extensions=None, **kwargs):
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            "text": " ".join(field.errors).strip()
+            "text": field.errors[0]
         }
 
     params = {
@@ -710,7 +710,7 @@ def govuk_checkboxes_field_widget(self, field, wrap_in_collapsible=False, param_
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            "text": " ".join(field.errors).strip()
+            "text": field.errors[0]
         }
 
     # returns either a list or a hierarchy of lists
@@ -765,7 +765,7 @@ def govuk_radios_field_widget(self, field, param_extensions=None, **kwargs):
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            "text": " ".join(field.errors).strip()
+            "text": field.errors[0]
         }
 
     # returns either a list or a hierarchy of lists

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1535,6 +1535,12 @@ class ChangeEmailForm(StripWhitespaceForm):
     email_address = email_address()
 
     def validate_email_address(self, field):
+        # The validate_email_func can be used to call API to check if the email address is already in
+        # use. We don't want to run that check for invalid email addresses, since that will cause an error.
+        # If there are any other validation errors on the email_address, we should skip this check.
+        if self.email_address.errors:
+            return
+
         is_valid = self.validate_email_func(field.data)
         if is_valid:
             raise ValidationError("The email address is already in use")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -231,7 +231,7 @@ def govuk_text_input_field_widget(self, field, type=None, param_extensions=None,
                 "data-error-type": field.errors[0],
                 "data-error-label": field.name
             },
-            error_message_format: " ".join(field.errors).strip()
+            error_message_format: field.errors[0]
         }
 
     # convert to parameters that govuk understands

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2361,6 +2361,27 @@ def test_incorrect_sms_sender_input(
         assert count_of_api_calls == 0
 
 
+def test_incorrect_sms_sender_input_with_multiple_errors_only_shows_the_first(
+    client_request,
+    no_sms_senders,
+    mock_add_sms_sender,
+):
+    # There are two errors with the SMS sender - the length and characters used. Only one
+    # should be displayed on the page.
+    page = client_request.post(
+        'main.service_add_sms_sender',
+        service_id=SERVICE_ONE_ID,
+        _data={'sms_sender': '{}'},
+        _expected_status=200
+    )
+
+    error_message = page.select_one('.govuk-error-message')
+    count_of_api_calls = len(mock_add_sms_sender.call_args_list)
+
+    assert normalize_spaces(error_message.text) == 'Error: Enter 3 characters or more'
+    assert count_of_api_calls == 0
+
+
 @pytest.mark.parametrize('reply_to_addresses, data, api_default_args', [
     ([], {}, True),
     (create_multiple_email_reply_to_addresses(), {}, False),

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -110,6 +110,26 @@ def test_should_redirect_after_email_change(
     )
 
 
+@pytest.mark.parametrize('email_address,error_message', [
+    ('me@example.com', 'Enter a public sector email address or find out who can use Notify'),
+    ('not_valid', 'Enter a valid email address')  # 2 errors with email address, only first error shown
+])
+def test_should_show_errors_if_new_email_address_does_not_validate(
+    client_request,
+    mock_email_is_not_already_in_use,
+    mock_get_organisations,
+    email_address,
+    error_message,
+):
+    page = client_request.post(
+        'main.user_profile_email',
+        _data={'email_address': email_address},
+        _expected_status=200,
+    )
+
+    assert normalize_spaces(page.find('span', class_='govuk-error-message').text) == f'Error: {error_message}'
+
+
 def test_should_show_authenticate_after_email_change(
     client_request,
 ):

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -74,7 +74,6 @@ def test_should_show_name_page(
 def test_should_redirect_after_name_change(
     client_request,
     mock_update_user_attribute,
-    mock_email_is_not_already_in_use
 ):
     client_request.post(
         'main.user_profile_name',
@@ -109,6 +108,8 @@ def test_should_redirect_after_email_change(
         )
     )
 
+    assert mock_email_is_not_already_in_use.called
+
 
 @pytest.mark.parametrize('email_address,error_message', [
     ('me@example.com', 'Enter a public sector email address or find out who can use Notify'),
@@ -128,6 +129,8 @@ def test_should_show_errors_if_new_email_address_does_not_validate(
     )
 
     assert normalize_spaces(page.find('span', class_='govuk-error-message').text) == f'Error: {error_message}'
+    # We only call API to check if the email address is already in use if there are no other errors
+    assert not mock_email_is_not_already_in_use.called
 
 
 def test_should_show_authenticate_after_email_change(


### PR DESCRIPTION
## Fix bug where multiple error messages for a form field could be shown
If a field on a form fails validation and has multiple errors we should only show the first error - we had been joining together all error messages and showing them. There are only a couple of places where it's possible to get more than one error showing for the same field, but this updates all the widgets that had the potential to show multiple errors at once.

### Before
<img width="500" alt="Screenshot 2021-12-07 at 16 35 42" src="https://user-images.githubusercontent.com/12881990/145599609-fb6aff20-2354-489e-a9af-79c5e56e9f39.png">

### After
<img width="450" alt="Screenshot 2021-12-10 at 15 32 56" src="https://user-images.githubusercontent.com/12881990/145599751-059c7260-c896-4fa0-b48d-a1208ee8200b.png">

## Fix bug which caused a `500` when trying to change an email address to an invalid one
We use the `ChangeEmailForm` if you want to change your own email address or someone else's email address. This has various validators which get run. We check if the email address is valid (by using a function from utils) and if the email address is already in use (by calling API).

If the email address is not valid, we should not call API to see if it's already in use because this will cause an exception in API leading to a `500` in admin. We now only call API if there were no other errors with the email address.

(The `test_should_redirect_after_name_change` test didn't need the `mock_email_is_not_already_in_use` fixture, so this has been removed.)