### PR TITLE
Pass admin URL to API for registration email

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -101,7 +101,10 @@ class UserApiClient(NotifyAdminAPIClient):
         self.post(endpoint, data=data)
 
     def send_verify_email(self, user_id, to):
-        data = {'to': to}
+        data = {
+            'to': to,
+            'admin_base_url': self.admin_url,
+        }
         endpoint = '/user/{0}/email-verification'.format(user_id)
         self.post(endpoint, data=data)
 

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -325,3 +325,22 @@ def test_reset_password(
             'admin_base_url': 'http://localhost:6012',
         },
     )
+
+
+def test_send_registration_email(
+    mocker,
+    fake_uuid,
+):
+    mock_post = mocker.patch(
+        'app.notify_client.user_api_client.UserApiClient.post'
+    )
+
+    user_api_client.send_verify_email(fake_uuid, 'test@example.com')
+
+    mock_post.assert_called_once_with(
+        f'/user/{fake_uuid}/email-verification',
+        data={
+            'to': 'test@example.com',
+            'admin_base_url': 'http://localhost:6012',
+        },
+    )


### PR DESCRIPTION
This follows the pattern for invite emails where the admin app tells the API which domain to use when generating the link.