### PR TITLE
Update a data description

### DIFF
--- a/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
@@ -34,7 +34,7 @@
         ('sms totals', 'The number of text messages sent'),
         ('sms fragments', 'The number of text message fragments sent'),
         ('sms chargeable units', 'The number of text message fragments sent times the rate multiplier'),
-        ('sms cost', 'The cost of text messages sent'),
+        ('sms cost', 'The cost to Notify’s users of text messages sent'),
       ] %}
         {% call row() %}
           {{ text_field(column_heading) }}


### PR DESCRIPTION
Update the description of the `sms cost` data field to make it clear that it’s the cost to our users, not our suppliers.

This request came from Caley.

The descriptions are fine for now – but if we open this page to people outside the team we might need to review the content.