### PR TITLE
Point people to Zendesk if there's a problem

### DIFF
--- a/app/assets/error_pages/5xx.html
+++ b/app/assets/error_pages/5xx.html
@@ -75,7 +75,7 @@
               Try again later.
             </p>
             <p class="govuk-body">
-              You can check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk/">system status</a> page to see if there are any known issues.<br/>To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
+              You can check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk/">system status</a> page to see if there are any known issues.<br/>To report a problem, email <a href="mailto:gov-uk-notify-support@digital.cabinet-office.gov.uk">gov-uk-notify-support@digital.cabinet-office.gov.uk</a>
           </div>
         </div>
       </main>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -13,7 +13,7 @@
         You can check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
       </p>
       <p class="govuk-body">
-        To report a problem, email <a class="govuk-link govuk-link--no-visited-state" href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
+        To report a problem, email <a class="govuk-link govuk-link--no-visited-state" href="mailto:gov-uk-notify-support@digital.cabinet-office.gov.uk">gov-uk-notify-support@digital.cabinet-office.gov.uk</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
This was a minor issue in a recent incident [1].

We don't want people emailing us directly:

- It's harder to collaborate on replies than in Zendesk, where I
can see who's editing.

- We can't take advantage of macros like we can in Zendesk.

- People emailing us directly creates an unnecessary distraction
and it's easy to lose track. We want to minimise distractions in
an incident situation.

- We use notify-support@ for monitoring, so we don't want noise.

[1]: https://docs.google.com/document/d/1eArpcYoCmhlgB45FZpGj1_HnkAgpgtgwr-KBiUq7h8c/edit#