### PR TITLE
Change default email branding for organisations

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1949,6 +1949,13 @@ class AdminEditEmailBrandingForm(StripWhitespaceForm):
             raise ValidationError('This field is required')
 
 
+class AdminChangeOrganisationDefaultEmailBrandingForm(StripWhitespaceForm):
+    email_branding_id = HiddenField(
+        'Email branding id',
+        validators=[DataRequired()],
+    )
+
+
 class AddEmailBrandingOptionsForm(StripWhitespaceForm):
     branding_field = GovukCheckboxesField(
         'Branding options',

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -3,7 +3,16 @@ from datetime import datetime
 from functools import partial
 from typing import Optional
 
-from flask import flash, redirect, render_template, request, send_file, url_for
+from flask import (
+    Markup,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from werkzeug import Response
@@ -23,6 +32,7 @@ from app.main.forms import (
     AddGPOrganisationForm,
     AddNHSLocalOrganisationForm,
     AdminBillingDetailsForm,
+    AdminChangeOrganisationDefaultEmailBrandingForm,
     AdminNewOrganisationForm,
     AdminNotesForm,
     AdminOrganisationDomainsForm,
@@ -449,7 +459,11 @@ def organisation_preview_email_branding(org_id):
     )
 
 
-def __handle_remove_branding(remove_branding_id) -> Optional[Response]:
+def _handle_remove_branding(remove_branding_id) -> Optional[Response]:
+    """
+    The user has clicked 'remove' on a brand and is either going to see a confirmation flash message
+    or has clicked to confirm that flash message.
+    """
     try:
         remove_branding = next(
             filter(lambda x: x['id'] == remove_branding_id, current_organisation.email_branding_pool)
@@ -462,14 +476,127 @@ def __handle_remove_branding(remove_branding_id) -> Optional[Response]:
             current_organisation.id,
             remove_branding_id
         )
-        flash(f'Email branding ‘{remove_branding["name"]}’ removed.', 'default_with_tick')
+        confirmation_message = f'Email branding ‘{remove_branding["name"]}’ removed.'
+        flash(confirmation_message, 'default_with_tick')
         return redirect(url_for('main.organisation_email_branding', org_id=current_organisation.id))
 
     else:
+        confirmation_question = Markup(
+            render_template(
+                'partials/flash_messages/email_branding_confirm_remove_brand.html',
+                branding_name=remove_branding['name'],
+            )
+        )
+
         flash(
-            f'Are you sure you want to remove the email brand ‘{remove_branding["name"]}’?',
+            confirmation_question,
             'delete',
         )
+
+    return None
+
+
+def _handle_change_default_branding_to_govuk(is_central_government) -> Optional[Response]:
+    """
+    This handles changing a central government organisation from a custom brand back to the default GOV.UK brand.
+    If we're in here, then the user has either clicked the 'Reset to GOV.UK' link or they're clicking the
+    button in the confirmation dialog.
+    """
+    # Only central government departments can have their brand reset to default GOV.UK
+    if not is_central_government:
+        return None
+
+    if request.method == 'POST':
+        organisations_client.update_organisation(
+            current_organisation.id,
+            email_branding_id=None,
+        )
+        return redirect(url_for('main.organisation_email_branding', org_id=current_organisation.id))
+
+    else:
+        current_brand = current_organisation.email_branding_name
+        confirmation_question = Markup(
+            render_template(
+                'partials/flash_messages/email_branding_confirm_change_default_to_govuk.html',
+                organisation_name=current_organisation.name,
+                current_brand=current_brand,
+            )
+        )
+        flash(
+            confirmation_question,
+            "yes, make this email branding the default"
+        )
+
+    return None
+
+
+def _handle_change_default_branding(form, new_default_branding_id) -> Optional[Response]:
+    """
+    Handle any change of branding to a non-default (GOV.UK) brand. This includes going from GOV.UK to a custom
+    brand, and going from a custom brand to another custom brand. When moving from GOV.UK to a custom brand,
+    there is a confirmation dialog step. When moving from a custom brand to another custom brand, it happens
+    without any further confirmation.
+    """
+    def __get_email_branding_name(branding_id):
+        try:
+            return next(
+                brand for brand in current_organisation.email_branding_pool if brand['id'] == branding_id
+            )['name']
+        except StopIteration:
+            current_app.logger.info(
+                f"Email branding ID {branding_id} is not present in organisation {current_organisation.name}'s "
+                f"email branding pool."
+            )
+            abort(400)
+
+    # This block handles the case where an organisation is changing from GOV.UK to another explicit brand. We handle
+    # this as a confirmation dialog + POST in order to explain to platform admins making this change that other services
+    # on the GOV.UK default brand will be affected.
+    if new_default_branding_id:
+        # This also validates that the chosen brand is valid for the organisation.
+        email_branding_name = __get_email_branding_name(new_default_branding_id)
+
+        if request.method == 'POST':
+            organisations_client.update_organisation(
+                current_organisation.id,
+                email_branding_id=new_default_branding_id,
+            )
+            return redirect(url_for('main.organisation_email_branding', org_id=current_organisation.id))
+
+        confirmation_question = Markup(
+            render_template(
+                'partials/flash_messages/email_branding_confirm_change_brand_from_govuk.html',
+                organisation_name=current_organisation.name,
+                branding_name=email_branding_name,
+            )
+        )
+        flash(
+            confirmation_question,
+            'yes, make this email branding the default',
+        )
+
+    # This form submission handles users pressing `Make default` on a brand. We handle two cases here:
+    # 1) If the org is currently on GOV.UK, we redirect them to the confirmation message explaining what happens when
+    #    changing from GOV.UK to an explicit brand. This is handled by the block above.
+    # 2) If the org is currently on an explicit brand and is changing to another, we just handle that change immediately
+    #    and don't require confirmation.
+    if form.validate_on_submit():
+        if current_organisation.email_branding_id is None:
+            return redirect(
+                url_for(
+                    'main.organisation_email_branding',
+                    org_id=current_organisation.id,
+                    new_default_branding_id=form.email_branding_id.data,
+                )
+            )
+
+        organisations_client.update_organisation(
+            current_organisation.id,
+            email_branding_id=form.email_branding_id.data,
+        )
+        return redirect(url_for('main.organisation_email_branding', org_id=current_organisation.id))
+
+    return None
 
 
 @main.route("/organisations/<uuid:org_id>/settings/email-branding", methods=['GET', 'POST'])
@@ -481,14 +608,31 @@ def organisation_email_branding(org_id):
         if option["name"] != current_organisation.email_branding_name
     ]
 
+    is_central_government = current_organisation.organisation_type == Organisation.TYPE_CENTRAL
     remove_branding_id = request.args.get('remove_branding_id')
+    change_default_branding_to_govuk = 'change_default_branding_to_govuk' in request.args
+    new_default_branding_id = request.args.get('new_default_branding_id')
+    form = AdminChangeOrganisationDefaultEmailBrandingForm()
+
     if remove_branding_id:
-        if response := __handle_remove_branding(remove_branding_id):
+        if response := _handle_remove_branding(remove_branding_id):
             return response
+
+    elif change_default_branding_to_govuk:
+        if response := _handle_change_default_branding_to_govuk(is_central_government):
+            return response
+
+    elif response := _handle_change_default_branding(form, new_default_branding_id):
+        return response
+
+    # We only show this link to central government organisations.
+    show_govuk_default_option = is_central_government and current_organisation.email_branding_id is not None
 
     return render_template(
         'views/organisations/organisation/settings/email-branding-options.html',
         email_branding_pool_options=email_branding_pool_options,
+        form=form,
+        show_govuk_default_option=show_govuk_default_option
     )
 
 

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -6,6 +6,8 @@
         {% set delete_button_text = "Yes, {}".format(category) %}
       {% elif category == 'try again' %}
         {% set delete_button_text = category|capitalize %}
+      {% elif category == 'yes, make this email branding the default' %}
+        {% set delete_button_text = category|capitalize %}
       {% else %}
         {% set delete_button_text = None %}
       {% endif %}

--- a/app/templates/partials/flash_messages/email_branding_confirm_change_brand_from_govuk.html
+++ b/app/templates/partials/flash_messages/email_branding_confirm_change_brand_from_govuk.html
@@ -1,0 +1,12 @@
+<h2 class="banner-title">
+  Are you sure you want to make ‘{{ branding_name }}’ the default email branding?
+</h2>
+
+<p class="govuk-body">
+  {{ organisation_name }} services currently using GOV.UK branding:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>will have their default email branding changed</li>
+  <li>will no longer be able to use the GOV.UK branding</li>
+</ul>

--- a/app/templates/partials/flash_messages/email_branding_confirm_change_default_to_govuk.html
+++ b/app/templates/partials/flash_messages/email_branding_confirm_change_default_to_govuk.html
@@ -1,0 +1,7 @@
+<h2 class="banner-title">
+  Are you sure you want to make GOV.UK the default email branding?
+</h2>
+
+<p class="govuk-body">
+  {{ organisation_name }} services currently using the {{ current_brand }} brand will not be updated.
+</p>

--- a/app/templates/partials/flash_messages/email_branding_confirm_remove_brand.html
+++ b/app/templates/partials/flash_messages/email_branding_confirm_remove_brand.html
@@ -1,0 +1,3 @@
+<h2 class="banner-title">
+  Are you sure you want to remove the email brand ‘{{ branding_name }}’?
+</h2>

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -3,6 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper%}
 {% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/button/macro.njk" import govukButton %}
 {%  from "components/branding-preview.html" import email_branding_preview %}
 
 {% set page_title = "Email branding" %}
@@ -16,7 +17,8 @@
 {%  endblock %}
 
 {% block maincolumn_content %}
-    {{ page_header(page_title) }}
+    <h1 class="govuk-heading-l">{{ page_title }}</h1>
+
     <!-- display default branding and it's preview -->
     <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
       {{ current_org.email_branding_name }}<span class="hint govuk-!-font-weight-normal">&ensp;(default)</span>
@@ -25,18 +27,46 @@
 
     <!--display the email-branding-pool options and the preview for each one -->
 
+    {% if show_govuk_default_option %}
+      <p class="govuk-body govuk-!-margin-bottom-7">
+        <a
+          class="govuk-link govuk-link--no-visited-state"
+          href="{{ url_for('main.organisation_email_branding', org_id=current_org.id) }}?change_default_branding_to_govuk"
+        >
+          Use GOV.UK as default instead
+        </a>
+      </p>
+    {% endif %}
+
     {% for option in email_branding_pool_options %}
       <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
         {{ option.name }}
       </h2>
       {{ email_branding_preview(option.id, classes='govuk-!-margin-bottom-0') }}
-      <p class="govuk-body govuk-!-margin-top-1 govuk-!-text-align-right">
-        <a href="{{ url_for('main.organisation_email_branding', org_id=current_org.id) }}?remove_branding_id={{ option.id }}"
-         class="govuk-link govuk-link govuk-link--destructive govuk-link--no-visited-state">
-          Remove <span class="govuk-visually-hidden">this branding option</span>
-        </a>
-      </p>
+      <div class="govuk-grid-row govuk-!-margin-top-2 govuk-!-margin-bottom-6">
+        <div class="govuk-grid-column-one-half">
+          {% call form_wrapper(action=url_for('main.organisation_email_branding', org_id=current_org.id)) %}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            {{ form.email_branding_id(value=option.id) }}
+            {{ govukButton({
+              "element": "input",
+              "text": "Make default",
+              "classes": "govuk-button--secondary"
+            }) }}
+          {% endcall %}
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body govuk-!-text-align-right">
+            <a href="{{ url_for('main.organisation_email_branding', org_id=current_org.id) }}?remove_branding_id={{ option.id }}"
+             class="govuk-link govuk-link govuk-link--destructive govuk-link--no-visited-state">
+              Remove <span class="govuk-visually-hidden">this branding option</span>
+            </a>
+          </p>
+        </div>
+      </div>
     {% endfor %}
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />
 
     <div class="js-stick-at-bottom-when-scrolling">
       {{ page_footer(


### PR DESCRIPTION
Make it possible for platform admins to set the default email branding
for an organisation from a single consolidated page, rather than having
one page to set the default and another to add/remove email brands.

Only central organisations are allowed to switch back to the platform
default GOV.UK branding if they are on another brand.

If an organisation is being switched away from GOV.UK, we want to warn
them that any services in that organisation currently also on the
implicit GOV.UK brand will have their brands updated to match. This only
happens when moving from GOV.UK (effectively 'no brand') to something
else. Switching between two explicit brands will not affect services at
all.

Another ticket covers removing the now-redundant default email branding
page.