### PR TITLE
Only show items not in branding pool on add branding pool page

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -455,14 +455,11 @@ def organisation_email_branding_options(org_id):
     form.branding_field.choices = [
         (branding['id'], branding['name'])
         for branding in email_branding_client.get_all_email_branding(sort_key='name')
-    ]
-    form.branding_field.data = [
-        branding['id']
-        for branding in current_organisation.email_branding_pool
+        if branding not in current_organisation.email_branding_pool
     ]
 
     return render_template(
-        'views/organisations/organisation/settings/change-email-branding-options.html',
+        'views/organisations/organisation/settings/add-email-branding-options.html',
         form=form,
         search_form=SearchByNameForm()
     )

--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -5,7 +5,7 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 
 {% block org_page_title %}
-  Change email branding options
+  Add email branding options
 {% endblock %}
 
 {% block backLink %}
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-  {{ page_header("Change email branding options") }}
+  {{ page_header("Add email branding options") }}
   {{ live_search(target_selector='.govuk-checkboxes__item', show=True, form=search_form, autofocus=True) }}
 
   <div class="govuk-grid-row">

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1705,7 +1705,7 @@ def test_organisation_email_branding_options_is_platform_admin_only(
     )
 
 
-def test_organisation_email_branding_options_shows_branding_pool(
+def test_organisation_email_branding_options_shows_branding_not_in_branding_pool(
     mocker,
     client_request,
     platform_admin_user,
@@ -1725,7 +1725,7 @@ def test_organisation_email_branding_options_shows_branding_pool(
         {
             'logo': 'logo4.png',
             'name': 'org 4',
-            'text': 'org 4',
+            'text': None,
             'id': '4',
             'colour': None,
             'brand_type': 'org',
@@ -1736,17 +1736,15 @@ def test_organisation_email_branding_options_shows_branding_pool(
     client_request.login(platform_admin_user)
     page = client_request.get('.organisation_email_branding_options', org_id=organisation_one['id'])
 
-    assert page.h1.text == 'Change email branding options'
+    assert page.h1.text == 'Add email branding options'
     assert page.select_one('[data-module=live-search]')['data-targets'] == ('.govuk-checkboxes__item')
 
     assert [
         (checkbox.text.strip(), checkbox.input['value'], checkbox.input.has_attr('checked'))
         for checkbox in page.select('.govuk-checkboxes__item')
         ] == [
-            ('org 1', '1', True),
             ('org 2', '2', False),
             ('org 3', '3', False),
-            ('org 4', '4', True),
             ('org 5', '5', False),
         ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2513,6 +2513,7 @@ def create_email_brandings(number_of_brandings, non_standard_values=None, shuffl
 
     for idx, row in enumerate(non_standard_values or {}):
         brandings[row['idx']].update(non_standard_values[idx])
+        brandings[row['idx']].pop('idx')
 
     if shuffle:
         brandings.insert(3, brandings.pop(4))


### PR DESCRIPTION
The page to add to the email branding pool for an organisation was showing all email branding, with the items already in the pool checked. We now only want to show items that are not in the pool, so this changes the page to only show branding that doesn't already exist in the pool and can be added.

The page title has also been updated.

[Pivotal story](https://www.pivotaltracker.com/story/show/182771038)

---
<img width="500" alt="Screenshot of updated page" src="https://user-images.githubusercontent.com/12881990/180391804-0051cba1-2e2a-4773-9faa-9ee902938904.png">

