### PR TITLE
Add tick image as SVG with new `$green` colour

### DIFF
--- a/app/assets/images/tick.svg
+++ b/app/assets/images/tick.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 128 128" style="enable-background:new 0 0 128 128;" xml:space="preserve">
+<g id="Layer_1">
+	<polygon fill="#00703C" points="103.5,13 127.9,37.4 46.400000000000006,118.9 22,94.5 103.5,13"></polygon>
+	<polygon fill="#00703C" points="24.4,48 0,72.4 43.6,116 68,91.6 24.4,48"></polygon>
+</g>
+</svg>


### PR DESCRIPTION
This PR just adds the image, without using it anywhere.

Once we switch to using the new colours from the Design System, we can replace uses of `tick.png` with this image.

This will give us:
- the correct green
- a resolution-independent image
- a smaller file size (55% of the original)

***

![tick](https://user-images.githubusercontent.com/355079/191941889-90d89001-e4b8-4540-8721-5d15acf1e937.svg)

