### PR TITLE
Fix current alerts focus styles - part 2

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -24,3 +24,12 @@ $(() => $('.banner-dangerous').eq(0).trigger('focus'));
 $(() => $('.govuk-header__container').on('click', function() {
   $(this).css('border-color', '#005ea5');
 }));
+
+$('.js-mark-focus-on-parent').on('focus blur', '*', e => {
+  $target = $(e.target);
+  if (e.type === 'focusin') {
+    $target.parent().addClass('js-child-has-focus');
+  } else {
+    $target.parent().removeClass('js-child-has-focus');
+  }
+});

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -25,6 +25,10 @@ $(() => $('.govuk-header__container').on('click', function() {
   $(this).css('border-color', '#005ea5');
 }));
 
+// Applies our expanded focus style to the siblings of links when that link is wrapped in a heading.
+//
+// This will be possible in CSS in the future, using the :has pseudo-class. When :has is available
+// in the browsers we support, this code can be replaced with a CSS-only solution.
 $('.js-mark-focus-on-parent').on('focus blur', '*', e => {
   $target = $(e.target);
   if (e.type === 'focusin') {

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -13,6 +13,10 @@
 
   // Methods to ensure the DOM fragment is clean of classes added by JS before diffing
   // and that they are replaced afterwards.
+  //
+  // Added to allow the use of JS, in main.js, to apply styles which in future could be
+  // achieved with the :has pseudo-class. If :has is available in our supported browsers,
+  // this can be removed in favour of a CSS-only solution.
   var classesPersister = {
     _classNames: [],
     _$els: [],
@@ -100,11 +104,15 @@
       var resource = $component.data('resource');
       var form = $component.data('form');
 
-      // replace component with contents
-      // the renderer does this anyway when diffing against the first response
+      // Replace component with contents.
+      // The renderer does this anyway when diffing against the first response
       $component.replaceWith($contents);
 
-      // store any classes that should persist through updates
+      // Store any classes that should persist through updates
+      //
+      // Added to allow the use of JS, in main.js, to apply styles which in future could be
+      // achieved with the :has pseudo-class. If :has is available in our supported browsers,
+      // this can be removed in favour of a CSS-only solution.
       if ($contents.data('classesToPersist') !== undefined) {
         $contents.data('classesToPersist')
           .split(' ')

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -19,33 +19,39 @@
   // this can be removed in favour of a CSS-only solution.
   var classesPersister = {
     _classNames: [],
-    _$els: [],
+    _classesTo$ElsMap: {},
     addClassName: function (className) {
       if (this._classNames.indexOf(className) === -1) {
         this._classNames.push(className);
       }
     },
     remove: function () {
+      // Store references to any elements with class names to persist
       this._classNames.forEach(className => {
         var $elsWithClassName = $('.' + className).removeClass(className);
 
-        // store elements for that className at the same index
-        this._$els.push($elsWithClassName);
+        if ($elsWithClassName.length > 0) {
+          this._classesTo$ElsMap[className] = $elsWithClassName;
+        }
       });
     },
     replace: function () {
-      this._classNames.forEach((className, index) => {
-        var $el = this._$els[index];
+      var className;
 
-        // Avoid updating elements that are no longer present.
-        // elements removed will still exist in memory but won't be attached to the DOM any more
-        if (global.document.body.contains($el.get(0))) {
-          $el.addClass(className);
-        }
-      });
+      for (className in this._classesTo$ElsMap) {
+        this._classesTo$ElsMap[className].each((idx, el) => {
+
+          // Avoid updating elements that are no longer present.
+          // elements removed will still exist in memory but won't be attached to the DOM any more
+          if (global.document.body.contains(el)) {
+            $(el).addClass(className);
+          }
+
+        });
+      }
 
       // remove references to elements
-      this._$els = [];
+      this._classesTo$ElsMap = {};
     }
   };
 

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -45,7 +45,7 @@
       });
 
       // remove references to elements
-      this.$els = [];
+      this._$els = [];
     }
   };
 

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -14,19 +14,22 @@
   // Methods to ensure the DOM fragment is clean of classes added by JS before diffing
   // and that they are replaced afterwards.
   var classesPersister = {
-    classNames: [],
-    $els: [],
+    _classNames: [],
+    _$els: [],
+    addClassName: function (className) {
+      this._classNames.push(className);
+    },
     remove: function () {
-      this.classNames.forEach(className => {
+      this._classNames.forEach(className => {
         var $elsWithClassName = $('.' + className).removeClass(className);
 
         // store elements for that className at the same index
-        this.$els.push($elsWithClassName);
+        this._$els.push($elsWithClassName);
       });
     },
     replace: function () {
-      this.classNames.forEach((className, index) => {
-        var $el = this.$els[index];
+      this._classNames.forEach((className, index) => {
+        var $el = this._$els[index];
 
         if (global.document.body.contains($el.get(0))) {
           $el.addClass(className);
@@ -101,7 +104,7 @@
       if ($contents.data('classesToPersist') !== undefined) {
         $contents.data('classesToPersist')
           .split(' ')
-          .forEach(className => classesPersister.classNames.push(className));
+          .forEach(className => classesPersister.addClassName(className));
       }
 
       setTimeout(

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -34,11 +34,11 @@
     }
   };
 
-  var getRenderer = $component => response => {
+  var getRenderer = ($contents, key) => response => {
     classesToPersist.remove();
     morphdom(
-      $component.get(0),
-      $(response[$component.data('key')]).get(0)
+      $contents.get(0),
+      $(response[key]).get(0)
     );
     classesToPersist.replace();
   };
@@ -84,6 +84,14 @@
 
     this.start = component => {
       var $component = $(component);
+      var $contents = $component.children().eq(0);
+      var key = $component.data('key');
+      var resource = $component.data('resource');
+      var form = $component.data('form');
+
+      // replace component with contents
+      // the renderer does this anyway when diffing against the first response
+      $component.replaceWith($contents);
 
       // store any classes that should persist through updates
       if ($contents.data('classesToPersist') !== undefined) {
@@ -94,10 +102,10 @@
 
       setTimeout(
         () => poll(
-          getRenderer($component),
-          $component.data('resource'),
-          getQueue($component.data('resource')),
-          $component.data('form')
+          getRenderer($contents, key),
+          resource,
+          getQueue(resource),
+          form
         ),
         defaultInterval
       );

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -38,18 +38,19 @@
     });
   };
   ClassesPersister.prototype.replace = function () {
+    var replaceClasses = (idx, el) => {
+
+      // Avoid updating elements that are no longer present.
+      // elements removed will still exist in memory but won't be attached to the DOM any more
+      if (global.document.body.contains(el)) {
+        $(el).addClass(className);
+      }
+
+    };
     var className;
 
     for (className in this._classesTo$ElsMap) {
-      this._classesTo$ElsMap[className].each((idx, el) => {
-
-        // Avoid updating elements that are no longer present.
-        // elements removed will still exist in memory but won't be attached to the DOM any more
-        if (global.document.body.contains(el)) {
-          $(el).addClass(className);
-        }
-
-      });
+      this._classesTo$ElsMap[className].each(replaceClasses);
     }
 
     // remove references to elements

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -26,7 +26,11 @@
     },
     replace: function () {
       this.classNames.forEach((className, index) => {
-        this.$els[index].addClass(className);
+        var $el = this.$els[index];
+
+        if (global.document.body.contains($el.get(0))) {
+          $el.addClass(className);
+        }
       });
 
       // remove references to elements

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -17,7 +17,9 @@
     _classNames: [],
     _$els: [],
     addClassName: function (className) {
-      this._classNames.push(className);
+      if (this._classNames.indexOf(className) === -1) {
+        this._classNames.push(className);
+      }
     },
     remove: function () {
       this._classNames.forEach(className => {
@@ -31,6 +33,8 @@
       this._classNames.forEach((className, index) => {
         var $el = this._$els[index];
 
+        // Avoid updating elements that are no longer present.
+        // elements removed will still exist in memory but won't be attached to the DOM any more
         if (global.document.body.contains($el.get(0))) {
           $el.addClass(className);
         }

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -13,7 +13,7 @@
 
   // Methods to ensure the DOM fragment is clean of classes added by JS before diffing
   // and that they are replaced afterwards.
-  var classesToPersist = {
+  var classesPersister = {
     classNames: [],
     $els: [],
     remove: function () {
@@ -39,12 +39,12 @@
   };
 
   var getRenderer = ($contents, key) => response => {
-    classesToPersist.remove();
+    classesPersister.remove();
     morphdom(
       $contents.get(0),
       $(response[key]).get(0)
     );
-    classesToPersist.replace();
+    classesPersister.replace();
   };
 
   var getQueue = resource => (
@@ -101,7 +101,7 @@
       if ($contents.data('classesToPersist') !== undefined) {
         $contents.data('classesToPersist')
           .split(' ')
-          .forEach(className => classesToPersist.classNames.push(className));
+          .forEach(className => classesPersister.classNames.push(className));
       }
 
       setTimeout(

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -44,6 +44,13 @@
 
 .file-list {
 
+  &-hint,
+  &-hint-large,
+  &-status {
+    pointer-events: none; // delegate clicks to the overlapping link
+    position: relative; // make non-static to sit above the overlapping focus style
+  }
+
   &-filename {
     @include bold-19;
     display: block;
@@ -84,7 +91,6 @@
     @include core-16;
     display: block;
     color: $secondary-text-colour;
-    pointer-events: none;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -95,7 +101,6 @@
     @include core-19;
     display: block;
     color: $secondary-text-colour;
-    pointer-events: none;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -110,13 +115,6 @@
 
 /* The focus state for sibling links overlaps the hint so the hint's text colour needs to adapt */
 .govuk-link:focus {
-  &.file-list-filename,
-  &.file-list-filename-large,
-  & + .file-list-hint,
-  & + .file-list-hint-large {
-    /* link needs non-static position to overlap the cell border, hint so it isn't overlapped itself */
-    position: relative;
-  }
 
   &.file-list-filename,
   &.file-list-filename-large {
@@ -126,6 +124,17 @@
 
   & + .file-list-hint,
   & + .file-list-hint-large {
+    color: $govuk-focus-text-colour;
+  }
+
+}
+
+// Note: this selector should use the :has() pseudo-class in the future when it is supported
+//       which will remove the need for JS
+.file-list .js-child-has-focus + .govuk-grid-row {
+
+  & .file-list-hint-large,
+  & .file-list-status > .govuk-hint {
     color: $govuk-focus-text-colour;
   }
 

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -120,6 +120,11 @@
   &.file-list-filename-large {
     /* override box-shadow to push underline down a bit */
     box-shadow: 0 -2px $govuk-focus-colour, 0 5px $govuk-focus-text-colour;
+
+    // File-list items contained by keyline-blocks have more spacing at the top so adapt to cover it
+    .keyline-block > .file-list & {
+      box-shadow: 0 -5px $govuk-focus-colour, 0 5px $govuk-focus-text-colour;
+    }
   }
 
   & + .file-list-hint,

--- a/app/templates/components/ajax-block.html
+++ b/app/templates/components/ajax-block.html
@@ -5,7 +5,6 @@
       data-resource="{{ url }}"
       data-key="{{ key }}"
       data-form="{{ form }}"
-      aria-live="polite"
     >
   {% endif %}
     {{ partials[key]|safe }}

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,6 +1,6 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
 
-<div class='ajax-block-container'>
+<div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in broadcasts|sort|reverse|list %}
   <div class="keyline-block">
     <div class="file-list govuk-!-margin-bottom-2">

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -317,7 +317,7 @@ describe('Update content', () => {
 
       document.body.innerHTML = initialHTMLString;
 
-      // make the response have an extra item
+      // make a response with no changes
       responseObj[updateKey] = HTMLString;
 
       // start the module
@@ -468,8 +468,29 @@ describe('Update content', () => {
       // Add class to indicate focus state of link on parent heading
       document.querySelectorAll('.file-list h2')[0].classList.add('js-child-has-focus');
 
-      // make the response match the initial HTML to emulate a response with no changes
-      responseObj[updateKey] = HTMLString;
+      var updatedHTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        },
+        {
+          title: "Reservoir flooding template",
+          hint: "The local reservoir has flooded. All people within 5 miles should move to a safer location.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi A",
+            "Santa Claus Village, Rovaniemi D"
+          ]
+        }
+      ]);
+
+      // make the response have an extra item
+      responseObj[updateKey] = updatedHTMLString;
 
       // start the module
       window.GOVUK.modules.start();

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -94,7 +94,7 @@ describe('Update content', () => {
         </div>`;
 
 
-      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
                           ${HTMLString}
                           </div>`;
 
@@ -102,6 +102,15 @@ describe('Update content', () => {
 
       // default the response to match the content inside div[data-module]
       responseObj[updateKey] = HTMLString;
+
+    });
+
+    test("It should replace the original HTML with that of the partial, to match that returned from AJAX responses", () => {
+
+      // start the module
+      window.GOVUK.modules.start();
+
+      expect(document.querySelector('.ajax-block-container').parentNode.hasAttribute('data-resource')).toBe(false);
 
     });
 
@@ -302,7 +311,7 @@ describe('Update content', () => {
         }
       ]);
 
-      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
                           ${HTMLString}
                           </div>`;
 
@@ -336,7 +345,7 @@ describe('Update content', () => {
         }
       ]);
 
-      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
                           ${HTMLString}
                           </div>`;
 
@@ -401,7 +410,7 @@ describe('Update content', () => {
         }
       ]);
 
-      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
                           ${HTMLString}
                           </div>`;
 
@@ -447,7 +456,7 @@ describe('Update content', () => {
         }
       ]);
 
-      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
                           ${HTMLString}
                           </div>`;
 

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -418,7 +418,7 @@ describe('Update content', () => {
 
     });
 
-    test("If other scripts have added classes to the DOM, they should persist through updates", () => {
+    test("If other scripts have added classes to the DOM, they should persist through updates to a single component", () => {
 
       document.body.innerHTML = getInitialHTMLString(getPartial(partialData));
 
@@ -448,6 +448,48 @@ describe('Update content', () => {
 
       // check the class is still there
       expect(document.querySelectorAll('.file-list h2')[0].classList.contains('js-child-has-focus')).toBe(true);
+
+    });
+
+    test("If other scripts have added classes to the DOM, they should persist through updates to multiple components", () => {
+
+      // Create duplicate components in the page
+      document.body.innerHTML = getInitialHTMLString(getPartial(partialData)) + "\n" + getInitialHTMLString(getPartial(partialData));
+
+      var partialsInPage = document.querySelectorAll('.ajax-block-container');
+
+      // Mark classes to persist on the partials (2nd is made up)
+      partialsInPage[0].setAttribute('data-classes-to-persist', 'js-child-has-focus');
+      partialsInPage[1].setAttribute('data-classes-to-persist', 'js-2nd-child-has-focus');
+
+      // Add examples of those classes on each partial (2nd is made up)
+      partialsInPage[0].querySelectorAll('.file-list h2')[0].classList.add('js-child-has-focus');
+      partialsInPage[1].querySelectorAll('.file-list h2')[0].classList.add('js-2nd-child-has-focus');
+
+      // Add an item to trigger an update
+      partialData.push({
+        title: "Reservoir flooding template",
+        hint: "The local reservoir has flooded. All people within 5 miles should move to a safer location.",
+        status: "Waiting for approval",
+        areas: [
+          "Santa Claus Village, Rovaniemi A",
+          "Santa Claus Village, Rovaniemi D"
+        ]
+      });
+
+      // make all responses have an extra item
+      responseObj[updateKey] = getPartial(partialData);
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // re-select in case nodes in partialsInPage have changed
+      partialsInPage = document.querySelectorAll('.ajax-block-container');
+
+      // check the classes are still there
+      expect(partialsInPage[0].querySelectorAll('.file-list h2')[0].classList.contains('js-child-has-focus')).toBe(true);
+      expect(partialsInPage[1].querySelectorAll('.file-list h2')[0].classList.contains('js-2nd-child-has-focus')).toBe(true);
 
     });
 

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -491,6 +491,10 @@ describe('Update content', () => {
       expect(partialsInPage[0].querySelectorAll('.file-list h2')[0].classList.contains('js-child-has-focus')).toBe(true);
       expect(partialsInPage[1].querySelectorAll('.file-list h2')[0].classList.contains('js-2nd-child-has-focus')).toBe(true);
 
+      // check each heading only has the classes assigned to it before updates occurred
+      expect(partialsInPage[0].querySelectorAll('.file-list h2')[0].classList.contains('js-2nd-child-has-focus')).toBe(false);
+      expect(partialsInPage[1].querySelectorAll('.file-list h2')[0].classList.contains('js-child-has-focus')).toBe(false);
+
     });
 
   });

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -50,56 +50,426 @@ describe('Update content', () => {
   let HTMLString;
   let initialHTMLString;
 
-  beforeEach(() => {
+  describe('When updating the contents of DOM nodes', () => {
 
-    // store HTML in string to allow use in AJAX responses
-    HTMLString = `
-      <div class="bottom-gutter ajax-block-container">
-        <ul role="tablist" class="pill">
-          <li aria-selected="true" role="tab">
-            <div class="pill-selected-item" tabindex="0">
-              <div class="big-number-smaller">
-                <div class="big-number-number">0</div>
+    beforeEach(() => {
+
+      // store HTML in string to allow use in AJAX responses
+      HTMLString = `
+        <div class="bottom-gutter ajax-block-container">
+          <ul role="tablist" class="pill">
+            <li aria-selected="true" role="tab">
+              <div class="pill-selected-item" tabindex="0">
+                <div class="big-number-smaller">
+                  <div class="big-number-number">0</div>
+                </div>
+                <div class="pill-label">total</div>
               </div>
-              <div class="pill-label">total</div>
+            </li>
+            <li aria-selected="false" role="tab">
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=sending">
+                <div class="big-number-smaller">
+                  <div class="big-number-number">0</div>
+                </div>
+                <div class="pill-label">sending</div>
+              </a>
+            </li>
+            <li aria-selected="false" role="tab">
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=delivered">
+                <div class="big-number-smaller">
+                  <div class="big-number-number">0</div>
+                </div>
+                <div class="pill-label">delivered</div>
+              </a>
+            </li>
+            <li aria-selected="false" role="tab">
+              <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=failed">
+                <div class="big-number-smaller">
+                  <div class="big-number-number">0</div>
+                </div>
+                <div class="pill-label">failed</div>
+              </a>
+            </li>
+          </ul>
+        </div>`;
+
+
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+                          ${HTMLString}
+                          </div>`;
+
+      document.body.innerHTML = initialHTMLString;
+
+      // default the response to match the content inside div[data-module]
+      responseObj[updateKey] = HTMLString;
+
+    });
+
+    test("It should make requests to the URL specified in the data-resource attribute", () => {
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      expect($.ajax.mock.calls[0][0]).toEqual(resourceURL);
+
+    });
+
+    test("If the response contains no changes, the DOM should stay the same", () => {
+
+      // send the done callback a response with updates included
+      responseObj[updateKey] = HTMLString;
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // check a sample DOM node is unchanged
+      expect(document.querySelectorAll('.big-number-number')[0].textContent.trim()).toEqual("0");
+
+    });
+
+    test("If the response contains changes, it should update the DOM with them", () => {
+
+      // send the done callback a response with updates included
+      responseObj[updateKey] = HTMLString.replace(/<div class="big-number-number">0<\/div>{1}/, '<div class="big-number-number">1</div>');
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // check the right DOM node is updated
+      expect(document.querySelectorAll('.big-number-number')[0].textContent.trim()).toEqual("1");
+
+    });
+
+    describe("By default", () => {
+
+      beforeEach(() => {
+
+        // start the module
+        window.GOVUK.modules.start();
+
+      });
+
+      test("It should use the GET HTTP method", () => {
+
+        jest.advanceTimersByTime(2000);
+        expect($.ajax.mock.calls[0][1].method).toEqual('get');
+
+      });
+
+      test("It shouldn't send any data as part of the requests", () => {
+
+        jest.advanceTimersByTime(2000);
+        expect($.ajax.mock.calls[0][1].data).toEqual({});
+
+      });
+
+      test("It should request updates with a dynamic interval", () => {
+
+        // First call doesn’t happen in the first 2000ms
+        jest.advanceTimersByTime(1999);
+        expect($.ajax).toHaveBeenCalledTimes(0);
+
+        // But it happens after 2000ms by default
+        jest.advanceTimersByTime(1);
+        expect($.ajax).toHaveBeenCalledTimes(1);
+
+        // It took the server 1000ms to respond to the first call so we
+        // will back off – the next call shouldn’t happen in the next 6904ms
+        jest.advanceTimersByTime(6904);
+        expect($.ajax).toHaveBeenCalledTimes(1);
+
+        // But it should happen after 6905ms
+        jest.advanceTimersByTime(1);
+        expect($.ajax).toHaveBeenCalledTimes(2);
+
+      });
+
+      each([
+        [1000, 0],
+        [1500, 100],
+        [4590, 500],
+        [6905, 1000],
+        [24000, 10000],
+      ]).test('It calculates a delay of %dms if the API responds in %dms', (waitTime, responseTime) => {
+          expect(
+            window.GOVUK.Modules.UpdateContent.calculateBackoff(responseTime)
+          ).toBe(
+            waitTime
+          );
+      });
+
+    });
+
+    describe("If a form is used as a source for data, referenced in the data-form attribute", () => {
+
+      beforeEach(() => {
+
+        document.body.innerHTML += `
+          <form method="post" id="service">
+            <input type="hidden" name="serviceName" value="Buckhurst surgery" />
+            <input type="hidden" name="serviceNumber" value="${serviceNumber}" />
+          </form>`;
+
+        document.querySelector('[data-module=update-content]').setAttribute('data-form', 'service');
+
+        // start the module
+        window.GOVUK.modules.start();
+
+      });
+
+      test("requests should use the same HTTP method as the form", () => {
+
+        jest.advanceTimersByTime(2000);
+        expect($.ajax.mock.calls[0][1].method).toEqual('post');
+
+      })
+
+      test("requests should use the data from the form", () => {
+
+        jest.advanceTimersByTime(2000);
+        expect($.ajax.mock.calls[0][1].data).toEqual(helpers.getFormDataFromPairs([
+          ['serviceName', 'Buckhurst surgery'],
+          ['serviceNumber', serviceNumber]
+        ]));
+
+      })
+
+    });
+
+  });
+
+  describe("When adding or removing DOM nodes", () => {
+    var getItemHTMLString = content => {
+      var areas = '';
+
+      content.areas.forEach(area =>
+        areas += "\n" + `<li class="area-list-item area-list-item--unremoveable area-list-item--smaller">${area}</li>`
+      );
+
+      return `
+        <div class="keyline-block">
+          <div class="file-list govuk-!-margin-bottom-2">
+            <h2>
+              <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="/services/7597847f-ad8e-4600-8faf-c42a647d8dee/current-alerts/b9e53cda-54f9-47bc-9fb2-b78a11eda6a9">${content.title}</a>
+            </h2>
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-one-half">
+                <span class="file-list-hint-large govuk-!-margin-bottom-2">
+                  ${content.hint}
+                </span>
+              </div>
+              <div class="govuk-grid-column-one-half file-list-status">
+                <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
+                  ${content.status}
+                </p>
+              </div>
             </div>
-          </li>
-          <li aria-selected="false" role="tab">
-            <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=sending">
-              <div class="big-number-smaller">
-                <div class="big-number-number">0</div>
-              </div>
-              <div class="pill-label">sending</div>
-            </a>
-          </li>
-          <li aria-selected="false" role="tab">
-            <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=delivered">
-              <div class="big-number-smaller">
-                <div class="big-number-number">0</div>
-              </div>
-              <div class="pill-label">delivered</div>
-            </a>
-          </li>
-          <li aria-selected="false" role="tab">
-            <a class="govuk-link govuk-link--no-visited-state" href="/services/6658542f-0cad-491f-bec8-ab8457700ead/notifications/email?status=failed">
-              <div class="big-number-smaller">
-                <div class="big-number-number">0</div>
-              </div>
-              <div class="pill-label">failed</div>
-            </a>
-          </li>
-        </ul>
-      </div>`;
+            <ul class="area-list">
+              ${areas}
+            </ul>
+          </div>
+        </div>`;
+    };
 
+    var getHTMLString = items => {
 
-    initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
-                        ${HTMLString}
-                        </div>`;
+      var itemsHTMLString = '';
 
-    document.body.innerHTML = initialHTMLString;
+      items.forEach(item => itemsHTMLString += "\n" + getItemHTMLString(item));
 
-    // default the response to match the content inside div[data-module]
-    responseObj[updateKey] = HTMLString;
+      return `<div class="ajax-block-container">
+                ${itemsHTMLString};
+                <div class="keyline-block"></div>
+              </div>`;
+
+    };
+
+    test("If the response contains no changes, the DOM should stay the same", () => {
+
+      // store HTML in string to allow use in AJAX responses
+      HTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        }
+      ]);
+
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+                          ${HTMLString}
+                          </div>`;
+
+      document.body.innerHTML = initialHTMLString;
+
+      // make the response have an extra item
+      responseObj[updateKey] = HTMLString;
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // check it has the same number of items
+      expect(document.querySelectorAll('.file-list').length).toEqual(1);
+      expect(document.querySelectorAll('.file-list h2 a')[0].textContent.trim()).toEqual("Gas leak");
+
+    });
+
+    test("If the response adds a node, the DOM should contain that node", () => {
+
+      // store HTML in string to allow use in AJAX responses
+      HTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        }
+      ]);
+
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+                          ${HTMLString}
+                          </div>`;
+
+      document.body.innerHTML = initialHTMLString;
+
+      var updatedHTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        },
+        {
+          title: "Reservoir flooding template",
+          hint: "The local reservoir has flooded. All people within 5 miles should move to a safer location.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi A",
+            "Santa Claus Village, Rovaniemi D"
+          ]
+        }
+      ]);
+
+      // make the response have an extra item
+      responseObj[updateKey] = updatedHTMLString;
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // check the node has been added
+      expect(document.querySelectorAll('.file-list').length).toEqual(2);
+      expect(document.querySelectorAll('.file-list h2 a')[0].textContent.trim()).toEqual("Gas leak");
+      expect(document.querySelectorAll('.file-list h2 a')[1].textContent.trim()).toEqual("Reservoir flooding template");
+
+    });
+
+    test("If the response removes a node, the DOM should not contain that node", () => {
+
+      // store HTML in string to allow use in AJAX responses
+      HTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        },
+        {
+          title: "Reservoir flooding template",
+          hint: "The local reservoir has flooded. All people within 5 miles should move to a safer location.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi A",
+            "Santa Claus Village, Rovaniemi D"
+          ]
+        }
+      ]);
+
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+                          ${HTMLString}
+                          </div>`;
+
+      document.body.innerHTML = initialHTMLString;
+
+      var updatedHTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        }
+      ]);
+
+      // default the response to match the content inside div[data-module]
+      responseObj[updateKey] = updatedHTMLString;
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // check the node has been removed
+      expect(document.querySelectorAll('.file-list').length).toEqual(1);
+      expect(document.querySelectorAll('.file-list h2 a')[0].textContent.trim()).toEqual("Gas leak");
+
+    });
+
+    test("If other scripts have added classes to the DOM, they should persist through updates", () => {
+
+      // store HTML in string to allow use in AJAX responses
+      HTMLString = getHTMLString([
+        {
+          title: "Gas leak",
+          hint: "There's a gas leak in the local area. Residents should vacate until further notice.",
+          status: "Waiting for approval",
+          areas: [
+            "Santa Claus Village, Rovaniemi B",
+            "Santa Claus Village, Rovaniemi C"
+          ]
+        }
+      ]);
+
+      initialHTMLString = `<div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}" aria-live="polite">
+                          ${HTMLString}
+                          </div>`;
+
+      document.body.innerHTML = initialHTMLString;
+
+      // mark classes to persist on the partial
+      document.querySelector('.ajax-block-container').setAttribute('data-classes-to-persist', 'js-child-has-focus');
+
+      // Add class to indicate focus state of link on parent heading
+      document.querySelectorAll('.file-list h2')[0].classList.add('js-child-has-focus');
+
+      // make the response match the initial HTML to emulate a response with no changes
+      responseObj[updateKey] = HTMLString;
+
+      // start the module
+      window.GOVUK.modules.start();
+      jest.advanceTimersByTime(2000);
+
+      // check the class is still there
+      expect(document.querySelectorAll('.file-list h2')[0].classList.contains('js-child-has-focus')).toBe(true);
+
+    });
 
   });
 
@@ -112,140 +482,6 @@ describe('Update content', () => {
 
     // ensure any timers set by continually starting the module are cleared
     jest.clearAllTimers();
-
-  });
-
-  test("It should make requests to the URL specified in the data-resource attribute", () => {
-
-    // start the module
-    window.GOVUK.modules.start();
-    jest.advanceTimersByTime(2000);
-
-    expect($.ajax.mock.calls[0][0]).toEqual(resourceURL);
-
-  });
-
-  test("If the response contains no changes, the DOM should stay the same", () => {
-
-    // send the done callback a response with updates included
-    responseObj[updateKey] = HTMLString;
-
-    // start the module
-    window.GOVUK.modules.start();
-    jest.advanceTimersByTime(2000);
-
-    // check the right DOM node is updated
-    expect(document.querySelectorAll('.big-number-number')[0].textContent.trim()).toEqual("0");
-
-  });
-
-  test("If the response contains changes, it should update the DOM with them", () => {
-
-    // send the done callback a response with updates included
-    responseObj[updateKey] = HTMLString.replace(/<div class="big-number-number">0<\/div>{1}/, '<div class="big-number-number">1</div>');
-
-    // start the module
-    window.GOVUK.modules.start();
-    jest.advanceTimersByTime(2000);
-
-    // check the right DOM node is updated
-    expect(document.querySelectorAll('.big-number-number')[0].textContent.trim()).toEqual("1");
-
-  });
-
-  describe("By default", () => {
-
-    beforeEach(() => {
-
-      // start the module
-      window.GOVUK.modules.start();
-
-    });
-
-    test("It should use the GET HTTP method", () => {
-
-      jest.advanceTimersByTime(2000);
-      expect($.ajax.mock.calls[0][1].method).toEqual('get');
-
-    });
-
-    test("It shouldn't send any data as part of the requests", () => {
-
-      jest.advanceTimersByTime(2000);
-      expect($.ajax.mock.calls[0][1].data).toEqual({});
-
-    });
-
-    test("It should request updates with a dynamic interval", () => {
-
-      // First call doesn’t happen in the first 2000ms
-      jest.advanceTimersByTime(1999);
-      expect($.ajax).toHaveBeenCalledTimes(0);
-
-      // But it happens after 2000ms by default
-      jest.advanceTimersByTime(1);
-      expect($.ajax).toHaveBeenCalledTimes(1);
-
-      // It took the server 1000ms to respond to the first call so we
-      // will back off – the next call shouldn’t happen in the next 6904ms
-      jest.advanceTimersByTime(6904);
-      expect($.ajax).toHaveBeenCalledTimes(1);
-
-      // But it should happen after 6905ms
-      jest.advanceTimersByTime(1);
-      expect($.ajax).toHaveBeenCalledTimes(2);
-
-    });
-
-    each([
-      [1000, 0],
-      [1500, 100],
-      [4590, 500],
-      [6905, 1000],
-      [24000, 10000],
-    ]).test('It calculates a delay of %dms if the API responds in %dms', (waitTime, responseTime) => {
-        expect(
-          window.GOVUK.Modules.UpdateContent.calculateBackoff(responseTime)
-        ).toBe(
-          waitTime
-        );
-    });
-
-  });
-
-  describe("If a form is used as a source for data, referenced in the data-form attribute", () => {
-
-    beforeEach(() => {
-
-      document.body.innerHTML += `
-        <form method="post" id="service">
-          <input type="hidden" name="serviceName" value="Buckhurst surgery" />
-          <input type="hidden" name="serviceNumber" value="${serviceNumber}" />
-        </form>`;
-
-      document.querySelector('[data-module=update-content]').setAttribute('data-form', 'service');
-
-      // start the module
-      window.GOVUK.modules.start();
-
-    });
-
-    test("requests should use the same HTTP method as the form", () => {
-
-      jest.advanceTimersByTime(2000);
-      expect($.ajax.mock.calls[0][1].method).toEqual('post');
-
-    })
-
-    test("requests should use the data from the form", () => {
-
-      jest.advanceTimersByTime(2000);
-      expect($.ajax.mock.calls[0][1].data).toEqual(helpers.getFormDataFromPairs([
-        ['serviceName', 'Buckhurst surgery'],
-        ['serviceNumber', serviceNumber]
-      ]));
-
-    })
 
   });
 


### PR DESCRIPTION
Fix for the large links on the current/past/rejected alerts pages, which currently overlap content below them:

<img width="743" alt="current_alerts_before" src="https://user-images.githubusercontent.com/87140/153191549-9544a5d2-78c1-4bfb-87d1-f8c4be6644a2.png">

Part of https://www.pivotaltracker.com/story/show/180011155.

This uses JavaScript to apply styles that make the content poke through the overlap and give them the right colour contrast.

<img width="731" alt="current_alerts_after_with_js" src="https://user-images.githubusercontent.com/87140/153191594-bd6ce638-7b19-4e28-824e-0489f588d70b.png">

## What caused the bug

We have CSS for this style of focus (see the templates page for an example) but the version on the current/past/rejected alerts pages has a slightly different HTML which means this CSS cannot target it.

These kind of links are normally made up of this kind of HTML:

```html
<li>
  <a>Title of item</a>
  <span>Description of it / more info about it</span>
</li>
```

So we can use a CSS selector like this to target the `<span>` when the link is focused:

`a:focus + span` (match a 'span' which is the next sibling of a focused 'a').

But these ones are more like:

```html
<div>
  <h2>
    <a>Title of item</a>
  </h2>
  <span>Description of it / more info about it</span>
  <span>Status of it</span>
</div>
```

Because the `<a>` is (correctly) wrapped in a `<h2>`, we can't target the `<span>`s as its siblings so our selector doesn't work. As far as I know, there's also no way you can currently write a selector for this HTML*. So we have to add a class to the `<h2>` using JS.

*The [:has() pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) will let us do this but is only supported in Safari tech preview at the moment.

## Problems with using JS on content that is updated via AJAX

Unfortunately it's not as simple as that because the `<h2>` is part of a block of HTML controlled by [the AJAXy code](https://github.com/alphagov/notifications-admin/blob/master/app/assets/javascripts/updateContent.js) that sync's it with HTML sent from the server-side app. This means any classes added to it will be wiped by the sync'ing because they don't exist in the HTML from the server-side app.

## The proposed solution

So this proposes the following solution:
- changes to the AJAXy code so it allows **some** classes to be ignored from comparisons with the server-side HTML and to persist through any updates
- some JS, that runs when the links are focused and unfocused, to add/remove a class on the `<h2>`

## Notes for reviewers

These changes are intended to be read commit-by-commit. The commits have more detail on the changes and the sequence is meant to make things a bit more digestible.