### PR TITLE
Remove extra ‘for’ in content

### DIFF
--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -29,7 +29,7 @@
 		    {{ current_org.name }} team members can:
 		  </p>
 		  <ul class="list list-bullet">
-		    <li>see usage for and team members for each service</li>
+		    <li>see usage and team members for each service</li>
         <li>invite other team members</li>
 		  </ul>
 		</div>


### PR DESCRIPTION
The PR fixes a possible typo to make the bullet point read more naturally.