### PR TITLE
Add internal routes

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,9 +1,9 @@
 {%- set apps = {
   'notify-admin': {
     'routes': {
-      'preview': ['www.notify.works'],
-      'staging': ['www.staging-notify.works'],
-      'production': ['www.notifications.service.gov.uk'],
+      'preview': ['www.notify.works', 'notify-admin-preview.apps.internal'],
+      'staging': ['www.staging-notify.works', 'notify-admin-staging.apps.internal'],
+      'production': ['www.notifications.service.gov.uk', 'notify-admin-production.apps.internal'],
     }
   },
   'notify-admin-prototype': {},


### PR DESCRIPTION
These will be used by prometheus to scrape the `/metrics` endpoint.

Look at https://github.com/alphagov/notifications-api/pull/3506 for more details