### PR TITLE
Remove GOVUK Frontend Toolkit [part 4]

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -130,7 +130,7 @@ details summary {
 
     th,
     td {
-      @include core-19;
+      @include govuk-font(19);
       word-wrap: break-word;
     }
 
@@ -145,7 +145,7 @@ details summary {
 }
 
 .tabular-numbers {
-  @include core-19($tabular-numbers: true);
+  @include govuk-font(19, $tabular: true);
 }
 
 summary::-moz-details-marker {
@@ -253,5 +253,5 @@ details .arrow {
 }
 
 input:-webkit-autofill::first-line {
-  @include core-19;
+  @include govuk-font(19);
 }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -58,7 +58,7 @@ td {
   margin-bottom: 5px;
 
   &.heading-small {
-    @include bold-19();
+    @include govuk-font(19, $weight: bold);
   }
 }
 
@@ -136,7 +136,7 @@ details summary {
 
     thead {
       th {
-        @include bold-19;
+        @include govuk-font(19, $weight: bold);
       }
     }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -171,7 +171,7 @@ details .arrow {
 }
 
 .block-label-hint {
-  @include core-16;
+  @include govuk-font(16);
   margin-top: 5px;
 }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -56,10 +56,6 @@ td {
 
 .form-label {
   margin-bottom: 5px;
-
-  &.heading-small {
-    @include govuk-font(19, $weight: bold);
-  }
 }
 
 .hint {
@@ -250,8 +246,4 @@ details .arrow {
 
   }
 
-}
-
-input:-webkit-autofill::first-line {
-  @include govuk-font(19);
 }

--- a/app/assets/stylesheets/components/area-list.scss
+++ b/app/assets/stylesheets/components/area-list.scss
@@ -111,7 +111,7 @@
     }
 
     &--smaller {
-      @include bold-16;
+      @include govuk-font(16, $weight: bold);
     }
 
   }

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -13,7 +13,7 @@
   border: 5px solid $button-colour;
 
   &-title {
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
   }
 
   p {

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -2,7 +2,7 @@
 .banner,
 .banner-default {
 
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   color: $button-colour;
   display: block;
   padding: govuk-spacing(3);
@@ -51,7 +51,7 @@
 .banner-dangerous {
 
   @extend %banner;
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   background: $white;
   color: $text-colour;
   border: 5px solid $error-colour;

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -94,7 +94,7 @@
   }
 
   .heading-medium {
-    @include core-24;
+    @include govuk-font(24);
   }
 
   p {
@@ -114,7 +114,7 @@
   }
 
   ul {
-    @include core-24;
+    @include govuk-font(24);
     color: $white;
     margin-bottom: govuk-spacing(5);
   }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -13,7 +13,7 @@
   }
 
   &-label {
-    @include core-19;
+    @include govuk-font(19);
     padding-bottom: 10px;
   }
 
@@ -139,7 +139,7 @@
   %big-number-status,
   .big-number-status {
 
-    @include core-19;
+    @include govuk-font(19);
     display: block;
     background: $green;
     color: $white;

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -38,7 +38,7 @@
   color: $white;
 
   .big-number-number {
-    @include bold-36($tabular-numbers: true);
+    @include govuk-font(36, $weight: bold, $tabular: true);
   }
 }
 
@@ -47,7 +47,7 @@
   @extend %big-number;
 
   .big-number-number {
-    @include bold-36($tabular-numbers: true);
+    @include govuk-font(36, $weight: bold, $tabular: true);
   }
 
 }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -57,7 +57,7 @@
   @extend %big-number;
 
   .big-number-number {
-    @include bold-24($tabular-numbers: true);
+    @include govuk-font(24, $weight: bold, $tabular: true);
   }
 
 }

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -9,7 +9,7 @@
   }
 
   &-number {
-    @include bold-48($tabular-numbers: true);
+    @include govuk-font(48, $weight: bold, $tabular: true);
   }
 
   &-label {

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -11,7 +11,7 @@
 
   &-item,
   &-sub-item {
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
     list-style: none;
     margin-bottom: govuk-spacing(3);
   }

--- a/app/assets/stylesheets/components/browse-list.scss
+++ b/app/assets/stylesheets/components/browse-list.scss
@@ -21,7 +21,7 @@
   }
 
   &-hint {
-    @include core-19;
+    @include govuk-font(19);
     margin: 5px 0 10px 0;
     color: $secondary-text-colour;
   }

--- a/app/assets/stylesheets/components/checkboxes.scss
+++ b/app/assets/stylesheets/components/checkboxes.scss
@@ -5,7 +5,7 @@ $govuk-checkboxes-size: 40px;
 .selection-summary {
 
   .selection-summary__text {
-    @include core-19($tabular-numbers: true);
+    @include govuk-font(19, $tabular: true);
     padding: 5px 0 0 0;
     margin-bottom: govuk-spacing(3);
 

--- a/app/assets/stylesheets/components/copy-to-clipboard.scss
+++ b/app/assets/stylesheets/components/copy-to-clipboard.scss
@@ -5,7 +5,7 @@
   display: flex;
 
   &__name {
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
     margin-bottom: 5px;
   }
 

--- a/app/assets/stylesheets/components/email-message.scss
+++ b/app/assets/stylesheets/components/email-message.scss
@@ -11,12 +11,12 @@ $email-message-gutter: govuk-spacing(9);
 
   &-meta {
 
-    @include core-19;
+    @include govuk-font(19);
     margin: 0;
 
     td,
     th {
-      @include core-19;
+      @include govuk-font(19);
       border-top: 0;
       border-bottom: 1px solid $border-colour;
       vertical-align: top;

--- a/app/assets/stylesheets/components/file-upload.scss
+++ b/app/assets/stylesheets/components/file-upload.scss
@@ -3,7 +3,7 @@
   &-label,
   &-button-label {
 
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
     display: block;
     margin: 0 0 10px 0;
 

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -208,7 +208,7 @@
   }
 
   &__item {
-    @include core-16;
+    @include govuk-font(16);
 
     border-bottom: 1px $grey-3 solid;
     display: block;

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -20,7 +20,7 @@
 
   &-service-type {
 
-    @include bold-16;
+    @include govuk-font(16, $weight: bold);
     position: relative;
     display: inline-block;
     margin-left: govuk-spacing(2);
@@ -234,7 +234,7 @@
   }
 
   &__item--active {
-    @include bold-16;
+    @include govuk-font(16, $weight: bold);
 
     a:link, a:visited {
       color: $text-colour;

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -176,7 +176,7 @@
     }
 
     &.selected {
-      @include bold-19;
+      @include govuk-font(19, $weight: bold);
       position: relative;
       // These two lines stop the width of the item jumping so much
       // between selected and unselected states

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -1,7 +1,7 @@
 %show-more,
 .show-more {
 
-  @include core-16;
+  @include govuk-font(16);
   display: block;
   padding: 0 0;
   margin: govuk-spacing(3) 0 govuk-spacing(3) 0;

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -61,7 +61,7 @@ $tail-angle: 20deg;
 }
 
 .sms-message-status {
-  @include core-16;
+  @include govuk-font(16);
   color: $secondary-text-colour;
   margin: -20px govuk-spacing(3) 20px govuk-spacing(3);
 }

--- a/app/assets/stylesheets/components/sms-message.scss
+++ b/app/assets/stylesheets/components/sms-message.scss
@@ -49,13 +49,13 @@ $tail-angle: 20deg;
 }
 
 .sms-message-sender {
-  @include copy-19;
+  @extend %govuk-body-m;
   color: $secondary-text-colour;
   margin: 0 0 -10px 0;
 }
 
 .sms-message-recipient {
-  @include copy-19;
+  @extend %govuk-body-m;
   color: $secondary-text-colour;
   margin: 10px 0 0 0;
 }

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -268,7 +268,7 @@
 
   &-index {
 
-    @include bold-16;
+    @include govuk-font(16, $weight: bold);
     width: 15px;
 
     a {
@@ -304,7 +304,7 @@
 }
 
 .table-font-xsmall td.table-field-index {  // overrides GOV.UK Elements
-  @include bold-16;
+  @include govuk-font(16, $weight: bold);
 }
 
 

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -87,7 +87,7 @@
 
   &-template-name {
 
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
     display: block;
     white-space: nowrap;
     overflow: hidden;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -62,7 +62,7 @@
   }
 
   .table-heading {
-    @include core-19;
+    @include govuk-font(19);
     margin: 0 0 10px 0;
   }
 
@@ -108,7 +108,7 @@
   }
 
   &-hint {
-    @include core-19;
+    @include govuk-font(19);
     color: $secondary-text-colour;
     pointer-events: none;
   }
@@ -398,7 +398,7 @@
 
 .table-empty-message,
 td.table-empty-message {
-  @include core-19;
+  @include govuk-font(19);
   color: $secondary-text-colour;
   border-bottom: 1px solid $border-colour;
   padding: 20px 0 20px 0;

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -406,7 +406,7 @@ td.table-empty-message {
 
 .table-show-more-link {
 
-  @include core-16;
+  @include govuk-font(16);
   color: $secondary-text-colour;
   margin-bottom: govuk-spacing(7);
   border-bottom: 1px solid $border-colour;
@@ -424,7 +424,7 @@ a.table-show-more-link {
 }
 
 .table-no-data {
-  @include core-16;
+  @include govuk-font(16);
   color: $secondary-text-colour;
   margin-top: 10px;
   margin-bottom: govuk-spacing(7);

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -330,7 +330,7 @@
 .table-field-headings-visible {
 
   th {
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
   }
 
   .dashboard-table &-first {

--- a/app/assets/stylesheets/components/task-list.scss
+++ b/app/assets/stylesheets/components/task-list.scss
@@ -1,7 +1,7 @@
 $indicator-colour: $black;
 
 %task-list-indicator {
-  @include bold-16;
+  @include govuk-font(16, $weight: bold);
   display: inline-block;
   padding: 3px 8px 1px 8px;
   position: absolute;

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -62,7 +62,7 @@
 }
 
 .extra-tracking .govuk-input {
-  @include core-19($tabular-numbers: true);
+  @include govuk-font(19, $tabular: true);
   padding-left: 5px;
   letter-spacing: 0.04em;
 }

--- a/app/assets/stylesheets/components/tick-cross.scss
+++ b/app/assets/stylesheets/components/tick-cross.scss
@@ -1,5 +1,5 @@
 %tick-cross {
-  @include core-19;
+  @include govuk-font(19);
   display: inline-block;
   background-size: 19px 19px;
   background-repeat: no-repeat;

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -71,7 +71,7 @@
     }
 
     &--active {
-      @include bold-16;
+      @include govuk-font(16, $weight: bold);
 
       a:link,
       a:visited {

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -58,7 +58,7 @@
 
     white-space: nowrap;
 
-    @include device-pixel-ratio(2) {
+    @include govuk-device-pixel-ratio(2) {
       background-image: file-url('separator-2x.png');
     }
 

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -30,7 +30,7 @@
 
 .breadcrumbs {
   @include govuk-width-container;
-  @include core-16($line-height: (25 / 16), $line-height-640: 1.75);
+  @include govuk-font(16, $line-height: (25 / 16));
 
   padding: govuk-spacing(2) 0;
   list-style: none;

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -64,7 +64,7 @@ $is-ie: false !default;
       }
 
       .pagination-part-title {
-        @include core-27($line-height: (33.75 / 27));
+        @include govuk-font(27, $line-height: (33.75 / 27));
         display: block;
       }
     }

--- a/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
+++ b/app/assets/stylesheets/components/vendor/previous-next-navigation.scss
@@ -42,7 +42,7 @@ $is-ie: false !default;
   }
 
   li {
-    @include core-16($line-height: (20 / 16));
+    @include govuk-font(16, $line-height: (25 / 16));
     float: left;
     list-style: none;
     text-align: right;

--- a/app/assets/stylesheets/govuk-elements/_elements-typography.scss
+++ b/app/assets/stylesheets/govuk-elements/_elements-typography.scss
@@ -35,7 +35,7 @@ main {
 }
 
 .heading-medium {
-  @include bold-24();
+  @include govuk-font(24, $weight: bold);
 
   margin-top: em(25, 20);
   margin-bottom: em(10, 20);

--- a/app/assets/stylesheets/govuk-elements/_elements-typography.scss
+++ b/app/assets/stylesheets/govuk-elements/_elements-typography.scss
@@ -48,7 +48,7 @@ main {
 }
 
 .heading-small {
-  @include bold-19();
+  @include govuk-font(19, $weight: bold);
 
   margin-top: em(10, 16);
   margin-bottom: em(5, 16);

--- a/app/assets/stylesheets/govuk-elements/_elements-typography.scss
+++ b/app/assets/stylesheets/govuk-elements/_elements-typography.scss
@@ -2,10 +2,10 @@
 // ==========================================================================
 
 // Increase the base font size to 19px for the main content area
-// Using the core-19 mixin from the govuk_toolkit _typography.scss file
+// Using the govuk-font(19) mixin from the design system
 
 main {
-    @include core-19;
+    @include govuk-font(19);
     -webkit-font-smoothing: antialiased;
 }
 

--- a/app/assets/stylesheets/govuk-elements/_elements-typography.scss
+++ b/app/assets/stylesheets/govuk-elements/_elements-typography.scss
@@ -15,7 +15,7 @@ main {
 
 // Headings
 .heading-large {
-  @include bold-36();
+  @include govuk-font(36, $weight: bold);
 
   margin-top: em(25, 24);
   margin-bottom: em(10, 24);

--- a/app/assets/stylesheets/govuk-elements/_elements-typography.scss
+++ b/app/assets/stylesheets/govuk-elements/_elements-typography.scss
@@ -25,13 +25,6 @@ main {
     margin-bottom: em(20, 36);
   }
 
-  .heading-secondary {
-    @include heading-24();
-
-    display: block;
-    color: $secondary-text-colour;
-  }
-
 }
 
 .heading-medium {

--- a/app/assets/stylesheets/govuk-elements/_forms.scss
+++ b/app/assets/stylesheets/govuk-elements/_forms.scss
@@ -65,7 +65,7 @@ textarea {
   color: $text-colour;
   padding-bottom: 2px;
 
-  @include core-19;
+  @include govuk-font(19);
 }
 
 // 4. Form hints
@@ -73,7 +73,7 @@ textarea {
 
 // Form hints and example text are light grey and sit above a form control
 .form-hint {
-  @include core-19;
+  @include govuk-font(19);
   display: block;
   color: $secondary-text-colour;
   font-weight: normal;
@@ -94,7 +94,7 @@ textarea {
 // and 100% width for mobile
 .form-control {
   @include box-sizing(border-box);
-  @include core-19;
+  @include govuk-font(19);
   width: 100%;
 
   padding: 5px 4px 4px;

--- a/app/assets/stylesheets/govuk-elements/_tables.scss
+++ b/app/assets/stylesheets/govuk-elements/_tables.scss
@@ -47,7 +47,7 @@ table {
     }
 
     td {
-      @include core-16;
+      @include govuk-font(16);
     }
 
     th,

--- a/app/assets/stylesheets/govuk-elements/_tables.scss
+++ b/app/assets/stylesheets/govuk-elements/_tables.scss
@@ -32,7 +32,7 @@ table {
     // Allow a qualifying element, only table data cells should use tabular numbers
     // scss-lint:disable QualifyingElement
     td.numeric {
-      font-family: $toolkit-font-stack-tabular;
+      @include govuk-font(19, $tabular: true);
     }
 
     caption {

--- a/app/assets/stylesheets/govuk-elements/_tables.scss
+++ b/app/assets/stylesheets/govuk-elements/_tables.scss
@@ -8,7 +8,7 @@ table {
 
     th,
     td {
-      @include core-19;
+      @include govuk-font(19);
       padding: em(12, 19) em(20, 19) em(9, 19) 0;
 
       text-align: left;

--- a/app/assets/stylesheets/govuk-elements/_tables.scss
+++ b/app/assets/stylesheets/govuk-elements/_tables.scss
@@ -43,7 +43,7 @@ table {
   .table-font-xsmall {
 
     th {
-      @include bold-16;
+      @include govuk-font(16, $weight: bold);
     }
 
     td {

--- a/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
@@ -21,7 +21,7 @@
 
 // Error messages should be red and bold
 .error-message {
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   color: $error-colour;
 
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -8,7 +8,6 @@ $path: '/static/images/';
 @import 'measurements';
 @import 'css3';
 @import 'colours';
-@import 'typography';
 
 // Dependencies from GOVU.UK Frontend Toolkit, rewritten for this application
 @import 'url-helpers';

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -17,6 +17,9 @@ $path: '/static/images/';
 @import 'reset';
 @import 'globals';
 
+// Dependencies from GOV.UK Frontend, packaged to be specific to this application
+@import './govuk-frontend/all';
+
 // Dependencies from GOV.UK Elements, moved here until all components are migrated
 // to GOVUK Frontend, and so no longer need these styles
 // https://github.com/alphagov/govuk_elements
@@ -26,9 +29,6 @@ $path: '/static/images/';
 @import './govuk-elements/forms/form-multiple-choice';
 @import './govuk-elements/forms/form-validation';
 @import './govuk-elements/tables';
-
-// Dependencies from GOV.UK Frontend, packaged to be specific to this application
-@import './govuk-frontend/all';
 
 // Specific to this application
 @import 'local/typography';

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -126,7 +126,7 @@
   }
 
   &-filename-unlinked {
-    @include core-19;
+    @include govuk-font(19);
   }
 
   &-hint {
@@ -140,7 +140,7 @@
   }
 
   &-hint-large {
-    @include core-19;
+    @include govuk-font(19);
     display: block;
     color: $secondary-text-colour;
     overflow: hidden;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -94,7 +94,7 @@
   }
 
   &-filename {
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
     display: block;
     white-space: nowrap;
     overflow: hidden;
@@ -188,7 +188,7 @@
 }
 
 .failure-highlight {
-  @include bold-19;
+  @include govuk-font(19, $weight: bold);
   color: $error-colour;
 }
 

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -17,7 +17,7 @@
 
 .spark-bar {
 
-  @include core-16;
+  @include govuk-font(16);
   box-sizing: border-box;
   display: block;
   width: 100%;
@@ -130,7 +130,7 @@
   }
 
   &-hint {
-    @include core-16;
+    @include govuk-font(16);
     display: block;
     color: $secondary-text-colour;
     overflow: hidden;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -27,7 +27,7 @@
   text-align: left;
 
   &-bar {
-    @include bold-27($tabular-numbers: true);
+    @include govuk-font(27, $weight: bold, $tabular: true);
     box-sizing: border-box;
     display: inline-block;
     overflow: visible;

--- a/app/assets/stylesheets/views/dashboard.scss
+++ b/app/assets/stylesheets/views/dashboard.scss
@@ -106,7 +106,7 @@
   }
 
   &-filename-large {
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
     display: block;
     white-space: nowrap;
     overflow: hidden;

--- a/app/assets/stylesheets/views/get_started.scss
+++ b/app/assets/stylesheets/views/get_started.scss
@@ -10,7 +10,7 @@
     position: relative;
 
     &:before {
-      @include bold-24;
+      @include govuk-font(24, $weight: bold);
       content: counter(get-started-counter) ".";
       position: absolute;
       top: 5px;
@@ -24,7 +24,7 @@
   }
 
   &__heading {
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
     display: inline-block;
     margin: 5px 0 govuk-spacing(3) 0;
   }

--- a/app/assets/stylesheets/views/history.scss
+++ b/app/assets/stylesheets/views/history.scss
@@ -2,7 +2,7 @@ $item-top-padding: govuk-spacing(3);
 
 .history-list {
 
-  @include core-19;
+  @include govuk-font(19);
   margin-bottom: govuk-spacing(6);
 
   &-item {

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -1,6 +1,6 @@
 .notification-status {
 
-  @include core-16;
+  @include govuk-font(16);
   color: $secondary-text-colour;
   margin-top: -1 * govuk-spacing(3);
 

--- a/app/assets/stylesheets/views/notification.scss
+++ b/app/assets/stylesheets/views/notification.scss
@@ -12,7 +12,7 @@
   }
 
   &-cancelled {
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
     color: $govuk-error-colour;
   }
 

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -43,7 +43,7 @@ $button-shadow-size: $govuk-border-width-form-element;
     }
 
     p {
-      @include core-24;
+      @include govuk-font(24);
       color: $white;
       margin: govuk-spacing(3) 0 govuk-spacing(6);
     }

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -74,7 +74,7 @@ $button-shadow-size: $govuk-border-width-form-element;
     margin-bottom: govuk-spacing(3);
 
     h2 {
-      @include bold-27;
+      @include govuk-font(27, $weight: bold);
       margin: 0 0 govuk-spacing(6);
     }
 

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -38,7 +38,7 @@ $button-shadow-size: $govuk-border-width-form-element;
     }
 
     h1 {
-      @include bold-48;
+      @include govuk-font(48, $weight: bold);
       margin: 20px 0 govuk-spacing(6) 0;
     }
 
@@ -91,7 +91,7 @@ $button-shadow-size: $govuk-border-width-form-element;
   }
 
   &-big-number {
-    @include bold-48($tabular-numbers: true);
+    @include govuk-font(48, $weight: bold, $tabular: true);
     margin: 0 0 0 0;
   }
 

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -5,7 +5,7 @@
 %edit-template-link,
 .edit-template-link {
 
-  @include core-19;
+  @include govuk-font(19);
   position: absolute;
   background: $link-colour;
   color: $white;
@@ -57,7 +57,7 @@
 }
 
 .template-content-count {
-  @include core-19($tabular-numbers: true);
+  @include govuk-font(19, $tabular: true);
   color: $secondary-text-colour;
   padding: 0 0 govuk-spacing(6) 0;
 

--- a/app/assets/stylesheets/views/users.scss
+++ b/app/assets/stylesheets/views/users.scss
@@ -2,7 +2,7 @@ $item-top-padding: govuk-spacing(3);
 
 .user-list {
 
-  @include core-19;
+  @include govuk-font(19);
   margin-bottom: govuk-spacing(6);
 
   &-item {


### PR DESCRIPTION
This is part 4 of a series of work to remove the GOVUK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

This part covers removal of the Sass typography code and so replaces all uses of its font mixins with equivalents from GOVUK Frontend, following design system guidelines:

https://design-system.service.gov.uk/get-started/updating-your-code/#typography

## Notes for reviewers

Our version of GOVUK Frontend still has 'compatibility mode' on, as per [design system guidelines for migration](https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/#add-gov-uk-frontend-to-your-project), which means we still use the old font and colours. Because of that, these commits don't result in much difference to the resulting CSS. We still checked all the uses and didn't see any differences.

There's also an extra commit in there removing some redundant CSS.