### PR TITLE
Store emailed address of archived user when archiving a user in the events table

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -18,8 +18,6 @@ EVENT_SCHEMAS = {
         "provider_restriction",
     },  # noqa: E501 (length)
     "archive_service": {"service_id", "archived_by_id"},
-    "suspend_service": {"service_id", "suspended_by_id"},
-    "resume_service": {"service_id", "resumed_by_id"},
 }
 
 

--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -9,7 +9,7 @@ EVENT_SCHEMAS = {
     "remove_user_from_service": {"user_id", "removed_by_id", "service_id"},
     "add_user_to_service": {"user_id", "invited_by_id", "service_id", "ui_permissions"},
     "set_user_permissions": {"user_id", "service_id", "original_ui_permissions", "new_ui_permissions", "set_by_id"},
-    "archive_user": {"user_id", "archived_by_id"},
+    "archive_user": {"user_id", "user_email_address", "archived_by_id"},
     "change_broadcast_account_type": {
         "service_id",
         "changed_by_id",

--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -33,6 +33,9 @@ def user_information(user_id):
 @user_is_platform_admin
 def archive_user(user_id):
     if request.method == "POST":
+        user = User.from_id(user_id)
+        original_email_address = user.email_address
+
         try:
             user_api_client.archive_user(user_id)
         except HTTPError as e:
@@ -42,7 +45,10 @@ def archive_user(user_id):
                     "check all services have another team member with manage_settings"
                 )
                 return redirect(url_for("main.user_information", user_id=user_id))
-        create_archive_user_event(user_id=str(user_id), archived_by_id=current_user.id)
+
+        create_archive_user_event(
+            user_id=str(user_id), user_email_address=original_email_address, archived_by_id=current_user.id
+        )
 
         return redirect(url_for(".user_information", user_id=user_id))
     else:

--- a/tests/app/test_event_handlers.py
+++ b/tests/app/test_event_handlers.py
@@ -73,7 +73,7 @@ def test_create_mobile_number_change_event_calls_events_api(client_request, mock
 
 
 def test_create_archive_user_event_calls_events_api(client_request, mock_events):
-    kwargs = {"user_id": str(uuid.uuid4()), "archived_by_id": str(uuid.uuid4())}
+    kwargs = {"user_id": str(uuid.uuid4()), "user_email_address": "user@gov.uk", "archived_by_id": str(uuid.uuid4())}
 
     create_archive_user_event(**kwargs)
     mock_events.assert_called_with("archive_user", event_dict(**kwargs))


### PR DESCRIPTION
We now store the email address of the user being archived in the events
table as part of the `archive_user` event.

This will enable us, in a separate story, to delete the user's name and
email from their row in the user table when we archive them and not
have to introduce a new job to remove user data that is older than 1
year for archived users.