### PR TITLE
Remove redundant conditional for CF Redis

### DIFF
--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -4,7 +4,4 @@ import os
 
 def extract_cloudfoundry_config():
     vcap_services = json.loads(os.environ['VCAP_SERVICES'])
-
-    # Redis config
-    if 'redis' in vcap_services:
-        os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']
+    os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -22,11 +22,3 @@ def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_servi
     extract_cloudfoundry_config()
 
     assert os.environ['REDIS_URL'] == 'redis uri'
-
-
-def test_extract_cloudfoundry_config_copes_if_redis_not_set(os_environ, vcap_services):
-    del vcap_services['redis']
-    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
-
-    extract_cloudfoundry_config()
-    assert 'REDIS_URL' not in os.environ


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181796569

This is now used in all environments and we've removed support for
non-CF Redis [1].

[1]: https://github.com/alphagov/notifications-admin/pull/4213