### PR TITLE
Reintroduce DiffDOM

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+app/assets/javascripts/modules/polyfills-for-diffdom.js

--- a/app/assets/javascripts/modules/all.mjs
+++ b/app/assets/javascripts/modules/all.mjs
@@ -6,6 +6,7 @@
 //
 // Exported items will be added to the window.GOVUK namespace.
 // For example, `export { Frontend }` will assign `Frontend` to `window.Frontend`
+import './polyfills-for-diffdom.js';
 import Header from 'govuk-frontend/components/header/header';
 import Details from 'govuk-frontend/components/details/details';
 import Button from 'govuk-frontend/components/button/button';

--- a/app/assets/javascripts/modules/all.mjs
+++ b/app/assets/javascripts/modules/all.mjs
@@ -10,6 +10,7 @@ import Header from 'govuk-frontend/components/header/header';
 import Details from 'govuk-frontend/components/details/details';
 import Button from 'govuk-frontend/components/button/button';
 import Radios from 'govuk-frontend/components/radios/radios';
+import {DiffDOM} from 'diff-dom';
 
 /**
  * TODO: Ideally this would be a NodeList.prototype.forEach polyfill
@@ -62,6 +63,11 @@ var Frontend = {
   "initAll": initAll
 }
 
+var vendor = {
+  "DiffDOM": DiffDOM
+}
+
 export {
-  Frontend
+  Frontend,
+  vendor
 }

--- a/app/assets/javascripts/modules/polyfills-for-diffdom.js
+++ b/app/assets/javascripts/modules/polyfills-for-diffdom.js
@@ -1,0 +1,1009 @@
+/* Polyfill service v3.109.0
+ * For detailed credits and licence information see https://github.com/financial-times/polyfill-service.
+ * 
+ * Features requested: Array.prototype.concat,Array.prototype.includes,Array.prototype.join,Array.prototype.slice,Array.prototype.sort,Array.prototype.splice,Function.prototype.name,JSON.Stringify,NodeList.prototype.forEach,Object.entries,Object.prototype.toString,RegExp.prototype.constructor,RegExp.prototype.exec,RegExp.prototype.sticky,RegExp.prototype.toString,String.prototype.match,String.prototype.replace,String.prototype.split,String.prototype.startsWith,String.prototype.trim
+ * 
+ * - _ESAbstract.Call, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive", "_ESAbstract.OrdinaryToPrimitive")
+ * - _ESAbstract.CreateMethodProperty, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties", "Object.keys")
+ * - _ESAbstract.Get, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive", "_ESAbstract.OrdinaryToPrimitive")
+ * - _ESAbstract.HasOwnProperty, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties", "Object.getOwnPropertyDescriptor")
+ * - _ESAbstract.IsCallable, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive", "_ESAbstract.OrdinaryToPrimitive")
+ * - _ESAbstract.RequireObjectCoercible, License: CC0 (required by "String.prototype.trim", "_ESAbstract.TrimString")
+ * - _ESAbstract.SameValueNonNumber, License: CC0 (required by "Array.prototype.includes", "_ESAbstract.SameValueZero")
+ * - _ESAbstract.ToBoolean, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.IsRegExp")
+ * - _ESAbstract.ToObject, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive", "_ESAbstract.GetMethod", "_ESAbstract.GetV")
+ * - _ESAbstract.GetV, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive", "_ESAbstract.GetMethod")
+ * - _ESAbstract.GetMethod, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive")
+ * - _ESAbstract.Type, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties", "Object.getOwnPropertyDescriptor", "_ESAbstract.ToPropertyKey")
+ * - _ESAbstract.IsRegExp, License: CC0 (required by "String.prototype.startsWith")
+ * - _ESAbstract.OrdinaryToPrimitive, License: CC0 (required by "String.prototype.startsWith", "_ESAbstract.ToString", "_ESAbstract.ToPrimitive")
+ * - _ESAbstract.SameValueZero, License: CC0 (required by "Array.prototype.includes")
+ * - _ESAbstract.ToInteger, License: CC0 (required by "Array.prototype.includes", "_ESAbstract.ToLength")
+ * - _ESAbstract.ToLength, License: CC0 (required by "Array.prototype.includes")
+ * - _ESAbstract.ToPrimitive, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties", "Object.getOwnPropertyDescriptor", "_ESAbstract.ToPropertyKey")
+ * - _ESAbstract.ToString, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties", "Object.getOwnPropertyDescriptor", "_ESAbstract.ToPropertyKey")
+ * - _ESAbstract.ToPropertyKey, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties", "Object.getOwnPropertyDescriptor")
+ * - _ESAbstract.TrimString, License: CC0 (required by "String.prototype.trim")
+ * - Array.prototype.includes, License: MIT
+ * - Array.prototype.sort, License: MIT
+ * - Function.prototype.name, License: MIT
+ * - NodeList.prototype.forEach, License: CC0
+ * - Object.getOwnPropertyDescriptor, License: CC0 (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties")
+ * - Object.keys, License: MIT (required by "Object.entries", "_ESAbstract.EnumerableOwnProperties")
+ * - _ESAbstract.EnumerableOwnProperties, License: CC0 (required by "Object.entries")
+ * - Object.entries, License: CC0
+ * - String.prototype.startsWith, License: CC0
+ * - String.prototype.trim, License: CC0
+ * 
+ * These features were not recognised:
+ * - Array.prototype.concat,- Array.prototype.join,- Array.prototype.slice,- Array.prototype.splice,- JSON.Stringify,- Object.prototype.toString,- RegExp.prototype.constructor,- RegExp.prototype.exec,- RegExp.prototype.sticky,- RegExp.prototype.toString,- String.prototype.match,- String.prototype.replace,- String.prototype.split */
+
+(function(self, undefined) {
+
+// _ESAbstract.Call
+/* global IsCallable */
+// 7.3.12. Call ( F, V [ , argumentsList ] )
+function Call(F, V /* [, argumentsList] */) { // eslint-disable-line no-unused-vars
+	// 1. If argumentsList is not present, set argumentsList to a new empty List.
+	var argumentsList = arguments.length > 2 ? arguments[2] : [];
+	// 2. If IsCallable(F) is false, throw a TypeError exception.
+	if (IsCallable(F) === false) {
+		throw new TypeError(Object.prototype.toString.call(F) + 'is not a function.');
+	}
+	// 3. Return ? F.[[Call]](V, argumentsList).
+	return F.apply(V, argumentsList);
+}
+
+// _ESAbstract.CreateMethodProperty
+// 7.3.5. CreateMethodProperty ( O, P, V )
+function CreateMethodProperty(O, P, V) { // eslint-disable-line no-unused-vars
+	// 1. Assert: Type(O) is Object.
+	// 2. Assert: IsPropertyKey(P) is true.
+	// 3. Let newDesc be the PropertyDescriptor{[[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}.
+	var newDesc = {
+		value: V,
+		writable: true,
+		enumerable: false,
+		configurable: true
+	};
+	// 4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+	Object.defineProperty(O, P, newDesc);
+}
+
+// _ESAbstract.Get
+// 7.3.1. Get ( O, P )
+function Get(O, P) { // eslint-disable-line no-unused-vars
+	// 1. Assert: Type(O) is Object.
+	// 2. Assert: IsPropertyKey(P) is true.
+	// 3. Return ? O.[[Get]](P, O).
+	return O[P];
+}
+
+// _ESAbstract.HasOwnProperty
+// 7.3.11 HasOwnProperty (O, P)
+function HasOwnProperty(o, p) { // eslint-disable-line no-unused-vars
+	// 1. Assert: Type(O) is Object.
+	// 2. Assert: IsPropertyKey(P) is true.
+	// 3. Let desc be ? O.[[GetOwnProperty]](P).
+	// 4. If desc is undefined, return false.
+	// 5. Return true.
+	// Polyfill.io - As we expect user agents to support ES3 fully we can skip the above steps and use Object.prototype.hasOwnProperty to do them for us.
+	return Object.prototype.hasOwnProperty.call(o, p);
+}
+
+// _ESAbstract.IsCallable
+// 7.2.3. IsCallable ( argument )
+function IsCallable(argument) { // eslint-disable-line no-unused-vars
+	// 1. If Type(argument) is not Object, return false.
+	// 2. If argument has a [[Call]] internal method, return true.
+	// 3. Return false.
+
+	// Polyfill.io - Only function objects have a [[Call]] internal method. This means we can simplify this function to check that the argument has a type of function.
+	return typeof argument === 'function';
+}
+
+// _ESAbstract.RequireObjectCoercible
+// 7.2.1. RequireObjectCoercible ( argument )
+// The abstract operation ToObject converts argument to a value of type Object according to Table 12:
+// Table 12: ToObject Conversions
+/*
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Argument Type | Result                                                                                                                             |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Undefined     | Throw a TypeError exception.                                                                                                       |
+| Null          | Throw a TypeError exception.                                                                                                       |
+| Boolean       | Return argument.                                                                                                                   |
+| Number        | Return argument.                                                                                                                   |
+| String        | Return argument.                                                                                                                   |
+| Symbol        | Return argument.                                                                                                                   |
+| Object        | Return argument.                                                                                                                   |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+*/
+function RequireObjectCoercible(argument) { // eslint-disable-line no-unused-vars
+	if (argument === null || argument === undefined) {
+		throw TypeError(Object.prototype.toString.call(argument) + ' is not coercible to Object.');
+	}
+	return argument;
+}
+
+// _ESAbstract.SameValueNonNumber
+// 7.2.12. SameValueNonNumber ( x, y )
+function SameValueNonNumber(x, y) { // eslint-disable-line no-unused-vars
+	// 1. Assert: Type(x) is not Number.
+	// 2. Assert: Type(x) is the same as Type(y).
+	// 3. If Type(x) is Undefined, return true.
+	// 4. If Type(x) is Null, return true.
+	// 5. If Type(x) is String, then
+		// a. If x and y are exactly the same sequence of code units (same length and same code units at corresponding indices), return true; otherwise, return false.
+	// 6. If Type(x) is Boolean, then
+		// a. If x and y are both true or both false, return true; otherwise, return false.
+	// 7. If Type(x) is Symbol, then
+		// a. If x and y are both the same Symbol value, return true; otherwise, return false.
+	// 8. If x and y are the same Object value, return true. Otherwise, return false.
+
+	// Polyfill.io - We can skip all above steps because the === operator does it all for us.
+	return x === y;
+}
+
+// _ESAbstract.ToBoolean
+// 7.1.2. ToBoolean ( argument )
+// The abstract operation ToBoolean converts argument to a value of type Boolean according to Table 9:
+/*
+--------------------------------------------------------------------------------------------------------------
+| Argument Type | Result                                                                                     |
+--------------------------------------------------------------------------------------------------------------
+| Undefined     | Return false.                                                                              |
+| Null          | Return false.                                                                              |
+| Boolean       | Return argument.                                                                           |
+| Number        | If argument is +0, -0, or NaN, return false; otherwise return true.                        |
+| String        | If argument is the empty String (its length is zero), return false; otherwise return true. |
+| Symbol        | Return true.                                                                               |
+| Object        | Return true.                                                                               |
+--------------------------------------------------------------------------------------------------------------
+*/
+function ToBoolean(argument) { // eslint-disable-line no-unused-vars
+	return Boolean(argument);
+}
+
+// _ESAbstract.ToObject
+// 7.1.13 ToObject ( argument )
+// The abstract operation ToObject converts argument to a value of type Object according to Table 12:
+// Table 12: ToObject Conversions
+/*
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Argument Type | Result                                                                                                                             |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Undefined     | Throw a TypeError exception.                                                                                                       |
+| Null          | Throw a TypeError exception.                                                                                                       |
+| Boolean       | Return a new Boolean object whose [[BooleanData]] internal slot is set to argument. See 19.3 for a description of Boolean objects. |
+| Number        | Return a new Number object whose [[NumberData]] internal slot is set to argument. See 20.1 for a description of Number objects.    |
+| String        | Return a new String object whose [[StringData]] internal slot is set to argument. See 21.1 for a description of String objects.    |
+| Symbol        | Return a new Symbol object whose [[SymbolData]] internal slot is set to argument. See 19.4 for a description of Symbol objects.    |
+| Object        | Return argument.                                                                                                                   |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+*/
+function ToObject(argument) { // eslint-disable-line no-unused-vars
+	if (argument === null || argument === undefined) {
+		throw TypeError();
+	}
+	return Object(argument);
+}
+
+// _ESAbstract.GetV
+/* global ToObject */
+// 7.3.2 GetV (V, P)
+function GetV(v, p) { // eslint-disable-line no-unused-vars
+	// 1. Assert: IsPropertyKey(P) is true.
+	// 2. Let O be ? ToObject(V).
+	var o = ToObject(v);
+	// 3. Return ? O.[[Get]](P, V).
+	return o[p];
+}
+
+// _ESAbstract.GetMethod
+/* global GetV, IsCallable */
+// 7.3.9. GetMethod ( V, P )
+function GetMethod(V, P) { // eslint-disable-line no-unused-vars
+	// 1. Assert: IsPropertyKey(P) is true.
+	// 2. Let func be ? GetV(V, P).
+	var func = GetV(V, P);
+	// 3. If func is either undefined or null, return undefined.
+	if (func === null || func === undefined) {
+		return undefined;
+	}
+	// 4. If IsCallable(func) is false, throw a TypeError exception.
+	if (IsCallable(func) === false) {
+		throw new TypeError('Method not callable: ' + P);
+	}
+	// 5. Return func.
+	return func;
+}
+
+// _ESAbstract.Type
+// "Type(x)" is used as shorthand for "the type of x"...
+function Type(x) { // eslint-disable-line no-unused-vars
+	switch (typeof x) {
+		case 'undefined':
+			return 'undefined';
+		case 'boolean':
+			return 'boolean';
+		case 'number':
+			return 'number';
+		case 'string':
+			return 'string';
+		case 'symbol':
+			return 'symbol';
+		default:
+			// typeof null is 'object'
+			if (x === null) return 'null';
+			// Polyfill.io - This is here because a Symbol polyfill will have a typeof `object`.
+			if ('Symbol' in self && (x instanceof self.Symbol || x.constructor === self.Symbol)) return 'symbol';
+
+			return 'object';
+	}
+}
+
+// _ESAbstract.IsRegExp
+/* global Type, Get, ToBoolean */
+// 7.2.8. IsRegExp ( argument )
+function IsRegExp(argument) { // eslint-disable-line no-unused-vars
+	// 1. If Type(argument) is not Object, return false.
+	if (Type(argument) !== 'object') {
+		return false;
+	}
+	// 2. Let matcher be ? Get(argument, @@match).
+	var matcher = 'Symbol' in self && 'match' in self.Symbol ? Get(argument, self.Symbol.match) : undefined;
+	// 3. If matcher is not undefined, return ToBoolean(matcher).
+	if (matcher !== undefined) {
+		return ToBoolean(matcher);
+	}
+	// 4. If argument has a [[RegExpMatcher]] internal slot, return true.
+	try {
+		var lastIndex = argument.lastIndex;
+		argument.lastIndex = 0;
+		RegExp.prototype.exec.call(argument);
+		return true;
+	// eslint-disable-next-line no-empty
+	} catch (e) {} finally {
+		argument.lastIndex = lastIndex;
+	}
+	// 5. Return false.
+	return false;
+}
+
+// _ESAbstract.OrdinaryToPrimitive
+/* global Get, IsCallable, Call, Type */
+// 7.1.1.1. OrdinaryToPrimitive ( O, hint )
+function OrdinaryToPrimitive(O, hint) { // eslint-disable-line no-unused-vars
+	// 1. Assert: Type(O) is Object.
+	// 2. Assert: Type(hint) is String and its value is either "string" or "number".
+	// 3. If hint is "string", then
+	if (hint === 'string') {
+		// a. Let methodNames be « "toString", "valueOf" ».
+		var methodNames = ['toString', 'valueOf'];
+		// 4. Else,
+	} else {
+		// a. Let methodNames be « "valueOf", "toString" ».
+		methodNames = ['valueOf', 'toString'];
+	}
+	// 5. For each name in methodNames in List order, do
+	for (var i = 0; i < methodNames.length; ++i) {
+		var name = methodNames[i];
+		// a. Let method be ? Get(O, name).
+		var method = Get(O, name);
+		// b. If IsCallable(method) is true, then
+		if (IsCallable(method)) {
+			// i. Let result be ? Call(method, O).
+			var result = Call(method, O);
+			// ii. If Type(result) is not Object, return result.
+			if (Type(result) !== 'object') {
+				return result;
+			}
+		}
+	}
+	// 6. Throw a TypeError exception.
+	throw new TypeError('Cannot convert to primitive.');
+}
+
+// _ESAbstract.SameValueZero
+/* global Type, SameValueNonNumber */
+// 7.2.11. SameValueZero ( x, y )
+function SameValueZero (x, y) { // eslint-disable-line no-unused-vars
+	// 1. If Type(x) is different from Type(y), return false.
+	if (Type(x) !== Type(y)) {
+		return false;
+	}
+	// 2. If Type(x) is Number, then
+	if (Type(x) === 'number') {
+		// a. If x is NaN and y is NaN, return true.
+		if (isNaN(x) && isNaN(y)) {
+			return true;
+		}
+		// b. If x is +0 and y is -0, return true.
+		if (1/x === Infinity && 1/y === -Infinity) {
+			return true;
+		}
+		// c. If x is -0 and y is +0, return true.
+		if (1/x === -Infinity && 1/y === Infinity) {
+			return true;
+		}
+		// d. If x is the same Number value as y, return true.
+		if (x === y) {
+			return true;
+		}
+		// e. Return false.
+		return false;
+	}
+	// 3. Return SameValueNonNumber(x, y).
+	return SameValueNonNumber(x, y);
+}
+
+// _ESAbstract.ToInteger
+/* global Type */
+// 7.1.4. ToInteger ( argument )
+function ToInteger(argument) { // eslint-disable-line no-unused-vars
+	if (Type(argument) === 'symbol') {
+		throw new TypeError('Cannot convert a Symbol value to a number');
+	}
+
+	// 1. Let number be ? ToNumber(argument).
+	var number = Number(argument);
+	// 2. If number is NaN, return +0.
+	if (isNaN(number)) {
+		return 0;
+	}
+	// 3. If number is +0, -0, +∞, or -∞, return number.
+	if (1/number === Infinity || 1/number === -Infinity || number === Infinity || number === -Infinity) {
+		return number;
+	}
+	// 4. Return the number value that is the same sign as number and whose magnitude is floor(abs(number)).
+	return ((number < 0) ? -1 : 1) * Math.floor(Math.abs(number));
+}
+
+// _ESAbstract.ToLength
+/* global ToInteger */
+// 7.1.15. ToLength ( argument )
+function ToLength(argument) { // eslint-disable-line no-unused-vars
+	// 1. Let len be ? ToInteger(argument).
+	var len = ToInteger(argument);
+	// 2. If len ≤ +0, return +0.
+	if (len <= 0) {
+		return 0;
+	}
+	// 3. Return min(len, 253-1).
+	return Math.min(len, Math.pow(2, 53) -1);
+}
+
+// _ESAbstract.ToPrimitive
+/* global Type, GetMethod, Call, OrdinaryToPrimitive */
+// 7.1.1. ToPrimitive ( input [ , PreferredType ] )
+function ToPrimitive(input /* [, PreferredType] */) { // eslint-disable-line no-unused-vars
+	var PreferredType = arguments.length > 1 ? arguments[1] : undefined;
+	// 1. Assert: input is an ECMAScript language value.
+	// 2. If Type(input) is Object, then
+	if (Type(input) === 'object') {
+		// a. If PreferredType is not present, let hint be "default".
+		if (arguments.length < 2) {
+			var hint = 'default';
+			// b. Else if PreferredType is hint String, let hint be "string".
+		} else if (PreferredType === String) {
+			hint = 'string';
+			// c. Else PreferredType is hint Number, let hint be "number".
+		} else if (PreferredType === Number) {
+			hint = 'number';
+		}
+		// d. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+		var exoticToPrim = typeof self.Symbol === 'function' && typeof self.Symbol.toPrimitive === 'symbol' ? GetMethod(input, self.Symbol.toPrimitive) : undefined;
+		// e. If exoticToPrim is not undefined, then
+		if (exoticToPrim !== undefined) {
+			// i. Let result be ? Call(exoticToPrim, input, « hint »).
+			var result = Call(exoticToPrim, input, [hint]);
+			// ii. If Type(result) is not Object, return result.
+			if (Type(result) !== 'object') {
+				return result;
+			}
+			// iii. Throw a TypeError exception.
+			throw new TypeError('Cannot convert exotic object to primitive.');
+		}
+		// f. If hint is "default", set hint to "number".
+		if (hint === 'default') {
+			hint = 'number';
+		}
+		// g. Return ? OrdinaryToPrimitive(input, hint).
+		return OrdinaryToPrimitive(input, hint);
+	}
+	// 3. Return input
+	return input;
+}
+
+// _ESAbstract.ToString
+/* global Type, ToPrimitive */
+// 7.1.12. ToString ( argument )
+// The abstract operation ToString converts argument to a value of type String according to Table 11:
+// Table 11: ToString Conversions
+/*
+|---------------|--------------------------------------------------------|
+| Argument Type | Result                                                 |
+|---------------|--------------------------------------------------------|
+| Undefined     | Return "undefined".                                    |
+|---------------|--------------------------------------------------------|
+| Null	        | Return "null".                                         |
+|---------------|--------------------------------------------------------|
+| Boolean       | If argument is true, return "true".                    |
+|               | If argument is false, return "false".                  |
+|---------------|--------------------------------------------------------|
+| Number        | Return NumberToString(argument).                       |
+|---------------|--------------------------------------------------------|
+| String        | Return argument.                                       |
+|---------------|--------------------------------------------------------|
+| Symbol        | Throw a TypeError exception.                           |
+|---------------|--------------------------------------------------------|
+| Object        | Apply the following steps:                             |
+|               | Let primValue be ? ToPrimitive(argument, hint String). |
+|               | Return ? ToString(primValue).                          |
+|---------------|--------------------------------------------------------|
+*/
+function ToString(argument) { // eslint-disable-line no-unused-vars
+	switch(Type(argument)) {
+		case 'symbol':
+			throw new TypeError('Cannot convert a Symbol value to a string');
+		case 'object':
+			var primValue = ToPrimitive(argument, String);
+			return ToString(primValue); // eslint-disable-line no-unused-vars
+		default:
+			return String(argument);
+	}
+}
+
+// _ESAbstract.ToPropertyKey
+/* globals ToPrimitive, Type, ToString */
+// 7.1.14. ToPropertyKey ( argument )
+function ToPropertyKey(argument) { // eslint-disable-line no-unused-vars
+	// 1. Let key be ? ToPrimitive(argument, hint String).
+	var key = ToPrimitive(argument, String);
+	// 2. If Type(key) is Symbol, then
+	if (Type(key) === 'symbol') {
+		// a. Return key.
+		return key;
+	}
+	// 3. Return ! ToString(key).
+	return ToString(key);
+}
+
+// _ESAbstract.TrimString
+/* eslint-disable no-control-regex */
+/* global RequireObjectCoercible, ToString */
+// TrimString ( string, where )
+function TrimString(string, where) { // eslint-disable-line no-unused-vars
+	// 1. Let str be ? RequireObjectCoercible(string).
+	var str = RequireObjectCoercible(string);
+	// 2. Let S be ? ToString(str).
+	var S = ToString(str);
+	// 3. If where is "start", let T be a String value that is a copy of S with leading white space removed.
+	// The definition of white space is the union of WhiteSpace and LineTerminator. When determining whether a Unicode code point is in Unicode general category “Space_Separator” (“Zs”), code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in 6.1.4.
+	var whitespace = /[\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF]+/.source;
+	if (where === 'start') {
+		var T = String.prototype.replace.call(S, new RegExp('^' + whitespace, 'g'), '');
+		// 4. Else if where is "end", let T be a String value that is a copy of S with trailing white space removed.
+	} else if (where === "end") {
+		T = String.prototype.replace.call(S, new RegExp(whitespace + '$', 'g'), '');
+		// 5. Else,
+	} else {
+		// a. Assert: where is "start+end".
+		// b. Let T be a String value that is a copy of S with both leading and trailing white space removed.
+		T = String.prototype.replace.call(S, new RegExp('^' + whitespace + '|' + whitespace + '$', 'g'), '');
+	}
+	// 6. Return T.
+	return T;
+}
+if (!("includes"in Array.prototype
+)) {
+
+// Array.prototype.includes
+/* global CreateMethodProperty, Get, SameValueZero, ToInteger, ToLength, ToObject, ToString */
+// 22.1.3.11. Array.prototype.includes ( searchElement [ , fromIndex ] )
+CreateMethodProperty(Array.prototype, 'includes', function includes(searchElement /* [ , fromIndex ] */) {
+	'use strict';
+	// 1. Let O be ? ToObject(this value).
+	var O = ToObject(this);
+	// 2. Let len be ? ToLength(? Get(O, "length")).
+	var len = ToLength(Get(O, "length"));
+	// 3. If len is 0, return false.
+	if (len === 0) {
+		return false;
+	}
+	// 4. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step produces the value 0.)
+	var n = ToInteger(arguments[1]);
+	// 5. If n ≥ 0, then
+	if (n >= 0) {
+		// a. Let k be n.
+		var k = n;
+		// 6. Else n < 0,
+	} else {
+		// a. Let k be len + n.
+		k = len + n;
+		// b. If k < 0, let k be 0.
+		if (k < 0) {
+			k = 0;
+		}
+	}
+	// 7. Repeat, while k < len
+	while (k < len) {
+		// a. Let elementK be the result of ? Get(O, ! ToString(k)).
+		var elementK = Get(O, ToString(k));
+		// b. If SameValueZero(searchElement, elementK) is true, return true.
+		if (SameValueZero(searchElement, elementK)) {
+			return true;
+		}
+		// c. Increase k by 1.
+		k = k + 1;
+	}
+	// 8. Return false.
+	return false;
+});
+
+}
+
+if (!("sort"in Array.prototype&&function(){var r={length:3,0:2,1:1,2:3}
+return Array.prototype.sort.call(r,function(r,t){return r-t})===r}()
+)) {
+
+// Array.prototype.sort
+/* global CreateMethodProperty, IsCallable */
+"use strict";
+
+var origSort = Array.prototype.sort;
+
+// 22.1.3.27 Array.prototype.sort ( comparefn )
+// The elements of this array are sorted. The sort must be stable (that is,
+// elements that compare equal must remain in their original order). If
+// comparefn is not undefined, it should be a function that accepts two
+// arguments x and y and returns a negative value
+// if x < y, zero if x = y, or a positive value if x > y.
+
+CreateMethodProperty(Array.prototype, "sort", function sort(compareFn) {
+	// 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw
+	//    a TypeError exception.
+	if (compareFn !== undefined && IsCallable(compareFn) === false) {
+		throw new TypeError(
+			"The comparison function must be either a function or undefined"
+		);
+	}
+
+	// Polyfill.io - the steps below are handled by the native
+	// Array.prototype.sort method that we call.
+	// 2.Let obj be ? ToObject(this value).
+	// 3.Let len be ? LengthOfArrayLike(obj).
+
+	// if comprateFn does not exist, use the spec defined in-built SortCompare.
+	if (compareFn === undefined) {
+		origSort.call(this);
+	} else {
+		// if compareFn exists, sort the array, breaking sorting ties by using the
+		// items' original index position.
+
+		// Keep track of the items starting index position.
+		var that = Array.prototype.map.call(this, function(item, index) {
+			return { item: item, index: index };
+		});
+		origSort.call(that, function(a, b) {
+			var compareResult = compareFn.call(undefined, a.item, b.item);
+			return compareResult === 0 ? a.index - b.index : compareResult;
+		});
+		// update the original object (`this`) with the new position for the items
+		// which were moved.
+		for (var a in that) {
+			if (Object.prototype.hasOwnProperty.call(that, a)) {
+				if (that[a].item !== this[a]) {
+					this[a] = that[a].item;
+				}
+			}
+		}
+	}
+
+	return this;
+});
+
+}
+
+if (!("name"in Function.prototype
+)) {
+
+// Function.prototype.name
+(function () {
+
+	var
+	accessorName = 'name',
+	fnNameMatchRegex = /^\s*function\s+([^(\s]*)\s*/,
+	$Function = Function,
+	FunctionName = 'Function',
+	FunctionProto = $Function.prototype,
+	FunctionProtoCtor = FunctionProto.constructor,
+
+	getFunctionName = function(fn) {
+		var match, name;
+
+		if (fn === $Function || fn === FunctionProtoCtor) {
+			name = FunctionName;
+		}
+		else if (fn !== FunctionProto) {
+			match = ('' + fn).match(fnNameMatchRegex);
+			name = match && match[1];
+		}
+		return name || '';
+	};
+
+
+	Object.defineProperty(FunctionProto, accessorName, {
+		get: function Function$name() {
+			var
+			fn = this,
+			fnName = getFunctionName(fn);
+
+			// Since named function definitions have immutable names, also memoize the
+			// output by defining the `name` property directly on this Function
+			// instance so the accessor function will not need to be invoked again.
+			if (fn !== FunctionProto) {
+				Object.defineProperty(fn, accessorName, {
+					value: fnName,
+					configurable: true
+				});
+			}
+
+			return fnName;
+		},
+		configurable: true
+	});
+
+}());
+
+}
+
+if (!("forEach"in NodeList.prototype
+)) {
+
+// NodeList.prototype.forEach
+NodeList.prototype.forEach = Array.prototype.forEach;
+
+}
+
+if (!("getOwnPropertyDescriptor"in Object&&"function"==typeof Object.getOwnPropertyDescriptor&&function(){try{return"3"===Object.getOwnPropertyDescriptor("13.7",1).value}catch(t){return!1}}()
+)) {
+
+// Object.getOwnPropertyDescriptor
+/* global CreateMethodProperty, ToObject, ToPropertyKey, HasOwnProperty, Type */
+(function () {
+	var nativeGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+	var supportsDOMDescriptors = (function () {
+		try {
+			return Object.defineProperty(document.createElement('div'), 'one', {
+				get: function () {
+					return 1;
+				}
+			}).one === 1;
+		} catch (e) {
+			return false;
+		}
+	});
+
+	var toString = ({}).toString;
+	var split = ''.split;
+
+	// 19.1.2.8 Object.getOwnPropertyDescriptor ( O, P )
+	CreateMethodProperty(Object, 'getOwnPropertyDescriptor', function getOwnPropertyDescriptor(O, P) {
+		// 1. Let obj be ? ToObject(O).
+		var obj = ToObject(O);
+		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+		obj = (Type(obj) === 'string' || obj instanceof String) && toString.call(O) == '[object String]' ? split.call(O, '') : Object(O);
+
+		// 2. Let key be ? ToPropertyKey(P).
+		var key = ToPropertyKey(P);
+
+		// 3. Let desc be ? obj.[[GetOwnProperty]](key).
+		// 4. Return FromPropertyDescriptor(desc).
+		// Polyfill.io Internet Explorer 8 natively supports property descriptors only on DOM objects.
+		// We will fallback to the polyfill implementation if the native implementation throws an error.
+		if (supportsDOMDescriptors) {
+			try {
+				return nativeGetOwnPropertyDescriptor(obj, key);
+			// eslint-disable-next-line no-empty
+			} catch (error) {}
+		}
+		if (HasOwnProperty(obj, key)) {
+			return {
+				enumerable: true,
+				configurable: true,
+				writable: true,
+				value: obj[key]
+			};
+		}
+	});
+}());
+
+}
+
+if (!("keys"in Object&&function(){return 2===Object.keys(arguments).length}(1,2)&&function(){try{return Object.keys(""),!0}catch(t){return!1}}()
+)) {
+
+// Object.keys
+/* global CreateMethodProperty */
+CreateMethodProperty(Object, "keys", (function() {
+	'use strict';
+
+	// modified from https://github.com/es-shims/object-keys
+
+	var has = Object.prototype.hasOwnProperty;
+	var toStr = Object.prototype.toString;
+	var isEnumerable = Object.prototype.propertyIsEnumerable;
+	var hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
+	var hasPrototypeEnumBug = isEnumerable.call(function () { }, 'prototype');
+	function hasProtoEnumBug() {
+		// Object.create polyfill creates an enumerable __proto__
+		var createdObj;
+		try {
+			createdObj = Object.create({});
+		} catch (e) {
+			// If this fails the polyfil isn't loaded yet, but will be.
+			// Can't add it to depedencies because of it would create a circular depedency.
+			return true;
+		}
+
+		return isEnumerable.call(createdObj, '__proto__')
+	}
+
+	var dontEnums = [
+		'toString',
+		'toLocaleString',
+		'valueOf',
+		'hasOwnProperty',
+		'isPrototypeOf',
+		'propertyIsEnumerable',
+		'constructor'
+	];
+	var equalsConstructorPrototype = function (o) {
+		var ctor = o.constructor;
+		return ctor && ctor.prototype === o;
+	};
+	var excludedKeys = {
+		$console: true,
+		$external: true,
+		$frame: true,
+		$frameElement: true,
+		$frames: true,
+		$innerHeight: true,
+		$innerWidth: true,
+		$outerHeight: true,
+		$outerWidth: true,
+		$pageXOffset: true,
+		$pageYOffset: true,
+		$parent: true,
+		$scrollLeft: true,
+		$scrollTop: true,
+		$scrollX: true,
+		$scrollY: true,
+		$self: true,
+		$webkitIndexedDB: true,
+		$webkitStorageInfo: true,
+		$window: true
+	};
+	var hasAutomationEqualityBug = (function () {
+		if (typeof window === 'undefined') { return false; }
+		for (var k in window) {
+			try {
+				if (!excludedKeys['$' + k] && has.call(window, k) && window[k] !== null && typeof window[k] === 'object') {
+					try {
+						equalsConstructorPrototype(window[k]);
+					} catch (e) {
+						return true;
+					}
+				}
+			} catch (e) {
+				return true;
+			}
+		}
+		return false;
+	}());
+	var equalsConstructorPrototypeIfNotBuggy = function (o) {
+		if (typeof window === 'undefined' || !hasAutomationEqualityBug) {
+			return equalsConstructorPrototype(o);
+		}
+		try {
+			return equalsConstructorPrototype(o);
+		} catch (e) {
+			return false;
+		}
+	};
+
+	function isArgumentsObject(value) {
+		var str = toStr.call(value);
+		var isArgs = str === '[object Arguments]';
+		if (!isArgs) {
+			isArgs = str !== '[object Array]' &&
+				value !== null &&
+				typeof value === 'object' &&
+				typeof value.length === 'number' &&
+				value.length >= 0 &&
+				toStr.call(value.callee) === '[object Function]';
+		}
+		return isArgs;
+	}
+
+	return function keys(object) {
+		var isFunction = toStr.call(object) === '[object Function]';
+		var isArguments = isArgumentsObject(object);
+		var isString = toStr.call(object) === '[object String]';
+		var theKeys = [];
+
+		if (object === undefined || object === null) {
+			throw new TypeError('Cannot convert undefined or null to object');
+		}
+
+		var skipPrototype = hasPrototypeEnumBug && isFunction;
+		if (isString && object.length > 0 && !has.call(object, 0)) {
+			for (var i = 0; i < object.length; ++i) {
+				theKeys.push(String(i));
+			}
+		}
+
+		if (isArguments && object.length > 0) {
+			for (var j = 0; j < object.length; ++j) {
+				theKeys.push(String(j));
+			}
+		} else {
+			for (var name in object) {
+				if (!(hasProtoEnumBug() && name === '__proto__') && !(skipPrototype && name === 'prototype') && has.call(object, name)) {
+					theKeys.push(String(name));
+				}
+			}
+		}
+
+		if (hasDontEnumBug) {
+			var skipConstructor = equalsConstructorPrototypeIfNotBuggy(object);
+
+			for (var k = 0; k < dontEnums.length; ++k) {
+				if (!(skipConstructor && dontEnums[k] === 'constructor') && has.call(object, dontEnums[k])) {
+					theKeys.push(dontEnums[k]);
+				}
+			}
+		}
+		return theKeys;
+	};
+}()));
+
+}
+
+
+// _ESAbstract.EnumerableOwnProperties
+/* globals Type, Get */
+// 7.3.21. EnumerableOwnProperties ( O, kind )
+function EnumerableOwnProperties(O, kind) { // eslint-disable-line no-unused-vars
+	// 1. Assert: Type(O) is Object.
+	// 2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
+	var ownKeys = Object.keys(O);
+	// 3. Let properties be a new empty List.
+	var properties = [];
+	// 4. For each element key of ownKeys in List order, do
+	var length = ownKeys.length;
+	for (var i = 0; i < length; i++) {
+		var key = ownKeys[i];
+		// a. If Type(key) is String, then
+		if (Type(key) === 'string') {
+			// i. Let desc be ? O.[[GetOwnProperty]](key).
+			var desc = Object.getOwnPropertyDescriptor(O, key);
+			// ii. If desc is not undefined and desc.[[Enumerable]] is true, then
+			if (desc && desc.enumerable) {
+				// 1. If kind is "key", append key to properties.
+				if (kind === 'key') {
+					properties.push(key);
+					// 2. Else,
+				} else {
+					// a. Let value be ? Get(O, key).
+					var value = Get(O, key);
+					// b. If kind is "value", append value to properties.
+					if (kind === 'value') {
+						properties.push(value);
+						// c. Else,
+					} else {
+						// i. Assert: kind is "key+value".
+						// ii. Let entry be CreateArrayFromList(« key, value »).
+						var entry = [key, value];
+						// iii. Append entry to properties.
+						properties.push(entry);
+					}
+				}
+			}
+		}
+	}
+	// 5. Order the elements of properties so they are in the same relative order as would be produced by the Iterator that would be returned if the EnumerateObjectProperties internal method were invoked with O.
+	// 6. Return properties.
+	return properties;
+}
+if (!("entries"in Object
+)) {
+
+// Object.entries
+/* global CreateMethodProperty, EnumerableOwnProperties, ToObject, Type */
+
+(function () {
+	var toString = ({}).toString;
+	var split = ''.split;
+
+	// 19.1.2.5. Object.entries ( O )
+	CreateMethodProperty(Object, 'entries', function entries(O) {
+		// 1. Let obj be ? ToObject(O).
+		var obj = ToObject(O);
+		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+		obj = (Type(obj) === 'string' || obj instanceof String) && toString.call(O) == '[object String]' ? split.call(O, '') : Object(O);
+		// 2. Let nameList be ? EnumerableOwnProperties(obj, "key+value").
+		var nameList = EnumerableOwnProperties(obj, "key+value");
+		// 3. Return CreateArrayFromList(nameList).
+		// Polyfill.io - nameList is already an array.
+		return nameList;
+	});
+}());
+
+}
+
+if (!("startsWith"in String.prototype
+)) {
+
+// String.prototype.startsWith
+/* global CreateMethodProperty, IsRegExp, RequireObjectCoercible, ToInteger, ToString */
+// 21.1.3.20. String.prototype.startsWith ( searchString [ , position ] )
+CreateMethodProperty(String.prototype, 'startsWith', function startsWith(searchString /* [ , position ] */) {
+	'use strict';
+	var position = arguments.length > 1 ? arguments[1] : undefined;
+	// 1. Let O be ? RequireObjectCoercible(this value).
+	var O = RequireObjectCoercible(this);
+	// 2. Let S be ? ToString(O).
+	var S = ToString(O);
+	// 3. Let isRegExp be ? IsRegExp(searchString).
+	var isRegExp = IsRegExp(searchString);
+	// 4. If isRegExp is true, throw a TypeError exception.
+	if (isRegExp) {
+		throw new TypeError('First argument to String.prototype.startsWith must not be a regular expression');
+	}
+	// 5. Let searchStr be ? ToString(searchString).
+	var searchStr = ToString(searchString);
+	// 6. Let pos be ? ToInteger(position). (If position is undefined, this step produces the value 0.)
+	var pos = ToInteger(position);
+	// 7. Let len be the length of S.
+	var len = S.length;
+	// 8. Let start be min(max(pos, 0), len).
+	var start = Math.min(Math.max(pos, 0), len);
+	// 9. Let searchLength be the length of searchStr.
+	var searchLength = searchStr.length;
+	// 10. If searchLength+start is greater than len, return false.
+	if (searchLength + start > len) {
+		return false;
+	}
+	// 11. If the sequence of elements of S starting at start of length searchLength is the same as the full element sequence of searchStr, return true.
+	if (S.substr(start).indexOf(searchString) === 0) {
+		return true;
+	}
+	// 12. Otherwise, return false.
+	return false;
+});
+
+}
+
+if (!("trim"in String.prototype&&function(){var r="​᠎"
+return!"\t\n\x0B\f\r                　\u2028\u2029\ufeff".trim()&&r.trim()===r}()
+)) {
+
+// String.prototype.trim
+/* global CreateMethodProperty, TrimString */
+// 21.1.3.27. String.prototype.trim ( )
+CreateMethodProperty(String.prototype, 'trim', function trim() {
+	'use strict';
+	// Let S be this value.
+	var S = this;
+	// Return ? TrimString(S, "start+end").
+	return TrimString(S, "start+end");
+});
+
+}
+
+})
+('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -2,7 +2,7 @@
   "use strict";
 
   var queues = {};
-  var dd = new global.diffDOM();
+  var dd = new global.GOVUK.vendor.DiffDOM();
   var defaultInterval = 2000;
   var interval = 0;
 

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -2,6 +2,7 @@
   "use strict";
 
   var queues = {};
+  var dd = new global.diffDOM();
   var defaultInterval = 2000;
   var interval = 0;
 
@@ -10,18 +11,10 @@
       1000
   ));
 
-  var getRenderer = $component => {
-    var key = $component.data('key'); // use closure to retain key when component is replaced
-    return response => {
-      $component = $(
-        global.domdiff(
-          $component.parent().get(0),
-          [$component.get(0)],
-          [$(response[key]).get(0)]
-        )[0]
-      );
-    };
-  };
+  var getRenderer = $component => response => dd.apply(
+    $component.get(0),
+    dd.diff($component.get(0), $(response[$component.data('key')]).get(0))
+  );
 
   var getQueue = resource => (
     queues[resource] = queues[resource] || []

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@
 const { src, pipe, dest, series, parallel, watch } = require('gulp');
 const rollupPluginCommonjs = require('rollup-plugin-commonjs');
 const rollupPluginNodeResolve = require('rollup-plugin-node-resolve');
-const rollupPluginBabel = require('@rollup/plugin-babel');
+const rollupPluginBabel = require('@rollup/plugin-babel').babel;
 const streamqueue = require('streamqueue');
 const stylish = require('jshint-stylish');
 
@@ -135,8 +135,9 @@ const javascripts = () => {
           rollupPluginCommonjs({
             include: 'node_modules/**'
           }),
-          rollupPluginBabel.babel({
-            babelHelpers: 'bundled'
+          rollupPluginBabel({
+            babelHelpers: 'bundled',
+            presets: ['@babel/preset-env']
           })
         ]
       },
@@ -150,7 +151,6 @@ const javascripts = () => {
       paths.npm + 'hogan.js/dist/hogan-3.0.2.js',
       paths.npm + 'jquery/dist/jquery.min.js',
       paths.npm + 'query-command-supported/dist/queryCommandSupported.min.js',
-      paths.npm + 'diff-dom/dist/index.js',
       paths.npm + 'timeago/jquery.timeago.js',
       paths.npm + 'textarea-caret/index.js',
       paths.npm + 'cbor-js/cbor.js'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@
 const { src, pipe, dest, series, parallel, watch } = require('gulp');
 const rollupPluginCommonjs = require('rollup-plugin-commonjs');
 const rollupPluginNodeResolve = require('rollup-plugin-node-resolve');
+const rollupPluginBabel = require('@rollup/plugin-babel');
 const streamqueue = require('streamqueue');
 const stylish = require('jshint-stylish');
 
@@ -133,6 +134,9 @@ const javascripts = () => {
           // this adds node_modules to the require path so it can find the GOVUK Frontend modules
           rollupPluginCommonjs({
             include: 'node_modules/**'
+          }),
+          rollupPluginBabel.babel({
+            babelHelpers: 'bundled'
           })
         ]
       },
@@ -146,7 +150,7 @@ const javascripts = () => {
       paths.npm + 'hogan.js/dist/hogan-3.0.2.js',
       paths.npm + 'jquery/dist/jquery.min.js',
       paths.npm + 'query-command-supported/dist/queryCommandSupported.min.js',
-      paths.npm + 'domdiff/min.js',
+      paths.npm + 'diff-dom/dist/index.js',
       paths.npm + 'timeago/jquery.timeago.js',
       paths.npm + 'textarea-caret/index.js',
       paths.npm + 'cbor-js/cbor.js'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "7.4.2",
     "cbor-js": "0.1.0",
     "del": "5.1.0",
-    "domdiff": "2.2.2",
+    "diff-dom": "4.2.3",
     "govuk_frontend_toolkit": "8.1.0",
     "govuk-elements-sass": "3.1.2",
     "govuk-frontend": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "license": "MIT",
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
-    "@babel/core": "7.4.0",
-    "@babel/preset-env": "7.4.2",
+    "@babel/core": "7.16.7",
+    "@babel/preset-env": "7.16.8",
     "cbor-js": "0.1.0",
     "del": "5.1.0",
     "diff-dom": "4.2.3",
@@ -47,6 +47,7 @@
     "timeago": "1.6.5"
   },
   "devDependencies": {
+    "@rollup/plugin-babel": "5.3.0",
     "gulp-css-url-adjuster": "0.2.3",
     "gulp-jshint": "2.1.0",
     "gulp-prettyerror": "2.0.0",

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -31,6 +31,9 @@ beforeAll(() => {
 
   $.ajax.mockImplementation(() => jqueryAJAXReturnObj);
 
+  // RollupJS assigns our bundled module code, including DiffDOM, to window.GOVUK.
+  // DiffDOM is assigned to its vendor property so we need to copy that here for the updateContent
+  // code to pick it up.
   window.GOVUK.vendor = {
     DiffDOM: require('diff-dom').DiffDOM
   };

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -31,13 +31,9 @@ beforeAll(() => {
 
   $.ajax.mockImplementation(() => jqueryAJAXReturnObj);
 
-  // using require to execute the version we use in our our frontend build here can't add
-  // the domdiff variable to this scope like it does when executed in browsers because
-  // that version doesn't export it
-  // we use CommonJS version instead because it does (as the default property)
-  // see https://nodejs.org/en/knowledge/getting-started/what-is-require/ for more info
-  // also, we're not a browser so we need to manually attach domdiff to window
-  window.domdiff = require('domdiff/cjs').default;
+  window.GOVUK.vendor = {
+    DiffDOM: require('diff-dom').DiffDOM
+  };
   require('../../app/assets/javascripts/updateContent.js');
 
 });


### PR DESCRIPTION
Fixes an issue raised in this story: https://www.pivotaltracker.com/story/show/180011155 by re-introducing the [DiffDOM](https://github.com/fiduswriter/diffDOM/blob/main/browser/diffDOM.js) library to our JavaScript and making it work in Internet Explorer (IE) down to version 9.

## What DiffDOM does in our code

Our `updateContent.js` script keeps parts of our pages in sync with the app's data. For example, it updates the number of emails sent on the dashboard when this changes.

It works by:
1. polling the server
2. getting new HTML for them
3. diff'ing it against the existing HTML
4. applying any changes
 
We used to use the DiffDOM library for this but changed it when its code was updated to a version of JavaScript that didn't work with IE (see https://www.pivotaltracker.com/story/show/165380360). Turns out, the replacement library just swapped all the old HTML for the new every time, irrelevant of differences which caused issues like https://www.pivotaltracker.com/story/show/180011155/comments/227516175.

DiffDOM, by contrast, only applies changes if there were some and only changed the different parts that differed. It also seems to be the only decently supported library that does this. So we have to reintroduce DiffDOM and make it work with IE (down to 9).

## Making it work with Internet Explorer

DiffDOM is now written in ECMAScript (the spec' for JavaScript) version 6 whereas IE9 uses a version closer to 3.

We therefore need to:
1. rewrite the ES6 syntax (ie. arrow functions, for...of loops, etc) to an ES3 equivalent
2. polyfill any new features
    - JS built-in objects (ie. Promises)
    - extensions to existing ones (ie. Object.entries)
    - DOM APIs (ie. Nodelist.prototype.forEach)

Because DiffDOM is 3rd party, we need to work out which polyfills it needs and in a repeatable way so we can add the right polyfills now but also in the future when it changes.

This pull request proposes using [BabelJS](https://babel.dev/) to determine which polyfills are needed, and the changes it makes come from this.

## BabelJS

BabelJS is a JS compiler. It turns JS code into an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (AST) which can then be used by other JS (plugins) to transform it into another type of code or to infer things about it. You can use it with a group of plugins (presets) called `preset-env` to transform newer versions of ECMAScript syntax into older. It can also be used to add polyfills based on target browsers and the language features used in the code.

If you use BabelJS to add polyfills, it will use those from [the CoreJS library](https://github.com/zloirock/core-js/), based on the target browser's support for the latest stable ECMAScript. This means any feature used where the target browsers don't support the latest ECMAScript version will be polyfilled. As an example, [here's BabelJS transpiling ES6 and adding polyfills to it, in its REPL (targeting IE9)](https://babeljs.io/repl#?browsers=ie%209&build=&builtIns=usage&corejs=3.6&spec=false&loose=false&code_lz=MYewdgzgLgBAhgJwQRhgXhgbWQGgEw4DMOALALoBQFoksiCe68SyAdBADYCWwApgBR4AlEA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Cstage-2&prettier=false&targets=&version=7.16.9&externalPlugins=&assumptions=%7B%7D). Note: it adds imports for the polyfill code as it assumes you will bundle the code up afterwards.

This can mean it adds a lot of code. In my tests with DiffDOM, BabelJS added ~60KB of polyfills vs ~8KB from Polyfill.io.

## Using Polyfill.io to add only the polyfills needed

The [Polyfill.io](https://polyfill.io/v3/) service takes a list of feature names and will respond with a bundle of those needed for the browser requesting them. You can try it out by [building a URL for your bundle](https://polyfill.io/v3/url-builder/) and `curl`ing it with the user agent header, like so:

```bash
curl https://polyfill.io/v3/polyfill.js?features=Object.entries -H 'User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)'
``` 

It uses Mozilla Developers Network (MDN) pages for browser support data and will assume any features a browser supports don't need polyfilling unless the newer version includes a major change (ie. `Array.prototype.sort`, which introduced [stable sorting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability) in newer versions). 

I sent the names of the features BabelJS used CoreJS to polyfill to Polyfill.io with an IE9 user agent string. The bundle it responded with is used in these changes to polyfill DiffDOM. I've used the uncompressed, commented version of the bundle because it lists all the polyfills used, those not included and all the internal dependencies.

I've recorded the decision-making process in [this document](https://docs.google.com/drawings/d/1k0z-TQdzuNb3nqgVwMfsobjEHp36kDwvW4zMJnnR3rw/edit).

## Caveats to the approach

There are necessary manual parts to this process:
- you need to be able to infer the features used from the core-js polyfills BabelJS adds
- some features polyfill.io doesn't have are because MDN says all browsers support them, some because it just doesn't have the polyfill yet. You need to figure out why a polyfill isn't included and whether it should be or not

Both require looking at the code you're polyfilling (DiffDOM here) for uses of the feature and making a decision about whether it needs a polyfill or not. For example, BabelJS added a polyfill for `RegExp.prototype.sticky` for DiffDOM. Polyfill.io didn't include a polyfill for this but it is a modern feature (so not omitted because all browsers support it) so the code needed checking. Having found no uses of it, I decided not to include it.

## How these changes are tested

I tested these changes by looking at the main dashboard when sending a notification (to test updates to notification numbers) and the 'current alerts' page when adding and rejecting an alert (to test additions to the DOM). Both tests were done in IE9 and IE11 and worked without errors.