### PR TITLE
Tweak layout and wording of ‘Apply branding’ page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1977,9 +1977,12 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
             f'this branding?'
         )
 
-        self.add_to_pool.param_extensions = {'items': [{'hint': {}},
-                                                       {'hint': {}}]
-                                             }
+        self.add_to_pool.param_extensions = {
+            'items': [
+                {'hint': {}},
+                {'hint': {}},
+            ]
+        }
         self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(f'''
             <ul class="govuk-list govuk-hint">
                 <li>Apply this branding to ‘{service_name}’</li>

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1981,13 +1981,17 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
         self.add_to_pool.param_extensions = {'items': [{'hint': {'html': ''}},
                                                        {'hint': {'html': ''}}]
                                              }
-        self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(
-            f'''
-                   Apply branding to {service_name}. <br>
-                   Let other {org_name} teams apply this branding themselves
-                ''')
-        self.add_to_pool.param_extensions['items'][1]['hint']['html'] = Markup(
-            f"Only apply branding to {service_name}")
+        self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(f'''
+            <ul class="govuk-list govuk-hint">
+                <li>Apply branding to {service_name}</li>
+                <li>Let other {org_name} teams apply this branding themselves</li>
+            </ul>
+        ''')
+        self.add_to_pool.param_extensions['items'][1]['hint']['html'] = Markup(f'''
+            <ul class="govuk-list govuk-hint">
+                <li>Only apply branding to {service_name}</li>
+            </ul>
+        ''')
 
     add_to_pool = GovukRadiosField(
         choices=[

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1991,14 +1991,14 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
             ],
         }
         self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(f'''
-            <ul class="govuk-list govuk-hint">
+            <ul class="govuk-list govuk-hint govuk-!-margin-bottom-0">
                 <li>Apply this branding to ‘{service_name}’</li>
-                <li>Let other {org_name} teams apply this branding themselves</li>
+                <li class="govuk-!-margin-bottom-0">Let other {org_name} teams apply this branding themselves</li>
             </ul>
         ''')
         self.add_to_pool.param_extensions['items'][1]['hint']['html'] = Markup(f'''
-            <ul class="govuk-list govuk-hint">
-                <li>Only apply this branding to ‘{service_name}’</li>
+            <ul class="govuk-list govuk-hint govuk-!-margin-bottom-0">
+                <li class="govuk-!-margin-bottom-0">Only apply this branding to ‘{service_name}’</li>
             </ul>
         ''')
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1964,11 +1964,15 @@ class AddEmailBrandingOptionsForm(StripWhitespaceForm):
 
 
 class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,
+        org_name,
+        service_name,
+        branding_name,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
-        org_name = kwargs['org_name']
-        service_name = kwargs['service_name']
-        branding_name = kwargs['branding_name']
         self.add_to_pool.label.text = (
             f'Should other teams in {org_name} have the option of using '
             f'the {branding_name} branding?'

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1969,13 +1969,12 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
         *args,
         org_name,
         service_name,
-        branding_name,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
         self.add_to_pool.label.text = (
-            f'Should other teams in {org_name} have the option of using '
-            f'the {branding_name} branding?'
+            f'Should other teams in {org_name} have the option to use '
+            f'this branding?'
         )
 
         self.add_to_pool.param_extensions = {'items': [{'hint': {'html': ''}},
@@ -1983,13 +1982,13 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
                                              }
         self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(f'''
             <ul class="govuk-list govuk-hint">
-                <li>Apply branding to {service_name}</li>
+                <li>Apply this branding to ‘{service_name}’</li>
                 <li>Let other {org_name} teams apply this branding themselves</li>
             </ul>
         ''')
         self.add_to_pool.param_extensions['items'][1]['hint']['html'] = Markup(f'''
             <ul class="govuk-list govuk-hint">
-                <li>Only apply branding to {service_name}</li>
+                <li>Only apply this branding to ‘{service_name}’</li>
             </ul>
         ''')
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1978,10 +1978,17 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
         )
 
         self.add_to_pool.param_extensions = {
+            'fieldset': {
+                'legend': {
+                    # This removes the `govuk-fieldset__legend--s` class, thereby
+                    # making the form label font regular weight, not bold
+                    'classes': '',
+                },
+            },
             'items': [
                 {'hint': {}},
                 {'hint': {}},
-            ]
+            ],
         }
         self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(f'''
             <ul class="govuk-list govuk-hint">

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1968,6 +1968,12 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
         org_name = kwargs['org_name']
         service_name = kwargs['service_name']
+        branding_name = kwargs['branding_name']
+        self.add_to_pool.label.text = (
+            f'Should other teams in {org_name} have the option of using '
+            f'the {branding_name} branding?'
+        )
+
         self.add_to_pool.param_extensions = {'items': [{'hint': {'html': ''}},
                                                        {'hint': {'html': ''}}]
                                              }

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1977,8 +1977,8 @@ class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
             f'this branding?'
         )
 
-        self.add_to_pool.param_extensions = {'items': [{'hint': {'html': ''}},
-                                                       {'hint': {'html': ''}}]
+        self.add_to_pool.param_extensions = {'items': [{'hint': {}},
+                                                       {'hint': {}}]
                                              }
         self.add_to_pool.param_extensions['items'][0]['hint']['html'] = Markup(f'''
             <ul class="govuk-list govuk-hint">

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1055,7 +1055,6 @@ def service_set_email_branding_add_to_branding_pool_step(service_id):
         'views/service-settings/set-email-branding-add-to-branding-pool-step.html',
         form=form,
         email_branding_name=email_branding_name,
-        org_name=org_name
     )
 
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1024,16 +1024,13 @@ def service_set_email_branding_add_to_branding_pool_step(service_id):
     email_branding_id = request.args.get('email_branding_id')
     email_branding = email_branding_client.get_email_branding(email_branding_id)['email_branding']
     email_branding_name = email_branding['name']
-    org_name = current_service.organisation.name
     org_id = current_service.organisation.id
-    service_name = current_service.name
-    data = {
-        'org_name': org_name,
-        'service_name': service_name,
-        'branding_name': email_branding_name
-    }
 
-    form = AdminSetEmailBrandingAddToBrandingPoolStepForm(**data)
+    form = AdminSetEmailBrandingAddToBrandingPoolStepForm(
+        org_name=current_service.organisation.name,
+        service_name=current_service.name,
+        branding_name=email_branding_name,
+    )
 
     if form.validate_on_submit():
         add_to_pool = form.add_to_pool.data
@@ -1044,7 +1041,7 @@ def service_set_email_branding_add_to_branding_pool_step(service_id):
             organisations_client.add_brandings_to_email_branding_pool(org_id,
                                                                       email_branding_ids)
             message = f"The email branding has been set to {email_branding_name} and it has been " \
-                      f"added to {org_name}'s email branding pool"
+                      f"added to {current_service.organisation.name}'s email branding pool"
 
         else:
             message = f"The email branding has been set to {email_branding_name}"

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1017,7 +1017,7 @@ def service_set_email_branding(service_id):
     )
 
 
-@main.route("/services/<uuid:service_id>/service-settings/set-email-branding/add_to_branding_pool_step", methods=[
+@main.route("/services/<uuid:service_id>/service-settings/set-email-branding/add-to-branding-pool-step", methods=[
     'GET', 'POST'])
 @user_is_platform_admin
 def service_set_email_branding_add_to_branding_pool_step(service_id):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1029,7 +1029,6 @@ def service_set_email_branding_add_to_branding_pool_step(service_id):
     form = AdminSetEmailBrandingAddToBrandingPoolStepForm(
         org_name=current_service.organisation.name,
         service_name=current_service.name,
-        branding_name=email_branding_name,
     )
 
     if form.validate_on_submit():

--- a/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
@@ -18,7 +18,7 @@ email_branding_name) %}
 
 
 {% block maincolumn_content %}
-    {{page_header(page_title, size="medium")}}
+    {{page_header(page_title)}}
 
     {{ page_blurb }}
 

--- a/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
@@ -20,14 +20,12 @@ email_branding_name) %}
 {% block maincolumn_content %}
     {{page_header(page_title, size="medium")}}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-five-sixths">
     {{ page_blurb }}
-      {% call form_wrapper() %}
-        {{ form.add_to_pool }}
-        {{ page_footer('Continue') }}
-      {% endcall %}
-    </div>
-  </div>
+
+    {% call form_wrapper() %}
+      {{ form.add_to_pool }}
+      {{ page_footer('Continue') }}
+    {% endcall %}
+
 {% endblock %}
 

--- a/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
@@ -5,8 +5,6 @@
 {% from "components/back-link/macro.njk" import govukBackLink %}
 
 {% set page_title = "Apply {} branding".format(email_branding_name) %}
-{% set  page_blurb = "Should other teams in {} have the option of using the {} branding?".format(org_name,
-email_branding_name) %}
 
 {% block backLink %}
   {{ govukBackLink({ "href": url_for('.service_set_email_branding', service_id=current_service.id) }) }}
@@ -19,8 +17,6 @@ email_branding_name) %}
 
 {% block maincolumn_content %}
     {{page_header(page_title)}}
-
-    {{ page_blurb }}
 
     {% call form_wrapper() %}
       {{ form.add_to_pool }}

--- a/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
@@ -4,7 +4,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
 
-{% set page_title = "Apply {} branding".format(email_branding_name) %}
+{% set page_title = "Apply ‘{}’ branding".format(email_branding_name) %}
 
 {% block backLink %}
   {{ govukBackLink({ "href": url_for('.service_set_email_branding', service_id=current_service.id) }) }}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3716,7 +3716,7 @@ def test_should_set_branding_for_service_with_organisation(
         _follow_redirects=True,
     )
 
-    assert normalize_spaces(page.find('h1').text) == f"Apply {email_branding_name} branding"
+    assert normalize_spaces(page.find('h1').text) == f"Apply ‘{email_branding_name}’ branding"
 
     mock_update_service.assert_called_once_with(
         SERVICE_ONE_ID,
@@ -3772,7 +3772,7 @@ def test_get_service_set_email_branding_add_to_branding_pool_step(
                               _expected_status=200,
                               service_id=SERVICE_ONE_ID,
                               email_branding_id=email_branding_id)
-    assert f"Apply {email_branding_name} branding" in normalize_spaces(page.find('title').text)
+    assert f"Apply ‘{email_branding_name}’ branding" in normalize_spaces(page.find('title').text)
 
 
 def test_service_set_email_branding_add_to_branding_pool_step_is_platform_admin_only(


### PR DESCRIPTION
Best reviewed commit by commit. 

Lots of small changes to make the page a bit clearer, and in line with the sizes, spacing, and font weights we use elsewhere.

Based on the content in this document: https://docs.google.com/document/d/1LLkTz5aBCsggERJZPZvZ1E5HSRrKfKVm3Yxcym9z-CY/edit?pli=1

Before | After 
---|---
<img width="783" alt="image" src="https://user-images.githubusercontent.com/355079/191282936-9111ee26-b3d3-4517-a818-873253a9d075.png"> | <img width="786" alt="image" src="https://user-images.githubusercontent.com/355079/191282820-fba7a3e3-9428-49ea-88a6-6aaa2a910d2c.png">
