### PR TITLE
Update minor and patch versions of some core dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,9 +7,9 @@ humanize==4.0.0
 Flask==1.1.2  # pyup: <2
 Flask-WTF==1.0.1
 wtforms==3.0.1
-Flask-Login==0.6.0
-werkzeug==2.0.2
-jinja2==3.0.2
+Flask-Login==0.6.1
+werkzeug==2.1.2
+jinja2==3.1.2
 
 blinker==1.4
 pyexcel==0.7.0
@@ -23,7 +23,7 @@ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b86
 notifications-python-client==6.3.0
 rtreelib==0.2.0
 fido2==0.9.3
-pyproj==3.3.0
+pyproj==3.3.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ flask==1.1.2
     #   flask-wtf
     #   gds-metrics
     #   notifications-utils
-flask-login==0.6.0
+flask-login==0.6.1
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
@@ -91,7 +91,7 @@ itsdangerous==1.1.0
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==3.0.2
+jinja2==3.1.2
     # via
     #   -r requirements.in
     #   flask
@@ -158,7 +158,7 @@ pyparsing==2.4.7
     # via packaging
 pypdf2==1.27.9
     # via notifications-utils
-pyproj==3.3.0
+pyproj==3.3.1
     # via
     #   -r requirements.in
     #   notifications-utils
@@ -213,7 +213,7 @@ urllib3==1.26.5
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==2.0.2
+werkzeug==2.1.2
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
### Update [Flask-Login](https://pypi.org/project/Flask-Login) from **0.6.0** to **0.6.1**.


<details>
  <summary>Changelog</summary>
  
  
   ### 0.6.1
   ```
   -------------

Released on May 1st, 2022

- Only preserve subdomain or host view args in unauthorized redirect 663
- The new utility function `login_remembered` returns `True` if the current
  login is remembered across sessions. 654
- Fix side effect potentially executing view twice for same request. 666
- Clarify usage of FlaskLoginClient test client in docs. 668
   ```
   
  
</details>


 

<details>
  <summary>Links</summary>
  
  - PyPI: https://pypi.org/project/flask-login
  - Changelog: https://pyup.io/changelogs/flask-login/
  - Repo: https://github.com/maxcountryman/flask-login
  - Docs: https://pythonhosted.org/Flask-Login/
</details>





### Update [werkzeug](https://pypi.org/project/werkzeug) from **2.0.2** to **2.1.2**.


<details>
  <summary>Changelog</summary>
  
  
   ### 2.1.2
   ```
   -------------

Released 2022-04-28

-   The development server does not set ``Transfer-Encoding: chunked``
    for 1xx, 204, 304, and HEAD responses. :issue:`2375`
-   Response HTML for exceptions and redirects starts with
    ``&lt;!doctype html&gt;`` and ``&lt;html lang=en&gt;``. :issue:`2390`
-   Fix ability to set some ``cache_control`` attributes to ``False``.
    :issue:`2379`
-   Disable ``keep-alive`` connections in the development server, which
    are not supported sufficiently by Python&#x27;s ``http.server``.
    :issue:`2397`
   ```
   
  
  
   ### 2.1.1
   ```
   -------------

Released 2022-04-01

-   ``ResponseCacheControl.s_maxage`` converts its value to an int, like
    ``max_age``. :issue:`2364`
   ```
   
  
  
   ### 2.1.0
   ```
   -------------

Released 2022-03-28

-   Drop support for Python 3.6. :pr:`2277`
-   Using gevent or eventlet requires greenlet&gt;=1.0 or PyPy&gt;=7.3.7.
    ``werkzeug.locals`` and ``contextvars`` will not work correctly with
    older versions. :pr:`2278`
-   Remove previously deprecated code. :pr:`2276`

    -   Remove the non-standard ``shutdown`` function from the WSGI
        environ when running the development server. See the docs for
        alternatives.
    -   Request and response mixins have all been merged into the
        ``Request`` and ``Response`` classes.
    -   The user agent parser and the ``useragents`` module is removed.
        The ``user_agent`` module provides an interface that can be
        subclassed to add a parser, such as ua-parser. By default it
        only stores the whole string.
    -   The test client returns ``TestResponse`` instances and can no
        longer be treated as a tuple. All data is available as
        properties on the response.
    -   Remove ``locals.get_ident`` and related thread-local code from
        ``locals``, it no longer makes sense when moving to a
        contextvars-based implementation.
    -   Remove the ``python -m werkzeug.serving`` CLI.
    -   The ``has_key`` method on some mapping datastructures; use
        ``key in data`` instead.
    -   ``Request.disable_data_descriptor`` is removed, pass
        ``shallow=True`` instead.
    -   Remove the ``no_etag`` parameter from ``Response.freeze()``.
    -   Remove the ``HTTPException.wrap`` class method.
    -   Remove the ``cookie_date`` function. Use ``http_date`` instead.
    -   Remove the ``pbkdf2_hex``, ``pbkdf2_bin``, and ``safe_str_cmp``
        functions. Use equivalents in ``hashlib`` and ``hmac`` modules
        instead.
    -   Remove the ``Href`` class.
    -   Remove the ``HTMLBuilder`` class.
    -   Remove the ``invalidate_cached_property`` function. Use
        ``del obj.attr`` instead.
    -   Remove ``bind_arguments`` and ``validate_arguments``. Use
        :meth:`Signature.bind` and :func:`inspect.signature` instead.
    -   Remove ``detect_utf_encoding``, it&#x27;s built-in to ``json.loads``.
    -   Remove ``format_string``, use :class:`string.Template` instead.
    -   Remove ``escape`` and ``unescape``. Use MarkupSafe instead.

-   The ``multiple`` parameter of ``parse_options_header`` is
    deprecated. :pr:`2357`
-   Rely on :pep:`538` and :pep:`540` to handle decoding file names
    with the correct filesystem encoding. The ``filesystem`` module is
    removed. :issue:`1760`
-   Default values passed to ``Headers`` are validated the same way
    values added later are. :issue:`1608`
-   Setting ``CacheControl`` int properties, such as ``max_age``, will
    convert the value to an int. :issue:`2230`
-   Always use ``socket.fromfd`` when restarting the dev server.
    :pr:`2287`
-   When passing a dict of URL values to ``Map.build``, list values do
    not filter out ``None`` or collapse to a single value. Passing a
    ``MultiDict`` does collapse single items. This undoes a previous
    change that made it difficult to pass a list, or ``None`` values in
    a list, to custom URL converters. :issue:`2249`
-   ``run_simple`` shows instructions for dealing with &quot;address already
    in use&quot; errors, including extra instructions for macOS. :pr:`2321`
-   Extend list of characters considered always safe in URLs based on
    :rfc:`3986`. :issue:`2319`
-   Optimize the stat reloader to avoid watching unnecessary files in
    more cases. The watchdog reloader is still recommended for
    performance and accuracy. :issue:`2141`
-   The development server uses ``Transfer-Encoding: chunked`` for
    streaming responses when it is configured for HTTP/1.1.
    :issue:`2090, 1327`, :pr:`2091`
-   The development server uses HTTP/1.1, which enables keep-alive
    connections and chunked streaming responses, when ``threaded`` or
    ``processes`` is enabled. :pr:`2323`
-   ``cached_property`` works for classes with ``__slots__`` if a
    corresponding ``_cache_{name}`` slot is added. :pr:`2332`
-   Refactor the debugger traceback formatter to use Python&#x27;s built-in
    ``traceback`` module as much as possible. :issue:`1753`
-   The ``TestResponse.text`` property is a shortcut for
    ``r.get_data(as_text=True)``, for convenient testing against text
    instead of bytes. :pr:`2337`
-   ``safe_join`` ensures that the path remains relative if the trusted
    directory is the empty string. :pr:`2349`
-   Percent-encoded newlines (``%0a``), which are decoded by WSGI
    servers, are considered when routing instead of terminating the
    match early. :pr:`2350`
-   The test client doesn&#x27;t set duplicate headers for ``CONTENT_LENGTH``
    and ``CONTENT_TYPE``. :pr:`2348`
-   ``append_slash_redirect`` handles ``PATH_INFO`` with internal
    slashes. :issue:`1972`, :pr:`2338`
-   The default status code for ``append_slash_redirect`` is 308 instead
    of 301. This preserves the request body, and matches a previous
    change to ``strict_slashes`` in routing. :issue:`2351`
-   Fix ``ValueError: I/O operation on closed file.`` with the test
    client when following more than one redirect. :issue:`2353`
-   ``Response.autocorrect_location_header`` is disabled by default.
    The ``Location`` header URL will remain relative, and exclude the
    scheme and domain, by default. :issue:`2352`
-   ``Request.get_json()`` will raise a 400 ``BadRequest`` error if the
    ``Content-Type`` header is not ``application/json``. This makes a
    very common source of confusion more visible. :issue:`2339`
   ```
   
  
  
   ### 2.0.3
   ```
   -------------

Released 2022-02-07

-   ``ProxyFix`` supports IPv6 addresses. :issue:`2262`
-   Type annotation for ``Response.make_conditional``,
    ``HTTPException.get_response``, and ``Map.bind_to_environ`` accepts
    ``Request`` in addition to ``WSGIEnvironment`` for the first
    parameter. :pr:`2290`
-   Fix type annotation for ``Request.user_agent_class``. :issue:`2273`
-   Accessing ``LocalProxy.__class__`` and ``__doc__`` on an unbound
    proxy returns the fallback value instead of a method object.
    :issue:`2188`
-   Redirects with the test client set ``RAW_URI`` and ``REQUEST_URI``
    correctly. :issue:`2151`
   ```
   
  
</details>


 

<details>
  <summary>Links</summary>
  
  - PyPI: https://pypi.org/project/werkzeug
  - Changelog: https://pyup.io/changelogs/werkzeug/
  - Homepage: https://palletsprojects.com/p/werkzeug/
</details>





### Update [jinja2](https://pypi.org/project/jinja2) from **3.0.2** to **3.1.2**.


*The bot wasn't able to find a changelog for this release. [Got an idea?](https://github.com/pyupio/changelogs/issues/new)*

<details>
  <summary>Links</summary>
  
  - PyPI: https://pypi.org/project/jinja2
  - Homepage: https://palletsprojects.com/p/jinja/
</details>





### Update [pyproj](https://pypi.org/project/pyproj) from **3.3.0** to **3.3.1**.


*The bot wasn't able to find a changelog for this release. [Got an idea?](https://github.com/pyupio/changelogs/issues/new)*

<details>
  <summary>Links</summary>
  
  - PyPI: https://pypi.org/project/pyproj
  - Repo: https://github.com/pyproj4/pyproj
</details>



