### PR TITLE
File upload accessibility changes

### DIFF
--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -9,13 +9,29 @@
       <a href="" class='govuk-button govuk-button--warning govuk-!-margin-right-1'>Cancel upload</a>
     `);
 
+    // Add a button that passes a click to the input[type=file]
+    this.addFakeButton = function () {
+      $(
+        '<button type="button" class="govuk-button govuk-!-margin-right-1">' +
+          this.$field.data('buttonText') +
+        '</button>'
+      )
+      .on('click', e => this.$field.click())
+      .insertAfter(this.$field);
+    };
+
     this.start = function(component) {
 
       this.$form = $(component);
+      this.$field = this.$form.find('.file-upload-field');
 
-      // The label gets styled like a button and is used to hide the native file upload control. This is so that
-      // users see a button that looks like the others on the site.
-      this.$form.find('label.file-upload-button').addClass('govuk-button govuk-!-margin-right-1');
+      // Hide all controls except the button, semantically and visually
+      // These elements are also hidden in their CSS to override any use of the display style
+      this.$form.find('.file-upload-label, .file-upload-submit')
+                .add(this.$field)
+                .attr('hidden', "");
+
+      this.addFakeButton();
 
       // Clear the form if the user navigates back to the page
       $(window).on("pageshow", () => this.$form[0].reset());

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -28,9 +28,10 @@
 
     // Add a button that passes a click to the input[type=file]
     this.addFakeButton = function () {
+      var buttonText = this.$field.data('buttonText');
       var buttonHTMLStr = `
         <button type="button" class="govuk-button govuk-!-margin-right-1" id="file-upload-button">
-          ${this.$field.data('buttonText')}
+          ${buttonText}
         </button>`;
 
       // If errors with the upload, copy into a label above the button
@@ -39,6 +40,7 @@
       if (this.$fieldErrors.length > 0) {
         buttonHTMLStr = `
           <label class="file-upload-button-label error-message" for="file-upload-button">
+            <span class="govuk-visually-hidden">${buttonText} </span>
             ${this.$fieldErrors.eq(0).text()}
           </label>
           ${buttonHTMLStr}`;

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -42,11 +42,8 @@
       this.$form = $(component);
       this.$field = this.$form.find('.file-upload-field');
 
-      // Hide all controls except the button, semantically and visually
-      // These elements are also hidden in their CSS to override any use of the display style
-      this.$form.find('.file-upload-label, .file-upload-submit')
-                .add(this.$field)
-                .attr('hidden', "");
+      // Note: label.file-upload-label, input.file-upload-field and button.file-upload-submit
+      // are all hidden by CSS that uses the .js-enabled class on the body tag
 
       this.addFakeButton();
 

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -5,32 +5,30 @@
 
     this.submit = () => this.$form.trigger('submit');
 
-    this.showLoadingContent = () => {
-      var $loadingContent = $(`
-        <p tabindex="0" class="file-upload-loading-content">
-          <span class="file-upload-loading-message govuk-!-margin-right-3">
-            Uploading your file.<span class="govuk-visually-hidden"> Use cancel button to stop.</span>
-          </span>
-          <a href="" role="button" class='govuk-button govuk-button--warning'>
-            Cancel upload
-          </a>
-        </p>
+    this.addCancelButton = () => {
+
+      var $cancelButton = $(`
+        <a href="" role="button" class="file-upload-button govuk-button govuk-button--warning">
+          Cancel upload
+        </a>
       `);
 
-      $('button[type=button]', this.$form).replaceWith($loadingContent);
+      $('button[type=button]', this.$form).replaceWith($cancelButton);
 
       // add GOVUK Frontend behaviours
       new window.GOVUK.Frontend.Button(this.$form[0]).init();
 
-      // move focus to the content, it is lost when the upload button is removed
-      $loadingContent.focus();
+      // move focus to the cancel button, it is lost when the upload button is removed
+      $cancelButton.focus();
+
     };
 
     // Add a button that passes a click to the input[type=file]
     this.addFakeButton = function () {
+
       var buttonText = this.$field.data('buttonText');
       var buttonHTMLStr = `
-        <button type="button" class="govuk-button govuk-!-margin-right-1" id="file-upload-button">
+        <button type="button" class="file-upload-button govuk-button govuk-!-margin-right-1" id="file-upload-button">
           ${buttonText}
         </button>`;
 
@@ -69,7 +67,7 @@
       // Need to put the event on the container, not the input for it to work properly
       this.$form.on(
         'change', '.file-upload-field',
-        () => this.submit() && this.showLoadingContent()
+        () => this.submit() && this.addCancelButton()
       );
 
     };

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -35,7 +35,7 @@
 
       // If errors with the upload, copy into a label above the button
       // Buttons don't need labels by default as the accessible name comes from their text but
-      // errors need to be added to that. A label will do that, and keeps the current visual style
+      // errors need to be added to that.
       if (this.$fieldErrors.length > 0) {
         buttonHTMLStr = `
           <label class="file-upload-button-label error-message" for="file-upload-button">

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -5,9 +5,26 @@
 
     this.submit = () => this.$form.trigger('submit');
 
-    this.showCancelButton = () => $('.file-upload-button', this.$form).replaceWith(`
-      <a href="" class='govuk-button govuk-button--warning govuk-!-margin-right-1'>Cancel upload</a>
-    `);
+    this.showLoadingContent = () => {
+      var $loadingContent = $(`
+        <p tabindex="0" class="file-upload-loading-content">
+          <span class="file-upload-loading-message govuk-!-margin-right-3">
+            Uploading your file.<span class="govuk-visually-hidden"> Use cancel button to stop.</span>
+          </span>
+          <a href="" role="button" class='govuk-button govuk-button--warning'>
+            Cancel upload
+          </a>
+        </p>
+      `);
+
+      $('button[type=button]', this.$form).replaceWith($loadingContent);
+
+      // add GOVUK Frontend behaviours
+      new window.GOVUK.Frontend.Button(this.$form[0]).init();
+
+      // move focus to the content, it is lost when the upload button is removed
+      $loadingContent.focus();
+    };
 
     // Add a button that passes a click to the input[type=file]
     this.addFakeButton = function () {
@@ -39,7 +56,7 @@
       // Need to put the event on the container, not the input for it to work properly
       this.$form.on(
         'change', '.file-upload-field',
-        () => this.submit() && this.showCancelButton()
+        () => this.submit() && this.showLoadingContent()
       );
 
     };

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -28,19 +28,33 @@
 
     // Add a button that passes a click to the input[type=file]
     this.addFakeButton = function () {
-      $(
-        '<button type="button" class="govuk-button govuk-!-margin-right-1">' +
-          this.$field.data('buttonText') +
-        '</button>'
-      )
+      var buttonHTMLStr = `
+        <button type="button" class="govuk-button govuk-!-margin-right-1" id="file-upload-button">
+          ${this.$field.data('buttonText')}
+        </button>`;
+
+      // If errors with the upload, copy into a label above the button
+      // Buttons don't need labels by default as the accessible name comes from their text but
+      // errors need to be added to that. A label will do that, and keeps the current visual style
+      if (this.$fieldErrors.length > 0) {
+        buttonHTMLStr = `
+          <label class="file-upload-button-label error-message" for="file-upload-button">
+            ${this.$fieldErrors.eq(0).text()}
+          </label>
+          ${buttonHTMLStr}`;
+      }
+
+      $(buttonHTMLStr)
       .on('click', e => this.$field.click())
       .insertAfter(this.$field);
+
     };
 
     this.start = function(component) {
 
       this.$form = $(component);
       this.$field = this.$form.find('.file-upload-field');
+      this.$fieldErrors = this.$form.find('.file-upload-label .error-message');
 
       // Note: label.file-upload-label, input.file-upload-field and button.file-upload-submit
       // are all hidden by CSS that uses the .js-enabled class on the body tag

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -23,6 +23,25 @@
     display: none;
   }
 
+  &-loading-content {
+    display: inline-block;
+
+    &:focus-visible {
+
+      outline: solid 3px $govuk-focus-colour;
+      outline-offset: 5px;
+
+    }
+
+  }
+
+  &-loading-message {
+
+    display: inline-block; // use to constrain width to contents
+    padding: 7px 0px 6px;
+
+  }
+
   &-alternate-link {
     display: inline-block;
     line-height: 35px;

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -1,52 +1,34 @@
-.js-enabled {
+.file-upload {
 
-  .file-upload {
+  &-label {
 
-    &-label {
+    @include bold-19;
+    display: block;
+    margin: 0 0 10px 0;
 
-      @include bold-19;
-      display: block;
-      margin: 0 0 10px 0;
-
-      .error-message {
-        padding: 0;
-      }
-
+    .error-message {
+      padding: 0;
     }
 
-    &-field {
-      width: 0.1px;
-      height: 0.1px;
-      opacity: 0;
-      overflow: hidden;
-      position: absolute;
-      z-index: -1;
+  }
 
-      &:focus + .file-upload-button {
-        background: $govuk-focus-colour;
-        color: $govuk-focus-text-colour;
-      }
+  &-field {
+    margin-bottom: 10px;
+  }
 
-    }
+  // Only show a button added by JS if JS is available
+  .js-enabled &-label,
+  .js-enabled &-field,
+  .js-enabled &-submit {
+    display: none;
+  }
 
-    &-filename {
-      @include bold-19;
-      display: inline-block;
-      padding-left: govuk-spacing(3);
-    }
+  &-alternate-link {
+    display: inline-block;
+    line-height: 35px;
 
-    &-submit {
-      display: none;
-    }
-
-    &-alternate-link {
-      display: inline-block;
-      line-height: 35px;
-
-      a {
-        font-weight: bold;
-      }
-
+    a {
+      font-weight: bold;
     }
 
   }

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -25,25 +25,6 @@
     display: none;
   }
 
-  &-loading-content {
-    display: inline-block;
-
-    &:focus-visible {
-
-      outline: solid 3px $govuk-focus-colour;
-      outline-offset: 5px;
-
-    }
-
-  }
-
-  &-loading-message {
-
-    display: inline-block; // use to constrain width to contents
-    padding: 7px 0px 6px;
-
-  }
-
   &-alternate-link {
     display: inline-block;
     line-height: 35px;

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -16,7 +16,7 @@
     margin-bottom: 10px;
   }
 
-  // Only show a button added by JS if JS is available
+  // Hide normal upload form if we're adding a custom version with JS
   .js-enabled &-label,
   .js-enabled &-field,
   .js-enabled &-submit {

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -1,15 +1,17 @@
 .file-upload {
 
-  &-label {
+  &-label,
+  &-button-label {
 
     @include bold-19;
     display: block;
     margin: 0 0 10px 0;
 
-    .error-message {
-      padding: 0;
-    }
+  }
 
+  &-label .error-message,
+  &-button-label.error-message {
+    padding: 0;
   }
 
   &-field {

--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -13,7 +13,7 @@
 ) %}
   <form method="post" enctype="multipart/form-data" {% if action %}action="{{ action }}"{% endif %} class="{% if field.errors and show_errors %}form-group-error{% endif %}" data-module="file-upload">
     <label class="file-upload-label" for="{{ field.name }}">
-      <span class="govuk-visually-hidden">{{ field.label.text }}</span>
+      {{ field.label.text }}
       {% if hint %}
         <span class="form-hint">
           {{ hint }}
@@ -27,17 +27,14 @@
     </label>
     {{ field(**{
       'class': 'file-upload-field',
-      'accept': allowed_file_extensions|format_list_items('.{item}')|join(',')|e
+      'accept': allowed_file_extensions|format_list_items('.{item}')|join(',')|e,
+      'data-button-text': button_text
     }) }}
-    <label class="file-upload-button" for="{{ field.name }}">
-      {{ button_text }}
-    </label>
     {% if alternate_link and alternate_link_text %}
       <span class="file-upload-alternate-link">
         or <a class="govuk-link govuk-link--no-visited-state" href="{{ alternate_link }}">{{ alternate_link_text }}</a>
       </span>
     {% endif %}
-    <label class="file-upload-filename" for="{{ field.name }}"></label>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     {{ govukButton({ "text": "Submit", "classes": "file-upload-submit" }) }}
   </form>

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -556,7 +556,7 @@ def test_upload_csv_file_with_errors_shows_check_page_with_errors(
     assert 'There’s a problem with example.csv' in page.text
     assert '+447700900986' in page.text
     assert 'Missing' in page.text
-    assert 'Upload your file again' in page.text
+    assert normalize_spaces(page.find('input', {'type': 'file'})['data-button-text']) == 'Upload your file again'
 
 
 def test_upload_csv_file_with_empty_message_shows_check_page_with_errors(

--- a/tests/app/main/views/uploads/test_upload_letter.py
+++ b/tests/app/main/views/uploads/test_upload_letter.py
@@ -19,7 +19,7 @@ def test_get_upload_letter(client_request):
     assert page.find('input', class_='file-upload-field')
     assert page.find('input', class_='file-upload-field')['accept'] == '.pdf'
     assert page.select('main button[type=submit]')
-    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Choose file'
+    assert normalize_spaces(page.find('input', type='file')['data-button-text']) == 'Choose file'
 
 
 @pytest.mark.parametrize('extra_permissions, expected_allow_international', (
@@ -226,7 +226,7 @@ def test_post_upload_letter_shows_error_when_file_is_not_a_pdf(client_request):
         )
     assert page.find('h1').text == 'Wrong file type'
     assert page.find('div', class_='banner-dangerous').find('p').text == 'Save your letter as a PDF and try again.'
-    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
+    assert normalize_spaces(page.find('input', type="file")['data-button-text']) == 'Upload your file again'
     assert page.find('input', type='file')['accept'] == '.pdf'
 
 
@@ -238,7 +238,7 @@ def test_post_upload_letter_shows_error_when_no_file_uploaded(client_request):
         _expected_status=200
     )
     assert page.find('div', class_='banner-dangerous').find('h1').text == 'You need to choose a file to upload'
-    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
+    assert normalize_spaces(page.find('input', type="file")['data-button-text']) == 'Upload your file again'
 
 
 def test_post_upload_letter_shows_error_when_file_contains_virus(mocker, client_request):
@@ -253,7 +253,7 @@ def test_post_upload_letter_shows_error_when_file_contains_virus(mocker, client_
             _expected_status=400
         )
     assert page.find('div', class_='banner-dangerous').find('h1').text == 'Your file contains a virus'
-    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
+    assert normalize_spaces(page.find('input', type="file")['data-button-text']) == 'Upload your file again'
     mock_s3_backup.assert_not_called()
 
 
@@ -269,7 +269,7 @@ def test_post_choose_upload_file_when_file_is_too_big(mocker, client_request):
         )
     assert page.find('div', class_='banner-dangerous').find('h1').text == 'Your file is too big'
     assert page.find('div', class_='banner-dangerous').find('p').text == 'Files must be smaller than 2MB.'
-    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
+    assert normalize_spaces(page.find('input', type="file")['data-button-text']) == 'Upload your file again'
 
 
 def test_post_choose_upload_file_when_file_is_malformed(mocker, client_request):
@@ -286,7 +286,7 @@ def test_post_choose_upload_file_when_file_is_malformed(mocker, client_request):
     assert page.find(
         'div', class_='banner-dangerous'
     ).find('p').text == 'Notify cannot read this PDF.Save a new copy of your file and try again.'
-    assert normalize_spaces(page.find('label', class_='file-upload-button').text) == 'Upload your file again'
+    assert normalize_spaces(page.find('input', type="file")['data-button-text']) == 'Upload your file again'
 
 
 def test_post_upload_letter_with_invalid_file(mocker, client_request, fake_uuid):
@@ -364,7 +364,7 @@ def test_post_upload_letter_shows_letter_preview_for_invalid_file(mocker, client
     assert len(page.select('.letter-postage')) == 0
 
     assert page.find("a", {"class": "govuk-back-link"})["href"] == "/services/{}/upload-letter".format(SERVICE_ONE_ID)
-    assert page.find("label", {"class": "file-upload-button"})
+    assert page.find("input", {"type": "file"}).has_attr("data-button-text")
     assert page.find("input", {"type": "file"})["accept"] == '.pdf'
 
     letter_images = page.select('main img')

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -1,7 +1,18 @@
 const helpers = require('./support/helpers.js');
 
 beforeAll(() => {
+
+  // Stub out JS from window.GOVUK namespace used by this component
+  window.GOVUK.Frontend = {
+    Button: function () {
+      return {
+        init: function () {}
+      }
+    }
+  };
+
   require('../../app/assets/javascripts/fileUpload.js');
+
 });
 
 afterAll(() => {
@@ -19,18 +30,16 @@ describe('File upload', () => {
     document.body.innerHTML = `
       <form method="post" enctype="multipart/form-data" class="" data-module="file-upload">
         <label class="file-upload-label" for="file">
-          <span class="visually-hidden">Upload a PNG logo</span>
+          Upload a PNG logo
         </label>
-        <input class="file-upload-field" id="file" name="file" type="file">
-        <label class="file-upload-button" for="file">
-          Upload logo
-        </label>
-        <label class="file-upload-filename" for="file"></label>
+        <input class="file-upload-field" data-button-text="Upload logo" id="file" name="file" type="file">
         <button type="submit" class="govuk-button file-upload-submit">Submit</button>
       </form>`;
 
     form = document.querySelector('form');
-    uploadControl = form.querySelector('input[type=file]');
+    uploadLabel = form.querySelector('label.file-upload-label');
+    uploadControl = form.querySelector('input.file-upload-field');
+    uploadSubmit = form.querySelector('button.file-upload-submit')
 
   });
 
@@ -53,7 +62,40 @@ describe('File upload', () => {
 
   });
 
-  describe("If the state of the upload form control changes", () => {
+  test("An 'upload' button should be added and the existing form contents hidden", () => {
+
+    // start module
+    window.GOVUK.modules.start();
+
+    expect(form.querySelector('button[type=button]')).not.toBeNull();
+    expect(uploadLabel.hasAttribute('hidden')).toBe(true);
+    expect(uploadControl.hasAttribute('hidden')).toBe(true);
+    expect(uploadSubmit.hasAttribute('hidden')).toBe(true);
+
+  });
+
+  /*
+    The file is selected by a click event on the input[type=file] control and the user choosing
+    a file from the OS dialog this opens. This creates an onchange event we use to submit the form.
+
+    We can't simulate the user choosing a file so we test the behaviours resulting from the click
+    and onchange events.
+  */
+  test("If the 'upload' button is clicked, it should click the file upload control", () => {
+
+    // start module
+    window.GOVUK.modules.start();
+
+    var fileUploadClickCallback = jest.fn(() => {});
+    uploadControl.addEventListener('click', fileUploadClickCallback);
+
+    helpers.triggerEvent(form.querySelector('button[type=button]'), 'click');
+
+    expect(fileUploadClickCallback).toHaveBeenCalled();
+
+  });
+
+  describe("If the state of the upload form control changes (from clicking the 'upload' button)", () => {
 
     beforeEach(() => {
 

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -62,15 +62,14 @@ describe('File upload', () => {
 
   });
 
-  test("An 'upload' button should be added and the existing form contents hidden", () => {
+  test("An 'upload' button should be added", () => {
 
     // start module
     window.GOVUK.modules.start();
 
     expect(form.querySelector('button[type=button]')).not.toBeNull();
-    expect(uploadLabel.hasAttribute('hidden')).toBe(true);
-    expect(uploadControl.hasAttribute('hidden')).toBe(true);
-    expect(uploadSubmit.hasAttribute('hidden')).toBe(true);
+
+    // Note: the existing form controls are also hidden but this is through CSS so out of scope
 
   });
 

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -94,7 +94,10 @@ describe('File upload', () => {
 
       uploadControl.addEventListener('click', fileUploadClickCallback);
 
+      // click the 'upload' button
       helpers.triggerEvent(form.querySelector('button[type=button]'), 'click');
+
+      // fake the 'onchange' event triggered in browsers by selection of a file
       helpers.triggerEvent(uploadControl, 'change', { eventInit: { bubbles: true } });
 
     });

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -67,7 +67,9 @@ describe('File upload', () => {
     // start module
     window.GOVUK.modules.start();
 
-    expect(form.querySelector('button[type=button]')).not.toBeNull();
+    var uploadButton = form.querySelector('button[type=button]');
+
+    expect(uploadButton).not.toBeNull();
 
     // Note: the existing form controls are also hidden but this is through CSS so out of scope
 
@@ -132,20 +134,14 @@ describe('File upload', () => {
 
     });
 
-    test("It should replace the upload button with a notice that uploading has started and a cancel upload button", () => {
+    test("It should replace the upload button with one for cancelling the upload", () => {
 
-      var uploadingContent = form.querySelector('p.file-upload-loading-content');
-
-      expect(uploadingContent).not.toBeNull();
-
-      var cancelLink = uploadingContent.querySelector("a[href='']");
+      var cancelLink = form.querySelector("a.file-upload-button");
 
       expect(cancelLink).not.toBeNull();
 
-      // the new content replaces the 'upload' button so needs focusing so:
-      // - focus is not lost
-      // - the text in the paragraph is announced to screen readers
-      expect(document.activeElement).toBe(uploadingContent);
+      // the cancel button should be focused
+      expect(document.activeElement).toBe(cancelLink);
 
     });
 

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -73,6 +73,24 @@ describe('File upload', () => {
 
   });
 
+  test("If the page loads with validation errors, they should be added to the 'upload' button", () => {
+
+    var buttonLabel;
+
+    uploadLabel.innerHTML += '<span class="error-message">PNG images only!</span>';
+
+    // start module
+    window.GOVUK.modules.start();
+
+    buttonLabel = form.querySelector('label.file-upload-button-label');
+
+    expect(buttonLabel).not.toBeNull();
+
+    // The button's label should include its existing text and the validation errors added together
+    expect(buttonLabel.textContent.trim().replace(/\s{2,}/g, ' ')).toEqual("Upload logo PNG images only!");
+
+  });
+
   /*
     The file is selected by a click event on the input[type=file] control and the user choosing
     a file from the OS dialog this opens. This creates an onchange event we use to submit the form.

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -80,30 +80,28 @@ describe('File upload', () => {
     We can't simulate the user choosing a file so we test the behaviours resulting from the click
     and onchange events.
   */
-  test("If the 'upload' button is clicked, it should click the file upload control", () => {
+  describe("If the 'upload' button is clicked", () => {
 
-    // start module
-    window.GOVUK.modules.start();
-
-    var fileUploadClickCallback = jest.fn(() => {});
-    uploadControl.addEventListener('click', fileUploadClickCallback);
-
-    helpers.triggerEvent(form.querySelector('button[type=button]'), 'click');
-
-    expect(fileUploadClickCallback).toHaveBeenCalled();
-
-  });
-
-  describe("If the state of the upload form control changes (from clicking the 'upload' button)", () => {
+    var fileUploadClickCallback;
 
     beforeEach(() => {
 
+      fileUploadClickCallback = jest.fn(() => {});
       form.submit = jest.fn(() => {});
 
       // start module
       window.GOVUK.modules.start();
 
+      uploadControl.addEventListener('click', fileUploadClickCallback);
+
+      helpers.triggerEvent(form.querySelector('button[type=button]'), 'click');
       helpers.triggerEvent(uploadControl, 'change', { eventInit: { bubbles: true } });
+
+    });
+
+    test("It should click the file upload control", () => {
+
+      expect(fileUploadClickCallback).toHaveBeenCalled();
 
     });
 

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -114,9 +114,20 @@ describe('File upload', () => {
 
     });
 
-    test("It should add a link to cancel the upload by reloading the page", () => {
+    test("It should replace the upload button with a notice that uploading has started and a cancel upload button", () => {
 
-      expect(form.querySelector("a[href='']")).not.toBeNull();
+      var uploadingContent = form.querySelector('p.file-upload-loading-content');
+
+      expect(uploadingContent).not.toBeNull();
+
+      var cancelLink = uploadingContent.querySelector("a[href='']");
+
+      expect(cancelLink).not.toBeNull();
+
+      // the new content replaces the 'upload' button so needs focusing so:
+      // - focus is not lost
+      // - the text in the paragraph is announced to screen readers
+      expect(document.activeElement).toBe(uploadingContent);
 
     });
 


### PR DESCRIPTION
Work to fix issues with our file upload component, spotted in a previous accessibility audit.

https://www.pivotaltracker.com/story/show/177000534

As well as this bug, I also found separate issues with some assistive technologies while testing the component. This pull request attempts to fix both.

## The current approach

It's worth explaining how the existing approach works.

<img width="378" alt="upload_current_state_diagram" src="https://user-images.githubusercontent.com/87140/173029259-6d142cf2-cae0-430d-b47a-fea44dc5bc91.png">

It involves the input[type=file] element being visually hidden and it having 3 labels:
1. the real label for the input[type=file] element. It's only visually hidden so it still applies
2. a label styled as a button which:
    - when clicked, activates the input[type=file] element
    - is styled to look focused when the input[type=file] element is focused so it looks like you can tab to it
3. a label that used to hold the name of the file selected. Now redundant since [we made the form submit when the file has been chosen](https://github.com/alphagov/notifications-admin/commit/97a3bf922580f61c81f386f9665a3f05724f4ec4)

This works for visual users with mouse/pointers and keyboard users because clicking on the button activates the file chooser:

![show_click_on_current_upload_button](https://user-images.githubusercontent.com/87140/173078667-685251dd-f413-4d3b-8d0d-33a28a3bc178.gif)

...and it 'looks like' you can tab to it:

![show_tab_to_current_upload_button](https://user-images.githubusercontent.com/87140/173079379-8659bb51-be4d-4779-8053-cd567181bd3f.gif)

The problems with it are:
- assistive technologies have problems with multiple labels
- the label styled as a button is announced as a label by screen readers, not a button
- saying 'Click upload file' to speech recognition software, to click a button with 'upload file' text, won't work because it isn't a button
- moving to the input[type=file], which makes the label button look focused, announces the input[type=file] element, which doesn't match the visuals

## Potential solutions

We could keep patching these issues individually: giving the label a 'button' role, hiding the input[type=file] element, etc... but I think it's simpler to just hide all the initial elements and add a real `<button>`. In full, this proposal is to:
1. hide all the existing elements in the upload form, visually and semantically
5. add a button
6. use JS to make clicks on the button click the input[type=file]

Effectively, all that's left in the page is a button and because it's a real `<button>` element it works as expected with all assistive technologies.

## Problems with the content you see when the file is uploading

While working on this, I noticed a few other problems with the content you see when your file is uploading.

When you click the upload button it sends your file to our S3 bucket and swaps out the upload button for another button to let you cancel this if it takes too long.

![show_full_flow_for_current_upload_button](https://user-images.githubusercontent.com/87140/173101768-aef68c70-774d-49fc-9f31-85d439273d1e.gif)

Problems with the loading state:
1. The current focus (style used by keyboard and screen reader users to see where they are) is lost because the upload button is removed
4. Screen reader users aren't told what's happening

This proposal tries to fix that by:
1. wrapping the cancel button in a paragraph with text telling you the file is uploading
2. adding some hidden text to the paragraph saying there's now a button you can use to cancel the upload
5. focusing the paragraph so focus isn't lost and the paragraph gets announced

It looks like this visually:

<img width="265" alt="upload_loading_content_visuals" src="https://user-images.githubusercontent.com/87140/172886895-c8cbd8e3-f6b4-4516-9b97-9ab142e5976f.png">

It sounds like this in screen readers:

<img width="490" alt="upload_loading_content_announcement" src="https://user-images.githubusercontent.com/87140/172886930-500884b7-f3dd-4fae-bb00-d4aec040a0a3.png">

I think this makes sense because it tells you what's happened and hints at the button being in the paragraph (called 'group' in the announcement). I plan to pair with @karlchillmaid to make it better soon.

## How do I check this?

I recommend reviewing commit-by-commit. I've checked it in all [the browsers required by the service manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in-from-june-2021) and [all the assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#which-assistive-technologies-to-test-with).

The upload field used when adding a new email brand is a good page to test on.

It's also worth checking without JS and, if you feel comfortable doing it, in a screen reader. I'd also be happy to demo it with some assistive technologies if that would help.