### PR TITLE
Force lxml to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ lml==0.1.0
     # via
     #   pyexcel
     #   pyexcel-io
-lxml==4.6.3
+lxml==4.6.5
     # via
     #   pyexcel-ezodf
     #   pyexcel-ods3


### PR DESCRIPTION
Lower versions have a security vulnerability, see https://github.com/lxml/lxml/security/advisories/GHSA-55x5-fj6c-h6m8

The `pyexcel-*` packages which require `lxml` don’t pin a version.