### PR TITLE
Bump utils to 55.1.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ pyproj==3.3.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==1.1.0  # pyup: <2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,7 +117,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
     # via -r requirements.in
 openpyxl==3.0.7
     # via pyexcel-xlsx
@@ -156,7 +156,7 @@ pyjwt==2.1.0
     # via notifications-python-client
 pyparsing==2.4.7
     # via packaging
-pypdf2==1.26.0
+pypdf2==1.27.9
     # via notifications-utils
 pyproj==3.3.0
     # via


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/958
- [x] https://github.com/alphagov/notifications-utils/pull/966 (will stop PyUp Safety-CI complaining)