### PR TITLE
Make form to set email branding pool for an org work

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1963,6 +1963,7 @@ class AdminEditEmailBrandingForm(StripWhitespaceForm):
 class AdminChangeEmailBrandingPoolForm(StripWhitespaceForm):
     branding_field = GovukCheckboxesField(
         'Branding options',
+        validators=[DataRequired(message="Select at least 1 email branding option")],
         param_extensions={
             "fieldset": {
                 "legend": {

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -447,7 +447,7 @@ def organisation_preview_email_branding(org_id):
     )
 
 
-@main.route("/organisations/<uuid:org_id>/settings/email-branding-options", methods=['GET'])
+@main.route("/organisations/<uuid:org_id>/settings/email-branding-options", methods=['GET', 'POST'])
 @user_is_platform_admin
 def organisation_email_branding_options(org_id):
     form = AdminChangeEmailBrandingPoolForm()
@@ -457,6 +457,20 @@ def organisation_email_branding_options(org_id):
         for branding in email_branding_client.get_all_email_branding(sort_key='name')
         if branding not in current_organisation.email_branding_pool
     ]
+
+    if form.validate_on_submit():
+        selected_email_branding_ids = form.branding_field.data
+
+        organisations_client.add_brandings_to_email_branding_pool(org_id, selected_email_branding_ids)
+
+        if len(selected_email_branding_ids) == 1:
+            msg = '1 email branding option added'
+        else:
+            msg = f'{len(selected_email_branding_ids)} email branding options added'
+
+        flash(msg, 'default_with_tick')
+        # TODO: redirect to page showing a preview of all branding in pool once it exists
+        return redirect(url_for('.organisation_settings', org_id=org_id))
 
     return render_template(
         'views/organisations/organisation/settings/add-email-branding-options.html',

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -61,6 +61,13 @@ class OrganisationsClient(NotifyAdminAPIClient):
 
         return api_response
 
+    @cache.delete('organisation-{org_id}-email-branding-pool')
+    def add_brandings_to_email_branding_pool(self, org_id, branding_ids):
+        return self.post(
+            url=f"/organisations/{org_id}/email-branding-pool",
+            data={'branding_ids': branding_ids}
+        )
+
     @cache.delete('service-{service_id}')
     @cache.delete('live-service-and-organisation-counts')
     @cache.delete('organisations')

--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -1,5 +1,6 @@
 {% extends "org_template.html" %}
 {% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
@@ -22,6 +23,7 @@
         <div class="brand-pool">
             {{ form.branding_field }}
         </div>
+      {{ page_footer('Add') }}
       {% endcall %}
     </div>
   </div>

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -211,6 +211,21 @@ def test_update_organisation_when_updating_org_type_but_org_has_no_services(mock
     ]
 
 
+def test_add_brandings_to_email_branding_pool(mocker, fake_uuid):
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')
+
+    organisations_client.add_brandings_to_email_branding_pool(
+        fake_uuid,
+        branding_ids=['abcd', 'efgh'],
+    )
+    mock_post.assert_called_with(
+        url=f'/organisations/{fake_uuid}/email-branding-pool',
+        data={'branding_ids': ['abcd', 'efgh']}
+    )
+    mock_redis_delete.assert_called_once_with(f'organisation-{fake_uuid}-email-branding-pool')
+
+
 def test_update_service_organisation_deletes_cache(mocker, fake_uuid):
     mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
     mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')


### PR DESCRIPTION
We had a form to let you pick email branding to add to the branding
pool for an org, but the functionality had not been implemented. This
adds the button and the POST endpoint for the form. At the moment, we
redirect to the organisation settings page when the form is successfully
submitted. Once the page to preview all email brandings in the pool for
an org exists, we can update the code to redirect there instead.

[Pivotal story](https://www.pivotaltracker.com/story/show/182771318)

**Merge after**
- [x] https://github.com/alphagov/notifications-api/pull/3583