### PR TITLE
Hide remaining free allowance if it starts at 0

### DIFF
--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -30,7 +30,9 @@
           <div class="keyline-block">
             {{ big_number(sms_sent, 'sent', smaller=True) }}
             {{ big_number(sms_free_allowance, 'free allowance', smaller=True) }}
-            {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
+            {% if sms_free_allowance > 0 %}
+              {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
+            {% endif %}
             {% if sms_chargeable %}
               {{ big_number(
                 sms_chargeable,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1137,6 +1137,45 @@ def test_usage_page_displays_letters_split_by_month_and_postage(
     assert '7 international letters at £1.00' in may_row
 
 
+@pytest.mark.parametrize('free_allowance, expected_sms_usage_breakdown', (
+    (0, (
+        'Text messages '
+        '252,190 sent '
+        '0 free allowance '
+        '252,190 at 1.65 pence per message'
+    )),
+    (100_000, (
+        'Text messages '
+        '252,190 sent '
+        '100,000 free allowance '
+        '0 free allowance remaining '
+        '152,190 at 1.65 pence per message'
+    )),
+))
+def test_usage_page_with_0_free_allowance(
+    mocker,
+    client_request,
+    mock_get_usage,
+    mock_get_billable_units,
+    free_allowance,
+    expected_sms_usage_breakdown,
+):
+    mocker.patch(
+        'app.billing_api_client.get_free_sms_fragment_limit_for_year',
+        return_value=free_allowance,
+    )
+    page = client_request.get(
+        'main.usage',
+        service_id=SERVICE_ONE_ID,
+        year=2020,
+    )
+    assert normalize_spaces(
+        page.select('main .govuk-grid-column-one-third')[1].text
+    ) == (
+        expected_sms_usage_breakdown
+    )
+
+
 def test_usage_page_with_year_argument(
     client_request,
     mock_get_usage,


### PR DESCRIPTION
If your free allowance starts a 0 (which we have done for some services this year) it’s redundant to say ‘0 of 0 remaining’.

Before | After 
---|---
<img width="255" alt="image" src="https://user-images.githubusercontent.com/355079/164201798-fce4993f-9843-4adf-86e6-ee6754e47ee3.png"> | <img width="250" alt="image" src="https://user-images.githubusercontent.com/355079/164201883-632464a8-5adc-404c-80d6-fe1589dd9f8b.png">
