### PR TITLE
Format phone numbers with spaces in download of received text messages

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -15,6 +15,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user
+from notifications_utils.recipients import format_phone_number_human_readable
 from werkzeug.utils import redirect
 
 from app import (
@@ -202,7 +203,7 @@ def inbox_download(service_id):
                 'Message',
                 'Received',
             ]] + [[
-                message['user_number'],
+                format_phone_number_human_readable(message['user_number']),
                 message['content'].lstrip(('=+-@')),
                 format_datetime_numeric(message['created_at']),
             ] for message in service_api_client.get_inbound_sms(service_id)['data']]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -364,6 +364,30 @@ def org_invite_json(id_, invited_by, org_id, email_address, created_at, status):
     }
 
 
+def inbound_sms_json():
+    return {
+        'has_next': True,
+        'data': [{
+            'user_number': phone_number,
+            'notify_number': '07900000002',
+            'content': f'message-{index + 1}',
+            'created_at': (
+                datetime.utcnow() - timedelta(minutes=60 * hours_ago, seconds=index)
+            ).isoformat(),
+            'id': sample_uuid(),
+        } for index, hours_ago, phone_number in (
+            (0, 1, '447900900000'),
+            (1, 1, '07900900000'),
+            (2, 1, '07900900000'),
+            (3, 3, '07900900002'),
+            (4, 5, '33(0)1 12345678'),  # France
+            (5, 7, '1-202-555-0104'),  # USA in one format
+            (6, 9, '+12025550104'),  # USA in another format
+            (7, 9, '+68212345'),  # Cook Islands
+        )]
+    }
+
+
 TEST_USER_EMAIL = 'test@user.gov.uk'
 
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -268,10 +268,10 @@ def test_inbound_messages_shows_count_of_messages_when_there_are_no_messages(
     '07900 900000 message-2 1 hour ago',
     '07900 900000 message-3 1 hour ago',
     '07900 900002 message-4 3 hours ago',
-    '07900 900004 message-5 5 hours ago',
-    '07900 900006 message-6 7 hours ago',
-    '07900 900008 message-7 9 hours ago',
-    '07900 900008 message-8 9 hours ago',
+    '+33 1 12 34 56 78 message-5 5 hours ago',
+    '+1 202-555-0104 message-6 7 hours ago',
+    '+1 202-555-0104 message-7 9 hours ago',
+    '+682 12345 message-8 9 hours ago',
 ]))
 def test_inbox_showing_inbound_messages(
     client_request,
@@ -434,14 +434,14 @@ def test_download_inbox(
     )
     assert response.get_data(as_text=True) == (
         'Phone number,Message,Received\r\n'
-        '07900900000,message-1,2016-07-01 13:00\r\n'
-        '07900900000,message-2,2016-07-01 12:59\r\n'
-        '07900900000,message-3,2016-07-01 12:59\r\n'
-        '07900900002,message-4,2016-07-01 10:59\r\n'
-        '07900900004,message-5,2016-07-01 08:59\r\n'
-        '07900900006,message-6,2016-07-01 06:59\r\n'
-        '07900900008,message-7,2016-07-01 04:59\r\n'
-        '07900900008,message-8,2016-07-01 04:59\r\n'
+        '07900 900000,message-1,2016-07-01 13:00\r\n'
+        '07900 900000,message-2,2016-07-01 12:59\r\n'
+        '07900 900000,message-3,2016-07-01 12:59\r\n'
+        '07900 900002,message-4,2016-07-01 10:59\r\n'
+        '+33 1 12 34 56 78,message-5,2016-07-01 08:59\r\n'
+        '+1 202-555-0104,message-6,2016-07-01 06:59\r\n'
+        '+1 202-555-0104,message-7,2016-07-01 04:59\r\n'
+        '+682 12345,message-8,2016-07-01 04:59\r\n'
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from . import (
     broadcast_message_json,
     contact_list_json,
     generate_uuid,
+    inbound_sms_json,
     invite_json,
     job_json,
     notification_json,
@@ -2021,16 +2022,7 @@ def mock_get_inbound_sms(mocker):
         user_number=None,
         page=1
     ):
-        return {
-            'has_next': True,
-            'data': [{
-                'user_number': '0790090000' + str(i),
-                'notify_number': '07900000002',
-                'content': 'message-{}'.format(index + 1),
-                'created_at': (datetime.utcnow() - timedelta(minutes=60 * (i + 1), seconds=index)).isoformat(),
-                'id': sample_uuid(),
-            } for index, i in enumerate([0, 0, 0, 2, 4, 6, 8, 8])]
-        }
+        return inbound_sms_json()
 
     return mocker.patch(
         'app.service_api_client.get_inbound_sms',
@@ -2059,16 +2051,7 @@ def mock_get_most_recent_inbound_sms(mocker):
         user_number=None,
         page=1
     ):
-        return {
-            'has_next': True,
-            'data': [{
-                'user_number': '0790090000' + str(i),
-                'notify_number': '07900000002',
-                'content': 'message-{}'.format(index + 1),
-                'created_at': (datetime.utcnow() - timedelta(minutes=60 * (i + 1), seconds=index)).isoformat(),
-                'id': sample_uuid(),
-            } for index, i in enumerate([0, 0, 0, 2, 4, 6, 8, 8])]
-        }
+        return inbound_sms_json()
 
     return mocker.patch(
         'app.service_api_client.get_most_recent_inbound_sms',


### PR DESCRIPTION
Some users have reported a problem with the received text message report:

> I have tested the reply service but in the excel report the mobile number is showing as 4.47900E+11. How can I change the format so that it is show the mobile number that has replied?

This is happening because Excel is interpreting a phone number in the format `447900900123` as a number in [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation), in other words 4.479 &times; 10<sup>11</sup>.

We can prevent this behaviour by putting spaces in the numbers. Excel and Google Sheets won’t try to convert a string with spaces into a number. We already format the phone number in this way when we display it on the page.

I think we used to do this for the sent text messages report but probably stopped because we decided it was better to keep the phone number in the same format as it had been supplied to us.

# Google Sheets

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/148414677-bebd9b89-e2ad-4822-89f9-1947cdcd9efe.png) | ![image](https://user-images.githubusercontent.com/355079/148414728-bf693723-e3c0-41e7-832e-9e71c7b17bd4.png)

# Excel

Before | After
---|---
![Screen Shot 2022-01-06 at 16 25 49](https://user-images.githubusercontent.com/355079/148416919-6fde7c39-6d2f-40e0-bd56-6103af859b71.png) | ![Screen Shot 2022-01-06 at 16 26 16](https://user-images.githubusercontent.com/355079/148416938-811af2ba-be7c-4821-80a3-c4d46ee43e1b.png)

