### PR TITLE
Upgrade itsdangerous from 1.1.0 to 2.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ pyproj==3.3.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
-itsdangerous==1.1.0  # pyup: <2
+itsdangerous==2.0.1  # pyup: <2.1.0  Release 2.1.0 introduced a change that is not compatible with Flask 1.x
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ humanize==4.1.0
     # via -r requirements.in
 idna==3.3
     # via requests
-itsdangerous==1.1.0
+itsdangerous==2.0.1
     # via
     #   -r requirements.in
     #   flask

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import freezegun
 import pytest
 from flask import session as flask_session
 from flask import url_for
@@ -10,6 +11,12 @@ from flask.testing import FlaskClient
 from flask_login import login_user
 
 from app.models.user import User
+
+# Add itsdangerous to the libraries which freezegun ignores to avoid errors.
+# In tests where we freeze time, the code in the test function will get the frozen time but the
+# fixtures will be using the current time. This causes itsdangerous to raise an exception - when
+# the session is decoded it appears to be created in the future.
+freezegun.configure(extend_ignore_list=['itsdangerous'])
 
 
 class TestClient(FlaskClient):


### PR DESCRIPTION
This upgrades itsdangerous by a major version.

When testing most routes we:
* use the `client_request` fixture
  * under the hood this logs in the user with `TestClient.login`
  * logging in the user signs their session with a secret and the current time

For some tests we also:
* wrap the test method with a `freeze_time()` decorator to simulate a past date and time

When Pytest calls the wrapped test method:
* any application code which tries to get the current time will get the frozen time
* any application code getting the current user means decoding the session
* the code which decodes the session will see that the session was created in the future, in other words it has a negative age
  * as of ItsDangerous 2.0.0 signatures with a negative age raise an exception

To avoid all the tests which freeze time failing, this adds itsdangerous to the list of packages that freezegun ignores.

We can't yet upgrade to a version of itsdangerous that is >= 2.1.0 because there are compatibility issues with Flask 1.x.

(All the investigation into the problem was done by @quis and the description is copied from https://github.com/alphagov/notifications-admin/pull/4044#issuecomment-997902771 😀)