### PR TITLE
Remove `<nav>` around template list items

### DIFF
--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -21,7 +21,7 @@
     {% endif %}
   </p>
 {% else %}
-  <nav id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
+  <div id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
     {% set checkboxes_data = [] %}
 
     {% if not current_user.has_permissions('manage_templates') %}
@@ -99,5 +99,5 @@
         "formGroup": False
       }) }}
     {% endif %}
-  </nav>
+  </div>
 {% endif %}


### PR DESCRIPTION
The `<nav>` tag we have around the template list items, on the templates
page, should be removed.

This issue was raised by the Digital Accessibility Centre (DAC), in their
audit on May 18th 2022. Their tester said it creates cognitive load and
doesn't really add much for it.

[Pivotal story](https://www.pivotaltracker.com/story/show/182500752)