### PR TITLE
Silence errors from Python Client

### DIFF
--- a/application.py
+++ b/application.py
@@ -3,6 +3,7 @@ import os
 import sentry_sdk
 from flask import Flask
 from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations import logging
 
 from app import create_app
 
@@ -13,7 +14,9 @@ sentry_sdk.init(
     attach_stacktrace=True,
     traces_sample_rate=0.00005  # avoid exceeding rate limits in Production
 )
+
 sentry_sdk.set_level('error')  # only record error logs or exceptions
+logging.ignore_logger('notifications_python_client.*')  # ignore logs about 404s, etc.
 
 application = Flask('app')
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180766893

Otherwise we start spamming Sentry with every 404 error log. Even
if the erorr is a 5xx, it depends on how we handle it in the calling
code as to whether we would want to consider it an error.

<img width="821" alt="Screenshot 2021-12-31 at 12 27 22" src="https://user-images.githubusercontent.com/9029009/147823431-91c88dd7-0e40-4058-9443-ea9f46f7c610.png">

I didn't spot this in initial testing on Preview because the 404s in
Preview are only triggered due to the functional tests, which only run
when we're deploying something.

Arguably we shouldn't be logging at error level in our Python Client,
since we're also raising an exception [1]. But changing that would be
a can of worms as it's not an internal-only library.

[1]: https://github.com/alphagov/notifications-python-client/blob/74a958de00d39571101996c8483869ba43068006/notifications_python_client/base.py#L118