### PR TITLE
Stop pyup trying to upgrade blocked dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,12 +4,12 @@
 ago==0.0.93
 govuk-bank-holidays==0.11
 humanize==4.1.0
-Flask==1.1.2  # pyup: <2
+Flask==1.1.2  # pyup: <1.1.3
 Flask-WTF==1.0.1
 wtforms==3.0.1
 Flask-Login==0.6.1
-werkzeug==2.0.3  # Can’t be upgraded until we are using Flask >= 2
-jinja2==3.0.3  # Can’t be upgraded until we are using Flask >= 2
+werkzeug==2.0.3  # pyup: <2.1
+jinja2==3.0.3  # pyup: <3.1
 
 blinker==1.4
 pyexcel==0.7.0


### PR DESCRIPTION
We can’t upgrade Jinja or Werkzeug until we’re on Flask 2.x.x. We can’t upgrade Flask to 1.1.3 because it pins older versions of Jinja and Werkzeug than the ones we’re using. We can’t upgrade Flask to 2.x.x until we upgrade itsdangerous to 2.x.x, which is blocked by https://github.com/alphagov/notifications-admin/pull/4044