### PR TITLE
Adjust spacing and font weight on branding pool page

### DIFF
--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -20,7 +20,7 @@
     <h1 class="govuk-heading-l">{{ page_title }}</h1>
 
     <!-- display default branding and it's preview -->
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
       {{ current_org.email_branding_name }}<span class="hint govuk-!-font-weight-normal">&ensp;(default)</span>
     </h2>
     {{ email_branding_preview(current_org.email_branding_id, classes='govuk-!-margin-bottom-8') }}

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -21,7 +21,7 @@
 
     <!-- display default branding and it's preview -->
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-      {{ current_org.email_branding_name }}<span class="hint govuk-!-font-weight-normal">&ensp;(default)</span>
+      {{ current_org.email_branding_name }}<span class="hint govuk-!-font-weight-regular">&ensp;(default)</span>
     </h2>
     {{ email_branding_preview(current_org.email_branding_id, classes='govuk-!-margin-bottom-8') }}
 


### PR DESCRIPTION
# Before

<img width="804" alt="image" src="https://user-images.githubusercontent.com/355079/191775668-d53641f7-df3f-4a8b-bc73-db54aa9bd56c.png">

# After

<img width="801" alt="image" src="https://user-images.githubusercontent.com/355079/191775528-ae1a8060-2cef-4a71-bb62-cde3153e5e92.png">

Matches this pattern on the team members page:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/355079/191776109-8a2f4a26-612d-48af-a427-5abc293d39ab.png">
