### PR TITLE
Refactor sort mixin to work on attributes other than `name`

### DIFF
--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -8,22 +8,10 @@ from rtreelib import Rect
 from werkzeug.utils import cached_property
 
 from app.formatters import square_metres_to_square_miles
-from app.models import SortByStringAttributeMixin
+from app.models import IdEqualityMixin, SortByStringAttributeMixin
 
 from .populations import CITY_OF_LONDON
 from .repo import BroadcastAreasRepository, rtree_index
-
-
-class IdEqualityMixin:
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}(<{self.id}>)'
-
-    def __eq__(self, other):
-        return self.id == other.id
-
-    def __hash__(self):
-        return hash(self.id)
 
 
 class GetItemByIdMixin:

--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -8,7 +8,7 @@ from rtreelib import Rect
 from werkzeug.utils import cached_property
 
 from app.formatters import square_metres_to_square_miles
-from app.models import SortByNameMixin
+from app.models import SortByStringAttributeMixin
 
 from .populations import CITY_OF_LONDON
 from .repo import BroadcastAreasRepository, rtree_index
@@ -75,7 +75,9 @@ class BaseBroadcastArea(ABC):
         return max(500, min(estimated_bleed, 5000))
 
 
-class BroadcastArea(BaseBroadcastArea, IdEqualityMixin, SortByNameMixin):
+class BroadcastArea(BaseBroadcastArea, IdEqualityMixin, SortByStringAttributeMixin):
+
+    __sort_attribute__ = 'name'
 
     def __init__(self, row):
         self.id, self.name, self._count_of_phones, self.library_id = row
@@ -220,9 +222,11 @@ class CustomBroadcastAreas(SerialisedModelCollection):
         )
 
 
-class BroadcastAreaLibrary(SerialisedModelCollection, SortByNameMixin, IdEqualityMixin, GetItemByIdMixin):
+class BroadcastAreaLibrary(SerialisedModelCollection, SortByStringAttributeMixin, IdEqualityMixin, GetItemByIdMixin):
 
     model = BroadcastArea
+
+    __sort_attribute__ = 'name'
 
     def __init__(self, row):
         id, name, name_singular, is_group = row

--- a/app/broadcast_areas/models.py
+++ b/app/broadcast_areas/models.py
@@ -8,7 +8,7 @@ from rtreelib import Rect
 from werkzeug.utils import cached_property
 
 from app.formatters import square_metres_to_square_miles
-from app.models import IdEqualityMixin, SortByStringAttributeMixin
+from app.models import SortingAndEqualityMixin
 
 from .populations import CITY_OF_LONDON
 from .repo import BroadcastAreasRepository, rtree_index
@@ -63,7 +63,7 @@ class BaseBroadcastArea(ABC):
         return max(500, min(estimated_bleed, 5000))
 
 
-class BroadcastArea(BaseBroadcastArea, IdEqualityMixin, SortByStringAttributeMixin):
+class BroadcastArea(BaseBroadcastArea, SortingAndEqualityMixin):
 
     __sort_attribute__ = 'name'
 
@@ -210,7 +210,7 @@ class CustomBroadcastAreas(SerialisedModelCollection):
         )
 
 
-class BroadcastAreaLibrary(SerialisedModelCollection, SortByStringAttributeMixin, IdEqualityMixin, GetItemByIdMixin):
+class BroadcastAreaLibrary(SerialisedModelCollection, SortingAndEqualityMixin, GetItemByIdMixin):
 
     model = BroadcastArea
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from functools import total_ordering
 
 from flask import abort
 from notifications_utils.serialised_model import (
@@ -7,6 +8,7 @@ from notifications_utils.serialised_model import (
 )
 
 
+@total_ordering
 class SortingAndEqualityMixin(ABC):
 
     @property

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -14,6 +14,12 @@ class SortingAndEqualityMixin(ABC):
     @property
     @abstractmethod
     def __sort_attribute__(self):
+        """
+        Subclasses that want sorting to work must set this property to the
+        string name of the attribute on which the instances should be
+        sorted. For example 'email_address' or 'created_at' to sort on
+        instance.email_address or instance.created_at respectively.
+        """
         pass
 
     def __repr__(self):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,18 @@ from notifications_utils.serialised_model import (
 )
 
 
+class IdEqualityMixin:
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}(<{self.id}>)'
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(self.id)
+
+
 class JSONModel(SerialisedModel):
 
     def __init__(self, _dict):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -19,7 +19,7 @@ class IdEqualityMixin:
         return hash(self.id)
 
 
-class JSONModel(SerialisedModel):
+class JSONModel(SerialisedModel, IdEqualityMixin):
 
     def __init__(self, _dict):
         # in the case of a bad request _dict may be `None`
@@ -30,12 +30,6 @@ class JSONModel(SerialisedModel):
 
     def __bool__(self):
         return self._dict != {}
-
-    def __hash__(self):
-        return hash(self.id)
-
-    def __eq__(self, other):
-        return self.id == other.id
 
     def _get_by_id(self, things, id):
         try:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,10 +7,22 @@ from notifications_utils.serialised_model import (
 )
 
 
-class IdEqualityMixin:
+class SortingAndEqualityMixin(ABC):
+
+    @property
+    @abstractmethod
+    def __sort_attribute__(self):
+        pass
 
     def __repr__(self):
         return f'{self.__class__.__name__}(<{self.id}>)'
+
+    def __lt__(self, other):
+        return (
+            getattr(self, self.__sort_attribute__).lower()
+        ) < (
+            getattr(other, self.__sort_attribute__).lower()
+        )
 
     def __eq__(self, other):
         return self.id == other.id
@@ -19,7 +31,7 @@ class IdEqualityMixin:
         return hash(self.id)
 
 
-class JSONModel(SerialisedModel, IdEqualityMixin):
+class JSONModel(SerialisedModel, SortingAndEqualityMixin):
 
     def __init__(self, _dict):
         # in the case of a bad request _dict may be `None`
@@ -66,18 +78,3 @@ class PaginatedModelList(ModelList):
         self.items = response[self.response_key]
         self.prev_page = response.get('links', {}).get('prev', None)
         self.next_page = response.get('links', {}).get('next', None)
-
-
-class SortByStringAttributeMixin(ABC):
-
-    @property
-    @abstractmethod
-    def __sort_attribute__(self):
-        pass
-
-    def __lt__(self, other):
-        return (
-            getattr(self, self.__sort_attribute__).lower()
-        ) < (
-            getattr(other, self.__sort_attribute__).lower()
-        )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from flask import abort
 from notifications_utils.serialised_model import (
@@ -62,7 +62,16 @@ class PaginatedModelList(ModelList):
         self.next_page = response.get('links', {}).get('next', None)
 
 
-class SortByNameMixin():
+class SortByStringAttributeMixin(ABC):
+
+    @property
+    @abstractmethod
+    def __sort_attribute__(self):
+        pass
 
     def __lt__(self, other):
-        return self.name.lower() < other.name.lower()
+        return (
+            getattr(self, self.__sort_attribute__).lower()
+        ) < (
+            getattr(other, self.__sort_attribute__).lower()
+        )

--- a/app/models/broadcast_message.py
+++ b/app/models/broadcast_message.py
@@ -48,6 +48,8 @@ class BroadcastMessage(JSONModel):
 
     libraries = broadcast_area_libraries
 
+    __sort_attribute__ = None  # Class defines its own sorting behaviour
+
     def __lt__(self, other):
         if self.starts_at and other.starts_at:
             return self.starts_at < other.starts_at

--- a/app/models/contact_list.py
+++ b/app/models/contact_list.py
@@ -32,6 +32,8 @@ class ContactList(JSONModel):
         'template_type',
     }
 
+    __sort_attribute__ = 'original_file_name'
+
     upload_type = 'contact_list'
 
     @classmethod

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -33,6 +33,8 @@ class Job(JSONModel):
         'recipient',
     }
 
+    __sort_attribute__ = 'original_file_name'
+
     @classmethod
     def from_id(cls, job_id, service_id):
         return cls(job_api_client.get_job(service_id, job_id)['data'])

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -7,14 +7,14 @@ from app.models import (
     JSONModel,
     ModelList,
     SerialisedModelCollection,
-    SortByNameMixin,
+    SortByStringAttributeMixin,
 )
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
 
 
-class Organisation(JSONModel, SortByNameMixin):
+class Organisation(JSONModel, SortByStringAttributeMixin):
 
     TYPE_CENTRAL = 'central'
     TYPE_LOCAL = 'local'
@@ -65,6 +65,8 @@ class Organisation(JSONModel, SortByNameMixin):
         'purchase_order_number',
         'notes',
     }
+
+    __sort_attribute__ = 'name'
 
     @classmethod
     def from_id(cls, org_id):
@@ -165,10 +167,7 @@ class Organisation(JSONModel, SortByNameMixin):
 
     @cached_property
     def team_members(self):
-        return sorted(
-            self.invited_users + self.active_users,
-            key=lambda user: user.email_address.lower(),
-        )
+        return self.invited_users + self.active_users
 
     @cached_property
     def email_branding(self):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -3,18 +3,13 @@ from collections import OrderedDict
 from flask import abort
 from werkzeug.utils import cached_property
 
-from app.models import (
-    JSONModel,
-    ModelList,
-    SerialisedModelCollection,
-    SortByStringAttributeMixin,
-)
+from app.models import JSONModel, ModelList, SerialisedModelCollection
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
 
 
-class Organisation(JSONModel, SortByStringAttributeMixin):
+class Organisation(JSONModel):
 
     TYPE_CENTRAL = 'central'
     TYPE_LOCAL = 'local'

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -2,7 +2,7 @@ from flask import abort, current_app
 from notifications_utils.serialised_model import SerialisedModelCollection
 from werkzeug.utils import cached_property
 
-from app.models import JSONModel, SortByStringAttributeMixin
+from app.models import JSONModel
 from app.models.contact_list import ContactLists
 from app.models.job import (
     ImmediateJobs,
@@ -27,7 +27,7 @@ from app.notify_client.template_folder_api_client import (
 from app.utils import get_default_sms_sender
 
 
-class Service(JSONModel, SortByStringAttributeMixin):
+class Service(JSONModel):
 
     ALLOWED_PROPERTIES = {
         'active',

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -2,7 +2,7 @@ from flask import abort, current_app
 from notifications_utils.serialised_model import SerialisedModelCollection
 from werkzeug.utils import cached_property
 
-from app.models import JSONModel, SortByNameMixin
+from app.models import JSONModel, SortByStringAttributeMixin
 from app.models.contact_list import ContactLists
 from app.models.job import (
     ImmediateJobs,
@@ -27,7 +27,7 @@ from app.notify_client.template_folder_api_client import (
 from app.utils import get_default_sms_sender
 
 
-class Service(JSONModel, SortByNameMixin):
+class Service(JSONModel, SortByStringAttributeMixin):
 
     ALLOWED_PROPERTIES = {
         'active',
@@ -56,6 +56,8 @@ class Service(JSONModel, SortByNameMixin):
         'volume_sms',
         'volume_letter',
     }
+
+    __sort_attribute__ = 'name'
 
     TEMPLATE_TYPES = (
         'email',
@@ -181,10 +183,7 @@ class Service(JSONModel, SortByNameMixin):
 
     @cached_property
     def team_members(self):
-        return sorted(
-            self.invited_users + self.active_users,
-            key=lambda user: user.email_address.lower(),
-        )
+        return self.invited_users + self.active_users
 
     @cached_property
     def has_team_members(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -32,7 +32,11 @@ def _get_org_id_from_view_args():
     return str(request.view_args.get('org_id', '')) or None
 
 
-class User(JSONModel, UserMixin, SortByStringAttributeMixin):
+class BaseUser(JSONModel, SortByStringAttributeMixin):
+    __sort_attribute__ = 'email_address'
+
+
+class User(BaseUser, UserMixin):
 
     MAX_FAILED_LOGIN_COUNT = 10
 
@@ -51,8 +55,6 @@ class User(JSONModel, UserMixin, SortByStringAttributeMixin):
         'permissions',
         'state',
     }
-
-    __sort_attribute__ = 'email_address'
 
     def __init__(self, _dict):
         super().__init__(_dict)
@@ -454,7 +456,7 @@ class User(JSONModel, UserMixin, SortByStringAttributeMixin):
         return False
 
 
-class InvitedUser(JSONModel, SortByStringAttributeMixin):
+class InvitedUser(BaseUser):
 
     ALLOWED_PROPERTIES = {
         'id',
@@ -466,8 +468,6 @@ class InvitedUser(JSONModel, SortByStringAttributeMixin):
         'auth_type',
         'folder_permissions',
     }
-
-    __sort_attribute__ = 'email_address'
 
     def __init__(self, _dict):
         super().__init__(_dict)
@@ -594,7 +594,7 @@ class InvitedUser(JSONModel, SortByStringAttributeMixin):
         return False
 
 
-class InvitedOrgUser(JSONModel, SortByStringAttributeMixin):
+class InvitedOrgUser(BaseUser):
 
     ALLOWED_PROPERTIES = {
         'id',
@@ -603,8 +603,6 @@ class InvitedOrgUser(JSONModel, SortByStringAttributeMixin):
         'status',
         'created_at',
     }
-
-    __sort_attribute__ = 'email_address'
 
     def __init__(self, _dict):
         super().__init__(_dict)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -10,7 +10,7 @@ from app.event_handlers import (
     create_add_user_to_service_event,
     create_set_user_permissions_event,
 )
-from app.models import JSONModel, ModelList, SortByStringAttributeMixin
+from app.models import JSONModel, ModelList
 from app.models.organisation import Organisation, Organisations
 from app.models.webauthn_credential import WebAuthnCredentials
 from app.notify_client import InviteTokenError
@@ -32,7 +32,7 @@ def _get_org_id_from_view_args():
     return str(request.view_args.get('org_id', '')) or None
 
 
-class BaseUser(JSONModel, SortByStringAttributeMixin):
+class BaseUser(JSONModel):
     __sort_attribute__ = 'email_address'
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -10,7 +10,7 @@ from app.event_handlers import (
     create_add_user_to_service_event,
     create_set_user_permissions_event,
 )
-from app.models import JSONModel, ModelList
+from app.models import JSONModel, ModelList, SortByStringAttributeMixin
 from app.models.organisation import Organisation, Organisations
 from app.models.webauthn_credential import WebAuthnCredentials
 from app.notify_client import InviteTokenError
@@ -32,7 +32,7 @@ def _get_org_id_from_view_args():
     return str(request.view_args.get('org_id', '')) or None
 
 
-class User(JSONModel, UserMixin):
+class User(JSONModel, UserMixin, SortByStringAttributeMixin):
 
     MAX_FAILED_LOGIN_COUNT = 10
 
@@ -51,6 +51,8 @@ class User(JSONModel, UserMixin):
         'permissions',
         'state',
     }
+
+    __sort_attribute__ = 'email_address'
 
     def __init__(self, _dict):
         super().__init__(_dict)
@@ -452,7 +454,7 @@ class User(JSONModel, UserMixin):
         return False
 
 
-class InvitedUser(JSONModel):
+class InvitedUser(JSONModel, SortByStringAttributeMixin):
 
     ALLOWED_PROPERTIES = {
         'id',
@@ -464,6 +466,8 @@ class InvitedUser(JSONModel):
         'auth_type',
         'folder_permissions',
     }
+
+    __sort_attribute__ = 'email_address'
 
     def __init__(self, _dict):
         super().__init__(_dict)
@@ -590,7 +594,7 @@ class InvitedUser(JSONModel):
         return False
 
 
-class InvitedOrgUser(JSONModel):
+class InvitedOrgUser(JSONModel, SortByStringAttributeMixin):
 
     ALLOWED_PROPERTIES = {
         'id',
@@ -599,6 +603,8 @@ class InvitedOrgUser(JSONModel):
         'status',
         'created_at',
     }
+
+    __sort_attribute__ = 'email_address'
 
     def __init__(self, _dict):
         super().__init__(_dict)

--- a/app/models/webauthn_credential.py
+++ b/app/models/webauthn_credential.py
@@ -24,6 +24,8 @@ class WebAuthnCredential(JSONModel):
         'updated_at'
     }
 
+    __sort_attribute__ = 'name'
+
     @classmethod
     def from_registration(cls, state, response):
         server = current_app.webauthn_server

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -20,7 +20,7 @@
   {% endif %}
 
   <div class="user-list">
-    {% for user in users %}
+    {% for user in users|sort %}
       <div class="user-list-item">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -30,7 +30,7 @@
   {% endif %}
 
   <div class="user-list">
-    {% for user in users %}
+    {% for user in users|sort %}
       <div class="user-list-item">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">

--- a/tests/app/models/test_base_model.py
+++ b/tests/app/models/test_base_model.py
@@ -7,6 +7,7 @@ def test_looks_up_from_dict():
 
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = {'foo'}
+        __sort_attribute__ = 'foo'
 
     assert Custom({'foo': 'bar'}).foo == 'bar'
 
@@ -16,6 +17,7 @@ def test_raises_when_overriding_custom_properties():
     class Custom(JSONModel):
 
         ALLOWED_PROPERTIES = {'foo'}
+        __sort_attribute__ = 'foo'
 
         @property
         def foo(self):
@@ -35,6 +37,7 @@ def test_model_raises_for_unknown_attributes(json_response):
 
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = set()
+        __sort_attribute__ = None
 
     model = Custom(json_response)
     assert model.ALLOWED_PROPERTIES == set()
@@ -49,6 +52,7 @@ def test_model_raises_keyerror_if_item_missing_from_dict():
 
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = {'foo'}
+        __sort_attribute__ = 'foo'
 
     with pytest.raises(AttributeError) as e:
         Custom({}).foo
@@ -64,6 +68,7 @@ def test_model_doesnt_swallow_attribute_errors(json_response):
 
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = set()
+        __sort_attribute__ = None
 
         @property
         def foo(self):
@@ -79,6 +84,7 @@ def test_dynamic_properties_are_introspectable():
 
     class Custom(JSONModel):
         ALLOWED_PROPERTIES = {'foo', 'bar', 'baz'}
+        __sort_attribute__ = 'foo'
 
     model = Custom({'foo': None, 'bar': None, 'baz': None})
 


### PR DESCRIPTION
`SortByNameMixin` is working well for classes where we want to sort objects by name. But it’s limited to the `name` attribute.

This commit makes it more generic, so that subclass-ees can choose which attribute to sort on. For example this means that users can be sorted by email address without having to do a custom call to `sorted` with an icky `lambda`.

This could also let us implement enhancements ascending/descending sorting in the future, for example.