### PR TITLE
Remove GOVUK Frontend Toolkit [part 2]

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -10,7 +10,6 @@ $path: '/static/images/';
 @import 'colours';
 @import 'typography';
 @import 'grid_layout';
-@import 'helpers';
 
 // Dependencies from GOVU.UK Frontend Toolkit, rewritten for this application
 @import 'url-helpers';


### PR DESCRIPTION
This is part 2 of a series of work to remove the GOVUK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

This removes the `helper.scss` import from `main.scss` which only contains the `pem` function. I can't find any usage of it in this codebase or in GOVUK Elements so removing it is non-destructive:
- https://github.com/alphagov/notifications-admin/search?q=pem
- https://github.com/alphagov/govuk_elements/search?q=pem