### PR TITLE
Add hscni.net to list of allowed domains

### DIFF
--- a/app/utils/email_domains.txt
+++ b/app/utils/email_domains.txt
@@ -8,3 +8,4 @@ ac.uk
 sch.uk
 onevoicewales.wales
 suttonmail.org
+hscni.net


### PR DESCRIPTION
We can't assign `hscni.net` to an organisation because it is used
by GP surgeries, so we don't always know which org it should be
associated with. This change allows people with the an `hscni.net`
email address to sign up and create a service.