### PR TITLE
Display if broadcast was cancelled via API

### DIFF
--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -181,7 +181,9 @@ class BroadcastMessage(JSONModel):
 
     @cached_property
     def cancelled_by(self):
-        return User.from_id(self.cancelled_by_id)
+        if not self.cancelled_by_id:
+            return "an API call"
+        return User.from_id(self.cancelled_by_id).name
 
     @cached_property
     def count_of_phones(self):

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -212,7 +212,7 @@
     </p>
   {% elif broadcast_message.status == 'cancelled' %}
     <p class="govuk-body">
-      Stopped by {{ broadcast_message.cancelled_by.name }}
+      Stopped by {{ broadcast_message.cancelled_by }}
       {{ broadcast_message.cancelled_at|format_datetime_human }}.
     </p>
   {% elif broadcast_message.status == 'completed' %}

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -1695,6 +1695,15 @@ def test_start_broadcasting(
         'Created by Alice and approved by Bob.',
         'Stopped by Carol yesterday at 9:21pm.',
     ]),
+    ('.view_previous_broadcast', False, {
+        'status': 'cancelled',
+        'cancelled_by_id': None,
+        'cancelled_at': '2020-02-21T21:21:21.000000',
+    }, [
+        'Sent on 20 February at 8:20pm.',
+        'Created by Alice and approved by Bob.',
+        'Stopped by an API call yesterday at 9:21pm.',
+    ]),
     ('.view_rejected_broadcast', False, {
         'status': 'rejected',
         'updated_at': '2020-02-21T21:21:21.000000',


### PR DESCRIPTION
If broadcast_message has no value under cancelled_by_id, display in the view that it was cancelled by API integration.