### PR TITLE
Fix relative URLs appearing in support tickets

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -114,17 +114,10 @@ def feedback(ticket_type):
     if form.validate_on_submit():
         user_email = form.email_address.data
         user_name = form.name.data or None
-        if current_service:
-            service_string = 'Service: "{name}"\n{url}\n'.format(
-                name=current_service.name,
-                url=url_for('main.service_dashboard', service_id=current_service.id)
-            )
-        else:
-            service_string = ''
 
-        feedback_msg = '{}\n{}'.format(
-            form.feedback.data,
-            service_string,
+        feedback_msg = render_template(
+            'support-tickets/support-ticket.txt',
+            content=form.feedback.data,
         )
 
         ticket = NotifySupportTicket(

--- a/app/templates/support-tickets/support-ticket.txt
+++ b/app/templates/support-tickets/support-ticket.txt
@@ -1,0 +1,5 @@
+{{ content }}
+{% if current_service -%}
+Service: "{{ current_service.name }}"
+{{ url_for('main.service_dashboard', service_id=current_service.id) }}
+{% endif %}

--- a/app/templates/support-tickets/support-ticket.txt
+++ b/app/templates/support-tickets/support-ticket.txt
@@ -1,5 +1,5 @@
 {{ content }}
 {% if current_service -%}
 Service: "{{ current_service.name }}"
-{{ url_for('main.service_dashboard', service_id=current_service.id) }}
+{{ url_for('main.service_dashboard', service_id=current_service.id, _external=True) }}
 {% endif %}

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -237,6 +237,7 @@ def test_passes_user_details_through_flow(
         url_for(
             'main.service_dashboard',
             service_id=SERVICE_ONE_ID,
+            _external=True,
         ),
         ''
     ])


### PR DESCRIPTION
When we get a support ticket we put a link to the service at the end.

As part of https://github.com/alphagov/notifications-admin/commit/8b7f2fbf041c182156cbdb4d3fbadc1c851e6653 we accidentally made these URLs relative, rather than absolute. This means they aren’t made into links by email clients or Zendesk.

For example:

<img width="659" alt="image" src="https://user-images.githubusercontent.com/355079/172382725-b362ba80-527b-4bcc-9ed5-7467cbe4b3b8.png">

This commit fixes the links to include the domain again.
