### PR TITLE
Remove grid from alerts file-list

### DIFF
--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -63,11 +63,13 @@
       // and making children inline mimic `justify-content: space-between`
       display: inline-block;
 
-      // simulate govuk-grid-column-one-half spacing - smaller screens
+      // This simulates a 50% column in a govuk grid on smaller screens
+      // govuk grid columns go to 100% width on smaller screens
       width: 100%;
-      flex-grow: 1;
 
-      // simulate govuk-grid-column-one-half spacing - larger screens
+      // This simulates a 50% column in a govuk grid on larger screens
+      // as with govuk grid, this includes a gap between columns to ensure the contents
+      // are separated by a space
       @include govuk-media-query($from: tablet) {
         max-width: calc(50% - #{$govuk-gutter-half});
       }
@@ -76,10 +78,6 @@
     & > .file-list-status {
       overflow: hidden; // old IE hack to make it vertically line up with the hint
       margin-bottom: 0; // cancel margin-bottom from .govuk-hint class
-
-      @include govuk-media-query($from: tablet) {
-        margin-bottom: 10px; // match margin-bottom on hint
-      }
     }
 
     & > .file-list-hint-large {

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -44,6 +44,49 @@
 
 .file-list {
 
+  // for file-lists with section-like content and a single item
+  &--sectioned {
+    display: flex;
+    flex-wrap: wrap;
+    text-align: justify; // fallback for browsers that don't support flexbox
+    justify-content: space-between;
+
+    // note: first-child of a section should be a heading
+    & > :first-child,
+    & > .area-list {
+      width: 100%;
+    }
+
+    & > .file-list-hint-large,
+    & > .file-list-status {
+      // fallback for browsers that don't support flexbox - let `text-align: justify` on parent
+      // and making children inline mimic `justify-content: space-between`
+      display: inline-block;
+
+      // simulate govuk-grid-column-one-half spacing - smaller screens
+      width: 100%;
+      flex-grow: 1;
+
+      // simulate govuk-grid-column-one-half spacing - larger screens
+      @include govuk-media-query($from: tablet) {
+        width: calc(50% - #{$govuk-gutter-half});
+      }
+    }
+
+    & > .file-list-status {
+      overflow: hidden; // old IE hack to make it vertically line up with the hint
+      margin-bottom: 0; // cancel margin-bottom from .govuk-hint class
+
+      @include govuk-media-query($from: tablet) {
+        margin-bottom: 10px; // match margin-bottom on hint
+      }
+    }
+
+    & > .file-list-hint-large {
+      text-align: left; // reset for text-align fallback on parent
+    }
+  }
+
   &-hint,
   &-hint-large,
   &-status {
@@ -136,10 +179,10 @@
 
 // Note: this selector should use the :has() pseudo-class in the future when it is supported
 //       which will remove the need for JS
-.file-list .js-child-has-focus + .govuk-grid-row {
+.file-list .js-child-has-focus {
 
-  & .file-list-hint-large,
-  & .file-list-status > .govuk-hint {
+  & + .file-list-hint-large,
+  & ~ .file-list-status {
     color: $govuk-focus-text-colour;
   }
 

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -69,7 +69,7 @@
 
       // simulate govuk-grid-column-one-half spacing - larger screens
       @include govuk-media-query($from: tablet) {
-        width: calc(50% - #{$govuk-gutter-half});
+        max-width: calc(50% - #{$govuk-gutter-half});
       }
     }
 

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -3,36 +3,30 @@
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in broadcasts|sort|reverse|list %}
   <div class="keyline-block">
-    <div class="file-list govuk-!-margin-bottom-2">
+    <div class="file-list file-list--sectioned govuk-!-margin-bottom-2">
       <h2>
         <a class="file-list-filename-large govuk-link govuk-link--no-visited-state" href="{{ url_for(view_broadcast_endpoint, service_id=current_service.id, broadcast_message_id=item.id) }}">{{ item.template.name }}</a>
       </h2>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <span class="file-list-hint-large govuk-!-margin-bottom-2">
-            {{ item.content }}
-          </span>
-        </div>
-        <div class="govuk-grid-column-one-half file-list-status">
-          {% if item.status == 'pending-approval' %}
-            <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
-              Waiting for approval
-            </p>
-          {% elif item.status == 'rejected' %}
-            <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
-              {{ item.updated_at|format_date_human|title }} at {{ item.updated_at|format_time }}
-            </p>
-          {% elif item.status == 'broadcasting' %}
-            <p class="govuk-body govuk-!-margin-bottom-0 live-broadcast">
-              Live since {{ item.starts_at|format_datetime_relative }}
-            </p>
-          {% else %}
-            <p class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
-              {{ item.starts_at|format_date_human|title }} at {{ item.starts_at|format_time }}
-            </p>
-          {% endif %}
-        </div>
-      </div>
+      <span class="file-list-hint-large govuk-!-margin-bottom-2">
+        {{ item.content }}
+      </span>
+      {% if item.status == 'pending-approval' %}
+        <p class="govuk-body govuk-hint file-list-status">
+          Waiting for approval
+        </p>
+      {% elif item.status == 'rejected' %}
+        <p class="govuk-body govuk-hint file-list-status">
+          {{ item.updated_at|format_date_human|title }} at {{ item.updated_at|format_time }}
+        </p>
+      {% elif item.status == 'broadcasting' %}
+        <p class="govuk-body live-broadcast file-list-status">
+          Live since {{ item.starts_at|format_datetime_relative }}
+        </p>
+      {% else %}
+        <p class="govuk-body govuk-hint file-list-status">
+          {{ item.starts_at|format_date_human|title }} at {{ item.starts_at|format_time }}
+        </p>
+      {% endif %}
       <ul class="area-list">
         {% for area in item.areas %}
           <li class="area-list-item area-list-item--unremoveable area-list-item--smaller">{{ area.name }}</li>


### PR DESCRIPTION
The alert listings on the current/past/rejected alerts pages need these parts to be clickable:
- the link
- the description text (underneath the link)
- the status text (underneath the link)

<img width="723" alt="alert_grid" src="https://user-images.githubusercontent.com/87140/155808967-e09b182e-6cad-42e2-a8e3-baeaee4943b4.png">

The last 2 are positioned in a grid which stops them being clickable. This removes it in favour using flexbox to position the elements in a similar way.

Part of this story: https://www.pivotaltracker.com/story/show/180011155

## Use of flexbox and fallbacks

Flexbox is a fairly complex layout system and Notify doesn't use it much so worth explaining these changes.

Setting `display: flex` on an element makes any direct descendents 'flex items', meaning flexbox styles are added to change their size and position. We're only using those that control position here, specifically the `justify-content: space-between` setting to arrange their children like so:

<img width="446" alt="flexbox-justify-content-space-between-visual" src="https://user-images.githubusercontent.com/87140/155809715-dd045ca6-b927-42b8-927e-9347fcf7b039.png">

(Image 'borrowed' from https://css-tricks.com/snippets/css/a-guide-to-flexbox/)


In our component, this pushes both bits of text to the outer edges. Their width is set using `calc` to make them take up half the space each but with a 30px gap between. This is intended to mimic the layout they had before by being in a 2-column govuk grid.

Note: these changes are only meant to replicate the current layout using flexbox. We could use flexbox rules to redesign how the elements adapt to different context sizes but that's out of scope for these changes.

### Fallbacks

These changes include fallback styles for browsers that don't support flexbox (IE<11). They work by making both bits of text display as inline content (like parts of text on the same line) and setting the alignment of the line to the 'justify' value. This spreads them out similar to our flexbox styles.

Note: 'display' is overriden on child items under flexbox so setting display: inline-block is ignored.

## Testing these changes

I've tested these changes on IE9-11, as well as Chrome, Edge, Safari and Firefox.