### PR TITLE
Fix alignment regression error with area lists

### DIFF
--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -55,6 +55,7 @@
     & > :first-child,
     & > .area-list {
       width: 100%;
+      text-align: left;
     }
 
     & > .file-list-hint-large,


### PR DESCRIPTION
When we changed the layout for each alert on the
current/past/rejected alerts pages to use flexbox,
we added a fallback for older browsers that set
text-align: justify on the container: https://github.com/alphagov/notifications-admin/pull/4171.

This has led to items in the list of areas an
alert will be sent to being laid out as justified
content when they were left-aligned.

These changes set the correct alignment.

## Before

<img width="736" alt="list_of_areas_before" src="https://user-images.githubusercontent.com/87140/166937843-1d14eee2-541b-40ab-8bc9-e5356c83815e.png">

## After

<img width="732" alt="list_of_areas_after" src="https://user-images.githubusercontent.com/87140/166937849-a56f32ef-4ecf-46e2-9511-a9ae5d2b729c.png">
