### PR TITLE
Update text message rate on 1 May 2022

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -13,6 +13,7 @@ from notifications_utils.template import HTMLEmailTemplate, LetterImageTemplate
 from app import email_branding_client, letter_branding_client, status_api_client
 from app.main import main
 from app.main.forms import FieldWithNoneOption
+from app.main.views.pricing import get_current_sms_rate
 from app.main.views.sub_navigation_dictionaries import (
     features_nav,
     using_notify_nav,
@@ -28,6 +29,7 @@ def index():
 
     return render_template(
         'views/signedout.html',
+        sms_rate=get_current_sms_rate(),
         counts=status_api_client.get_count_of_live_services_and_organisations(),
     )
 

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -1,19 +1,28 @@
+from datetime import datetime
+
 from flask import current_app, render_template
 from flask_login import current_user
 from notifications_utils.international_billing_rates import (
     INTERNATIONAL_BILLING_RATES,
 )
+from notifications_utils.timezones import convert_utc_to_bst
 
 from app.main import main
 from app.main.forms import SearchByNameForm
 from app.main.views.sub_navigation_dictionaries import pricing_nav
 
 
+def get_current_sms_rate():
+    if convert_utc_to_bst(datetime.utcnow()) < convert_utc_to_bst(datetime(2022, 5, 1)):
+        return '1.61'
+    return '1.72'
+
+
 @main.route('/pricing')
 def pricing():
     return render_template(
         'views/pricing/index.html',
-        sms_rate=0.0158,
+        sms_rate=get_current_sms_rate(),
         international_sms_rates=sorted([
             (cc, country['names'], country['billable_units'])
             for cc, country in INTERNATIONAL_BILLING_RATES.items()

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -42,7 +42,7 @@
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
-  <p class="govuk-body">When a service has used its annual allowance, it costs 1.72 pence (plus VAT) for each text message you send.</p>
+  <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
   <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">text messages longer than 160 characters</a>.</p>
   <p class="govuk-body">You may also use more free messages, or pay more for each message, if you:</p>
   <ul class="list list-bullet">

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -15,7 +15,7 @@
 
     {{ content_metadata(
       data={
-        "Last updated": "22 April 2022"
+        "Last updated": "1 May 2022"
       }
     ) }}
 

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -42,10 +42,7 @@
 
   <h2 class="heading-medium" id="text-messages">Text messages</h2>
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
-  <p class="govuk-body">When a service has used its annual allowance, it costs 1.61 pence (plus VAT) for each text message you send.</p>
-  <div class="panel panel-border-wide">  
-    <p class="govuk-body">On 1 May 2022 the cost of sending a text message will go up to 1.72 pence (plus VAT).</p>
-  </div>
+  <p class="govuk-body">When a service has used its annual allowance, it costs 1.72 pence (plus VAT) for each text message you send.</p>
   <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">text messages longer than 160 characters</a>.</p>
   <p class="govuk-body">You may also use more free messages, or pay more for each message, if you:</p>
   <ul class="list list-bullet">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -153,7 +153,7 @@
           <h3 class="govuk-visually-hidden">Text messages</h3>
           <div class="product-page-big-number">Up to 40,000</div>
           free text messages a year,<br>
-          then 1.72 pence per message
+          then {{ sms_rate }} pence per message
         </div>
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Letters</h3>

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -153,7 +153,7 @@
           <h3 class="govuk-visually-hidden">Text messages</h3>
           <div class="product-page-big-number">Up to 40,000</div>
           free text messages a year,<br>
-          then 1.61 pence per message
+          then 1.72 pence per message
         </div>
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Letters</h3>

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -356,3 +356,36 @@ def test_font_preload(
     for element in preload_tags:
         assert element['href'].startswith('https://static.example.com/fonts/')
         assert element['href'].endswith('.woff2')
+
+
+@pytest.mark.parametrize('current_date, expected_rate', (
+    ('2022-04-30', '1.61'),
+    ('2022-05-01', '1.72'),
+))
+def test_sms_price(
+    client_request,
+    mock_get_service_and_organisation_counts,
+    current_date,
+    expected_rate,
+):
+    client_request.logout()
+
+    with freeze_time(current_date):
+        home_page = client_request.get('main.index', _test_page_title=False)
+        pricing_page = client_request.get('main.pricing')
+
+    assert normalize_spaces(
+        home_page.select('.product-page-section')[5].select('.govuk-grid-column-one-half')[1].text
+    ) == (
+        f'Text messages '
+        f'Up to 40,000 free text messages a year, '
+        f'then {expected_rate} pence per message'
+    )
+
+    assert normalize_spaces(
+        pricing_page.select_one('#text-messages + p + p').text
+    ) == (
+        f'When a service has used its annual allowance, it costs '
+        f'{expected_rate} pence (plus VAT) for each text message you '
+        f'send.'
+    )


### PR DESCRIPTION
This PR updates the pricing and product pages so they display the current text message rate automatically.

This means we no longer need to manually update this content when we change our prices.

We’re making this change now so we can automate the text message price increase that comes into effect over the bank holiday weekend.