### PR TITLE
Fix billing page to show correct user who signed MOU

### DIFF
--- a/app/templates/views/organisations/organisation/billing.html
+++ b/app/templates/views/organisations/organisation/billing.html
@@ -19,7 +19,7 @@
           and financial agreement on {{ current_org.agreement_signed_at | format_date_normal }}.
         </p>
         <p class="govuk-body">
-          {{ current_org.agreement_signed_by.name or current_org.agreement_signed_on_behalf_of_name }} signed the agreement
+          {{ current_org.agreement_signed_on_behalf_of_name or current_org.agreement_signed_by.name }} signed the agreement
           on behalf of {{ current_org.name}}.
         </p>
         <p class="govuk-body">

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1600,6 +1600,7 @@ def test_organisation_billing_page_not_accessible_if_not_platform_admin(
 @pytest.mark.parametrize('signed_by_id, signed_by_name, expected_signatory', [
     ('1234', None, 'Test User'),
     (None, 'The Org Manager', 'The Org Manager'),
+    ('1234', 'The Org Manager', 'The Org Manager'),
 ])
 def test_organisation_billing_page_when_the_agreement_is_signed_by_a_known_person(
     organisation_one,


### PR DESCRIPTION
If the organisation table contains an entry for `agreement_signed_by_id` and for `agreement_signed_on_behalf_of_name` then we should show the person who signed the MOU as being the `agreement_signed_on_behalf_of_name`.

This was wrongly showing the `agreement_signed_by_id` as the person who signed the agreement.