### PR TITLE
Remove GOV.UK Frontend Toolkit [part 10]

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,7 +228,6 @@ const sass = () => {
 const images = () => {
   return src([
       paths.src + 'images/**/*',
-      paths.template + 'assets/images/**/*',
       paths.govuk_frontend + 'assets/images/**/*'
     ])
     .pipe(dest(paths.dist + 'images/'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -210,7 +210,6 @@ const sass = () => {
     .pipe(plugins.prettyerror())
     .pipe(plugins.sass.sync({
       includePaths: [
-        paths.npm + 'govuk-elements-sass/public/sass/',
         paths.govuk_frontend,
         paths.npm
       ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,6 @@ const paths = {
   dist: 'app/static/',
   templates: 'app/templates/',
   npm: 'node_modules/',
-  toolkit: 'node_modules/govuk_frontend_toolkit/',
   govuk_frontend: 'node_modules/govuk-frontend/'
 };
 // Rewrite /static prefix for URLs in CSS files
@@ -212,7 +211,6 @@ const sass = () => {
     .pipe(plugins.sass.sync({
       includePaths: [
         paths.npm + 'govuk-elements-sass/public/sass/',
-        paths.toolkit + 'stylesheets/',
         paths.govuk_frontend,
         paths.npm
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk_frontend_toolkit": "8.1.0",
         "govuk-frontend": "2.13.0",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
@@ -6414,11 +6413,6 @@
       "engines": {
         "node": ">=0.6.0"
       }
-    },
-    "node_modules/govuk_frontend_toolkit": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.1.0.tgz",
-      "integrity": "sha512-KzuMy+xhH/QKJHYJYS4p6ZiPg1CWSd4TKJFBFzngpVnk2tbvEvfAw/yLoRmzgukd/9V4d9oDSA4dIXRFb7XvDA=="
     },
     "node_modules/govuk-frontend": {
       "version": "2.13.0",
@@ -21204,11 +21198,6 @@
       "requires": {
         "minimist": "1.1.x"
       }
-    },
-    "govuk_frontend_toolkit": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.1.0.tgz",
-      "integrity": "sha512-KzuMy+xhH/QKJHYJYS4p6ZiPg1CWSd4TKJFBFzngpVnk2tbvEvfAw/yLoRmzgukd/9V4d9oDSA4dIXRFb7XvDA=="
     },
     "govuk-frontend": {
       "version": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk_frontend_toolkit": "8.1.0",
     "govuk-frontend": "2.13.0",
     "hogan": "1.0.2",
     "jquery": "3.5.0",

--- a/tests/javascripts/support/setup.js
+++ b/tests/javascripts/support/setup.js
@@ -6,4 +6,4 @@ window.jQuery = require('jquery');
 $ = window.jQuery;
 
 // load module code
-require('govuk_frontend_toolkit/javascripts/govuk/modules.js');
+require('../../../app/assets/javascripts/modules.js');


### PR DESCRIPTION
This is part 10 of a series of work to remove the GOV.UK Frontend Toolkit library from our codebase:

https://www.pivotaltracker.com/story/show/182596710

We want to remove GOV.UK Frontend Toolkit from our code to replace it with GOV.UK Frontend.

This is the final part, where we remove the package and all references to it. The last two commits also tidy up a couple of other things that were missed in previous work.