### PR TITLE
Hide ‘Download this report’ link when no services

### DIFF
--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -110,12 +110,12 @@
       {{ current_org.name }} has no live services on GOV.UK Notify
     </p>
     <div class="keyline-block govuk-!-margin-top-2"></div>
+  {% else %}
+    <div class="js-stick-at-bottom-when-scrolling">
+      <p class="govuk-!-margin-bottom-1">
+        <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
+      </p>
+    </div>
   {% endif %}
-
-  <div class="js-stick-at-bottom-when-scrolling">
-    <p class="govuk-!-margin-bottom-1">
-      <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
-    </p>
-  </div>
 
 {% endblock %}

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -92,6 +92,7 @@ def test_view_organisation_shows_the_correct_organisation(
     assert normalize_spaces(page.select_one('.govuk-hint').text) == (
         'Test 1 has no live services on GOV.UK Notify'
     )
+    assert not page.select('a[download]')
 
 
 def test_page_to_create_new_organisation(
@@ -668,7 +669,8 @@ def test_organisation_services_links_to_downloadable_report(
     client_request.login(active_user_with_permissions)
     page = client_request.get('.organisation_dashboard', org_id=ORGANISATION_ID)
 
-    link_to_report = page.find('a', text="Download this report")
+    link_to_report = page.select_one('a[download]')
+    assert normalize_spaces(link_to_report.text) == 'Download this report'
     assert link_to_report.attrs["href"] == url_for(
         '.download_organisation_usage_report',
         org_id=ORGANISATION_ID,


### PR DESCRIPTION
If an organisation doesn’t have any live services then there’s no data to download. To make things less confusing we should hide the link in this case.

This commit also modifies the existing test so that the assertions are consistent.

# Before

![image](https://user-images.githubusercontent.com/355079/147086924-23afa2f3-85c4-4a5e-acc5-01fd00bc41c2.png)

# After 

![image](https://user-images.githubusercontent.com/355079/147086976-07056630-1388-4944-a2bf-de53111af754.png)
