### PR TITLE
Fix address block measurements

### DIFF
--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -37,7 +37,7 @@
 
   <h3 class="heading-small">Address block</h3>
 
-  <p class="govuk-body">Position: 39.5mm from left edge, 24.6mm from top edge</p>
+  <p class="govuk-body">Position: 24.6mm from left edge, 39.5mm from top edge</p>
   <p class="govuk-body">Size: 95.4mm wide by 26.8mm high</p>
 
   <h3 class="heading-small">Letter contact block</h3>


### PR DESCRIPTION
A user spotted that the measurements for the address block position are the wrong way round in the text version of the letter specification. 