### PR TITLE
Fix back link on final page to copy a template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -391,13 +391,27 @@ def copy_template(service_id, template_id):
     template['name'] = _get_template_copy_name(template, current_service.all_templates)
     form = form_objects[template['template_type']](**template)
 
+    if template['folder']:
+        back_link = url_for(
+            '.choose_template_to_copy',
+            service_id=current_service.id,
+            from_service=from_service,
+            from_folder=template['folder'],
+        )
+    else:
+        back_link = url_for(
+            '.choose_template_to_copy',
+            service_id=current_service.id,
+            from_service=from_service,
+        )
+
     return render_template(
         'views/edit-{}-template.html'.format(template['template_type']),
         form=form,
         template=template,
         heading_action='Add',
         services=current_user.service_ids,
-        back_link='#',  # TODO: broken
+        back_link=back_link,
     )
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -397,6 +397,7 @@ def copy_template(service_id, template_id):
         template=template,
         heading_action='Add',
         services=current_user.service_ids,
+        back_link='#',  # TODO: broken
     )
 
 
@@ -574,6 +575,11 @@ def add_service_template(service_id, template_type, template_folder_id=None):
         template_type=template_type,
         template_folder_id=template_folder_id,
         heading_action='New',
+        back_link=url_for(
+            'main.choose_template',
+            service_id=current_service.id,
+            template_folder_id=template_folder_id
+        )
     )
 
 
@@ -657,6 +663,11 @@ def edit_service_template(service_id, template_id):
             form=form,
             template=template,
             heading_action='Edit',
+            back_link=url_for(
+                'main.view_template',
+                service_id=current_service.id,
+                template_id=template['id']
+            )
         )
 
 

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    "href": back_link
   }) }}
 {% endblock %}
 

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    "href": back_link
   }) }}
 {% endblock %}
 

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    "href": back_link
   }) }}
 {% endblock %}
 

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -11,7 +11,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    "href": url_for('main.view_template', service_id=current_service.id, template_id=template.id) if template else url_for('main.choose_template', service_id=current_service.id, template_folder_id=template_folder_id)
+    "href": back_link
   }) }}
 {% endblock %}
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1517,6 +1517,13 @@ def test_load_edit_template_with_copy_of_template(
         from_service=SERVICE_TWO_ID,
     )
 
+    back_link = page.select_one('.govuk-back-link')
+    assert back_link['href'] == url_for(
+        'main.choose_template_to_copy',
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+    )
+
     assert page.select_one('form')['method'] == 'post'
 
     assert page.select_one('input')['value'] == (
@@ -1560,6 +1567,14 @@ def test_copy_template_loads_template_from_within_subfolder(
         service_id=SERVICE_ONE_ID,
         template_id=TEMPLATE_ONE_ID,
         from_service=SERVICE_TWO_ID,
+    )
+
+    back_link = page.select_one('.govuk-back-link')
+    assert back_link['href'] == url_for(
+        'main.choose_template_to_copy',
+        service_id=SERVICE_ONE_ID,
+        from_service=SERVICE_TWO_ID,
+        from_folder=PARENT_FOLDER_ID,
     )
 
     assert page.select_one('input')['value'] == 'foo (copy)'

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -489,6 +489,13 @@ def test_should_show_page_for_one_template(
         template_id=template_id,
     )
 
+    back_link = page.select_one('.govuk-back-link')
+    assert back_link['href'] == url_for(
+        'main.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=template_id,
+    )
+
     assert page.select_one('input[type=text]')['value'] == "Two week reminder"
     assert "Template &lt;em&gt;content&lt;/em&gt; with &amp; entity" in str(
         page.select_one('textarea')
@@ -2308,7 +2315,7 @@ def test_route_invalid_permissions(
     ('sms', 'New text message template'),
     ('broadcast', 'New template'),
 ))
-def test_add_template_page_title(
+def test_add_template_page_furniture(
     client_request,
     service_one,
     template_type,
@@ -2321,6 +2328,13 @@ def test_add_template_page_title(
         template_type=template_type,
     )
     assert normalize_spaces(page.select_one('h1').text) == expected
+
+    back_link = page.select_one('.govuk-back-link')
+    assert back_link['href'] == url_for(
+        'main.choose_template',
+        service_id=SERVICE_ONE_ID,
+        template_folder_id=None
+    )
 
 
 def test_can_create_email_template_with_emoji(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179736794

This was broken in two ways:

- It would take the user to a 404 page if the template they copy is from a
different service. To reproduce:

- In all other cases it would exit the copy workflow and go to the preview
page for the original template.

The new tests aren't comprehensive but I think they're sufficient to cover 
the majority of cases for a fairly low use feature.

Please see the commit messages for more details.

## Screenshots (before, after clicking "Back")

| Copy from another service (bug) | Copy from the same service (bug) |
| - | - |
| <img width="987" alt="Screenshot 2022-06-22 at 11 09 14" src="https://user-images.githubusercontent.com/9029009/175004123-4e794fda-cc0b-488e-a3c2-e1830463ea72.png"> | <img width="993" alt="Screenshot 2022-06-22 at 11 09 43" src="https://user-images.githubusercontent.com/9029009/175004151-1cc1eb69-08c8-4e97-b279-1559944c192b.png"> |

## Screenshots (after, after clicking "Back")

| Copy from another service (fixed) | Copy from the same service (fixed) |
| - | - |
| <img width="994" alt="Screenshot 2022-06-22 at 11 10 25" src="https://user-images.githubusercontent.com/9029009/175004362-a9520299-1525-4de0-b191-8432c63ce19d.png"> | <img width="1021" alt="Screenshot 2022-06-22 at 11 09 56" src="https://user-images.githubusercontent.com/9029009/175004331-bbd7a125-f04d-49e3-919a-5abe1fbf49dd.png"> |


