### PR TITLE
Revert "Remove free text allowance remaining column from organisation report"

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -188,8 +188,7 @@ def download_organisation_usage_report(org_id):
         ('service_id', 'Service ID'),
         ('service_name', 'Service Name'),
         ('emails_sent', 'Emails sent'),
-        # TODO: reinstate this once the API is returning correct data
-        # ('sms_remainder', 'Free text message allowance remaining'),
+        ('sms_remainder', 'Free text message allowance remaining'),
     ])
 
     monetary_column_names = OrderedDict([

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -696,7 +696,7 @@ def test_download_organisation_usage_report(
                 'letter_cost': 30.5,
                 'sms_billable_units': 122,
                 'sms_cost': 1.934,
-                'sms_remainder': None
+                'sms_remainder': 0
             },
             {
                 'service_id': SERVICE_TWO_ID,
@@ -707,7 +707,7 @@ def test_download_organisation_usage_report(
                 'letter_cost': 60.5,
                 'sms_billable_units': 322,
                 'sms_cost': 3.935,
-                'sms_remainder': None
+                'sms_remainder': 0
             },
         ]}
     )
@@ -722,8 +722,8 @@ def test_download_organisation_usage_report(
     assert csv_report.string == (
         "Service ID,Service Name,Emails sent,Free text message allowance remaining,"
         "Spent on text messages (£),Spent on letters (£)"
-        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,,1.93,30.50"
-        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,,3.94,60.50\r\n"
+        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,0,1.93,30.50"
+        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,0,3.94,60.50\r\n"
     )
 
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -720,10 +720,10 @@ def test_download_organisation_usage_report(
     )
 
     assert csv_report.string == (
-        "Service ID,Service Name,Emails sent,"
+        "Service ID,Service Name,Emails sent,Free text message allowance remaining,"
         "Spent on text messages (£),Spent on letters (£)"
-        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,1.93,30.50"
-        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,3.94,60.50\r\n"
+        "\r\n596364a0-858e-42c8-9062-a8fe822260eb,Service 1,13000,,1.93,30.50"
+        "\r\n147ad62a-2951-4fa1-9ca0-093cd1a52c52,Service 1,23000,,3.94,60.50\r\n"
     )
 
 


### PR DESCRIPTION
The bug that led to us temporarily removing this column from the report has now been fixed, so we can reinstate the column.