### PR TITLE
Try simplifying the way we filter templates

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -485,7 +485,7 @@ def delete_template_folder(service_id, template_folder_id):
     template_folder = current_service.get_template_folder_with_user_permission_or_403(template_folder_id, current_user)
     template_list = TemplateList(service=current_service, template_folder_id=template_folder_id)
 
-    if not template_list.folder_is_empty:
+    if any(template_list):
         flash("You must empty this folder before you can delete it", 'info')
         return redirect(
             url_for(

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -14,10 +14,10 @@
 
 {% if template_list.template_folder_id and not template_list.templates_to_show %}
   <p class="template-list-empty">
-    {% if template_list.folder_is_empty %}
-      This folder is empty
-    {% else %}
+    {% if template_list.template_type != 'all' %}
       There are no {{ 1|message_count_label(template_type, suffix='') }} templates in this folder
+    {% else %}
+      This folder is empty
     {% endif %}
   </p>
 {% else %}

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -357,7 +357,7 @@ def _folder(name, folder_id=None, parent=None, users_with_permission=None):
             [],
             [],
             [],
-            'This folder is empty',
+            'There are no text message templates in this folder',
         ),
         (
             'folder_two – Templates – service one – GOV.UK Notify',
@@ -1671,7 +1671,7 @@ def test_show_custom_error_message(
             {'template_folder_id': CHILD_FOLDER_ID, 'template_type': 'sms'},
             [],
             [],
-            'This folder is empty',
+            'There are no text message templates in this folder',
         ),
     ]
 )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179736794

This is one of the smaller follow-up actions to [^1], where we 
moved a bunch of template rendering code into a model file.

In the second commit I'm arguing for a really small change in 
how we show empty folders to users, so that we can simplify 
some of the rendering code.

## Screenshots (folder with other templates)

| Before | After |
| - | - |
| <img width="766" alt="Screenshot 2022-06-20 at 16 50 31" src="https://user-images.githubusercontent.com/9029009/174639187-05253f5b-87f4-4c27-9318-a50c4ca042cb.png"> | <img width="757" alt="Screenshot 2022-06-20 at 16 50 17" src="https://user-images.githubusercontent.com/9029009/174639203-fdc99054-1f76-4f99-a444-f59ab9230795.png"> |

