### PR TITLE
Bump utils to 53.0.0

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -10,9 +10,9 @@ from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed
 from flask_wtf.file import FileField as FileField_wtf
 from flask_wtf.file import FileSize
-from notifications_utils.columns import Columns
 from notifications_utils.countries.data import Postage
 from notifications_utils.formatters import strip_all_whitespace
+from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import (
     InvalidPhoneError,
@@ -360,7 +360,7 @@ class SMSCode(GovukTextInputField):
 
     def process_formdata(self, valuelist):
         if valuelist:
-            self.data = Columns.make_key(valuelist[0])
+            self.data = InsensitiveDict.make_key(valuelist[0])
 
 
 class ForgivingIntegerField(GovukTextInputField):
@@ -2105,12 +2105,12 @@ def get_placeholder_form_instance(
 ):
 
     if (
-        Columns.make_key(placeholder_name) == 'emailaddress' and
+        InsensitiveDict.make_key(placeholder_name) == 'emailaddress' and
         template_type == 'email'
     ):
         field = email_address(label=placeholder_name, gov_user=False)
     elif (
-        Columns.make_key(placeholder_name) == 'phonenumber' and
+        InsensitiveDict.make_key(placeholder_name) == 'phonenumber' and
         template_type == 'sms'
     ):
         if allow_international_phone_numbers:

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -15,7 +15,7 @@ from flask import (
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils import LETTER_MAX_PAGE_COUNT, SMS_CHAR_COUNT_LIMIT
-from notifications_utils.columns import Columns
+from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.pdf import is_letter_too_long
 from notifications_utils.postal_address import (
     PostalAddress,
@@ -87,7 +87,7 @@ def get_example_csv_rows(template, use_example_as_example=True, submitted_fields
     }[template.template_type] + get_example_csv_fields(
         (
             placeholder for placeholder in template.placeholders
-            if placeholder not in Columns.from_keys(
+            if placeholder not in InsensitiveDict.from_keys(
                 first_column_headings[template.template_type]
             )
         ),
@@ -471,7 +471,7 @@ def send_one_off_step(service_id, template_id, step_index):
                 service_id=service_id,
                 template_id=template_id,
             ))
-        if current_placeholder in Columns(PostalAddress('').as_personalisation):
+        if current_placeholder in InsensitiveDict(PostalAddress('').as_personalisation):
             return redirect(url_for(
                 request.endpoint,
                 service_id=service_id,
@@ -839,7 +839,7 @@ def fields_to_fill_in(template, prefill_current_user=False):
 
 
 def get_normalised_placeholders_from_session():
-    return Columns(session.get('placeholders', {}))
+    return InsensitiveDict(session.get('placeholders', {}))
 
 
 def get_recipient_and_placeholders_from_session(template_type):
@@ -888,7 +888,7 @@ def get_back_link(service_id, template, step_index, placeholders=None):
             for index, placeholder in reversed(
                 list(enumerate(placeholders[:step_index]))
             )
-            if placeholder not in Columns(
+            if placeholder not in InsensitiveDict(
                 PostalAddress('').as_personalisation
             )
         ), 1)
@@ -1038,7 +1038,7 @@ def send_notification(service_id, template_id):
         noti = notification_api_client.send_notification(
             service_id,
             template_id=db_template['id'],
-            recipient=session['recipient'] or Columns(session['placeholders'])['address line 1'],
+            recipient=session['recipient'] or InsensitiveDict(session['placeholders'])['address line 1'],
             personalisation=session['placeholders'],
             sender_id=session['sender_id'] if 'sender_id' in session else None
         )
@@ -1092,7 +1092,7 @@ def get_spreadsheet_column_headings_from_template(template):
     for column_heading in (
         recipient_columns + list(template.placeholders)
     ):
-        if column_heading not in Columns.from_keys(column_headings):
+        if column_heading not in InsensitiveDict.from_keys(column_headings):
             column_headings.append(column_heading)
 
     return column_headings

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -18,7 +18,7 @@ from flask import (
     send_file,
     url_for,
 )
-from notifications_utils.columns import Columns
+from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.pdf import pdf_page_count
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import RecipientCSV
@@ -443,10 +443,10 @@ def check_contact_list(service_id, upload_id):
     first_row = contents.splitlines()[0].strip().rstrip(',') if contents else ''
     original_file_name = ContactList.get_metadata(service_id, upload_id).get('original_file_name', '')
 
-    template_type = {
-        'emailaddress': 'email',
-        'phonenumber': 'sms',
-    }.get(Columns.make_key(first_row))
+    template_type = InsensitiveDict({
+        'email address': 'email',
+        'phone number': 'sms',
+    }).get(first_row)
 
     recipients = RecipientCSV(
         contents,

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ pyproj==3.2.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,7 +121,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.2.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx


### PR DESCRIPTION
Changes:

53.0.0
---

* `notifications_utils.columns.Columns` has moved to `notifications_utils.insensitive_dict.InsensitiveDict`
* `notifications_utils.columns.Rows` has moved to `notifications_utils.recipients.Rows`
* `notifications_utils.columns.Cell` has moved to `notifications_utils.recipients.Cell`

52.0.0
---

* Deprecate the following unused `redis_client` functions:
  - `redis_client.increment_hash_value`
  - `redis_client.decrement_hash_value`
  - `redis_client.get_all_from_hash`
  - `redis_client.set_hash_and_expire`
  - `redis_client.expire`

51.3.1
---

* Bump govuk-bank-holidays to cache holidays for next year.

51.3.0
---

* Log exception and stacktrace when Celery tasks fail.