### PR TITLE
Update retention period for send-a-file-by-email

### DIFF
--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -26,7 +26,7 @@
     <li>it’s stored on the service</li>
   </ul>
   <p class="govuk-body">Any recipient data you upload is only held for 7 days.</p>
-  <p class="govuk-body">If you <a class="govuk-link govuk-link--no-visited-state" href="/features/email#send-files">send a file by email</a>, the file will be available for the recipient to download for 18 months.</p>
+  <p class="govuk-body">If you <a class="govuk-link govuk-link--no-visited-state" href="/features/email#send-files">send a file by email</a>, the file will be available for the recipient to download for up to 78 weeks (18 months).</p>
   <p class="govuk-body">The Cabinet Office acts as data processor for Notify. Your organisation is the data controller.</p>
   <h3 class="heading-small">Data Protection Act</h3>
   <p class="govuk-body">Notify complies with data protection law. To make sure it stays compliant, there are regular legal reviews of the service’s:</p>


### PR DESCRIPTION
**What it is**

Update the content on the Security page that describes the retention period for files sent by email.

**Why do we need it**

The current content does not reflect the changes we’re making. When we launch the changes it will be misleading.

**Done when / Acceptance criteria**

The content has been updated to say that files sent by email will be stored for ‘up to 78 weeks (18 months)’.