### PR TITLE
Remove GOVUK Elements [Part 3]

### DIFF
--- a/app/assets/stylesheets/govuk_elements/_forms.scss
+++ b/app/assets/stylesheets/govuk_elements/_forms.scss
@@ -1,0 +1,239 @@
+// Forms
+// ==========================================================================
+
+// Contents:
+//
+// 1. Helpers
+// 2. Form wrappers
+// 3. Form labels
+// 4. Form hints
+// 5. Form controls
+// 6. Form control widths
+// 7. Browser accessibility fixes
+
+// 1. Helpers
+// ==========================================================================
+
+// Fieldset is used to group more than one .form-group
+fieldset {
+  @extend %contain-floats;
+  width: 100%;
+}
+
+// Hack to let legends or elements within legends have margins in webkit browsers
+legend {
+  overflow: hidden;
+}
+
+// Fix left hand gap in IE7 and below
+@include ie-lte(7) {
+  legend {
+    margin-left: -7px;
+  }
+}
+
+// Remove margin under textarea in Chrome and FF
+textarea {
+  display: block;
+}
+
+
+// 2. Form wrappers
+// ==========================================================================
+
+.form-section,
+.form-group {
+  @extend %contain-floats;
+  @include box-sizing(border-box);
+}
+
+// Form section is used to wrap .form-group and has twice its margin
+.form-section {
+  margin-bottom: $gutter;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 2;
+  }
+}
+
+// Form group is used to wrap label and input pairs
+.form-group {
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter;
+  }
+}
+
+// Form group related is used to reduce the space between label and input pairs
+.form-group-related {
+  margin-bottom: 10px;
+
+  @include media(tablet) {
+    margin-bottom: 20px;
+  }
+}
+
+// Form group compound is used to reduce the space between label and input pairs
+.form-group-compound {
+  margin-bottom: 10px;
+}
+
+
+// 3. Form labels
+// ==========================================================================
+
+// Form labels, or for legends styled to look like labels
+// TODO: Amend so there is only one label style
+.form-label,
+.form-label-bold {
+  display: block;
+  color: $text-colour;
+  padding-bottom: 2px;
+}
+
+.form-label {
+  @include core-19;
+}
+
+.form-label-bold {
+  @include bold-19;
+}
+
+// Used for the 'or' in between block label options
+.form-block {
+  float: left;
+  clear: left;
+
+  margin-top: -5px;
+  margin-bottom: 5px;
+
+  @include media(tablet) {
+    margin-top: 0;
+    margin-bottom: 10px;
+  }
+}
+
+// 4. Form hints
+// ==========================================================================
+
+// Form hints and example text are light grey and sit above a form control
+.form-hint {
+  @include core-19;
+  display: block;
+  color: $secondary-text-colour;
+  font-weight: normal;
+
+  margin-top: -2px;
+  padding-bottom: 2px;
+}
+
+.form-label .form-hint,
+.form-label-bold .form-hint {
+  margin-top: 0;
+  padding-bottom: 0;
+}
+
+// 5. Form controls
+// ==========================================================================
+
+// By default, form controls are 50% width for desktop,
+// and 100% width for mobile
+.form-control {
+  @include box-sizing(border-box);
+  @include core-19;
+  width: 100%;
+
+  padding: 5px 4px 4px;
+  // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
+  // as background-color and color need to always be set together, color should not be set either
+  border: 2px solid $text-colour;
+
+  // TODO: Remove 50% width set for tablet and up
+  // !! BREAKING CHANGE !!
+  @include media(tablet) {
+    width: 50%;
+  }
+
+}
+
+// Allow a qualifying element, remove rounded corners from inputs and textareas
+// scss-lint:disable QualifyingElement
+input.form-control,
+textarea.form-control {
+  // Disable inner shadow and remove rounded corners
+  -webkit-appearance: none;
+  border-radius: 0;
+}
+
+textarea.form-control {
+  // Disable opacity and background image for Firefox
+  opacity: 1;
+  background-image: none;
+}
+// scss-lint:enable QualifyingElement
+
+
+// 6. Form control widths
+// ==========================================================================
+
+// TODO: Update these
+// Form control widths
+
+.form-control-3-4 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 75%;
+  }
+}
+
+.form-control-2-3 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 66.66%;
+  }
+}
+
+.form-control-1-2 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 50%;
+  }
+}
+
+.form-control-1-3 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 33.33%;
+  }
+}
+
+.form-control-1-4 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 25%;
+  }
+}
+
+.form-control-1-8 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 12.5%;
+  }
+}
+
+// 7. Browser accessibility fixes
+// ==========================================================================
+
+option:active,
+option:checked,
+select:focus::-ms-value {
+  color: $white;
+  background-color: $govuk-blue;
+}

--- a/app/assets/stylesheets/govuk_elements/_forms.scss
+++ b/app/assets/stylesheets/govuk_elements/_forms.scss
@@ -180,13 +180,3 @@ textarea.form-control {
     width: 12.5%;
   }
 }
-
-// 7. Browser accessibility fixes
-// ==========================================================================
-
-option:active,
-option:checked,
-select:focus::-ms-value {
-  color: $white;
-  background-color: $govuk-blue;
-}

--- a/app/assets/stylesheets/govuk_elements/_forms.scss
+++ b/app/assets/stylesheets/govuk_elements/_forms.scss
@@ -41,19 +41,9 @@ textarea {
 // 2. Form wrappers
 // ==========================================================================
 
-.form-section,
 .form-group {
   @extend %contain-floats;
   @include box-sizing(border-box);
-}
-
-// Form section is used to wrap .form-group and has twice its margin
-.form-section {
-  margin-bottom: $gutter;
-
-  @include media(tablet) {
-    margin-bottom: $gutter * 2;
-  }
 }
 
 // Form group is used to wrap label and input pairs
@@ -65,53 +55,17 @@ textarea {
   }
 }
 
-// Form group related is used to reduce the space between label and input pairs
-.form-group-related {
-  margin-bottom: 10px;
-
-  @include media(tablet) {
-    margin-bottom: 20px;
-  }
-}
-
-// Form group compound is used to reduce the space between label and input pairs
-.form-group-compound {
-  margin-bottom: 10px;
-}
-
-
 // 3. Form labels
 // ==========================================================================
 
 // Form labels, or for legends styled to look like labels
 // TODO: Amend so there is only one label style
-.form-label,
-.form-label-bold {
+.form-label {
   display: block;
   color: $text-colour;
   padding-bottom: 2px;
-}
 
-.form-label {
   @include core-19;
-}
-
-.form-label-bold {
-  @include bold-19;
-}
-
-// Used for the 'or' in between block label options
-.form-block {
-  float: left;
-  clear: left;
-
-  margin-top: -5px;
-  margin-bottom: 5px;
-
-  @include media(tablet) {
-    margin-top: 0;
-    margin-bottom: 10px;
-  }
 }
 
 // 4. Form hints
@@ -128,8 +82,7 @@ textarea {
   padding-bottom: 2px;
 }
 
-.form-label .form-hint,
-.form-label-bold .form-hint {
+.form-label .form-hint {
   margin-top: 0;
   padding-bottom: 0;
 }

--- a/app/assets/stylesheets/govuk_elements/forms/_form-multiple-choice.scss
+++ b/app/assets/stylesheets/govuk_elements/forms/_form-multiple-choice.scss
@@ -1,0 +1,143 @@
+// Radio buttons & checkboxes
+
+// By default, multiple choice inputs stack vertically
+.multiple-choice {
+
+  display: block;
+  float: none;
+  clear: left;
+  position: relative;
+
+  padding: 0 0 0 38px;
+  margin-bottom: $gutter-one-third;
+
+  @include media(tablet) {
+    float: left;
+  }
+
+  // Absolutely position inputs within label, to allow text to wrap
+  input {
+    position: absolute;
+    cursor: pointer;
+    left: 0;
+    top: 0;
+    width: 38px;
+    height: 38px;
+    z-index: 1;
+
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    @if ($is-ie == false) or ($ie-version == 9) {
+      margin: 0;
+      @include opacity(0);
+    }
+  }
+
+  label {
+    cursor: pointer;
+    padding: 8px $gutter-one-third 9px 12px;
+    display: block;
+
+    // remove 300ms pause on mobile
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+
+    @include media(tablet) {
+      float: left;
+      padding-top: 7px;
+      padding-bottom: 7px;
+    }
+  }
+
+  [type=radio] + label::before {
+    content: "";
+    border: 2px solid;
+    background: transparent;
+    width: 34px;
+    height: 34px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    @include border-radius(50%);
+  }
+
+  [type=radio] + label::after {
+    content: "";
+    border: 10px solid;
+    width: 0;
+    height: 0;
+    position: absolute;
+    top: 9px;
+    left: 9px;
+    @include border-radius(50%);
+    @include opacity(0);
+  }
+
+  [type=checkbox] + label::before {
+    content: "";
+    border: 2px solid;
+    background: transparent;
+    width: 34px;
+    height: 34px;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  [type=checkbox] + label::after {
+    content: "";
+    border: solid;
+    border-width: 0 0 5px 5px;
+    background: transparent;
+    border-top-color: transparent;
+    width: 17px;
+    height: 7px;
+    position: absolute;
+    top: 10px;
+    left: 8px;
+    -moz-transform: rotate(-45deg); // Firefox 15 compatibility
+    -o-transform: rotate(-45deg); // Opera 12.0 compatibility
+    -webkit-transform: rotate(-45deg); // Safari 8 compatibility
+    -ms-transform: rotate(-45deg); // IE9 compatibility
+    transform: rotate(-45deg);
+    @include opacity(0);
+  }
+
+  // Focused state
+  [type=radio]:focus + label::before {
+    @include box-shadow(0 0 0 4px $focus-colour);
+  }
+
+  [type=checkbox]:focus + label::before {
+    @include box-shadow(0 0 0 3px $focus-colour);
+  }
+
+  // Selected state
+  input:checked + label::after {
+    @include opacity(1);
+  }
+
+  // Disabled state
+  input:disabled {
+    cursor: default;
+  }
+
+  input:disabled + label {
+    @include opacity(0.5);
+    cursor: default;
+  }
+
+  &:last-child,
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+// To sit multiple choice inputs next to each other, use .inline on parent
+.inline .multiple-choice {
+  clear: none;
+
+  @include media (tablet) {
+    margin-bottom: 0;
+    margin-right: $gutter;
+  }
+}

--- a/app/assets/stylesheets/govuk_elements/forms/_form-multiple-choice.scss
+++ b/app/assets/stylesheets/govuk_elements/forms/_form-multiple-choice.scss
@@ -72,48 +72,9 @@
     @include opacity(0);
   }
 
-  [type=checkbox] + label::before {
-    content: "";
-    border: 2px solid;
-    background: transparent;
-    width: 34px;
-    height: 34px;
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
-
-  [type=checkbox] + label::after {
-    content: "";
-    border: solid;
-    border-width: 0 0 5px 5px;
-    background: transparent;
-    border-top-color: transparent;
-    width: 17px;
-    height: 7px;
-    position: absolute;
-    top: 10px;
-    left: 8px;
-    -moz-transform: rotate(-45deg); // Firefox 15 compatibility
-    -o-transform: rotate(-45deg); // Opera 12.0 compatibility
-    -webkit-transform: rotate(-45deg); // Safari 8 compatibility
-    -ms-transform: rotate(-45deg); // IE9 compatibility
-    transform: rotate(-45deg);
-    @include opacity(0);
-  }
-
   // Focused state
   [type=radio]:focus + label::before {
     @include box-shadow(0 0 0 4px $focus-colour);
-  }
-
-  [type=checkbox]:focus + label::before {
-    @include box-shadow(0 0 0 3px $focus-colour);
-  }
-
-  // Selected state
-  input:checked + label::after {
-    @include opacity(1);
   }
 
   // Disabled state

--- a/app/assets/stylesheets/govuk_elements/forms/_form-validation.scss
+++ b/app/assets/stylesheets/govuk_elements/forms/_form-validation.scss
@@ -1,0 +1,94 @@
+// Form validation
+// ==========================================================================
+
+// Use .form-group-error to add a red border to the left of a .form-group
+.form-group-error {
+  margin-right: 15px;
+  border-left: 4px solid $error-colour;
+  padding-left: 10px;
+
+  @include media(tablet) {
+    border-left: 5px solid $error-colour;
+    padding-left: $gutter-half;
+  }
+}
+
+// Use .form-control-error to add a red border to .form-control
+.form-control-error {
+  border: 4px solid $error-colour;
+}
+
+
+// Error messages should be red and bold
+.error-message {
+  @include bold-19;
+  color: $error-colour;
+
+
+  display: block;
+  clear: both;
+
+  margin: 0;
+  padding: 2px 0;
+}
+
+.form-label .error-message,
+.form-label-bold .error-message {
+  padding-top: 4px;
+  padding-bottom: 0;
+}
+
+// Summary of multiple error messages
+.error-summary {
+
+  // Error summary has a border on all sides
+  border: 4px solid $error-colour;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  padding: $gutter-half 10px;
+
+  @include media(tablet) {
+    border: 5px solid $error-colour;
+
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+
+    padding: $gutter-two-thirds $gutter-half $gutter-half;
+  }
+
+  @include ie-lte(6) {
+    zoom: 1;
+  }
+
+  // Use the GOV.UK outline focus style
+  &:focus {
+    outline: 3px solid $focus-colour;
+  }
+
+  .error-summary-heading {
+    margin-top: 0;
+  }
+
+  p {
+    margin-bottom: 10px;
+  }
+
+  .error-summary-list {
+    padding-left: 0;
+
+    li {
+
+      @include media(tablet) {
+        margin-bottom: 5px;
+      }
+    }
+
+    a {
+      color: $error-colour;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk_elements/forms/_form-validation.scss
+++ b/app/assets/stylesheets/govuk_elements/forms/_form-validation.scss
@@ -32,63 +32,7 @@
   padding: 2px 0;
 }
 
-.form-label .error-message,
-.form-label-bold .error-message {
+.form-label .error-message {
   padding-top: 4px;
   padding-bottom: 0;
-}
-
-// Summary of multiple error messages
-.error-summary {
-
-  // Error summary has a border on all sides
-  border: 4px solid $error-colour;
-
-  margin-top: $gutter-half;
-  margin-bottom: $gutter-half;
-
-  padding: $gutter-half 10px;
-
-  @include media(tablet) {
-    border: 5px solid $error-colour;
-
-    margin-top: $gutter;
-    margin-bottom: $gutter;
-
-    padding: $gutter-two-thirds $gutter-half $gutter-half;
-  }
-
-  @include ie-lte(6) {
-    zoom: 1;
-  }
-
-  // Use the GOV.UK outline focus style
-  &:focus {
-    outline: 3px solid $focus-colour;
-  }
-
-  .error-summary-heading {
-    margin-top: 0;
-  }
-
-  p {
-    margin-bottom: 10px;
-  }
-
-  .error-summary-list {
-    padding-left: 0;
-
-    li {
-
-      @include media(tablet) {
-        margin-bottom: 5px;
-      }
-    }
-
-    a {
-      color: $error-colour;
-      font-weight: bold;
-      text-decoration: underline;
-    }
-  }
 }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -24,9 +24,9 @@ $path: '/static/images/';
 @import 'elements/reset';
 @import 'elements/details';
 @import 'elements/elements-typography';
-@import 'elements/forms';
-@import 'elements/forms/form-multiple-choice';
-@import 'elements/forms/form-validation';
+@import 'govuk_elements/forms';
+@import 'govuk_elements/forms/form-multiple-choice';
+@import 'govuk_elements/forms/form-validation';
 @import 'govuk_elements/tables';
 
 // Dependencies from GOV.UK Frontend, packaged to be specific to this application


### PR DESCRIPTION
This is part 3 of a series of work to remove the GOVUK Elements frontend library from our codebase:

https://www.pivotaltracker.com/story/show/182596680

These changes remove all the forms styles that weren't being used and copy all those that were into our codebase - this will need to be removed separately.

Paired with @klssmith 

---

Merge after

- [x] https://github.com/alphagov/notifications-admin/pull/4301
- [x] https://github.com/alphagov/notifications-admin/pull/4302