### PR TITLE
Add `govuk-list` class where it was missing

### DIFF
--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -29,7 +29,7 @@
     <h2 class="heading-small top-gutter">
       {{ events[0].time|format_date_human|title }}
     </h2>
-    <ul class="bottom-gutter">
+    <ul class="bottom-gutter govuk-list">
       {% for event in events %}
         <li class="history-list-item">
           <div class="govuk-grid-row">

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -38,7 +38,7 @@
     {{ live_search(target_selector='#template-list .template-list-item', show=True, form=search_form) }}
 
     <nav id="template-list">
-      <ul>
+      <ul class="govuk-list">
       {% for item in templates_and_folders %}
         <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           {% for ancestor in item.ancestors %}


### PR DESCRIPTION
This adds the `govuk-list` to two `<ul>` where it was missing and where we don't want the bullet points to be visible.

Hopefully I've now caught all the places that were missed in https://github.com/alphagov/notifications-admin/pull/4302