### PR TITLE
Unbind app from PaaS metrics service

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -31,7 +31,6 @@ applications:
 
     services:
       - logit-ssl-syslog-drain
-      - notify-prometheus
       - notify-splunk
       - notify-redis
 


### PR DESCRIPTION
We have migrated to our own Prometheus metrics stack and no longer require the gds-prometheus backing service used to configure the TechOps shared Prometheus metrics system. This is being decommissioned.

We have been running the new metrics stack alongside the existing service for a few weeks and have tested and correlated collected metrics in both systems for correctness.

Changes to the manifest are non-destructive so the service will need to be manually unbound in each environment using the cf cli.

cf unbind-service APP_NAME SERVICE_INSTANCE

See: [alphagov/notifications-cf-monitoring](https://github.com/alphagov/notifications-cf-monitoring)