### PR TITLE
Bump govuk-bank-holidays to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.93
-govuk-bank-holidays==0.8
+govuk-bank-holidays==0.10
 humanize==3.12.0
 Flask==1.1.2  # pyup: <2
 Flask-WTF==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ gds-metrics==0.2.4
     # via -r requirements.in
 geojson==2.5.0
     # via notifications-utils
-govuk-bank-holidays==0.8
+govuk-bank-holidays==0.10
     # via
     #   -r requirements.in
     #   notifications-utils
@@ -209,7 +209,6 @@ six==1.16.0
     #   cryptography
     #   eventlet
     #   fido2
-    #   govuk-bank-holidays
     #   python-dateutil
 smartypants==2.0.1
     # via notifications-utils


### PR DESCRIPTION
While the package can always fetch new holidays via the GOV.UK API,
the latest version of the packages also caches ones for next year,
which means we can avoid unnecessary web requests.