### PR TITLE
Clean up old text message price

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -13,7 +13,7 @@ from notifications_utils.template import HTMLEmailTemplate, LetterImageTemplate
 from app import email_branding_client, letter_branding_client, status_api_client
 from app.main import main
 from app.main.forms import FieldWithNoneOption
-from app.main.views.pricing import SMS_RATE
+from app.main.views.pricing import CURRENT_SMS_RATE
 from app.main.views.sub_navigation_dictionaries import (
     features_nav,
     using_notify_nav,
@@ -29,7 +29,7 @@ def index():
 
     return render_template(
         'views/signedout.html',
-        sms_rate=SMS_RATE,
+        sms_rate=CURRENT_SMS_RATE,
         counts=status_api_client.get_count_of_live_services_and_organisations(),
     )
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -13,7 +13,7 @@ from notifications_utils.template import HTMLEmailTemplate, LetterImageTemplate
 from app import email_branding_client, letter_branding_client, status_api_client
 from app.main import main
 from app.main.forms import FieldWithNoneOption
-from app.main.views.pricing import get_current_sms_rate
+from app.main.views.pricing import SMS_RATE
 from app.main.views.sub_navigation_dictionaries import (
     features_nav,
     using_notify_nav,
@@ -29,7 +29,7 @@ def index():
 
     return render_template(
         'views/signedout.html',
-        sms_rate=get_current_sms_rate(),
+        sms_rate=SMS_RATE,
         counts=status_api_client.get_count_of_live_services_and_organisations(),
     )
 

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -8,15 +8,14 @@ from app.main import main
 from app.main.forms import SearchByNameForm
 from app.main.views.sub_navigation_dictionaries import pricing_nav
 
-
-SMS_RATE = '1.72'
+CURRENT_SMS_RATE = '1.72'
 
 
 @main.route('/pricing')
 def pricing():
     return render_template(
         'views/pricing/index.html',
-        sms_rate=SMS_RATE,
+        sms_rate=CURRENT_SMS_RATE,
         international_sms_rates=sorted([
             (cc, country['names'], country['billable_units'])
             for cc, country in INTERNATIONAL_BILLING_RATES.items()

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -13,8 +13,6 @@ from app.main.views.sub_navigation_dictionaries import pricing_nav
 
 
 def get_current_sms_rate():
-    if convert_utc_to_bst(datetime.utcnow()) < convert_utc_to_bst(datetime(2022, 5, 1)):
-        return '1.61'
     return '1.72'
 
 

--- a/app/main/views/pricing.py
+++ b/app/main/views/pricing.py
@@ -1,26 +1,22 @@
-from datetime import datetime
-
 from flask import current_app, render_template
 from flask_login import current_user
 from notifications_utils.international_billing_rates import (
     INTERNATIONAL_BILLING_RATES,
 )
-from notifications_utils.timezones import convert_utc_to_bst
 
 from app.main import main
 from app.main.forms import SearchByNameForm
 from app.main.views.sub_navigation_dictionaries import pricing_nav
 
 
-def get_current_sms_rate():
-    return '1.72'
+SMS_RATE = '1.72'
 
 
 @main.route('/pricing')
 def pricing():
     return render_template(
         'views/pricing/index.html',
-        sms_rate=get_current_sms_rate(),
+        sms_rate=SMS_RATE,
         international_sms_rates=sorted([
             (cc, country['names'], country['billable_units'])
             for cc, country in INTERNATIONAL_BILLING_RATES.items()

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -359,7 +359,6 @@ def test_font_preload(
 
 
 @pytest.mark.parametrize('current_date, expected_rate', (
-    ('2022-04-30', '1.61'),
     ('2022-05-01', '1.72'),
 ))
 def test_sms_price(


### PR DESCRIPTION
Now that the new price is in effect, we don’t need to check the date to see which price should be displayed to the user.