### PR TITLE
Format `auth_type` in a consistent way in the UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,6 +40,7 @@ from app.config import configs
 from app.extensions import antivirus_client, redis_client, zendesk_client
 from app.formatters import (
     convert_to_boolean,
+    format_auth_type,
     format_billions,
     format_date,
     format_date_human,
@@ -527,6 +528,7 @@ def setup_event_handlers():
 
 def add_template_filters(application):
     for fn in [
+        format_auth_type,
         format_billions,
         format_datetime,
         format_datetime_24h,

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -528,3 +528,16 @@ def format_yes_no(value, yes='Yes', no='No', none='No'):
 
 def square_metres_to_square_miles(area):
     return area * 3.86e-7
+
+
+def format_auth_type(auth_type, with_indefinite_article=False):
+    indefinite_article, auth_type = {
+        'email_auth': ('an', 'Email link'),
+        'sms_auth': ('a', 'Text message code'),
+        'webauthn_auth': ('a', 'Security key'),
+    }.get(auth_type, ('a', auth_type))
+
+    if with_indefinite_article:
+        return f'{indefinite_article} {auth_type.lower()}'
+
+    return auth_type

--- a/app/formatters.py
+++ b/app/formatters.py
@@ -535,7 +535,7 @@ def format_auth_type(auth_type, with_indefinite_article=False):
         'email_auth': ('an', 'Email link'),
         'sms_auth': ('a', 'Text message code'),
         'webauthn_auth': ('a', 'Security key'),
-    }.get(auth_type, ('a', auth_type))
+    }[auth_type]
 
     if with_indefinite_article:
         return f'{indefinite_article} {auth_type.lower()}'

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -50,7 +50,11 @@ from wtforms.validators import (
     Regexp,
 )
 
-from app.formatters import format_thousands, guess_name_from_email_address
+from app.formatters import (
+    format_auth_type,
+    format_thousands,
+    guess_name_from_email_address,
+)
 from app.main.validators import (
     BroadcastLength,
     CommonlyUsedPassword,
@@ -1021,8 +1025,8 @@ class AuthTypeForm(StripWhitespaceForm):
     auth_type = GovukRadiosField(
         'Sign in using',
         choices=[
-            ('sms_auth', 'Text message code'),
-            ('email_auth', 'Email link'),
+            ('sms_auth', format_auth_type('sms_auth')),
+            ('email_auth', format_auth_type('email_auth')),
         ]
     )
 

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -48,7 +48,7 @@
       </nav>
 
       <h2 class="heading-medium">Authentication</h2>
-      <p class="govuk-body">{{ user.auth_type }}</p>
+      <p class="govuk-body">{{ user.auth_type | format_auth_type }}</p>
       {% if user.auth_type != 'webauthn_auth' %}
         <a class="govuk-link govuk-link" href="{{ url_for('main.change_user_auth', user_id=user.id) }}">
           Change authentication for this user

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -64,13 +64,8 @@
             {% endif %}
             {% if current_service.has_permission('email_auth') %}
               <p class="govuk-body tick-cross-list-hint">
-                {% if user.auth_type == 'sms_auth' %}
-                  Signs in with a text message code
-                {% elif user.auth_type == 'email_auth' %}
-                  Signs in with an email link
-                {% elif user.auth_type == 'webauthn_auth' %}
-                  Signs in with a security key
-                {% endif %}
+                Signs in with
+                {{ user.auth_type | format_auth_type(with_indefinite_article=True) }}
               </p>
             {% endif %}
             </div>

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -120,7 +120,7 @@ def test_user_information_page_shows_information_about_user(
     ] == [
         'test@gov.uk',
         '+447700900986',
-        'sms_auth',
+        'Text message code',
         'Last logged in just now',
     ]
 


### PR DESCRIPTION
On the ‘find user’ page it says ‘sms_auth’ instead of ‘Text message code’.

This commit fixes that, and adds a handy formatter so it’s easier to do the right thing in the future.