### PR TITLE
Tweak Sentry config to work in development

### DIFF
--- a/application.py
+++ b/application.py
@@ -8,16 +8,16 @@ from sentry_sdk.integrations import logging
 
 from app import create_app
 
-sentry_sdk.init(
-    dsn=os.environ['SENTRY_DSN'],
-    integrations=[FlaskIntegration(), RedisIntegration()],
-    environment=os.environ['NOTIFY_ENVIRONMENT'],
-    attach_stacktrace=True,
-    traces_sample_rate=0.00005  # avoid exceeding rate limits in Production
-)
+if 'SENTRY_DSN' in os.environ:
+    sentry_sdk.init(
+        dsn=os.environ['SENTRY_DSN'],
+        integrations=[FlaskIntegration(), RedisIntegration()],
+        environment=os.environ['NOTIFY_ENVIRONMENT'],
+        attach_stacktrace=True,
+        traces_sample_rate=0.00005  # avoid exceeding rate limits in Production
+    )
 
-sentry_sdk.set_level('error')  # only record error logs or exceptions
-logging.ignore_logger('notifications_python_client.*')  # ignore logs about 404s, etc.
+    logging.ignore_logger('notifications_python_client.*')  # ignore logs about 404s, etc.
 
 application = Flask('app')
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180766893

This makes a couple of changes:

- Most importantly, it wraps the setup code in a conditional so that
developers don't need to have a DSN set to start the app locally.

- Secondly, it removes the redundant call to "set_level". Originally
I thought the integration was sending info/warning events, but this
isn't the case [1] and even if it was, "set_level" affects the level
of custom events [2], not the level they are dispatched at.

[1]: https://github.com/getsentry/sentry-python/blob/4c09f3203d6d19789c6fa729a2e46557ad4ea913/sentry_sdk/integrations/logging.py#L56
[2]: https://docs.sentry.io/platforms/python/guides/logging/usage/set-level/