### PR TITLE
Spike fix to performance issue for /templates

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -547,6 +547,12 @@ class Service(JSONModel, SortByNameMixin):
         return {folder['id'] for folder in self.all_template_folders}
 
     def get_user_template_folders(self, user):
+        if not hasattr(self, '_cache'):
+            self._cache = {}
+
+        if user in self._cache:
+            return self._cache[user]
+
         """Returns a modified list of folders a user has permission to view
 
         For each folder, we do the following:
@@ -585,6 +591,7 @@ class Service(JSONModel, SortByNameMixin):
                         if user.has_template_folder_permission(parent, service=self):
                             break
                 user_folders.append(folder_attrs)
+        self._cache[user] = user_folders
         return user_folders
 
     def get_template_folders(self, template_type='all', parent_folder_id=None, user=None):

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -1,4 +1,5 @@
 from app import format_notification_type
+from werkzeug.utils import cached_property
 
 
 class TemplateList():
@@ -16,10 +17,13 @@ class TemplateList():
         self.user = user
 
     def __iter__(self):
-        for item in self.get_templates_and_folders(
+        yield from self.items
+
+    @cached_property
+    def items(self):
+        return list(self.get_templates_and_folders(
             self.template_type, self.template_folder_id, self.user, ancestors=[]
-        ):
-            yield item
+        ))
 
     def get_templates_and_folders(self, template_type, template_folder_id, user, ancestors):
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179736794

## Local testing

The affected service currently has ~190 folders and ~1800 templates, arranged in a multi-level hierarchy.

<details>
<summary>I reproduced a similar-looking service locally, with roughly double the number of folders and templates.</summary>

```
@notify_command(name='create-fake-service-folders')
def create_fake_service_folders():
    from app.models import Template, TemplateFolder, User
    from app import db

    service_id='824229f9-fb72-4113-9722-67bd58388607'

    def create_level(parent_folder_id=None, level=1):
        if level > 5:
            return

        for i in range(0, 3):
            tf = TemplateFolder(
                name=f'Test folder {level}-{i}',
                parent_id=parent_folder_id,
                service_id=service_id
            )
            db.session.add(tf)
            db.session.commit()

            for j in range(0, 10):
                t = Template(
                    service_id=service_id,
                    template_type='email',
                    name=f'Test template {level}-{i}-{j}',
                    content='foo',
                    created_by_id=str(User.query.first().id),
                    folder=tf
                )
                db.session.add(t)
            db.session.commit()

            create_level(str(tf.id), level+1)

    create_level()
```
</details>

The end result was slow, taking around 10s to load locally. 

<details>
<summary>Command to time page load over 5 repetitions</summary>
repeat 5 { time curl -b "notify_admin_session=<value from browser dev tools" localhost:6012/services/824229f9-fb72-4113-9722-67bd58388607/templates > /dev/null 2>&1 | grep cpu } 
</details>

<details>
<summary>Commands to cleanup.</summary>

```
delete from template_folder_map where template_folder_id in (select id from template_folder where service_id='824229f9-fb72-4113-9722-67bd58388607');
delete from user_folder_permissions where template_folder_id in (select id from template_folder where service_id='824229f9-fb72-4113-9722-67bd58388607');
delete from template_folder where service_id='824229f9-fb72-4113-9722-67bd58388607';
delete from templates where service_id='824229f9-fb72-4113-9722-67bd58388607';
```
</details>

## Local profiling

Looking at the code suggests the likely culprit is the commit to ["Put all nested items on page"](https://github.com/alphagov/notifications-admin/commit/148492a63567f623be6f6bf1ef16d79ef7b94841). We do this multiple times: once for [the hidden search items](https://github.com/alphagov/notifications-admin/blob/d1c6e06bf1ba52b43158cce46a3ca86d8921a43a/app/templates/views/templates/_template_list.html#L83) and again for [the form to move templates to a folder](https://github.com/alphagov/notifications-admin/blob/d1c6e06bf1ba52b43158cce46a3ca86d8921a43a/app/main/forms.py#L2371).

To illustrate the sheer volume of rendering going on, compare the response sizes:

- Affected service (linked in card description): 3.8MB*
- Local test service (roughly double the size): 9.9MB
- Small service (three template): 8.1KB

*Note: the value reported by Chrome's network inspector can be misleading; save the page to disk to be sure.

However, while it's not ideal that we're sending MBs of data to a user's browser, using [Flask's inbuilt request profiler](https://stackoverflow.com/questions/59955328/how-to-profile-flask-endpoint) and [snapviz](https://dev.to/yellalena/profiling-flask-application-to-improve-performance-4970) to visualise the results shows the slow response times are primarily due to backend computation.

| API calls are quick* | `get_user_template_folders` is slow |
| - | - |
| <img width="1487" alt="api_calls_are_quick" src="https://user-images.githubusercontent.com/9029009/170068420-d0c4d7dd-7157-45a7-a70c-22f04b973272.png"> _We cache the API set of templates/folders retrieved from the API ([example](https://github.com/alphagov/notifications-admin/blob/d1c6e06bf1ba52b43158cce46a3ca86d8921a43a/app/models/service.py#L539))._ | <img width="1491" alt="get_user_template_folders_is_slow" src="https://user-images.githubusercontent.com/9029009/170068442-bd9affc8-76c8-4cfb-a105-aa7893afbef9.png"> |

The slowness is apparently due to the sheer number of times we are calling `get_user_template_folders` (1457). The cumulative time spent in the function is entirely made up of basic Python getters and loops.

## Fixing the issue

Since the individual functions are already quite fast, caching is the obvious solution.

This draft PR contains two proposed caching additions that significantly improve performance of the page when testing locally, both separately and together. See the commits for more details.

Next steps:

- Investigate test failures due to these changes.
- Find a simpler way of doing instance-based caching.