### PR TITLE
GOVUK Elements bonus removals

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -19,7 +19,8 @@ $path: '/static/images/';
 @import 'reset';
 @import 'globals';
 
-// Dependencies from GOV.UK Elements
+// Dependencies from GOV.UK Elements, moved here until all components are migrated
+// to GOVUK Frontend, and so no longer need these styles
 // https://github.com/alphagov/govuk_elements
 @import './govuk-elements/helpers';
 @import './govuk-elements/elements-typography';

--- a/app/templates/views/api/guest-list.html
+++ b/app/templates/views/api/guest-list.html
@@ -23,7 +23,7 @@
         There was a problem with your guest list
       </h1>
       <p class="govuk-body">Fix these errors:</p>
-      <ul>
+      <ul class="govuk-list govuk-!-margin-bottom-0">
         {% if form.email_addresses.errors %}
           <li>
             <a class="govuk-link govuk-link--destructive" href="#{{ form.email_addresses.name }}">Enter valid email addresses</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "cbor-js": "0.1.0",
         "govuk_frontend_toolkit": "8.1.0",
-        "govuk-elements-sass": "3.1.2",
         "govuk-frontend": "2.13.0",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
@@ -6420,22 +6419,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.1.0.tgz",
       "integrity": "sha512-KzuMy+xhH/QKJHYJYS4p6ZiPg1CWSd4TKJFBFzngpVnk2tbvEvfAw/yLoRmzgukd/9V4d9oDSA4dIXRFb7XvDA=="
-    },
-    "node_modules/govuk-elements-sass": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/govuk-elements-sass/-/govuk-elements-sass-3.1.2.tgz",
-      "integrity": "sha1-THmmiTxQDlyBet6NUAjnCfcYo8M=",
-      "dependencies": {
-        "govuk_frontend_toolkit": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/govuk-elements-sass/node_modules/govuk_frontend_toolkit": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.6.0.tgz",
-      "integrity": "sha1-sJpgYxr7ukv6x2qLfALnJBnCnPU="
     },
     "node_modules/govuk-frontend": {
       "version": "2.13.0",
@@ -21226,21 +21209,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.1.0.tgz",
       "integrity": "sha512-KzuMy+xhH/QKJHYJYS4p6ZiPg1CWSd4TKJFBFzngpVnk2tbvEvfAw/yLoRmzgukd/9V4d9oDSA4dIXRFb7XvDA=="
-    },
-    "govuk-elements-sass": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/govuk-elements-sass/-/govuk-elements-sass-3.1.2.tgz",
-      "integrity": "sha1-THmmiTxQDlyBet6NUAjnCfcYo8M=",
-      "requires": {
-        "govuk_frontend_toolkit": "^7.1.0"
-      },
-      "dependencies": {
-        "govuk_frontend_toolkit": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.6.0.tgz",
-          "integrity": "sha1-sJpgYxr7ukv6x2qLfALnJBnCnPU="
-        }
-      }
     },
     "govuk-frontend": {
       "version": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "cbor-js": "0.1.0",
     "govuk_frontend_toolkit": "8.1.0",
-    "govuk-elements-sass": "3.1.2",
     "govuk-frontend": "2.13.0",
     "hogan": "1.0.2",
     "jquery": "3.5.0",


### PR DESCRIPTION
Unoffical part 9 of this story:

https://www.pivotaltracker.com/story/show/182596680

Removes the GOVUK Elements NPM package and rolls in a fix for a list broken by the removal of GOVUK Elements styles that targeted `<ul>`s directly.

## Notes for reviewers

This just removes the package so a working build (`npm run build`) should be proof enough that nothing imports anything from it any more.