### PR TITLE
Update bleach and cachetools to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ awscli==1.22.93
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-bleach==4.1.0
+bleach==5.0.0
     # via notifications-utils
 blinker==1.4
     # via
@@ -23,7 +23,7 @@ botocore==1.24.38
     #   awscli
     #   boto3
     #   s3transfer
-cachetools==4.2.2
+cachetools==5.0.0
     # via notifications-utils
 certifi==2021.5.30
     # via


### PR DESCRIPTION
### Update [bleach](https://pypi.org/project/bleach) from **4.1.0** to **5.0.0**.


<details>
  <summary>Changelog</summary>
  
  
   ### 5.0.0
   ```
   -------------------------------

**Backwards incompatible changes**

* ``clean`` and ``linkify`` now preserve the order of HTML attributes. Thank
  you, askoretskly! (566)

* Drop support for Python 3.6. Thank you, hugovk! (629)

* CSS sanitization in style tags is completely different now. If you&#x27;re using
  Bleach ``clean`` to sanitize css in style tags, you&#x27;ll need to update your
  code and you&#x27;ll need to install the ``css`` extras::

      pip install &#x27;bleach[css]&#x27;

  See `the documentation on sanitizing CSS for how to do it
  &lt;https://bleach.readthedocs.io/en/latest/clean.html#sanitizing-css&gt;`_. (633)

**Bug fixes**

* Rework dev dependencies. We no longer have
  ``requirements-dev.in``/``requirements-dev.txt``. Instead, we&#x27;re using
  ``dev`` extras.

  See `development docs &lt;https://bleach.readthedocs.io/en/latest/dev.html&gt;`_
  for more details. (620)

* Add newline when dropping block-level tags. Thank you, jvanasco! (369)
   ```
   
  
</details>


 

<details>
  <summary>Links</summary>
  
  - PyPI: https://pypi.org/project/bleach
  - Changelog: https://pyup.io/changelogs/bleach/
  - Repo: https://github.com/mozilla/bleach
  - Docs: https://pythonhosted.org/bleach/
</details>


### Update [cachetools](https://pypi.org/project/cachetools) from **4.2.2** to **5.0.0**.


<details>
  <summary>Changelog</summary>
  
  
   ### 5.0.0
   ```
   ===================

- Require Python 3.7 or later (breaking change).

- Remove deprecated submodules (breaking change).

  The ``cache``, ``fifo``, ``lfu``, ``lru``, ``mru``, ``rr`` and
  ``ttl`` submodules have been deleted.  Therefore, statements like

  ``from cachetools.ttl import TTLCache``

  will no longer work. Use

  ``from cachetools import TTLCache``

  instead.

- Pass ``self`` to ``cachedmethod`` key function (breaking change).

  The ``key`` function passed to the ``cachedmethod`` decorator is
  now called as ``key(self, *args, **kwargs)``.

  The default key function has been changed to ignore its first
  argument, so this should only affect applications using custom key
  functions with the ``cachedmethod`` decorator.

- Change exact time of expiration in ``TTLCache`` (breaking change).

  ``TTLCache`` items now get expired if their expiration time is less
  than *or equal to* ``timer()``.  For applications using the default
  ``timer()``, this should be barely noticable, but it may affect the
  use of custom timers with larger tick intervals.  Note that this
  also implies that a ``TTLCache`` with ``ttl=0`` can no longer hold
  any items, since they will expire immediately.

- Change ``Cache.__repr__()`` format (breaking change).

  String representations of cache instances now use a more compact and
  efficient format, e.g.

  ``LRUCache({1: 1, 2: 2}, maxsize=10, currsize=2)``

- Add TLRU cache implementation.

- Documentation improvements.
   ```
   
  
  
   ### 4.2.4
   ```
   ===================

- Add submodule shims for backward compatibility.
   ```
   
  
  
   ### 4.2.3
   ```
   ===================

- Add documentation and tests for using ``TTLCache`` with
  ``datetime``.

- Link to typeshed typing stubs.

- Flatten package file hierarchy.
   ```
   
  
</details>


 

<details>
  <summary>Links</summary>
  
  - PyPI: https://pypi.org/project/cachetools
  - Changelog: https://pyup.io/changelogs/cachetools/
  - Repo: https://github.com/tkem/cachetools/
</details>


