### PR TITLE
Pin govuk-frontend-jinja to version published by CCS

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ pyproj==3.3.1
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
-govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
+govuk-frontend-jinja @ git+https://github.com/Crown-Commercial-Service/govuk-frontend-jinja.git@v0.5.8-alpha  # pyup: ignore # can’t be upgraded until we migrate to https://github.com/LandRegistry/govuk-frontend-jinja
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ govuk-bank-holidays==0.11
     # via
     #   -r requirements.in
     #   notifications-utils
-govuk-frontend-jinja @ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.8-alpha
+govuk-frontend-jinja @ git+https://github.com/Crown-Commercial-Service/govuk-frontend-jinja.git@v0.5.8-alpha
     # via -r requirements.in
 greenlet==1.1.2
     # via eventlet


### PR DESCRIPTION
The version of `govuk-frontend-jinja` we are using was developed in GDS and is now owned by Crown Commercial Service.

It doesn’t seem to be maintained any more.

There is a different package with the same name which is owned by the Land Registry and is maintained. It is published on PyPi, so PyUp tries to upgrade to it. We can’t automatically upgrade to it because it’s not a like-for-like replacement for the Crown Commercial Service package.

This commit:
- clarifies that it’s the Crown Commercial Service package we are using (the alphagov URL redirects to this)
- tells PyUp to stop trying to upgrade the package