### PR TITLE
Bump Flask, Jinja and Werkzeug to their latest versions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -162,6 +162,9 @@ def create_app(application):
 
     init_app(application)
 
+    if 'extensions' not in application.jinja_options:
+        application.jinja_options['extensions'] = []
+
     init_govuk_frontend(application)
     init_jinja(application)
 

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -117,7 +117,7 @@ def feedback(ticket_type):
         if current_service:
             service_string = 'Service: "{name}"\n{url}\n'.format(
                 name=current_service.name,
-                url=url_for('main.service_dashboard', service_id=current_service.id, _external=True)
+                url=url_for('main.service_dashboard', service_id=current_service.id)
             )
         else:
             service_string = ''

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -26,7 +26,7 @@ def accept_invite(token):
             and click the link again to accept this invite.
             """.format(
             current_user.email_address,
-            url_for("main.sign_out", _external=True)))
+            url_for("main.sign_out")))
 
         flash(message=message)
 
@@ -96,7 +96,7 @@ def accept_org_invite(token):
             and click the link again to accept this invite.
             """.format(
             current_user.email_address,
-            url_for("main.sign_out", _external=True)))
+            url_for("main.sign_out")))
 
         flash(message=message)
 

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -230,7 +230,7 @@ def view_letter_notification_as_preview(
     mimetype = 'image/png' if filetype == 'png' else 'application/pdf'
 
     return send_file(
-        filename_or_fp=file,
+        path_or_file=file,
         mimetype=mimetype,
     )
 

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -584,7 +584,7 @@ def delete_contact_list(service_id, contact_list_id):
 def download_contact_list(service_id, contact_list_id):
     contact_list = ContactList.from_id(contact_list_id, service_id=service_id)
     return send_file(
-        filename_or_fp=BytesIO(contact_list.contents.encode('utf-8')),
+        path_or_file=BytesIO(contact_list.contents.encode('utf-8')),
         attachment_filename=contact_list.saved_file_name,
         as_attachment=True,
     )

--- a/app/s3_client/s3_mou_client.py
+++ b/app/s3_client/s3_mou_client.py
@@ -13,7 +13,7 @@ def get_mou(organisation_is_crown):
     try:
         key = get_s3_object(bucket, filename)
         return {
-            'filename_or_fp': key.get()['Body'],
+            'path_or_file': key.get()['Body'],
             'attachment_filename': attachment_filename,
             'as_attachment': True,
         }

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ pyproj==3.3.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
-itsdangerous==2.0.1  # pyup: <2.1.0  Release 2.1.0 introduced a change that is not compatible with Flask 1.x
+itsdangerous==2.1.2
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 

--- a/requirements.in
+++ b/requirements.in
@@ -4,12 +4,12 @@
 ago==0.0.93
 govuk-bank-holidays==0.11
 humanize==4.1.0
-Flask==1.1.2  # pyup: <1.1.3
+Flask==2.1.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
 Flask-Login==0.6.1
-werkzeug==2.0.3  # pyup: <2.1
-jinja2==3.0.3  # pyup: <3.1
+Werkzeug==2.1.2
+jinja2==3.1.2
 
 blinker==1.4
 pyexcel==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ idna==3.3
     # via requests
 importlib-metadata==4.11.4
     # via flask
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ eventlet==0.33.1
     # via gunicorn
 fido2==0.9.3
     # via -r requirements.in
-flask==1.1.2
+flask==2.1.2
     # via
     #   -r requirements.in
     #   flask-login
@@ -89,13 +89,15 @@ humanize==4.1.0
     # via -r requirements.in
 idna==3.3
     # via requests
+importlib-metadata==4.11.4
+    # via flask
 itsdangerous==2.0.1
     # via
     #   -r requirements.in
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements.in
     #   flask
@@ -219,7 +221,7 @@ urllib3==1.26.9
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==2.0.3
+werkzeug==2.1.2
     # via
     #   -r requirements.in
     #   flask
@@ -234,6 +236,8 @@ xlrd==2.0.1
     # via pyexcel-xls
 xlwt==1.3.0
     # via pyexcel-xls
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -62,7 +62,7 @@ def test_csrf_redirects_to_sign_in_page_if_not_signed_in(client_request, mocker)
     client_request.logout()
     client_request.get_url(
         '/cookies',
-        _expected_redirect=url_for('main.sign_in', next='/cookies', _external=True),
+        _expected_redirect=url_for('main.sign_in', next='/cookies'),
     )
 
 

--- a/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
+++ b/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
@@ -38,7 +38,7 @@ def test_show_accounts_or_dashboard_redirects_to_choose_account_or_service_dashb
 
     client_request.get(
         'main.show_accounts_or_dashboard',
-        _expected_redirect=url_for(endpoint, _external=True, **endpoint_kwargs)
+        _expected_redirect=url_for(endpoint, **endpoint_kwargs)
     )
 
 
@@ -53,7 +53,6 @@ def test_show_accounts_or_dashboard_redirects_if_service_in_session(client_reque
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id='service1',
-            _external=True
         ),
     )
 
@@ -69,7 +68,6 @@ def test_show_accounts_or_dashboard_redirects_if_org_in_session(client_request):
         _expected_redirect=url_for(
             'main.organisation_dashboard',
             org_id='org1',
-            _external=True
         ),
     )
 
@@ -86,7 +84,7 @@ def test_show_accounts_or_dashboard_doesnt_redirect_to_service_dashboard_if_user
 
     client_request.get(
         '.show_accounts_or_dashboard',
-        _expected_redirect=url_for('main.organisation_dashboard', org_id='org1', _external=True)
+        _expected_redirect=url_for('main.organisation_dashboard', org_id='org1')
     )
 
 
@@ -101,7 +99,7 @@ def test_show_accounts_or_dashboard_doesnt_redirect_to_org_dashboard_if_user_not
 
     client_request.get(
         '.show_accounts_or_dashboard',
-        _expected_redirect=url_for('main.organisation_dashboard', org_id='org1', _external=True)
+        _expected_redirect=url_for('main.organisation_dashboard', org_id='org1')
     )
 
 
@@ -112,7 +110,7 @@ def test_show_accounts_or_dashboard_redirects_if_not_logged_in(
     client_request.logout()
     client_request.get(
         'main.show_accounts_or_dashboard',
-        _expected_redirect=url_for('main.index', _external=True),
+        _expected_redirect=url_for('main.index'),
     )
 
 
@@ -131,7 +129,6 @@ def test_show_accounts_or_dashboard_redirects_to_service_dashboard_if_platform_a
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id='service2',
-            _external=True
         ),
     )
 
@@ -149,6 +146,5 @@ def test_show_accounts_or_dashboard_redirects_to_org_dashboard_if_platform_admin
         _expected_redirect=url_for(
             'main.organisation_dashboard',
             org_id='org2',
-            _external=True
         ),
     )

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -145,7 +145,6 @@ def test_user_invite_already_accepted(
         _expected_redirect=url_for(
             'main.organisation_dashboard',
             org_id=ORGANISATION_ID,
-            _external=True,
         ),
     )
 
@@ -170,7 +169,6 @@ def test_existing_user_invite_already_is_member_of_organisation(
         _expected_redirect=url_for(
             'main.organisation_dashboard',
             org_id=ORGANISATION_ID,
-            _external=True
         ),
     )
 
@@ -203,7 +201,6 @@ def test_existing_user_invite_not_a_member_of_organisation(
         _expected_redirect=url_for(
             'main.organisation_dashboard',
             org_id=ORGANISATION_ID,
-            _external=True,
         ),
     )
 
@@ -231,7 +228,7 @@ def test_user_accepts_invite(
     client_request.get(
         'main.accept_org_invite',
         token='thisisnotarealtoken',
-        _expected_redirect=url_for('main.register_from_org_invite', _external=True)
+        _expected_redirect=url_for('main.register_from_org_invite')
     )
 
     mock_check_org_invite_token.assert_called_once_with('thisisnotarealtoken')
@@ -337,7 +334,7 @@ def test_org_user_registers_with_email_already_in_use(
             'email_address': sample_org_invite['email_address'],
             'organisation': sample_org_invite['organisation'],
         },
-        _expected_redirect=url_for('main.verify', _external=True),
+        _expected_redirect=url_for('main.verify'),
     )
 
     mock_get_user_by_email.assert_called_once_with(
@@ -372,7 +369,7 @@ def test_org_user_registration(
             'password': 'validPassword!',
             'organisation': sample_org_invite['organisation'],
         },
-        _expected_redirect=url_for('main.verify', _external=True)
+        _expected_redirect=url_for('main.verify')
     )
 
     assert mock_get_user_by_email.called is False
@@ -412,6 +409,5 @@ def test_verified_org_user_redirects_to_dashboard(
         _expected_redirect=url_for(
             'main.organisation_dashboard',
             org_id=invited_org_user['organisation'],
-            _external=True
         ),
     )

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -139,7 +139,6 @@ def test_create_new_organisation(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=ORGANISATION_ID,
-            _external=True,
         ),
     )
 
@@ -366,7 +365,6 @@ def test_gps_can_name_their_organisation(
         _expected_redirect=url_for(
             'main.service_agreement',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 
@@ -436,7 +434,6 @@ def test_nhs_local_assigns_to_selected_organisation(
         _expected_redirect=url_for(
             'main.service_agreement',
             service_id=SERVICE_ONE_ID,
-            _external=True
         )
     )
     mock_update_service_organisation.assert_called_once_with(SERVICE_ONE_ID, ORGANISATION_ID)
@@ -904,7 +901,6 @@ def test_remove_user_from_organisation_makes_api_request_to_remove_user(
         user_id=fake_uuid,
         _expected_redirect=url_for(
             'main.show_accounts_or_dashboard',
-            _external=True,
         ),
     )
 
@@ -1123,7 +1119,6 @@ def test_update_organisation_settings(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         ),
     )
 
@@ -1151,7 +1146,6 @@ def test_update_organisation_sector_sends_service_id_data_to_api_client(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         ),
     )
 
@@ -1272,7 +1266,6 @@ def test_update_organisation_domains(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         ),
     )
 
@@ -1329,7 +1322,6 @@ def test_update_organisation_name(
         _expected_redirect=url_for(
             '.organisation_settings',
             org_id=fake_uuid,
-            _external=True,
         )
     )
     mock_update_organisation.assert_called_once_with(
@@ -1425,7 +1417,6 @@ def test_post_edit_organisation_go_live_notes_updates_go_live_notes(
         _expected_redirect=url_for(
             '.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         ),
     )
     mock_update_organisation.assert_called_once_with(
@@ -1481,7 +1472,6 @@ def test_update_organisation_notes(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         ),
     )
     mock_update_organisation.assert_called_with(
@@ -1525,7 +1515,6 @@ def test_update_organisation_notes_doesnt_call_api_when_notes_dont_change(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         ),
     )
     assert not mock_update_organisation.called
@@ -1604,7 +1593,6 @@ def test_update_organisation_billing_details(
         _expected_redirect=url_for(
             'main.organisation_settings',
             org_id=organisation_one['id'],
-            _external=True,
         )
     )
     mock_update_organisation.assert_called_with(

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -153,7 +153,6 @@ def test_email_branding_request_submit(
         _expected_redirect=url_for(
             endpoint,
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -204,14 +204,14 @@ def test_letter_branding_request_submit_redirects_if_from_template_is_set(
             '.letter_branding_request', service_id=SERVICE_ONE_ID, from_template=from_template,
             _data=data,
             _expected_redirect=url_for(
-                'main.view_template', service_id=SERVICE_ONE_ID, template_id=from_template, _external=True
+                'main.view_template', service_id=SERVICE_ONE_ID, template_id=from_template,
             )
         )
     else:
         client_request.post(
             '.letter_branding_request', service_id=SERVICE_ONE_ID,
             _data=data,
-            _expected_redirect=url_for('main.service_settings', service_id=SERVICE_ONE_ID, _external=True)
+            _expected_redirect=url_for('main.service_settings', service_id=SERVICE_ONE_ID)
         )
 
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -113,7 +113,6 @@ def test_service_set_permission(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=service_one['id'],
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -636,7 +636,6 @@ def test_switch_service_to_live(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update_service.assert_called_with(
@@ -679,7 +678,6 @@ def test_switch_service_to_restricted(
         _expected_response=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update_service.assert_called_with(
@@ -740,7 +738,6 @@ def test_switch_service_to_count_as_live(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update_service.assert_called_with(
@@ -778,7 +775,6 @@ def test_should_redirect_after_service_name_change(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -1455,7 +1451,6 @@ def test_should_show_persist_estimated_volumes(
         _expected_redirect=url_for(
             'main.request_to_go_live',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update_service.assert_called_once_with(
@@ -2201,7 +2196,6 @@ def test_remove_default_from_default_letter_contact_block(
     letter_contact_details_page = url_for(
         'main.service_letter_contact_details',
         service_id=SERVICE_ONE_ID,
-        _external=True,
     )
 
     link = client_request.get_url(letter_contact_details_page).select_one('.user-list-item a')
@@ -2379,7 +2373,6 @@ def test_add_reply_to_email_address_sends_test_notification(
             'main.service_verify_reply_to_address',
             service_id=SERVICE_ONE_ID,
             notification_id="123",
-            _external=True,
         ) + "?is_default={}".format(api_default_args)
     )
     mock_verify.assert_called_once_with(SERVICE_ONE_ID, "test@example.com")
@@ -2409,7 +2402,6 @@ def test_service_add_reply_to_email_address_without_verification_for_platform_ad
         _expected_redirect=url_for(
             'main.service_email_reply_to',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update.assert_called_once_with(
@@ -2571,7 +2563,6 @@ def test_add_letter_contact_when_coming_from_template(
             'main.view_template',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -2709,7 +2700,6 @@ def test_service_edit_email_reply_to_updates_email_address_without_verification_
         _expected_redirect=url_for(
             'main.service_email_reply_to',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update.assert_called_once_with(
@@ -2936,7 +2926,6 @@ def test_delete_reply_to_email_address(
         _expected_redirect=url_for(
             'main.service_email_reply_to',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_delete.assert_called_once_with(service_id=SERVICE_ONE_ID, reply_to_email_id=fake_uuid)
@@ -3010,7 +2999,6 @@ def test_delete_letter_contact_block(
         _expected_redirect=url_for(
             'main.service_letter_contact_details',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_delete.assert_called_once_with(
@@ -3257,7 +3245,6 @@ def test_delete_sms_sender(
         _expected_redirect=url_for(
             'main.service_sms_senders',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_delete.assert_called_once_with(service_id=SERVICE_ONE_ID, sms_sender_id=fake_uuid)
@@ -3444,7 +3431,6 @@ def test_service_set_letter_branding_redirects_to_preview_page_when_form_submitt
         _expected_redirect=url_for(
             expected_redirect,
             branding_style=expected_post_data,
-            _external=True,
             **extra_args
         ),
         **extra_args
@@ -3517,7 +3503,6 @@ def test_service_preview_letter_branding_saves(
         _expected_status=302,
         _expected_redirect=url_for(
             expected_redirect,
-            _external=True,
             **extra_args
         ),
         **extra_args
@@ -3652,7 +3637,6 @@ def test_should_send_branding_and_organisations_to_preview(
         _expected_location=url_for(
             expected_redirect,
             branding_style='1',
-            _external=True,
             **extra_args
         ),
         **extra_args
@@ -3735,7 +3719,6 @@ def test_should_set_branding_and_organisations(
         _expected_status=302,
         _expected_redirect=url_for(
             expected_redirect,
-            _external=True,
             **extra_args
         ),
         **extra_args
@@ -3822,7 +3805,6 @@ def test_should_set_sms_allowance(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -3909,7 +3891,6 @@ def test_old_set_letters_page_redirects(
             'main.service_set_channel',
             service_id=SERVICE_ONE_ID,
             channel='letter',
-            _external=True,
         )
     )
 
@@ -4016,7 +3997,6 @@ def test_switch_service_channels_on_and_off(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=service_one['id'],
-            _external=True
         )
     )
     assert set(mocked_fn.call_args[1]['permissions']) == set(expected_updated_permissions)
@@ -4099,7 +4079,7 @@ def test_switch_service_enable_international_sms_and_letters(
         _data={
             'enabled': post_value
         },
-        _expected_redirect=url_for('main.service_settings', service_id=service_one['id'], _external=True)
+        _expected_redirect=url_for('main.service_settings', service_id=service_one['id'])
     )
 
     if permission_expected_in_api_call:
@@ -4237,7 +4217,6 @@ def test_suspend_service_after_confirm(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True
         ),
     )
 
@@ -4310,7 +4289,6 @@ def test_resume_service_after_confirm(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True
         )
     )
 
@@ -4663,7 +4641,6 @@ def test_updates_sms_prefixing(
         _data={'enabled': post_value},
         _expected_redirect=url_for(
             'main.service_settings', service_id=SERVICE_ONE_ID,
-            _external=True
         )
     )
     mock_update_service.assert_called_once_with(
@@ -4842,7 +4819,6 @@ def test_add_service_data_retention(
         _expected_redirect=url_for(
             'main.data_retention',
             service_id=service_one['id'],
-            _external=True,
         ),
     )
     assert mock_create_service_data_retention.called
@@ -4865,7 +4841,6 @@ def test_update_service_data_retention(
         _expected_redirect=url_for(
             'main.data_retention',
             service_id=service_one['id'],
-            _external=True,
         ),
     )
     assert mock_update_service_data_retention.called
@@ -4958,7 +4933,6 @@ def test_update_service_notes(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_update_service.assert_called_with(SERVICE_ONE_ID, notes="Very fluffy")
@@ -5039,7 +5013,6 @@ def test_update_service_billing_details(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_update_service.assert_called_with(
@@ -5194,7 +5167,6 @@ def test_service_set_broadcast_channel_redirects(
         _expected_redirect=url_for(
             expected_redirect_endpoint,
             service_id=SERVICE_ONE_ID,
-            _external=True,
             **extra_args,
         )
     )
@@ -5289,7 +5261,6 @@ def test_service_set_broadcast_network(
             'main.service_confirm_broadcast_account_type',
             service_id=SERVICE_ONE_ID,
             account_type=expected_result,
-            _external=True,
         )
     )
 
@@ -5436,7 +5407,6 @@ def test_service_confirm_broadcast_account_type_posts_data_to_api_and_redirects(
         _expected_redirect=url_for(
             'main.service_settings',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     set_service_broadcast_settings_mock.assert_called_once_with(

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -53,7 +53,7 @@ def test_existing_user_accept_invite_calls_api_and_redirects_to_dashboard(
     client_request.get(
         'main.accept_invite',
         token='thisisnotarealtoken',
-        _expected_redirect=url_for('main.service_dashboard', service_id=expected_service, _external=True),
+        _expected_redirect=url_for('main.service_dashboard', service_id=expected_service),
     )
 
     mock_check_invite_token.assert_called_with('thisisnotarealtoken')
@@ -101,7 +101,6 @@ def test_broadcast_service_shows_tour(
             expected_endpoint,
             service_id=SERVICE_ONE_ID,
             step_index=1,
-            _external=True,
         ),
     )
 
@@ -192,7 +191,6 @@ def test_invite_goes_in_session(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
         _follow_redirects=False,
     )
@@ -308,7 +306,7 @@ def test_accept_invite_redirects_if_api_raises_an_error_that_they_are_already_pa
         'main.accept_invite',
         token='thisisnotarealtoken',
         _follow_redirects=False,
-        _expected_redirect=url_for('main.service_dashboard', service_id=SERVICE_ONE_ID, _external=True)
+        _expected_redirect=url_for('main.service_dashboard', service_id=SERVICE_ONE_ID)
     )
 
 
@@ -368,7 +366,7 @@ def test_new_user_accept_invite_calls_api_and_redirects_to_registration(
     client_request.get(
         'main.accept_invite',
         token='thisisnotarealtoken',
-        _expected_redirect='http://localhost/register-from-invite',
+        _expected_redirect='/register-from-invite',
     )
 
     mock_check_invite_token.assert_called_with('thisisnotarealtoken')
@@ -492,7 +490,7 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
     mocker,
 ):
     client_request.logout()
-    expected_redirect_location = 'http://localhost/register-from-invite'
+    expected_redirect_location = '/register-from-invite'
 
     client_request.get(
         'main.accept_invite',
@@ -511,7 +509,7 @@ def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
             'auth_type': 'email_auth'
             }
 
-    expected_redirect_location = 'http://localhost/verify'
+    expected_redirect_location = '/verify'
     client_request.post(
         'main.register_from_invite',
         _data=data,
@@ -578,7 +576,6 @@ def test_accept_invite_does_not_treat_email_addresses_as_case_sensitive(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 
@@ -618,7 +615,7 @@ def test_new_invited_user_verifies_and_added_to_service(
     client_request.get(
         'main.accept_invite',
         token='thisisnotarealtoken',
-        _expected_redirect=url_for('main.register_from_invite', _external=True),
+        _expected_redirect=url_for('main.register_from_invite'),
     )
 
     # get redirected to register from invite
@@ -634,7 +631,7 @@ def test_new_invited_user_verifies_and_added_to_service(
     client_request.post(
         'main.register_from_invite',
         _data=data,
-        _expected_redirect=url_for('main.verify', _external=True),
+        _expected_redirect=url_for('main.verify'),
     )
 
     # that sends user on to verify
@@ -708,7 +705,6 @@ def test_new_invited_user_is_redirected_to_correct_place(
         _expected_redirect=url_for(
             expected_endpoint,
             service_id=sample_invite['service'],
-            _external=True,
             **extra_args
         )
     )
@@ -737,7 +733,7 @@ def test_existing_user_accepts_and_sets_email_auth(
         'main.accept_invite',
         token='thisisnotarealtoken',
         _expected_status=302,
-        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id'], _external=True),
+        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id']),
     )
 
     mock_get_existing_user_by_email.assert_called_once_with('test@user.gov.uk')
@@ -776,7 +772,7 @@ def test_platform_admin_user_accepts_and_preserves_auth(
         'main.accept_invite',
         token='thisisnotarealtoken',
         _expected_status=302,
-        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id'], _external=True),
+        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id']),
     )
 
     mock_update_user_attribute.assert_called_once_with(
@@ -810,7 +806,7 @@ def test_existing_user_doesnt_get_auth_changed_by_service_without_permission(
         'main.accept_invite',
         token='thisisnotarealtoken',
         _expected_status=302,
-        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id'], _external=True),
+        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id']),
     )
 
     mock_update_user_attribute.assert_called_once_with(
@@ -846,7 +842,7 @@ def test_existing_email_auth_user_without_phone_cannot_set_sms_auth(
         'main.accept_invite',
         token='thisisnotarealtoken',
         _expected_status=302,
-        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id'], _external=True),
+        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id']),
     )
 
     mock_update_user_attribute.assert_called_once_with(
@@ -877,7 +873,7 @@ def test_existing_email_auth_user_with_phone_can_set_sms_auth(
         'main.accept_invite',
         token='thisisnotarealtoken',
         _expected_status=302,
-        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id'], _external=True),
+        _expected_redirect=url_for('main.service_dashboard', service_id=service_one['id']),
     )
 
     mock_get_existing_user_by_email.assert_called_once_with(sample_invite['email_address'])

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from functools import partial
-from urllib.parse import parse_qs, quote, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from flask import url_for
@@ -600,7 +600,7 @@ def test_get_status_filters_constructs_links(client_request):
     ret = get_status_filters(Service({'id': 'foo'}), 'sms', STATISTICS)
 
     link = ret[0][2]
-    assert link == '/services/foo/notifications/sms?status={}'.format(quote('sending,delivered,failed'))
+    assert link == '/services/foo/notifications/sms?status={}'.format('sending,delivered,failed')
 
 
 def test_html_contains_notification_id(

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -148,7 +148,6 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
             'main.begin_tour',
             service_id=101,
             template_id="Example%20text%20message%20template",
-            _external=True,
         ),
     )
     assert mock_get_services_with_no_services.called
@@ -270,7 +269,6 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=101,
-            _external=True,
         )
     )
     assert mock_get_services.called

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -121,7 +121,6 @@ def test_unknown_gps_and_trusts_are_redirected(
         _expected_redirect=url_for(
             expected_endpoint,
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -406,7 +405,6 @@ def test_accept_agreement_page_persists(
         _expected_redirect=url_for(
             'main.service_confirm_agreement',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     assert mock_update_organisation.call_args_list == [expected_persisted]
@@ -476,7 +474,6 @@ def test_confirm_agreement_page_persists(
         _expected_redirect=url_for(
             'main.request_to_go_live',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_update_organisation.assert_called_once_with(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -165,7 +165,6 @@ def test_api_documentation_page_should_redirect(
         _expected_status=301,
         _expected_redirect=url_for(
             'main.documentation',
-            _external=True,
         ),
     )
 
@@ -366,7 +365,6 @@ def test_should_redirect_after_revoking_api_key(
         _expected_redirect=url_for(
             '.api_keys',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_revoke_api_key.assert_called_once_with(service_id=SERVICE_ONE_ID, key_id=fake_uuid)
@@ -567,7 +565,6 @@ def test_callback_forms_can_be_cleared(
         _expected_redirect=url_for(
             'main.api_callbacks',
             service_id=service_one['id'],
-            _external=True,
         )
     )
 
@@ -614,7 +611,6 @@ def test_callback_forms_can_be_cleared_when_callback_and_inbound_apis_are_empty(
         _expected_redirect=url_for(
             'main.api_callbacks',
             service_id=service_one['id'],
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_broadcast.py
+++ b/tests/app/main/views/test_broadcast.py
@@ -445,7 +445,6 @@ def test_dashboard_redirects_to_broadcast_dashboard(
         _expected_redirect=url_for(
             '.broadcast_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     ),
 
@@ -687,7 +686,6 @@ def test_new_broadcast_page_redirects(
         _expected_redirect=url_for(
             expected_redirect_endpoint,
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 
@@ -761,7 +759,6 @@ def test_write_new_broadcast_posts(
             '.choose_broadcast_library',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         ),
     )
     mock_create_broadcast_message.assert_called_once_with(
@@ -822,7 +819,6 @@ def test_broadcast_page(
             '.choose_broadcast_library',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         ),
     ),
 
@@ -1554,7 +1550,6 @@ def test_remove_broadcast_area_page(
             '.preview_broadcast_areas',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         ),
     )
     mock_get_polygons_from_areas.assert_called_once_with(area_attribute='simple_polygons')
@@ -1631,7 +1626,6 @@ def test_start_broadcasting(
             'main.view_current_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         ),
     ),
     mock_update_broadcast_message_status.assert_called_once_with(
@@ -2513,7 +2507,6 @@ def test_confirm_approve_broadcast(
         broadcast_message_id=fake_uuid,
         _expected_redirect=expected_redirect(
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
         _data=post_data,
     )
@@ -2572,7 +2565,6 @@ def test_reject_broadcast(
         _expected_redirect=url_for(
             '.broadcast_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 
@@ -2629,7 +2621,6 @@ def test_cant_reject_broadcast_in_wrong_state(
             '.view_current_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -2727,7 +2718,6 @@ def test_confirm_cancel_broadcast(
             '.view_previous_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         ),
     )
     mock_update_broadcast_message_status.assert_called_once_with(
@@ -2757,7 +2747,6 @@ def test_cant_cancel_broadcast_in_a_different_state(
             '.view_current_broadcast',
             service_id=SERVICE_ONE_ID,
             broadcast_message_id=fake_uuid,
-            _external=True,
         ),
     )
     assert mock_update_broadcast_message_status.called is False

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -106,7 +106,7 @@ def test_should_resend_verify_code_and_update_mobile_for_pending_user(
         'main.check_and_resend_text_code',
         next=redirect_url,
         _data={'mobile_number': phone_number_to_register_with},
-        _expected_redirect=url_for('main.verify', _external=True, next=redirect_url),
+        _expected_redirect=url_for('main.verify', next=redirect_url),
     )
 
     mock_update_user_attribute.assert_called_once_with(
@@ -139,7 +139,7 @@ def test_check_and_redirect_to_two_factor_if_user_active(
     client_request.get(
         'main.check_and_resend_verification_code',
         next=redirect_url,
-        _expected_redirect=url_for('main.two_factor_sms', _external=True, next=redirect_url)
+        _expected_redirect=url_for('main.two_factor_sms', next=redirect_url)
     )
 
 
@@ -166,7 +166,7 @@ def test_check_and_redirect_to_verify_if_user_pending(
     client_request.get(
         'main.check_and_resend_verification_code',
         next=redirect_url,
-        _expected_redirect=url_for('main.verify', _external=True, next=redirect_url),
+        _expected_redirect=url_for('main.verify', next=redirect_url),
     )
 
 
@@ -182,7 +182,7 @@ def test_redirect_to_sign_in_if_not_logged_in(
     client_request.logout()
     client_request.get(
         endpoint,
-        _expected_redirect=url_for('main.sign_in', _external=True),
+        _expected_redirect=url_for('main.sign_in'),
     )
 
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -106,14 +106,14 @@ def test_redirect_from_old_dashboard(
     mocker,
 ):
     mocker.patch('app.user_api_client.get_user', return_value=user)
-    expected_location = 'http://localhost/services/{}'.format(SERVICE_ONE_ID)
+    expected_location = '/services/{}'.format(SERVICE_ONE_ID)
 
     client_request.get_url(
         '/services/{}/dashboard'.format(SERVICE_ONE_ID),
         _expected_redirect=expected_location,
     )
 
-    assert expected_location == url_for('main.service_dashboard', service_id=SERVICE_ONE_ID, _external=True)
+    assert expected_location == url_for('main.service_dashboard', service_id=SERVICE_ONE_ID)
 
 
 def test_redirect_caseworkers_to_templates(
@@ -129,7 +129,6 @@ def test_redirect_caseworkers_to_templates(
         _expected_redirect=url_for(
             'main.choose_template',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -18,7 +18,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 
 def no_redirect():
-    return lambda _external=True: None
+    return lambda: None
 
 
 def test_get_support_index_page(
@@ -165,7 +165,6 @@ def test_passed_non_logged_in_user_details_through_flow(client_request, mocker, 
             'main.thanks',
             out_of_hours_emergency=False,
             email_address_provided=True,
-            _external=True,
         ),
     )
 
@@ -217,7 +216,6 @@ def test_passes_user_details_through_flow(
             'main.thanks',
             email_address_provided=True,
             out_of_hours_emergency=False,
-            _external=True,
         ),
     )
     mock_create_ticket.assert_called_once_with(
@@ -239,7 +237,6 @@ def test_passes_user_details_through_flow(
         url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True
         ),
         ''
     ])
@@ -343,7 +340,6 @@ def test_urgency(
             'main.thanks',
             out_of_hours_emergency=is_out_of_hours_emergency,
             email_address_provided=True,
-            _external=True,
         ),
     )
     assert mock_ticket.call_args[1]['p1'] == is_out_of_hours_emergency
@@ -405,7 +401,7 @@ def test_redirects_to_triage(
         'main.feedback',
         ticket_type=ticket_type,
         _expected_status=expected_status,
-        _expected_redirect=expected_redirect(_external=True),
+        _expected_redirect=expected_redirect(),
     )
 
 
@@ -437,7 +433,7 @@ def test_doesnt_lose_message_if_post_across_closing(
         ticket_type=PROBLEM_TICKET_TYPE,
         _data={'feedback': 'foo'},
         _expected_status=302,
-        _expected_redirect=url_for('.triage', ticket_type=PROBLEM_TICKET_TYPE, _external=True),
+        _expected_redirect=url_for('.triage', ticket_type=PROBLEM_TICKET_TYPE),
     )
     with client_request.session_transaction() as session:
         assert session['feedback_message'] == 'foo'
@@ -498,7 +494,6 @@ def test_triage_redirects_to_correct_url(
             'main.feedback',
             ticket_type=ticket_type,
             severe=expected_redirect_param,
-            _external=True,
         ),
     )
 
@@ -604,7 +599,7 @@ def test_should_be_shown_the_bat_email(
     client_request.get_url(
         feedback_page,
         _expected_status=expected_status_code,
-        _expected_redirect=expected_redirect(_external=True),
+        _expected_redirect=expected_redirect(),
     )
 
     # logged in users should never be redirected to the bat email page
@@ -612,7 +607,7 @@ def test_should_be_shown_the_bat_email(
     client_request.get_url(
         feedback_page,
         _expected_status=expected_status_code_when_logged_in,
-        _expected_redirect=expected_redirect_when_logged_in(_external=True),
+        _expected_redirect=expected_redirect_when_logged_in(),
     )
 
 
@@ -659,7 +654,7 @@ def test_should_be_shown_the_bat_email_for_general_questions(
     client_request.get_url(
         feedback_page,
         _expected_status=expected_status_code,
-        _expected_redirect=expected_redirect(_external=True),
+        _expected_redirect=expected_redirect(),
     )
 
     # logged in users should never be redirected to the bat email page
@@ -667,7 +662,7 @@ def test_should_be_shown_the_bat_email_for_general_questions(
     client_request.get_url(
         feedback_page,
         _expected_status=expected_status_code_when_logged_in,
-        _expected_redirect=expected_redirect_when_logged_in(_external=True),
+        _expected_redirect=expected_redirect_when_logged_in(),
     )
 
 
@@ -692,7 +687,7 @@ def test_bat_email_page(
     client_request.login(active_user_with_permissions)
     client_request.get(
         bat_phone_page,
-        _expected_redirect=url_for('main.feedback', ticket_type=PROBLEM_TICKET_TYPE, _external=True)
+        _expected_redirect=url_for('main.feedback', ticket_type=PROBLEM_TICKET_TYPE)
     )
 
 

--- a/tests/app/main/views/test_find_services.py
+++ b/tests/app/main/views/test_find_services.py
@@ -88,6 +88,5 @@ def test_find_services_by_name_redirects_for_uuid(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=fake_uuid,
-            _external=True,
         ),
     )

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -235,7 +235,7 @@ def test_change_user_auth(
         _data={
             'auth_type': 'email_auth'
         },
-        _expected_redirect=url_for('main.user_information', user_id=api_user_active['id'], _external=True)
+        _expected_redirect=url_for('main.user_information', user_id=api_user_active['id'])
     )
 
     mock_update.assert_called_once_with(
@@ -332,7 +332,6 @@ def test_archive_user_posts_to_user_client(
         _expected_redirect=url_for(
             'main.user_information',
             user_id=api_user_active['id'],
-            _external=True,
         ),
     )
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -54,7 +54,7 @@ def test_logged_in_user_redirects_to_choose_account(
     client_request.get(
         'main.sign_in',
         _expected_status=302,
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True)
+        _expected_redirect=url_for('main.show_accounts_or_dashboard')
     )
 
 
@@ -177,7 +177,6 @@ def test_old_static_pages_redirect(
         _expected_status=301,
         _expected_redirect=url_for(
             'main.{}'.format(expected_view),
-            _external=True,
         ),
     )
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -28,7 +28,6 @@ def test_old_jobs_hub_redirects(
         _expected_redirect=url_for(
             'main.uploads',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 
@@ -507,7 +506,6 @@ def test_should_cancel_job(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
 
@@ -557,7 +555,6 @@ def test_should_cancel_letter_job(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_cancel.assert_called_once_with(SERVICE_ONE_ID, job_id)

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -633,7 +633,6 @@ def test_edit_user_permissions(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_set_user_permissions.assert_called_with(
@@ -713,7 +712,6 @@ def test_edit_user_permissions_for_broadcast_service(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_set_user_permissions.assert_called_with(
@@ -762,7 +760,6 @@ def test_edit_user_folder_permissions(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_set_user_permissions.assert_called_with(
@@ -811,7 +808,6 @@ def test_cant_edit_user_folder_permissions_for_platform_admin_users(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_set_user_permissions.assert_called_with(
@@ -874,7 +870,6 @@ def test_edit_user_permissions_including_authentication_with_email_auth_service(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -1697,7 +1692,7 @@ def test_remove_user_from_service(
         'main.remove_user_from_service',
         service_id=service_one['id'],
         user_id=active_user_with_permissions['id'],
-        _expected_redirect=url_for('main.manage_users', service_id=service_one['id'], _external=True)
+        _expected_redirect=url_for('main.manage_users', service_id=service_one['id'])
     )
     mock_remove_user_from_service.assert_called_once_with(
         service_one['id'],
@@ -1778,7 +1773,6 @@ def test_edit_user_email_redirects_to_confirmation(
             'main.confirm_edit_user_email',
             service_id=SERVICE_ONE_ID,
             user_id=active_user_with_permissions['id'],
-            _external=True,
         ),
     )
     with client_request.session_transaction() as session:
@@ -1805,7 +1799,6 @@ def test_edit_user_email_without_changing_goes_back_to_team_members(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True
         ),
     )
     assert mock_update_user_attribute.called is False
@@ -1835,7 +1828,6 @@ def test_edit_user_email_can_change_any_email_address_to_a_gov_email_address(
             'main.confirm_edit_user_email',
             service_id=SERVICE_ONE_ID,
             user_id=active_user_with_permissions['id'],
-            _external=True
         ),
     )
 
@@ -1862,7 +1854,6 @@ def test_edit_user_email_can_change_a_non_gov_email_address_to_another_non_gov_e
             'main.confirm_edit_user_email',
             service_id=SERVICE_ONE_ID,
             user_id=active_user_with_permissions['id'],
-            _external=True
         ),
     )
 
@@ -1975,7 +1966,6 @@ def test_confirm_edit_user_email_changes_user_email(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -2087,7 +2077,6 @@ def test_edit_user_mobile_number_redirects_to_confirmation(
             'main.confirm_edit_user_mobile_number',
             service_id=SERVICE_ONE_ID,
             user_id=active_user_with_permissions['id'],
-            _external=True,
         ),
     )
 
@@ -2109,7 +2098,6 @@ def test_edit_user_mobile_number_redirects_to_manage_users_if_number_not_changed
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -2189,7 +2177,6 @@ def test_confirm_edit_user_mobile_number_changes_user_mobile_number(
         _expected_redirect=url_for(
             'main.manage_users',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
     mock_update_user_attribute.assert_called_once_with(

--- a/tests/app/main/views/test_new_password.py
+++ b/tests/app/main/views/test_new_password.py
@@ -72,7 +72,7 @@ def test_should_redirect_to_two_factor_when_password_reset_is_successful(
     client_request.post_url(
         url_for_endpoint_with_token('.new_password', token=token, next=redirect_url),
         _data={'new_password': 'a-new_password'},
-        _expected_redirect=url_for('.two_factor_sms', _external=True, next=redirect_url),
+        _expected_redirect=url_for('.two_factor_sms', next=redirect_url),
     )
     mock_get_user_by_email_request_password_reset.assert_called_once_with(user['email_address'])
 
@@ -97,7 +97,7 @@ def test_should_redirect_to_two_factor_webauthn_when_password_reset_is_successfu
     client_request.post_url(
         url_for_endpoint_with_token('.new_password', token=token, next=redirect_url),
         _data={'new_password': 'a-new_password'},
-        _expected_redirect=url_for('.two_factor_webauthn', _external=True, next=redirect_url),
+        _expected_redirect=url_for('.two_factor_webauthn', next=redirect_url),
     )
     mock_get_user_by_email_request_password_reset.assert_called_once_with(user['email_address'])
 
@@ -120,7 +120,7 @@ def test_should_redirect_index_if_user_has_already_changed_password(
     client_request.post_url(
         url_for_endpoint_with_token('.new_password', token=token),
         _data={'new_password': 'a-new_password'},
-        _expected_redirect=url_for('.index', _external=True),
+        _expected_redirect=url_for('.index'),
     )
     mock_get_user_by_email_user_changed_password.assert_called_once_with(user['email_address'])
 
@@ -137,7 +137,7 @@ def test_should_redirect_to_forgot_password_with_flash_message_when_token_is_exp
 
     client_request.get_url(
         url_for_endpoint_with_token('.new_password', token=token),
-        _expected_redirect=url_for('.forgot_password', _external=True),
+        _expected_redirect=url_for('.forgot_password'),
     )
 
 
@@ -162,7 +162,7 @@ def test_should_sign_in_when_password_reset_is_successful_for_email_auth(
     client_request.post_url(
         url_for_endpoint_with_token('.new_password', token=token),
         _data={'new_password': 'a-new_password'},
-        _expected_redirect=url_for('.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('.show_accounts_or_dashboard'),
     )
 
     assert mock_get_user_by_email_request_password_reset.called

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -31,7 +31,7 @@ def test_should_redirect_if_not_logged_in(
     client_request.logout()
     client_request.get(
         endpoint,
-        _expected_redirect=url_for('main.sign_in', next=url_for(endpoint), _external=True),
+        _expected_redirect=url_for('main.sign_in', next=url_for(endpoint)),
     )
 
 
@@ -693,7 +693,6 @@ def test_platform_admin_submit_returned_letters(
         _data={'references': ' NOTIFY000REF1 \n NOTIFY002REF2 '},
         _expected_redirect=url_for(
             'main.platform_admin_returned_letters',
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -391,7 +391,6 @@ def test_edit_sms_provider_ratio_submit(
         _data=post_data,
         _expected_redirect=url_for(
             '.view_providers',
-            _external=True,
         ),
     )
 

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -26,7 +26,7 @@ def test_logged_in_user_redirects_to_account(
     client_request.get(
         'main.register',
         _expected_status=302,
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('main.show_accounts_or_dashboard'),
     )
 
 
@@ -80,7 +80,7 @@ def test_register_continue_handles_missing_session_sensibly(
     # session is not set
     client_request.get(
         'main.registration_continue',
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('main.show_accounts_or_dashboard'),
     )
 
 
@@ -196,7 +196,7 @@ def test_register_with_existing_email_sends_emails(
     client_request.post(
         'main.register',
         _data=user_data,
-        _expected_redirect=url_for('main.registration_continue', _external=True),
+        _expected_redirect=url_for('main.registration_continue'),
     )
 
 
@@ -295,7 +295,7 @@ def test_register_from_invite(
             auth_type='sms_auth',
             **extra_data
         ),
-        _expected_redirect=url_for('main.verify', _external=True),
+        _expected_redirect=url_for('main.verify'),
     )
     mock_register_user.assert_called_once_with(
         'Registered in another Browser',
@@ -329,7 +329,7 @@ def test_register_from_invite_when_user_registers_in_another_browser(
             'password': 'somreallyhardthingtoguess',
             'auth_type': 'sms_auth'
         },
-        _expected_redirect=url_for('main.verify', _external=True),
+        _expected_redirect=url_for('main.verify'),
     )
 
 
@@ -376,7 +376,6 @@ def test_register_from_email_auth_invite(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=sample_invite['service'],
-            _external=True,
         ),
     )
 
@@ -448,7 +447,6 @@ def test_can_register_email_auth_without_phone_number(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=sample_invite['service'],
-            _external=True,
         ),
     )
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -228,7 +228,6 @@ def test_set_sender_redirects_if_no_reply_to_email_addresses(
             '.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -248,7 +247,6 @@ def test_set_sender_redirects_if_no_sms_senders(
             '.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -268,7 +266,6 @@ def test_set_sender_redirects_if_one_email_sender(
             '.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -291,7 +288,6 @@ def test_set_sender_redirects_if_one_sms_sender(
             '.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -1008,7 +1004,6 @@ def test_upload_valid_csv_redirects_to_check_page(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             upload_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -1294,7 +1289,6 @@ def test_send_one_off_step_redirects_to_start_if_session_not_setup(
             'main.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -1715,7 +1709,6 @@ def test_send_one_off_redirects_to_end_if_step_out_of_bounds(
             'main.check_notification',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -1752,7 +1745,6 @@ def test_send_one_off_redirects_to_start_if_you_skip_steps(
             'main.send_one_off',
             service_id=service_one['id'],
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -1787,7 +1779,6 @@ def test_send_one_off_redirects_to_start_if_index_out_of_bounds_and_some_placeho
             'main.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -1817,7 +1808,6 @@ def test_send_one_off_sms_message_redirects(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=0,
-            _external=True,
         )
     )
 
@@ -1962,7 +1952,6 @@ def test_send_one_off_letter_redirects_to_right_url(
             'main.check_notification',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -2158,7 +2147,6 @@ def test_send_one_off_sms_message_puts_submitted_data_in_session(
             'main.check_notification',
             service_id=service_one['id'],
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -2245,7 +2233,6 @@ def test_send_one_off_redirects_to_letter_address(client_request, fake_uuid, moc
             'main.send_one_off_letter_address',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
     # make sure it cleared session first
@@ -2355,7 +2342,6 @@ def test_send_one_off_letter_address_populates_address_fields_in_session(
             'main.check_notification',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
     with client_request.session_transaction() as session:
@@ -2447,7 +2433,6 @@ def test_send_one_off_letter_address_goes_to_next_placeholder(client_request, mo
             service_id=SERVICE_ONE_ID,
             template_id=template_data['id'],
             step_index=7,
-            _external=True,
         )
     )
 
@@ -3783,7 +3768,6 @@ def test_check_notification_redirects_if_session_not_populated(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=1,
-            _external=True,
         )
     )
 
@@ -3994,7 +3978,6 @@ def test_send_notification_redirects_if_missing_data(
             '.send_one_off',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -4024,7 +4007,6 @@ def test_send_notification_redirects_to_view_page(
             '.view_notification',
             service_id=SERVICE_ONE_ID,
             notification_id=fake_uuid,
-            _external=True,
             **extra_redirect_args
         ),
         **extra_args
@@ -4256,7 +4238,6 @@ def test_redirects_to_template_if_job_exists_already(
             'main.send_messages',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
 
@@ -4405,7 +4386,6 @@ def test_send_from_contact_list(
             template_id=fake_uuid,
             upload_id=new_uuid,
             contact_list_id=fake_uuid,
-            _external=True,
         )
     )
     mock_download.assert_called_once_with(
@@ -4439,7 +4419,6 @@ def test_send_to_myself_sets_placeholder_and_redirects_for_email(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=1,
-            _external=True,
         )
     )
 
@@ -4465,7 +4444,6 @@ def test_send_to_myself_sets_placeholder_and_redirects_for_sms(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=1,
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -92,7 +92,7 @@ def test_redirect_to_sign_in_if_logged_in_from_other_browser(
     client_request.get(
         'main.choose_account',
         _expected_status=302,
-        _expected_redirect=url_for('main.sign_in', next='/accounts', _external=True),
+        _expected_redirect=url_for('main.sign_in', next='/accounts'),
     )
 
 
@@ -102,7 +102,7 @@ def test_logged_in_user_redirects_to_account(
     client_request.get(
         'main.sign_in',
         _expected_status=302,
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('main.show_accounts_or_dashboard'),
     )
 
 
@@ -113,7 +113,7 @@ def test_logged_in_user_redirects_to_next_url(
         'main.sign_in',
         next='/user-profile',
         _expected_status=302,
-        _expected_redirect=url_for('main.user_profile', _external=True),
+        _expected_redirect=url_for('main.user_profile'),
     )
 
 
@@ -124,7 +124,7 @@ def test_logged_in_user_doesnt_do_evil_redirect(
         'main.sign_in',
         next='http://www.evil.com',
         _expected_status=302,
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('main.show_accounts_or_dashboard'),
     )
 
 
@@ -155,7 +155,7 @@ def test_process_sms_auth_sign_in_return_2fa_template(
             'email_address': email_address,
             'password': password,
         },
-        _expected_redirect=url_for('.two_factor_sms', next=redirect_url, _external=True),
+        _expected_redirect=url_for('.two_factor_sms', next=redirect_url),
     )
     mock_verify_password.assert_called_with(api_user_active['id'], password)
     mock_get_user_by_email.assert_called_with('valid@example.gov.uk')
@@ -184,7 +184,7 @@ def test_process_email_auth_sign_in_return_2fa_template(
             'email_address': 'valid@example.gov.uk',
             'password': 'val1dPassw0rd!',
         },
-        _expected_redirect=url_for('.two_factor_email_sent', _external=True, next=redirect_url),
+        _expected_redirect=url_for('.two_factor_email_sent', next=redirect_url),
     )
 
     mock_send_verify_code.assert_called_with(api_user_active_email_auth['id'], 'email', None, redirect_url)
@@ -213,7 +213,7 @@ def test_process_webauthn_auth_sign_in_redirects_to_webauthn_with_next_redirect(
             'email_address': 'valid@example.gov.uk',
             'password': 'val1dPassw0rd!',
         },
-        _expected_redirect=url_for('.two_factor_webauthn', _external=True, next=redirect_url)
+        _expected_redirect=url_for('.two_factor_webauthn', next=redirect_url)
     )
 
     mock_get_user_by_email.assert_called_once_with('valid@example.gov.uk')
@@ -265,7 +265,7 @@ def test_should_return_redirect_when_user_is_pending(
             'email_address': 'pending_user@example.gov.uk',
             'password': 'val1dPassw0rd!'
         },
-        _expected_redirect=url_for('main.resend_email_verification', _external=True),
+        _expected_redirect=url_for('main.resend_email_verification'),
     )
     with client_request.session_transaction() as s:
         assert s['user_details'] == {
@@ -292,7 +292,7 @@ def test_should_attempt_redirect_when_user_is_pending(
             'email_address': 'pending_user@example.gov.uk',
             'password': 'val1dPassw0rd!'
         },
-        _expected_redirect=url_for('main.resend_email_verification', _external=True, next=redirect_url)
+        _expected_redirect=url_for('main.resend_email_verification', next=redirect_url)
     )
 
 

--- a/tests/app/main/views/test_sign_out.py
+++ b/tests/app/main/views/test_sign_out.py
@@ -12,7 +12,6 @@ def test_render_sign_out_redirects_to_sign_in(
         'main.sign_out',
         _expected_redirect=url_for(
             'main.index',
-            _external=True,
         )
     )
     with client_request.session_transaction() as session:
@@ -48,7 +47,6 @@ def test_sign_out_user(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.index',
-            _external=True,
         )
     )
     with client_request.session_transaction() as session:

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -563,8 +563,7 @@ def test_can_create_email_template_with_parent_folder(
                         _data=data,
                         _expected_redirect=url_for("main.view_template",
                                                    service_id=SERVICE_ONE_ID,
-                                                   template_id="new%20name",
-                                                   _external=True)
+                                                   template_id="new%20name",)
                         )
     mock_create_service_template.assert_called_once_with(
         data['name'],
@@ -831,8 +830,7 @@ def test_rename_folder(client_request, active_user_with_permissions, service_one
         _data={"name": "new beautiful name", "users_with_permission": []},
         _expected_redirect=url_for("main.choose_template",
                                    service_id=service_one['id'],
-                                   template_folder_id=folder_id,
-                                   _external=True)
+                                   template_folder_id=folder_id,)
     )
 
     mock_update.assert_called_once_with(
@@ -864,8 +862,7 @@ def test_manage_folder_users(
         _data={"name": "new beautiful name", "users_with_permission": []},
         _expected_redirect=url_for("main.choose_template",
                                    service_id=service_one['id'],
-                                   template_folder_id=folder_id,
-                                   _external=True)
+                                   template_folder_id=folder_id,)
     )
 
     mock_update.assert_called_once_with(
@@ -907,8 +904,7 @@ def test_manage_folder_users_doesnt_change_permissions_current_user_cannot_manag
         _data={"name": "new beautiful name", "users_with_permission": []},
         _expected_redirect=url_for("main.choose_template",
                                    service_id=service_one['id'],
-                                   template_folder_id=folder_id,
-                                   _external=True)
+                                   template_folder_id=folder_id,)
     )
 
     mock_update.assert_called_once_with(
@@ -978,7 +974,6 @@ def test_delete_template_folder_should_detect_non_empty_folder_on_get(
             template_type="all",
             service_id=service_one['id'],
             template_folder_id=folder_id,
-            _external=True
         ),
         _expected_status=302
     )
@@ -1007,7 +1002,6 @@ def test_delete_folder(client_request, service_one, mock_get_template_folders, m
             "main.choose_template",
             service_id=service_one['id'],
             template_folder_id=parent_folder_id,
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -580,7 +580,6 @@ def test_caseworker_redirected_to_set_sender_for_one_off(
             'main.set_sender',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -633,7 +632,6 @@ def test_user_with_only_send_and_view_redirected_to_set_sender_for_one_off(
             'main.set_sender',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -1207,7 +1205,6 @@ def test_choosing_to_copy_redirects(
         _expected_redirect=url_for(
             'main.choose_template_to_copy',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         ),
     )
 
@@ -1722,7 +1719,6 @@ def test_should_redirect_when_saving_a_template(
             '.view_template',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
     mock_update_service_template.assert_called_with(
@@ -1753,7 +1749,6 @@ def test_should_edit_content_when_process_type_is_priority_not_platform_admin(
             '.view_template',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         )
     )
     mock_update_service_template.assert_called_with(
@@ -1956,7 +1951,6 @@ def test_removing_placeholders_is_not_a_breaking_change(
             'main.view_template',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
     assert mock_update_service_template.called is True
@@ -2066,7 +2060,6 @@ def test_should_redirect_when_saving_a_template_email(
             '.view_template',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
     mock_update_service_template.assert_called_with(
@@ -2183,7 +2176,6 @@ def test_should_redirect_when_deleting_a_template(
             '.choose_template',
             service_id=SERVICE_ONE_ID,
             template_folder_id=parent,
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -301,7 +301,6 @@ def test_tour_step_redirects_to_tour_start_if_placeholders_doesnt_exist_in_sessi
             'main.begin_tour',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -374,7 +373,6 @@ def test_post_tour_step_saves_data_and_redirects_to_next_step(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=2,
-            _external=True,
         ),
     )
 
@@ -403,7 +401,6 @@ def test_post_tour_step_adds_data_to_saved_data_and_redirects_to_next_step(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=3,
-            _external=True,
         ),
     )
 
@@ -473,7 +470,6 @@ def test_post_final_tour_step_saves_data_and_redirects_to_check_notification(
             'main.check_tour_notification',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True
         ),
     )
 
@@ -503,7 +499,6 @@ def test_get_test_step_out_of_index_redirects_to_first_step(
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=1,
-            _external=True
         ),
     )
 
@@ -527,7 +522,6 @@ def test_get_test_step_out_of_index_redirects_to_check_notification_if_all_place
             'main.check_tour_notification',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True
         ),
     )
 
@@ -619,7 +613,6 @@ def test_check_tour_notification_redirects_to_tour_start_if_placeholders_doesnt_
             'main.begin_tour',
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
-            _external=True,
         ),
     )
 
@@ -643,7 +636,6 @@ def test_check_tour_notification_redirects_to_first_step_if_not_all_placeholders
             service_id=SERVICE_ONE_ID,
             template_id=fake_uuid,
             step_index=1,
-            _external=True
         ),
     )
 
@@ -685,7 +677,6 @@ def test_go_to_dashboard_after_tour_link(
         _expected_redirect=url_for(
             "main.service_dashboard",
             service_id=fake_uuid,
-            _external=True,
         )
     )
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -100,7 +100,6 @@ def test_should_login_user_and_should_redirect_to_next_url(
         _expected_redirect=url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
-            _external=True
         ),
     )
 
@@ -128,7 +127,6 @@ def test_should_send_email_and_redirect_to_info_page_if_user_needs_to_revalidate
         _data={'sms_code': '12345'},
         _expected_redirect=url_for(
             'main.revalidate_email_sent',
-            _external=True,
             next=f'/services/{SERVICE_ONE_ID}'
         ),
     )
@@ -157,7 +155,7 @@ def test_should_login_user_and_not_redirect_to_external_url(
         'main.two_factor_sms',
         next='http://www.google.com',
         _data={'sms_code': '12345'},
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True)
+        _expected_redirect=url_for('main.show_accounts_or_dashboard')
     )
 
 
@@ -185,7 +183,7 @@ def test_should_login_user_and_redirect_to_show_accounts(
     client_request.post(
         'main.two_factor_sms',
         _data={'sms_code': '12345'},
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True)
+        _expected_redirect=url_for('main.show_accounts_or_dashboard')
     )
 
 
@@ -257,7 +255,7 @@ def test_two_factor_sms_should_set_password_when_new_password_exists_in_session(
     client_request.post(
         'main.two_factor_sms',
         _data={'sms_code': '12345'},
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('main.show_accounts_or_dashboard'),
     )
 
     mock_update_user_password.assert_called_once_with(
@@ -293,7 +291,7 @@ def test_two_factor_sms_post_should_redirect_to_sign_in_if_user_not_in_session(
     client_request.post(
         'main.two_factor_sms',
         _data={'sms_code': '12345'},
-        _expected_redirect=url_for('main.sign_in', _external=True)
+        _expected_redirect=url_for('main.sign_in')
     )
 
 
@@ -304,7 +302,7 @@ def test_two_factor_endpoints_get_should_redirect_to_sign_in_if_user_not_in_sess
 ):
     client_request.get(
         endpoint,
-        _expected_redirect=url_for('main.sign_in', _external=True)
+        _expected_redirect=url_for('main.sign_in')
     )
 
 
@@ -421,7 +419,7 @@ def test_valid_two_factor_email_link_logs_in_user(
 
     client_request.post_url(
         url_for_endpoint_with_token('main.two_factor_email', token=valid_token),
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True)
+        _expected_redirect=url_for('main.show_accounts_or_dashboard')
     )
 
 
@@ -518,5 +516,5 @@ def test_two_factor_email_link_used_when_user_already_logged_in(
 ):
     client_request.post_url(
         url_for_endpoint_with_token('main.two_factor_email', token=valid_token),
-        _expected_redirect=url_for('main.show_accounts_or_dashboard', _external=True),
+        _expected_redirect=url_for('main.show_accounts_or_dashboard'),
     )

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -81,7 +81,7 @@ def test_should_redirect_after_name_change(
         'main.user_profile_name',
         _data={'new_name': 'New Name'},
         _expected_status=302,
-        _expected_redirect=url_for('main.user_profile', _external=True),
+        _expected_redirect=url_for('main.user_profile'),
     )
     assert mock_update_user_attribute.called is True
 
@@ -108,7 +108,6 @@ def test_should_redirect_after_email_change(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_email_authenticate',
-            _external=True,
         )
     )
 
@@ -178,7 +177,7 @@ def test_should_redirect_to_user_profile_when_user_confirms_email_link(
             'main.user_profile_email_confirm',
             token=token,
         ),
-        _expected_redirect=url_for('main.user_profile', _external=True),
+        _expected_redirect=url_for('main.user_profile'),
     )
 
 
@@ -249,7 +248,6 @@ def test_delete_mobile_number(
         '.user_profile_mobile_number_delete',
         _expected_redirect=url_for(
             '.user_profile',
-            _external=True,
         )
     )
     mock_delete.assert_called_once_with(
@@ -272,7 +270,6 @@ def test_should_redirect_after_mobile_number_change(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_mobile_number_authenticate',
-            _external=True,
         )
     )
     with client_request.session_transaction() as session:
@@ -307,7 +304,6 @@ def test_should_redirect_after_mobile_number_authenticate(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_mobile_number_confirm',
-            _external=True,
         )
     )
 
@@ -355,7 +351,6 @@ def test_should_redirect_after_mobile_number_confirm(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile',
-            _external=True,
         )
     )
 
@@ -386,7 +381,6 @@ def test_should_redirect_after_password_change(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile',
-            _external=True,
         ),
     )
 
@@ -433,7 +427,7 @@ def test_can_disable_platform_admin(client_request, platform_admin_user):
         'main.user_profile_disable_platform_admin_view',
         _data={'enabled': False},
         _expected_status=302,
-        _expected_redirect=url_for('main.user_profile', _external=True),
+        _expected_redirect=url_for('main.user_profile'),
     )
 
     with client_request.session_transaction() as session:
@@ -450,7 +444,7 @@ def test_can_reenable_platform_admin(client_request, platform_admin_user):
         'main.user_profile_disable_platform_admin_view',
         _data={'enabled': True},
         _expected_status=302,
-        _expected_redirect=url_for('main.user_profile', _external=True),
+        _expected_redirect=url_for('main.user_profile'),
     )
 
     with client_request.session_transaction() as session:
@@ -607,7 +601,6 @@ def test_should_redirect_after_change_of_security_key_name(
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_security_keys',
-            _external=True,
         )
     )
 
@@ -640,7 +633,6 @@ def test_user_profile_manage_security_key_should_not_call_api_if_key_name_stays_
         _expected_status=302,
         _expected_redirect=url_for(
             'main.user_profile_security_keys',
-            _external=True,
         )
     )
 
@@ -709,7 +701,6 @@ def test_delete_security_key(
         key_id=webauthn_credential['id'],
         _expected_redirect=url_for(
             '.user_profile_security_keys',
-            _external=True,
         )
     )
     mock_delete.assert_called_once_with(

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -48,7 +48,7 @@ def test_should_redirect_to_add_service_when_sms_code_is_correct(
     client_request.post(
         'main.verify',
         _data={'sms_code': '12345'},
-        _expected_redirect=url_for('main.add_service', first='first', _external=True),
+        _expected_redirect=url_for('main.add_service', first='first'),
     )
 
     # make sure the current_session_id has changed to what the API returned
@@ -113,7 +113,7 @@ def test_verify_email_redirects_to_verify_if_token_valid(
     client_request.get(
         'main.verify_email',
         token='notreal',
-        _expected_redirect=url_for('main.verify', _external=True),
+        _expected_redirect=url_for('main.verify'),
     )
 
     assert not mock_check_verify_code.called
@@ -140,7 +140,7 @@ def test_verify_email_doesnt_verify_sms_if_user_on_email_auth(
     client_request.get(
         'main.verify_email',
         token='notreal',
-        _expected_redirect=url_for('main.add_service', first='first', _external=True),
+        _expected_redirect=url_for('main.add_service', first='first'),
     )
 
     assert not mock_check_verify_code.called
@@ -164,7 +164,7 @@ def test_verify_email_redirects_to_email_sent_if_token_expired(
     client_request.get(
         'main.verify_email',
         token='notreal',
-        _expected_redirect=url_for('main.resend_email_verification', _external=True),
+        _expected_redirect=url_for('main.resend_email_verification'),
     )
 
 
@@ -193,7 +193,7 @@ def test_verify_redirects_to_sign_in_if_not_logged_in(
     client_request.logout()
     client_request.get(
         'main.verify',
-        _expected_redirect=url_for('main.sign_in', _external=True),
+        _expected_redirect=url_for('main.sign_in'),
     )
 
 

--- a/tests/app/main/views/uploads/test_upload_contact_list.py
+++ b/tests/app/main/views/uploads/test_upload_contact_list.py
@@ -432,7 +432,6 @@ def test_save_contact_list(
         _expected_redirect=url_for(
             'main.uploads',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_get_metadata.assert_called_once_with(
@@ -721,7 +720,6 @@ def test_delete_contact_list(
         _expected_redirect=url_for(
             'main.uploads',
             service_id=SERVICE_ONE_ID,
-            _external=True,
         )
     )
     mock_delete.assert_called_once_with(

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -481,7 +481,6 @@ def test_uploaded_letter_preview_redirects_if_file_not_in_s3(
             'main.view_notification',
             service_id=SERVICE_ONE_ID,
             notification_id=fake_uuid,
-            _external=True
         )
     )
 
@@ -636,7 +635,6 @@ def test_send_uploaded_letter_sends_letter_and_redirects_to_notification_page(
             'main.view_notification',
             service_id=SERVICE_ONE_ID,
             notification_id=fake_uuid,
-            _external=True
         )
     )
     mock_send.assert_called_once_with(
@@ -670,7 +668,6 @@ def test_send_uploaded_letter_redirects_if_file_not_in_s3(
             'main.view_notification',
             service_id=SERVICE_ONE_ID,
             notification_id=fake_uuid,
-            _external=True
         )
     )
 

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -24,9 +24,10 @@ def _test_permissions(
         decorated_index()
     else:
         try:
-            if (
-                decorated_index().location != '/sign-in?next=%2F' or
-                decorated_index().status_code != 302
+            response = decorated_index()
+            if not (
+                response.location.startswith('/sign-in?next=') and
+                response.status_code == 302
             ):
                 pytest.fail("Failed to throw a forbidden or unauthorised exception")
         except (Forbidden, Unauthorized):


### PR DESCRIPTION
Now that we’ve upgraded itsdangerous to the latest version (https://github.com/alphagov/notifications-admin/pull/4255) we are:
- unblocked from upgrading to Flask 2, which requires a recent version of itsdangerous
- unblocked from upgrading Jinja and Werkzeug to the latest versions, which require Flask 2

There are a few breaking changes to account for, details of which are in the individual commits.