### PR TITLE
Refactor Template List models (follow-up to #4258)

### DIFF
--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -7,7 +7,7 @@ from notifications_utils.template import SMSPreviewTemplate
 from app import current_service, notification_api_client, service_api_client
 from app.main import main
 from app.main.forms import SearchByNameForm
-from app.models.template_list import TemplateList
+from app.models.template_list import UserTemplateList
 from app.utils.user import user_has_permissions
 
 
@@ -46,7 +46,7 @@ def conversation_reply(
 ):
     return render_template(
         'views/templates/choose-reply.html',
-        templates_and_folders=TemplateList(
+        templates_and_folders=UserTemplateList(
             service=current_service,
             template_folder_id=from_folder,
             user=current_user,

--- a/app/main/views/conversation.py
+++ b/app/main/views/conversation.py
@@ -47,7 +47,7 @@ def conversation_reply(
     return render_template(
         'views/templates/choose-reply.html',
         templates_and_folders=TemplateList(
-            current_service,
+            service=current_service,
             template_folder_id=from_folder,
             user=current_user,
             template_type='sms'

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -112,9 +112,10 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
         user=current_user
     )
 
-    all_template_folders = [
-        item.folder for item in UserTemplateList(service=current_service, user=current_user) if item.is_folder
-    ]
+    all_template_folders = UserTemplateList(
+        service=current_service,
+        user=current_user
+    ).all_template_folders
 
     templates_and_folders_form = TemplateAndFoldersSelectionForm(
         all_template_folders=all_template_folders,

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -37,7 +37,11 @@ from app.main.forms import (
 )
 from app.main.views.send import get_sender_details
 from app.models.service import Service
-from app.models.template_list import TemplateList, TemplateLists
+from app.models.template_list import (
+    TemplateList,
+    UserTemplateList,
+    UserTemplateLists,
+)
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import NOTIFICATION_TYPES, should_skip_template_page
 from app.utils.templates import get_template
@@ -99,10 +103,9 @@ def view_template(service_id, template_id):
 @user_has_permissions()
 def choose_template(service_id, template_type='all', template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
-
     user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
 
-    template_list = TemplateList(
+    template_list = UserTemplateList(
         service=current_service,
         template_type=template_type,
         template_folder_id=template_folder_id,
@@ -110,7 +113,7 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
     )
 
     all_template_folders = [
-        item.folder for item in TemplateList(service=current_service, user=current_user) if item.is_folder
+        item.folder for item in UserTemplateList(service=current_service, user=current_user) if item.is_folder
     ]
 
     templates_and_folders_form = TemplateAndFoldersSelectionForm(
@@ -349,7 +352,7 @@ def choose_template_to_copy(
 
         return render_template(
             'views/templates/copy.html',
-            services_templates_and_folders=TemplateList(
+            services_templates_and_folders=UserTemplateList(
                 service=service,
                 template_folder_id=from_folder,
                 user=current_user
@@ -362,7 +365,7 @@ def choose_template_to_copy(
     else:
         return render_template(
             'views/templates/copy.html',
-            services_templates_and_folders=TemplateLists(current_user),
+            services_templates_and_folders=UserTemplateLists(current_user),
             search_form=SearchTemplatesForm(current_service.api_keys),
         )
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -102,7 +102,12 @@ def choose_template(service_id, template_type='all', template_folder_id=None):
 
     user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
 
-    template_list = TemplateList(current_service, template_type, template_folder_id, current_user)
+    template_list = TemplateList(
+        service=current_service,
+        template_type=template_type,
+        template_folder_id=template_folder_id,
+        user=current_user
+    )
 
     all_template_folders = [
         item.folder for item in TemplateList(service=current_service, user=current_user) if item.is_folder
@@ -345,7 +350,7 @@ def choose_template_to_copy(
         return render_template(
             'views/templates/copy.html',
             services_templates_and_folders=TemplateList(
-                service,
+                service=service,
                 template_folder_id=from_folder,
                 user=current_user
             ),

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -277,7 +277,6 @@ class TemplateListFolder(TemplateListItem):
         service_id,
     ):
         super().__init__(folder, ancestors)
-        self.folder = folder
         self.service_id = service_id
         self.number_of_templates = len(templates)
         self.number_of_folders = len(folders)

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -4,6 +4,23 @@ from app import format_notification_type
 
 
 class TemplateList():
+    """
+    Represents a list of all templates and folders for a service,
+    with optional filtering by "template_type", and by an ancestor
+    template_folder_id i.e. only return templates and folders that
+    are somewhere inside the specified folder.
+
+    This is used in several places:
+
+    - On the "Templates" page to show whether a folder is totally
+    empty or has other types of template in it.
+
+    - On the "Delete template" page to check whether a folder is
+    totally empty before deleting it.
+
+    Subclasses of this class are also used in several places - see
+    comments on those classes for more details.
+    """
 
     def __init__(
         self,
@@ -117,6 +134,23 @@ class TemplateList():
 
 
 class UserTemplateList(TemplateList):
+    """
+    Represents a filtered list of templates and folders for a
+    service based on which folders the specified user has access
+    to. See the comment on "all_template_folders".
+
+    This is used in several places:
+
+    - On the "Templates" page. We render all the templates and
+    folders to support JS search, hiding nested items with CSS.
+
+    - On the "Templates" page, we also use "all_template_folders"
+    to render the list of folders to move a template to.
+
+    - On the SMS reply-to page. We render all the templates and
+    folders to support JS search, hiding nested items with CSS.
+    """
+
     def __init__(self, user, **kwargs):
         self.user = user
         super().__init__(**kwargs)
@@ -176,6 +210,14 @@ class UserTemplateList(TemplateList):
 
 
 class ServiceTemplateList(UserTemplateList):
+    """
+    Represents a list of templates and folders for a service,
+    with the service itself returned first in the iterable as
+    a "fake" folder - a TemplateListService.
+
+    This is used exclusively by the UserTemplateLists class.
+    """
+
     def __iter__(self):
         template_list_service = TemplateListService(
             self.service,
@@ -199,6 +241,13 @@ class ServiceTemplateList(UserTemplateList):
 
 
 class UserTemplateLists():
+    """
+    Represents one or more lists of templates and folders
+    for each service a user has access to.
+
+    This is used exclusively on the "Copy template" page.
+    """
+
     def __init__(self, user):
         self.services = sorted(
             user.services,

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -163,6 +163,9 @@ class UserTemplateList(TemplateList):
 
         return [
             template for template in self.service.all_templates
+            # Check if each template is in a folder the user has
+            # access to. If it's not in a folder ("None"), then
+            # it's at the top level and all users have access.
             if template['folder'] in (all_folder_ids + [None])
         ]
 
@@ -213,7 +216,10 @@ class ServiceTemplateList(UserTemplateList):
     """
     Represents a list of templates and folders for a service,
     with the service itself returned first in the iterable as
-    a "fake" folder - a TemplateListService.
+    a "fake" folder - a TemplateListService. As this inherits
+    from UserTemplateList, the list of templates and folders
+    is filtered based on which folders the specified user has
+    access to.
 
     This is used exclusively by the UserTemplateLists class.
     """

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -7,6 +7,7 @@ class TemplateList():
 
     def __init__(
         self,
+        *,
         service,
         template_type='all',
         template_folder_id=None,

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -64,15 +64,12 @@ class TemplateList():
             )
 
     def get_templates(self, template_type, template_folder_id):
-        if isinstance(template_type, str):
-            template_type = [template_type]
-
         if template_folder_id:
             template_folder_id = str(template_folder_id)
 
         return [
             template for template in self.all_templates
-            if (set(template_type) & {'all', template['template_type']})
+            if (set([template_type]) & {'all', template['template_type']})
             and template.get('folder') == template_folder_id
         ]
 

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -63,7 +63,7 @@ class TemplateList():
                 service_id=self.service.id,
             )
 
-    def get_templates(self, template_type='all', template_folder_id=None):
+    def get_templates(self, template_type, template_folder_id):
         if isinstance(template_type, str):
             template_type = [template_type]
 
@@ -76,7 +76,7 @@ class TemplateList():
             and template.get('folder') == template_folder_id
         ]
 
-    def get_template_folders(self, template_type='all', parent_folder_id=None):
+    def get_template_folders(self, template_type, parent_folder_id):
         if parent_folder_id:
             parent_folder_id = str(parent_folder_id)
 
@@ -88,7 +88,7 @@ class TemplateList():
             )
         ]
 
-    def is_folder_visible(self, template_folder_id, template_type='all'):
+    def is_folder_visible(self, template_folder_id, template_type):
 
         if template_type == 'all':
             return True
@@ -183,9 +183,11 @@ class ServiceTemplateList(UserTemplateList):
         template_list_service = TemplateListService(
             self.service,
             templates=self.get_templates(
+                template_type='all',
                 template_folder_id=None,
             ),
             folders=self.get_template_folders(
+                template_type='all',
                 parent_folder_id=None,
             ),
         )

--- a/app/models/template_list.py
+++ b/app/models/template_list.py
@@ -29,6 +29,10 @@ class TemplateList():
     def all_template_folders(self):
         return self.service.all_template_folders
 
+    @property
+    def all_templates(self):
+        return self.service.all_templates
+
     def get_templates_and_folders(self, template_type, template_folder_id, ancestors):
 
         for item in self.get_template_folders(
@@ -67,7 +71,7 @@ class TemplateList():
             template_folder_id = str(template_folder_id)
 
         return [
-            template for template in self.service.all_templates
+            template for template in self.all_templates
             if (set(template_type) & {'all', template['template_type']})
             and template.get('folder') == template_folder_id
         ]
@@ -120,16 +124,16 @@ class UserTemplateList(TemplateList):
         self.user = user
         super().__init__(**kwargs)
 
-    def get_templates(self, template_type='all', template_folder_id=None):
-        if template_folder_id:
-            folder = self.service.get_template_folder(template_folder_id)
-            if not self.user.has_template_folder_permission(folder):
-                return []
+    @cached_property
+    def all_templates(self):
+        all_folder_ids = [
+            folder['id'] for folder in self.all_template_folders
+        ]
 
-        return super().get_templates(
-            template_type=template_type,
-            template_folder_id=template_folder_id
-        )
+        return [
+            template for template in self.service.all_templates
+            if template['folder'] in (all_folder_ids + [None])
+        ]
 
     @cached_property
     def all_template_folders(self):

--- a/tests/app/models/test_template_list.py
+++ b/tests/app/models/test_template_list.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 
 from app.models.service import Service
-from app.models.template_list import TemplateList
+from app.models.template_list import TemplateList, UserTemplateList
 from app.models.user import User
 
 INV_PARENT_FOLDER_ID = '7e979e79-d970-43a5-ac69-b625a8d147b0'
@@ -86,7 +86,7 @@ def test_template_list_yields_folders_visible_to_user(
 
     result_folder_names = tuple(
         result.name for result in
-        TemplateList(service=service, user=user)
+        UserTemplateList(service=service, user=user)
         if result.is_folder
     )
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179736794

In [^1] we moved lots of code from the Service class into TemplateList, 
which has made this class a lot more complex. It also gives us new ways 
to simplify the code, which is what we look at here:

- Separating the user-specific parts of the code out into a new class,
which removes a layer of recursive, conditional logic.

- Standardising, simplifying and documenting the TemplateList classes,
so they require less mental effort to understand.

[^1]: https://github.com/alphagov/notifications-admin/pull/4258