### PR TITLE
Apply design to org email branding options

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -285,8 +285,17 @@ def cancel_invited_org_user(org_id, invited_user_id):
 @main.route("/organisations/<uuid:org_id>/settings/", methods=["GET"])
 @user_is_platform_admin
 def organisation_settings(org_id):
+    default_email_branding_name = current_organisation.email_branding_name
+    other_email_branding_options = [
+        email_branding_name
+        for email_branding_name in current_organisation.email_branding_pool_names
+        if email_branding_name != default_email_branding_name
+    ]
+
     return render_template(
         "views/organisations/organisation/settings/index.html",
+        default_email_branding_name=default_email_branding_name,
+        other_email_branding_options=other_email_branding_options,
     )
 
 

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -101,7 +101,7 @@
       {% call row() %}
         {{ text_field('Email branding options') }}
         {% set email_branding_html %}
-          <div {% if other_email_branding_options %}class="govuk-!-margin-bottom-5"{% endif %}>
+          <div {% if other_email_branding_options %}class="govuk-!-margin-bottom-3"{% endif %}>
             {{ default_email_branding_name }}
             <br>
             <div class="table-field-status-default">

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -1,5 +1,5 @@
 {% extends "org_template.html" %}
-{% from "components/table.html" import mapping_table, optional_text_field, row, text_field, edit_field with context %}
+{% from "components/table.html" import mapping_table, optional_text_field, row, field, text_field, edit_field with context %}
 
 {% block org_page_title %}
   Settings
@@ -100,7 +100,28 @@
       {% endcall %}
       {% call row() %}
         {{ text_field('Email branding options') }}
-        {{ optional_text_field(current_org.email_branding_pool_names, default="None") }}
+        {% set email_branding_html %}
+          <div {% if other_email_branding_options %}class="govuk-!-margin-bottom-5"{% endif %}>
+            {{ default_email_branding_name }}
+            <br>
+            <div class="table-field-status-default">
+              Default
+            </div>
+          </div>
+
+          {% if other_email_branding_options %}
+            <ul>
+            {% for item in other_email_branding_options %}
+              <li>
+                {{ item }}
+              </li>
+            {% endfor %}
+            </ul>
+          {% endif %}
+        {% endset %}
+        {% call field() %}
+          {{ email_branding_html }}
+        {% endcall %}
         {{ edit_field(
             'Change',
             url_for('.organisation_email_branding', org_id=current_org.id),


### PR DESCRIPTION
Show the default email brand at the top of the list with 'Default' beneath it and a small gap before any other options in the pool.

If no default branding is set, show the default as GOV.UK.

## Images
<img width="746" alt="image" src="https://user-images.githubusercontent.com/2920760/195299041-d1837d82-a237-4c2f-a604-73863e1d5599.png">

<img width="745" alt="image" src="https://user-images.githubusercontent.com/2920760/195299225-37cf9af6-b72e-4a26-9af2-dbe4112ae353.png">

<img width="750" alt="image" src="https://user-images.githubusercontent.com/2920760/195299144-e4c7e578-f683-4be0-80b9-74c5181e4363.png">