### PR TITLE
Add missing </a> tag

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -61,7 +61,7 @@
 
   <ul class="list list-bullet">
 
-    <li>improved our performance by <a class="govuk-link govuk-link--no-visited-state" href="https://technology.blog.gov.uk/2022/02/01/upgrading-celery-on-gov-uk-notify/">upgrading the software we use</li>
+    <li>improved our performance by <a class="govuk-link govuk-link--no-visited-state" href="https://technology.blog.gov.uk/2022/02/01/upgrading-celery-on-gov-uk-notify/">upgrading the software we use</a></li>
     <li>made our website work better in Windows high contrast mode</li>
     <li>increased our capacity at short notice during a busy period</li>
     <li>added quarterly billing reports that organisations can download</li>


### PR DESCRIPTION
This PR fixes the link to the Celery blog on the roadmap page