### PR TITLE
Add a link to the Celery 5 blog post from our roadmap

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -61,7 +61,7 @@
 
   <ul class="list list-bullet">
 
-    <li>improved our performance by upgrading the software we use</li>
+    <li>improved our performance by <a class="govuk-link govuk-link--no-visited-state" href="https://technology.blog.gov.uk/2022/02/01/upgrading-celery-on-gov-uk-notify/">upgrading the software we use</li>
     <li>made our website work better in Windows high contrast mode</li>
     <li>increased our capacity at short notice during a busy period</li>
     <li>added quarterly billing reports that organisations can download</li>


### PR DESCRIPTION
This PR adds a link to a recent blog post from the ‘Things we’ve done’ section of the roadmap.