### PR TITLE
Refactor permissions tests

### DIFF
--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -1,6 +1,6 @@
 import pytest
 from flask import request
-from werkzeug.exceptions import Forbidden, Unauthorized
+from werkzeug.exceptions import Forbidden
 
 from app.main.views.index import index
 from app.utils.user import user_has_permissions
@@ -30,7 +30,7 @@ def _test_permissions(
                 response.status_code == 302
             ):
                 pytest.fail("Failed to throw a forbidden or unauthorised exception")
-        except (Forbidden, Unauthorized):
+        except Forbidden:
             pass
 
 

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -3,7 +3,6 @@ from flask import request
 from werkzeug.exceptions import Forbidden
 
 from app.utils.user import user_has_permissions
-from tests.conftest import create_user, sample_uuid
 
 
 @pytest.mark.parametrize('permissions', (
@@ -20,14 +19,14 @@ from tests.conftest import create_user, sample_uuid
 def test_permissions(
     client_request,
     permissions,
+    api_user_active,
 ):
     request.view_args.update({'service_id': 'foo'})
-    user = create_user(
-        id=sample_uuid(),
-        permissions={'foo': ['manage_users', 'manage_templates', 'manage_settings']},
-        services=['foo', 'bar'],
-    )
-    client_request.login(user)
+
+    api_user_active['permissions'] = {'foo': ['manage_users', 'manage_templates', 'manage_settings']}
+    api_user_active['services'] = ['foo', 'bar']
+
+    client_request.login(api_user_active)
 
     @user_has_permissions(*permissions)
     def index():
@@ -67,12 +66,10 @@ def test_no_user_returns_redirect_to_sign_in(
 
 def test_user_has_permissions_for_organisation(
     client_request,
+    api_user_active,
 ):
-    user = create_user(
-        id=sample_uuid(),
-        organisations=['org_1', 'org_2'],
-    )
-    client_request.login(user)
+    api_user_active['organisations'] = ['org_1', 'org_2']
+    client_request.login(api_user_active)
 
     request.view_args = {'org_id': 'org_2'}
 
@@ -117,12 +114,10 @@ def test_cant_use_decorator_without_view_args(
 
 def test_user_doesnt_have_permissions_for_organisation(
     client_request,
+    api_user_active,
 ):
-    user = create_user(
-        id=sample_uuid(),
-        organisations=['org_1', 'org_2'],
-    )
-    client_request.login(user)
+    api_user_active['organisations'] = ['org_1', 'org_2']
+    client_request.login(api_user_active)
 
     request.view_args = {'org_id': 'org_3'}
 
@@ -136,13 +131,11 @@ def test_user_doesnt_have_permissions_for_organisation(
 
 def test_user_with_no_permissions_to_service_goes_to_templates(
     client_request,
+    api_user_active,
 ):
-    user = create_user(
-        id=sample_uuid(),
-        permissions={'foo': ['manage_users', 'manage_templates', 'manage_settings']},
-        services=['foo', 'bar'],
-    )
-    client_request.login(user)
+    api_user_active['permissions'] = {'foo': ['manage_users', 'manage_templates', 'manage_settings']}
+    api_user_active['services'] = ['foo', 'bar']
+    client_request.login(api_user_active)
     request.view_args = {'service_id': 'bar'}
 
     @user_has_permissions()

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -6,12 +6,6 @@ from app.main.views.index import index
 from app.utils.user import user_has_permissions
 from tests.conftest import create_user, sample_uuid
 
-_user_with_permissions = create_user(
-    id=sample_uuid(),
-    permissions={'foo': ['manage_users', 'manage_templates', 'manage_settings']},
-    services=['foo', 'bar'],
-)
-
 
 @pytest.mark.parametrize('permissions', (
     pytest.param(
@@ -29,7 +23,12 @@ def test_permissions(
     permissions,
 ):
     request.view_args.update({'service_id': 'foo'})
-    client_request.login(_user_with_permissions)
+    user = create_user(
+        id=sample_uuid(),
+        permissions={'foo': ['manage_users', 'manage_templates', 'manage_settings']},
+        services=['foo', 'bar'],
+    )
+    client_request.login(user)
 
     decorator = user_has_permissions(*permissions)
     decorated_index = decorator(index)
@@ -133,7 +132,12 @@ def test_user_doesnt_have_permissions_for_organisation(
 def test_user_with_no_permissions_to_service_goes_to_templates(
     client_request,
 ):
-    client_request.login(_user_with_permissions)
+    user = create_user(
+        id=sample_uuid(),
+        permissions={'foo': ['manage_users', 'manage_templates', 'manage_settings']},
+        services=['foo', 'bar'],
+    )
+    client_request.login(user)
     request.view_args = {'service_id': 'bar'}
 
     @user_has_permissions()

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -6,15 +6,25 @@ from app.utils.user import user_has_permissions
 
 
 @pytest.mark.parametrize('permissions', (
-    pytest.param(
-        ['send_messages'],
-        marks=pytest.mark.xfail(raises=Forbidden),
-    ),
-    ['manage_service'],
-    ['send_messages', 'manage_service'],
-    ['manage_templates', 'manage_service'],
-    ['manage_service', 'manage_templates'],
-    [],
+    pytest.param([
+        # Route has a permission which the user doesn’t have
+        'send_messages'
+    ], marks=pytest.mark.xfail(raises=Forbidden)),
+    [
+        # Route has one of the permissions which the user has
+        'manage_service'
+    ],
+    [
+        # Route has more than one of the permissions which the user has
+        'manage_templates', 'manage_service'
+    ],
+    [
+        # Route has one of the permissions which the user has, and one they do not
+        'manage_service', 'send_messages',
+    ],
+    [
+        # Route has no specific permissions required
+    ],
 ))
 def test_permissions(
     client_request,


### PR DESCRIPTION
The tests in this file are very old, and don’t make use of the fixtures and techniques we’ve since developed.

By refactoring them a bit we:
- delete a bunch of lines of code
- make it easier to see what cases the tests are covering

I don’t think it’s worth trying to cover more or fewer cases at this point, but this should make it easier for anyone who comes along and wants to add to or fix one of these tests.