### PR TITLE
Remove GOV.UK Frontend Toolkit [part 7]

### DIFF
--- a/app/assets/stylesheets/govuk-elements/_forms.scss
+++ b/app/assets/stylesheets/govuk-elements/_forms.scss
@@ -48,7 +48,7 @@ textarea {
 
 // Form group is used to wrap label and input pairs
 .form-group {
-  margin-bottom: $gutter-half;
+  margin-bottom: $govuk-gutter-half;
 
   @include media(tablet) {
     margin-bottom: $govuk-gutter;

--- a/app/assets/stylesheets/govuk-elements/_forms.scss
+++ b/app/assets/stylesheets/govuk-elements/_forms.scss
@@ -51,7 +51,7 @@ textarea {
   margin-bottom: $gutter-half;
 
   @include media(tablet) {
-    margin-bottom: $gutter;
+    margin-bottom: $govuk-gutter;
   }
 }
 

--- a/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
@@ -14,7 +14,7 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
   position: relative;
 
   padding: 0 0 0 38px;
-  margin-bottom: $gutter-one-third;
+  margin-bottom: $govuk-gutter / 3;
 
   @include media(tablet) {
     float: left;
@@ -39,7 +39,7 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
 
   label {
     cursor: pointer;
-    padding: 8px $gutter-one-third 9px 12px;
+    padding: 8px ($govuk-gutter / 3) 9px 12px;
     display: block;
 
     // remove 300ms pause on mobile

--- a/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
@@ -129,6 +129,6 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
 
   @include media (tablet) {
     margin-bottom: 0;
-    margin-right: $gutter;
+    margin-right: $govuk-gutter;
   }
 }

--- a/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
@@ -9,7 +9,7 @@
 
   @include media(tablet) {
     border-left: 5px solid $govuk-error-colour;
-    padding-left: $gutter-half;
+    padding-left: $govuk-gutter-half;
   }
 }
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -5,7 +5,6 @@ $path: '/static/images/';
 // https://github.com/alphagov/govuk_frontend_toolkit/
 @import 'conditionals';
 @import 'shims';
-@import 'measurements';
 
 // Dependencies from GOVU.UK Frontend Toolkit, rewritten for this application
 @import 'url-helpers';


### PR DESCRIPTION
This is part 7 of a series of work to remove the GOVUK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

We want to remove GOV.UK Frontend Toolkit from our code to replace it with GOV.UK Frontend.

This removes all the measurements we were [using from this file](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_measurements.scss) and replaces them with the GOV.UK Frontend equivalents.

### Merge after
- [x] https://github.com/alphagov/notifications-admin/pull/4352
- [x] https://github.com/alphagov/notifications-admin/pull/4370