### PR TITLE
Add sticky footer for the form to add email branding to pool

### DIFF
--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -23,7 +23,9 @@
         <div class="brand-pool">
             {{ form.branding_field }}
         </div>
-      {{ page_footer('Add') }}
+      <div class="js-stick-at-bottom-when-scrolling">
+        {{ page_footer('Add') }}
+      </div>
       {% endcall %}
     </div>
   </div>


### PR DESCRIPTION
There are a lot of email brandings in production, so this changes the
form to add branding for an org so that the "Add" button is in a
sticky-footer. Without this change, you have to scroll a long way down
each time you need to add a brand.