### PR TITLE
Allow use of fingerprint or face recognition instead of a USB security key

### DIFF
--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -28,7 +28,7 @@ def webauthn_begin_register():
         },
         credentials=current_user.webauthn_credentials.as_cbor,
         user_verification="discouraged",  # don't ask for PIN
-        authenticator_attachment="cross-platform",
+        authenticator_attachment=None,
     )
 
     session["webauthn_registration_state"] = state

--- a/tests/app/main/views/test_webauthn_credentials.py
+++ b/tests/app/main/views/test_webauthn_credentials.py
@@ -70,7 +70,7 @@ def test_begin_register_returns_encoded_options(
     assert webauthn_options["timeout"] == 30_000
 
     auth_selection = webauthn_options["authenticatorSelection"]
-    assert auth_selection["authenticatorAttachment"] == "cross-platform"
+    assert "authenticatorAttachment" not in auth_selection
     assert auth_selection["userVerification"] == "discouraged"
 
     user_options = webauthn_options["user"]


### PR DESCRIPTION
Modern browsers accept two type of authenticator (security key) attachment:
1. `cross-platform`: the authenticator (security key) can be removed (unplugged) from the platform (your laptop) and used on another platform (laptop). In other words a USB stick.
2. `platform`: the authenticator (security key) is built into the platform (your laptop)

An example of a platform authenticator is the touch ID sensor on newer Macbooks. It stores a hash of a scan of a fingerprint, which is then checked when a user wants to authenticate.

This commit sets the attachment to `None`, which means that both platform and cross-platform authenticators can be added.

This means we can use Touch ID to log into Notify, which is useful when you leave your Yubikey at home on a mandatory day in the office.

***

Here’s what it looks like to register and use Touch ID:

https://user-images.githubusercontent.com/355079/193250700-c1e399d5-e097-40ea-9120-c7aa1ff69409.mov


***

Here’s how you can still use your Yubikey instead, if you really want to:

https://user-images.githubusercontent.com/355079/193251454-2b83cab4-859c-461b-9f9c-6469a8d411a9.mov

***

See:
- W3C standard: https://www.w3.org/TR/webauthn-2/#dom-authenticatorselectioncriteria-authenticatorattachment
- Implementation in the library we are using: https://github.com/Yubico/python-fido2/blob/8c00d0494501028135fd13adbe8c56a8d8b7e437/fido2/server.py#L176-L177