### PR TITLE
Catch error if letter does not exist on send

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -270,8 +270,10 @@ def uploaded_letter_preview(service_id, file_id):
     except LetterNotFoundError as e:
         current_app.logger.warning(e)
 
-        # if the file's not there, it's probably because we've already created the notification and the letter has been
-        # moved to the normal letters-pdf bucket. So lets just bounce out to the notification page
+        # If the file is missing it could be because this is a duplicate
+        # request, the notification already exists and the file has been
+        # moved to a different bucket. Note that the ID of a precompiled
+        # notification is always set to the file_id.
         return redirect(url_for(
             '.view_notification',
             service_id=service_id,
@@ -356,8 +358,10 @@ def send_uploaded_letter(service_id, file_id):
     except LetterNotFoundError as e:
         current_app.logger.error(e)
 
-        # if the file's not there, it's probably because we've already created the notification and the letter has been
-        # moved to the normal letters-pdf bucket. So lets just bounce out to the notification page
+        # If the file is missing it could be because this is a duplicate
+        # request, the notification already exists and the file has been
+        # moved to a different bucket. Note that the ID of a precompiled
+        # notification is always set to the file_id.
         return redirect(url_for(
             '.view_notification',
             service_id=service_id,

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -9,6 +9,7 @@ freezegun==1.1.0
 flake8==4.0.1
 flake8-bugbear==21.9.2
 flake8-print==4.0.0
+moto==3.0.4
 requests-mock==1.9.3
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.7.0


### PR DESCRIPTION
This repeats the pattern we already have for previewing a letter,
where we assume the error is because the notification has already
been sent and redirect the user to see it.

I've improved the original pattern a bit:

- I've DRYed-up the low-level boto code and moved the error handler
there so it can be reused.

- I've introduced a custom exception, which the calling code can
choose to log.

- I've introduced the moto library, which we use elsewhere, to make
it easier to test S3 code.

I've used an error level log when sending a notification - now that
we have a more descriptive log, we can verify the assumption is true
and then make an informed decision to downgrade the log.

In future we may want to merge this handler with the similar code
in utils [1], but we'll need to be careful as the utils handler is
superficial - it doesn't check the reason for the error.

[1]: https://github.com/alphagov/notifications-utils/blob/bce0f4e596af9451212d0026c8ecc27b636eed38/notifications_utils/s3.py#L52