### PR TITLE
Remove GOV.UK Frontend Toolkit [part 6]

### DIFF
--- a/app/assets/stylesheets/components/live-search.scss
+++ b/app/assets/stylesheets/components/live-search.scss
@@ -1,10 +1,3 @@
-input[type=search] {
-  // overrides this nasty global from GOV.UK template
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-}
-
 .live-search {
 
   display: none;

--- a/app/assets/stylesheets/globals.scss
+++ b/app/assets/stylesheets/globals.scss
@@ -28,29 +28,6 @@ abbr[title] {
   display: none;
 }
 
-// To be removed when all search inputs use the GOV.UK Frontend text input component:
-// https://design-system.service.gov.uk/components/text-input/
-/*
- * 1. Addresses `appearance` set to `searchfield` in Safari 5 and Chrome.
- * 2. Addresses `box-sizing` set to `border-box` in Safari 5 and Chrome
- *    (include `-moz` to future-proof). 
- */
-
-input[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box; /* 2 */
-  box-sizing: content-box;
-}
-input[type="search"]::-webkit-search-cancel-button {
-  -webkit-appearance: searchfield-cancel-button;
-  margin-right: 2px;
-}
-
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
 // Each selector, and then the whole block when only one remains, to be removed when the
 // element comes from the corresponding GOV.UK Frontend component:
 // - https://design-system.service.gov.uk/components/text-input/

--- a/app/assets/stylesheets/govuk-elements/_forms.scss
+++ b/app/assets/stylesheets/govuk-elements/_forms.scss
@@ -43,7 +43,7 @@ textarea {
 
 .form-group {
   @extend %contain-floats;
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 }
 
 // Form group is used to wrap label and input pairs
@@ -93,7 +93,7 @@ textarea {
 // By default, form controls are 50% width for desktop,
 // and 100% width for mobile
 .form-control {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include govuk-font(19);
   @include govuk-focusable; // hack to give GOVUK Frontend v3 focus styling.
   width: 100%;

--- a/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
@@ -33,7 +33,7 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
     // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
     @if ($is-ie == false) or ($ie-version == 9) {
       margin: 0;
-      @include opacity(0);
+      opacity: 0;
     }
   }
 
@@ -113,7 +113,7 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
   }
 
   input:disabled + label {
-    @include opacity(0.5);
+    opacity: 0.5;
     cursor: default;
   }
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -6,7 +6,6 @@ $path: '/static/images/';
 @import 'conditionals';
 @import 'shims';
 @import 'measurements';
-@import 'css3';
 
 // Dependencies from GOVU.UK Frontend Toolkit, rewritten for this application
 @import 'url-helpers';

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -65,13 +65,13 @@ describe('Live search', () => {
       // set up DOM
       document.body.innerHTML = `
         <div class="live-search js-header" data-module="live-search" data-targets=".govuk-radios__item">
-          <div class="form-group">
-            <label class="form-label" for="search">
-                ${searchLabelText}
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="search">
+              ${searchLabelText}
             </label>
-            <input autocomplete="off" class="form-control form-control-1-1 " id="search" name="search" rows="8" type="search" value="">
-            <div role="region" aria-live="polite" class="live-search__status govuk-visually-hidden"></div>
+            <input class="govuk-input govuk-!-width-full" id="search" name="search" type="search" autocomplete="off">
           </div>
+          <div aria-live="polite" class="live-search__status govuk-visually-hidden"></div>
         </div>
         <form method="post" autocomplete="off" novalidate>
         </form>`;


### PR DESCRIPTION
This is part 6 of a series of work to remove the GOVUK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

We want to remove GOV.UK Frontend Toolkit from our code to replace it with GOV.UK Frontend.

This removes all the Sass mixins (see [Sass docs](https://sass-lang.com/documentation/at-rules/mixin)) that we had to let us use 'more modern' features like `box-sizing` and `transition` while still supporting browsers that don't recognise them. This was from a long time ago. All those features are now supported by the browsers we support.

## Browser support for features the mixins provide

Because the browsers we support now ([GDS matrix](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in-from-june-2022) + IE11) have these features, most of these changes just swap the mixins out for the native version.

The oldest browser we support is IE11. MDN doesn't list IE11 in browser support any more so here's some tables from caniuse to reference instead:
- [support for opacity](https://caniuse.com/?search=opacity)
- [support for calc](https://caniuse.com/?search=calc) (includes some issues in IE11)
- [support for appearance](https://caniuse.com/?search=appearance)
- [support for box-sizing](https://caniuse.com/css3-boxsizing)
- [support for transition](https://caniuse.com/?search=transition)

This doesn't include `gradient`, `translate` or `scale` as the mixin, or native feature, are not used in our code.

### Caveats

We don't use the `appearance` mixin anywhere, preferring the webkit-specific `-webkit-appearance`.

We only use the native version of `calc`. IE11 has some issues with it but all the places we use it have been tested in IE11.

## Other changes

This pull request also includes removal of some styles for our uses of the `input[type=search]` element. Our live search component is the only use of `input[type=search]`s and now uses the GOVUK Frontend input component so doesn't need them.

### Merge after
- https://github.com/alphagov/notifications-admin/pull/4352