### PR TITLE
Remove GOVUK Elements [Part 4]

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -50,10 +50,6 @@ td {
   vertical-align: top;
 }
 
-.heading-xlarge {
-  margin-bottom: 20px;
-}
-
 .heading-medium {
   margin-top: govuk-spacing(6);
 }

--- a/app/assets/stylesheets/govuk_elements/_elements-typography.scss
+++ b/app/assets/stylesheets/govuk_elements/_elements-typography.scss
@@ -1,0 +1,72 @@
+// Typography
+// ==========================================================================
+
+// Increase the base font size to 19px for the main content area
+// Using the core-19 mixin from the govuk_toolkit _typography.scss file
+
+main {
+    @include core-19;
+    -webkit-font-smoothing: antialiased;
+}
+
+// Common heading sizes
+// Using the bold-xx mixins from the govuk_toolkit _typography.scss file
+// Spacing is set in em, using the px to em function in the elements _helpers.scss file
+
+// Headings
+.heading-large {
+  @include bold-36();
+
+  margin-top: em(25, 24);
+  margin-bottom: em(10, 24);
+
+  @include media(tablet) {
+    margin-top: em(45, 36);
+    margin-bottom: em(20, 36);
+  }
+
+  .heading-secondary {
+    @include heading-24();
+
+    display: block;
+    color: $secondary-text-colour;
+  }
+
+}
+
+.heading-medium {
+  @include bold-24();
+
+  margin-top: em(25, 20);
+  margin-bottom: em(10, 20);
+
+  @include media(tablet) {
+    margin-top: em(45, 24);
+    margin-bottom: em(20, 24);
+  }
+
+}
+
+.heading-small {
+  @include bold-19();
+
+  margin-top: em(10, 16);
+  margin-bottom: em(5, 16);
+
+  @include media(tablet) {
+    margin-top: em(20, 19);
+  }
+
+}
+
+// Text
+p {
+  margin-top: em(5, 16);
+  margin-bottom: em(20, 16);
+
+  @include media(tablet) {
+    margin-top: em(5);
+    margin-bottom: em(20);
+  }
+
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -23,7 +23,7 @@ $path: '/static/images/';
 @import 'elements/helpers';
 @import 'elements/reset';
 @import 'elements/details';
-@import 'elements/elements-typography';
+@import 'govuk_elements/elements-typography';
 @import 'govuk_elements/forms';
 @import 'govuk_elements/forms/form-multiple-choice';
 @import 'govuk_elements/forms/form-validation';

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -43,7 +43,7 @@
       <li class="browse-list-item">
         <a href="{{url_for('.service_dashboard', service_id=service.id)}}" class="govuk-link govuk-link--no-visited-state">{{ service.name }}</a>
       </li>
-      <hr>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     {% endfor %}
     </ul>
   </nav>

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -44,7 +44,7 @@
         <a href="{{url_for('.user_information', user_id=user.id)}}" class="govuk-link govuk-link--no-visited-state browse-list-link">{{ user.email_address }}</a>
         <p class="browse-list-hint">{{ user.name }}</p>
       </li>
-      <hr>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     {% endfor %}
     </ul>
   </nav>


### PR DESCRIPTION
This is part 4 of a series of work to remove the GOVUK Elements frontend library from our codebase:

https://www.pivotaltracker.com/story/show/182596680

These changes remove all the typography that wasn't being used and copy all the typography that was used into our codebase - this will need to be removed separately.

Paired with @tombye 

---

Merge after

- [x] https://github.com/alphagov/notifications-admin/pull/4301
- [x] https://github.com/alphagov/notifications-admin/pull/4302
- [x] https://github.com/alphagov/notifications-admin/pull/4304