### PR TITLE
Unpin the prometheus-client and use the latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,5 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
-# version 0.10.0 introduced exceptions when workers crashed due to deprecating lower case `prometheus_multiproc_dir`.
-prometheus-client>=0.9.0,!=0.10.0
+prometheus-client==0.14.0
 gds-metrics==0.2.4

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ pyexcel==0.7.0
 pyexcel-io==0.6.6
 pyexcel-xls==0.7.0
 pyexcel-xlsx==0.6.0
-pyexcel-ods3==0.6.0
+pyexcel-ods3==0.6.1
 pytz==2022.1
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -148,7 +148,7 @@ pyexcel-io==0.6.6
     #   pyexcel-ods3
     #   pyexcel-xls
     #   pyexcel-xlsx
-pyexcel-ods3==0.6.0
+pyexcel-ods3==0.6.1
     # via -r requirements.in
 pyexcel-xls==0.7.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,7 @@ packaging==20.9
     # via bleach
 phonenumbers==8.12.24
     # via notifications-utils
-prometheus-client==0.10.1
+prometheus-client==0.14.0
     # via
     #   -r requirements.in
     #   gds-metrics


### PR DESCRIPTION
The prometheus-client was pinned to avoid installing version `0.10.0`, which removed support for `prometheus_multiproc_dir` and renamed the variable `PROMETHEUS_MULTIPROC_DIR`. Version `0.10.1` reintroduced support for the lowercase `prometheus_multiproc_dir` environment variable.

Also bumps `pyexcel-ods3` to `0.6.1`, but there are no changes which affect our code in the new version.