### PR TITLE
Rename sms_fragments to sms_chargeable_units

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1962,6 +1962,11 @@ class RequiredDateFilterForm(StripWhitespaceForm):
     end_date = GovukDateField("End Date")
 
 
+class BillingReportDateFilterForm(StripWhitespaceForm):
+    start_date = GovukDateField("First day covered by report")
+    end_date = GovukDateField("Last day covered by report")
+
+
 class SearchByNameForm(StripWhitespaceForm):
 
     search = GovukSearchField(

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -279,8 +279,8 @@ def get_billing_report():
         end_date = form.end_date.data
         headers = [
             "organisation_id", "organisation_name", "service_id", "service_name",
-            "sms_cost", "sms_fragments", "total_letters", "letter_cost", "letter_breakdown", "purchase_order_number",
-            "contact_names", "contact_email_addresses", "billing_reference"
+            "sms_cost", "sms_chargeable_units", "total_letters", "letter_cost", "letter_breakdown",
+            "purchase_order_number", "contact_names", "contact_email_addresses", "billing_reference"
         ]
         try:
             result = billing_api_client.get_data_for_billing_report(start_date, end_date)
@@ -294,7 +294,7 @@ def get_billing_report():
         rows = [
             [
                 r["organisation_id"], r["organisation_name"], r["service_id"], r["service_name"],
-                r["sms_cost"], r["sms_fragments"], r["total_letters"], r["letter_cost"], r["letter_breakdown"].strip(),
+                r["sms_cost"], r["sms_chargeable_units"], r["total_letters"], r["letter_cost"], r["letter_breakdown"].strip(),
                 r.get("purchase_order_number"), r.get("contact_names"), r.get("contact_email_addresses"),
                 r.get("billing_reference")
             ]

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -18,6 +18,7 @@ from app import (
 from app.extensions import redis_client
 from app.main import main
 from app.main.forms import (
+    BillingReportDateFilterForm,
     ClearCacheForm,
     DateFilterForm,
     RequiredDateFilterForm,
@@ -272,7 +273,7 @@ def notifications_sent_by_service():
 @main.route("/platform-admin/reports/usage-for-all-services", methods=['GET', 'POST'])
 @user_is_platform_admin
 def get_billing_report():
-    form = RequiredDateFilterForm()
+    form = BillingReportDateFilterForm()
 
     if form.validate_on_submit():
         start_date = form.start_date.data

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -294,9 +294,9 @@ def get_billing_report():
         rows = [
             [
                 r["organisation_id"], r["organisation_name"], r["service_id"], r["service_name"],
-                r["sms_cost"], r["sms_chargeable_units"], r["total_letters"], r["letter_cost"], r["letter_breakdown"].strip(),
-                r.get("purchase_order_number"), r.get("contact_names"), r.get("contact_email_addresses"),
-                r.get("billing_reference")
+                r["sms_cost"], r["sms_chargeable_units"], r["total_letters"], r["letter_cost"],
+                r["letter_breakdown"].strip(), r.get("purchase_order_number"), r.get("contact_names"),
+                r.get("contact_email_addresses"), r.get("billing_reference")
             ]
             for r in result
         ]

--- a/app/templates/views/platform-admin/get-billing-report.html
+++ b/app/templates/views/platform-admin/get-billing-report.html
@@ -13,8 +13,8 @@
   </h1>
 
   {% call form_wrapper() %}
-    {{ form.start_date(param_extensions={"hint": {"text": "Enter start date in format YYYY-MM-DD"}}) }}
-    {{ form.end_date(param_extensions={"hint": {"text": "Enter end date in format YYYY-MM-DD"}}) }}
+    {{ form.start_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
+    {{ form.end_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
     {{ page_footer('Download report') }}
   {% endcall %}
 
@@ -32,7 +32,7 @@
         ('sms cost', 'The total cost of text messages sent after a service has used its free allowance.'),
         ('sms chargeable units', 'The number of fragments sent after a service has used its free allowance. This number takes into account the cost multiplier for <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/pricing#international-numbers">sending international text messages</a>.'),
         ('letter cost', 'The total cost of letters sent by a service.'),
-        ('letter breakdown', 'The number and cost of letters sent by a service, grouped by postage.'),
+        ('letter breakdown', 'The number of letters sent by a service, grouped by postage and unit cost.'),
         ('purchase order number, contact names, contact email addresses and billing reference', 'We add this data manually based on the information we get from services. You can help by adding it to the service settings page.'),
       ] %}
         {% call row() %}

--- a/app/templates/views/platform-admin/get-billing-report.html
+++ b/app/templates/views/platform-admin/get-billing-report.html
@@ -1,5 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/table.html" import mapping_table, row, text_field %}
 
 {% block per_page_title %}
   Billing Report
@@ -18,21 +19,28 @@
   {% endcall %}
 
   <h2 class="heading-medium">
-    Guidance for interpreting the report
+    Data included in the report
   </h2>
-  <p class="govuk-body">
-    Billing report shows data for period between start date and end date, inclusive of both dates.
-  </p>
-  <p class="govuk-body">
-    Explanation for more confusing column names in the report:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>sms cost - cost accrued by a service through sending text messages after they run out of free allowance</li>
-    <li>sms chargeable units - sms fragments that go over free allowance multiplied by rate multiplier (so higher costs of sending international SMS are taken into consideration)</li>
-    <li>letter cost - cost accrued by a service through sending letters (number of letters * numbers of paper sheets * postage)</li>
-    <li>letter breakdown - amount and cost of letters sent by a service for each postage class</li>
-    <li> purchase order number, contact names, contact email addresses, billing reference - this data is manually filled in by us based on the information we get from services. You can help by filling it in (on Service Settings page)</li>
-
-  </ul>
+<div class="bottom-gutter-3-2">
+    {% call mapping_table(
+      caption='Descriptions of billing report data',
+      field_headings=['Name', 'Description'],
+      field_headings_visible=True,
+      caption_visible=False
+    ) %}
+      {% for message_length, charge in [
+        ('sms cost', 'The total cost of text messages sent after a service has used its free allowance.'),
+        ('sms chargeable units', 'The number of fragments sent after a service has used its free allowance. This number takes into account the cost multiplier for <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/pricing#international-numbers">sending international text messages</a>.'),
+        ('letter cost', 'The total cost of letters sent by a service.'),
+        ('letter breakdown', 'The number and cost of letters sent by a service, grouped by postage.'),
+        ('purchase order number, contact names, contact email addresses and billing reference', 'We add this data manually based on the information we get from services. You can help by adding it to the service settings page.'),
+      ] %}
+        {% call row() %}
+          {{ text_field(message_length) }}
+          {{ text_field(charge | safe) }}
+        {% endcall %}
+      {% endfor %}
+    {% endcall %}
+  </div>
 
 {% endblock %}

--- a/app/templates/views/platform-admin/get-billing-report.html
+++ b/app/templates/views/platform-admin/get-billing-report.html
@@ -17,4 +17,22 @@
     {{ page_footer('Download report') }}
   {% endcall %}
 
+  <h2 class="heading-medium">
+    Guidance for interpreting the report
+  </h2>
+  <p class="govuk-body">
+    Billing report shows data for period between start date and end date, inclusive of both dates.
+  </p>
+  <p class="govuk-body">
+    Explanation for more confusing column names in the report:
+  </p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>sms cost - cost accrued by a service through sending text messages after they run out of free allowance</li>
+    <li>sms chargeable units - sms fragments that go over free allowance multiplied by rate multiplier (so higher costs of sending international SMS are taken into consideration)</li>
+    <li>letter cost - cost accrued by a service through sending letters (number of letters * numbers of paper sheets * postage)</li>
+    <li>letter breakdown - amount and cost of letters sent by a service for each postage class</li>
+    <li> purchase order number, contact names, contact email addresses, billing reference - this data is manually filled in by us based on the information we get from services. You can help by filling it in (on Service Settings page)</li>
+
+  </ul>
+
 {% endblock %}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -935,7 +935,7 @@ def test_get_billing_report_when_calls_api_and_download_data(
             'service_id': '48e82ac0-c8c4-4e46-8712-c83c35a94006',
             'service_name': 'a - with sms and letter',
             'sms_cost': 0,
-            'sms_fragments': 0,
+            'sms_chargeable_units': 0,
             'purchase_order_number': 'PO1234',
             'contact_names': 'Anne, Marie, Josh',
             'contact_email_addresses': 'billing@example.com, accounts@example.com',
@@ -956,10 +956,10 @@ def test_get_billing_report_when_calls_api_and_download_data(
     )
 
     assert response.get_data(as_text=True) == (
-        'organisation_id,organisation_name,service_id,service_name,sms_cost,sms_fragments,total_letters,letter_cost' +
-        ',letter_breakdown,purchase_order_number,contact_names,contact_email_addresses,billing_reference' +
+        'organisation_id,organisation_name,service_id,service_name,sms_cost,sms_chargeable_units' +
+        ',total_letters,letter_cost,letter_breakdown,purchase_order_number,contact_names,contact_email_addresses' +
 
-        '\r\n' +
+        ',billing_reference\r\n' +
 
         '7832a1be-a1f0-4f2a-982f-05adfd3d6354,' +
         'Org for a - with sms and letter,' +


### PR DESCRIPTION
This field caused some confusion and lots of unnecessary work to our colleague because of unclear name.

The field was named sms_fragments, where in fact the value of the field is: those sms fragments that go above free allowance multiplied by the rate multiplier.

The new name was chosen through consultation with colleagues who use billing report the most.

This change should go out together with: https://github.com/alphagov/notifications-api/pull/3430

TODO: see if we need guidance to explain column names in the billing report