### PR TITLE
Re-add page to confirm NHS branding

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -20,6 +20,7 @@ from notifications_utils.recipients import (
     normalise_phone_number,
     validate_phone_number,
 )
+from orderedset import OrderedSet
 from werkzeug.utils import cached_property
 from wtforms import (
     BooleanField,
@@ -2035,15 +2036,7 @@ class ChooseEmailBrandingForm(ChooseBrandingForm):
 
     def __init__(self, service):
         super().__init__()
-
-        branding_choices = list(branding.get_email_choices(service)) + [self.FALLBACK_OPTION]
-
-        # If NHS branding is an option for the service and NHS branding is also in the branding pool we remove the
-        # version in the pool to stop it appearing twice on the form
-        if (("nhs", "NHS") in branding_choices) and ((branding.NHS_EMAIL_BRANDING_ID, "NHS") in branding_choices):
-            branding_choices.remove((branding.NHS_EMAIL_BRANDING_ID, "NHS"))
-
-        self.options.choices = tuple(branding_choices)
+        self.options.choices = tuple(OrderedSet(branding.get_email_choices(service)) | {self.FALLBACK_OPTION})
 
 
 class ChooseLetterBrandingForm(ChooseBrandingForm):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1148,6 +1148,13 @@ def email_branding_request(service_id):
 
         branding_choice = form.options.data
 
+        if branding_choice == NHS_EMAIL_BRANDING_ID:
+            return redirect(
+                url_for(
+                    ".email_branding_nhs",
+                    service_id=current_service.id,
+                )
+            )
         if branding_choice in [branding["id"] for branding in current_service.email_branding_pool]:
             return redirect(
                 url_for(".email_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1155,7 +1155,7 @@ def email_branding_request(service_id):
                     service_id=current_service.id,
                 )
             )
-        if branding_choice in [branding["id"] for branding in current_service.email_branding_pool]:
+        if branding_choice in current_service.email_branding_pool_ids:
             return redirect(
                 url_for(".email_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)
             )

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1237,7 +1237,7 @@ def email_branding_govuk_and_org(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/nhs", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def email_branding_nhs(service_id):
-    check_email_branding_allowed_for_service("nhs")
+    check_email_branding_allowed_for_service(NHS_EMAIL_BRANDING_ID)
 
     if request.method == "POST":
         current_service.update(email_branding=NHS_EMAIL_BRANDING_ID)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -605,6 +605,10 @@ class Service(JSONModel):
         else:
             return []
 
+    @property
+    def email_branding_pool_ids(self):
+        return [branding["id"] for branding in self.email_branding_pool]
+
 
 class Services(SerialisedModelCollection):
     model = Service

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -14,7 +14,7 @@ def get_email_choices(service):
         yield ("govuk", "GOV.UK")
 
     if service.organisation_type in Organisation.NHS_TYPES and service.email_branding_id != NHS_EMAIL_BRANDING_ID:
-        yield ("nhs", "NHS")
+        yield (NHS_EMAIL_BRANDING_ID, "NHS")
 
     if service.email_branding_pool:
         for branding in service.email_branding_pool:

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -46,7 +46,7 @@ def test_email_branding_request_page_when_no_branding_is_set(
     assert [
         (radio["value"], page.select_one("label[for={}]".format(radio["id"])).text.strip())
         for radio in page.select("input[type=radio]")
-    ] == [("nhs", "NHS"), ("something_else", "Something else")]
+    ] == [("a7dc4e56-660b-4db7-8cff-12c37b12b5ea", "NHS"), ("something_else", "Something else")]
 
     assert button_text == "Continue"
 
@@ -57,7 +57,7 @@ def test_email_branding_request_page_when_no_branding_is_set(
         (
             "nhs_central",
             [
-                ("nhs", "NHS"),
+                ("a7dc4e56-660b-4db7-8cff-12c37b12b5ea", "NHS"),
                 ("email-branding-1-id", "Email branding name 1"),
                 ("email-branding-2-id", "Email branding name 2"),
                 ("something_else", "Something else"),
@@ -140,7 +140,7 @@ def test_email_branding_request_does_not_show_nhs_branding_twice(
         (radio["value"], page.select_one(f'label[for={radio["id"]}]').text.strip())
         for radio in page.select("input[type=radio]")
     ] == [
-        ("nhs", "NHS"),
+        (NHS_EMAIL_BRANDING_ID, "NHS"),
         ("email-branding-1-id", "Email branding name 1"),
         ("email-branding-2-id", "Email branding name 2"),
         ("something_else", "Something else"),
@@ -376,7 +376,7 @@ def test_email_branding_request_page_back_link(
         ),
         (
             {
-                "options": "nhs",
+                "options": "a7dc4e56-660b-4db7-8cff-12c37b12b5ea",
             },
             "nhs_local",
             "main.email_branding_nhs",

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -173,6 +173,40 @@ def test_email_branding_request_page_redirects_to_something_else_page_if_that_is
     )
 
 
+def test_email_branding_request_page_redirects_nhs_specific_page(
+    mocker,
+    service_one,
+    client_request,
+    mock_get_email_branding,
+    organisation_one,
+):
+    service_one["organisation"] = organisation_one["id"]
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_one,
+    )
+
+    mocker.patch(
+        "app.organisations_client.get_email_branding_pool",
+        return_value=[
+            {
+                "name": "NHS",
+                "id": "a7dc4e56-660b-4db7-8cff-12c37b12b5ea",
+            },
+        ],
+    )
+
+    client_request.post(
+        ".email_branding_request",
+        service_id=SERVICE_ONE_ID,
+        _data={"options": "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"},
+        _expected_redirect=url_for(
+            "main.email_branding_nhs",
+            service_id=SERVICE_ONE_ID,
+        ),
+    )
+
+
 def test_email_branding_request_redirects_to_branding_preview_for_a_branding_pool_option(
     mocker, service_one, organisation_one, client_request, mock_get_email_branding, mock_get_email_branding_pool
 ):

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -46,7 +46,7 @@ def test_email_branding_request_page_when_no_branding_is_set(
     assert [
         (radio["value"], page.select_one("label[for={}]".format(radio["id"])).text.strip())
         for radio in page.select("input[type=radio]")
-    ] == [("a7dc4e56-660b-4db7-8cff-12c37b12b5ea", "NHS"), ("something_else", "Something else")]
+    ] == [(NHS_EMAIL_BRANDING_ID, "NHS"), ("something_else", "Something else")]
 
     assert button_text == "Continue"
 
@@ -57,7 +57,7 @@ def test_email_branding_request_page_when_no_branding_is_set(
         (
             "nhs_central",
             [
-                ("a7dc4e56-660b-4db7-8cff-12c37b12b5ea", "NHS"),
+                (NHS_EMAIL_BRANDING_ID, "NHS"),
                 ("email-branding-1-id", "Email branding name 1"),
                 ("email-branding-2-id", "Email branding name 2"),
                 ("something_else", "Something else"),
@@ -191,7 +191,7 @@ def test_email_branding_request_page_redirects_nhs_specific_page(
         return_value=[
             {
                 "name": "NHS",
-                "id": "a7dc4e56-660b-4db7-8cff-12c37b12b5ea",
+                "id": NHS_EMAIL_BRANDING_ID,
             },
         ],
     )
@@ -199,7 +199,7 @@ def test_email_branding_request_page_redirects_nhs_specific_page(
     client_request.post(
         ".email_branding_request",
         service_id=SERVICE_ONE_ID,
-        _data={"options": "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"},
+        _data={"options": NHS_EMAIL_BRANDING_ID},
         _expected_redirect=url_for(
             "main.email_branding_nhs",
             service_id=SERVICE_ONE_ID,
@@ -376,7 +376,7 @@ def test_email_branding_request_page_back_link(
         ),
         (
             {
-                "options": "a7dc4e56-660b-4db7-8cff-12c37b12b5ea",
+                "options": NHS_EMAIL_BRANDING_ID,
             },
             "nhs_local",
             "main.email_branding_nhs",

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -12,13 +12,15 @@ from tests import organisation_json
 from tests.conftest import create_email_branding
 
 
-@pytest.mark.parametrize("function", [get_email_choices, get_letter_choices])
 @pytest.mark.parametrize(
-    "org_type, expected_options",
+    "function, org_type, expected_options",
     [
-        ("central", []),
-        ("local", []),
-        ("nhs_central", [("nhs", "NHS")]),
+        (get_email_choices, "central", []),
+        (get_letter_choices, "central", []),
+        (get_email_choices, "local", []),
+        (get_letter_choices, "local", []),
+        (get_email_choices, "nhs_central", [(NHS_EMAIL_BRANDING_ID, "NHS")]),
+        (get_letter_choices, "nhs_central", [("nhs", "NHS")]),
     ],
 )
 def test_get_choices_service_not_assigned_to_org(
@@ -57,7 +59,7 @@ def test_get_choices_service_not_assigned_to_org(
         ),
         ("local", None, [("organisation", "Test Organisation")]),
         ("local", "some-branding-id", [("organisation", "Test Organisation")]),
-        ("nhs_central", None, [("nhs", "NHS")]),
+        ("nhs_central", None, [(NHS_EMAIL_BRANDING_ID, "NHS")]),
         (
             "nhs_central",
             NHS_EMAIL_BRANDING_ID,


### PR DESCRIPTION
In 92f76638c891487889b7debcdc8c7914da5a804a, when we let people choose NHS branding for themselves, we added a bespoke confirmation page with guidance about whether using the NHS branding was appropriate.

This was lost once we put NHS branding in the pool, and choosing it was just picking another `id`, rather than `nhs` as a special case.

This commit restores the behaviour by adding an extra check against the `id` of the NHS branding, and treating it the same as if they had previously chosen `nhs` as a special case.