### PR TITLE
Use `govukButton` to display 'Preview this alert' button

### DIFF
--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -63,9 +63,12 @@
 
   {% if broadcast_message.areas %}
     {{ map(broadcast_message) }}
-    <form action="{{ url_for('.preview_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id) }}" method="get" class="govuk-!-margin-top-1">
-      {{ page_footer('Preview this alert') }}
-    </form>
+    {{ govukButton({
+      "element": "a",
+      "text": "Preview this alert",
+      "href": url_for('.preview_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+      "classes": "govuk-button"
+    }) }}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
There are no changes to appearance of the 'Preview this alert' button or what it does, but this stops a CSRF token appearing in the query string when you click the button. We don't need a CSRF token - it's a simple GET request which doesn't change any data. Before, we had a form with `method="get"` but because we were using a `page_footer` a CSRF token was being added.

We can replace both the `<form>` element and `page_footer` with a `govukButton`. This means that we make a GET request with no CSRF token without changing the appearance of the button.

[Pivotal story](https://www.pivotaltracker.com/story/show/177666361)