### PR TITLE
Fix 500 error due to inconsistent recipient check

### DIFF
--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3969,12 +3969,18 @@ def test_send_notification_clears_session(
         assert 'placeholders' not in session
 
 
+@pytest.mark.parametrize('session_data', [
+    {'placeholders': {'a': 'b'}},  # missing recipient
+    {'recipient': '123'},  # missing placeholders
+    {'placeholders': {}, 'recipient': ''},  # missing address
+])
 def test_send_notification_redirects_if_missing_data(
     client_request,
     fake_uuid,
+    session_data,
 ):
     with client_request.session_transaction() as session:
-        session['placeholders'] = {'a': 'b'}
+        session.update(session_data)
 
     client_request.post(
         'main.send_notification',


### PR DESCRIPTION
This strengthens the initial check of what's in the session to make
sure it contains some kind of recipient. Without this, we get:

    Traceback (most recent call last):
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
        rv = self.dispatch_request()
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
        return self.view_functions[rule.endpoint](**req.view_args)
      File "/home/vcap/app/app/utils/user.py", line 26, in wrap_func
        return func(*args, **kwargs)
      File "/home/vcap/app/app/main/views/send.py", line 1041, in send_notification
        recipient=session['recipient'] or InsensitiveDict(session['placeholders'])['address line 1'],
      File "/home/vcap/deps/0/python/lib/python3.9/site-packages/notifications_utils/insensitive_dict.py", line 41, in __getitem__
        return super().__getitem__(self.make_key(key))
    KeyError: 'addressline1'

I'm not sure how to reproduce this, but this should at least give
the user a better experience, instead of a 500 page.