### PR TITLE
Add a link to our terms of use

### DIFF
--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -38,7 +38,7 @@
     <li>add examples of the messages you want to send</li>
     <li>update your settings so you’re ready to send and receive messages</li>
     <li>accept our data sharing and financial agreement</li>
-    <li>accept our terms of use</li>
+    <li>accept our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.terms') }}">terms of use</li>
   </ul>
   
 

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -38,7 +38,7 @@
     <li>add examples of the messages you want to send</li>
     <li>update your settings so you’re ready to send and receive messages</li>
     <li>accept our data sharing and financial agreement</li>
-    <li>accept our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.terms') }}">terms of use</li>
+    <li>accept our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.terms') }}">terms of use</a></li>
   </ul>
   
 


### PR DESCRIPTION
This PR adds a link to our terms of use from the Trial mode page.