### PR TITLE
Allow SMS fragment limit to be 0

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,6 @@ class Config(object):
     CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'
     CONTACT_LIST_UPLOAD_BUCKET_NAME = 'local-contact-list'
     ACTIVITY_STATS_LIMIT_DAYS = 7
-    TEST_MESSAGE_FILENAME = 'Report'
 
     REPLY_TO_EMAIL_ADDRESS_VALIDATION_TIMEOUT = 45
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -40,7 +40,14 @@ from wtforms import (
     ValidationError,
     validators,
 )
-from wtforms.validators import URL, DataRequired, Length, Optional, Regexp
+from wtforms.validators import (
+    URL,
+    DataRequired,
+    InputRequired,
+    Length,
+    Optional,
+    Regexp,
+)
 
 from app.formatters import format_thousands, guess_name_from_email_address
 from app.main.validators import (
@@ -1300,7 +1307,7 @@ class FreeSMSAllowance(StripWhitespaceForm):
     free_sms_allowance = GovukIntegerField(
         'Numbers of text message fragments per year',
         validators=[
-            DataRequired(message='Cannot be empty')
+            InputRequired(message='Cannot be empty')
         ]
     )
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3800,6 +3800,7 @@ def test_should_show_page_to_set_sms_allowance(
 
 @freeze_time("2017-04-01 11:09:00.061258")
 @pytest.mark.parametrize('given_allowance, expected_api_argument', [
+    ('0', 0),
     ('1', 1),
     ('250000', 250000),
     pytest.param('foo', 'foo', marks=pytest.mark.xfail),


### PR DESCRIPTION
We want to be able to set the free allowance for a service to 0, but the form was not allowing this - it gave an error message of `Cannot be empty`. This can be fixed by changing the WTForms validator from `DataRequired` (which coerces 0 to falsey) to the `InputRequired` validator.

Should be merged after https://github.com/alphagov/notifications-api/pull/3469

[Pivotal story](https://www.pivotaltracker.com/story/show/181282523)