### PR TITLE
Strip underline from focused + hovered nav links

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -68,6 +68,10 @@
       text-decoration: underline;
     }
 
+    &:focus {
+      text-decoration: none; // override the :hover style (the focus style has its own underline)
+    }
+
   }
 
   &-service {
@@ -165,6 +169,10 @@
 
     &:hover {
       text-decoration: underline;
+    }
+
+    &:focus { // override the :hover style (the focus style has its own underline)
+      text-decoration: none;
     }
 
     &.selected {


### PR DESCRIPTION
Noticed the links in our navigation still show the underline on hover, while focused. The focus style already contains an underline so this is wrong.

This fixes it by cancelling the underline in the focus state.

Links this effects:
- those in the side nav for most pages
- those in the top nav (showing org, service and 'switch service' links) for most pages
- the 'Back to [service name]' link on the /accounts page

## Before

![nav_hover_when_focused](https://user-images.githubusercontent.com/87140/158846593-9b31f09d-610c-4801-8a24-e7af9a497381.gif)

## After

![nav_hover_when_focused_fixed](https://user-images.githubusercontent.com/87140/158846631-a4d89bad-c22f-42d2-8db3-10114e2b042e.gif)
