### PR TITLE
Remove GOV.UK Frontend Toolkit [part 5]

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -198,19 +198,19 @@ details .arrow {
 @keyframes live-pulse {
   0%   {
     background: govuk-colour("red");
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px $white;
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px govuk-colour("white");
   }
   40%   {
     background: govuk-colour("red");
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px $white;
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px govuk-colour("white");
   }
   50% {
-    background: $white;
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 2px $white;
+    background: govuk-colour("white");
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 2px govuk-colour("white");
   }
   100% {
-    background: $white;
-    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px $white;
+    background: govuk-colour("white");
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px govuk-colour("white");
   }
 }
 
@@ -233,7 +233,6 @@ details .arrow {
     height: 19px;
     border-radius: 50%;
     animation: live-pulse 1.5s infinite;
-    //box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 5px $white;
   }
 
   &--left {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -83,7 +83,7 @@ details summary {
 
   th,
   .table-field-index {
-    background: $grey-4;
+    background: govuk-colour("grey-4");
     font-weight: bold;
     text-align: center;
   }
@@ -113,7 +113,7 @@ details summary {
     z-index: 1000;
 
     .table-field-heading-first {
-      background: $grey-4;
+      background: govuk-colour("grey-4");
     }
 
   }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -183,7 +183,7 @@ details .arrow {
 
 .bordered-text-box {
   padding: 5px;
-  outline: 2px solid $black;
+  outline: 2px solid $govuk-input-border-colour;
   max-width: 100%;
 }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -59,7 +59,7 @@ td {
 }
 
 .hint {
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
 
   .form-label + & {
     display: block;
@@ -173,7 +173,7 @@ details .arrow {
 
 .multiple-choice input:disabled+label {
   opacity: 1;
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   cursor: default;
 }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -91,7 +91,7 @@ details summary {
   th, td {
     padding-left: 10px;
     padding-right: 10px;
-    border: 1px solid $border-colour;
+    border: 1px solid $govuk-border-colour;
   }
 
   td {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -197,26 +197,26 @@ details .arrow {
 
 @keyframes live-pulse {
   0%   {
-    background: $red;
-    box-shadow: inset 0 0 0 2px $red, inset 0 0 0 4px $white;
+    background: govuk-colour("red");
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px $white;
   }
   40%   {
-    background: $red;
-    box-shadow: inset 0 0 0 2px $red, inset 0 0 0 4px $white;
+    background: govuk-colour("red");
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px $white;
   }
   50% {
     background: $white;
-    box-shadow: inset 0 0 0 2px $red, inset 0 0 0 2px $white;
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 2px $white;
   }
   100% {
     background: $white;
-    box-shadow: inset 0 0 0 2px $red, inset 0 0 0 4px $white;
+    box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 4px $white;
   }
 }
 
 .live-broadcast {
 
-  color: $red;
+  color: govuk-colour("red");
   font-weight: bold;
   position: relative;
   display: inline-block;
@@ -228,12 +228,12 @@ details .arrow {
     margin-top: 1px;
     margin-left: 5px;
     border: none;
-    background: $red;
+    background: govuk-colour("red");
     width: 19px;
     height: 19px;
     border-radius: 50%;
     animation: live-pulse 1.5s infinite;
-    //box-shadow: inset 0 0 0 2px $red, inset 0 0 0 5px $white;
+    //box-shadow: inset 0 0 0 2px govuk-colour("red"), inset 0 0 0 5px $white;
   }
 
   &--left {

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -37,7 +37,7 @@
       }
 
       &:hover {
-        color: $light-blue-25;
+        color: govuk-tint(govuk-colour("light-blue"), 75);
       }
 
       // set styles so they don't get overriden by govuk-button styles
@@ -103,9 +103,9 @@
 
     &--unremoveable {
       padding-right: govuk-spacing(2);
-      background: $light-blue-25;
+      background: govuk-tint(govuk-colour("light-blue"), 75);
       color: mix(govuk-colour("black"), $govuk-brand-colour, 66%);
-      border-color: $light-blue-25;
+      border-color: govuk-tint(govuk-colour("light-blue"), 75);
       margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
       font-weight: bold;
     }
@@ -146,7 +146,7 @@
   &--certain {
     &:before {
       border: 2px solid $govuk-input-border-colour;
-      background: $light-blue-50;
+      background: govuk-tint(govuk-colour("light-blue"), 50);
     }
   }
 
@@ -155,7 +155,7 @@
       padding: 1px;
       border: 2px dashed $govuk-brand-colour;
       border-image: file-url('dashed-border-govuk-blue.svg') 4 round;
-      background: $light-blue-25;
+      background: govuk-tint(govuk-colour("light-blue"), 75);
     }
   }
 

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -5,7 +5,7 @@
   &-item {
 
     display: inline-block;
-    border: 2px solid $black;
+    border: 2px solid $govuk-input-border-colour;
     // Create space for the remove link on the right of the list item (including borders)
     padding: (govuk-spacing(1) + 1px) (govuk-spacing(2) + 37px) govuk-spacing(1) govuk-spacing(2);
     margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
@@ -64,18 +64,18 @@
       &,
       &:focus,
       &:focus:not(:active):not(:hover) {
-        box-shadow: -2px 0 0 0 $black, inset 1px 0 0 0 rgba($white, 0.1);
+        box-shadow: -2px 0 0 0 $govuk-focus-text-colour, inset 1px 0 0 0 rgba($white, 0.1);
       }
 
       // set styles so they don't get overriden by govuk-button styles
       &:focus,
       &:focus:not(:active):not(:hover) {
-        border-color: $black;
+        border-color: $govuk-input-border-colour;
       }
 
       &:focus:hover {
         background-color: $govuk-focus-colour;
-        color: $black;
+        color: $govuk-focus-text-colour;
       }
 
       // show outline to make focus visible when background colours are overridden
@@ -104,7 +104,7 @@
     &--unremoveable {
       padding-right: govuk-spacing(2);
       background: $light-blue-25;
-      color: mix($black, $govuk-brand-colour, 66%);
+      color: mix(govuk-colour("black"), $govuk-brand-colour, 66%);
       border-color: $light-blue-25;
       margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
       font-weight: bold;
@@ -145,7 +145,7 @@
 
   &--certain {
     &:before {
-      border: 2px solid $black;
+      border: 2px solid $govuk-input-border-colour;
       background: $light-blue-50;
     }
   }

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -182,7 +182,7 @@
   .govuk-details__text {
     padding: 0;
     border: none;
-    border-bottom: 1px solid $border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
     margin-top: -1px;
   }
 

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -64,7 +64,7 @@
       &,
       &:focus,
       &:focus:not(:active):not(:hover) {
-        box-shadow: -2px 0 0 0 $govuk-focus-text-colour, inset 1px 0 0 0 rgba($white, 0.1);
+        box-shadow: -2px 0 0 0 $govuk-focus-text-colour, inset 1px 0 0 0 rgba(govuk-colour("white"), 0.1);
       }
 
       // set styles so they don't get overriden by govuk-button styles

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -24,7 +24,7 @@
       bottom: -2px; // cover list-item border-bottom
       width: 37px;
       padding: 0;
-      border: 2px solid $govuk-blue;
+      border: 2px solid $govuk-brand-colour;
       border-left: none;
       text-align: center;
       font-size: inherit; // counter govuk-button styles
@@ -33,7 +33,7 @@
       // set styles so they don't get overriden by govuk-button styles
       &,
       &:hover {
-        background: $govuk-blue;
+        background: $govuk-brand-colour;
       }
 
       &:hover {
@@ -54,7 +54,7 @@
         &:active,
         &:hover,
         &:focus:not(:active):not(:hover) {
-          border-left: 2px solid $govuk-blue;
+          border-left: 2px solid $govuk-brand-colour;
           color: LinkText;
         }
 
@@ -104,7 +104,7 @@
     &--unremoveable {
       padding-right: govuk-spacing(2);
       background: $light-blue-25;
-      color: mix($black, $govuk-blue, 66%);
+      color: mix($black, $govuk-brand-colour, 66%);
       border-color: $light-blue-25;
       margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
       font-weight: bold;
@@ -153,7 +153,7 @@
   &--likely {
     &:before {
       padding: 1px;
-      border: 2px dashed $govuk-blue;
+      border: 2px dashed $govuk-brand-colour;
       border-image: file-url('dashed-border-govuk-blue.svg') 4 round;
       background: $light-blue-25;
     }

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -104,7 +104,7 @@
     &--unremoveable {
       padding-right: govuk-spacing(2);
       background: govuk-tint(govuk-colour("light-blue"), 75);
-      color: mix(govuk-colour("black"), $govuk-brand-colour, 66%);
+      color: govuk-tint($govuk-brand-colour, 33%);
       border-color: govuk-tint(govuk-colour("light-blue"), 75);
       margin: 0 govuk-spacing(1) govuk-spacing(2) 0;
       font-weight: bold;

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -3,14 +3,16 @@
 .banner-default {
 
   @include govuk-font(19, $weight: bold);
-  color: $button-colour;
+  // TODO: replace with `$govuk-success-colour` when GOV.UK Frontend version >= 3.10.0
+  color: govuk-colour("green");
   display: block;
   padding: govuk-spacing(3);
   margin: govuk-spacing(3) 0 govuk-spacing(6) 0;
   text-align: left;
   position: relative;
   clear: both;
-  border: 5px solid $button-colour;
+  // TODO: replace with `$govuk-success-colour` when GOV.UK Frontend version >= 3.10.0
+  border: 5px solid govuk-colour("green");
 
   &-title {
     @include govuk-font(24, $weight: bold);

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -52,7 +52,7 @@
 
   @extend %banner;
   @include govuk-font(19, $weight: bold);
-  background: $white;
+  background: govuk-colour("white");
   color: $text-colour;
   border: 5px solid $error-colour;
   margin: 15px 0;
@@ -72,7 +72,7 @@
 
   @extend %banner;
   background: $govuk-brand-colour;
-  color: $white;
+  color: govuk-colour("white");
   margin-top: 10px;
   margin-bottom: 0;
   padding: govuk-spacing(6);
@@ -101,7 +101,7 @@
 
     margin-top: 0;
     margin-bottom: govuk-spacing(6);
-    color: $white;
+    color: govuk-colour("white");
 
     &:last-child {
       margin-bottom: 0;
@@ -115,7 +115,7 @@
 
   ul {
     @include govuk-font(24);
-    color: $white;
+    color: govuk-colour("white");
     margin-bottom: govuk-spacing(5);
   }
 
@@ -134,11 +134,11 @@
 
     &:link,
     &:visited {
-      color: $white;
+      color: govuk-colour("white");
     }
 
     &:hover {
-      color: $white;
+      color: govuk-colour("white");
       background-color: $link-hover-colour;
       box-shadow: 0 0 0 10px $link-hover-colour;
     }

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -53,7 +53,7 @@
   @extend %banner;
   @include govuk-font(19, $weight: bold);
   background: govuk-colour("white");
-  color: $text-colour;
+  color: $govuk-text-colour;
   border: 5px solid $error-colour;
   margin: 15px 0;
   text-align: left;

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -173,8 +173,8 @@
   align-items: baseline;
   flex-wrap: wrap;
   padding: (govuk-spacing(3) - 1px) 0 (govuk-spacing(3) + 1px) 0;
-  border-top: 1px solid $border-colour;
-  border-bottom: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
   margin-bottom: govuk-spacing(6);
   text-decoration: none;
 

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -54,7 +54,7 @@
   @include govuk-font(19, $weight: bold);
   background: govuk-colour("white");
   color: $govuk-text-colour;
-  border: 5px solid $error-colour;
+  border: 5px solid $govuk-error-colour;
   margin: 15px 0;
   text-align: left;
 

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -139,8 +139,8 @@
 
     &:hover {
       color: govuk-colour("white");
-      background-color: $link-hover-colour;
-      box-shadow: 0 0 0 10px $link-hover-colour;
+      background-color: $govuk-link-hover-colour;
+      box-shadow: 0 0 0 10px $govuk-link-hover-colour;
     }
 
     &:focus,

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -71,7 +71,7 @@
 .banner-tour {
 
   @extend %banner;
-  background: $govuk-blue;
+  background: $govuk-brand-colour;
   color: $white;
   margin-top: 10px;
   margin-bottom: 0;
@@ -90,7 +90,7 @@
   &-with-service-name {
     margin-top: -10px;
     padding-top: 0;
-    box-shadow: 0 -1px 0 0 darken($govuk-blue, 10%);
+    box-shadow: 0 -1px 0 0 darken($govuk-brand-colour, 10%);
   }
 
   .heading-medium {

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -98,13 +98,13 @@
 
     &:hover {
 
-      color: $light-blue-25;
+      color: govuk-tint(govuk-colour("light-blue"), 75);
 
       .big-number,
       .big-number-number,
       .big-number-smaller,
       .big-number-label {
-        color: $light-blue-25;
+        color: govuk-tint(govuk-colour("light-blue"), 75);
       }
 
     }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -175,7 +175,7 @@
 
   position: relative;
   margin: govuk-spacing(3) 0 govuk-spacing(6) 0;
-  background: $govuk-blue;
+  background: $govuk-brand-colour;
 
   .big-number-meta {
 

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -141,7 +141,7 @@
 
     @include govuk-font(19);
     display: block;
-    background: $green;
+    background: govuk-colour("green");
     color: $white;
     padding: 15px;
 

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -35,7 +35,7 @@
   padding: govuk-spacing(3);
   position: relative;
   background: govuk-colour("black");
-  color: $white;
+  color: govuk-colour("white");
 
   .big-number-number {
     @include govuk-font(36, $weight: bold, $tabular: true);
@@ -73,7 +73,7 @@
     padding: govuk-spacing(3);
     position: relative;
     background: govuk-colour("black");
-    color: $white;
+    color: govuk-colour("white");
   }
 
   .big-number-label {
@@ -91,7 +91,7 @@
 
     text-decoration: none;
     background: $link-colour;
-    color: $white;
+    color: govuk-colour("white");
     display: block;
     border: 2px solid $link-colour;
     margin-bottom: 5px;
@@ -142,7 +142,7 @@
     @include govuk-font(19);
     display: block;
     background: govuk-colour("green");
-    color: $white;
+    color: govuk-colour("white");
     padding: 15px;
 
     a {
@@ -151,7 +151,7 @@
       &:visited,
       &:active,
       &:hover {
-        color: $white;
+        color: govuk-colour("white");
         text-decoration: underline;
       }
 
@@ -180,7 +180,7 @@
   .big-number-meta {
 
     padding: govuk-spacing(2) govuk-spacing(3);
-    color: $white;
+    color: govuk-colour("white");
     pointer-events: none;
 
     @include media(desktop) {

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -82,7 +82,7 @@
 
     &:link,
     &:visited {
-      color: $link-colour;
+      color: $govuk-link-colour;
     }
 
   }
@@ -90,10 +90,10 @@
   .big-number-link {
 
     text-decoration: none;
-    background: $link-colour;
+    background: $govuk-link-colour;
     color: govuk-colour("white");
     display: block;
-    border: 2px solid $link-colour;
+    border: 2px solid $govuk-link-colour;
     margin-bottom: 5px;
 
     &:hover {

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -166,7 +166,7 @@
 
   .big-number-status-failing {
     @extend %big-number-status;
-    background: $error-colour;
+    background: $govuk-error-colour;
   }
 
 }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -34,7 +34,7 @@
   @extend %big-number;
   padding: govuk-spacing(3);
   position: relative;
-  background: $black;
+  background: govuk-colour("black");
   color: $white;
 
   .big-number-number {
@@ -72,7 +72,7 @@
   .big-number-smaller {
     padding: govuk-spacing(3);
     position: relative;
-    background: $black;
+    background: govuk-colour("black");
     color: $white;
   }
 
@@ -157,7 +157,7 @@
 
       &:active,
       &:focus {
-        color: $black;
+        color: $govuk-focus-text-colour;
       }
 
     }

--- a/app/assets/stylesheets/components/broadcast-message.scss
+++ b/app/assets/stylesheets/components/broadcast-message.scss
@@ -26,7 +26,7 @@
     width: calc(100% + 2px); // grow to overlap wrapper's border (when combined with top and left)
     box-sizing: border-box;
     font-weight: bold;
-    background: $grey-1;
+    background: govuk-colour("grey-1");
     color: $white;
     border-top-right-radius: 5px;
     border-top-left-radius: 5px;

--- a/app/assets/stylesheets/components/broadcast-message.scss
+++ b/app/assets/stylesheets/components/broadcast-message.scss
@@ -7,7 +7,7 @@
     box-sizing: border-box;
     padding: govuk-spacing(9) govuk-spacing(3) govuk-spacing(3) govuk-spacing(3);
     border: solid 1px transparent; // to show it's area in high contrast mode
-    background: $panel-colour;
+    background: govuk-colour("grey-3");
     box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.05);
     border-radius: 5px;
     white-space: normal;

--- a/app/assets/stylesheets/components/broadcast-message.scss
+++ b/app/assets/stylesheets/components/broadcast-message.scss
@@ -27,7 +27,7 @@
     box-sizing: border-box;
     font-weight: bold;
     background: govuk-colour("grey-1");
-    color: $white;
+    color: govuk-colour("white");
     border-top-right-radius: 5px;
     border-top-left-radius: 5px;
     box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -23,6 +23,6 @@
   &-hint {
     @include govuk-font(19);
     margin: 5px 0 10px 0;
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
   }
 }

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -33,7 +33,7 @@ $govuk-checkboxes-size: 40px;
     $circle-diameter: 39px;
     $border-thickness: 4px;
     $border-indent: ($circle-diameter / 2) - ($border-thickness / 2);
-    $border-colour: $border-colour;
+    $govuk-border-colour: $govuk-border-colour;
 
     float: none;
     position: relative;
@@ -45,7 +45,7 @@ $govuk-checkboxes-size: 40px;
       left: $border-indent;
       width: $border-thickness;
       height: 100%;
-      background: $border-colour;
+      background: $govuk-border-colour;
     }
 
     label {

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -54,7 +54,7 @@ $govuk-checkboxes-size: 40px;
 
     [type=checkbox]+label::before {
       // To overlap the grey inset line
-      background: $white;
+      background: govuk-colour("white");
     }
 
     ul {

--- a/app/assets/stylesheets/components/conditional-radios.scss
+++ b/app/assets/stylesheets/components/conditional-radios.scss
@@ -7,7 +7,7 @@ $top-spacing: govuk-spacing(5);
 
   .block-label {
     &:before {
-      box-shadow: 0 5px 0 0 $white;
+      box-shadow: 0 5px 0 0 govuk-colour("white");
     }
   }
 

--- a/app/assets/stylesheets/components/conditional-radios.scss
+++ b/app/assets/stylesheets/components/conditional-radios.scss
@@ -16,7 +16,7 @@ $top-spacing: govuk-spacing(5);
 .conditional-radios {
 
   &-panel {
-    border-left: $border-thickness solid $border-colour;
+    border-left: $border-thickness solid $govuk-border-colour;
     margin: 0 0 (-1 * govuk-spacing(3)) (govuk-spacing(3) + ($border-thickness / 2));
     padding: govuk-spacing(3) 0 0 (govuk-spacing(6) - ($border-thickness / 2));
     position: relative;

--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -21,7 +21,7 @@ $email-message-gutter: govuk-spacing(9);
     }
 
     th {
-      color: $secondary-text-colour;
+      color: $govuk-secondary-text-colour;
       padding-left: $email-message-gutter;
     }
 

--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -1,5 +1,3 @@
-$white-50-opaque: rgba($white, 0.5);
-$button-bottom-border-colour: rgba(0, 0, 0, 0.17);
 $email-message-gutter: govuk-spacing(9);
 
 // sass-lint:disable no-important

--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -5,7 +5,7 @@ $email-message-gutter: govuk-spacing(9);
 .email-message {
 
   margin-bottom: govuk-spacing(6);
-  border: 1px solid $border-colour;
+  border: 1px solid $govuk-border-colour;
 
   &-meta {
 
@@ -16,7 +16,7 @@ $email-message-gutter: govuk-spacing(9);
     th {
       @include govuk-font(19);
       border-top: 0;
-      border-bottom: 1px solid $border-colour;
+      border-bottom: 1px solid $govuk-border-colour;
       vertical-align: top;
     }
 

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -9,7 +9,7 @@
     margin: 0 0 govuk-spacing(6) 0;
     padding: 0 0 0 0;
     overflow: hidden;
-    border-bottom: 1px solid $border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
 
     .table {
 
@@ -46,7 +46,7 @@
         transition: box-shadow 0.6s ease-out;
       }
 
-      box-shadow: inset -1px 0 0 0 $border-colour, inset -3px 0 0 0 rgba($border-colour, 0.2);
+      box-shadow: inset -1px 0 0 0 $govuk-border-colour, inset -3px 0 0 0 rgba($govuk-border-colour, 0.2);
 
     }
 
@@ -124,7 +124,7 @@
     .table-field-heading-first,
     .table-field-index {
       transition: box-shadow 0.3s ease-in-out;
-      box-shadow: 1px 0 0 0 $border-colour, 3px 0 0 0 rgba($border-colour, 0.2);
+      box-shadow: 1px 0 0 0 $govuk-border-colour, 3px 0 0 0 rgba($govuk-border-colour, 0.2);
     }
 
   }

--- a/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/app/assets/stylesheets/components/fullscreen-table.scss
@@ -2,7 +2,7 @@
 
   &-content {
 
-    background: $white;
+    background: govuk-colour("white");
     z-index: 10;
     overflow-y: hidden;
     box-sizing: border-box;
@@ -17,7 +17,7 @@
 
       tr:last-child {
         td {
-          border-bottom: 1px solid $white;
+          border-bottom: 1px solid govuk-colour("white");
         }
       }
 
@@ -65,7 +65,7 @@
     .table-field-left-aligned {
       position: relative;
       z-index: 150;
-      background: $white;
+      background: govuk-colour("white");
     }
 
     &::-webkit-scrollbar {
@@ -74,17 +74,17 @@
 
     &::-webkit-scrollbar:horizontal {
       height: 11px;
-      background-color: $white;
+      background-color: govuk-colour("white");
     }
 
     &::-webkit-scrollbar-thumb {
       border-radius: 8px;
-      border: 2px solid $white;
+      border: 2px solid govuk-colour("white");
       background-color: rgba(0, 0, 0, .5);
     }
 
     &::-webkit-scrollbar-track {
-      background-color: $white;
+      background-color: govuk-colour("white");
       border-radius: 8px;
     }
 
@@ -112,7 +112,7 @@
       transition: none;
       position: relative;
       z-index: 200;
-      background: $white;
+      background: govuk-colour("white");
     }
 
   }

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -19,7 +19,7 @@ $iso-paper-ratio: 141.42135624%;
     left: 50%;
     margin-left: -0.5em;
     font-size: 96px;
-    color: $white;
+    color: govuk-colour("white");
     overflow: hidden;
     display: block;
     vertical-align: bottom;
@@ -86,7 +86,7 @@ $iso-paper-ratio: 141.42135624%;
   img {
     display: block;
     width: 100%;
-    background: $white;
+    background: govuk-colour("white");
     position: absolute;
     top: 0;
     left: 0;

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -35,7 +35,7 @@ $iso-paper-ratio: 141.42135624%;
     left: 0;
     width: 100%;
     height: 100%;
-    box-shadow: inset 0 0 0 1px $border-colour;
+    box-shadow: inset 0 0 0 1px $govuk-border-colour;
   }
 
   &-postage {
@@ -58,9 +58,9 @@ $iso-paper-ratio: 141.42135624%;
     background-repeat: no-repeat;
     background-origin: border-box;
     text-indent: -1000em;
-    border-bottom: 1px solid $border-colour;
-    border-left: 1px solid $border-colour;
-    box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
+    border-bottom: 1px solid $govuk-border-colour;
+    border-left: 1px solid $govuk-border-colour;
+    box-shadow: 0 2px 0 0 rgba($govuk-border-colour, 0.2);
 
     &-first {
       background-image: file-url('envelope-1st-class.svg');

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -11,7 +11,7 @@ $iso-paper-ratio: 141.42135624%;
   padding: $iso-paper-ratio 0 0 0;
   margin: 0 0 govuk-spacing(6) 0;
   position: relative;
-  background: $panel-colour;
+  background: govuk-colour("grey-3");
 
   &:before {
     position: absolute;

--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -52,7 +52,7 @@ $iso-paper-ratio: 141.42135624%;
     width: $fold-height * ($art-width / $art-height);
     height: $fold-height;
     margin: 0;
-    background-color: mix($envelope-colour, $grey-1);
+    background-color: mix($envelope-colour,govuk-colour("grey-1"));
     background-size: auto $fold-height;
     background-position: right 0;
     background-repeat: no-repeat;

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -43,7 +43,7 @@ a {
     margin-left: -2px;
 
     &:before {
-      border-color: $link-colour;
+      border-color: $govuk-link-colour;
     }
   }
 

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -23,7 +23,7 @@ $app-body-text-line-height-tablet: get-govuk-typography-style($size: 19, $breakp
     transform: rotate(45deg);
     border: solid;
     border-width: 2px 2px 0 0;
-    border-color: $secondary-text-colour;
+    border-color: $govuk-secondary-text-colour;
   }
 }
 
@@ -196,14 +196,14 @@ a {
   }
 
   &-empty {
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
     padding: govuk-spacing(3) 0 govuk-spacing(2) 0;
   }
 }
 
 .checkbox-list {
   &-selected-counter {
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
     margin: govuk-spacing(3) 0;
 
     @include media(tablet) {

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -34,7 +34,7 @@ $message-type-bottom-spacing: govuk-spacing(4);
 a {
 
   &:hover .message-name-separator:before {
-    border-color: $link-hover-colour;
+    border-color: $govuk-link-hover-colour;
   }
 
   .message-name-separator {
@@ -294,7 +294,7 @@ a {
     }
 
     &:hover {
-      color: $link-hover-colour;
+      color: $govuk-link-hover-colour;
     }
 
   }

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -136,7 +136,7 @@
       transform: rotate(45deg);
       border: solid;
       border-width: 1px 1px 0 0;
-      border-color: $secondary-text-colour;
+      border-color: $govuk-secondary-text-colour;
     }
 
     &:focus:before {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -30,13 +30,13 @@
 
     &--training {
       background: govuk-colour("grey-3");
-      color: mix(govuk-colour("grey-1"), $text-colour);
+      color: mix(govuk-colour("grey-1"), $govuk-text-colour);
       box-shadow: 0 -3px 0 0 govuk-colour("grey-3");
     }
 
     &--suspended {
       background: govuk-colour("grey-3");
-      color: mix(govuk-colour("grey-1"), $text-colour);
+      color: mix(govuk-colour("grey-1"), $govuk-text-colour);
       box-shadow: 0 -3px 0 0 govuk-colour("grey-3");
     }
 
@@ -237,7 +237,7 @@
     @include govuk-font(16, $weight: bold);
 
     a:link, a:visited {
-      color: $text-colour;
+      color: $govuk-text-colour;
     }
   }
 }

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -29,15 +29,15 @@
     letter-spacing: 0.05em;
 
     &--training {
-      background: $grey-3;
-      color: mix($grey-1, $text-colour);
-      box-shadow: 0 -3px 0 0 $grey-3;
+      background: govuk-colour("grey-3");
+      color: mix(govuk-colour("grey-1"), $text-colour);
+      box-shadow: 0 -3px 0 0 govuk-colour("grey-3");
     }
 
     &--suspended {
-      background: $grey-3;
-      color: mix($grey-1, $text-colour);
-      box-shadow: 0 -3px 0 0 $grey-3;
+      background: govuk-colour("grey-3");
+      color: mix(govuk-colour("grey-1"), $text-colour);
+      box-shadow: 0 -3px 0 0 govuk-colour("grey-3");
     }
 
     &--live, &--test, &--operator {
@@ -203,14 +203,14 @@
     ol,
     ul {
       margin-top: govuk-spacing(2);
-      border-top: 1px $grey-3 solid;
+      border-top: 1px govuk-colour("grey-3") solid;
     }
   }
 
   &__item {
     @include govuk-font(16);
 
-    border-bottom: 1px $grey-3 solid;
+    border-bottom: 1px govuk-colour("grey-3") solid;
     display: block;
     padding: govuk-spacing(2) 0;
 

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -77,7 +77,7 @@
   &-service {
 
     @include govuk-font($size: 19);
-    border-bottom: 1px solid $border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
     margin: 0 0 10px;
     position: relative;
 

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -65,7 +65,7 @@
 
   &-item--selected {
     background: inherit;
-    border: 2px solid $black;
+    border: 2px solid $govuk-input-border-colour;
     outline: 1px solid rgba($white, 0.1);
     position: relative;
     z-index: 10;
@@ -83,7 +83,7 @@
     &:focus {
       z-index: 1000;
       color: $govuk-focus-text-colour;
-      border: solid 2px $black;
+      border: solid 2px $govuk-focus-text-colour;
       padding: 10px 0px; /* reset padding to default */
       box-shadow: inset 0 -2px $govuk-focus-text-colour; /* remove bottom border from underline */
     }

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -37,7 +37,7 @@
   &-item {
     $background: $link-colour;
     background: $background;
-    color: $white;
+    color: govuk-colour("white");
     border: 2px solid $background;
     position: relative;
     text-decoration: none;
@@ -45,7 +45,7 @@
 
     &:link,
     &:visited {
-      color: $white;
+      color: govuk-colour("white");
     }
 
     &:hover {
@@ -66,7 +66,7 @@
   &-item--selected {
     background: inherit;
     border: 2px solid $govuk-input-border-colour;
-    outline: 1px solid rgba($white, 0.1);
+    outline: 1px solid rgba(govuk-colour("white"), 0.1);
     position: relative;
     z-index: 10;
 
@@ -129,7 +129,7 @@
     &:link,
     &:visited {
       background: $link-colour;
-      color: $white;
+      color: govuk-colour("white");
       text-decoration: underline;
     }
 

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -35,7 +35,7 @@
   }
 
   &-item {
-    $background: $link-colour;
+    $background: $govuk-link-colour;
     background: $background;
     color: govuk-colour("white");
     border: 2px solid $background;
@@ -128,7 +128,7 @@
 
     &:link,
     &:visited {
-      background: $link-colour;
+      background: $govuk-link-colour;
       color: govuk-colour("white");
       text-decoration: underline;
     }

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -49,7 +49,7 @@
     }
 
     &:hover {
-      color: $light-blue-25;
+      color: govuk-tint(govuk-colour("light-blue"), 75);
     }
 
     &:active,
@@ -134,7 +134,7 @@
     }
 
     &:hover {
-      color: $light-blue-25;
+      color: govuk-tint(govuk-colour("light-blue"), 75);
     }
 
     &:focus,

--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -10,7 +10,7 @@
   box-shadow: inset 0.47em 0 0 0 govuk-colour("white"), inset -0.47em 0 0 0 govuk-colour("white"), inset 0 -0.15em 0 0 govuk-colour("white"), inset 0 0.15em 0 0 govuk-colour("white");
 
   .sms-message-wrapper & {
-    box-shadow: inset 0.47em 0 0 0 $panel-colour, inset -0.47em 0 0 0 $panel-colour, inset 0 -0.18em 0 0 $panel-colour, inset 0 0.18em 0 0 $panel-colour;
+    box-shadow: inset 0.47em 0 0 0 govuk-colour("grey-3"), inset -0.47em 0 0 0 govuk-colour("grey-3"), inset 0 -0.18em 0 0 govuk-colour("grey-3"), inset 0 0.18em 0 0 govuk-colour("grey-3");
   }
 
 }
@@ -34,7 +34,7 @@
   box-shadow: inset 0.47em 0 0 0 govuk-colour("white"), inset -0.89em 0 0 0 govuk-colour("white"), inset 0 -0.16em 0 0 govuk-colour("white"), inset 0 0.16em 0 0 govuk-colour("white");
 
   .sms-message-wrapper & {
-    box-shadow: inset 0.47em 0 0 0 $panel-colour, inset -0.89em 0 0 0 $panel-colour, inset 0 -0.18em 0 0 $panel-colour, inset 0 0.18em 0 0 $panel-colour;
+    box-shadow: inset 0.47em 0 0 0 govuk-colour("grey-3"), inset -0.89em 0 0 0 govuk-colour("grey-3"), inset 0 -0.18em 0 0 govuk-colour("grey-3"), inset 0 0.18em 0 0 govuk-colour("grey-3");
   }
 
 }
@@ -49,7 +49,7 @@
   top: 0.1em;
 
   .sms-message-wrapper & {
-    box-shadow: inset 0 -0.35em 0 0 $panel-colour;
+    box-shadow: inset 0 -0.35em 0 0 govuk-colour("grey-3");
   }
 
   *:focus + p & {

--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -3,7 +3,7 @@
 
   display: inline;
   background: $govuk-focus-colour;
-  color: $text-colour;
+  color: $govuk-text-colour;
   overflow-wrap: break-word;
   word-wrap: break-word;
   border-radius: 20px;

--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -7,7 +7,7 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   border-radius: 20px;
-  box-shadow: inset 0.47em 0 0 0 $white, inset -0.47em 0 0 0 $white, inset 0 -0.15em 0 0 $white, inset 0 0.15em 0 0 $white;
+  box-shadow: inset 0.47em 0 0 0 govuk-colour("white"), inset -0.47em 0 0 0 govuk-colour("white"), inset 0 -0.15em 0 0 govuk-colour("white"), inset 0 0.15em 0 0 govuk-colour("white");
 
   .sms-message-wrapper & {
     box-shadow: inset 0.47em 0 0 0 $panel-colour, inset -0.47em 0 0 0 $panel-colour, inset 0 -0.18em 0 0 $panel-colour, inset 0 0.18em 0 0 $panel-colour;
@@ -20,7 +20,7 @@
   padding-left: 3px;
   padding-right: 3px;
   border-radius: 1px;
-  box-shadow: inset 0 -0.1em 0 0 $white, inset 0 0.1em 0 0 $white;
+  box-shadow: inset 0 -0.1em 0 0 govuk-colour("white"), inset 0 0.1em 0 0 govuk-colour("white");
 }
 
 .placeholder-conditional {
@@ -31,7 +31,7 @@
   border-bottom-left-radius: 20px;
   border-top-right-radius: 8px;
   border-bottom-right-radius: 8px;
-  box-shadow: inset 0.47em 0 0 0 $white, inset -0.89em 0 0 0 $white, inset 0 -0.16em 0 0 $white, inset 0 0.16em 0 0 $white;
+  box-shadow: inset 0.47em 0 0 0 govuk-colour("white"), inset -0.89em 0 0 0 govuk-colour("white"), inset 0 -0.16em 0 0 govuk-colour("white"), inset 0 0.16em 0 0 govuk-colour("white");
 
   .sms-message-wrapper & {
     box-shadow: inset 0.47em 0 0 0 $panel-colour, inset -0.89em 0 0 0 $panel-colour, inset 0 -0.18em 0 0 $panel-colour, inset 0 0.18em 0 0 $panel-colour;
@@ -44,7 +44,7 @@
   background: currentColor;
   padding: 0 0.5em;
   opacity: 0.8;
-  box-shadow: inset 0 -0.35em 0 0 $white;
+  box-shadow: inset 0 -0.35em 0 0 govuk-colour("white");
   position: relative;
   top: 0.1em;
 

--- a/app/assets/stylesheets/components/preview-pane.scss
+++ b/app/assets/stylesheets/components/preview-pane.scss
@@ -2,7 +2,7 @@
   width: 100%;
   display: block;
   box-sizing: border-box;
-  border: solid 1px $border-colour;
+  border: solid 1px $govuk-border-colour;
   min-height: 200px;
   margin-bottom: govuk-spacing(6)
 }

--- a/app/assets/stylesheets/components/preview-pane.scss
+++ b/app/assets/stylesheets/components/preview-pane.scss
@@ -8,8 +8,8 @@
 }
 
 #logo-img {
-  background-color: $grey-4;
-  background-image: linear-gradient(45deg, $grey-3 25%, transparent 25%), linear-gradient(-45deg, $grey-3 25%, transparent 25%), linear-gradient(45deg, transparent 75%, $grey-3 75%), linear-gradient(-45deg, transparent 75%, $grey-3 75%);
+  background-color: govuk-colour("grey-4");
+  background-image: linear-gradient(45deg, govuk-colour("grey-3") 25%, transparent 25%), linear-gradient(-45deg, govuk-colour("grey-3") 25%, transparent 25%), linear-gradient(45deg, transparent 75%, govuk-colour("grey-3") 75%), linear-gradient(-45deg, transparent 75%, govuk-colour("grey-3") 75%);
   background-size: 20px 20px;
   background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
 

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -60,7 +60,7 @@
     $circle-diameter: 39px;
     $border-thickness: 4px;
     $border-indent: ($circle-diameter / 2) - ($border-thickness / 2);
-    $border-colour: $border-colour;
+    $govuk-border-colour: $govuk-border-colour;
 
     float: none;
     position: relative;
@@ -72,7 +72,7 @@
       left: $border-indent;
       width: $border-thickness;
       height: 100%;
-      background: $border-colour;
+      background: $govuk-border-colour;
     }
 
     label {
@@ -102,7 +102,7 @@
         left: $border-indent;
         width: $border-thickness;
         height: 25px;
-        background: $border-colour;
+        background: $govuk-border-colour;
       }
     }
 

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -118,7 +118,7 @@
 
 .radio-slider {
 
-  border-bottom: 2px solid $black;
+  border-bottom: 2px solid $govuk-input-border-colour;
   height: 18px;
   margin-bottom: 18px + 30px;
   margin-right: -18px;

--- a/app/assets/stylesheets/components/radios.scss
+++ b/app/assets/stylesheets/components/radios.scss
@@ -81,7 +81,7 @@
 
     [type=radio]+label::before {
       // To overlap the grey inset line
-      background: $white;
+      background: govuk-colour("white");
     }
 
     ul {
@@ -146,7 +146,7 @@
       padding: 0;
 
       &:before {
-        background: $white;
+        background: govuk-colour("white");
       }
 
     }

--- a/app/assets/stylesheets/components/research-mode.scss
+++ b/app/assets/stylesheets/components/research-mode.scss
@@ -2,7 +2,7 @@
   font-weight: bold;
   display: inline-block;
   padding: 5px 10px;
-  background: $govuk-blue;
+  background: $govuk-brand-colour;
   color: $white;
   border-radius: 2px;
 }

--- a/app/assets/stylesheets/components/research-mode.scss
+++ b/app/assets/stylesheets/components/research-mode.scss
@@ -3,6 +3,6 @@
   display: inline-block;
   padding: 5px 10px;
   background: $govuk-brand-colour;
-  color: $white;
+  color: govuk-colour("white");
   border-radius: 2px;
 }

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -26,7 +26,7 @@
     position: relative;
     top: -11px;
     outline: 10px solid white;
-    background: $white;
+    background: govuk-colour("white");
     display: inline-block;
     border-bottom: 1px solid govuk-colour("light-blue");
   }

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -6,7 +6,7 @@
   padding: 0 0;
   margin: govuk-spacing(3) 0 govuk-spacing(3) 0;
   text-align: center;
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
 
   &:focus {
 

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -28,7 +28,7 @@
     outline: 10px solid white;
     background: $white;
     display: inline-block;
-    border-bottom: 1px solid $light-blue;
+    border-bottom: 1px solid govuk-colour("light-blue");
   }
 
 }

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -7,8 +7,8 @@ $tail-angle: 20deg;
   max-width: 464px;
   box-sizing: border-box;
   padding: govuk-spacing(3);
-  background: $panel-colour;
-  border: 1px solid $panel-colour;
+  background: govuk-colour("grey-3");
+  border: 1px solid govuk-colour("grey-3");
   border-radius: 5px;
   white-space: normal;
   margin: 0 0 govuk-spacing(6) 0;
@@ -24,8 +24,8 @@ $tail-angle: 20deg;
     border: 10px solid transparent;
     border-left-width: 13px;
     border-right-width: 13px;
-    border-bottom-color: $panel-colour;
-    border-left-color: $panel-colour;
+    border-bottom-color: govuk-colour("grey-3");
+    border-left-color: govuk-colour("grey-3");
     transform: rotate($tail-angle);
   }
 
@@ -37,8 +37,8 @@ $tail-angle: 20deg;
 
     &:after {
       border-left-color: transparent;
-      border-bottom-color: $panel-colour;
-      border-right-color: $panel-colour;
+      border-bottom-color: govuk-colour("grey-3");
+      border-right-color: govuk-colour("grey-3");
       right: auto;
       left: -20px;
       transform: rotate(-$tail-angle);

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -50,19 +50,19 @@ $tail-angle: 20deg;
 
 .sms-message-sender {
   @extend %govuk-body-m;
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   margin: 0 0 -10px 0;
 }
 
 .sms-message-recipient {
   @extend %govuk-body-m;
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   margin: 10px 0 0 0;
 }
 
 .sms-message-status {
   @include govuk-font(16);
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   margin: -20px govuk-spacing(3) 20px govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -88,8 +88,8 @@ $sticky-padding: govuk-spacing(4);
 
 .js-stick-at-top-when-scrolling.content-fixed__top {
 
-  border-bottom: 1px solid $border-colour;
-  box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
+  border-bottom: 1px solid $govuk-border-colour;
+  box-shadow: 0 2px 0 0 rgba($govuk-border-colour, 0.2);
 
 }
 
@@ -109,8 +109,8 @@ $sticky-padding: govuk-spacing(4);
 
 .js-stick-at-bottom-when-scrolling.content-fixed__bottom {
 
-  border-top: 1px solid $border-colour;
-  box-shadow: 0 -2px 0 0 rgba($border-colour, 0.2);
+  border-top: 1px solid $govuk-border-colour;
+  box-shadow: 0 -2px 0 0 rgba($govuk-border-colour, 0.2);
 
 }
 

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -142,7 +142,7 @@ $sticky-padding: govuk-spacing(4);
   cursor: pointer;
 
   &:hover {
-    color: $link-hover-colour;
+    color: $govuk-link-hover-colour;
   }
 
   &:focus {

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -66,7 +66,7 @@ $sticky-padding: govuk-spacing(4);
 .content-fixed-onload {
 
   position: fixed;
-  background: $white;
+  background: govuk-colour("white");
   z-index: 100;
   padding-right: govuk-spacing(3);
   margin-top: 0;

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -138,7 +138,7 @@ $sticky-padding: govuk-spacing(4);
   margin-top: -10px;
   margin-right: -10px;
   text-decoration: underline;
-  color: $govuk-blue;
+  color: $govuk-brand-colour;
   cursor: pointer;
 
   &:hover {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -199,13 +199,13 @@
 
   &-error {
 
-    border-left: 5px solid $error-colour;
+    border-left: 5px solid $govuk-error-colour;
     padding-left: 7px;
     display: block;
 
     &-label {
       display: block;
-      color: $error-colour;
+      color: $govuk-error-colour;
       font-weight: bold;
     }
 
@@ -225,7 +225,7 @@
 
     &-error {
 
-      color: $error-colour;
+      color: $govuk-error-colour;
       font-weight: bold;
 
       .status-hint {

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -109,7 +109,7 @@
 
   &-hint {
     @include govuk-font(19);
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
     pointer-events: none;
   }
 
@@ -220,7 +220,7 @@
   &-status {
 
     &-default {
-      color: $secondary-text-colour;
+      color: $govuk-secondary-text-colour;
     }
 
     &-error {
@@ -399,7 +399,7 @@
 .table-empty-message,
 td.table-empty-message {
   @include govuk-font(19);
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   border-bottom: 1px solid $border-colour;
   padding: 20px 0 20px 0;
 }
@@ -407,7 +407,7 @@ td.table-empty-message {
 .table-show-more-link {
 
   @include govuk-font(16);
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   margin-bottom: govuk-spacing(7);
   border-bottom: 1px solid $border-colour;
   padding: 35px 0 10px 0;
@@ -425,7 +425,7 @@ a.table-show-more-link {
 
 .table-no-data {
   @include govuk-font(16);
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   margin-top: 10px;
   margin-bottom: govuk-spacing(7);
   border-top: 1px solid $border-colour;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -231,7 +231,7 @@
       .status-hint {
         display: block;
         font-weight: normal;
-        color: $red;
+        color: $govuk-error-colour;
         margin-top: 5px;
       }
 

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -97,10 +97,10 @@
 
     &:focus {
 
-      color: $text-colour;
+      color: $govuk-text-colour;
 
       & + .template-statistics-table-hint {
-        color: $text-colour;
+        color: $govuk-text-colour;
       }
 
     }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -392,15 +392,15 @@
 
 
 .table-row-group {
-  border-top: 1px solid $border-colour;
-  border-bottom: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
 }
 
 .table-empty-message,
 td.table-empty-message {
   @include govuk-font(19);
   color: $govuk-secondary-text-colour;
-  border-bottom: 1px solid $border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
   padding: 20px 0 20px 0;
 }
 
@@ -409,7 +409,7 @@ td.table-empty-message {
   @include govuk-font(16);
   color: $govuk-secondary-text-colour;
   margin-bottom: govuk-spacing(7);
-  border-bottom: 1px solid $border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
   padding: 35px 0 10px 0;
   text-align: center;
 
@@ -428,8 +428,8 @@ a.table-show-more-link {
   color: $govuk-secondary-text-colour;
   margin-top: 10px;
   margin-bottom: govuk-spacing(7);
-  border-top: 1px solid $border-colour;
-  border-bottom: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
   padding: 0.75em 0 0.5625em 0;
 }
 

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -420,7 +420,7 @@ td.table-empty-message {
 }
 
 a.table-show-more-link {
-  color: $link-colour;
+  color: $govuk-link-colour;
 }
 
 .table-no-data {

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -55,7 +55,7 @@ $indicator-colour: govuk-colour("black");
 
   &-indicator-not-completed {
     @extend %task-list-indicator;
-    background-color: $white;
+    background-color: govuk-colour("white");
     color: $indicator-colour;
   }
 

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -47,7 +47,7 @@ $indicator-colour: govuk-colour("black");
   &-indicator-completed {
     @extend %task-list-indicator;
     background-color: $indicator-colour;
-    color: $grey-4;
+    color: govuk-colour("grey-4");
     // Just a pinch of letter spacing to make reversed-out text a bit
     // easier to read
     letter-spacing: 0.02em;

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -1,4 +1,4 @@
-$indicator-colour: $black;
+$indicator-colour: govuk-colour("black");
 
 %task-list-indicator {
   @include govuk-font(16, $weight: bold);

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -17,7 +17,7 @@ $indicator-colour: govuk-colour("black");
 
 .task-list {
 
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
   margin: govuk-spacing(6) 0;
 
   &-item {
@@ -25,7 +25,7 @@ $indicator-colour: govuk-colour("black");
     position: relative;
 
     a {
-      border-bottom: 1px solid $border-colour;
+      border-bottom: 1px solid $govuk-border-colour;
       display: block;
       padding: govuk-spacing(3) 0;
       padding-right: 20%;

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -71,7 +71,7 @@
     height: 38px;
     margin-left: 5px;
     border-radius: 50%;
-    box-shadow: inset 0 0 0 1px rgba($black, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(govuk-colour("black"), 0.2);
     display: inline-block;
     vertical-align: top;
     transition: background 0.3s ease-out;

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -16,7 +16,7 @@
 
   &-cross {
     @extend %tick-cross;
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
     background-image: file-url('cross-grey.svg');
   }
 

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -67,7 +67,7 @@
     a:hover,
     a:active,
     a:visited {
-      color: $black;
+      color: $govuk-text-colour;
     }
 
     &--active {
@@ -99,7 +99,7 @@
       }
 
       a:focus {
-        color: $black;
+        color: $govuk-focus-text-colour;
       }
     }
   }

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -86,8 +86,8 @@
   }
 
   &--inverse {
-    border-bottom: 1px $white solid;
-    border-bottom-color: rgba($white, 0.25);
+    border-bottom: 1px govuk-colour("white") solid;
+    border-bottom-color: rgba(govuk-colour("white"), 0.25);
 
     .breadcrumbs__item {
       &--active,
@@ -95,7 +95,7 @@
       a:hover,
       a:active,
       a:visited {
-        color: $white;
+        color: govuk-colour("white");
       }
 
       a:focus {

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -56,7 +56,7 @@ $is-ie: false !default;
       text-decoration: none;
 
       &:hover {
-        background-color: $canvas-colour;
+        background-color: govuk-colour("grey-4");
       }
 
       &:focus {

--- a/app/assets/stylesheets/components/vendor/responsive-embed.scss
+++ b/app/assets/stylesheets/components/vendor/responsive-embed.scss
@@ -42,7 +42,7 @@
 
 .responsive-embed--bordered {
   padding: 5px;
-  outline: 1px solid $border-colour;
+  outline: 1px solid $govuk-border-colour;
 }
 
 // Modifier class for 16:9 aspect ratio
@@ -58,3 +58,4 @@
     padding-bottom: 75%;
   }
 }
+

--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -60,10 +60,14 @@ input[type="search"]::-webkit-search-decoration {
 
 // Global styles for form controls
 
+// TODO: remove these styles once the text areas and radio buttons are using GOV.UK Frontend
+//
+// This is the focus colour from GOV.UK Frontend ($govuk-focus-colour).
+// We can't use the colour variable from GOV.UK Frontend, since this file is
+// above GOV.UK Frontend in the cascade.
 input:focus,
 textarea:focus,
-select:focus
 {
-  outline: 3px solid $focus-colour;
+  outline: 3px solid #FFDD00;
   outline-offset: 0;
 }

--- a/app/assets/stylesheets/govuk-elements/_forms.scss
+++ b/app/assets/stylesheets/govuk-elements/_forms.scss
@@ -62,7 +62,7 @@ textarea {
 // TODO: Amend so there is only one label style
 .form-label {
   display: block;
-  color: $text-colour;
+  color: $govuk-text-colour;
   padding-bottom: 2px;
 
   @include govuk-font(19);
@@ -101,7 +101,7 @@ textarea {
   padding: 5px 4px 4px;
   // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
   // as background-color and color need to always be set together, color should not be set either
-  border: 2px solid $text-colour;
+  border: 2px solid $govuk-text-colour;
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!

--- a/app/assets/stylesheets/govuk-elements/_forms.scss
+++ b/app/assets/stylesheets/govuk-elements/_forms.scss
@@ -75,7 +75,7 @@ textarea {
 .form-hint {
   @include govuk-font(19);
   display: block;
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   font-weight: normal;
 
   margin-top: -2px;

--- a/app/assets/stylesheets/govuk-elements/_tables.scss
+++ b/app/assets/stylesheets/govuk-elements/_tables.scss
@@ -12,7 +12,7 @@ table {
       padding: em(12, 19) em(20, 19) em(9, 19) 0;
 
       text-align: left;
-      border-bottom: 1px solid $border-colour;
+      border-bottom: 1px solid $govuk-border-colour;
     }
 
     thead th {

--- a/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
@@ -4,18 +4,18 @@
 // Use .form-group-error to add a red border to the left of a .form-group
 .form-group-error {
   margin-right: 15px;
-  border-left: 4px solid $error-colour;
+  border-left: 4px solid $govuk-error-colour;
   padding-left: 10px;
 
   @include media(tablet) {
-    border-left: 5px solid $error-colour;
+    border-left: 5px solid $govuk-error-colour;
     padding-left: $gutter-half;
   }
 }
 
 // Use .form-control-error to add a red border to .form-control
 .form-control-error {
-  border: 4px solid $error-colour;
+  border: 4px solid $govuk-error-colour;
 
   // Hack to give GOVUK Frontend styling
   &:focus {
@@ -30,8 +30,7 @@
 // Error messages should be red and bold
 .error-message {
   @include govuk-font(19, $weight: bold);
-  color: $error-colour;
-
+  color: $govuk-error-colour;
 
   display: block;
   clear: both;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -7,7 +7,6 @@ $path: '/static/images/';
 @import 'shims';
 @import 'measurements';
 @import 'css3';
-@import 'colours';
 
 // Dependencies from GOVU.UK Frontend Toolkit, rewritten for this application
 @import 'url-helpers';

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -69,7 +69,7 @@
     }
 
     &__data-value {
-      color: $text-colour;
+      color: $govuk-text-colour;
       padding-bottom: 15px;
     }
 

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -3,11 +3,11 @@
   font-family: monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  border-bottom: 1px solid $border-colour;
+  border-bottom: 1px solid $govuk-border-colour;
 
   &-item {
 
-    border-top: 1px solid $border-colour;
+    border-top: 1px solid $govuk-border-colour;
     padding: 10px 0 0 0;
 
     // We can't assign classes to the summary.govuk-details__summary or div.govuk-details__text

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -30,12 +30,12 @@
     &__meta {
 
       display: block;
-      color: $secondary-text-colour;
+      color: $govuk-secondary-text-colour;
       text-decoration: none;
 
       &-key,
       &-time {
-        color: $secondary-text-colour;
+        color: $govuk-secondary-text-colour;
         display: inline-block;
         width: auto;
       }
@@ -65,7 +65,7 @@
     }
 
     &__data-name {
-      color: $secondary-text-colour;
+      color: $govuk-secondary-text-colour;
     }
 
     &__data-value {

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -23,7 +23,7 @@
   width: 100%;
   margin-bottom: govuk-spacing(3);
   height: govuk-spacing(3);
-  color: $text-colour;
+  color: $govuk-text-colour;
   text-align: left;
 
   &-bar {

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -31,7 +31,7 @@
     box-sizing: border-box;
     display: inline-block;
     overflow: visible;
-    background: $panel-colour;
+    background: govuk-colour("grey-3");
     color: $govuk-text-colour;
     padding: 10px 6px 8px 0;
     text-indent: 12px;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -132,7 +132,7 @@
   &-hint {
     @include govuk-font(16);
     display: block;
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -142,7 +142,7 @@
   &-hint-large {
     @include govuk-font(19);
     display: block;
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -11,7 +11,7 @@
 }
 
 .keyline-block {
-  border-top: 1px solid $border-colour;
+  border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -32,7 +32,7 @@
     display: inline-block;
     overflow: visible;
     background: $panel-colour;
-    color: $black;
+    color: $govuk-text-colour;
     padding: 10px 6px 8px 0;
     text-indent: 12px;
     text-align: right;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -189,7 +189,7 @@
 
 .failure-highlight {
   @include govuk-font(19, $weight: bold);
-  color: $error-colour;
+  color: $govuk-error-colour;
 }
 
 .align-with-message-body {

--- a/app/assets/stylesheets/views/history.scss
+++ b/app/assets/stylesheets/views/history.scss
@@ -27,6 +27,6 @@ $item-top-padding: govuk-spacing(3);
 
   &-time {
     display: block;
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
   }
 }

--- a/app/assets/stylesheets/views/history.scss
+++ b/app/assets/stylesheets/views/history.scss
@@ -8,11 +8,11 @@ $item-top-padding: govuk-spacing(3);
   &-item {
 
     padding: $item-top-padding 0 govuk-spacing(3) 0;
-    border-top: 1px solid $border-colour;
+    border-top: 1px solid $govuk-border-colour;
     position: relative;
 
     &:last-child {
-      border-bottom: 1px solid $border-colour;
+      border-bottom: 1px solid $govuk-border-colour;
     }
 
     .page-footer {

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -1,7 +1,7 @@
 .notification-status {
 
   @include govuk-font(16);
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   margin-top: -1 * govuk-spacing(3);
 
   &.error {

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -13,7 +13,7 @@ $button-shadow-size: $govuk-border-width-form-element;
     position: relative;
     margin: -10px 0 govuk-spacing(6) * 1.5 0;
     background: $product-page-blue;
-    color: $white;
+    color: govuk-colour("white");
 
     &-wrapper {
 
@@ -44,7 +44,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
     p {
       @include govuk-font(24);
-      color: $white;
+      color: govuk-colour("white");
       margin: govuk-spacing(3) 0 govuk-spacing(6);
     }
 
@@ -52,7 +52,7 @@ $button-shadow-size: $govuk-border-width-form-element;
 
       &:link,
       &:visited {
-        color: $white;
+        color: govuk-colour("white");
       }
 
       &:hover {
@@ -112,7 +112,7 @@ $button-shadow-size: $govuk-border-width-form-element;
   @include govuk-font($size: 24, $weight: bold);
   color: $product-page-blue;
   box-shadow: 0 $button-shadow-size 0 govuk-shade($colour: $product-page-blue, $percentage: 15%);
-  background: $white;
+  background: govuk-colour("white");
 
   &:link,
   &:visited,
@@ -121,7 +121,7 @@ $button-shadow-size: $govuk-border-width-form-element;
   }
 
   &:focus {
-    background: $white;
+    background: govuk-colour("white");
   }
 
   &:hover {

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -56,7 +56,7 @@ $button-shadow-size: $govuk-border-width-form-element;
       }
 
       &:hover {
-        color: $light-blue-25;
+        color: govuk-tint(govuk-colour("light-blue"), 75);
       }
 
       &:active,
@@ -125,7 +125,7 @@ $button-shadow-size: $govuk-border-width-form-element;
   }
 
   &:hover {
-    background: $light-blue-25;
+    background: govuk-tint(govuk-colour("light-blue"), 75);
     outline: none;
   }
 

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -79,7 +79,7 @@ $button-shadow-size: $govuk-border-width-form-element;
     }
 
     .with-keyline {
-      border-top: 1px solid $border-colour;
+      border-top: 1px solid $govuk-border-colour;
       padding: govuk-spacing(6) * 1.5 0 0 0;
     }
 

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -17,7 +17,7 @@
   }
 
   &:hover {
-    color: $light-blue-25;
+    color: govuk-tint(govuk-colour("light-blue"), 75);
   }
 
   &:focus {

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -58,7 +58,7 @@
 
 .template-content-count {
   @include govuk-font(19, $tabular: true);
-  color: $secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   padding: 0 0 govuk-spacing(6) 0;
 
   & .govuk-error-message {

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -7,7 +7,7 @@
 
   @include govuk-font(19);
   position: absolute;
-  background: $link-colour;
+  background: $govuk-link-colour;
   color: govuk-colour("white");
   padding: 10px govuk-spacing(3);
   z-index: 10000;

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -8,12 +8,12 @@
   @include govuk-font(19);
   position: absolute;
   background: $link-colour;
-  color: $white;
+  color: govuk-colour("white");
   padding: 10px govuk-spacing(3);
   z-index: 10000;
 
   &:link, &:visited {
-    color: $white;
+    color: govuk-colour("white");
   }
 
   &:hover {

--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -17,7 +17,7 @@ $item-top-padding: govuk-spacing(3);
       overflow-wrap: break-word;
 
       .heading-small {
-        color: $black;
+        color: $govuk-text-colour;
       }
 
     }

--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -8,7 +8,7 @@ $item-top-padding: govuk-spacing(3);
   &-item {
 
     padding: govuk-spacing(3) 0px;
-    border-top: 1px solid $border-colour;
+    border-top: 1px solid $govuk-border-colour;
 
     &-heading {
 
@@ -23,7 +23,7 @@ $item-top-padding: govuk-spacing(3);
     }
 
     &:last-child {
-      border-bottom: 1px solid $border-colour;
+      border-bottom: 1px solid $govuk-border-colour;
     }
 
     & :last-child {


### PR DESCRIPTION
This is part 5 of a series of work to remove the GOVUK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

We want to remove GOV.UK Frontend Toolkit from our code to replace it with GOV.UK Frontend.

This replaces all the colour variables and functions from toolkit with ones from GOV.UK Frontend (or hardcoded values where necessary). This is stage one - we have legacy mode on (`$govuk-compatibility-govukfrontendtoolkit: true;`) so we have access to the [legacy colour palette](https://github.com/alphagov/govuk-frontend/blob/062946035cf9d105b6ce045f4866927605d42675/src/govuk/settings/_colours-palette.scss#L70). At this point, the colours look the same. When we turn legacy mode off (stage two) we will need to use the [modern colour palette](https://github.com/alphagov/govuk-frontend/blob/062946035cf9d105b6ce045f4866927605d42675/src/govuk/settings/_colours-palette.scss#L37) and this will change the appearance of the colours.

There are a couple of places where things _have_ changed in this PR:
- where we use `govuk-tint()` it affects the colour now
- We were [using the new focus colour early](https://github.com/alphagov/notifications-admin/blob/89c6384ea04f95ec896cdd7b00dc0e31a6f26f1f/app/assets/stylesheets/govuk-frontend/focus/settings.scss), but were still using the old colour in `app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss`. This updates `app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss` to be consistent.

https://www.pivotaltracker.com/story/show/182596710

**Merge after**
- https://github.com/alphagov/notifications-admin/pull/4359 has been merged