### PR TITLE
Pass admin URL to API when resetting password

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -176,7 +176,10 @@ class UserApiClient(NotifyAdminAPIClient):
 
     def send_reset_password_url(self, email_address, next_string=None):
         endpoint = '/user/reset-password'
-        data = {'email': email_address}
+        data = {
+            'email': email_address,
+            'admin_base_url': self.admin_url,
+        }
         if next_string:
             data['next'] = next_string
         self.post(endpoint, data=data)

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -306,3 +306,22 @@ def test_complete_webauthn_login_attempt_raises_on_api_error(fake_uuid, mocker):
 
     with pytest.raises(HTTPError):
         user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True)
+
+
+def test_reset_password(
+    mocker,
+    fake_uuid,
+):
+    mock_post = mocker.patch(
+        'app.notify_client.user_api_client.UserApiClient.post'
+    )
+
+    user_api_client.send_reset_password_url('test@example.com')
+
+    mock_post.assert_called_once_with(
+        '/user/reset-password',
+        data={
+            'email': 'test@example.com',
+            'admin_base_url': 'http://localhost:6012',
+        },
+    )


### PR DESCRIPTION
This follows the pattern for invite emails where the admin app tells the API which domain to use when generating the link.