### PR TITLE
Update `get_notifications_for_service` to make POST requests

### DIFF
--- a/tests/app/notify_client/test_notification_client.py
+++ b/tests/app/notify_client/test_notification_client.py
@@ -24,19 +24,56 @@ from tests import notification_json, single_notification_json
         {'url': '/service/abcd1234/notifications', 'params': {'include_from_test_key': True}}
     ),
     (
+        {'page': 48, 'limit_days': 3},
+        {'url': '/service/abcd1234/notifications', 'params': {'page': 48, 'limit_days': 3}}
+    ),
+    (
         {'job_id': 'efgh5678'},
         {'url': '/service/abcd1234/job/efgh5678/notifications', 'params': {}}
     ),
     (
         {'job_id': 'efgh5678', 'page': 48},
         {'url': '/service/abcd1234/job/efgh5678/notifications', 'params': {'page': 48}}
-    )
+    ),
+    (
+        {'job_id': 'efgh5678', 'page': 48, 'limit_days': 3},
+        {'url': '/service/abcd1234/job/efgh5678/notifications', 'params': {'page': 48}}
+    ),
 ])
 def test_client_gets_notifications_for_service_and_job_by_page(mocker, arguments, expected_call):
 
     mock_get = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.get')
     NotificationApiClient().get_notifications_for_service('abcd1234', **arguments)
     mock_get.assert_called_once_with(**expected_call)
+
+
+@pytest.mark.parametrize("arguments,expected_call", [
+    (
+        {'to': "0793433"},
+        {'url': '/service/abcd1234/notifications', 'data': {'to': "0793433"}}
+    ),
+    (
+        {'to': "0793433", 'job_id': 'efgh5678'},
+        {'url': '/service/abcd1234/job/efgh5678/notifications', 'data': {'to': "0793433"}}
+    ),
+    (
+        {'to': "0793433", 'page': 99},
+        {'url': '/service/abcd1234/notifications', 'data': {'to': "0793433", 'page': 99}}
+    ),
+    (
+        {'to': "0793433", 'limit_days': 3},
+        {'url': '/service/abcd1234/notifications', 'data': {'to': "0793433", 'limit_days': 3}}
+    ),
+    (
+        {'to': "0793433", 'job_id': 'efgh5678', 'limit_days': 3},
+        {'url': '/service/abcd1234/job/efgh5678/notifications', 'data': {'to': "0793433"}}
+    ),
+])
+def test_client_gets_notifications_for_service_and_job_by_page_posts_for_to(mocker, arguments, expected_call):
+
+    mock_post = mocker.patch('app.notify_client.notification_api_client.NotificationApiClient.post')
+    NotificationApiClient().get_notifications_for_service('abcd1234', **arguments)
+    mock_post.assert_called_once_with(**expected_call)
 
 
 def test_send_notification(mocker, logged_in_client, active_user_with_permissions):


### PR DESCRIPTION
This updates the `get_notifications_for_service` of the
`NotificationApiClient` to make POST request to the api when the `to`
field is provided. This is done so that we avoid logging personal
details such as email addreses.

If the `to` field is not present, the method will make a GET request and
there will be no change to how it works.

Merge after https://github.com/alphagov/notifications-api/pull/3403