### PR TITLE
Allow template changes if Redis is down

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -352,10 +352,10 @@ def platform_admin_returned_letters():
 
         try:
             letter_jobs_client.submit_returned_letters(references)
-            redis_client.delete_cache_keys_by_pattern(
+            redis_client.delete_by_pattern(
                 'service-????????-????-????-????-????????????-returned-letters-statistics'
             )
-            redis_client.delete_cache_keys_by_pattern(
+            redis_client.delete_by_pattern(
                 'service-????????-????-????-????-????????????-returned-letters-summary'
             )
         except HTTPError as error:
@@ -431,7 +431,7 @@ def clear_cache():
         patterns = list(itertools.chain(*groups))
 
         num_deleted = sum(
-            redis_client.delete_cache_keys_by_pattern(pattern)
+            redis_client.delete_by_pattern(pattern)
             for pattern in patterns
         )
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -216,8 +216,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             })
         data = _attach_current_user(data)
         endpoint = "/service/{0}/template/{1}".format(service_id, id_)
+        ret = self.post(endpoint, data)
         self._delete_template_cache_for_service(service_id)
-        return self.post(endpoint, data)
+        return ret
 
     @cache.delete('service-{service_id}-templates')
     def redact_service_template(self, service_id, id_):
@@ -311,8 +312,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             'archived': True
         }
         data = _attach_current_user(data)
+        ret = self.post(endpoint, data=data)
         self._delete_template_cache_for_service(service_id)
-        return self.post(endpoint, data=data)
+        return ret
 
     # Temp access of service history data. Includes service and api key history
     def get_service_history(self, service_id):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -193,7 +193,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('service-{service_id}-template-{id_}-versions')
     def update_service_template(
         self, id_, name, type_, content, service_id, subject=None, process_type=None
     ):
@@ -221,7 +220,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('service-{service_id}-template-{id_}-versions')
     def redact_service_template(self, service_id, id_):
         ret = self.post(
             "/service/{}/template/{}".format(service_id, id_),
@@ -233,7 +231,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return ret
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('service-{service_id}-template-{template_id}-versions')
     def update_service_template_sender(self, service_id, template_id, reply_to):
         data = {
             'reply_to': reply_to,
@@ -247,7 +244,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return ret
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('service-{service_id}-template-{template_id}-versions')
     def update_service_template_postage(self, service_id, template_id, postage):
         ret = self.post(
             "/service/{0}/template/{1}".format(service_id, template_id),
@@ -306,7 +302,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         ])
 
     @cache.delete('service-{service_id}-templates')
-    @cache.delete('service-{service_id}-template-{template_id}-versions')
     def delete_service_template(self, service_id, template_id):
         """
         Set a service template's archived flag to True

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -9,7 +9,7 @@ from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
 class ServiceAPIClient(NotifyAdminAPIClient):
 
     def _delete_template_cache_for_service(self, service_id):
-        redis_client.delete_cache_keys_by_pattern(f"service-{service_id}-template-*")
+        redis_client.delete_by_pattern(f"service-{service_id}-template-*")
 
     @cache.delete('user-{user_id}')
     def create_service(

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ pyproj==3.2.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.0.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ pyproj==3.2.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,7 +121,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,7 +121,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.0.0
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -698,7 +698,7 @@ def test_platform_admin_submit_returned_letters(
     )
 
     mock_client.assert_called_once_with(['REF1', 'REF2'])
-    assert redis.delete_cache_keys_by_pattern.call_args_list == [
+    assert redis.delete_by_pattern.call_args_list == [
         call('service-????????-????-????-????-????????????-returned-letters-statistics'),
         call('service-????????-????-????-????-????????????-returned-letters-summary'),
     ]
@@ -734,7 +734,7 @@ def test_clear_cache_shows_form(
 
     page = client_request.get('main.clear_cache')
 
-    assert not redis.delete_cache_keys_by_pattern.called
+    assert not redis.delete_by_pattern.called
     radios = {el['value'] for el in page.select('input[type=checkbox]')}
 
     assert radios == {
@@ -780,7 +780,7 @@ def test_clear_cache_submits_and_tells_you_how_many_things_were_deleted(
     expected_confirmation,
 ):
     redis = mocker.patch('app.main.views.platform_admin.redis_client')
-    redis.delete_cache_keys_by_pattern.return_value = 2
+    redis.delete_by_pattern.return_value = 2
     client_request.login(platform_admin_user)
 
     page = client_request.post(
@@ -789,7 +789,7 @@ def test_clear_cache_submits_and_tells_you_how_many_things_were_deleted(
         _expected_status=200
     )
 
-    assert redis.delete_cache_keys_by_pattern.call_args_list == expected_calls
+    assert redis.delete_by_pattern.call_args_list == expected_calls
 
     flash_banner = page.find('div', class_='banner-default')
     assert flash_banner.text.strip() == expected_confirmation
@@ -806,7 +806,7 @@ def test_clear_cache_requires_option(
     page = client_request.post('main.clear_cache', _data={}, _expected_status=200)
 
     assert normalize_spaces(page.find('span', class_='govuk-error-message').text) == 'Error: Select at least one option'
-    assert not redis.delete_cache_keys_by_pattern.called
+    assert not redis.delete_by_pattern.called
 
 
 def test_reports_page(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4135,7 +4135,7 @@ def test_archive_service_after_confirm(
     mock_api = mocker.patch('app.service_api_client.post')
     mock_event = mocker.patch('app.main.views.service_settings.create_archive_service_event')
     redis_delete_mock = mocker.patch('app.notify_client.service_api_client.redis_client.delete')
-    mocker.patch('app.notify_client.service_api_client.redis_client.delete_cache_keys_by_pattern')
+    mocker.patch('app.notify_client.service_api_client.redis_client.delete_by_pattern')
 
     client_request.login(user)
     page = client_request.post(

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -12,7 +12,7 @@ FAKE_TEMPLATE_ID = uuid4()
 
 def test_client_posts_archived_true_when_deleting_template(mocker):
     mocker.patch('app.notify_client.current_user', id='1')
-    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_cache_keys_by_pattern')
+    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_by_pattern')
     expected_data = {
         'archived': True,
         'created_by': '1'
@@ -467,7 +467,7 @@ def test_deletes_caches_when_modifying_templates(
 ):
     mocker.patch('app.notify_client.current_user', id='1')
     mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
-    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_cache_keys_by_pattern')
+    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_by_pattern')
     mock_request = mocker.patch('notifications_python_client.base.BaseAPIClient.request')
 
     getattr(service_api_client, method)(*extra_args)
@@ -482,7 +482,7 @@ def test_deletes_caches_when_modifying_templates(
 
 def test_deletes_cached_users_when_archiving_service(mocker, mock_get_service_templates):
     mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
-    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_cache_keys_by_pattern')
+    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_by_pattern')
 
     mocker.patch('notifications_python_client.base.BaseAPIClient.request', return_value={'data': ""})
 
@@ -542,7 +542,7 @@ def test_client_doesnt_delete_service_template_cache_when_none_exist(
     mocker.patch('app.notify_client.current_user', id='1')
     mocker.patch('notifications_python_client.base.BaseAPIClient.request')
     mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
-    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_cache_keys_by_pattern')
+    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_by_pattern')
 
     service_api_client.update_reply_to_email_address(SERVICE_ONE_ID, uuid4(), 'foo@bar.com')
 
@@ -560,7 +560,7 @@ def test_client_deletes_service_template_cache_when_service_is_updated(
     mocker.patch('app.notify_client.current_user', id='1')
     mocker.patch('notifications_python_client.base.BaseAPIClient.request')
     mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
-    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_cache_keys_by_pattern')
+    mock_redis_delete_by_pattern = mocker.patch('app.extensions.RedisClient.delete_by_pattern')
 
     service_api_client.update_reply_to_email_address(SERVICE_ONE_ID, uuid4(), 'foo@bar.com')
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -433,23 +433,18 @@ def test_deletes_service_cache(
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template', [FAKE_TEMPLATE_ID, 'foo', 'sms', 'bar', SERVICE_ONE_ID], [
-        'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('redact_service_template', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID], [
-        'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template_sender', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 'foo'], [
-        'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('update_service_template_postage', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 'first'], [
-        'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('delete_service_template', [SERVICE_ONE_ID, FAKE_TEMPLATE_ID], [
-        'service-{}-template-{}-versions'.format(SERVICE_ONE_ID, FAKE_TEMPLATE_ID),
         'service-{}-templates'.format(SERVICE_ONE_ID),
     ]),
     ('archive_service', [SERVICE_ONE_ID, []], [


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180663519

This updates the version of -utils, which provides this
new behaviour. See the screenshots for the main effect.

I've also included some extra commits to tidy up how we
manage the cache in service_api_client.py. The last commit
is an optional suggestion - let me know what you think.

## Before

Users can't change templates - inconsistent.

<img width="1276" alt="Screenshot 2022-02-22 at 12 39 53" src="https://user-images.githubusercontent.com/9029009/155134179-af438640-2151-408a-89cd-982dc256ce62.png">

## After

This is consistent with the behaviour for all other cached items e.g. services, broadcasts.

| 1. Added "redis offline" to template | 2. Refresh after Redis returns | 3. Refresh after cache clear |
| - | - | - |
| <img width="791" alt="Screenshot 2022-02-22 at 12 35 03" src="https://user-images.githubusercontent.com/9029009/155133491-1d212d88-5003-45bf-94ea-4105bf7b9187.png"> | <img width="801" alt="Screenshot 2022-02-22 at 12 35 13" src="https://user-images.githubusercontent.com/9029009/155133492-70972bab-94dc-44d3-b03d-e277802db53f.png"> | <img width="809" alt="Screenshot 2022-02-22 at 12 36 34" src="https://user-images.githubusercontent.com/9029009/155133872-0328bdff-6359-4d01-83e2-17532223fa67.png">

