### PR TITLE
Trial running Sentry in a Flask app

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,6 +1,19 @@
+import os
+
+import sentry_sdk
 from flask import Flask
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from app import create_app
+
+sentry_sdk.init(
+    dsn=os.environ['SENTRY_DSN'],
+    integrations=[FlaskIntegration()],
+    environment=os.environ['NOTIFY_ENVIRONMENT'],
+    attach_stacktrace=True,
+    traces_sample_rate=0.00005  # avoid exceeding rate limits in Production
+)
+sentry_sdk.set_level('error')  # only record error logs or exceptions
 
 application = Flask('app')
 

--- a/requirements.in
+++ b/requirements.in
@@ -41,3 +41,5 @@ cryptography<3.4 # pyup: ignore
 # version 0.10.0 introduced exceptions when workers crashed due to deprecating lower case `prometheus_multiproc_dir`.
 prometheus-client>=0.9.0,!=0.10.0
 gds-metrics==0.2.4
+
+sentry-sdk[flask]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ blinker==1.4
     # via
     #   -r requirements.in
     #   gds-metrics
+    #   sentry-sdk
 boto3==1.17.84
     # via notifications-utils
 botocore==1.20.84
@@ -31,6 +32,7 @@ certifi==2021.5.30
     # via
     #   pyproj
     #   requests
+    #   sentry-sdk
 cffi==1.14.5
     # via cryptography
 chardet==4.0.0
@@ -65,6 +67,7 @@ flask==1.1.2
     #   flask-wtf
     #   gds-metrics
     #   notifications-utils
+    #   sentry-sdk
 flask-login==0.5.0
     # via -r requirements.in
 flask-redis==0.4.0
@@ -198,6 +201,8 @@ s3transfer==0.4.2
     # via
     #   awscli
     #   boto3
+sentry-sdk[flask]==1.5.1
+    # via -r requirements.in
 shapely==1.7.1
     # via
     #   -r requirements.in
@@ -221,6 +226,7 @@ urllib3==1.26.5
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180766893

This will capture and send various events to Sentry:

- Any unhandled exceptions.
- Any logger.error calls.
- Some request traces.

The latter are severely limited to avoid going over the free tier limits
for Sentry, and to avoid excess effort on our end.

## App selection

This app was chosen because:

- It emits a variety of errors (logs and exceptions) on a regular basis.
- It doesn't have any significant performance concerns (relative to API).

## Deployment

This PR is intended to be a trial: after merging, I'll raise a PR to revert, with the intention of deploying in about a week.

In order to deploy this, we'll need to temporarily set the `SENTRY_DSN` environment variable in all environments. One option is to add it to `credentials`, which is annoying as it's another PR to revert. Another option is to manually set it and remove it (we'll need to do this anyway) by doing `cf set-env notify-admin SENTRY_DSN <dsn>`.

I prefer the second option.