### PR TITLE
Bump dependencies

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -434,10 +434,10 @@ def get_job_partials(job):
 def add_preview_of_content_to_notifications(notifications):
 
     for notification in notifications:
-        yield(dict(
+        yield dict(
             preview_of_content=get_preview_of_content(notification),
             **notification
-        ))
+        )
 
 
 def get_preview_of_content(notification):

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -141,11 +141,11 @@ def uploaded_letters(service_id, letter_print_day):
 def add_preview_of_content_uploaded_letters(notifications):
 
     for notification in notifications:
-        yield(dict(
+        yield dict(
             preview_of_content=', '.join(notification.pop('to').splitlines()),
             to=notification['client_reference'],
             **notification
-        ))
+        )
 
 
 @main.route("/services/<uuid:service_id>/upload-letter", methods=['GET', 'POST'])

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-ago==0.0.93
+ago==0.0.95
 govuk-bank-holidays==0.11
-humanize==4.1.0
+humanize==4.3.0
 Flask==2.1.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
@@ -11,13 +11,13 @@ Flask-Login==0.6.1
 Werkzeug==2.1.2
 jinja2==3.1.2
 
-blinker==1.4
+blinker==1.5
 pyexcel==0.7.0
 pyexcel-io==0.6.6
 pyexcel-xls==0.7.0
 pyexcel-xlsx==0.6.0
 pyexcel-ods3==0.6.1
-pytz==2022.1
+pytz==2022.2.1
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 notifications-python-client==6.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,44 +4,44 @@
 #
 #    pip-compile requirements.in
 #
-ago==0.0.93
+ago==0.0.95
     # via -r requirements.in
 async-timeout==4.0.2
     # via redis
-awscli==1.25.2
+awscli==1.25.57
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-bleach==5.0.0
+bleach==5.0.1
     # via notifications-utils
-blinker==1.4
+blinker==1.5
     # via
     #   -r requirements.in
     #   gds-metrics
-boto3==1.24.2
+boto3==1.24.56
     # via notifications-utils
-botocore==1.27.2
+botocore==1.27.56
     # via
     #   awscli
     #   boto3
     #   s3transfer
 cachetools==5.2.0
     # via notifications-utils
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   pyproj
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-chardet==4.0.0
+chardet==5.0.0
     # via pyexcel
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via flask
 colorama==0.4.4
     # via awscli
-cryptography==37.0.2
+cryptography==37.0.4
     # via fido2
 deprecated==1.2.13
     # via redis
@@ -85,7 +85,7 @@ greenlet==1.1.2
     # via eventlet
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
-humanize==4.1.0
+humanize==4.3.0
     # via -r requirements.in
 idna==3.3
     # via requests
@@ -103,7 +103,7 @@ jinja2==3.1.2
     #   flask
     #   govuk-frontend-jinja
     #   notifications-utils
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
@@ -131,7 +131,7 @@ orderedset==2.0.3
     # via notifications-utils
 packaging==21.3
     # via redis
-phonenumbers==8.12.49
+phonenumbers==8.12.54
     # via notifications-utils
 prometheus-client==0.14.1
     # via
@@ -162,7 +162,7 @@ pyjwt==2.4.0
     # via notifications-python-client
 pyparsing==3.0.9
     # via packaging
-pypdf2==2.0.0
+pypdf2==2.10.3
     # via notifications-utils
 pyproj==3.3.1
     # via
@@ -172,9 +172,9 @@ python-dateutil==2.8.2
     # via
     #   awscli-cwlogs
     #   botocore
-python-json-logger==2.0.2
+python-json-logger==2.0.4
     # via notifications-utils
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   -r requirements.in
     #   notifications-utils
@@ -182,9 +182,9 @@ pyyaml==5.4.1
     # via
     #   awscli
     #   notifications-utils
-redis==4.3.3
+redis==4.3.4
     # via flask-redis
-requests==2.27.1
+requests==2.28.1
     # via
     #   awscli-cwlogs
     #   govuk-bank-holidays
@@ -198,7 +198,7 @@ s3transfer==0.6.0
     # via
     #   awscli
     #   boto3
-shapely==1.8.2
+shapely==1.8.4
     # via notifications-utils
 six==1.16.0
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,14 +2,14 @@
 isort==5.10.1
 pytest==7.1.2
 pytest-env==0.6.2
-pytest-mock==3.7.0
+pytest-mock==3.8.2
 pytest-xdist==2.5.0
 beautifulsoup4==4.11.1
-freezegun==1.2.1
-flake8==4.0.1
-flake8-bugbear==22.4.25
+freezegun==1.2.2
+flake8==5.0.4
+flake8-bugbear==22.7.1
 flake8-print==5.0.0
-moto==3.1.12
+moto==3.1.2
 requests-mock==1.9.3
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.8.2

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -437,7 +437,7 @@ def test_search_recipient_form(
     assert page.select_one('label[for=to]').text.strip() == expected_search_box_label
 
     recipient_inputs = page.select("input[name=to]")
-    assert(len(recipient_inputs) == 2)
+    assert len(recipient_inputs) == 2
 
     for field in recipient_inputs:
         assert field.get("value") == expected_search_box_contents


### PR DESCRIPTION
Bump dependencies

Most of these bumped dependencies come from
https://github.com/alphagov/notifications-admin/pull/4327 - but I've
removed the bump on moto for test dependencies as this was causing a
conflict preventing us from rolling out any of the changes.

Since moto is only installed for tests, and we don't need any of the
changes from the new version, it's feel fine to leave it out for now.