### PR TITLE
Bump utils to 57.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ pyproj==3.3.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.0.0
 govuk-frontend-jinja @ git+https://github.com/Crown-Commercial-Service/govuk-frontend-jinja.git@v0.5.8-alpha  # pyup: ignore # can’t be upgraded until we migrate to https://github.com/LandRegistry/govuk-frontend-jinja
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ awscli==1.25.57
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-bleach==5.0.1
-    # via notifications-utils
 blinker==1.5
     # via
     #   -r requirements.in
@@ -123,7 +121,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.0.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx
@@ -203,7 +201,6 @@ shapely==1.8.4
 six==1.16.0
     # via
     #   awscli-cwlogs
-    #   bleach
     #   eventlet
     #   fido2
     #   python-dateutil
@@ -219,8 +216,6 @@ urllib3==1.26.9
     # via
     #   botocore
     #   requests
-webencodings==0.5.1
-    # via bleach
 werkzeug==2.1.2
     # via
     #   -r requirements.in


### PR DESCRIPTION
Major changes:

> ## 57.0.0
>
> * Breaking changes to `field.Field`:
>
>  - The `html` argument must now be `escape` or `passthrough`. `strip` is no longer valid
>  - The default value of the `html` argument is now `escape` not `strip`
>
> * Removal of `formatters.strip_html`

Full diff: https://github.com/alphagov/notifications-utils/compare/56.0.3...57.0.0