### PR TITLE
Fix go-live checks ignoring nested templates

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -284,13 +284,19 @@ class Service(JSONModel, SortByNameMixin):
             ))
         )
 
+    def has_templates_of_type(self, template_type):
+        return any(
+            template for template in self.all_templates
+            if template['template_type'] == template_type
+        )
+
     @property
     def has_email_templates(self):
-        return len(self.get_templates('email')) > 0
+        return self.has_templates_of_type('email')
 
     @property
     def has_sms_templates(self):
-        return len(self.get_templates('sms')) > 0
+        return self.has_templates_of_type('sms')
 
     @property
     def intending_to_send_email(self):

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -267,29 +267,7 @@ def test_service_billing_details(purchase_order_number, expected_result):
     assert service.billing_details == expected_result
 
 
-@pytest.mark.xfail
-def test_has_email_templates_includes_folders(
-    mocker,
-    service_one,
-    mock_get_template_folders,
-):
-    mocker.patch(
-        'app.service_api_client.get_service_templates',
-        return_value={'data': [create_template(
-            folder='something', template_type='email'
-        )]}
-    )
-
-    mocker.patch(
-        'app.template_folder_api_client.get_template_folders',
-        return_value=[create_folder(id='something')]
-    )
-
-    assert Service(service_one).has_email_templates
-
-
-@pytest.mark.xfail
-def test_has_sms_templates_includes_folders(
+def test_has_templates_of_type_includes_folders(
     mocker,
     service_one,
     mock_get_template_folders,
@@ -306,4 +284,4 @@ def test_has_sms_templates_includes_folders(
         return_value=[create_folder(id='something')]
     )
 
-    assert Service(service_one).has_sms_templates
+    assert Service(service_one).has_templates_of_type('sms')

--- a/tests/app/models/test_service.py
+++ b/tests/app/models/test_service.py
@@ -6,7 +6,7 @@ from app.models.organisation import Organisation
 from app.models.service import Service
 from app.models.user import User
 from tests import organisation_json, service_json
-from tests.conftest import ORGANISATION_ID
+from tests.conftest import ORGANISATION_ID, create_folder, create_template
 
 INV_PARENT_FOLDER_ID = '7e979e79-d970-43a5-ac69-b625a8d147b0'
 INV_CHILD_1_FOLDER_ID = '92ee1ee0-e4ee-4dcc-b1a7-a5da9ebcfa2b'
@@ -265,3 +265,45 @@ def test_service_billing_details(purchase_order_number, expected_result):
     service = Service(service_json(purchase_order_number=purchase_order_number))
     service._dict['purchase_order_number'] = purchase_order_number
     assert service.billing_details == expected_result
+
+
+@pytest.mark.xfail
+def test_has_email_templates_includes_folders(
+    mocker,
+    service_one,
+    mock_get_template_folders,
+):
+    mocker.patch(
+        'app.service_api_client.get_service_templates',
+        return_value={'data': [create_template(
+            folder='something', template_type='email'
+        )]}
+    )
+
+    mocker.patch(
+        'app.template_folder_api_client.get_template_folders',
+        return_value=[create_folder(id='something')]
+    )
+
+    assert Service(service_one).has_email_templates
+
+
+@pytest.mark.xfail
+def test_has_sms_templates_includes_folders(
+    mocker,
+    service_one,
+    mock_get_template_folders,
+):
+    mocker.patch(
+        'app.service_api_client.get_service_templates',
+        return_value={'data': [create_template(
+            folder='something', template_type='sms'
+        )]}
+    )
+
+    mocker.patch(
+        'app.template_folder_api_client.get_template_folders',
+        return_value=[create_folder(id='something')]
+    )
+
+    assert Service(service_one).has_sms_templates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3982,6 +3982,14 @@ def create_notifications(
     )
 
 
+def create_folder(id):
+    return {
+        'id': id,
+        'parent_id': None,
+        'name': 'My folder'
+    }
+
+
 def create_template(
     service_id=SERVICE_ONE_ID,
     template_id=None,
@@ -3990,7 +3998,8 @@ def create_template(
     content='Template content',
     subject='Template subject',
     redact_personalisation=False,
-    postage=None
+    postage=None,
+    folder=None
 ):
     return template_json(
         service_id=service_id,
@@ -4001,6 +4010,7 @@ def create_template(
         subject=subject,
         redact_personalisation=redact_personalisation,
         postage=postage,
+        folder=folder,
     )
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179736794

This is a very low impact bug since a user can always create such templates
after their service is live and not be subject to checks we do before that
point. Still, we may as well fix it.

The main benefit of this change is actually to contribute towards moving
methods like "get_templates" out of the Service class so we can simplify
and cache their results more effectively.

## Screenshots (service with a nested email template)

| Before | After |
| - | - |
| <img width="749" alt="Screenshot 2022-05-27 at 10 35 46" src="https://user-images.githubusercontent.com/9029009/170673528-5c640f2e-cecd-4004-befe-87d50dc39d2a.png"> | <img width="762" alt="Screenshot 2022-05-27 at 10 35 36" src="https://user-images.githubusercontent.com/9029009/170673545-21a9c920-79a8-48f5-afd5-ea66f6466f24.png"> |

