### PR TITLE
Review and update accessibility statement

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -113,7 +113,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <li>
-      the code for the ‘upload a file’ button may cause issues for assistive technology users - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships">success criterion 1.3.1: info and relationships</a>
+      the <abbr title="HyperText Markup Language">HTML</abbr> code for the ‘upload a file’ button may cause issues for assistive technology users - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships">success criterion 1.3.1: info and relationships</a>
     </li>
     <li>
       the JAWS and NVDA screen readers do not announce the ‘copy to clipboard’ button - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html">success criterion 4.1.3: status messages</a>

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -13,8 +13,8 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "27 October 2021",
-      "Next review due": "20 January 2022" 
+      "Last updated": "20 January 2022",
+      "Next review due": "20 April 2022"
     }
     ) }}
 
@@ -113,7 +113,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <li>
-      the (before <abbr title="HyperText Markup Language">HTML</abbr>) code for the ‘upload a file’ button may cause issues for assistive technology users - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships">success criterion 1.3.1: info and relationships</a>
+      the code for the ‘upload a file’ button may cause issues for assistive technology users - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships">success criterion 1.3.1: info and relationships</a>
     </li>
     <li>
       the JAWS and NVDA screen readers do not announce the ‘copy to clipboard’ button - this fails <a class="govuk-link govuk-link--no-visited-state" href="https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html">success criterion 4.1.3: status messages</a>
@@ -124,7 +124,7 @@
   </ul>
 
   <p class="govuk-body">
-    We expect to fix these issues by the end of December 2021.
+    We expect to fix these issues by the end of March 2022.
   </p>
 
   <h3 class="heading-small">Problems with using the interface</h3>
@@ -152,7 +152,7 @@
   </ul>
 
   <p class="govuk-body">
-    We hope to fix these issues by the end of January 2022.
+    We hope to fix these issues by the end of June 2022.
   </p>
 
   <h3 class="heading-small">
@@ -175,7 +175,7 @@
   </p>
 
   <p class="govuk-body">
-    We’ll continue to investigate the cause of this issue and, if possible, fix it by the end of 2021.
+    We’ll continue to investigate the cause of this issue and, if possible, fix it by the end of June 2021.
   </p>
 
   <h3 class="heading-small">
@@ -199,7 +199,7 @@
   </ul>
 
   <p class="govuk-body">
-    We plan to have the status page issues addressed by the current supplier or move to an alternative supplier in 2021.
+    We plan to have the status page issues addressed by the current supplier or move to an alternative supplier in 2022.
   </p>
 
   <h2 class="heading-medium">

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -13,7 +13,7 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "20 January 2022",
+      "Last updated": "21 January 2022",
       "Next review due": "20 April 2022"
     }
     ) }}


### PR DESCRIPTION
As with the last update, the work prepping the
interface that will be used for emergency alerts
for its accessibility audit took priority and has
taken longer than expected. Because of this, we
haven't had time to work on the issues listed
here.

This updates the planned timings to reflect what
we now believe will be possible with the work left
on emergency alerts and amount of work required to
fix them.