### PR TITLE
Change annual usage to work with multiple SMS rates

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -328,8 +328,6 @@ def get_dashboard_totals(statistics):
 
 def get_annual_usage_breakdown(usage, free_sms_fragment_limit):
     sms = get_usage_breakdown_by_type(usage, 'sms')
-    # this relies on the assumption: only one SMS rate per financial year.
-    sms_rate = 0 if len(sms) == 0 else sms[0].get("rate", 0)
     sms_chargeable_units = sum(row['chargeable_units'] for row in sms)
     sms_free_allowance = free_sms_fragment_limit
     sms_cost = sum(row['cost'] for row in sms)
@@ -346,9 +344,8 @@ def get_annual_usage_breakdown(usage, free_sms_fragment_limit):
         'sms_free_allowance': sms_free_allowance,
         'sms_sent': sms_chargeable_units,
         'sms_allowance_remaining': max(0, (sms_free_allowance - sms_chargeable_units)),
-        'sms_charged': max(0, sms_chargeable_units - sms_free_allowance),
         'sms_cost': sms_cost,
-        'sms_rate': sms_rate,
+        'sms_breakdown': sms,
         'letter_sent': letters_sent,
         'letter_cost': letters_cost
     }

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -330,14 +330,14 @@ def get_annual_usage_breakdown(usage, free_sms_fragment_limit):
     sms = get_usage_breakdown_by_type(usage, 'sms')
     # this relies on the assumption: only one SMS rate per financial year.
     sms_rate = 0 if len(sms) == 0 else sms[0].get("rate", 0)
-    sms_chargeable_units = sum(row['billing_units'] for row in sms)
+    sms_chargeable_units = sum(row['chargeable_units'] for row in sms)
     sms_free_allowance = free_sms_fragment_limit
 
     emails = get_usage_breakdown_by_type(usage, 'email')
-    emails_sent = sum(row['billing_units'] for row in emails)
+    emails_sent = sum(row['notifications_sent'] for row in emails)
 
     letters = get_usage_breakdown_by_type(usage, 'letter')
-    letters_sent = sum(row['billing_units'] for row in letters)
+    letters_sent = sum(row['notifications_sent'] for row in letters)
     letters_cost = sum(row['letter_total'] for row in letters)
 
     return {

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -346,7 +346,7 @@ def get_annual_usage_breakdown(usage, free_sms_fragment_limit):
         'sms_free_allowance': sms_free_allowance,
         'sms_sent': sms_chargeable_units,
         'sms_allowance_remaining': max(0, (sms_free_allowance - sms_chargeable_units)),
-        'sms_chargeable': max(0, sms_chargeable_units - sms_free_allowance),
+        'sms_charged': max(0, sms_chargeable_units - sms_free_allowance),
         'sms_cost': sms_cost,
         'sms_rate': sms_rate,
         'letter_sent': letters_sent,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -332,13 +332,14 @@ def get_annual_usage_breakdown(usage, free_sms_fragment_limit):
     sms_rate = 0 if len(sms) == 0 else sms[0].get("rate", 0)
     sms_chargeable_units = sum(row['chargeable_units'] for row in sms)
     sms_free_allowance = free_sms_fragment_limit
+    sms_cost = sum(row['cost'] for row in sms)
 
     emails = get_usage_breakdown_by_type(usage, 'email')
     emails_sent = sum(row['notifications_sent'] for row in emails)
 
     letters = get_usage_breakdown_by_type(usage, 'letter')
     letters_sent = sum(row['notifications_sent'] for row in letters)
-    letters_cost = sum(row['letter_total'] for row in letters)
+    letters_cost = sum(row['cost'] for row in letters)
 
     return {
         'emails_sent': emails_sent,
@@ -346,6 +347,7 @@ def get_annual_usage_breakdown(usage, free_sms_fragment_limit):
         'sms_sent': sms_chargeable_units,
         'sms_allowance_remaining': max(0, (sms_free_allowance - sms_chargeable_units)),
         'sms_chargeable': max(0, sms_chargeable_units - sms_free_allowance),
+        'sms_cost': sms_cost,
         'sms_rate': sms_rate,
         'letter_sent': letters_sent,
         'letter_cost': letters_cost

--- a/app/templates/views/dashboard/_usage.html
+++ b/app/templates/views/dashboard/_usage.html
@@ -8,9 +8,9 @@
   </div>
   <div class='govuk-grid-column-one-third'>
     <div class="keyline-block">
-      {% if sms_chargeable %}
+      {% if sms_cost %}
         {{ big_number(
-          sms_chargeable * sms_rate,
+          sms_cost,
           'spent on text messages',
           currency="£",
           smaller=True

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -33,13 +33,15 @@
             {% if sms_free_allowance > 0 %}
               {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
             {% endif %}
-            {% if sms_charged %}
-              {{ big_number(
-                sms_charged,
-                'at {:.2f} pence per message'.format(sms_rate * 100),
-                smaller=True
-              ) }}
-            {% endif %}
+            {% for row in sms_breakdown %}
+              {% if row.charged_units > 0 %}
+                {{ big_number(
+                  row.charged_units,
+                  'at {:.2f} pence per message'.format(row.rate * 100),
+                  smaller=True
+                ) }}
+              {% endif %}
+            {% endfor %}
           </div>
         </div>
         <div class='govuk-grid-column-one-third'>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -59,7 +59,7 @@
         <div class='govuk-grid-column-one-third'>
           <div class="keyline-block">
             {{ big_number(
-              (sms_chargeable * sms_rate),
+              sms_cost,
               'spent',
               currency="£",
               smaller=True

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -33,9 +33,9 @@
             {% if sms_free_allowance > 0 %}
               {{ big_number(sms_allowance_remaining, 'free allowance remaining', smaller=True) }}
             {% endif %}
-            {% if sms_chargeable %}
+            {% if sms_charged %}
               {{ big_number(
-                sms_chargeable,
+                sms_charged,
                 'at {:.2f} pence per message'.format(sms_rate * 100),
                 smaller=True
               ) }}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1012,22 +1012,9 @@ def test_usage_page(
     assert '252,190' in cols[1].text
     assert 'Text messages' in cols[1].text
 
-    table = page.find('table').text.strip()
-
-    assert '249,860 free text messages' in table
-    assert '40 free text messages' in table
-    assert '960 text messages at 1.65p' in table
-    assert 'April' in table
-    assert 'February' in table
-    assert 'March' in table
-    assert '£28.99' in table
-    assert '140 free text messages' in table
-    assert '£20.91' in table
-    assert '1,230 text messages at 1.70p' in table
-
 
 @freeze_time("2012-03-31 12:12:12")
-def test_usage_page_with_letters(
+def test_usage_page_monthly_breakdown(
     client_request,
     service_one,
     mock_get_usage,
@@ -1040,35 +1027,21 @@ def test_usage_page_with_letters(
         service_id=SERVICE_ONE_ID,
     )
 
-    mock_get_billable_units.assert_called_once_with(SERVICE_ONE_ID, 2011)
-    mock_get_usage.assert_called_once_with(SERVICE_ONE_ID, 2011)
-    mock_get_free_sms_fragment_limit.assert_called_with(SERVICE_ONE_ID, 2011)
+    monthly_breakdown = normalize_spaces(page.find('table').text)
 
-    cols = page.find_all('div', {'class': 'govuk-grid-column-one-third'})
-    nav = page.find('ul', {'class': 'pill'})
-    unselected_nav_links = nav.select('a:not(.pill-item--selected)')
-
-    assert normalize_spaces(nav.find('a', {'aria-current': 'page'}).text) == '2011 to 2012 financial year'
-    assert normalize_spaces(unselected_nav_links[0].text) == '2010 to 2011 financial year'
-    assert normalize_spaces(unselected_nav_links[1].text) == '2009 to 2010 financial year'
-    assert '252,190' in cols[1].text
-    assert 'Text messages' in cols[1].text
-
-    table = page.find('table').text.strip()
-
-    assert '249,860 free text messages' in table
-    assert '40 free text messages' in table
-    assert '960 text messages at 1.65p' in table
-    assert 'April' in table
-    assert 'February' in table
-    assert 'March' in table
-    assert '£28.99' in table
-    assert '140 free text messages' in table
-    assert '£20.91' in table
-    assert '1,230 text messages at 1.70p' in table
-    assert '10 second class letters at 31p' in normalize_spaces(table)
-    assert '5 first class letters at 33p' in normalize_spaces(table)
-    assert '10 international letters at 84p' in normalize_spaces(table)
+    assert '249,860 free text messages' in monthly_breakdown
+    assert '40 free text messages' in monthly_breakdown
+    assert '960 text messages at 1.65p' in monthly_breakdown
+    assert 'April' in monthly_breakdown
+    assert 'February' in monthly_breakdown
+    assert 'March' in monthly_breakdown
+    assert '£28.99' in monthly_breakdown
+    assert '140 free text messages' in monthly_breakdown
+    assert '£20.91' in monthly_breakdown
+    assert '1,230 text messages at 1.70p' in monthly_breakdown
+    assert '10 second class letters at 31p' in monthly_breakdown
+    assert '5 first class letters at 33p' in monthly_breakdown
+    assert '10 international letters at 84p' in monthly_breakdown
 
 
 @freeze_time("2012-04-30 12:12:12")

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1126,32 +1126,15 @@ def test_usage_page_displays_letters_split_by_month_and_postage(
     assert '7 international letters at £1.00' in may_row
 
 
-@pytest.mark.parametrize('free_allowance, expected_sms_usage_breakdown', (
-    (0, (
-        'Text messages '
-        '252,190 sent '
-        '0 free allowance '
-        '252,190 at 1.65 pence per message'
-    )),
-    (100_000, (
-        'Text messages '
-        '252,190 sent '
-        '100,000 free allowance '
-        '0 free allowance remaining '
-        '152,190 at 1.65 pence per message'
-    )),
-))
 def test_usage_page_with_0_free_allowance(
     mocker,
     client_request,
     mock_get_usage,
     mock_get_billable_units,
-    free_allowance,
-    expected_sms_usage_breakdown,
 ):
     mocker.patch(
         'app.billing_api_client.get_free_sms_fragment_limit_for_year',
-        return_value=free_allowance,
+        return_value=0,
     )
     page = client_request.get(
         'main.usage',
@@ -1161,7 +1144,10 @@ def test_usage_page_with_0_free_allowance(
     assert normalize_spaces(
         page.select('main .govuk-grid-column-one-third')[1].text
     ) == (
-        expected_sms_usage_breakdown
+        'Text messages '
+        '251,800 sent '
+        '0 free allowance '
+        '251,800 at 1.65 pence per message'
     )
 
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1020,7 +1020,7 @@ def test_usage_page(
     assert '251,800 sent' in sms_column
     assert '250,000 free allowance' in sms_column
     assert '0 free allowance remaining' in sms_column
-    assert '£36.14 spent' in sms_column
+    assert '£29.85 spent' in sms_column
     assert '1,800 at 1.65 pence' in sms_column
 
     letter_column = normalize_spaces(annual_usage[2].text + annual_usage[5].text)
@@ -1855,7 +1855,7 @@ def test_service_dashboard_shows_usage(
     ) == (
         'Unlimited '
         'free email allowance '
-        '£36.14 '
+        '£29.85 '
         'spent on text messages '
         '£30.00 '
         'spent on letters'

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1890,3 +1890,30 @@ def test_service_dashboard_shows_usage(
         '£30.00 '
         'spent on letters'
     )
+
+
+def test_service_dashboard_shows_free_allowance(
+    mocker,
+    client_request,
+    service_one,
+    mock_get_service_templates,
+    mock_get_template_statistics,
+    mock_has_no_jobs,
+    mock_get_free_sms_fragment_limit,
+    mock_get_returned_letter_statistics_with_no_returned_letters,
+):
+    mocker.patch('app.billing_api_client.get_service_usage', return_value=[
+        {
+            "notification_type": "sms",
+            "chargeable_units": 1000,
+            "charged_units": 0,
+            "rate": 0.0165,
+            "cost": 0
+        }
+    ])
+
+    page = client_request.get('main.service_dashboard', service_id=SERVICE_ONE_ID)
+
+    usage_text = normalize_spaces(page.select_one('[data-key=usage]').text)
+    assert 'spent on text messages' not in usage_text
+    assert '249,000 free text messages left' in usage_text

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1017,11 +1017,11 @@ def test_usage_page(
 
     sms_column = normalize_spaces(annual_usage[1].text + annual_usage[4].text)
     assert 'Text messages' in sms_column
-    assert '252,190 sent' in sms_column
+    assert '251,800 sent' in sms_column
     assert '250,000 free allowance' in sms_column
     assert '0 free allowance remaining' in sms_column
     assert '£36.14 spent' in sms_column
-    assert '2,190 at 1.65 pence' in sms_column
+    assert '1,800 at 1.65 pence' in sms_column
 
     letter_column = normalize_spaces(annual_usage[2].text + annual_usage[5].text)
     assert 'Letters' in letter_column

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2350,7 +2350,14 @@ def mock_get_usage(mocker, service_one, fake_uuid):
                 "notifications_sent": 90,
                 "rate": 0.0165,
                 "letter_total": 0
-            }
+            },
+            {
+                "notification_type": "letter",
+                "chargeable_units": 300,
+                "notifications_sent": 100,
+                "rate": 0.1,
+                "letter_total": 30
+            },
         ]
 
     return mocker.patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2320,6 +2320,7 @@ def mock_get_usage(mocker, service_one, fake_uuid):
                 "notification_type": "email",
                 "chargeable_units": 1000,
                 "notifications_sent": 1000,
+                "charged_units": 1000,
                 "rate": 0.00,
                 "cost": 0
             },
@@ -2327,6 +2328,7 @@ def mock_get_usage(mocker, service_one, fake_uuid):
                 "notification_type": "sms",
                 "chargeable_units": 251500,
                 "notifications_sent": 105000,
+                "charged_units": 1500,
                 "rate": 0.0165,
                 "cost": 24.75  # 250K free allowance
             },
@@ -2334,13 +2336,15 @@ def mock_get_usage(mocker, service_one, fake_uuid):
                 "notification_type": "sms",
                 "chargeable_units": 300,
                 "notifications_sent": 300,
-                "rate": 0.0165,
+                "charged_units": 300,
+                "rate": 0.017,
                 "cost": 5.1
             },
             {
                 "notification_type": "letter",
                 "chargeable_units": 300,
                 "notifications_sent": 100,
+                "charged_units": 300,
                 "rate": 0.1,
                 "cost": 30
             },
@@ -2466,6 +2470,7 @@ def mock_get_future_usage(mocker, service_one, fake_uuid):
                 'notification_type': 'sms',
                 'chargeable_units': 0,
                 'notifications_sent': 0,
+                'charged_units': 0,
                 'rate': 0.0158,
                 'cost': 0
             },
@@ -2473,6 +2478,7 @@ def mock_get_future_usage(mocker, service_one, fake_uuid):
                 'notification_type': 'email',
                 'chargeable_units': 0,
                 'notifications_sent': 0,
+                'charged_units': 0,
                 'rate': 0.0,
                 'cost': 0
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2321,28 +2321,28 @@ def mock_get_usage(mocker, service_one, fake_uuid):
                 "chargeable_units": 1000,
                 "notifications_sent": 1000,
                 "rate": 0.00,
-                "letter_total": 0
+                "cost": 0
             },
             {
                 "notification_type": "sms",
                 "chargeable_units": 251500,
                 "notifications_sent": 105000,
                 "rate": 0.0165,
-                "letter_total": 0
+                "cost": 24.75  # 250K free allowance
             },
             {
                 "notification_type": "sms",
                 "chargeable_units": 300,
                 "notifications_sent": 300,
                 "rate": 0.0165,
-                "letter_total": 0
+                "cost": 5.1
             },
             {
                 "notification_type": "letter",
                 "chargeable_units": 300,
                 "notifications_sent": 100,
                 "rate": 0.1,
-                "letter_total": 30
+                "cost": 30
             },
         ]
 
@@ -2467,14 +2467,14 @@ def mock_get_future_usage(mocker, service_one, fake_uuid):
                 'chargeable_units': 0,
                 'notifications_sent': 0,
                 'rate': 0.0158,
-                'letter_total': 0
+                'cost': 0
             },
             {
                 'notification_type': 'email',
                 'chargeable_units': 0,
                 'notifications_sent': 0,
                 'rate': 0.0,
-                'letter_total': 0
+                'cost': 0
             }
         ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2316,11 +2316,41 @@ def mock_get_monthly_notification_stats(mocker, service_one, fake_uuid):
 def mock_get_usage(mocker, service_one, fake_uuid):
     def _get_usage(service_id, year=None):
         return [
-            {"notification_type": "email", "billing_units": 1000, "rate": 0.00, "letter_total": 0},
-            {"notification_type": "sms", "billing_units": 251500, "rate": 0.0165, "letter_total": 0},
-            {"notification_type": "sms", "billing_units": 300, "rate": 0.0165, "letter_total": 0},
-            {"notification_type": "sms", "billing_units": 300, "rate": 0.0165, "letter_total": 0},
-            {"notification_type": "sms", "billing_units": 90, "rate": 0.0165, "letter_total": 0}
+            {
+                "notification_type": "email",
+                "chargeable_units": 1000,
+                "notifications_sent": 1000,
+                "rate": 0.00,
+                "letter_total": 0
+            },
+            {
+                "notification_type": "sms",
+                "chargeable_units": 251500,
+                "notifications_sent": 105000,
+                "rate": 0.0165,
+                "letter_total": 0
+            },
+            {
+                "notification_type": "sms",
+                "chargeable_units": 300,
+                "notifications_sent": 300,
+                "rate": 0.0165,
+                "letter_total": 0
+            },
+            {
+                "notification_type": "sms",
+                "chargeable_units": 300,
+                "notifications_sent": 150,
+                "rate": 0.0165,
+                "letter_total": 0
+            },
+            {
+                "notification_type": "sms",
+                "chargeable_units": 90,
+                "notifications_sent": 90,
+                "rate": 0.0165,
+                "letter_total": 0
+            }
         ]
 
     return mocker.patch(
@@ -2440,12 +2470,18 @@ def mock_get_future_usage(mocker, service_one, fake_uuid):
     def _get_usage(service_id, year=None):
         return [
             {
-                'notification_type': 'sms', 'billing_units': 0,
-                'rate': 0.0158, 'letter_total': 0
+                'notification_type': 'sms',
+                'chargeable_units': 0,
+                'notifications_sent': 0,
+                'rate': 0.0158,
+                'letter_total': 0
             },
             {
-                'notification_type': 'email', 'billing_units': 0,
-                'rate': 0.0, 'letter_total': 0
+                'notification_type': 'email',
+                'chargeable_units': 0,
+                'notifications_sent': 0,
+                'rate': 0.0,
+                'letter_total': 0
             }
         ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2338,20 +2338,6 @@ def mock_get_usage(mocker, service_one, fake_uuid):
                 "letter_total": 0
             },
             {
-                "notification_type": "sms",
-                "chargeable_units": 300,
-                "notifications_sent": 150,
-                "rate": 0.0165,
-                "letter_total": 0
-            },
-            {
-                "notification_type": "sms",
-                "chargeable_units": 90,
-                "notifications_sent": 90,
-                "rate": 0.0165,
-                "letter_total": 0
-            },
-            {
                 "notification_type": "letter",
                 "chargeable_units": 300,
                 "notifications_sent": 100,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181934027

This starts shifting SMS usage calculations to new
fields in the API [^1]. Key changes include:

- Costs are now calculated correctly in the API -
Admin just sums them together to get a total.

- We now show a breakdown by rate for each distinct
rate that SMS was charged at.

The first few commits are some general changes and
refactoring to make the main changes clearer.

## Screenshots

| Before | After |
| - | - |
| <img width="247" alt="Screenshot 2022-04-26 at 17 52 50" src="https://user-images.githubusercontent.com/9029009/165352497-813dcaad-cca8-42f7-ae10-ef5272d33487.png"> | <img width="244" alt="Screenshot 2022-04-26 at 17 30 50" src="https://user-images.githubusercontent.com/9029009/165352518-1555d4b2-af2c-4a84-bc6b-a0153cf65614.png"> |

[^1]: https://github.com/alphagov/notifications-api/pull/3520