### PR TITLE
Add the filetype to download links

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -34,7 +34,7 @@
           </p>
         {% elif notifications %}
           <p class="{% if job.template_type != 'letter' %}bottom-gutter{% endif %}">
-            <a href="{{ download_link }}" download class="govuk-link govuk-link--no-visited-state heading-small">Download this report</a>
+            <a href="{{ download_link }}" download class="govuk-link govuk-link--no-visited-state heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
             &emsp;
             <span id="time-left">{{ time_left }}</span>
           </p>

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -15,7 +15,7 @@
     </h1>
 
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ download_link }}">Download the agreement</a>{% if owner %} for {{ owner }}{% endif %}.
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ download_link }}">Download the agreement (PDF)</a>{% if owner %} for {{ owner }}{% endif %}.
     </p>
     <p class="govuk-body">
       The agreement contains commercially sensitive information. Do not share it outside your organisation.

--- a/app/templates/views/agreement/service-agreement-signed.html
+++ b/app/templates/views/agreement/service-agreement-signed.html
@@ -21,7 +21,7 @@
       {{ current_service.organisation.name }} has already accepted the GOV.UK
       Notify data sharing and financial agreement.
     </p>
-    <p class="govuk-body">For more information, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">download a copy of the agreement</a>.
+    <p class="govuk-body">For more information, you can <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">download a copy of the agreement (PDF)</a>.
     </p>
     <p class="govuk-body">
       The agreement is confidential and should not be shared outside your organisation.

--- a/app/templates/views/agreement/service-agreement.html
+++ b/app/templates/views/agreement/service-agreement.html
@@ -28,7 +28,7 @@
       Once accepted, the agreement covers all Notify services from {{ current_service.organisation.name }}.
     </p>
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">Download a copy of the data sharing and financial agreement</a>.
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.service_download_agreement', service_id=current_service.id) }}">Download a copy of the data sharing and financial agreement (PDF)</a>.
     </p>
     <p class="govuk-body">
       The agreement is confidential and should not be shared outside your organisation.

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -66,7 +66,7 @@
 
   {% if current_user.has_permissions('view_activity') %}
     <p class="bottom-gutter">
-      <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
+      <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
       &emsp;
       Data available for {{ partials.service_data_retention_days }} days
     </p>

--- a/app/templates/views/organisations/organisation/billing.html
+++ b/app/templates/views/organisations/organisation/billing.html
@@ -24,7 +24,7 @@
         </p>
         <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state"
-             href="{{ url_for('.organisation_download_agreement', org_id=current_org.id) }}">Download the current version of the agreement
+             href="{{ url_for('.organisation_download_agreement', org_id=current_org.id) }}">Download the current version of the agreement (PDF)
           </a>
         </p>
       {% elif current_org.agreement_signed %}
@@ -33,7 +33,7 @@
         </p>
         <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state"
-             href="{{ url_for('.organisation_download_agreement', org_id=current_org.id) }}">Download the current version of the agreement
+             href="{{ url_for('.organisation_download_agreement', org_id=current_org.id) }}">Download the current version of the agreement (PDF)
           </a>
         </p>
       {% elif current_org.agreement_signed is false %}

--- a/app/templates/views/organisations/organisation/index.html
+++ b/app/templates/views/organisations/organisation/index.html
@@ -113,7 +113,7 @@
   {% else %}
     <div class="js-stick-at-bottom-when-scrolling">
       <p class="govuk-!-margin-bottom-1">
-        <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report</a>
+        <a href="{{ download_link }}" download="download" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
       </p>
     </div>
   {% endif %}

--- a/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
@@ -15,7 +15,7 @@
   {% call form_wrapper() %}
     {{ form.start_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
     {{ form.end_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
-    {{ page_footer('Download report') }}
+    {{ page_footer('Download report (CSV)') }}
   {% endcall %}
 
   <h2 class="heading-medium">

--- a/app/templates/views/platform-admin/daily-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-volumes-report.html
@@ -15,7 +15,7 @@
   {% call form_wrapper() %}
     {{ form.start_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
     {{ form.end_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
-    {{ page_footer('Download report') }}
+    {{ page_footer('Download report (CSV)') }}
   {% endcall %}
 
   <h2 class="heading-medium">

--- a/app/templates/views/platform-admin/get-billing-report.html
+++ b/app/templates/views/platform-admin/get-billing-report.html
@@ -15,7 +15,7 @@
   {% call form_wrapper() %}
     {{ form.start_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
     {{ form.end_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
-    {{ page_footer('Download report') }}
+    {{ page_footer('Download report (CSV)') }}
   {% endcall %}
 
   <h2 class="heading-medium">

--- a/app/templates/views/platform-admin/notifications_by_service.html
+++ b/app/templates/views/platform-admin/notifications_by_service.html
@@ -14,7 +14,7 @@
   {% call form_wrapper() %}
     {{ form.start_date(param_extensions={"hint": {"text": "Enter start date in format YYYY-MM-DD"}}) }}
     {{ form.end_date(param_extensions={"hint": {"text": "Enter end date in format YYYY-MM-DD"}}) }}
-    {{ page_footer('Download report') }}
+    {{ page_footer('Download report (CSV)') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/platform-admin/volumes-by-service-report.html
+++ b/app/templates/views/platform-admin/volumes-by-service-report.html
@@ -15,7 +15,7 @@
   {% call form_wrapper() %}
     {{ form.start_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
     {{ form.end_date(param_extensions={"hint": {"text": "Use the format YYYY-MM-DD"}}) }}
-    {{ page_footer('Download report') }}
+    {{ page_footer('Download report (CSV)') }}
   {% endcall %}
 
   <h2 class="heading-medium">

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -17,7 +17,7 @@
 {{ page_header('Returned letters for {}'.format(reported_at|format_date_normal)) }}
 
 <p class="bottom-gutter">
-  <a download href="{{ url_for('.returned_letters_report', service_id=current_service.id, reported_at=reported_at) }}" class="govuk-link heading-small">Download this report</a>
+  <a download href="{{ url_for('.returned_letters_report', service_id=current_service.id, reported_at=reported_at) }}" class="govuk-link heading-small">Download this report (<abbr title="Comma separated values">CSV</abbr>)</a>
 </p>
 
 <div class="dashboard-table">

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -52,7 +52,7 @@
     <li>your email address and password</li>
     <li>a text message code that Notify sends to your phone</li>
   </ul>
-  <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
+  <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a> to find out about using an email link instead.</p>
 
   <h2 class="heading-medium" id="information-risk-management">Information risk management</h2>
   <p class="govuk-body">Our approach to information risk management follows NCSC guidance. It assesses:</p>
@@ -67,7 +67,7 @@
   <p class="govuk-body">Things we do to manage risks on Notify include:</p>
   <ul class="list list-bullet">
     <li>formal risk assessments based on <a class="govuk-link govuk-link--no-visited-state" href="http://www.iso.org/iso/catalogue_detail?csnumber=56742">ISO 27005:2011</a> and National Cyber Security Centre guidance</li>
-    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.cesg.gov.uk/articles/check-fundamental-principles">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
+    <li><a class="govuk-link govuk-link--no-visited-state" href="https://www.ncsc.gov.uk/information/check-penetration-testing">CHECK</a>-based testing, both annually and when any major changes are made to Notify</li>
     <li>residual risk statement preparation and active management of the risk treatment plan</li>
     <li>regular updates to the Privacy Impact Assessment</li>
     <li>security impact assessments</li>

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -50,7 +50,7 @@
     {% endcall %}
   </div>
   <p class="table-show-more-link">
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download>Download this example</a>
+    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.get_example_csv', service_id=current_service.id, template_id=template.id) }}" download>Download this example (<abbr title="Comma separated values">CSV</abbr>)</a>
   </p>
 
   <h2 class="heading-medium">Your file will populate this template ({{ template.name }})</h2>

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -134,7 +134,7 @@
           <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.delete_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Delete this contact list</a>
         </span>
       {% endif %}
-      <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" download href="{{ url_for('main.download_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Download this contact list</a>
+      <a class="govuk-link govuk-link--no-visited-state page-footer-right-aligned-link-without-button" download href="{{ url_for('main.download_contact_list', service_id=current_service.id, contact_list_id=contact_list.id) }}">Download this contact list (<abbr title="Comma separated values">CSV</abbr>)</a>
     </div>
   </div>
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -666,7 +666,7 @@ def test_organisation_services_links_to_downloadable_report(
     page = client_request.get('.organisation_dashboard', org_id=ORGANISATION_ID)
 
     link_to_report = page.select_one('a[download]')
-    assert normalize_spaces(link_to_report.text) == 'Download this report'
+    assert normalize_spaces(link_to_report.text) == 'Download this report (CSV)'
     assert link_to_report.attrs["href"] == url_for(
         '.download_organisation_usage_report',
         org_id=ORGANISATION_ID,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -106,7 +106,7 @@ def test_should_show_page_for_one_job(
         job_id=fake_uuid,
         status=status_argument
     )
-    assert csv_link.text == 'Download this report'
+    assert csv_link.text == 'Download this report (CSV)'
     assert page.find('span', {'id': 'time-left'}).text == 'Data available for 7 days'
 
     assert normalize_spaces(page.select_one('tbody tr').text) == normalize_spaces(

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -146,7 +146,7 @@ def test_returned_letters_page_with_many_letters(
         expected_message
     )
     assert page.select_one('a[download]').text == (
-        'Download this report'
+        'Download this report (CSV)'
     )
     assert page.select_one('a[download]')['href'] == url_for(
         '.returned_letters_report',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170148870

This adds the filetype to links as part of the link text. Adding the file size would be trickier - we generally don't know the file size, so to add the file size to the link text would involve making an extra request to find out. I've not included file size for now, but we can review whether this should be added later.

**Examples of new links:**
<img width="500" alt="Screenshot 2022-05-19 at 12 22 02" src="https://user-images.githubusercontent.com/12881990/169282095-d35d1aee-63b1-4c50-b1bd-565b73f4cf28.png">


<img width="500" alt="Screenshot 2022-05-19 at 12 21 46" src="https://user-images.githubusercontent.com/12881990/169282109-80472fab-1b79-40b5-9e12-de87ff7353b4.png">


<img width="500" alt="Screenshot 2022-05-19 at 12 23 46" src="https://user-images.githubusercontent.com/12881990/169282421-16177411-ca50-47e9-a146-b94d97fa1a77.png">