### PR TITLE
Do not verify sms for pending users with email auth

### DIFF
--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -63,6 +63,13 @@ def verify_email(token):
         return redirect(url_for('main.sign_in'))
 
     session['user_details'] = {"email": user.email_address, "id": user.id}
+
+    if user.auth_type == 'email_auth':
+        try:
+            return activate_user(user.id)
+        finally:
+            session.pop('user_details', None)
+
     user.send_verify_code()
     return redirect(url_for('main.verify'))
 

--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -64,7 +64,7 @@ def verify_email(token):
 
     session['user_details'] = {"email": user.email_address, "id": user.id}
 
-    if user.auth_type == 'email_auth':
+    if user.email_auth:
         try:
             return activate_user(user.id)
         finally:

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from datetime import datetime
 from unittest.mock import Mock
 
 from flask import session as flask_session
@@ -9,6 +8,7 @@ from itsdangerous import SignatureExpired
 from notifications_python_client.errors import HTTPError
 
 from app.main.views.verify import activate_user
+from tests.conftest import create_user
 
 
 def test_should_return_verify_template(
@@ -110,12 +110,6 @@ def test_verify_email_redirects_to_verify_if_token_valid(
     token_data = {"user_id": api_user_pending['id'], "secret_code": 'UNUSED'}
     mocker.patch('app.main.views.verify.check_token', return_value=json.dumps(token_data))
 
-    with client_request.session_transaction() as session:
-        session['user_details'] = {
-            'email_address': api_user_pending['email_address'],
-            'id': api_user_pending['id'],
-        }
-
     client_request.get(
         'main.verify_email',
         token='notreal',
@@ -137,34 +131,11 @@ def test_verify_email_doesnt_verify_sms_if_user_on_email_auth(
     mock_activate_user,
     fake_uuid,
 ):
-    pending_user_with_email_auth = {
-        'id': fake_uuid,
-        'name': 'Test User',
-        'password': 'somepassword',
-        'email_address': 'test@user.gov.uk',
-        'mobile_number': '07700 900762',
-        'state': 'pending',
-        'failed_login_count': 0,
-        'permissions': {},
-        'platform_admin': False,
-        'auth_type': 'email_auth',
-        'password_changed_at': str(datetime.utcnow()),
-        'services': [],
-        'organisations': [],
-        'current_session_id': None,
-        'logged_in_at': None,
-        'email_access_validated_at': None,
-        'can_use_webauthn': False,
-    }
+    pending_user_with_email_auth = create_user(auth_type='email_auth', state='pending', id=fake_uuid)
+
     mocker.patch('app.user_api_client.get_user', return_value=pending_user_with_email_auth)
     token_data = {"user_id": pending_user_with_email_auth['id'], "secret_code": 'UNUSED'}
     mocker.patch('app.main.views.verify.check_token', return_value=json.dumps(token_data))
-
-    with client_request.session_transaction() as session:
-        session['user_details'] = {
-            'email_address': pending_user_with_email_auth['email_address'],
-            'id': pending_user_with_email_auth['id'],
-        }
 
     client_request.get(
         'main.verify_email',


### PR DESCRIPTION
This is to fix a bug where a user creates an account but doesn't complete registration, then they are invited to a service that changes their auth to email_auth, and then when they try to complete registration they are still asked for sms code.

It should save users some pain, and reduce number of support tickets.

This is for this bug ticket: https://www.pivotaltracker.com/story/show/180597596