### PR TITLE
Update review date

### DIFF
--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -13,7 +13,7 @@
   {{ content_metadata(
     data={
       "Last updated": "27 April 2022",
-      "Next review due": "21 June 2022"
+      "Next review due": "12 July 2022"
     }
   ) }}
 


### PR DESCRIPTION
This PR updates the review date for our public roadmap.

We’re doing this because we’re working on a new roadmap for Notify and we need a couple of extra weeks to prepare it.