### PR TITLE
Upgrade minor dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 
 ago==0.0.93
 govuk-bank-holidays==0.11
-humanize==3.12.0
+humanize==4.0.0
 Flask==1.1.2  # pyup: <2
 Flask-WTF==1.0.0
 wtforms==3.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 ago==0.0.93
-govuk-bank-holidays==0.10
+govuk-bank-holidays==0.11
 humanize==3.12.0
 Flask==1.1.2  # pyup: <2
 Flask-WTF==1.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ govuk-bank-holidays==0.11
 humanize==4.0.0
 Flask==1.1.2  # pyup: <2
 Flask-WTF==1.0.0
-wtforms==3.0.0
+wtforms==3.0.1
 Flask-Login==0.5.0
 werkzeug==2.0.2
 jinja2==3.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ jinja2==3.0.2
 
 blinker==1.4
 pyexcel==0.6.7
-pyexcel-io==0.6.5
+pyexcel-io==0.6.6
 pyexcel-xls==0.7.0
 pyexcel-xlsx==0.6.0
 pyexcel-ods3==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ gds-metrics==0.2.4
     # via -r requirements.in
 geojson==2.5.0
     # via notifications-utils
-govuk-bank-holidays==0.10
+govuk-bank-holidays==0.11
     # via
     #   -r requirements.in
     #   notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -223,7 +223,7 @@ werkzeug==2.0.2
     # via
     #   -r requirements.in
     #   flask
-wtforms==3.0.0
+wtforms==3.0.1
     # via
     #   -r requirements.in
     #   flask-wtf

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ pyexcel==0.6.7
     # via -r requirements.in
 pyexcel-ezodf==0.3.4
     # via pyexcel-ods3
-pyexcel-io==0.6.5
+pyexcel-io==0.6.6
     # via
     #   -r requirements.in
     #   pyexcel

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ greenlet==1.1.0
     # via eventlet
 gunicorn==20.1.0
     # via -r requirements.in
-humanize==3.12.0
+humanize==4.0.0
     # via -r requirements.in
 idna==2.10
     # via requests

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
-isort==5.9.3
-pytest==6.2.5
+isort==5.10.1
+pytest==7.0.1
 pytest-env==0.6.2
-pytest-mock==3.6.1
-pytest-xdist==2.4.0
+pytest-mock==3.7.0
+pytest-xdist==2.5.0
 beautifulsoup4==4.10.0
 freezegun==1.1.0
 flake8==4.0.1
-flake8-bugbear==21.9.2
+flake8-bugbear==22.1.11
 flake8-print==4.0.0
-moto==3.0.4
+moto==3.0.5
 requests-mock==1.9.3
 # used for creating manifest file locally
-jinja2-cli[yaml]==0.7.0
+jinja2-cli[yaml]==0.8.1


### PR DESCRIPTION
This upgrades some of the safer or more minor dependencies from https://github.com/alphagov/notifications-admin/pull/4172 instead of attempting to do all at once.