### PR TITLE
Remove GOVUK Elements [Part 1]

### DIFF
--- a/app/assets/stylesheets/govuk_elements/tables.scss
+++ b/app/assets/stylesheets/govuk_elements/tables.scss
@@ -1,0 +1,57 @@
+// Tables
+// ==========================================================================
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+
+    th,
+    td {
+      @include core-19;
+      padding: em(12, 19) em(20, 19) em(9, 19) 0;
+
+      text-align: left;
+      border-bottom: 1px solid $border-colour;
+    }
+
+    thead th {
+      font-weight: 700;
+    }
+
+    td:last-child,
+    th:last-child {
+      padding-right: 0;
+    }
+
+    // Right align table header cells and table cells with a numeric class
+    .numeric {
+      text-align: right;
+    }
+
+    // Allow a qualifying element, only table data cells should use tabular numbers
+    // scss-lint:disable QualifyingElement
+    td.numeric {
+      font-family: $toolkit-font-stack-tabular;
+    }
+
+    caption {
+      text-align: left;
+    }
+  }
+
+  .table-font-xsmall {
+
+    th {
+      @include bold-16;
+    }
+
+    td {
+      @include core-16;
+    }
+
+    th,
+    td {
+      padding: em(12, 16) em(20, 16) em(9, 16) 0;
+    }
+  }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -28,7 +28,6 @@ $path: '/static/images/';
 @import 'elements/forms/form-multiple-choice';
 @import 'elements/forms/form-validation';
 @import 'elements/lists';
-@import 'elements/panels';
 @import 'govuk_elements/tables';
 
 // Dependencies from GOV.UK Frontend, packaged to be specific to this application

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -29,7 +29,7 @@ $path: '/static/images/';
 @import 'elements/forms/form-validation';
 @import 'elements/lists';
 @import 'elements/panels';
-@import 'elements/tables';
+@import 'govuk_elements/tables';
 
 // Dependencies from GOV.UK Frontend, packaged to be specific to this application
 @import './govuk-frontend/all';

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1786,7 +1786,7 @@ class AdminProviderRatioForm(Form):
 
 
 class ServiceContactDetailsForm(StripWhitespaceForm):
-    contact_details_type = RadioField(
+    contact_details_type = GovukRadiosField(
         'Type of contact details',
         choices=[
             ('url', 'Link'),

--- a/app/templates/views/manage-users/confirm-edit-user-email.html
+++ b/app/templates/views/manage-users/confirm-edit-user-email.html
@@ -21,7 +21,7 @@
   <div class="govuk-grid-column-full">
   {% call form_wrapper() %}
     <p class="govuk-body">New email address:</p>
-    <div class="panel panel-border-wide bottom-gutter">
+    <div class="govuk-inset-text govuk-!-margin-top-0">
       <p class="govuk-body">{{ new_email }}</p>
     </div>
     <p class="govuk-body">We will send {{ user.name }} an email to tell them about the change.</p>

--- a/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
+++ b/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
@@ -20,7 +20,7 @@
   <div class="govuk-grid-column-full">
   {% call form_wrapper() %}
     <p class="govuk-body">New mobile number:</p>
-    <div class="panel panel-border-wide bottom-gutter">
+    <div class="govuk-inset-text govuk-!-margin-top-0">
       <p class="govuk-body">{{ new_mobile_number }}</p>
     </div>
     <p class="govuk-body">We will send {{ user.name }} a text message to tell them about the change.</p>

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -30,16 +30,13 @@
       </p>
       {% call form_wrapper() %}
 
-        {% call select_wrapper(form.contact_details_type, hide_legend=true) %}
-          {% for option in form.contact_details_type %}
-            {% set data_target = option.data.replace('_', '-') ~ "-type" %}
-
-            {{ radio(option, data_target=data_target) }}
-            <div class="panel panel-border-narrow js-hidden" id={{data_target}}>
-              {{ form|attr(option.data)(param_extensions={"classes": "govuk-!-width-full", "label": {"text": " "}}) }}
-            </div>
-          {% endfor %}
-        {% endcall %}
+        {{ form.contact_details_type(param_extensions={
+          "items": [
+            { "conditional": { "html": form.url(param_extensions={ "label": { "classes": "govuk-visually-hidden" } }) } },
+            { "conditional": { "html": form.email_address(param_extensions={ "label": { "classes": "govuk-visually-hidden" } }) } },
+            { "conditional": { "html": form.phone_number(param_extensions={ "label": { "classes": "govuk-visually-hidden" } }) } }
+          ]
+        }) }}
 
         {{ page_footer('Save') }}
       {% endcall %}

--- a/app/templates/views/support/form.html
+++ b/app/templates/views/support/form.html
@@ -19,7 +19,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {% if show_status_page_banner %}
-          <div class="panel panel-border-wide">
+          <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-3">
             <p class="govuk-body">
               Check our <a class="govuk-link govuk-link--no-visited-state" href="https://status.notifications.service.gov.uk">system status</a>
               page to see if there are any known issues with GOV.UK Notify.

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4451,7 +4451,7 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
         },
         _follow_redirects=True
     )
-    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Select an option'
+    assert normalize_spaces(page.find('span', class_='govuk-error-message').text) == 'Error: Select an option'
     assert normalize_spaces(page.h1.text) == "Send files by email"
 
 


### PR DESCRIPTION
This is part 1 of a series of work to remove the GOVUK Elements frontend library from our codebase:

https://www.pivotaltracker.com/story/show/182596680

These changes:
- replace [the GOVUK Elements inset text styles](https://govuk-elements.herokuapp.com/typography/#typography-inset-text) with [the GOVUK Frontend inset text component](https://design-system.service.gov.uk/components/inset-text/) or, when they are in the conditional sections of radios replace those radios with [the GOVUK Frontend radios component](https://design-system.service.gov.uk/components/radios/#conditionally-revealing-a-related-question)
- move [the GOVUK Elements table styles](https://govuk-elements.herokuapp.com/data/) into our codebase

## Notes for reviewers

### Moving GOVUK Elements tables CSS into admin

We have stories to convert all our tables to use GOVUK Frontend components (see[^1] and[^2]) so it isn't worth rewriting the GOVUK Elements styles we currently use until that work happens. Because of that, this just moves those styles into our codebase. We added comments to both stories including that work in each story.

### Making some conditional radios use the GOVUK Frontend radios component

Some uses of the GOVUK Elements inset text style were in groups of radios where selecting an option reveals some content styled like inset text. [The GOVUK Frontend radios component has this style built in](https://design-system.service.gov.uk/components/radios/#conditionally-revealing-a-related-question) so we have *just* swapped out the existing radios code for the GOVUK Frontend version.

#### Design changes from move to GOVUK Frontend radios

Reviewers (probably @quis) might be interested to know that the GOVUK Frontend radios styling changes how the conditional sections look:

##### Before

<img width="598" alt="conditional_radios_current" src="https://user-images.githubusercontent.com/87140/181537131-da40d41e-01fb-44a0-8979-d5a0142876cc.png">

##### After

<img width="609" alt="conditional_radios_govuk_frontend" src="https://user-images.githubusercontent.com/87140/181537766-3a172008-debd-47aa-81ca-c47a52f71140.png">

##### Before

<img width="600" alt="conditional_radios_current_with_errors" src="https://user-images.githubusercontent.com/87140/181537366-3b8d81cf-c88c-487a-9911-696e115c9f0f.png">

##### After

<img width="618" alt="conditional_radios_govuk_frontend_with_errors" src="https://user-images.githubusercontent.com/87140/181537821-439e4e64-2131-4a72-8071-4f6b3e367e9b.png">

[^1]: https://www.pivotaltracker.com/story/show/170030357
[^2]: https://www.pivotaltracker.com/story/show/182595331