### PR TITLE
Show link to service history page

### DIFF
--- a/app/navigation.py
+++ b/app/navigation.py
@@ -282,6 +282,9 @@ class MainNavigation(Navigation):
             'guest_list',
             'old_guest_list',
         },
+        'history': {
+            'history'
+        }
     }
 
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -32,6 +32,9 @@
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
+  {% if current_user.platform_admin %}
+    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('history') }}" href="{{ url_for('.history', service_id=current_service.id) }}">Service history</a></li>
+  {% endif %}
   </ul>
 </nav>
 {% endif %}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -538,6 +538,22 @@ def test_navigation_for_services_with_broadcast_permission(
     ]
 
 
+def test_navigation_for_platform_admins(
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    mock_get_api_keys,
+    platform_admin_user,
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
+
+    assert '/services/{}/history'.format(SERVICE_ONE_ID) in [
+        a['href'] for a in page.select('.navigation a')
+    ]
+
+
 def test_caseworkers_get_caseworking_navigation(
     client_request,
     mocker,


### PR DESCRIPTION
This makes the feature more visible to platform admins, although a
service manager can technically view the page as well.

I toyed with putting the link at the bottom of the settings page,
but this was a bit easier than untangling the "if" blocks there.

## Screenshot

<img width="1010" alt="Screenshot 2022-02-16 at 13 05 28" src="https://user-images.githubusercontent.com/9029009/154270621-086d21c0-855f-4d6c-bbf7-34eb98a119e0.png">