### PR TITLE
bind to notify-redis automatically

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -4,7 +4,4 @@ import os
 
 def extract_cloudfoundry_config():
     vcap_services = json.loads(os.environ['VCAP_SERVICES'])
-
-    # Redis config
-    if 'redis' in vcap_services:
-        os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']
+    os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -33,6 +33,7 @@ applications:
       - logit-ssl-syslog-drain
       - notify-prometheus
       - notify-splunk
+      - notify-redis
 
     env:
       NOTIFY_APP_NAME: admin
@@ -61,6 +62,5 @@ applications:
       TEMPLATE_PREVIEW_API_KEY: '{{ TEMPLATE_PREVIEW_API_KEY }}'
 
       REDIS_ENABLED: '{{ REDIS_ENABLED }}'
-      REDIS_URL: '{{ REDIS_URL }}'
 
       NOTIFY_BILLING_DETAILS: '{{ NOTIFY_BILLING_DETAILS | tojson }}'

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -22,11 +22,3 @@ def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_servi
     extract_cloudfoundry_config()
 
     assert os.environ['REDIS_URL'] == 'redis uri'
-
-
-def test_extract_cloudfoundry_config_copes_if_redis_not_set(os_environ, vcap_services):
-    del vcap_services['redis']
-    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
-
-    extract_cloudfoundry_config()
-    assert 'REDIS_URL' not in os.environ


### PR DESCRIPTION
this ensures that if we create a new version of the app, it'll connect to redis properly (for example a UR prototype)


to be merged once manual deploy has been rolled out to all apps/envs.