### PR TITLE
Prevent scrolling of branding previews

### DIFF
--- a/app/assets/javascripts/previewPane.js
+++ b/app/assets/javascripts/previewPane.js
@@ -13,7 +13,7 @@
   const $paneWrapper = $('<div class="govuk-grid-column-full"></div>');
   const $form = $('form');
   const previewType = $form.data('previewType');
-  const $previewPane = $(`<iframe src="/_${previewType}?${buildQueryString(['branding_style', branding_style])}" class="branding-preview"></iframe>`);
+  const $previewPane = $(`<iframe src="/_${previewType}?${buildQueryString(['branding_style', branding_style])}" class="branding-preview" scrolling="no"></iframe>`);
 
   function buildQueryString () {
     return $.map(arguments, (val, idx) => encodeURI(val[0]) + '=' + encodeURI(val[1])).join('&');

--- a/app/templates/components/branding-preview.html
+++ b/app/templates/components/branding-preview.html
@@ -1,5 +1,5 @@
 {% macro branding_preview(branding_style, endpoint) %}
-  <iframe src="{{ url_for(endpoint, branding_style=branding_style) }}" class="branding-preview"></iframe>
+  <iframe src="{{ url_for(endpoint, branding_style=branding_style) }}" class="branding-preview" scrolling="no"></iframe>
 {% endmacro %}
 
 {% macro email_branding_preview(branding_style) %}

--- a/app/templates/components/branding-preview.html
+++ b/app/templates/components/branding-preview.html
@@ -1,0 +1,3 @@
+{% macro branding_preview(branding_style) %}
+  <iframe src="{{ url_for('main.email_template', branding_style=branding_style) }}" class="branding-preview"></iframe>
+{% endmacro %}

--- a/app/templates/components/branding-preview.html
+++ b/app/templates/components/branding-preview.html
@@ -1,3 +1,11 @@
-{% macro branding_preview(branding_style) %}
-  <iframe src="{{ url_for('main.email_template', branding_style=branding_style) }}" class="branding-preview"></iframe>
+{% macro branding_preview(branding_style, endpoint) %}
+  <iframe src="{{ url_for(endpoint, branding_style=branding_style) }}" class="branding-preview"></iframe>
+{% endmacro %}
+
+{% macro email_branding_preview(branding_style) %}
+  {{ branding_preview(branding_style, 'main.email_template') }}
+{% endmacro %}
+
+{% macro letter_branding_preview(branding_style) %}
+  {{ branding_preview(branding_style, 'main.letter_template') }}
 {% endmacro %}

--- a/app/templates/views/organisations/organisation/settings/preview-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-email-branding.html
@@ -1,7 +1,7 @@
 {% extends "org_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/branding-preview.html" import branding_preview %}
+{% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block org_page_title %}
   Preview email branding
@@ -12,7 +12,7 @@
   <h1 class="heading-large">Preview email branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {{ branding_preview(form.branding_style.data) }}
+      {{ email_branding_preview(form.branding_style.data) }}
       {% call form_wrapper(action=action) %}
         <div class="form-group">
           {{ form.hidden_tag() }}

--- a/app/templates/views/organisations/organisation/settings/preview-email-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-email-branding.html
@@ -1,6 +1,7 @@
 {% extends "org_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/branding-preview.html" import branding_preview %}
 
 {% block org_page_title %}
   Preview email branding
@@ -11,7 +12,7 @@
   <h1 class="heading-large">Preview email branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
+      {{ branding_preview(form.branding_style.data) }}
       {% call form_wrapper(action=action) %}
         <div class="form-group">
           {{ form.hidden_tag() }}

--- a/app/templates/views/organisations/organisation/settings/preview-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/preview-letter-branding.html
@@ -1,6 +1,8 @@
 {% extends "org_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/branding-preview.html" import letter_branding_preview %}
+
 {% block per_page_title %}
   Preview letter branding
 {% endblock %}
@@ -10,7 +12,7 @@
   <h1 class="heading-large">Preview letter branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <iframe src="{{ url_for('main.letter_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
+      {{ letter_branding_preview(form.branding_style.data) }}
       {% call form_wrapper(action=action) %}
         <div class="form-group">
           {{ form.hidden_tag() }}

--- a/app/templates/views/service-settings/branding/email-branding-govuk.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk.html
@@ -3,6 +3,7 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
+{% from "components/branding-preview.html" import branding_preview %}
 
 {% block service_page_title %}
   Check your new branding
@@ -22,7 +23,7 @@
     Emails from {{ current_service.name }} will look like this.
   </p>
 
-  <iframe src="{{ url_for('main.email_template', branding_style='__NONE__') }}" class="branding-preview"></iframe>
+  {{ branding_preview('__NONE__') }}
 
   <h2 class="heading-medium">Before you continue</h2>
 

--- a/app/templates/views/service-settings/branding/email-branding-govuk.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk.html
@@ -3,7 +3,7 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/branding-preview.html" import branding_preview %}
+{% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block service_page_title %}
   Check your new branding
@@ -23,7 +23,7 @@
     Emails from {{ current_service.name }} will look like this.
   </p>
 
-  {{ branding_preview('__NONE__') }}
+  {{ email_branding_preview('__NONE__') }}
 
   <h2 class="heading-medium">Before you continue</h2>
 

--- a/app/templates/views/service-settings/branding/email-branding-nhs.html
+++ b/app/templates/views/service-settings/branding/email-branding-nhs.html
@@ -3,6 +3,7 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
+{% from "components/branding-preview.html" import branding_preview %}
 
 {% block service_page_title %}
   Check your new branding
@@ -21,8 +22,7 @@
   <p class="govuk-body">
     Emails from {{ current_service.name }} will look like this.
   </p>
-
-  <iframe src="{{ url_for('main.email_template', branding_style=nhs_branding_id) }}" class="branding-preview"></iframe>
+  {{ branding_preview(nhs_branding_id) }}
 
   <h2 class="heading-medium">Before you continue</h2>
 

--- a/app/templates/views/service-settings/branding/email-branding-nhs.html
+++ b/app/templates/views/service-settings/branding/email-branding-nhs.html
@@ -3,7 +3,7 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/branding-preview.html" import branding_preview %}
+{% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block service_page_title %}
   Check your new branding
@@ -22,7 +22,7 @@
   <p class="govuk-body">
     Emails from {{ current_service.name }} will look like this.
   </p>
-  {{ branding_preview(nhs_branding_id) }}
+  {{ email_branding_preview(nhs_branding_id) }}
 
   <h2 class="heading-medium">Before you continue</h2>
 

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -6,7 +6,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
-{% from "components/branding-preview.html" import branding_preview %}
+{% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block service_page_title %}
   Change email branding
@@ -26,7 +26,7 @@
     Your emails currently have {{ branding_name }} branding.
   </p>
 
-  {{ branding_preview(
+  {{ email_branding_preview(
     current_service.email_branding_id if current_service.email_branding else '__NONE__'
   ) }}
 

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -6,6 +6,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/branding-preview.html" import branding_preview %}
 
 {% block service_page_title %}
   Change email branding
@@ -25,8 +26,9 @@
     Your emails currently have {{ branding_name }} branding.
   </p>
 
-  {% set branding_id = current_service.email_branding_id if current_service.email_branding else '__NONE__' %}
-  <iframe src="{{ url_for('main.email_template', branding_style=branding_id) }}" class="branding-preview"></iframe>
+  {{ branding_preview(
+    current_service.email_branding_id if current_service.email_branding else '__NONE__'
+  ) }}
 
   {% if current_service.needs_to_change_email_branding %}
     <p class="govuk-body">

--- a/app/templates/views/service-settings/preview-email-branding.html
+++ b/app/templates/views/service-settings/preview-email-branding.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/branding-preview.html" import branding_preview %}
 
 {% block service_page_title %}
   Preview email branding
@@ -11,7 +12,7 @@
   <h1 class="heading-large">Preview email branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <iframe src="{{ url_for('main.email_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
+      {{ branding_preview(form.branding_style.data) }}
       {% call form_wrapper(action=action) %}
         <div class="form-group">
           {{ form.hidden_tag() }}

--- a/app/templates/views/service-settings/preview-email-branding.html
+++ b/app/templates/views/service-settings/preview-email-branding.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/branding-preview.html" import branding_preview %}
+{% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block service_page_title %}
   Preview email branding
@@ -12,7 +12,7 @@
   <h1 class="heading-large">Preview email branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {{ branding_preview(form.branding_style.data) }}
+      {{ email_branding_preview(form.branding_style.data) }}
       {% call form_wrapper(action=action) %}
         <div class="form-group">
           {{ form.hidden_tag() }}

--- a/app/templates/views/service-settings/preview-letter-branding.html
+++ b/app/templates/views/service-settings/preview-letter-branding.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/branding-preview.html" import letter_branding_preview %}
 
 {% block per_page_title %}
   Preview letter branding
@@ -11,7 +12,7 @@
   <h1 class="heading-large">Preview letter branding</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <iframe src="{{ url_for('main.letter_template', branding_style=form.branding_style.data) }}" class="branding-preview"></iframe>
+      {{ letter_branding_preview(form.branding_style.data) }}
       {% call form_wrapper(action=action) %}
         <div class="form-group">
           {{ form.hidden_tag() }}


### PR DESCRIPTION
In user research we quite often saw people accidentally scroll the branding preview `<iframe>` when trying to scroll the page.

This is suboptimal because they:
- were confused why the page wasn’t scrolling
- lost visibility of the branding they were trying to preview because it scrolled outside the bounds of the `<iframe>`