### PR TITLE
Remove GOVUK Frontend Toolkit [part 3]

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -9,7 +9,6 @@ $path: '/static/images/';
 @import 'css3';
 @import 'colours';
 @import 'typography';
-@import 'grid_layout';
 
 // Dependencies from GOVU.UK Frontend Toolkit, rewritten for this application
 @import 'url-helpers';


### PR DESCRIPTION
This is part 3 of a series of work to remove the GOVUK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

This removes the Sass code for the GOVUK Frontend Toolkit's grid system. The toolkit's grid system was all converted to
GOVUK Frontend's one in https://github.com/alphagov/notifications-admin/pull/3321.

I tested this by searching for all the toolkit grid classes and Sass code. I found none of either in this codebase.