### PR TITLE
Remove redundant CloudFoundry config code

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -1,8 +1,3 @@
-"""
-Extracts cloudfoundry config from its json and populates the environment variables that we would expect to be populated
-on local/aws boxes
-"""
-
 import json
 import os
 
@@ -13,7 +8,3 @@ def extract_cloudfoundry_config():
     # Redis config
     if 'redis' in vcap_services:
         os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']
-
-    vcap_application = json.loads(os.environ.get('VCAP_APPLICATION'))
-    os.environ['NOTIFY_ENVIRONMENT'] = vcap_application['space_name']
-    os.environ['NOTIFY_LOG_PATH'] = '/home/vcap/logs/app.log'

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -36,7 +36,9 @@ applications:
 
     env:
       NOTIFY_APP_NAME: admin
+      NOTIFY_LOG_PATH: /home/vcap/logs/app.log
       FLASK_APP: application.py
+      NOTIFY_ENVIRONMENT: {{ environment }}
 
       # Credentials variables
       ADMIN_CLIENT_SECRET: '{{ ADMIN_CLIENT_SECRET }}'

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -7,7 +7,7 @@ from app.cloudfoundry_config import extract_cloudfoundry_config
 
 
 @pytest.fixture
-def cloudfoundry_config():
+def vcap_services():
     return {
         'redis': [{
             'credentials': {
@@ -17,23 +17,16 @@ def cloudfoundry_config():
     }
 
 
-@pytest.fixture
-def vcap_application(os_environ):
-    os.environ['VCAP_APPLICATION'] = '{"space_name":"🚀🌌"}'
-
-
-def test_extract_cloudfoundry_config_populates_other_vars(vcap_application, cloudfoundry_config):
-    os.environ['VCAP_SERVICES'] = json.dumps(cloudfoundry_config)
+def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_services):
+    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
     extract_cloudfoundry_config()
 
     assert os.environ['REDIS_URL'] == 'redis uri'
-    assert os.environ['NOTIFY_ENVIRONMENT'] == '🚀🌌'
-    assert os.environ['NOTIFY_LOG_PATH'] == '/home/vcap/logs/app.log'
 
 
-def test_set_config_env_vars_copes_if_redis_not_set(vcap_application, cloudfoundry_config):
-    del cloudfoundry_config['redis']
-    os.environ['VCAP_SERVICES'] = json.dumps(cloudfoundry_config)
+def test_extract_cloudfoundry_config_copes_if_redis_not_set(os_environ, vcap_services):
+    del vcap_services['redis']
+    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
 
     extract_cloudfoundry_config()
     assert 'REDIS_URL' not in os.environ


### PR DESCRIPTION
These env vars can be set directly in the manifest, like we do for
Template Preview [^1].

[^1]: https://github.com/alphagov/notifications-template-preview/blob/c08036189bf40b37516f921967dd21943bb72a63/manifest.yml.j2#L23-L26