### PR TITLE
Make it easy to see API keys for broadcast service

### DIFF
--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -25,8 +25,12 @@
     {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
       <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
     {% endif %}
-    {% if current_user.has_permissions('manage_api_keys') and not current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
+    {% if current_user.has_permissions('manage_api_keys') %}
+      {% if current_service.has_permission('broadcast') %}
+        <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API integration</a></li>
+      {% else %}
+        <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
+      {% endif %}
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
     <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -521,13 +521,20 @@ def test_navigation_urls(
 
 
 def test_navigation_for_services_with_broadcast_permission(
+    mocker,
     client_request,
     service_one,
     mock_get_service_templates,
     mock_get_template_folders,
     mock_get_api_keys,
+    active_user_create_broadcasts_permission,
 ):
     service_one['permissions'] += ['broadcast']
+    mocker.patch(
+        'app.user_api_client.get_user',
+        return_value=active_user_create_broadcasts_permission
+    )
+
     page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
     assert [
         a['href'] for a in page.select('.navigation a')
@@ -537,7 +544,6 @@ def test_navigation_for_services_with_broadcast_permission(
         '/services/{}/rejected-alerts'.format(SERVICE_ONE_ID),
         '/services/{}/templates'.format(SERVICE_ONE_ID),
         '/services/{}/users'.format(SERVICE_ONE_ID),
-        '/services/{}/service-settings'.format(SERVICE_ONE_ID),
     ]
 
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -547,6 +547,35 @@ def test_navigation_for_services_with_broadcast_permission(
     ]
 
 
+def test_navigation_for_services_with_broadcast_permission_platform_admin(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_folders,
+    mock_get_api_keys,
+    platform_admin_user,
+):
+    service_one['permissions'] += ['broadcast']
+    mocker.patch(
+        'app.user_api_client.get_user',
+        return_value=platform_admin_user,
+    )
+
+    page = client_request.get('main.choose_template', service_id=SERVICE_ONE_ID)
+    assert [
+        a['href'] for a in page.select('.navigation a')
+    ] == [
+        '/services/{}/current-alerts'.format(SERVICE_ONE_ID),
+        '/services/{}/past-alerts'.format(SERVICE_ONE_ID),
+        '/services/{}/rejected-alerts'.format(SERVICE_ONE_ID),
+        '/services/{}/templates'.format(SERVICE_ONE_ID),
+        '/services/{}/users'.format(SERVICE_ONE_ID),
+        '/services/{}/service-settings'.format(SERVICE_ONE_ID),
+        '/services/{}/api/keys'.format(SERVICE_ONE_ID),
+    ]
+
+
 def test_caseworkers_get_caseworking_navigation(
     client_request,
     mocker,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3604,6 +3604,7 @@ def create_active_user_create_broadcasts_permissions(with_unique_id=False):
             'create_broadcasts',
             'reject_broadcasts',
             'cancel_broadcasts',
+            'view_activity',  # added automatically by API
         ]},
         auth_type='webauthn_auth',
     )
@@ -3617,6 +3618,7 @@ def create_active_user_approve_broadcasts_permissions(with_unique_id=False):
             'approve_broadcasts',
             'reject_broadcasts',
             'cancel_broadcasts',
+            'view_activity',  # added automatically by API
         ]},
         auth_type='webauthn_auth',
     )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179120842

This made it easier to debug a problem with the functional tests due to the
fixtures not working correctly [^1].

We may want to expose the top-level "/api-integration" page but that will
require more work to show which broadcasts were sent with which key -
currently it's oriented around "messages". For now I think it's useful to
see what keys a service has.

## Screenshots

| Before | After |
| - | - |
| <img width="995" alt="Screenshot 2022-03-24 at 12 34 59" src="https://user-images.githubusercontent.com/9029009/159917335-2e1dac64-e521-47d8-a2f2-391871a3a791.png"> | <img width="992" alt="Screenshot 2022-03-24 at 12 34 45" src="https://user-images.githubusercontent.com/9029009/159917366-4c328cae-d48e-4dd7-9f03-c8731adb3330.png"> |

[^1]:
https://github.com/alphagov/notifications-functional-tests/pull/411#pullrequestreview-920069799