### PR TITLE
Revert "Trial running Sentry in Admin"

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,23 +1,5 @@
-import os
-
-import sentry_sdk
 from flask import Flask
-from sentry_sdk.integrations.flask import FlaskIntegration
-from sentry_sdk.integrations.redis import RedisIntegration
-from sentry_sdk.integrations import logging
-
 from app import create_app
-
-if 'SENTRY_DSN' in os.environ:
-    sentry_sdk.init(
-        dsn=os.environ['SENTRY_DSN'],
-        integrations=[FlaskIntegration(), RedisIntegration()],
-        environment=os.environ['NOTIFY_ENVIRONMENT'],
-        attach_stacktrace=True,
-        traces_sample_rate=0.00005  # avoid exceeding rate limits in Production
-    )
-
-    logging.ignore_logger('notifications_python_client.*')  # ignore logs about 404s, etc.
 
 application = Flask('app')
 

--- a/requirements.in
+++ b/requirements.in
@@ -41,5 +41,3 @@ cryptography<3.4 # pyup: ignore
 # version 0.10.0 introduced exceptions when workers crashed due to deprecating lower case `prometheus_multiproc_dir`.
 prometheus-client>=0.9.0,!=0.10.0
 gds-metrics==0.2.4
-
-sentry-sdk[flask]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ blinker==1.4
     # via
     #   -r requirements.in
     #   gds-metrics
-    #   sentry-sdk
 boto3==1.17.84
     # via notifications-utils
 botocore==1.20.84
@@ -32,7 +31,6 @@ certifi==2021.5.30
     # via
     #   pyproj
     #   requests
-    #   sentry-sdk
 cffi==1.14.5
     # via cryptography
 chardet==4.0.0
@@ -67,7 +65,6 @@ flask==1.1.2
     #   flask-wtf
     #   gds-metrics
     #   notifications-utils
-    #   sentry-sdk
 flask-login==0.5.0
     # via -r requirements.in
 flask-redis==0.4.0
@@ -201,8 +198,6 @@ s3transfer==0.4.2
     # via
     #   awscli
     #   boto3
-sentry-sdk[flask]==1.5.1
-    # via -r requirements.in
 shapely==1.7.1
     # via
     #   -r requirements.in
@@ -225,7 +220,6 @@ urllib3==1.26.5
     # via
     #   botocore
     #   requests
-    #   sentry-sdk
 webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180766893

This reverts commit 5ae8acb8aa995b6e423ac4691cbe13dcc145f159.

After deploying this PR, we should also remove the redundant
environment "SENTRY_DSN" environment variable:

   cf unset-env notify-admin SENTRY_DSN

Note this needs to be done in each environment, with a Cyber
approval required for Production.

Note that notify-admin-prototype should also be deployed and
the environment variable removed, as this app was used for the
initial testing of the Sentry client.