### PR TITLE
Make it more obvious that ‘send files’ is API-only

### DIFF
--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -35,6 +35,7 @@
     <!--<li>you can track when the recipient downloads your document</li>-->
     <li>email attachments are often marked as spam</li>
   </ul>
+  <p class="govuk-body">This is an API-only feature. You’ll need a developer on your team to set it up for you.</p>
   <p class="govuk-body">Read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">API documentation</a> for more information.</p>
 
   <h3 class="heading heading-small" id="reply-to">Add a reply-to address</h3>


### PR DESCRIPTION
This PR adds a line to try and make it clearer that ‘send a file by email’ is an API-only feature.

We get questions about this through support, so we’re changing the content here to match what we say in the Zendesk macro.