### PR TITLE
Allow platform admins to change user auth in the UI

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1015,6 +1015,16 @@ def filter_by_broadcast_permissions(valuelist):
         return [entry for entry in valuelist if any(entry in option for option in broadcast_permission_options)]
 
 
+class AuthTypeForm(StripWhitespaceForm):
+    auth_type = GovukRadiosField(
+        'Sign in using',
+        choices=[
+            ('sms_auth', 'Text message code'),
+            ('email_auth', 'Email link'),
+        ]
+    )
+
+
 class BasePermissionsForm(StripWhitespaceForm):
     def __init__(self, all_template_folders=None, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -79,6 +79,7 @@ class HeaderNavigation(Navigation):
         },
         'platform-admin': {
             'archive_user',
+            'change_user_auth',
             'clear_cache',
             'create_email_branding',
             'create_letter_branding',

--- a/app/templates/views/find-users/auth_type.html
+++ b/app/templates/views/find-users/auth_type.html
@@ -1,0 +1,28 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
+{% block per_page_title %}
+  Set auth type for {{ user.name }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for('main.user_information', user_id=user.id) }) }}
+{% endblock %}
+
+{% block platform_admin_content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-five-sixths">
+      {{ page_header('Set auth type for ' + user.name) }}
+
+      {% call form_wrapper() %}
+        {{ form.auth_type }}
+        {{ page_footer('Save') }}
+      {% endcall %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -13,6 +13,7 @@
       </h1>
       <p class="govuk-body">{{ user.email_address }}</p>
       <p class="{{ '' if user.mobile_number else 'hint' }}">{{ user.mobile_number or 'No mobile number'}}</p>
+
       <h2 class="heading-medium">Live services</h2>
       <nav class="browse-list">
         {% if user.live_services %}
@@ -45,6 +46,15 @@
           </p>
         {% endif %}
       </nav>
+
+      <h2 class="heading-medium">Authentication</h2>
+      <p class="govuk-body">{{ user.auth_type }}</p>
+      {% if user.auth_type != 'webauthn_auth' %}
+        <a class="govuk-link govuk-link" href="{{ url_for('main.change_user_auth', user_id=user.id) }}">
+          Change authentication for this user
+        </a>
+      {% endif %}
+
       <h2 class="heading-medium">Last login</h2>
       {% if not user.logged_in_at %}
       <p class="hint">This person has never logged in</p>

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -47,6 +47,7 @@ EXCLUDED_ENDPOINTS = tuple(map(Navigation.get_endpoint_with_blueprint, {
     'cancel_job',
     'cancel_letter',
     'cancel_letter_job',
+    'change_user_auth',
     'check_and_resend_text_code',
     'check_and_resend_verification_code',
     'check_contact_list',


### PR DESCRIPTION
So we do not have to go into the db when we need to change user auth

Part of this story: https://www.pivotaltracker.com/story/show/180597596

![Screenshot 2022-02-24 at 10 15 51](https://user-images.githubusercontent.com/20957548/155504956-b74dc6ac-2827-4814-80d3-e1bddf74f611.png)

![Screenshot 2022-02-24 at 10 16 02](https://user-images.githubusercontent.com/20957548/155504961-1a625723-e8f0-4716-8978-003f98f92225.png)
auth.