### PR TITLE
Fix SMS price on /set-sms page

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -68,6 +68,7 @@ from app.main.forms import (
     SMSPrefixForm,
     SomethingElseBrandingForm,
 )
+from app.main.views.pricing import CURRENT_SMS_RATE
 from app.utils import DELIVERED_STATUSES, FAILURE_STATUSES, SENDING_STATUSES
 from app.utils.branding import NHS_EMAIL_BRANDING_ID
 from app.utils.branding import get_email_choices as get_email_branding_choices
@@ -779,6 +780,7 @@ def service_set_channel(service_id, channel):
     return render_template(
         'views/service-settings/set-{}.html'.format(channel),
         form=form,
+        sms_rate=CURRENT_SMS_RATE,
     )
 
 

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -23,7 +23,7 @@
         financial year.
       </p>
       <p class="govuk-body">
-        It costs 1.58 pence (plus VAT) for each text message you send
+        It costs {{ sms_rate }} pence (plus VAT) for each text message you send
         after your free allowance.
       </p>
       <p class="govuk-body">


### PR DESCRIPTION
The price shown here was out of date. We can use the `CURRENT_SMS_RATE`
constant instead of hard-coding a minimum SMS price which means that we
don't need to remember to update this page in future.