### PR TITLE
Don’t allow @ symbol in organisation domains

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 # Bulk changes for black formatting changes
 8a9ee35a0a4d9e1f8a8547af382ff4db630ddd5f
-
+508d2d2568fa116ab65a5de56284c6bb6c4e46a5

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
-# Bulk change for black formatting changes
+# Bulk changes for black formatting changes
 8a9ee35a0a4d9e1f8a8547af382ff4db630ddd5f
+

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -58,12 +58,12 @@ from app.formatters import (
 )
 from app.main.validators import (
     BroadcastLength,
+    CharactersNotAllowed,
     CommonlyUsedPassword,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly,
     MustContainAlphanumericCharacters,
-    NoAtSymbols,
     NoCommasInPlaceHolders,
     NoEmbeddedImagesInSVG,
     NoPlaceholders,
@@ -1166,7 +1166,7 @@ class AdminOrganisationDomainsForm(StripWhitespaceForm):
         StripWhitespaceStringField(
             "",
             validators=[
-                NoAtSymbols(),
+                CharactersNotAllowed('@'),
                 Optional(),
             ],
             default="",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -63,6 +63,7 @@ from app.main.validators import (
     DoesNotStartWithDoubleZero,
     LettersNumbersSingleQuotesFullStopsAndUnderscoresOnly,
     MustContainAlphanumericCharacters,
+    NoAtSymbols,
     NoCommasInPlaceHolders,
     NoEmbeddedImagesInSVG,
     NoPlaceholders,
@@ -1165,6 +1166,7 @@ class AdminOrganisationDomainsForm(StripWhitespaceForm):
         StripWhitespaceStringField(
             "",
             validators=[
+                NoAtSymbols(),
                 Optional(),
             ],
             default="",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1166,7 +1166,7 @@ class AdminOrganisationDomainsForm(StripWhitespaceForm):
         StripWhitespaceStringField(
             "",
             validators=[
-                CharactersNotAllowed('@'),
+                CharactersNotAllowed("@"),
                 Optional(),
             ],
             default="",

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -183,3 +183,13 @@ class MustContainAlphanumericCharacters:
     def __call__(self, form, field):
         if field.data and not re.match(self.regex, field.data):
             raise ValidationError(self.message)
+
+
+class NoAtSymbols:
+
+    def __init__(self, message='Enter a domain name without a leading ‘@’'):
+        self.message = message
+
+    def __call__(self, form, field):
+        if '@' in field.data:
+            raise ValidationError(self.message)

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -187,7 +187,6 @@ class MustContainAlphanumericCharacters:
 
 
 class CharactersNotAllowed:
-
     def __init__(self, characters_not_allowed, *, message=None):
         self.characters_not_allowed = OrderedSet(characters_not_allowed)
         self.message = message
@@ -199,6 +198,6 @@ class CharactersNotAllowed:
             if self.message:
                 raise ValidationError(self.message)
             raise ValidationError(
-                f'Cannot contain '
+                f"Cannot contain "
                 f'{formatted_list(illegal_characters, conjunction="or", before_each="", after_each="")}'
             )

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -664,7 +664,7 @@ def edit_organisation_domains(org_id):
                 raise e
         return redirect(url_for(".organisation_settings", org_id=org_id))
 
-    if request.method == 'GET':
+    if request.method == "GET":
         form.populate(current_organisation.domains)
 
     return render_template(

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -664,7 +664,8 @@ def edit_organisation_domains(org_id):
                 raise e
         return redirect(url_for(".organisation_settings", org_id=org_id))
 
-    form.populate(current_organisation.domains)
+    if request.method == 'GET':
+        form.populate(current_organisation.domains)
 
     return render_template(
         "views/organisations/organisation/settings/edit-domains.html",

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -4,6 +4,7 @@
 {% from "components/list-entry.html" import list_entry %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/banner.html" import banner_wrapper %}
 
 {% block org_page_title %}
   Known email domains
@@ -14,6 +15,25 @@
 {% endblock %}
 
 {% block maincolumn_content %}
+
+  {% if form.domains.errors %}
+    {% call banner_wrapper(type='dangerous') %}
+
+      <h1 class='banner-title'>
+        There is a problem
+      </h1>
+
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+        {% for field_errors in form.domains.errors %}
+          {% if field_errors %}
+            <li>Item {{ loop.index }}: {{ field_errors[0] }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+
+    {% endcall %}
+  {% endif %}
+
   {{ page_header("Known email domains") }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -131,16 +131,15 @@ def test_if_string_contains_alphanumeric_characters_does_not_raise(string):
 
 def test_string_cannot_contain_characters():
     with pytest.raises(ValidationError) as error:
-        CharactersNotAllowed('abcdef')(None, _gen_mock_field('abc'))
+        CharactersNotAllowed("abcdef")(None, _gen_mock_field("abc"))
 
     assert str(error.value) == "Cannot contain a, b or c"
 
 
 def test_string_cannot_contain_characters_with_custom_error_message():
     with pytest.raises(ValidationError) as error:
-        CharactersNotAllowed(
-            'abcdef',
-            message='Cannot use first 3 letters of the alphabet'
-        )(None, _gen_mock_field('abc'))
+        CharactersNotAllowed("abcdef", message="Cannot use first 3 letters of the alphabet")(
+            None, _gen_mock_field("abc")
+        )
 
     assert str(error.value) == "Cannot use first 3 letters of the alphabet"

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -4,6 +4,7 @@ import pytest
 from wtforms import ValidationError
 
 from app.main.validators import (
+    CharactersNotAllowed,
     MustContainAlphanumericCharacters,
     NoCommasInPlaceHolders,
     OnlySMSCharacters,
@@ -126,3 +127,20 @@ def test_if_string_does_not_contain_alphanumeric_characters_raises(string):
 @pytest.mark.parametrize("string", [".A8", "AB.", ".42...."])
 def test_if_string_contains_alphanumeric_characters_does_not_raise(string):
     MustContainAlphanumericCharacters()(None, _gen_mock_field(string))
+
+
+def test_string_cannot_contain_characters():
+    with pytest.raises(ValidationError) as error:
+        CharactersNotAllowed('abcdef')(None, _gen_mock_field('abc'))
+
+    assert str(error.value) == "Cannot contain a, b or c"
+
+
+def test_string_cannot_contain_characters_with_custom_error_message():
+    with pytest.raises(ValidationError) as error:
+        CharactersNotAllowed(
+            'abcdef',
+            message='Cannot use first 3 letters of the alphabet'
+        )(None, _gen_mock_field('abc'))
+
+    assert str(error.value) == "Cannot use first 3 letters of the alphabet"

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1473,8 +1473,8 @@ def test_update_organisation_domains_with_more_than_just_domain(
         page.select_one(".banner-dangerous").text
      ) == (
         "There is a problem "
-        "Item 1: Enter a domain name without a leading ‘@’ "
-        "Item 3: Enter a domain name without a leading ‘@’"
+        "Item 1: Cannot contain @ "
+        "Item 3: Cannot contain @"
     )
 
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1452,11 +1452,18 @@ def test_update_organisation_domains_with_more_than_just_domain(
     mocker,
     client_request,
     fake_uuid,
-    organisation_one,
-    mock_get_organisation,
 ):
     user = create_platform_admin_user()
     client_request.login(user)
+
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        side_effect=lambda org_id: organisation_json(
+            org_id,
+            "Org 1",
+            domains=["test.example.gov.uk"],
+        ),
+    )
 
     page = client_request.post(
         'main.edit_organisation_domains',
@@ -1476,6 +1483,14 @@ def test_update_organisation_domains_with_more_than_just_domain(
         "Item 1: Cannot contain @ "
         "Item 3: Cannot contain @"
     )
+
+    assert [
+        field['value'] for field in page.select("input[type=text][value]")
+    ] == [
+        'test@example.gov.uk',
+        'example.gov.uk',
+        '@example.gov.uk',
+    ]
 
 
 def test_update_organisation_name(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1448,6 +1448,36 @@ def test_update_organisation_domains_when_domain_already_exists(
     assert response.select_one("div.banner-dangerous").text.strip() == "This domain is already in use"
 
 
+def test_update_organisation_domains_with_more_than_just_domain(
+    mocker,
+    client_request,
+    fake_uuid,
+    organisation_one,
+    mock_get_organisation,
+):
+    user = create_platform_admin_user()
+    client_request.login(user)
+
+    page = client_request.post(
+        'main.edit_organisation_domains',
+        org_id=ORGANISATION_ID,
+        _data={
+            'domains-0': 'test@example.gov.uk',
+            'domains-1': 'example.gov.uk',
+            'domains-2': '@example.gov.uk',
+        },
+        _expected_status=200,
+    )
+
+    assert normalize_spaces(
+        page.select_one(".banner-dangerous").text
+     ) == (
+        "There is a problem "
+        "Item 1: Enter a domain name without a leading ‘@’ "
+        "Item 3: Enter a domain name without a leading ‘@’"
+    )
+
+
 def test_update_organisation_name(
     client_request,
     platform_admin_user,

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1466,30 +1466,24 @@ def test_update_organisation_domains_with_more_than_just_domain(
     )
 
     page = client_request.post(
-        'main.edit_organisation_domains',
+        "main.edit_organisation_domains",
         org_id=ORGANISATION_ID,
         _data={
-            'domains-0': 'test@example.gov.uk',
-            'domains-1': 'example.gov.uk',
-            'domains-2': '@example.gov.uk',
+            "domains-0": "test@example.gov.uk",
+            "domains-1": "example.gov.uk",
+            "domains-2": "@example.gov.uk",
         },
         _expected_status=200,
     )
 
-    assert normalize_spaces(
-        page.select_one(".banner-dangerous").text
-     ) == (
-        "There is a problem "
-        "Item 1: Cannot contain @ "
-        "Item 3: Cannot contain @"
+    assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
+        "There is a problem " "Item 1: Cannot contain @ " "Item 3: Cannot contain @"
     )
 
-    assert [
-        field['value'] for field in page.select("input[type=text][value]")
-    ] == [
-        'test@example.gov.uk',
-        'example.gov.uk',
-        '@example.gov.uk',
+    assert [field["value"] for field in page.select("input[type=text][value]")] == [
+        "test@example.gov.uk",
+        "example.gov.uk",
+        "@example.gov.uk",
     ]
 
 


### PR DESCRIPTION
The domain will only work if it’s just the domain. If it’s an email address or part thereof it won’t be accepted.

We have a few of these in our production database, let’s not have any more.