### PR TITLE
Make ‘last updated’ section consistent

### DIFF
--- a/app/assets/stylesheets/components/content-metadata.scss
+++ b/app/assets/stylesheets/components/content-metadata.scss
@@ -1,0 +1,43 @@
+.content-metadata {
+  @include govuk-font(16);
+  @include govuk-clearfix;
+  @include govuk-responsive-margin(5, "bottom");
+  color: $govuk-text-colour;
+  margin-top: 15px;
+
+  .content-metadata__term,
+  .content-metadata__definition {
+    line-height: 1.4;
+  }
+
+  .content-metadata__term {
+    margin-top: .5em;
+
+    @include govuk-media-query($from: tablet) {
+      box-sizing: border-box;
+      float: left;
+      clear: left;
+      padding-right: govuk-spacing(1);
+      margin-top: 0;
+    }
+  }
+
+  .content-metadata__definition {
+    margin: 0;
+
+    @include govuk-media-query($from: tablet) {
+      &:not(:last-of-type) {
+        margin-bottom: govuk-spacing(1);
+      }
+    }
+  }
+
+  .content-metadata__suffix {
+    margin-top: 0.628em;
+    margin-bottom: 0;
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: 6px;
+    }
+  }
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -72,6 +72,7 @@ $path: '/static/images/';
 @import 'components/loading-indicator';
 @import 'components/area-list';
 @import 'components/broadcast-message';
+@import 'components/content-metadata';
 
 @import 'views/dashboard';
 @import 'views/users';

--- a/app/templates/components/content-metadata.html
+++ b/app/templates/components/content-metadata.html
@@ -1,0 +1,13 @@
+{% macro content_metadata(data, suffix=False) %}
+<div class="content-metadata">
+  <dl>
+  {% for key, value in data.items() %}
+    <dt class="content-metadata__term">{{ key }}</dt>
+    <dd class="content-metadata__definition">{{ value }}</dd>
+  {% endfor %}
+  </dl>
+  {% if suffix %}
+  <p class="content-metadata__suffix">{{ suffix }}</p>
+  {% endif %}
+</div>
+{% endmacro %}

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -208,8 +208,4 @@
   <p class="govuk-body">
     We decided which pages to test based on the most common tasks that GOV.UK Notify users need to complete. We also tested a sample of pages with common user interface components.
   </p>
-
-  <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 27 October 2021.
-  </p>
 {% endblock %}

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -9,6 +9,10 @@
 
   <h1 class="heading-large">Accessibility statement</h1>
 
+<p class="govuk-body">
+    Last updated: 27 October 2021
+  </p>
+
   <p class="govuk-body">
     This accessibility statement applies to the www.notifications.service.gov.uk domain. It does not apply to the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk">GOV.UK Notify API documentation subdomain</a>.
   </p>

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -10,7 +10,7 @@
   <h1 class="heading-large">Accessibility statement</h1>
 
 <p class="govuk-body">
-    Last updated: 27 October 2021
+    Updated: 27 October 2021
   </p>
 
   <p class="govuk-body">

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -1,5 +1,6 @@
 {% extends "content_template.html" %}
 {% from "components/service-link.html" import service_link %}
+{% from "components/content-metadata.html" import content_metadata %}
 
 {% block per_page_title %}
   Accessibility statement
@@ -9,9 +10,13 @@
 
   <h1 class="heading-large">Accessibility statement</h1>
 
-<p class="govuk-body">
-    Published 23 September 2020<br>Last updated 27 October 2021<br>We review this page every 3 months.
-  </p>
+  {{ content_metadata(
+    data={
+      "Published": "23 September 2020",
+      "Last updated": "27 October 2021"
+    },
+    suffix="We review this page every 3 months"
+  ) }}
 
   <p class="govuk-body">
     This accessibility statement applies to the www.notifications.service.gov.uk domain. It does not apply to the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk">GOV.UK Notify API documentation subdomain</a>.

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -10,7 +10,7 @@
   <h1 class="heading-large">Accessibility statement</h1>
 
 <p class="govuk-body">
-    Updated: 27 October 2021
+    Published 23 September 2020<br>Last updated 27 October 2021<br>We review this page every 3 months.
   </p>
 
   <p class="govuk-body">

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -1,4 +1,5 @@
 {% extends "withoutnav_template.html" %}
+{% from "components/content-metadata.html" import content_metadata %}
 
 {% block per_page_title %}
   Privacy notice: how we use your data
@@ -10,7 +11,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Privacy notice: how we use your data</h1>
 
-    <p class="govuk-body">Last updated 1 October 2021</p>
+    {{ content_metadata(
+      data={
+        "Last updated": "1 October 2021"
+      }
+    ) }}
 
     <h2 class="heading-medium">Who we are</h2>
 

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Privacy notice: how we use your data</h1>
 
-    <p class="govuk-body">Last update: 1 October 2021</p>
+    <p class="govuk-body">Updated: 1 October 2021</p>
 
     <h2 class="heading-medium">Who we are</h2>
 

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="heading-large">Privacy notice: how we use your data</h1>
 
-    <p class="govuk-body">Updated: 1 October 2021</p>
+    <p class="govuk-body">Last updated 1 October 2021</p>
 
     <h2 class="heading-medium">Who we are</h2>
 

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -9,9 +9,10 @@
 
   <h1 class="heading-large">Roadmap</h1>
 
+  <p class="govuk-body">Updated: 30 November 2021<br>We review this page every 3 months.</p>
+
   <p class="govuk-body">The GOV.UK Notify roadmap shows what we’re working on and some of the <a class="govuk-link govuk-link--no-visited-state" href="#things-we-have-done">things we’ve done</a>.</p>
   <p class="govuk-body">The roadmap is only a guide. It does not cover everything we do, and some things may change.</p>
-  <div class="govuk-inset-text">We review this page every 3 months. It was last updated on 30 November 2021.</div>
   <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
   <h2 class="heading-medium">Things we’re working on</h2>

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -9,7 +9,7 @@
 
   <h1 class="heading-large">Roadmap</h1>
 
-  <p class="govuk-body">Updated: 30 November 2021<br>We review this page every 3 months.</p>
+  <p class="govuk-body">Last updated 30 November 2021<br>We review this page every 3 months.</p>
 
   <p class="govuk-body">The GOV.UK Notify roadmap shows what we’re working on and some of the <a class="govuk-link govuk-link--no-visited-state" href="#things-we-have-done">things we’ve done</a>.</p>
   <p class="govuk-body">The roadmap is only a guide. It does not cover everything we do, and some things may change.</p>

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -1,5 +1,6 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% extends "content_template.html" %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
+{% from "components/content-metadata.html" import content_metadata %}
 
 {% block per_page_title %}
   Roadmap
@@ -9,7 +10,12 @@
 
   <h1 class="heading-large">Roadmap</h1>
 
-  <p class="govuk-body">Last updated 30 November 2021<br>We review this page every 3 months.</p>
+  {{ content_metadata(
+    data={
+      "Last updated": "30 November 2021"
+    },
+    suffix="We review this page every 3 months"
+  ) }}
 
   <p class="govuk-body">The GOV.UK Notify roadmap shows what we’re working on and some of the <a class="govuk-link govuk-link--no-visited-state" href="#things-we-have-done">things we’ve done</a>.</p>
   <p class="govuk-body">The roadmap is only a guide. It does not cover everything we do, and some things may change.</p>

--- a/tests/app/test_accessibility_statement.py
+++ b/tests/app/test_accessibility_statement.py
@@ -15,10 +15,9 @@ def test_last_review_date():
         raw_diff = statement_diff.stdout.decode('utf-8')
         today = datetime.now().strftime('%d %B %Y')
         with open(statement_file_path, 'r') as statement_file:
-            current_review_date = re.search((r'This statement was prepared on 23 September 2020\. '
-                                             r'It was last reviewed on (\d{1,2} [A-Z]{1}[a-z]+ \d{4})'),
+            current_review_date = re.search((r'"Last updated": "(\d{1,2} [A-Z]{1}[a-z]+ \d{4})"'),
                                             statement_file.read()).group(1)
 
         # guard against changes that don't need to update the review date
         if current_review_date != today:
-            assert 'This statement was prepared on 23 September 2020. It was last reviewed on' in raw_diff
+            assert '"Last updated": "' in raw_diff


### PR DESCRIPTION
There are 3 pages on Notify where the date the page was last reviewed is important. We should present this information in a consistent way.

We’re going to use the GOV.UK [‘metadata block’ component](https://components.publishing.service.gov.uk/component-guide/metadata) to format key information about when a page was created and updated, as well as how often we expect to review it.

This change affects our:

1. Roadmap
2. Accessibility statement
3. Privacy statement
