### PR TITLE
Fix focus and spacing on counties page

### DIFF
--- a/app/templates/views/broadcast/counties.html
+++ b/app/templates/views/broadcast/counties.html
@@ -25,15 +25,17 @@
     </div>
     {{ live_search(target_selector='.file-list-item', show=show_search_form, form=search_form, label='Or by district') }}
 
+    <div class="govuk-!-margin-bottom-6">
     {% for area in county.sub_areas|sort %}
       <div class="file-list-item">
       {# these are districts within a county#}
         <a
-          class="file-list-filename-large govuk-link govuk-link--no-visited-state"
+          class="file-list-filename-large file-list-filename-large-no-hint govuk-link govuk-link--no-visited-state"
           href="{{ url_for('.choose_broadcast_sub_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, library_slug=library_slug, area_slug=area.id, prev_area_slug=county.id) }}"
         >{{ area.name }}</a>
       </div>
     {% endfor %}
+    </div>
 
     {{ sticky_page_footer('Continue') }}
 


### PR DESCRIPTION
We fixed a problem with the focus styles of list
items in https://github.com/alphagov/notifications-admin/pull/4141.

This missed out pages for areas with counties in
them. This adds the fix to those pages.

These changes also include some extra spacing
between the end of the list and the button which
is lost by the new styles we're giving the list
items.

## Focus style issue

### Before

<img width="748" alt="counties_focus_issue_before" src="https://user-images.githubusercontent.com/87140/166702109-0c18cc2b-758b-428c-a89d-29ef8334b8a2.png">

### After

<img width="746" alt="countries_focus_issue_after" src="https://user-images.githubusercontent.com/87140/166702161-3748929c-5184-4aa1-b5f7-d62e5ca97891.png">

## Spacing issue

### Before

<img width="314" alt="counties_spacing_issue_before" src="https://user-images.githubusercontent.com/87140/166702224-c01819ee-781c-492e-91ac-eedbae356fa5.png">

### After

<img width="271" alt="counties_spacing_issue_after" src="https://user-images.githubusercontent.com/87140/166702229-dbb6c379-746e-4183-b1f2-aa4bcb6a8164.png">
