### PR TITLE
Add message count to link

### DIFF
--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -4,7 +4,7 @@
 <div class="ajax-block-container">
   {% if messages %}
     <p class="bottom-gutter-2-3 top-gutter-1-2">
-      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download {{ current_service.inbound_sms_summary.count|format_thousands }} messages</a>
+      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download all messages</a>
     </p>
   {% endif %}
   {% call(item, row_number) list_table(

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -4,7 +4,7 @@
 <div class="ajax-block-container">
   {% if messages %}
     <p class="bottom-gutter-2-3 top-gutter-1-2">
-      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download these messages</a>
+      <a href="{{ url_for('.inbox_download', service_id=current_service.id) }}" download class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Download {{ current_service.inbound_sms_summary.count|format_thousands }} messages</a>
     </p>
   {% endif %}
   {% call(item, row_number) list_table(


### PR DESCRIPTION
We got some feedback about the Received messages page from GOVwifi: “I didn’t realise you get a few days worth of responses when you download the CSV, I thought it was only the first 50 responses”

The current link `Download these messages` really doesn’t tell you that you’re going to get *everything*. There isn’t a count on the page, and you can’t see that it’s paginated until you scroll down. Even then you can’t see how many pages there are.

We should help.

At some point we might want to update our pagination to tell users how many pages there are, but for now we can probably just make the download link text better.

## Current page
<img width="1048" alt="Screenshot 2022-08-03 at 10 25 12" src="https://user-images.githubusercontent.com/28294225/182574099-90611d5c-34cc-4416-b47c-90b2d16bc3a4.png">

## New content

`Download all messages`
