### PR TITLE
Downgrade error log for expected exception

### DIFF
--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -270,7 +270,7 @@ def uploaded_letter_preview(service_id, file_id):
     except LetterNotFoundError as e:
         current_app.logger.warning(e)
 
-        # If the file is missing it could be because this is a duplicate
+        # If the file is missing it's likely because this is a duplicate
         # request, the notification already exists and the file has been
         # moved to a different bucket. Note that the ID of a precompiled
         # notification is always set to the file_id.
@@ -356,9 +356,9 @@ def send_uploaded_letter(service_id, file_id):
     try:
         metadata = get_letter_metadata(service_id, file_id)
     except LetterNotFoundError as e:
-        current_app.logger.error(e)
+        current_app.logger.warning(e)
 
-        # If the file is missing it could be because this is a duplicate
+        # If the file is missing it's likely because this is a duplicate
         # request, the notification already exists and the file has been
         # moved to a different bucket. Note that the ID of a precompiled
         # notification is always set to the file_id.


### PR DESCRIPTION
Previously we weren't sure if the cause of this exception was what
the comment below suggested [1]. I've now verified this from:

        Letter not found for service 0bd1d970-f11c-40e1-8319-4baefe6239d7 and file aa07ed06-3161-4795-93b3-b45d7c576af9

I checked that aa07ed06-3161-4795-93b3-b45d7c576af9 exists already
as a notification i.e. the comment is correct and we're not sending
users to a 404 page. It's possible there are other scenarios where
the comment is wrong, but I don't think it's worth keeping the error.

[1]: https://github.com/alphagov/notifications-admin/pull/4159