### PR TITLE
remove cryptography pin

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ eventlet==0.30.2 # pyup: ignore
 notifications-python-client==6.3.0
 Shapely==1.7.1
 rtreelib==0.2.0
-fido2==0.9.1
+fido2==0.9.3
 importlib-metadata==4.2.0
 pyproj==3.2.1
 
@@ -32,10 +32,6 @@ awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.1
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
-
-# cryptography 3.4+ incorporates Rust code, which isn't supported on PaaS
-# e.g. https://github.com/alphagov/notifications-api/pull/3126
-cryptography<3.4 # pyup: ignore
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 # version 0.10.0 introduced exceptions when workers crashed due to deprecating lower case `prometheus_multiproc_dir`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,10 +41,8 @@ click==8.0.1
     # via flask
 colorama==0.4.3
     # via awscli
-cryptography==3.3.2
-    # via
-    #   -r requirements.in
-    #   fido2
+cryptography==36.0.1
+    # via fido2
 dnspython==1.16.0
     # via eventlet
 docopt==0.6.2
@@ -53,9 +51,9 @@ docutils==0.15.2
     # via awscli
 et-xmlfile==1.1.0
     # via openpyxl
-eventlet==0.30.2 # pyup: ignore
+eventlet==0.30.2
     # via -r requirements.in
-fido2==0.9.1
+fido2==0.9.3
     # via -r requirements.in
 flask==1.1.2
     # via
@@ -206,7 +204,6 @@ six==1.16.0
     # via
     #   awscli-cwlogs
     #   bleach
-    #   cryptography
     #   eventlet
     #   fido2
     #   python-dateutil


### PR DESCRIPTION
we previously pinned cryptography to versions less than 3.4 since after that point, cryptography started using rust as a dependency. This isn't an issue if you install from wheel, but we found that the version of pip bundled with the python buildpack was too old to support this. However, since upgrading from python 3.6 to python 3.9, the pip version has been bumped and we now no longer need to pin cryptography as it installs correctly.

(i tested this by pushing an admin prototype to preview)