### PR TITLE
Clear organisation email branding pool

### DIFF
--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -59,6 +59,9 @@ class OrganisationsClient(NotifyAdminAPIClient):
         if 'name' in kwargs:
             redis_client.delete(f'organisation-{org_id}-name')
 
+        if 'email_branding_id' in kwargs and kwargs['email_branding_id']:
+            redis_client.delete(f'organisation-{org_id}-email-branding-pool')
+
         return api_response
 
     @cache.delete('organisation-{org_id}-email-branding-pool')

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -198,14 +198,15 @@ def test_update_organisation_when_updating_org_type_but_org_has_no_services(mock
     organisations_client.update_organisation(
         fake_uuid,
         cached_service_ids=[],
-        organisation_type='central',
+        email_branding_id=fake_uuid,
     )
 
     mock_post.assert_called_with(
         url='/organisations/{}'.format(fake_uuid),
-        data={'organisation_type': 'central'}
+        data={'email_branding_id': fake_uuid}
     )
     assert mock_redis_delete.call_args_list == [
+        call(f'organisation-{fake_uuid}-email-branding-pool'),
         call('organisations'),
         call('domains'),
     ]


### PR DESCRIPTION
When we set a new default email branding for an organisation, it gets
added to their email branding pool, so we need to clear that cache
entry.

This is a slightly weird way of doing - we have to 'know' that the API
call does this extra thing in this situation and manage the cache from
the frontend. But that's how it works at the moment, so this is at least
consistent...