### PR TITLE
Refactor mixins for reuse and clearer naming

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -14,7 +14,7 @@ from .populations import CITY_OF_LONDON
 from .repo import BroadcastAreasRepository, rtree_index
 
 
-class SortableMixin(SortByNameMixin):
+class IdEqualityMixin:
 
     def __repr__(self):
         return f'{self.__class__.__name__}(<{self.id}>)'
@@ -75,7 +75,7 @@ class BaseBroadcastArea(ABC):
         return max(500, min(estimated_bleed, 5000))
 
 
-class BroadcastArea(BaseBroadcastArea, SortableMixin):
+class BroadcastArea(BaseBroadcastArea, IdEqualityMixin, SortByNameMixin):
 
     def __init__(self, row):
         self.id, self.name, self._count_of_phones, self.library_id = row
@@ -220,7 +220,7 @@ class CustomBroadcastAreas(SerialisedModelCollection):
         )
 
 
-class BroadcastAreaLibrary(SerialisedModelCollection, SortableMixin, GetItemByIdMixin):
+class BroadcastAreaLibrary(SerialisedModelCollection, SortByNameMixin, IdEqualityMixin, GetItemByIdMixin):
 
     model = BroadcastArea
 

--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -8,20 +8,16 @@ from rtreelib import Rect
 from werkzeug.utils import cached_property
 
 from app.formatters import square_metres_to_square_miles
+from app.models import SortByNameMixin
 
 from .populations import CITY_OF_LONDON
 from .repo import BroadcastAreasRepository, rtree_index
 
 
-class SortableMixin:
+class SortableMixin(SortByNameMixin):
 
     def __repr__(self):
         return f'{self.__class__.__name__}(<{self.id}>)'
-
-    def __lt__(self, other):
-        # Implementing __lt__ means any classes inheriting from this
-        # method are sortable
-        return self.name < other.name
 
     def __eq__(self, other):
         return self.id == other.id

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -64,9 +64,6 @@ class Organisation(JSONModel, SortByNameMixin):
             return cls({})
         return cls(organisations_client.get_organisation(org_id))
 
-    def __lt__(self, other):
-        return self.name.lower() < other.name.lower()
-
     @classmethod
     def from_domain(cls, domain):
         return cls(organisations_client.get_organisation_by_domain(domain))


### PR DESCRIPTION
Implementing `__lt__` makes objects sortable.

Rather than reimplementing `__lt__` each time we want to make an object sortable by name, we can inherit from the extant `SortByNameMixin`.
  
Once we’re using `SortByNameMixin` everywhere can extract the extra parts of `SortableMixin` that enable `id`-based equality checking into their own mixin.
