### PR TITLE
Remove GOVUK Elements [Part 5]

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -24,6 +24,13 @@
     margin-bottom: govuk-spacing(1);
   }
 
+  // Remove inset-text styling from contents of details in banners
+  // The style clashes with that of the banner (double border)
+  .govuk-details__text {
+    border-left: none;
+    padding: 0;
+  }
+
 }
 
 %banner-with-tick,

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -22,7 +22,6 @@ $path: '/static/images/';
 // https://github.com/alphagov/govuk_elements
 @import 'elements/helpers';
 @import 'elements/reset';
-@import 'elements/details';
 @import 'govuk_elements/elements-typography';
 @import 'govuk_elements/forms';
 @import 'govuk_elements/forms/form-multiple-choice';

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -10,13 +10,15 @@
     border-top: 1px solid $border-colour;
     padding: 10px 0 0 0;
 
-    &__heading,
-    &__data,
-    &__view {
+    // We can't assign classes to the summary.govuk-details__summary or div.govuk-details__text
+    // elements so we have to target them as children of details.api-notifications-item
+    // This will result in selectors like .api-notifications-item > .govuk-details__summary
+    > .govuk-details__summary,
+    > .govuk-details__text {
       font-family: monospace;
     }
 
-    &__heading {
+    > .govuk-details__summary {
       display: block;
       margin-bottom: govuk-spacing(3);
 
@@ -51,20 +53,24 @@
 
     }
 
-    &__data {
+    // We can't assign classes to the div.govuk-details__text element so we have to target it as a
+    // child of details.api-notifications-item instead
+    // This will result in .api-notifications-item > .govuk-details__text
+    > .govuk-details__text {
 
       border-left: none;
       padding-left: 25px;
+      padding-top: 0;
 
-      &-name {
-        color: $secondary-text-colour;
-      }
+    }
 
-      &-value {
-        color: $text-colour;
-        padding-bottom: 15px;
-      }
+    &__data-name {
+      color: $secondary-text-colour;
+    }
 
+    &__data-value {
+      color: $text-colour;
+      padding-bottom: 15px;
     }
 
   }

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -1,6 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/banner.html" import banner_wrapper %}
+{% from "components/details/macro.njk" import govukDetails %}
 
 {% block service_page_title %}
   API integration
@@ -46,40 +47,45 @@
       </div>
     {% endif %}
     {% for notification in api_notifications.notifications %}
-      <details class="api-notifications-item govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-        <summary class="govuk-details__summary govuk-clearfix api-notifications-item__heading">
-          <h3>
-            <span class="govuk-details__summary-text">
-            {{ notification.to }}
-            </span>
-            <span class="govuk-grid-row api-notifications-item__meta">
-              <span class="govuk-grid-column-one-half api-notifications-item__meta-key">
-                {{notification.key_name}}
-              </span>
-              <span class="govuk-grid-column-one-half api-notifications-item__meta-time">
-                <time class="timeago" datetime="{{ notification.created_at }}">
-                  {{ notification.created_at|format_delta }}
-                </time>
-              </span>
-            </span>
-          </h3>
-        </summary>
-        <div class="govuk-details__text api-notifications-item__data govuk-!-padding-top-0">
-          <dl id="notification-{{ notification.id }}">
-            {% for key in [
-              'id', 'client_reference', 'notification_type', 'created_at', 'updated_at', 'sent_at', 'status'
+      {% set summary_html %}
+      <h3>
+        <span class="api-notifications-item__recipient">
+        {{ notification.to }}
+        </span>
+        <span class="govuk-grid-row api-notifications-item__meta">
+          <span class="govuk-grid-column-one-half api-notifications-item__meta-key">
+            {{notification.key_name}}
+          </span>
+          <span class="govuk-grid-column-one-half api-notifications-item__meta-time">
+            <time class="timeago" datetime="{{ notification.created_at }}">
+              {{ notification.created_at|format_delta }}
+            </time>
+          </span>
+        </span>
+      </h3>
+      {% endset %}
+
+      {% set htmlcontent %}
+        <dl id="notification-{{ notification.id }}">
+          {% for key in [
+            'id', 'client_reference', 'notification_type', 'created_at', 'updated_at', 'sent_at', 'status'
             ] %}
-              {% if notification[key] %}
-                <dt class="api-notifications-item__data-name">{{ key }}:</dt>
-                <dd class="api-notifications-item__data-value">{{ notification[key] }}</dd>
-              {% endif %}
+            {% if notification[key] %}
+            <dt class="api-notifications-item__data-name">{{ key }}:</dt>
+            <dd class="api-notifications-item__data-value">{{ notification[key] }}</dd>
+            {% endif %}
             {% endfor %}
             {% if notification.status not in ('pending-virus-check', 'virus-scan-failed') %}
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=notification.id) }}">View {{ 1|message_count_label(notification.template.template_type, suffix='') }}</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=notification.id) }}">View {{ 1|message_count_label(notification.template.template_type, suffix='') }}</a>
             {% endif %}
           </dl>
-        </div>
-      </details>
+      {% endset %}
+
+      {{ govukDetails({
+        "summaryHtml": summary_html,
+        "html": htmlcontent,
+        "classes": "api-notifications-item govuk-details govuk-!-margin-bottom-0"
+      }) }}
     {% endfor %}
     {% if api_notifications.notifications %}
       <div class="api-notifications-item">

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -5,6 +5,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
+{% from "components/details/macro.njk" import govukDetails %}
 
 {% extends "withnav_template.html" %}
 
@@ -63,25 +64,28 @@
             When you use a live account you’ll need another member of
             your team to approve your alert.
           </p>
-          <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-            <summary class="govuk-details__summary govuk-clearfix">
-              Approve your own alert
-            </summary>
+          {% set approve_details %}
             {% call form_wrapper() %}
-              <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3">
-                Because you’re in training mode you can approve
-                your own alerts, to see how it works.
-              </p>
-              <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-                No real alerts will be broadcast to anyone’s phone.
-              </p>
-              {{ page_footer(
-                "Start broadcasting now",
-                delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
-                delete_link_text='Reject this alert'
-              ) }}
+            <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-3">
+              Because you’re in training mode you can approve
+              your own alerts, to see how it works.
+            </p>
+            <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+              No real alerts will be broadcast to anyone’s phone.
+            </p>
+            {{ page_footer(
+              "Start broadcasting now",
+              delete_link=url_for('main.reject_broadcast_message', service_id=current_service.id, broadcast_message_id=broadcast_message.id),
+              delete_link_text='Reject this alert'
+            ) }}
             {% endcall %}
-          </details>
+          {% endset %}
+
+          {{ govukDetails({
+            "classes": "govuk-!-margin-bottom-0",
+            "summaryText": "Approve your own alert",
+            "html": approve_details
+          }) }}
         {% elif current_user.has_permissions('create_broadcasts', restrict_admin_usage=True) %}
           <p class="govuk-body">
             You need another member of your team to approve this alert.

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -1,7 +1,6 @@
 {% extends "content_template.html" %}
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
-{% from "components/details/macro.njk" import govukDetails %}
 
 {% block per_page_title %}
   Get started

--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -1,5 +1,6 @@
 {% extends "content_template.html" %}
 {% from "components/service-link.html" import service_link %}
+{% from "components/details/macro.njk" import govukDetails %}
 
 {% block per_page_title %}
   Letter specification
@@ -16,42 +17,40 @@
 
   <p class="govuk-body">To help you set up your letter, you can download our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.letter_spec') }}">letter specification as a PDF</a>.</p>
 
-  <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      See a text version of the letter specification
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-  <h2 class="heading-medium">Page 1 of 10</h2>
+  {% set letter_spec %}
+    <h2 class="heading-medium">Page 1 of 10</h2>
 
-  <p class="govuk-body">Left margin 15mm</p>
-  <p class="govuk-body">Right margin 15mm</p>
-  <p class="govuk-body">Top margin 5mm</p>
-  <p class="govuk-body">Bottom margin 5mm</p>
+    <p class="govuk-body">Left margin 15mm</p>
+    <p class="govuk-body">Right margin 15mm</p>
+    <p class="govuk-body">Top margin 5mm</p>
+    <p class="govuk-body">Bottom margin 5mm</p>
 
-  <h3 class="heading-small">Logo block</h3>
+    <h3 class="heading-small">Logo block</h3>
 
-  <p class="govuk-body">Position: 15mm from left edge, 5mm from top edge</p>
-  <p class="govuk-body">Size: 200mm wide by 25mm high</p>
+    <p class="govuk-body">Position: 15mm from left edge, 5mm from top edge</p>
+    <p class="govuk-body">Size: 200mm wide by 25mm high</p>
 
-  <h3 class="heading-small">Address block</h3>
+    <h3 class="heading-small">Address block</h3>
 
-  <p class="govuk-body">Position: 24.6mm from left edge, 39.5mm from top edge</p>
-  <p class="govuk-body">Size: 95.4mm wide by 26.8mm high</p>
+    <p class="govuk-body">Position: 24.6mm from left edge, 39.5mm from top edge</p>
+    <p class="govuk-body">Size: 95.4mm wide by 26.8mm high</p>
 
-  <h3 class="heading-small">Letter contact block</h3>
+    <h3 class="heading-small">Letter contact block</h3>
 
-  <p class="govuk-body">Position: 125mm from left edge, 30mm from top edge</p>
-  <p class="govuk-body">Size: 65mm wide by 65mm high</p>
+    <p class="govuk-body">Position: 125mm from left edge, 30mm from top edge</p>
+    <p class="govuk-body">Size: 65mm wide by 65mm high</p>
 
-  <h2 class="heading-medium">Pages 2 to 10</h2>
+    <h2 class="heading-medium">Pages 2 to 10</h2>
 
-  <p class="govuk-body">Left margin 15mm</p>
-  <p class="govuk-body">Right margin 15mm</p>
-  <p class="govuk-body">Top margin 5mm</p>
-  <p class="govuk-body">Bottom margin 5mm</p>
-  </div>
-</details>
+    <p class="govuk-body">Left margin 15mm</p>
+    <p class="govuk-body">Right margin 15mm</p>
+    <p class="govuk-body">Top margin 5mm</p>
+    <p class="govuk-body">Bottom margin 5mm</p>
+  {% endset %}
+
+  {{ govukDetails({
+    "summaryText": "See a text version of the letter specification",
+    "html": letter_spec
+  }) }}
 
 {% endblock %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -29,7 +29,7 @@ def test_should_show_api_page(
     rows = page.find_all('details')
     assert len(rows) == 5
     for row in rows:
-        assert row.select('h3 .govuk-details__summary-text')[0].string.strip() == '07123456789'
+        assert row.select('h3 .api-notifications-item__recipient')[0].string.strip() == '07123456789'
 
 
 def test_should_show_api_page_with_lots_of_notifications(


### PR DESCRIPTION
This is part 5 of a series of work to remove the GOVUK Elements frontend library from our codebase:

https://www.pivotaltracker.com/story/show/182596680

Part 5 focuses on removing the styles for the GOVUK Elements version of the `<details>` element.

## Notes for reviewers

We already moved most of our `<details>` HTML over to using [the design system details component](https://design-system.service.gov.uk/components/details/) in https://github.com/alphagov/notifications-admin/pull/3225 but there were a few we couldn't make work.

We've since learnt a few tricks that let us do it (notably use of `set` to assign blocks of HTML to jinja variables) so this:
- moves all remaining `<details>` HTML over
- removes all GOVUK Elements CSS for `<details>` elements
- removes an unused import