### PR TITLE
Bump utils to version 56.0.0

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -24,7 +24,7 @@ from notifications_utils.letter_timings import (
     letter_can_be_cancelled,
 )
 from notifications_utils.pdf import pdf_page_count
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 
 from app import (
     current_service,

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -22,7 +22,7 @@ from notifications_utils.pdf import pdf_page_count
 from notifications_utils.postal_address import PostalAddress
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.sanitise_text import SanitiseASCII
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 from requests import RequestException
 from xlrd.biffh import XLRDError
 from xlrd.xldate import XLDateError

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ pyproj==3.3.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.0.1  # pyup: <2.1.0  Release 2.1.0 introduced a change that is not compatible with Flask 1.x
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
 govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,7 +121,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -160,7 +160,7 @@ pyjwt==2.4.0
     # via notifications-python-client
 pyparsing==3.0.9
     # via packaging
-pypdf2==1.28.2
+pypdf2==2.0.0
     # via notifications-utils
 pyproj==3.3.1
     # via
@@ -211,6 +211,8 @@ statsd==3.3.0
     # via notifications-utils
 texttable==1.6.4
     # via pyexcel
+typing-extensions==4.2.0
+    # via pypdf2
 urllib3==1.26.9
     # via
     #   botocore

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -6,7 +6,7 @@ import pytest
 from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import APIError, HTTPError
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 
 from tests.conftest import (
     SERVICE_ONE_ID,


### PR DESCRIPTION
The only impactful change is the major version itself, where I've
fixed the breaking changes due to the upgrade of PyPDF2 [^1] and
checked there are no deprecation warnings when I run the tests.

[^1]: https://github.com/alphagov/notifications-utils/pull/973