### PR TITLE
Fix issue with GOVUK Elements radios

### DIFF
--- a/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-multiple-choice.scss
@@ -29,6 +29,8 @@ $govuk-radios-focus-width: $govuk-focus-width + 1px;
     width: 38px;
     height: 38px;
     z-index: 1;
+    margin: 0;
+    opacity: 0;
   }
 
   label {


### PR DESCRIPTION
A block of code targeting non-ie browsers, and IE9 was removed mistakenly in this commit:

https://github.com/alphagov/notifications-admin/pull/4379/commits/8fd533dfb9096b17f560471192c5349cb34269ff#

Removing it revealled the `<input>` for those radios:

<img width="387" alt="image" src="https://user-images.githubusercontent.com/87140/194529425-fb55096c-afb3-4625-a467-e81b72614dc8.png">

which is hidden in favour of using psuedo-elements to show a custom shape

This replaces it, without the conditional because
we don't support IE8 or 9 any more so it applies
to all.