### PR TITLE
Document +882 numbers are not supported

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -197,7 +197,7 @@
 
     <div id="international-pricing" class="bottom-gutter-3-2">
       {% call mapping_table(
-        caption='Letter pricing',
+        caption='International text message rates',
         field_headings=['Country code', 'Country', 'Cost multiplier'],
         field_headings_visible=True,
         caption_visible=False
@@ -213,10 +213,16 @@
             {{ text_field('{}&hairsp;&times;'.format(billable_units)|safe) }}
           {% endcall %}
         {% endfor %}
+
+        {% call row() %}
+          {{ text_field('+882') }}
+          {% call field() %}Worldwide{% endcall %}
+          {{ text_field('Not supported') }}
+        {% endcall %}
       {% endcall %}
     </div>
-
   {% endset %}
+
   {{ govukDetails({
     "summaryText": "International text message rates",
     "html": smsIntRates


### PR DESCRIPTION
These are "countryless" phone numbers used by e.g. satellite phone
providers [^1]. We decided not to support them for now because:

- The use case is low: only one service is asking for this prefix.
- MMG will charge at 4x for them but apparently they cost more.

We can't put this "negative" data in the usual place [^2] because
this would _enable_ sending via this number. Until we have more
cases like this it's easiest to just tack on this fake info.

## Screenshot

<img width="667" alt="Screenshot 2022-05-31 at 17 39 01" src="https://user-images.githubusercontent.com/9029009/171227841-0ecf0bce-a5ec-42dd-94aa-6fc1fde6112e.png">


[^1]: https://en.wikipedia.org/wiki/International_Networks_(country_code)
[^2]: https://github.com/alphagov/notifications-utils/blob/ca2506c6a626d25f76a25c4a94b7288e1c3aa2b5/notifications_utils/recipients.py#L569