### PR TITLE
More fixes to spacing on the pool page

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -554,13 +554,13 @@ def organisation_email_branding(org_id):
         return response
 
     # We only show this link to central government organisations.
-    show_govuk_default_option = is_central_government and current_organisation.email_branding_id is not None
+    show_use_govuk_as_default_link = is_central_government and current_organisation.email_branding_id is not None
 
     return render_template(
         "views/organisations/organisation/settings/email-branding-options.html",
         email_branding_pool_options=email_branding_pool_options,
         form=form,
-        show_govuk_default_option=show_govuk_default_option,
+        show_use_govuk_as_default_link=show_use_govuk_as_default_link,
     )
 
 

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -39,7 +39,7 @@
     {% endif %}
 
     {% for option in email_branding_pool_options %}
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
         {{ option.name }}
       </h2>
       {{ email_branding_preview(option.id, classes='govuk-!-margin-bottom-0') }}

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -23,12 +23,10 @@
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
       {{ current_org.email_branding_name }}<span class="hint govuk-!-font-weight-regular">&ensp;(default)</span>
     </h2>
-    {{ email_branding_preview(current_org.email_branding_id, classes='govuk-!-margin-bottom-8') }}
 
-    <!--display the email-branding-pool options and the preview for each one -->
-
-    {% if show_govuk_default_option %}
-      <p class="govuk-body govuk-!-margin-bottom-7">
+    {% if show_use_govuk_as_default_link %}
+      {{ email_branding_preview(current_org.email_branding_id, classes='govuk-!-margin-bottom-2') }}
+      <p class="govuk-body govuk-!-margin-bottom-6">
         <a
           class="govuk-link govuk-link--no-visited-state"
           href="{{ url_for('main.organisation_email_branding', org_id=current_org.id) }}?change_default_branding_to_govuk"
@@ -36,7 +34,11 @@
           Use GOV.UK as default instead
         </a>
       </p>
+    {% else %}
+      {{ email_branding_preview(current_org.email_branding_id, classes='govuk-!-margin-bottom-8') }}
     {% endif %}
+
+    <!--display the email-branding-pool options and the preview for each one -->
 
     {% for option in email_branding_pool_options %}
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">


### PR DESCRIPTION
- Makes the spacing under the headings for both default and pool options consistent
- moves the ‘Use GOV.UK as default instead’ link closer to the default branding preview so they group better 

Before | After
---|---
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/355079/193077610-26c304d9-c89d-4c5a-9f55-54e6468ce7e1.png"> | <img width="1063" alt="image" src="https://user-images.githubusercontent.com/355079/193077528-6c7ec3b0-a875-4348-93f9-67537e9994b6.png">
