### PR TITLE
Fix email branding page title

### DIFF
--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -5,8 +5,8 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
 
-{% block service_page_title %}
-  {{ '{} email branding'.format('Update' if email_branding else 'Create')}}
+{% block per_page_title %}
+  {{ '{} email branding'.format('Update' if email_branding else 'Add')}}
 {% endblock %}
 
 


### PR DESCRIPTION
Noticed that the template this page inherits from doesn't declare the `service_page_title` block so the page title ends up just being `- GOV.UK Notify`.

This fixes that, to use the same block as other platform admin pages, `per_page_title`.