### PR TITLE
Add anchor IDs to headings on GOV.UK Notify

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -285,7 +285,7 @@ def format_notification_status_as_url(status, notification_type):
 
     return {
         'email': url(_anchor='email-statuses'),
-        'sms': url(_anchor='sms-statuses')
+        'sms': url(_anchor='text-message-statuses')
     }.get(notification_type)
 
 

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -41,7 +41,7 @@
     <a class="govuk-link govuk-link--no-visited-state" href="https://mcmw.abilitynet.org.uk">AbilityNet</a> has advice on making your device easier to use if you have a disability.
   </p>
 
-  <h2 class="heading-medium">How accessible this website is</h2>
+  <h2 class="heading-medium" id="how-accessible-this-website-is">How accessible this website is</h2>
 
   <p class="govuk-body">
     We know some parts of this website are not fully accessible:
@@ -63,7 +63,7 @@
     We also know that the emails Notify sends are not fully accessible. The JAWS and NVDA screen readers announce extra spaces in emails when you view them in Microsoft Outlook.
   </p>
 
-  <h2 class="heading-medium">Feedback and contact information</h2>
+  <h2 class="heading-medium" id="feedback-and-contact-information">Feedback and contact information</h2>
 
   <p class="govuk-body">
     If you need any part of this service in a different format like large print, audio recording or braille, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a>.
@@ -73,13 +73,13 @@
     We’ll consider your request and get back to you within one working day.
   </p>
 
-  <h2 class="heading-medium">Reporting accessibility problems with this website</h2>
+  <h2 class="heading-medium" id="reporting-accessibility-problems">Reporting accessibility problems with this website</h2>
 
   <p class="govuk-body">
     We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a>.
   </p>
 
-  <h2 class="heading-medium">Enforcement procedure</h2>
+  <h2 class="heading-medium" id="enforcement-procedure">Enforcement procedure</h2>
 
   <p class="govuk-body">
     The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the Equality Advisory and Support Service (EASS).
@@ -89,7 +89,7 @@
     Find out how to <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a>.
   </p>
 
-  <h2 class="heading-medium">Technical information about this website’s accessibility</h2>
+  <h2 class="heading-medium" id="technical-information">Technical information about this website’s accessibility</h2>
 
   <p class="govuk-body">
     GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
@@ -99,13 +99,13 @@
     GOV.UK Notify is partially compliant with the Web Content Accessibility Guidelines (WCAG) version 2.1 AA standard, due to the non-compliances listed below.
   </p>
 
-  <h2 class="heading-medium">Non-accessible content</h2>
+  <h2 class="heading-medium" id="non-accessible-content">Non-accessible content</h2>
 
   <p class="govuk-body">
     The content listed below is non-accessible for the following reasons.
   </p>
 
-  <h3 class="heading-small">Non compliance with the accessibility regulations</h3>
+  <h3 class="heading-small" id="non-compliance">Non compliance with the accessibility regulations</h3>
 
   <p class="govuk-body">
     The following content on the Notify website is not compliant with the WCAG version 2.1 AA standard:
@@ -127,7 +127,7 @@
     We expect to fix these issues by the end of December 2021.
   </p>
 
-  <h3 class="heading-small">Problems with using the interface</h3>
+  <h3 class="heading-small" id="problems-with-using-the-interface">Problems with using the interface</h3>
 
   <p class="govuk-body">
     We’ve identified the following problems with the user interface:
@@ -155,7 +155,7 @@
     We hope to fix these issues by the end of January 2022.
   </p>
 
-  <h3 class="heading-small">
+  <h3 class="heading-small" id="pdfs-documents">
     PDFs and other documents
   </h3>
 
@@ -166,7 +166,7 @@
     We provide a written description of the information in the PDF on an HTML page as an accessible alternative.
   </p>
 
-  <h3 class="heading-small">
+  <h3 class="heading-small" id="emails">
     Emails
   </h3>
 
@@ -178,7 +178,7 @@
     We’ll continue to investigate the cause of this issue and, if possible, fix it by the end of 2021.
   </p>
 
-  <h3 class="heading-small">
+  <h3 class="heading-small" id="status-page">
     Status page
   </h3>
 
@@ -202,7 +202,7 @@
     We plan to have the status page issues addressed by the current supplier or move to an alternative supplier in 2021.
   </p>
 
-  <h2 class="heading-medium">
+  <h2 class="heading-medium" id="how-we-tested-this-service">
     How we tested this service
   </h2>
 

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -13,7 +13,7 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "27 October 2021",
+      "Last updated": "14 January 2022",
       "Next review due": "20 January 2022" 
     }
     ) }}

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -23,7 +23,7 @@
     </p>
     <p class="govuk-body">We use cookies to make GOV.UK Notify work and collect information about how you use our service.</p>
 
-    <h2 class="heading-medium">Essential cookies</h2>
+    <h2 class="heading-medium" id="essential-cookies">Essential cookies</h2>
     <p class="govuk-body">
       Essential cookies keep your information secure while you use Notify. We do not need to ask permission to use them.
     </p>
@@ -62,7 +62,7 @@
         </tbody>
     </table>
 
-    <h2 class="heading-medium">Analytics cookies (optional)</h2>
+    <h2 class="heading-medium" id="analytics-cookies">Analytics cookies (optional)</h2>
     <p class="govuk-body">
       With your permission, we use Google Analytics to collect data about how you use Notify. This information helps us to improve our service.
     </p>

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -8,7 +8,7 @@
 
   <h1 class="heading-large">Documentation</h1>
     <p class="govuk-body">This documentation is for developers who want to integrate the GOV.UK Notify API with a web application or back office system.</p>
-  <h2 class="heading-medium">Client libraries</h2>
+  <h2 class="heading-medium" id="client-libraries">Client libraries</h2>
     <p class="govuk-body">Links to documentation open in a new tab.</p>
   <ul class="list list-bullet">
     {% for key, label in [
@@ -23,7 +23,7 @@
     {% endfor %}
   </ul>
     <p class="govuk-body">A developer should be able to set up the API client and start sending test messages in around 30 minutes. A full integration can take a few days, depending on the other systems you’re using.</p>
-  <h2 class="heading-medium">Integrate directly with the API</h2>
+  <h2 class="heading-medium" id="integrate-directly-with-the-api">Integrate directly with the API</h2>
     <p class="govuk-body">If you cannot use the client libraries, you can integrate directly with the API instead.</p>
 <p class="govuk-body">Read the <a class="govuk-link govuk-link--no-visited-state" href="https://docs.notifications.service.gov.uk/rest-api.html" target="_blank" rel="noopener">REST API documentation</a> (this link opens in a new tab).</p>
 

--- a/app/templates/views/guidance/who-can-use-notify.html
+++ b/app/templates/views/guidance/who-can-use-notify.html
@@ -26,7 +26,7 @@
     If you work for one of these organisations but get an error when you try to create an account, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact support</a>.
   </p>
 
-  <h2 class="govuk-heading-m">Suppliers</h2>
+  <h2 class="govuk-heading-m" id="suppliers">Suppliers</h2>
   <p class="govuk-body">
     If you’re doing work for a public sector organisation you can use GOV.UK&nbsp;Notify.
   </p>
@@ -34,12 +34,12 @@
     Someone from the public sector organisation you’re working with needs to set up the account. Then they can invite you as a team member.
   </p>
 
-  <h2 class="govuk-heading-m">Charities</h2>
+  <h2 class="govuk-heading-m" id="charities">Charities</h2>
   <p class="govuk-body">
     Notify is not currently available to charities.
   </p>
 
-  <h2 class="govuk-heading-m">Members of the public</h2>
+  <h2 class="govuk-heading-m" id="public">Members of the public</h2>
   <p class="govuk-body">
     The GOV.UK Notify service is only for people who work in the government
     or other public sector organisations.

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -43,7 +43,7 @@
   <h3 id="open-rates" class="heading-small">Open rates and click-throughs</h3>
   <p class="govuk-body">Notify cannot tell you if your users open an email or click on the links in an email. We do not track open rates and click-throughs because there are privacy issues. Tracking emails without asking permission from users could breach General Data Protection Regulations (GDPR).</p>
 
-  <h2 id="sms-statuses" class="heading-medium">Text messages</h2>
+  <h2 id="text-message-statuses" class="heading-medium">Text messages</h2>
   <div class="bottom-gutter-3-2">
     {% call mapping_table(
       caption='Message statuses – text messages',

--- a/app/templates/views/pricing/billing-details.html
+++ b/app/templates/views/pricing/billing-details.html
@@ -19,7 +19,7 @@
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Contact us</a> if you need any other details.
     </p>
 
-    <h2 class="heading-medium govuk-!-margin-top-7">
+    <h2 class="heading-medium govuk-!-margin-top-7" id="supplier-details">
       Supplier details
     </h2>
 
@@ -34,7 +34,7 @@
       E1 8QS
     </p>
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="email-addresses">
       Email addresses
     </h3>
 
@@ -46,7 +46,7 @@
       {% endfor %}
     </ul>
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="vat-number">
       <abbr title="Value Added Tax">VAT</abbr> number
     </h3>
 
@@ -57,7 +57,7 @@
     ) }}
     </div>
 
-    <h2 class="heading-medium govuk-!-margin-top-7">
+    <h2 class="heading-medium govuk-!-margin-top-7" id="bank-details">
       Bank details
     </h2>
 
@@ -70,7 +70,7 @@
       EC2M 4RB
     </p>
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="account-name">
       Account name
     </h3>
 
@@ -78,7 +78,7 @@
       Cabinet Office
     </p>
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="account-number">
       Account number
     </h3>
 
@@ -89,7 +89,7 @@
       ) }}
     </div>
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="sort-code">
       Sort code
     </h3>
 
@@ -101,7 +101,7 @@
     </div>
 
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="iban">
       <abbr title="International Bank Account Number">IBAN</abbr>
     </h3>
     <div class="govuk-!-margin-bottom-4">
@@ -111,7 +111,7 @@
       ) }}
     </div>
 
-    <h3 class="heading-small">
+    <h3 class="heading-small" id="swift-code">
       Swift code
     </h3>
 
@@ -122,7 +122,7 @@
       ) }}
     </div>
 
-    <h2 class="heading-medium govuk-!-margin-top-7">
+    <h2 class="heading-medium govuk-!-margin-top-7" id="invoice-address">
       Invoice address
     </h2>
 

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -17,7 +17,7 @@
       }
     ) }}
 
-    <h2 class="heading-medium">Who we are</h2>
+    <h2 class="heading-medium" id="who-we-are">Who we are</h2>
 
     <p class="govuk-body">GOV.UK Notify is a service that lets public service teams in the UK send emails, text messages, and letters
       to users of their service.</p>
@@ -31,7 +31,7 @@
     <p class="govuk-body">For more information see the Information Commissioner’s Office (ICO) <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/esdwebpages/search">Data Protection Public Register</a>.
       The Cabinet Office registration number is: Z7414053</p>
 
-    <h2 class="heading-medium">What data we collect from you</h2>
+    <h2 class="heading-medium" id="what-data-we-collect-from-you">What data we collect from you</h2>
 
     <p class="govuk-body">The personal data we collect from public sector employees that create a GOV.UK Notify account includes:</p>
 
@@ -45,11 +45,11 @@
     <p class="govuk-body">The legal basis for processing this data is ‘public task’ – allowing you to access GOV.UK Notify to send notifications
       to users of your public service.</p>
 
-    <h2 class="heading-medium">Why we need your data</h2>
+    <h2 class="heading-medium" id="why-we-need-your-data">Why we need your data</h2>
 
     <p class="govuk-body">We need your personal data to ensure that only legitimate users of GOV.UK Notify can use it to send notifications.</p>
 
-    <h2 class="heading-medium">What we do with your data</h2>
+    <h2 class="heading-medium" id="what-we-do-with-your-data">What we do with your data</h2>
 
     <p class="govuk-body">We use your data to check that you are allowed to access GOV.UK Notify and to record your activity when using it. We use third party suppliers to do this.</p>
 
@@ -62,31 +62,31 @@
 
     <p class="govuk-body">We will share your data if we are required to do so by law – for example, by court order, or to prevent fraud or other crime.</p>
 
-    <h2 class="heading-medium">How long we keep your data</h2>
+    <h2 class="heading-medium" id="how-long-we-keep-your-data">How long we keep your data</h2>
 
     <p class="govuk-body">We will retain your personal data for as long as you have a GOV.UK Notify account.</p>
 
-    <h2 class="heading-medium">Where your data is processed and stored</h2>
+    <h2 class="heading-medium" id="where-your-data-is-processed">Where your data is processed and stored</h2>
 
     <p class="govuk-body">We design, build and run our systems to make sure that your data is as safe as possible at any stage, both while it’s
       processed and when it’s stored.</p>
 
     <p class="govuk-body">Your personal data will be processed both in the UK and the European Economic Area (EEA). Your data receives the same level of protection in the EEA as it does in the UK through the safeguard of <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/for-organisations/dp-at-the-end-of-the-transition-period/data-protection-and-the-eu-in-detail/adequacy/">Adequacy Decisions</a>.</p>
    
-    <h2 class="heading-medium">How we protect your data and keep it secure</h2>
+    <h2 class="heading-medium" id="how-we-protect-your-data">How we protect your data and keep it secure</h2>
 
     <p class="govuk-body">We are committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have
       put in place technical and organisational procedures to secure the data we collect about you – for example, we protect your
       data using varying levels of encryption. We also make sure that any third parties that we deal with have an obligation to
       keep all personal data they process on our behalf secure.</p>
 
-    <h2 class="heading-medium">Children’s privacy protection</h2>
+    <h2 class="heading-medium" id="childrens-privacy-protection">Children’s privacy protection</h2>
 
     <p class="govuk-body">We understand the importance of protecting children’s privacy online. Our services are not designed for, or intentionally
       targeted at, children 13 years of age or younger. It is not our policy to intentionally collect or maintain data about anyone
       under the age of 13.</p>
 
-    <h2 class="heading-medium">What are your rights</h2>
+    <h2 class="heading-medium" id="your-rights">What are your rights</h2>
 
     <p class="govuk-body">You have the right to request:</p>
 
@@ -106,14 +106,14 @@
 
     <p class="govuk-body">If you have any of these requests, get in contact with our Data Protection Officer - you can find their contact details below.</p>
 
-    <h2 class="heading-medium">Changes to this notice</h2>
+    <h2 class="heading-medium" id="changes-to-this-notice">Changes to this notice</h2>
 
     <p class="govuk-body">We may modify or amend this privacy notice at our discretion at any time. When we make changes to this notice, we will
       amend the last modified date at the top of this page. Any modification or amendment to this privacy notice will be applied
       to you and your data as of that revision date. We encourage you to periodically review this privacy notice to be informed
       about how we are protecting your data.</p>
 
-    <h2 class="heading-medium">Questions and complaints</h2>
+    <h2 class="heading-medium" id="questions-and-complaints">Questions and complaints</h2>
 
     <p class="govuk-body">Contact the GDS Privacy Team if you either:</p>
 

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -22,7 +22,7 @@
   <p class="govuk-body">The roadmap is only a guide. It does not cover everything we do, and some things may change.</p>
   <p class="govuk-body">You can <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> if you have any questions about the roadmap or suggestions for new features.</p>
 
-  <h2 class="heading-medium">Things we’re working on</h2>
+  <h2 class="heading-medium" id="things-we-are-working-on">Things we’re working on</h2>
 
 <h3 class="heading-small">Now</h3>
 

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -24,7 +24,7 @@
 
   <h2 class="heading-medium" id="things-we-are-working-on">Things we’re working on</h2>
 
-<h3 class="heading-small">Now</h3>
+<h3 class="heading-small" id="now">Now</h3>
 
   <ul class="list list-bullet">
     
@@ -34,7 +34,7 @@
     <li>Help teams understand how their organisation uses Notify</li>    
   </ul>
 
-  <h3 class="heading-small">Next</h3>
+  <h3 class="heading-small" id="next">Next</h3>
 
   <ul class="list list-bullet">
     <li>Design a way for services to upload their own logo and <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('main.branding_and_customisation')}}">branding for emails and letters</a></li>
@@ -42,7 +42,7 @@
     <li>Prototype new ways to <a class="govuk-link govuk-link--no-visited-state" href="https://gds.blog.gov.uk/2020/08/18/can-gov-uk-notify-help-the-public-sector-write-better-emails-text-messages-and-letters/">help teams write cheaper, more effective messages</a></li>
   </ul>
 
-  <h3 class="heading-small">Later</h3>
+  <h3 class="heading-small" id="later">Later</h3>
 
   <ul class="list list-bullet">
 

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -15,7 +15,7 @@
     <li>manage risks around information</li>
   </ul>
 
-  <h2 class="heading-medium">Data</h2>
+  <h2 class="heading-medium" id="data">Data</h2>
   <p class="govuk-body">On Notify, data is encrypted:</p>
   <ul class="list list-bullet">
     <li>when it passes through the service</li>
@@ -32,7 +32,7 @@
     <li>approach to data sharing</li>
   </ul>
 
-  <h2 class="heading-medium">Technical security</h2>
+  <h2 class="heading-medium" id="technical-security">Technical security</h2>
   <p class="govuk-body">Other technical security controls on Notify include:</p>
   <ul class="list list-bullet">
     <li>compliance with National Cyber Security Centre (NCSC) Cloud Security Principles</li>
@@ -44,7 +44,7 @@
   <p class="govuk-body">Some messages include sensitive information like security codes or password reset links.</p>
   <p class="govuk-body">If you’re sending a message with sensitive information, you can choose to hide those details on the Notify dashboard once the message has been sent. This means that only the message recipient will be able to see that information.</p>
 
-  <h2 class="heading-medium">User permissions and signing in</h2>
+  <h2 class="heading-medium" id="user-permissions-signing-in">User permissions and signing in</h2>
   <p class="govuk-body">You can set different user permissions in Notify. This lets you control who in your team has access to certain parts of the service.</p>
   <h3 class="heading-small">Two-factor authentication</h3>
   <p class="govuk-body">To sign in to Notify, you’ll need to enter:</p>
@@ -54,7 +54,7 @@
   </ul>
   <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
 
-  <h2 class="heading-medium">Information risk management</h2>
+  <h2 class="heading-medium" id="information-risk-management">Information risk management</h2>
   <p class="govuk-body">Our approach to information risk management follows NCSC guidance. It assesses:</p>
   <ul class="list list-bullet">
     <li>how Notify is built</li>
@@ -63,7 +63,7 @@
   </ul>
   <p class="govuk-body">This approach also applies to the service providers Notify uses to send messages.</p>
 
-  <h2 class="heading-medium">How we manage risks on Notify</h2>
+  <h2 class="heading-medium" id="how-we-manage-risk">How we manage risks on Notify</h2>
   <p class="govuk-body">Things we do to manage risks on Notify include:</p>
   <ul class="list list-bullet">
     <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 27005:2011</a> and National Cyber Security Centre guidance</li>
@@ -73,11 +73,11 @@
     <li>security impact assessments</li>
   </ul>
 
-  <h2 class="heading-medium">Cabinet Office approval</h2>
+  <h2 class="heading-medium" id="cabinet-office-approval">Cabinet Office approval</h2>
   <p class="govuk-body">Notify has been assessed and approved by the Cabinet Office Senior Information Risk Officer (SIRO). The SIRO checks this approval once a year.</p>
   <p class="govuk-body">Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
 
-  <h2 class="heading-medium">Classifications and security vetting</h2>
+  <h2 class="heading-medium" id="classifications-and-security-vetting">Classifications and security vetting</h2>
   <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
   <p class="govuk-body">Notify does not process data classified as ‘SECRET’ or ‘TOP SECRET’.</p>
   <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/organisations/united-kingdom-security-vetting">United Kingdom Security Vetting</a> (UKSV).</p>

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -13,7 +13,7 @@
     These terms apply to your service’s use of GOV.UK&nbsp;Notify. You must be the service manager to accept them.
   </p>
 
-  <h2 class="heading-medium">When using Notify</h2>
+  <h2 class="heading-medium" id="when-using-notify">When using Notify</h2>
   <p class="govuk-body">You must:</p>
   <ul class="list list-bullet">
     <li>complete your organisation’s information assurance process (you do not need to include Notify or our delivery partners, we’ve already done that)</li>
@@ -37,7 +37,7 @@
     <li>give you one month’s notice by email if we change our terms of use or delivery providers</li>
   </ul>
 
-  <h2 class="heading-medium">Leaving Notify</h2>
+  <h2 class="heading-medium" id="leaving-notify">Leaving Notify</h2>
   <p class="govuk-body">You can leave Notify at any time. Just <a class="govuk-link govuk-link--no-visited-state" href="{{url_for('.support')}}">contact us</a> and we’ll close your account.</p>
   <p class="govuk-body">When you leave Notify, all your data will be deleted.</p>
 

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -22,9 +22,9 @@ from app.formatters import (
     ('temporary-failure', 'email', partial(url_for, 'main.message_status', _anchor='email-statuses')),
     ('permanent-failure', 'email', partial(url_for, 'main.message_status', _anchor='email-statuses')),
     ('technical-failure', 'email', partial(url_for, 'main.message_status', _anchor='email-statuses')),
-    ('temporary-failure', 'sms', partial(url_for, 'main.message_status', _anchor='sms-statuses')),
-    ('permanent-failure', 'sms', partial(url_for, 'main.message_status', _anchor='sms-statuses')),
-    ('technical-failure', 'sms', partial(url_for, 'main.message_status', _anchor='sms-statuses')),
+    ('temporary-failure', 'sms', partial(url_for, 'main.message_status', _anchor='text-message-statuses')),
+    ('permanent-failure', 'sms', partial(url_for, 'main.message_status', _anchor='text-message-statuses')),
+    ('technical-failure', 'sms', partial(url_for, 'main.message_status', _anchor='text-message-statuses')),
     # Letter statuses are never linked
     ('technical-failure', 'letter', lambda: None),
     ('cancelled', 'letter', lambda: None),

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -188,12 +188,12 @@ def test_message_status_page_contains_message_status_ids(client_request):
     page = client_request.get('main.message_status')
 
     assert page.find(id='email-statuses')
-    assert page.find(id='sms-statuses')
+    assert page.find(id='text-message-statuses')
 
 
 def test_message_status_page_contains_link_to_support(client_request):
     page = client_request.get('main.message_status')
-    sms_status_table = page.find(id='sms-statuses').findNext('tbody')
+    sms_status_table = page.find(id='text-message-statuses').findNext('tbody')
 
     temp_fail_details_cell = sms_status_table.select_one('tr:nth-child(4) > td:nth-child(2)')
     assert temp_fail_details_cell.find('a').attrs['href'] == url_for('main.support')


### PR DESCRIPTION
This PR adds anchor IDs to (most) headings on public-facing Notify pages.

This will let us link to specific information when replying to support queries.

Some IDs will prove to be redundant, some will be removed in time, but we’ve added them all for now, just in case.