### PR TITLE
Update navigation landmarks give them all unique accessible names

### DIFF
--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -22,9 +22,10 @@
 {% endmacro %}
 
 {% macro sub_navigation(
-  item_set
+  item_set,
+  nav_label_prefix
 ) %}
-  <nav class="sub-navigation">
+  <nav class="sub-navigation" aria-label="{{ nav_label_prefix }}">
     <ol itemscope itemtype="http://schema.org/ItemList">
       {% for item in item_set %}
         {% if item.sub_navigation_items %}

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -1,4 +1,5 @@
 {% extends "withoutnav_template.html" %}
+
 {% from "components/sub-navigation.html" import sub_navigation %}
 {% from "components/page-header.html" import page_header %}
 
@@ -10,9 +11,9 @@
 
   <div class="govuk-grid-row">
 
-    {% if navigation_links %}
+    {% if navigation_links and navigation_label_prefix %}
       <div class="govuk-grid-column-one-quarter">
-        {{ sub_navigation(navigation_links) }}
+        {{ sub_navigation(navigation_links, navigation_label_prefix) }}
       </div>
       <div class="govuk-grid-column-five-eighths">
     {% else %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -1,7 +1,7 @@
 {% if help %}
   {% include 'partials/tour.html' %}
 {% else %}
-<nav class="navigation">
+<nav class="navigation" aria-label="Service">
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -1,4 +1,4 @@
-<nav class="navigation">
+<nav class="navigation" aria-label="Organisation">
   <ul>
     <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('dashboard') }}" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Usage</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>

--- a/app/templates/views/documentation.html
+++ b/app/templates/views/documentation.html
@@ -1,5 +1,8 @@
 {% extends "content_template.html" %}
 
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+
 {% block per_page_title %}
   Documentation
 {% endblock %}

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -1,6 +1,10 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Features

--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Emails

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Letters

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Text messages

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -1,10 +1,14 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
   Get started
 {% endblock %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block content_column_content %}
 

--- a/app/templates/views/guidance/branding-and-customisation.html
+++ b/app/templates/views/guidance/branding-and-customisation.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Branding and customisation

--- a/app/templates/views/guidance/create-and-send-messages.html
+++ b/app/templates/views/guidance/create-and-send-messages.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Send messages

--- a/app/templates/views/guidance/edit-and-format-messages.html
+++ b/app/templates/views/guidance/edit-and-format-messages.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Edit and format messages

--- a/app/templates/views/guidance/index.html
+++ b/app/templates/views/guidance/index.html
@@ -1,6 +1,10 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/sub-navigation.html" import sub_navigation %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Guidance

--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -1,6 +1,10 @@
 {% extends "content_template.html" %}
+
 {% from "components/service-link.html" import service_link %}
 {% from "components/details/macro.njk" import govukDetails %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Letter specification

--- a/app/templates/views/guidance/send-files-by-email.html
+++ b/app/templates/views/guidance/send-files-by-email.html
@@ -1,5 +1,8 @@
 {% extends "content_template.html" %}
 
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+
 {% block per_page_title %}
   Send files by email
 {% endblock %}

--- a/app/templates/views/guidance/upload-a-letter.html
+++ b/app/templates/views/guidance/upload-a-letter.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/service-link.html" import service_link %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Upload a letter

--- a/app/templates/views/guidance/who-can-use-notify.html
+++ b/app/templates/views/guidance/who-can-use-notify.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/page-header.html" import page_header %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Who can use Notify

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
 
 {% block per_page_title %}
   Delivery status

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -11,7 +11,7 @@
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
-        <nav class="navigation">
+        <nav class="navigation" aria-label="Platform admin">
             {% for link_text, url in [
             ('Summary', url_for('main.platform_admin')),
             ('Live services', url_for('main.live_services')),

--- a/app/templates/views/pricing/billing-details-signed-out.html
+++ b/app/templates/views/pricing/billing-details-signed-out.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/page-header.html" import page_header %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Pricing information' %}
 
 {% block per_page_title %}
   Billing details

--- a/app/templates/views/pricing/billing-details.html
+++ b/app/templates/views/pricing/billing-details.html
@@ -1,7 +1,10 @@
 {% extends "content_template.html" %}
-{% from "components/page-header.html" import page_header %}
 
+{% from "components/page-header.html" import page_header %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Pricing information' %}
 
 {% block per_page_title %}
   Billing details

--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/page-header.html" import page_header %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Pricing information' %}
 
 {% block per_page_title %}
   How to pay

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -1,9 +1,12 @@
+{% extends "content_template.html" %}
+
 {% from "components/content-metadata.html" import content_metadata %}
 {% from "components/table.html" import mapping_table, row, text_field, field, row_heading %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/details/macro.njk" import govukDetails %}
 
-{% extends "content_template.html" %}
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Pricing information' %}
 
 {% block per_page_title %}
   Pricing

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -1,6 +1,10 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/content-metadata.html" import content_metadata %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Roadmap

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Security

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -1,5 +1,9 @@
 {% extends "content_template.html" %}
+
 {% from "components/banner.html" import banner_wrapper %}
+
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'About Notify' %}
 
 {% block per_page_title %}
   Terms of use

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -1,5 +1,8 @@
 {% extends "content_template.html" %}
 
+{# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
+{% set navigation_label_prefix = 'Using Notify' %}
+
 {% block per_page_title %}
   Trial mode
 {% endblock %}

--- a/app/templates/views/using-notify.html
+++ b/app/templates/views/using-notify.html
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    {{ sub_navigation(navigation_links) }}
+    {{ sub_navigation(navigation_links, 'Using Notify') }}
   </div>
   <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
Makes all `<nav>` tags on our pages uniquely labelled by giving all except one a label.

https://www.pivotaltracker.com/story/show/176180604

Note: the accessible name for a `<nav>` tag is computed as its role (ie. "navigation") prefixed by its label, if it has one (ie. "Service"). So a `<nav>` with `aria-label="Service"` would have an accessible name of "Service navigation"

## Pages involved

### Information pages

Each page's side navigation gets its label from the `navigation_label_prefix` variable, like this:

```jinja
{% set navigation_label_prefix = 'Using Notify' %}
```

#### 'Using Notify'

- app/templates/views/get-started.html
- app/templates/views/message-status.html
- app/templates/views/trial-mode.html
- app/templates/views/guidance/index.html
app/templates/views/guidance/create-and-send-messages.html
- app/templates/views/guidance/edit-and-format-messages.html
- app/templates/views/guidance/branding-and-customisation.html
- app/templates/views/guidance/send-files-by-email.html
- app/templates/views/guidance/upload-a-letter.html
- app/templates/views/guidance/letter-specification.html
- app/templates/views/documentation.html

Example on live: https://www.notifications.service.gov.uk/using-notify/get-started

#### 'About Notify'

- app/templates/views/features.html
- app/templates/views/features/emails.html
- app/templates/views/features/text-messages.html
- app/templates/views/features/letters.html
- app/templates/views/roadmap.html
- app/templates/views/guidance/who-can-use-notify.html
- app/templates/views/security.html
- app/templates/views/terms-of-use.html

Example on live: https://www.notifications.service.gov.uk/features

#### Pricing

- app/templates/views/pricing/index.html
- app/templates/views/pricing/billing-details-signed-out.html
- app/templates/views/pricing/billing-details.html
- app/templates/views/pricing/how-to-pay.html

Example on live: https://www.notifications.service.gov.uk/pricing

### Service pages

All the service pages use `app/templates/main_nav.html` for their side navigation so adding a label to this changes all of them.

Example on live: https://www.notifications.service.gov.uk/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553

### Organisation pages

All the organisation pages use `app/templates/org_nav.html` for their side navigation so adding a label to this changes all of them.

Example on live: https://www.notifications.service.gov.uk/organisations/ee0e5030-3a7b-4da8-8685-b6efb770231f

### Platform admin pages

The platform admin pages use `app/templates/views/platform-admin/_base_template.html` for the bits they all share. This includes the side navigation so adding a label here changes all of them.

Example on live: https://www.notifications.service.gov.uk/platform-admin

## Notes for reviewers

The content should be reviewed as well as the code changes, so I've assigned @saimaghafoor for that. For the content review, I'm happy to either demo it or you can check the changes against how the accessible name is computed (see explanation above).