### PR TITLE
Show link to service history in the settings page

### DIFF
--- a/app/assets/stylesheets/components/page-footer.scss
+++ b/app/assets/stylesheets/components/page-footer.scss
@@ -3,7 +3,7 @@
   position: relative;
   margin-bottom: 30px;
 
-  &-delete-link {
+  &-link {
 
     line-height: 40px;
     padding: 1px 0 0 15px;

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -31,7 +31,7 @@
 
     {% endif %}
     {% if delete_link %}
-      <span class="page-footer-delete-link {% if not button_text %}page-footer-delete-link-without-button{% endif %}">
+      <span class="page-footer-link {% if not button_text %}page-footer-delete-link-without-button{% endif %}">
         <a class="govuk-link govuk-link--destructive" href="{{ delete_link }}">{{ delete_link_text }}</a>
       </span>
     {% endif %}

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -71,7 +71,7 @@
       </p>
       {% endif %}
       {% if user.state == 'active' %}
-        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+        <span class="page-footer-link page-footer-delete-link-without-button">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.archive_user', user_id=user.id) }}">
             Archive user
           </a>

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -30,7 +30,7 @@
     {% if job.letter_job_can_be_cancelled %}
       <div class="js-stick-at-bottom-when-scrolling">
         <div class="page-footer">
-          <span class="page-footer-delete-link page-footer-delete-link-without-button">
+          <span class="page-footer-link page-footer-delete-link-without-button">
             <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
           </span>
     {% else %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -471,6 +471,12 @@
                 Suspend service
               </a>
           </span>
+
+          <span class="page-footer-link">
+            <a href="{{ url_for('.history', service_id=current_service.id) }}" class="govuk-link govuk-link--no-visited-state page-footer-link">
+              Service history
+            </a>
+          </span>
         {% endif %}
       </p>
     {% endif %}
@@ -483,6 +489,12 @@
         <span class="page-footer-link page-footer-delete-link-without-button">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('.resume_service', service_id=current_service.id) }}">
             Resume service
+          </a>
+        </span>
+
+        <span class="page-footer-link">
+          <a href="{{ url_for('.history', service_id=current_service.id) }}" class="govuk-link govuk-link--no-visited-state page-footer-link">
+            Service history
           </a>
         </span>
       </p>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -460,14 +460,14 @@
 
     {% if current_service.active and (current_service.trial_mode or current_user.platform_admin) %}
       <p class="top-gutter-1-2">
-        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+        <span class="page-footer-link page-footer-delete-link-without-button">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('.archive_service', service_id=current_service.id) }}">
             Delete this service
           </a>
         </span>
         {% if current_user.platform_admin %}
-          <span class="page-footer-delete-link">
-            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="govuk-link govuk-link--destructive page-footer-delete-link">
+          <span class="page-footer-link">
+            <a href="{{ url_for('.suspend_service', service_id=current_service.id) }}" class="govuk-link govuk-link--destructive page-footer-link">
                 Suspend service
               </a>
           </span>
@@ -479,7 +479,8 @@
         <div class="hint bottom-gutter-1-2">
           Service suspended
         </div>
-        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+
+        <span class="page-footer-link page-footer-delete-link-without-button">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('.resume_service', service_id=current_service.id) }}">
             Resume service
           </a>

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -67,14 +67,14 @@
     {% endif %}
     {% if current_user.has_permissions('manage_templates') and user_has_template_permission %}
       {% if not template._template.archived %}
-        <span class="page-footer-delete-link page-footer-delete-link-without-button bottom-gutter-2-3">
+        <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('.delete_service_template', service_id=current_service.id, template_id=template.id) }}">Delete this template</a>
         </span>
         &emsp;
       {% endif %}
       {% if template.template_type not in ('letter', 'broadcast') %}
         {% if not template._template.redact_personalisation %}
-          <span class="page-footer-delete-link page-footer-delete-link-without-button">
+          <span class="page-footer-link page-footer-delete-link-without-button">
             <a class="govuk-link govuk-link--destructive" href="{{ url_for('.confirm_redact_template', service_id=current_service.id, template_id=template.id) }}">Hide personalisation after sending</a>
           </span>
         {% else %}

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -130,7 +130,7 @@
   <div class="js-stick-at-bottom-when-scrolling">
     <div class="page-footer">
       {% if not confirm_delete_banner %}
-        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+        <span class="page-footer-link page-footer-delete-link-without-button">
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.delete_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Delete this contact list</a>
         </span>
       {% endif %}

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -168,7 +168,7 @@ def test_service_setting_link_toggles(
     link_url = url_for(endpoint, service_id=service_one['id'])
     service_one.update(service_fields)
     page = get_service_settings_page()
-    link = page.select('.page-footer-delete-link a')[index]
+    link = page.select('.page-footer-link a')[index]
     assert normalize_spaces(link.text) == text
     assert link['href'] == link_url
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -151,9 +151,11 @@ def test_service_setting_toggles_show(
 @pytest.mark.parametrize('service_fields, endpoint, index, text', [
     ({'active': True}, '.archive_service', 0, 'Delete this service'),
     ({'active': True}, '.suspend_service', 1, 'Suspend service'),
+    ({'active': True}, '.history', 2, 'Service history'),
     ({'active': False}, '.resume_service', 0, 'Resume service'),
+    ({'active': False}, '.history', 1, 'Service history'),
     pytest.param(
-        {'active': False}, '.archive_service', 1, 'Resume service',
+        {'active': False}, '.archive_service', 2, 'Resume service',
         marks=pytest.mark.xfail(raises=IndexError)
     )
 ])

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -4181,7 +4181,7 @@ def test_archive_service_prompts_user(
         'main.archive_service',
         service_id=SERVICE_ONE_ID
     )
-    delete_link = settings_page.select('.page-footer-delete-link a')[0]
+    delete_link = settings_page.select('.page-footer-link a')[0]
     assert normalize_spaces(delete_link.text) == 'Delete this service'
     assert delete_link['href'] == url_for(
         'main.archive_service',


### PR DESCRIPTION
This makes the feature more visible to platform admins, although a
service manager can technically view the page as well.

Based on discussion in [^1].

## Screenshots (Platform Admin only)

| Active | Suspended |
| - | - |
| <img width="773" alt="Screenshot 2022-03-24 at 13 05 42" src="https://user-images.githubusercontent.com/9029009/159922551-a5b70577-0473-4c3d-89e0-66b75bc944f5.png"> | <img width="771" alt="Screenshot 2022-03-24 at 13 05 54" src="https://user-images.githubusercontent.com/9029009/159922574-f4ee19f4-8815-4610-84cd-4d42f268cfb2.png"> |

[^1]: https://github.com/alphagov/notifications-admin/pull/4157