### PR TITLE
Update letter prices

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -233,11 +233,11 @@
       caption_visible=False
     ) %}
       {% for sheets, second, first, international in [
-        ('1 sheet', '39p', '69p', '89p'),
-        ('2 sheets', '44p', '74p', '97p'),
-        ('3 sheets', '49p', '79p', '£1.05'),
-        ('4 sheets', '54p', '84p', '£1.13'),
-        ('5 sheets', '59p', '89p', '£1.21'),
+        ('1 sheet', '41p', '63p', '96p'),
+        ('2 sheets', '46p', '68p', '£1.04'),
+        ('3 sheets', '51p', '73p', '£1.12'),
+        ('4 sheets', '56p', '78p', '£1.20'),
+        ('5 sheets', '61p', '83p', '£1.28'),
       ] %}
         {% call row() %}
           {% call row_heading() %} {{ sheets }} {% endcall %}
@@ -250,12 +250,7 @@
   </div>
 
   <div class="panel panel-border-wide">  
-    <p class="govuk-body">On 1 March 2022:</p>
-    <ul class="list list-bullet">
-    <li>second class postage will go up by 2 pence, plus VAT</li>
-    <li>international postage will go up by 7 pence, plus VAT</li>
-    <li>first class postage will go down by 6 pence, plus VAT</li>
-  </ul>
+    <p class="govuk-body">These prices were updated on 1 March 2022.</p>
   </div>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -1,3 +1,4 @@
+{% from "components/content-metadata.html" import content_metadata %}
 {% from "components/table.html" import mapping_table, row, text_field, field, row_heading %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/details/macro.njk" import govukDetails %}
@@ -11,6 +12,13 @@
 {% block content_column_content %}
 
   <h1 class="heading-large">Pricing</h1>
+
+    {{ content_metadata(
+      data={
+        "Last updated": "1 March 2022"
+      }
+    ) }}
+
   <p class="govuk-body">GOV.UK Notify is free to use unless you:</p>
   <ul class="list list-bullet">
     <li>exceed your <a class="govuk-link govuk-link--no-visited-state" href="#text-messages">free text message allowance</a></li>
@@ -247,10 +255,6 @@
         {% endcall %}
       {% endfor %}
     {% endcall %}
-  </div>
-
-  <div class="panel panel-border-wide">  
-    <p class="govuk-body">These prices were updated on 1 March 2022.</p>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
This PR updates the:
* postage pricing table
* last updated information

To make the pricing page consistent with the roadmap, privacy notice and accessibility statement, we’re moving the ‘last updated’ information to the top of the page.