### PR TITLE
Remove whitespace from copy to clipboard component

### DIFF
--- a/app/templates/components/copy-to-clipboard.html
+++ b/app/templates/components/copy-to-clipboard.html
@@ -6,7 +6,7 @@
   {% endif %}
   <div data-module="copy-to-clipboard" data-value="{{ value }}" data-thing="{{ thing }}" data-name="{{ name }}">
     <span class="copy-to-clipboard__value">
-      {% if name|lower != thing|lower %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ value }}
+      {%- if name|lower != thing|lower %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ value -}}
     </span>
     <span class="copy-to-clipboard__notice" aria-live="assertive"></span>
   </div>

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -281,8 +281,9 @@ def test_should_create_api_key_with_type_normal(
         _expected_status=200,
     )
 
-    assert page.select_one('span.copy-to-clipboard__value').text.strip() == (
-        'some_default_key_name_12-{}-{}'.format(SERVICE_ONE_ID, fake_uuid)
+    assert page.select_one('span.copy-to-clipboard__value').text == (
+        # The text should be exactly this, with no leading or trailing whitespace
+        f'some_default_key_name_12-{SERVICE_ONE_ID}-{fake_uuid}'
     )
 
     post.assert_called_once_with(url='/service/{}/api-key'.format(SERVICE_ONE_ID), data={


### PR DESCRIPTION
If there is whitespace in the element containing the value to be copied then Firefox<sup>1</sup> includes that space in the value it puts in the clipboard.

This is obviously annoying since `foo-bar` might be a valid API key where `foo-bar ` is not.

This commit fixes that by [using the `-` in Jinja to gobble whitespace](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control).

I also looked at doing this in the Javascript, but the browser API for selecting some text and copying it doesn’t give an obvious place for using [`String.prototype.trim()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim).

***

Fixes #4216

***
1. Tested with Firefox 100.0 on Mac OS 12.2.1