### PR TITLE
Tidy up new email branding routes

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1153,7 +1153,6 @@ def create_email_branding_zendesk_ticket(form_option_selected, detail=None):
     zendesk_client.send_ticket_to_zendesk(ticket)
 
 
-@main.route("/services/<uuid:service_id>/branding-request/email", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/service-settings/email-branding", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def email_branding_request(service_id):
@@ -1260,7 +1259,6 @@ def email_branding_something_else(service_id):
     return render_template('views/service-settings/branding/email-branding-something-else.html', form=form)
 
 
-@main.route("/services/<uuid:service_id>/branding-request/letter", methods=['GET', 'POST'])
 @main.route("/services/<uuid:service_id>/service-settings/letter-branding", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def letter_branding_request(service_id):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1168,19 +1168,10 @@ def email_branding_request(service_id):
             flash('Thanks for your branding request. We’ll get back to you within one working day.', 'default')
             return redirect(url_for('.service_settings', service_id=current_service.id))
         else:
-            endpoint = {
-                'govuk': '.email_branding_govuk',
-                'govuk_and_org': '.email_branding_govuk',
-                'nhs': '.email_branding_nhs',
-                'organisation': '.email_branding_organisation',
-                'something_else': '.email_branding_something_else',
-            }[form.options.data]
-
             return redirect(
                 url_for(
-                    endpoint,
+                    f'.email_branding_{form.options.data}',
                     service_id=current_service.id,
-                    with_org=(True if form.options.data == 'govuk_and_org' else None),
                 )
             )
 
@@ -1202,9 +1193,7 @@ def check_branding_allowed_for_service(branding):
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/govuk", methods=['GET', 'POST'])
 @user_has_permissions('manage_service')
 def email_branding_govuk(service_id):
-    with_org = request.args.get('with_org')
-
-    check_branding_allowed_for_service('govuk_and_org' if with_org else 'govuk')
+    check_branding_allowed_for_service('govuk')
 
     if request.method == 'POST':
         create_email_branding_zendesk_ticket(request.form['branding_choice'])
@@ -1212,7 +1201,21 @@ def email_branding_govuk(service_id):
         flash('Thanks for your branding request. We’ll get back to you within one working day.', 'default')
         return redirect(url_for('.service_settings', service_id=current_service.id))
 
-    return render_template('views/service-settings/branding/email-branding-govuk.html', with_org=with_org)
+    return render_template('views/service-settings/branding/email-branding-govuk.html')
+
+
+@main.route("/services/<uuid:service_id>/service-settings/email-branding/govuk-and-org", methods=['GET', 'POST'])
+@user_has_permissions('manage_service')
+def email_branding_govuk_and_org(service_id):
+    check_branding_allowed_for_service('govuk_and_org')
+
+    if request.method == 'POST':
+        create_email_branding_zendesk_ticket(request.form['branding_choice'])
+
+        flash('Thanks for your branding request. We’ll get back to you within one working day.', 'default')
+        return redirect(url_for('.service_settings', service_id=current_service.id))
+
+    return render_template('views/service-settings/branding/email-branding-govuk.html', with_org=True)
 
 
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/nhs", methods=['GET', 'POST'])

--- a/app/templates/views/service-settings/branding/email-branding-govuk.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk.html
@@ -37,7 +37,7 @@
   <p class="govuk-body">We’ll email you once your branding’s ready to use, or if we need any more information.</p>
 
   {% call form_wrapper() %}
-    {{ page_footer('Request new branding', button_name='branding_choice', button_value=('govuk_and_org' if with_org == 'True' else 'govuk')) }}
+    {{ page_footer('Request new branding', button_name='branding_choice', button_value=('govuk_and_org' if with_org else 'govuk')) }}
   {% endcall %}
 
 {% endblock %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -112,6 +112,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'edit_user_permissions',
     'email_branding',
     'email_branding_govuk',
+    'email_branding_govuk_and_org',
     'email_branding_nhs',
     'email_branding_organisation',
     'email_branding_request',


### PR DESCRIPTION
**Remove old branding URLs**
We've changed the URLs for these endpoints but needed to keep the old URLs in place in addition to the new URLs in case anyone was in the middle of changing their branding as the change was being deployed. We can now safely remove the old URLs.

**Make separate endpoints for GOV.UK email branding options**
The endpoint to change the email branding to "GOV.UK" branding and "GOV.UK and organisation" branding was the same but with a query string used to determine which of the two options had been selected. This makes them two separate endpoints, which makes the code a bit simpler and hopefully means there is less chance of things not working as expected.

[Pivotal story](https://www.pivotaltracker.com/story/show/180807160)