### PR TITLE
Bump utils to 55.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ pyproj==3.3.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,8 @@
 #
 ago==0.0.93
     # via -r requirements.in
-awscli==1.19.84
-    # via
-    #   awscli-cwlogs
-    #   notifications-utils
+awscli==1.22.93
+    # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 bleach==4.1.0
@@ -18,9 +16,9 @@ blinker==1.4
     # via
     #   -r requirements.in
     #   gds-metrics
-boto3==1.17.84
+boto3==1.21.38
     # via notifications-utils
-botocore==1.20.84
+botocore==1.24.38
     # via
     #   awscli
     #   boto3
@@ -119,7 +117,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx
@@ -190,7 +188,7 @@ rsa==4.7.2
     # via awscli
 rtreelib==0.2.0
     # via -r requirements.in
-s3transfer==0.4.2
+s3transfer==0.5.2
     # via
     #   awscli
     #   boto3


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

This required bumping the minimum version of boto3 with:

    pip-compile -P awscli requirements.in

I haven't looked into the awscli/boto3/botocore changes due to the
high churn on those libraries. Given they're minor changes we can
assume they are benign. s3transfer changes are also benign [^1]

[^1]: https://github.com/boto/s3transfer/blob/develop/CHANGELOG.rst