### PR TITLE
Support API errors for `email_from`

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -25,11 +25,14 @@ def _create_service(service_name, organisation_type, email_from, form):
 
         return service_id, None
     except HTTPError as e:
-        if e.status_code == 400 and e.message['name']:
-            form.name.errors.append("This service name is already in use")
+        if e.status_code == 400:
+            error_message = service_api_client.parse_edit_service_http_error(e)
+            if not error_message:
+                raise e
+
+            form.name.errors.append(error_message)
+
             return None, e
-        else:
-            raise e
 
 
 def _create_example_template(service_id):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -106,13 +106,13 @@ def service_name_change(service_id):
                 email_from=email_safe(form.name.data),
             )
         except HTTPError as http_error:
-            if http_error.status_code == 400 and any(
-                name_error_message.startswith('Duplicate service name')
-                for name_error_message in http_error.message['name']
-            ):
-                form.name.errors.append('This service name is already in use')
-            else:
-                raise http_error
+            if http_error.status_code == 400:
+                error_message = service_api_client.parse_edit_service_http_error(http_error)
+                if not error_message:
+                    raise http_error
+
+                form.name.errors.append(error_message)
+
         else:
             return redirect(url_for('.service_settings', service_id=service_id))
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -611,5 +611,16 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         count = redis_client.get(daily_limit_cache_key(service_id)) or 0
         return int(count)
 
+    @classmethod
+    def parse_edit_service_http_error(cls, http_error):
+        """Inspect the HTTPError from a create_service/update_service call and return a human-friendly error message"""
+        if http_error.message.get('email_from'):
+            return "Service name must not include characters from a non-Latin alphabet"
+
+        elif http_error.message.get('name'):
+            return "This service name is already in use"
+
+        return None
+
 
 service_api_client = ServiceAPIClient()

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import call
+from unittest.mock import Mock, call
 from uuid import uuid4
 
 import pytest
@@ -611,3 +611,24 @@ def test_client_updates_service_with_allowed_attributes(
         f'/service/{SERVICE_ONE_ID}',
         {**{'created_by': '123'}, **attrs_dict}
     )
+
+
+@pytest.mark.parametrize(
+    'err_data, expected_message',
+    (
+        ({'name': 'Service name error'}, "This service name is already in use"),
+        (
+            {'email_from': 'email_from disallowed characters'},
+            "Service name must not include characters from a non-Latin alphabet"
+        ),
+        ({'other': 'blah'}, None),
+    )
+)
+def test_client_parsing_service_name_errors(err_data, expected_message):
+    client = ServiceAPIClient()
+    error = Mock()
+    error.message = err_data
+
+    error_message = client.parse_edit_service_http_error(error)
+
+    assert error_message == expected_message


### PR DESCRIPTION
We are updating the notifications-api to reject `email_from` values
which contain 'uncleanable' characters (basically anything that can't be
reduced to alphanumeric characters or full-stops).

This is because AWS SES doesn't allow sending rich unicode characters in
the local portion of an email address. We could punycode the values, but
this looks very odd in emails and so for now we're leaving this alone -
to be addressed potentially in the future. We're also leaving it as a
future endeavour to allow separating service name and email_from, due to
the need for research+design.

**NOTE**: ~The error message content is a placeholder and waiting for input from @karlchillmaid.~ Error message content has now come from Karl.

This PR can go out any time ahead of the corresponding enforcement PR for notifications-api