### PR TITLE
Proof of concept for redis producing dashboard stats

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -69,7 +69,7 @@ class Config(object):
     ANTIVIRUS_ENABLED = True
 
     REDIS_URL = os.environ.get('REDIS_URL')
-    REDIS_ENABLED = os.environ.get('REDIS_ENABLED') == '1'
+    REDIS_ENABLED = True
 
     ASSET_DOMAIN = ''
     ASSET_PATH = '/static/'

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -16,11 +16,11 @@
     </div>
     <div id="total-sms" class="govuk-grid-column-one-third">
       {{ big_number_with_status(
-        statistics['sms']['requested'],
-        statistics['sms']['requested']|message_count_label('sms', suffix='sent'),
-        statistics['sms']['failed'],
-        statistics['sms']['failed_percentage'],
-        statistics['sms']['show_warning'],
+        statistics['text']['requested'],
+        statistics['text']['requested']|message_count_label('sms', suffix='sent'),
+        statistics['text']['failed'],
+        statistics['text']['failed_percentage'],
+        statistics['text']['show_warning'],
         failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
         link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed'),
         smaller=True,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179338377

![image](https://user-images.githubusercontent.com/7228605/153255380-bba1b2da-2a77-403d-aaca-1159c615cee1.png)


This PR is a proof of concept/discussion starter for how to use redis to give our dashboard page its stats. I've implemented a very basic version of one of our options and have created the equivalent bit needed on the API in https://github.com/alphagov/notifications-api/pull/3450.

Have a read, have a browse of the code and then please let me know your thoughts!

## Option 1 - a redis key that doesn't include a day

We could store redis keys of the following

`service-id-xxxxxxxx-email-sending`
`service-id-xxxxxxxx-sms-failed`

These keys would never expire.

Everytime an email is created, we add one to the count of `service-id-xxxxxxxx-email-sending`
Everytime an email is delivered, we add one to the count of `service-id-xxxxxxxx-email-delivered` and subtract one from `service-id-xxxxxxxx-email-sending`

We would need a nightly job of some sort to remove any notifications at the end of 7 days from the count.

The admin app can go and grab these keys and display them directly on the dashboard page.

## Option 2 - a redis key, per day, that counts the number of messages in the past 7 days

`service-id-xxxxxxxx-date-2022-02-09-email-sending` which would represent the number of messages that are in sending that have been created in the last 7 days

These keys would expire after about 8 days.

Everytime an email is created, we add one to the count of:

`service-id-xxxxxxxx-date-2022-02-09-email-sending`
`service-id-xxxxxxxx-date-2022-02-10-email-sending`
`service-id-xxxxxxxx-date-2022-02-11-email-sending`
...
`service-id-xxxxxxxx-date-2022-02-17-email-sending`

Everytime an email is delivered, we add one to the count of 
`service-id-xxxxxxxx-date-2022-02-09-email-delivered`
`service-id-xxxxxxxx-date-2022-02-10-email-delivered`
`service-id-xxxxxxxx-date-2022-02-11-email-delivered`
...
`service-id-xxxxxxxx-date-2022-02-17-email-delivered`

and subtract one from:

`service-id-xxxxxxxx-date-2022-02-09-email-sending`
`service-id-xxxxxxxx-date-2022-02-10-email-sending`
`service-id-xxxxxxxx-date-2022-02-11-email-sending`
...
`service-id-xxxxxxxx-date-2022-02-17-email-sending`

The admin app can grab the key for todays date and display it directly on the dashboard page. (it would have to do the same for each of the other notification types and for each of the other notification statuses).

## Option 3 - store each days count by itself and get the admin app to sum up the last 7 days worth

We could store redis keys of the following

`service-id-xxxxxxxx-date-2022-02-09-email-sending`
`service-id-xxxxxxxx-date-2022-02-09-sms-failed`

These keys would expire after about 8 days.

Everytime an email is created, we add one to the count of `service-id-xxxxxxxx-date-2022-02-09-email-sending`
Everytime an email is delivered, we add one to the count of `service-id-xxxxxxxx-date-2022-02-09-email-delivered` and subtract one from `service-id-xxxxxxxx-date-2022-02-09-email-sending`

The admin app would then ask for the past 7 days by summing 
`service-id-xxxxxxxx-date-2022-02-02-email-sending`
`service-id-xxxxxxxx-date-2022-02-03-email-sending`
...
`service-id-xxxxxxxx-date-2022-02-09-email-sending`


## Option 4 - use redis to support our current API route and the admin app stays as is

We could store redis keys of the following

`service-id-xxxxxxxx-date-2022-02-09-email-sending`
`service-id-xxxxxxxx-date-2022-02-09-sms-failed`

These keys would expire after 24 hours.

Everytime an email is created, we add one to the count of `service-id-xxxxxxxx-date-2022-02-09-email-sending`
Everytime an email is delivered, we add one to the count of `service-id-xxxxxxxx-date-2022-02-09-email-delivered` and subtract one from `service-id-xxxxxxxx-date-2022-02-09-email-sending`

When the API comes to get the data for how many notifications have been sent in the last 7 days, it gets the previous days data from the `ft_notification_status` table and then gets todays data from todays key `service-id-xxxxxxxx-date-2022-02-09-email-sending`.

## Things I haven't dealt with here

The following will need to be solved but I don't see them as particularly difficult or noteworthy compared to picking the larger strategy from above

BST/UTC - will be some nuance around making sure notifications are marked against the correct days redis key. 

Which statuses to have keys for. We could split our keys by just 'sending', 'delivered', 'failed' which would match up exactly to what we show in the admin app. Or we could split them by every status we have (ie splitting failed in to tech failure, perm failure, temp failure)

Template stats. The API route that is slow also gives us stats on how many times a template has been used in the past 7 days. We would need to take care of this either by making the suggested keys more granular (adding in template ids) or by creating different redis keys just to count template usage. 

Making the code be correct and pretty. I've scraped some stuff together, more to illustrate. It would need to be rewritten but should roughly demonstrate what option 3 would look like. It works locally for me :) Everytime I sent an email, the number on the dashboard goes up by 1!

Storing the data in simple keys like this or storing it in something like a redis hash.


## Thoughts on which option is best

I think option 4 is not the best option. It doesn't also solve the problem of the dashboard not being in realtime (bug card https://www.pivotaltracker.com/story/show/172026169), which I think we should try and solve as part of this. You technically could solve it as notifications enter their final state after 72 hours, so by getting the most recent 72 hours of data from redis and the older days from `ft_notification_status` but at this point, you might as well be doing one of the other options.

I think option 2 is not the best option, it is a more complex and confusing version of option 3, with not that much more benefit.

That leaves option 1 or option 3.

I think I prefer option 3 because 

- option 3 is easier to inspect and debug. You can match daily tallys. If there are any problems, you can always track it down to a single day causing the issue.
- option 1 may be harder to debug. If something goes wrong and our count accidentally goes wrong, it won't get fixed over time. For example, if our nightly job failed and didn't remove 300 delivered emails from the count of delivered emails, then those 300 delivered emails would stay counted and would never be removed. It might be hard to figure out what is going wrong with a number that is constantly moving.
- option 3 will closer match the `ft_notification_status` table which gives some nicer consistency

Therefore I have implemented a rough sketch of what option 3 could look like in this PR and the related API PR.

## One final note

This is very different usage of redis to all our other usage. Our current usage of redis is as a cache and redis should always hold the same value as a value in the database.

The exception to this is the rate limits, which count how many notifications someone has sent in the past minute and in the past day. However, these are not explicitly shown to the user. And if something went wrong with them, it generally wouldn't be the end of the world if we lost the data for a day. 

This new use case is different because if there is a problem with redis, lets say redis went down for 2 hours, then our dashboards would just say 0 or break. Equally, we can't just solve problems with purging redis. If we delete these keys, we lose our lovely tallys of how many notifications have been sent and we don't get those back (unless we add some sort of command/job that would repopulate these keys for every service for every notification type based on the database).

## What I would l like from you please

- Comment and critique on the above options
- Which option/options do you think we should go for?
- Any other solutions I haven't considered


