### PR TITLE
Change namespace for Notify's JS modules pattern

### DIFF
--- a/app/assets/javascripts/addEmailBrandingOptionsForm.js
+++ b/app/assets/javascripts/addEmailBrandingOptionsForm.js
@@ -177,4 +177,4 @@
     `).get(0);
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/authenticateSecurityKey.js
+++ b/app/assets/javascripts/authenticateSecurityKey.js
@@ -1,7 +1,7 @@
 (function (window) {
   "use strict";
 
-  window.GOVUK.Modules.AuthenticateSecurityKey = function () {
+  window.GOVUK.NotifyModules.AuthenticateSecurityKey = function () {
     this.start = function (component) {
       $(component)
         .on('click', function (event) {

--- a/app/assets/javascripts/autofocus.js
+++ b/app/assets/javascripts/autofocus.js
@@ -24,4 +24,4 @@
     };
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/collapsibleCheckboxes.js
+++ b/app/assets/javascripts/collapsibleCheckboxes.js
@@ -169,6 +169,6 @@
     this.summary.bindEvents(this);
   };
 
-  GOVUK.Modules.CollapsibleCheckboxes = CollapsibleCheckboxes;
+  GOVUK.NotifyModules.CollapsibleCheckboxes = CollapsibleCheckboxes;
 
 }(window));

--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -26,4 +26,4 @@
 
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/cookieMessage.js
+++ b/app/assets/javascripts/cookieMessage.js
@@ -1,5 +1,5 @@
 window.GOVUK = window.GOVUK || {};
-window.GOVUK.Modules = window.GOVUK.Modules || {};
+window.GOVUK.NotifyModules = window.GOVUK.NotifyModules || {};
 
 (function (Modules) {
   function CookieBanner () { }
@@ -100,5 +100,5 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   };
 
   Modules.CookieBanner = CookieBanner;
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);
 

--- a/app/assets/javascripts/cookieSettings.js
+++ b/app/assets/javascripts/cookieSettings.js
@@ -1,5 +1,5 @@
 window.GOVUK = window.GOVUK || {};
-window.GOVUK.Modules = window.GOVUK.Modules || {};
+window.GOVUK.NotifyModules = window.GOVUK.NotifyModules || {};
 
 (function (Modules) {
   function CookieSettings () {}
@@ -80,5 +80,5 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   };
 
   Modules.CookieSettings = CookieSettings;
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);
 

--- a/app/assets/javascripts/cookieSettings.js
+++ b/app/assets/javascripts/cookieSettings.js
@@ -9,7 +9,7 @@ window.GOVUK.NotifyModules = window.GOVUK.NotifyModules || {};
 
     this.$module.submitSettingsForm = this.submitSettingsForm.bind(this);
 
-    document.querySelector('form[data-module=cookie-settings]')
+    document.querySelector('form[data-notify-module=cookie-settings]')
       .addEventListener('submit', this.$module.submitSettingsForm);
 
     this.setInitialFormValues();

--- a/app/assets/javascripts/copyToClipboard.js
+++ b/app/assets/javascripts/copyToClipboard.js
@@ -97,4 +97,4 @@
     };
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/enhancedTextbox.js
+++ b/app/assets/javascripts/enhancedTextbox.js
@@ -84,4 +84,4 @@
 
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/errorTracking.js
+++ b/app/assets/javascripts/errorTracking.js
@@ -1,7 +1,7 @@
 (function(window) {
   "use strict";
 
-  window.GOVUK.Modules.TrackError = function() {
+  window.GOVUK.NotifyModules.TrackError = function() {
 
     this.start = function(component) {
 

--- a/app/assets/javascripts/fileUpload.js
+++ b/app/assets/javascripts/fileUpload.js
@@ -74,4 +74,4 @@
 
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/fullscreenTable.js
+++ b/app/assets/javascripts/fullscreenTable.js
@@ -121,4 +121,4 @@
 
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/homepage.js
+++ b/app/assets/javascripts/homepage.js
@@ -1,7 +1,7 @@
 (function(window) {
   "use strict";
 
-  window.GOVUK.Modules.Homepage = function() {
+  window.GOVUK.NotifyModules.Homepage = function() {
 
     this.start = function(component) {
 

--- a/app/assets/javascripts/listEntry.js
+++ b/app/assets/javascripts/listEntry.js
@@ -204,4 +204,4 @@
 
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/liveSearch.js
+++ b/app/assets/javascripts/liveSearch.js
@@ -85,4 +85,4 @@
 
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,7 +1,7 @@
 window.GOVUK.Frontend.initAll();
 
 var consentData = window.GOVUK.getConsentCookie();
-window.GOVUK.Modules.CookieBanner.clearOldCookies(consentData);
+window.GOVUK.NotifyModules.CookieBanner.clearOldCookies(consentData);
 
 if (window.GOVUK.hasConsentFor('analytics', consentData)) {
   window.GOVUK.initAnalytics();
@@ -15,7 +15,7 @@ $(() => GOVUK.stickAtBottomWhenScrolling.init());
 var showHideContent = new GOVUK.ShowHideContent();
 showHideContent.init();
 
-$(() => GOVUK.modules.start());
+$(() => GOVUK.notifyModules.start());
 
 $(() => $('.error-message, .govuk-error-message').eq(0).parent('label').next('input').trigger('focus'));
 

--- a/app/assets/javascripts/modules.js
+++ b/app/assets/javascripts/modules.js
@@ -3,14 +3,14 @@
 
   var $ = global.jQuery;
   var GOVUK = global.GOVUK || {};
-  GOVUK.Modules = GOVUK.Modules || {};
+  GOVUK.NotifyModules = GOVUK.NotifyModules || {};
 
-  GOVUK.modules = {
+  GOVUK.notifyModules = {
     find: function (container) {
       container = container || $('body');
 
       var modules;
-      var moduleSelector = '[data-module]';
+      var moduleSelector = '[data-notify-module]';
 
       modules = container.find(moduleSelector);
 
@@ -28,11 +28,11 @@
       for (var i = 0, l = modules.length; i < l; i++) {
         var module;
         var element = $(modules[i]);
-        var type = camelCaseAndCapitalise(element.data('module'));
+        var type = camelCaseAndCapitalise(element.data('notifyModule'));
         var started = element.data('module-started');
 
-        if (typeof GOVUK.Modules[type] === 'function' && !started) {
-          module = new GOVUK.Modules[type]();
+        if (typeof GOVUK.NotifyModules[type] === 'function' && !started) {
+          module = new GOVUK.NotifyModules[type]();
           module.start(element);
           element.data('module-started', true);
         }

--- a/app/assets/javascripts/radioSelect.js
+++ b/app/assets/javascripts/radioSelect.js
@@ -2,7 +2,7 @@
 
   "use strict";
 
-  var Modules = global.GOVUK.Modules;
+  var Modules = global.GOVUK.NotifyModules;
   var Hogan = global.Hogan;
 
   // Object holding all the states for the component's HTML

--- a/app/assets/javascripts/radioSlider.js
+++ b/app/assets/javascripts/radioSlider.js
@@ -2,7 +2,7 @@
 
   "use strict";
 
-  global.GOVUK.Modules.RadioSlider = function() {
+  global.GOVUK.NotifyModules.RadioSlider = function() {
 
     this.start = function(component) {
 

--- a/app/assets/javascripts/registerSecurityKey.js
+++ b/app/assets/javascripts/registerSecurityKey.js
@@ -1,7 +1,7 @@
 (function(window) {
   "use strict";
 
-  window.GOVUK.Modules.RegisterSecurityKey = function() {
+  window.GOVUK.NotifyModules.RegisterSecurityKey = function() {
     this.start = function(component) {
       $(component)
         .on('click', function(event) {

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -329,4 +329,4 @@
     `).get(0);
   };
 
-})(window.GOVUK.Modules);
+})(window.GOVUK.NotifyModules);

--- a/app/assets/javascripts/updateContent.js
+++ b/app/assets/javascripts/updateContent.js
@@ -103,7 +103,7 @@
     );
   };
 
-  global.GOVUK.Modules.UpdateContent = function() {
+  global.GOVUK.NotifyModules.UpdateContent = function() {
 
     this.start = component => {
       var $component = $(component);
@@ -141,6 +141,6 @@
 
   };
 
-  global.GOVUK.Modules.UpdateContent.calculateBackoff = calculateBackoff;
+  global.GOVUK.NotifyModules.UpdateContent.calculateBackoff = calculateBackoff;
 
 })(window);

--- a/app/assets/javascripts/updateStatus.js
+++ b/app/assets/javascripts/updateStatus.js
@@ -1,7 +1,7 @@
 (function(window) {
   "use strict";
 
-  window.GOVUK.Modules.UpdateStatus = function() {
+  window.GOVUK.NotifyModules.UpdateStatus = function() {
 
     const getRenderer = $component => response => $component.html(
       response.html

--- a/app/templates/components/ajax-block.html
+++ b/app/templates/components/ajax-block.html
@@ -1,7 +1,7 @@
 {% macro ajax_block(partials, url, key, finished=False, form='') %}
   {% if not finished %}
     <div
-      data-module="update-content"
+      data-notify-module="update-content"
       data-resource="{{ url }}"
       data-key="{{ key }}"
       data-form="{{ form }}"

--- a/app/templates/components/cookie-banner.html
+++ b/app/templates/components/cookie-banner.html
@@ -1,6 +1,6 @@
 {% macro cookie_banner(id='global-cookie-message') %}
 
-<div id="{{ id }}" class="notify-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner">
+<div id="{{ id }}" class="notify-cookie-banner" data-notify-module="cookie-banner" role="region" aria-label="cookie banner">
   <div class="notify-cookie-banner__wrapper govuk-width-container">
     <h2 class="notify-cookie-banner__heading govuk-heading-m" id="notify-cookie-banner__heading">Can we store analytics cookies on your device?</h2>
     <p class="govuk-body">Analytics cookies help us understand how our website is being used.</p>

--- a/app/templates/components/copy-to-clipboard.html
+++ b/app/templates/components/copy-to-clipboard.html
@@ -4,7 +4,7 @@
       {{ name }}
     </h2>
   {% endif %}
-  <div data-module="copy-to-clipboard" data-value="{{ value }}" data-thing="{{ thing }}" data-name="{{ name }}">
+  <div data-notify-module="copy-to-clipboard" data-value="{{ value }}" data-thing="{{ thing }}" data-name="{{ name }}">
     <span class="copy-to-clipboard__value">
       {%- if name|lower != thing|lower %}<span class="govuk-visually-hidden">{{ thing }}: </span>{% endif %}{{ value -}}
     </span>

--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -11,7 +11,7 @@
   show_errors=True
 
 ) %}
-  <form method="post" enctype="multipart/form-data" {% if action %}action="{{ action }}"{% endif %} class="{% if field.errors and show_errors %}form-group-error{% endif %}" data-module="file-upload">
+  <form method="post" enctype="multipart/form-data" {% if action %}action="{{ action }}"{% endif %} class="{% if field.errors and show_errors %}form-group-error{% endif %}" data-notify-module="file-upload">
     <label class="file-upload-label" for="{{ field.name }}">
       {{ field.label.text }}
       {% if hint %}

--- a/app/templates/components/form.html
+++ b/app/templates/components/form.html
@@ -13,7 +13,7 @@
     {% if not autocomplete %}autocomplete="off"{% endif %}
     {% if class %}class="{{ class }}"{% endif %}
     {% if id %}id="{{ id }}"{% endif %}
-    {% if module %}data-module="{{ module }}"{% endif %}
+    {% if module %}data-notify-module="{{ module }}"{% endif %}
     {% for key, val in data_kwargs.items() %}
       {% if val %}
         data-{{ key }}="{{ val }}"

--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -27,7 +27,7 @@
         {{ hint }}
       </div>
     {% endif %}
-    <div class="input-list" data-module="list-entry" data-list-item-name="{{ item_name }}" id="list-entry-{{ field.name }}">
+    <div class="input-list" data-notify-module="list-entry" data-list-item-name="{{ item_name }}" id="list-entry-{{ field.name }}">
       {% for entry in field.entries %}
         <div class="list-entry">
           {% if not autocomplete %}

--- a/app/templates/components/live-search.html
+++ b/app/templates/components/live-search.html
@@ -13,11 +13,11 @@
     } %}
 
     {% if autofocus %}
-      {% set x=param_extensions.__setitem__("attributes", {"data-module": "autofocus"}) %}
+      {% set x=param_extensions.__setitem__("attributes", {"data-notify-module": "autofocus"}) %}
     {% endif %}
 
     {% if show %}
-        <div class="live-search js-header" data-module="live-search" data-targets="{{ target_selector }}">
+        <div class="live-search js-header" data-notify-module="live-search" data-targets="{{ target_selector }}">
           {{ form.search(param_extensions=param_extensions) }}
           <div aria-live="polite" class="live-search__status govuk-visually-hidden"></div>
         </div>

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -32,12 +32,12 @@
      <legend class="form-label {% if bold_legend %}govuk-!-font-weight-bold{% endif %}">
        {{ field.label.text }}
        {% if field.errors %}
-         <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
+         <span class="error-message" data-notify-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
            {{ field.errors[0] }}
          </span>
        {% endif %}
      </legend>
-     <div class="radio-select" data-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default|string|lower }}">
+     <div class="radio-select" data-notify-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default|string|lower }}">
        <div class="radio-select-column">
        {% for option in field %}
          <div class="multiple-choice">

--- a/app/templates/components/select-input.html
+++ b/app/templates/components/select-input.html
@@ -37,7 +37,7 @@
 
 {% macro select_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False, collapsible_opts={}, legend_style="text", inline=False) %}
   {% set is_collapsible = collapsible_opts|length %}
-  <div class="form-group {% if field.errors %} form-group-error{% endif %}"{% if is_collapsible %} data-module="collapsible-checkboxes"{% if collapsible_opts.field %} data-field-label="{{ collapsible_opts.field }}"{% endif %}{% endif %}>
+  <div class="form-group {% if field.errors %} form-group-error{% endif %}"{% if is_collapsible %} data-notify-module="collapsible-checkboxes"{% if collapsible_opts.field %} data-field-label="{{ collapsible_opts.field }}"{% endif %}{% endif %}>
     {% if is_collapsible %}
     <div class="selection-summary" role="region" aria-live="polite"></div>
     {% endif %}
@@ -52,7 +52,7 @@
           </span>
         {% endif %}
         {% if field.errors %}
-          <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
+          <span class="error-message" data-notify-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
             {{ field.errors[0] }}
           </span>
         {% endif %}

--- a/app/templates/components/textbox.html
+++ b/app/templates/components/textbox.html
@@ -16,7 +16,7 @@
 ) %}
   <div
     class="form-group{% if field.errors %} form-group-error{% endif %} {{ extra_form_group_classes }}"
-    data-module="{% if autofocus %}autofocus{% elif colour_preview %}colour-preview{% endif %}"
+    data-notify-module="{% if autofocus %}autofocus{% elif colour_preview %}colour-preview{% endif %}"
   >
     <label class="form-label" for="{{ field.name }}">
       {% if label %}
@@ -30,7 +30,7 @@
         </span>
       {% endif %}
       {% if field.errors %}
-        <span class="error-message" data-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
+        <span class="error-message" data-notify-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
           {% if not safe_error_message %}{{ field.errors[0] }}{% else %}{{ field.errors[0]|safe }}{% endif %}
         </span>
       {% endif %}

--- a/app/templates/partials/check/letter-too-long.html
+++ b/app/templates/partials/check/letter-too-long.html
@@ -1,4 +1,4 @@
-<h1 h1 class="banner-title" data-module="track-error" data-error-type="letter-too-long" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
+<h1 h1 class="banner-title" data-notify-module="track-error" data-error-type="letter-too-long" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
   Your letter is too long
 </h1>
 <p class="govuk-body">

--- a/app/templates/partials/check/letter-validation-failed-banner.html
+++ b/app/templates/partials/check/letter-validation-failed-banner.html
@@ -6,7 +6,7 @@
       {{ message }}
     </h1>
   {% else %}
-    <h1 class="banner-title" data-module="track-error" data-error-type="{{ error_code }}" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
+    <h1 class="banner-title" data-notify-module="track-error" data-error-type="{{ error_code }}" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
       {{ message.title }}
     </h1>
     {% if message.detail %}

--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -1,4 +1,4 @@
-<h1 class='banner-title' data-module="track-error" data-error-type="Trial mode: bad recipients" data-error-label="{{ upload_id }}">
+<h1 class='banner-title' data-notify-module="track-error" data-error-type="Trial mode: bad recipients" data-error-label="{{ upload_id }}">
   You cannot send to
   {{ 'this' if count_of_recipients == 1 else 'these' }}
   {{ template_type_label }}

--- a/app/templates/partials/check/sent-previously.html
+++ b/app/templates/partials/check/sent-previously.html
@@ -1,4 +1,4 @@
-<h1 class='banner-title' data-module="track-error" data-error-type="File previously sent" data-error-label="{{ upload_id }}">
+<h1 class='banner-title' data-notify-module="track-error" data-error-type="File previously sent" data-error-label="{{ upload_id }}">
   These messages have already been sent today
 </h1>
 <p class="govuk-body">

--- a/app/templates/partials/check/too-many-messages.html
+++ b/app/templates/partials/check/too-many-messages.html
@@ -1,4 +1,4 @@
-<h1 class='banner-title' data-module="track-error" data-error-type="Trial mode: too many recipients" data-error-label="{{ upload_id }}">
+<h1 class='banner-title' data-notify-module="track-error" data-error-type="Trial mode: too many recipients" data-error-label="{{ upload_id }}">
   {% if original_file_name %}
     Too many recipients
   {% else %}

--- a/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
+++ b/app/templates/partials/check/trying-to-send-letters-in-trial-mode.html
@@ -1,4 +1,4 @@
-<h1 class='banner-title' data-module="track-error" data-error-type="Trying to send letters in trial mode" data-error-label="{{ upload_id }}">
+<h1 class='banner-title' data-notify-module="track-error" data-error-type="Trying to send letters in trial mode" data-error-label="{{ upload_id }}">
   You cannot send
   {{ 'this letter' if count_of_recipients == 1 else 'these letters' }}
 </h1>

--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -37,7 +37,7 @@
       </div>
       <div class="govuk-grid-column-full">
         <div class="template-content-count">
-          <div data-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='broadcast') }}" aria-live="polite">
+          <div data-notify-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='broadcast') }}" aria-live="polite">
             &nbsp;
           </div>
         </div>

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -20,7 +20,7 @@
 
       {% if recipients.too_many_rows %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file has too many rows
         </h1>
         <p class="govuk-body">
@@ -31,7 +31,7 @@
 
       {% elif not count_of_recipients %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="No rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="No rows" data-error-label="{{ upload_id }}">
           Your file is missing some rows
         </h1>
         {% if recipients.missing_column_headers %}
@@ -49,7 +49,7 @@
 
       {% elif not recipients.has_recipient_columns %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Missing recipient columns" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Missing recipient columns" data-error-label="{{ upload_id }}">
           There’s a problem with your column names
         </h1>
         {% if template.template_type == 'letter' %}
@@ -71,7 +71,7 @@
 
       {% elif recipients.duplicate_recipient_column_headers %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Duplicate recipient columns" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Duplicate recipient columns" data-error-label="{{ upload_id }}">
           There’s a problem with your column names
         </h1>
            <p class="govuk-body">
@@ -89,7 +89,7 @@
 
       {% elif recipients.missing_column_headers %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Missing placeholder columns" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Missing placeholder columns" data-error-label="{{ upload_id }}">
           Your column names need to match the double brackets in your template
         </h1>
           <p class="govuk-body">
@@ -153,7 +153,7 @@
 
     <h2 class="heading-medium" id="file-preview">{{ original_file_name }}</h2>
 
-    <div class="fullscreen-content" data-module="fullscreen-table">
+    <div class="fullscreen-content" data-notify-module="fullscreen-table">
       {% call(item, row_number) list_table(
         recipients.displayed_rows,
         caption=original_file_name,

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -41,7 +41,7 @@
         {{ choose_time_form.scheduled_for(param_extensions={
           'formGroup': {'classes': 'bottom-gutter-2-3'},
           'attributes': {
-            'data-module': 'radio-select',
+            'data-notify-module': 'radio-select',
             'data-categories': choose_time_form.scheduled_for.categories|join(','),
             'data-show-now-as-default': 'true'
           }
@@ -66,7 +66,7 @@
 
     <h2 class="heading-medium" id="{{ file_contents_header_id }}">{{ original_file_name }}</h2>
 
-    <div class="fullscreen-content" data-module="fullscreen-table">
+    <div class="fullscreen-content" data-notify-module="fullscreen-table">
       {% call(item, row_number) list_table(
         recipients.displayed_rows,
         caption=original_file_name,

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -18,14 +18,14 @@
   <div class="bottom-gutter-1-2">
     {% call banner_wrapper(type='dangerous') %}
       {% if row_errors|length == 1 %}
-        <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There’s a problem with {{ original_file_name }}
         </h1>
         <p class="govuk-body">
           You need to {{ row_errors[0] }}.
         </p>
       {% else %}
-        <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There are some problems with {{ original_file_name }}
         </h1>
         <p class="govuk-body">
@@ -52,7 +52,7 @@
     <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
   </div>
 
-  <div class="fullscreen-content" data-module="fullscreen-table">
+  <div class="fullscreen-content" data-notify-module="fullscreen-table">
     {% call(item, row_number) mapping_table(
       caption="Errors in " + original_file_name,
       caption_visible=False,

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
       <h2 class="banner-title">Your cookie settings were saved</h2>
-      <a class="govuk_link cookie-settings__prev-page govuk-!-margin-top-1" href="#" data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
+      <a class="govuk_link cookie-settings__prev-page govuk-!-margin-top-1" href="#" data-notify-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
         Go back to the page you were looking at
       </a>
     </div>
@@ -120,7 +120,7 @@
       </ul>
     </div>
     <div class="cookie-settings__form-wrapper">
-      <form data-module="cookie-settings">
+      <form data-notify-module="cookie-settings">
         <div class="govuk-form-group govuk-!-margin-top-6">
           <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -37,7 +37,7 @@
       </div>
       <div class="govuk-grid-column-full">
         <div class="template-content-count">
-          <div data-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='broadcast') }}" aria-live="polite">
+          <div data-notify-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='broadcast') }}" aria-live="polite">
             &nbsp;
           </div>
         </div>

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -44,7 +44,7 @@
         </div>
         <div class="govuk-grid-column-full">
           <div class="template-content-count">
-            <div data-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='sms') }}" aria-live="polite">
+            <div data-notify-module="update-status" data-target="template_content" data-updates-url="{{ url_for('.count_content_length', service_id=current_service.id, template_type='sms') }}" aria-live="polite">
               &nbsp;
             </div>
           </div>

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -14,7 +14,7 @@
   </h1>
 
   {% if show_search_box %}
-    <div data-module="autofocus">
+    <div data-notify-module="autofocus">
       {{ live_search(target_selector='.user-list-item', show=True, form=form) }}
     </div>
   {% endif %}

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -24,7 +24,7 @@
   </h1>
 
   {% if show_search_box %}
-    <div data-module="autofocus">
+    <div data-notify-module="autofocus">
       {{ live_search(target_selector='.user-list-item', show=True, form=form) }}
     </div>
   {% endif %}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -36,7 +36,7 @@
     or Microsoft Excel spreadsheet
   </p>
 
-  <div class="spreadsheet" data-module="fullscreen-table">
+  <div class="spreadsheet" data-notify-module="fullscreen-table">
     {% call(item, row_number) list_table(
       example,
       caption="Example",

--- a/app/templates/views/service-settings/email-reply-to/_verify-updates.html
+++ b/app/templates/views/service-settings/email-reply-to/_verify-updates.html
@@ -27,7 +27,7 @@
   {% elif verification_status == "failure" %}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
-        <h2 class='banner-title' data-module="track-error" data-error-type="reply-to-email-not-working" data-error-label="{{ upload_id }}">
+        <h2 class='banner-title' data-notify-module="track-error" data-error-type="reply-to-email-not-working" data-error-label="{{ upload_id }}">
           There’s a problem with your reply-to address
         </h2>
         <p class="govuk-body">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -12,7 +12,7 @@
 {% block content %}
 
   <div class="product-page-intro">
-    <div class="product-page-intro-wrapper" data-module="homepage">
+    <div class="product-page-intro-wrapper" data-notify-module="homepage">
       <nav class="breadcrumbs breadcrumbs--inverse" aria-label="Breadcrumbs">
        <ol itemscope itemtype="http://schema.org/BreadcrumbList">
          <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">

--- a/app/templates/views/two-factor-sms.html
+++ b/app/templates/views/two-factor-sms.html
@@ -17,7 +17,7 @@
     {% call form_wrapper(class="extra-tracking") %}
       {{ form.sms_code(param_extensions={
           "classes": "govuk-input govuk-input--width-5",
-          "attributes": {"data-module": "autofocus"}
+          "attributes": {"data-notify-module": "autofocus"}
       }) }}
       {{ page_footer(
         "Continue",

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -49,7 +49,7 @@
         "text": "Check security key",
         "classes": "govuk-button--secondary webauthn__api-required",
         "attributes": {
-          "data-module": "authenticate-security-key",
+          "data-notify-module": "authenticate-security-key",
           "data-csrf-token": csrf_token(),
         }
       }) }}

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -20,7 +20,7 @@
 
       {% if recipients.too_many_rows %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file has too many rows
         </h1>
         <p class="govuk-body">
@@ -31,7 +31,7 @@
 
       {% elif not recipients.allowed_to_send_to %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Trial mode: bad recipients" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Trial mode: bad recipients" data-error-label="{{ upload_id }}">
           You cannot save
           {{ 'this' if recipients|length == 1 else 'these' }}
           {{ recipients|length|recipient_count_label(recipients.template_type) }}

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -18,14 +18,14 @@
   <div class="bottom-gutter-1-2">
     {% call banner_wrapper(type='dangerous') %}
       {% if row_errors|length == 1 %}
-        <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There’s a problem with {{ original_file_name }}
         </h1>
         <p class="govuk-body">
           You need to {{ row_errors[0] }}.
         </p>
       {% else %}
-        <h1 class='banner-title' data-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Bad rows" data-error-label="{{ upload_id }}">
           There are some problems with {{ original_file_name }}
         </h1>
         <p class="govuk-body">

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -20,7 +20,7 @@
 
       {% if not recipients|length %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="No rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="No rows" data-error-label="{{ upload_id }}">
           Your file is missing some rows
         </h1>
         <p class="govuk-body">
@@ -30,7 +30,7 @@
 
       {% elif recipients.column_headers|length == 1 %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file needs a column called ‘email address’ or ‘phone number’.
         </h1>
         <p class="govuk-body">
@@ -39,7 +39,7 @@
 
       {% else %}
 
-        <h1 class='banner-title' data-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
+        <h1 class='banner-title' data-notify-module="track-error" data-error-type="Too many rows" data-error-label="{{ upload_id }}">
           Your file has too many columns
         </h1>
         <p class="govuk-body">
@@ -70,7 +70,7 @@
 
     <h2 class="heading-medium" id="file-preview">{{ original_file_name }}</h2>
 
-    <div class="fullscreen-content" data-module="fullscreen-table">
+    <div class="fullscreen-content" data-notify-module="fullscreen-table">
       {% call(item, row_number) list_table(
         recipients.displayed_rows,
         caption=original_file_name,

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -24,7 +24,7 @@
       {% call form_wrapper() %}
         {{ form_field(param_extensions={
             "classes": "govuk-input govuk-input--width-5",
-            "attributes": {"data-module": "autofocus"}
+            "attributes": {"data-notify-module": "autofocus"}
         }) }}
 
         {{ page_footer('Confirm') }}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -29,7 +29,7 @@
     "text": "Register a key",
     "classes": "govuk-button--secondary webauthn__api-required",
     "attributes": {
-      "data-module": "register-security-key",
+      "data-notify-module": "register-security-key",
       "data-csrf-token": csrf_token(),
     }
   }) }}

--- a/tests/javascripts/addEmailBrandingOptionsForm.test.js
+++ b/tests/javascripts/addEmailBrandingOptionsForm.test.js
@@ -18,7 +18,7 @@ describe('AddEmailBrandingOptionsForm', () => {
   beforeEach(() => {
 
     const htmlFragment = `
-      <form method="post" autocomplete="off" data-module="add-email-branding-options-form" novalidate="">
+      <form method="post" autocomplete="off" data-notify-module="add-email-branding-options-form" novalidate="">
         <div class="brand-pool">
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset" id="branding_field">
@@ -61,7 +61,7 @@ describe('AddEmailBrandingOptionsForm', () => {
 
     document.body.innerHTML = htmlFragment;
 
-    addEmailBrandingOptionsForm = document.querySelector('form[data-module=add-email-branding-options-form]');
+    addEmailBrandingOptionsForm = document.querySelector('form[data-notify-module=add-email-branding-options-form]');
 
   });
 

--- a/tests/javascripts/addEmailBrandingOptionsForm.test.js
+++ b/tests/javascripts/addEmailBrandingOptionsForm.test.js
@@ -88,7 +88,7 @@ describe('AddEmailBrandingOptionsForm', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       formControls = addEmailBrandingOptionsForm.querySelector('.js-stick-at-bottom-when-scrolling');
       visibleCounter = getVisibleCounter();
@@ -141,7 +141,7 @@ describe('AddEmailBrandingOptionsForm', () => {
       beforeEach(() => {
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         EmailBrandingOptionsCheckboxes = getEmailBrandingOptionsCheckboxes();
 

--- a/tests/javascripts/authenticateSecurityKey.test.js
+++ b/tests/javascripts/authenticateSecurityKey.test.js
@@ -42,7 +42,7 @@ describe('Authenticate with security key', () => {
       <button type="submit" data-module="authenticate-security-key" data-csrf-token="abc123"></button>`
 
     button = document.querySelector('[data-module="authenticate-security-key"]')
-    window.GOVUK.modules.start()
+    window.GOVUK.notifyModules.start()
   })
 
   afterEach(() => {

--- a/tests/javascripts/authenticateSecurityKey.test.js
+++ b/tests/javascripts/authenticateSecurityKey.test.js
@@ -39,9 +39,9 @@ describe('Authenticate with security key', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
 
     document.body.innerHTML = `
-      <button type="submit" data-module="authenticate-security-key" data-csrf-token="abc123"></button>`
+      <button type="submit" data-notify-module="authenticate-security-key" data-csrf-token="abc123"></button>`
 
-    button = document.querySelector('[data-module="authenticate-security-key"]')
+    button = document.querySelector('[data-notify-module="authenticate-security-key"]')
     window.GOVUK.notifyModules.start()
   })
 

--- a/tests/javascripts/autofocus.test.js
+++ b/tests/javascripts/autofocus.test.js
@@ -44,7 +44,7 @@ describe('Autofocus', () => {
   test('is focused when modules start', () => {
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(focusHandler).toHaveBeenCalled();
 
@@ -56,7 +56,7 @@ describe('Autofocus', () => {
     document.getElementById('wrapper').setAttribute('data-module', 'autofocus');
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(focusHandler).toHaveBeenCalled();
 
@@ -68,7 +68,7 @@ describe('Autofocus', () => {
     $.prototype.scrollTop = jest.fn(() => 25);
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(focusHandler).not.toHaveBeenCalled();
 
@@ -83,7 +83,7 @@ describe('Autofocus', () => {
     document.querySelector('#search').setAttribute('data-force-focus', true);
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(focusHandler).toHaveBeenCalled();
 

--- a/tests/javascripts/autofocus.test.js
+++ b/tests/javascripts/autofocus.test.js
@@ -24,7 +24,7 @@ describe('Autofocus', () => {
         <label class="form-label" for="search">
           ${labelText}
         </label>
-        <input autocomplete="off" class="form-control form-control-1-1" id="search" name="search" type="search" value="" data-module="autofocus">
+        <input autocomplete="off" class="form-control form-control-1-1" id="search" name="search" type="search" value="" data-notify-module="autofocus">
       </div>`;
 
     focusHandler = jest.fn();
@@ -52,8 +52,8 @@ describe('Autofocus', () => {
 
   test('is focused when attribute is set on outer element', () => {
 
-    document.getElementById('search').removeAttribute('data-module');
-    document.getElementById('wrapper').setAttribute('data-module', 'autofocus');
+    document.getElementById('search').removeAttribute('data-notify-module');
+    document.getElementById('wrapper').setAttribute('data-notify-module', 'autofocus');
 
     // start module
     window.GOVUK.notifyModules.start();

--- a/tests/javascripts/collapsibleCheckboxes.test.js
+++ b/tests/javascripts/collapsibleCheckboxes.test.js
@@ -75,7 +75,7 @@ describe('Collapsible fieldset', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
     });
 
@@ -172,7 +172,7 @@ describe('Collapsible fieldset', () => {
   test('has the right summary text when started with no checkboxes selected', () => {
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     const summaryText = document.querySelector('.selection-summary__text');
 
@@ -189,7 +189,7 @@ describe('Collapsible fieldset', () => {
     });
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     const summaryText = document.querySelector('.selection-summary__text');
 
@@ -203,7 +203,7 @@ describe('Collapsible fieldset', () => {
     checkboxes.forEach(el => el.setAttribute('checked', ''));
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     const summaryText = document.querySelector('.selection-summary__text');
 
@@ -216,7 +216,7 @@ describe('Collapsible fieldset', () => {
     wrapper.dataset.fieldLabel = 'team member';
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     const summaryText = document.querySelector('.selection-summary__text');
 
@@ -229,7 +229,7 @@ describe('Collapsible fieldset', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
 
@@ -266,7 +266,7 @@ describe('Collapsible fieldset', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       // show the checkboxes
       helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
@@ -308,7 +308,7 @@ describe('Collapsible fieldset', () => {
       test("after the fieldset", () => {
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // show the checkboxes
         helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
@@ -326,7 +326,7 @@ describe('Collapsible fieldset', () => {
         checkboxesContainer.querySelector('.govuk-checkboxes__item').appendChild(nestedCheckboxes);
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // show the checkboxes
         helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
@@ -345,7 +345,7 @@ describe('Collapsible fieldset', () => {
         window.GOVUK.stickAtBottomWhenScrolling.recalculate = jest.fn(() => {});
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // show the checkboxes
         helpers.triggerEvent(formGroup.querySelector('.govuk-button'), 'click');
@@ -409,7 +409,7 @@ describe('Collapsible fieldset', () => {
         checkFirstCheckbox();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 
@@ -429,7 +429,7 @@ describe('Collapsible fieldset', () => {
         checkFirstCheckbox();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 
@@ -449,7 +449,7 @@ describe('Collapsible fieldset', () => {
         checkFirstCheckbox();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 
@@ -473,7 +473,7 @@ describe('Collapsible fieldset', () => {
         checkAllCheckboxes();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 
@@ -493,7 +493,7 @@ describe('Collapsible fieldset', () => {
         checkAllCheckboxes();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 
@@ -517,7 +517,7 @@ describe('Collapsible fieldset', () => {
         checkAllCheckboxesButTheLast();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 
@@ -536,7 +536,7 @@ describe('Collapsible fieldset', () => {
         checkAllCheckboxesButTheLast();
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         showCheckboxes();
 

--- a/tests/javascripts/collapsibleCheckboxes.test.js
+++ b/tests/javascripts/collapsibleCheckboxes.test.js
@@ -40,7 +40,7 @@ describe('Collapsible fieldset', () => {
 
     // set up DOM
     document.body.innerHTML =
-      `<div class="selection-wrapper" data-module="collapsible-checkboxes" data-field-label="folder">
+      `<div class="selection-wrapper" data-notify-module="collapsible-checkboxes" data-field-label="folder">
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" id="folder_permissions" aria-describedby="users_with_permission-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/tests/javascripts/colourPreview.test.js
+++ b/tests/javascripts/colourPreview.test.js
@@ -22,7 +22,7 @@ describe('Colour preview', () => {
         <label class="govuk-form-label" for="colour">
           Colour
         </label>
-        <input class="govuk-input govuk-input--width-6" id="colour" name="colour" rows="8" type="text" value="" data-module="colour-preview">
+        <input class="govuk-input govuk-input--width-6" id="colour" name="colour" rows="8" type="text" value="" data-notify-module="colour-preview">
       </div>`;
 
     field = document.querySelector('.govuk-form-group');

--- a/tests/javascripts/colourPreview.test.js
+++ b/tests/javascripts/colourPreview.test.js
@@ -41,7 +41,7 @@ describe('Colour preview', () => {
     test("It should add a swatch element for the preview", () => {
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       swatchEl = document.querySelector('.textbox-colour-preview');
 
@@ -52,7 +52,7 @@ describe('Colour preview', () => {
     test("If the textbox is empty it should make the swatch white", () => {
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       swatchEl = document.querySelector('.textbox-colour-preview');
 
@@ -67,7 +67,7 @@ describe('Colour preview', () => {
       textbox.setAttribute('value', '#00FF00');
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       swatchEl = document.querySelector('.textbox-colour-preview');
 
@@ -81,7 +81,7 @@ describe('Colour preview', () => {
       textbox.setAttribute('value', 'green');
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       swatchEl = document.querySelector('.textbox-colour-preview');
 
@@ -97,7 +97,7 @@ describe('Colour preview', () => {
     beforeEach(() => {
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       swatchEl = document.querySelector('.textbox-colour-preview');
 

--- a/tests/javascripts/cookieMessage.test.js
+++ b/tests/javascripts/cookieMessage.test.js
@@ -40,7 +40,7 @@ describe("Cookie message", () => {
     jest.spyOn(window.GOVUK, 'initAnalytics');
 
     cookieMessage = `
-      <div id="global-cookie-message" class="notify-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="">
+      <div id="global-cookie-message" class="notify-cookie-banner" data-notify-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="">
         <div class="notify-cookie-banner__wrapper govuk-width-container govuk-!-padding-4">
           <h2 class="notify-cookie-banner__heading govuk-heading-m">Cookies on GOV.UK Notify</h2>
           <p class="notify-cookie-banner__message govuk-body">We use <a class="govuk-link govuk-link--no-visited-state" href="/cookies">small files called cookies</a> to make GOV.UK Notify work.</p>

--- a/tests/javascripts/cookieMessage.test.js
+++ b/tests/javascripts/cookieMessage.test.js
@@ -105,7 +105,7 @@ describe("Cookie message", () => {
       // seen_cookie_message was set on the www domain, which setCookie defaults to
       helpers.setCookie('seen_cookie_message', 'true', { 'days': 365 });
 
-      window.GOVUK.Modules.CookieBanner.clearOldCookies({ "analytics": false });
+      window.GOVUK.NotifyModules.CookieBanner.clearOldCookies({ "analytics": false });
 
       expect(window.GOVUK.cookie('seen_cookie_message')).toBeNull();
 
@@ -117,7 +117,7 @@ describe("Cookie message", () => {
       helpers.setCookie('_ga', 'GA1.1.123.123', { 'days': 365, 'domain': '.notifications.service.gov.uk' });
       helpers.setCookie('_gid', 'GA1.1.456.456', { 'days': 1, 'domain': '.notifications.service.gov.uk' });
 
-      window.GOVUK.Modules.CookieBanner.clearOldCookies(null);
+      window.GOVUK.NotifyModules.CookieBanner.clearOldCookies(null);
 
       expect(window.GOVUK.cookie('_ga')).toBeNull();
       expect(window.GOVUK.cookie('_gid')).toBeNull();
@@ -129,7 +129,7 @@ describe("Cookie message", () => {
       helpers.setCookie('_ga', 'GA1.1.123.123', { 'days': 365 });
       helpers.setCookie('_gid', 'GA1.1.456.456', { 'days': 1 });
 
-      window.GOVUK.Modules.CookieBanner.clearOldCookies({ "analytics": true });
+      window.GOVUK.NotifyModules.CookieBanner.clearOldCookies({ "analytics": true });
 
       expect(window.GOVUK.cookie('_ga')).not.toBeNull();
       expect(window.GOVUK.cookie('_gid')).not.toBeNull();
@@ -142,7 +142,7 @@ describe("Cookie message", () => {
 
     window.GOVUK.setConsentCookie({ 'analytics': false });
 
-    window.GOVUK.modules.start()
+    window.GOVUK.notifyModules.start()
 
     expect(helpers.element(document.querySelector('.notify-cookie-banner')).is('hidden')).toBe(true);
 
@@ -152,7 +152,7 @@ describe("Cookie message", () => {
 
     beforeEach(() => {
 
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
     });
 

--- a/tests/javascripts/cookieSettings.test.js
+++ b/tests/javascripts/cookieSettings.test.js
@@ -119,7 +119,7 @@ describe("Cookie settings", () => {
 
     test("If user has not chosen to accept or reject analytics, the radios for making that choice should be set to unchecked", () => {
 
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       expect(yesRadio.checked).toBe(false);
       expect(noRadio.checked).toBe(false);
@@ -130,7 +130,7 @@ describe("Cookie settings", () => {
 
       window.GOVUK.setConsentCookie({ 'analytics': true });
 
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       expect(yesRadio.checked).toBe(true);
       expect(noRadio.checked).toBe(false);
@@ -141,7 +141,7 @@ describe("Cookie settings", () => {
 
       window.GOVUK.setConsentCookie({ 'analytics': false });
 
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       expect(yesRadio.checked).toBe(false);
       expect(noRadio.checked).toBe(true);
@@ -154,7 +154,7 @@ describe("Cookie settings", () => {
 
     beforeEach(() => {
 
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
     });
 
@@ -222,7 +222,7 @@ describe("Cookie settings", () => {
 
       test("if user accepted analytics, the analytics code should initialise and register a pageview", () => {
 
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         yesRadio.checked = true;
 
@@ -238,7 +238,7 @@ describe("Cookie settings", () => {
 
       test("if user rejected analytics, the analytics code should not run", () => {
 
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         noRadio.checked = true;
 

--- a/tests/javascripts/cookieSettings.test.js
+++ b/tests/javascripts/cookieSettings.test.js
@@ -34,7 +34,7 @@ describe("Cookie settings", () => {
     cookiesPageContent = `
       <div class="cookie-settings__confirmation banner banner-with-tick" data-cookie-confirmation="true" role="group" tabindex="-1">
         <h2 class="banner-title">Your cookie settings were saved</h2>
-        <a class="govuk_link govuk_link--no-visited-state cookie-settings__prev-page" href="#" data-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
+        <a class="govuk_link govuk_link--no-visited-state cookie-settings__prev-page" href="#" data-notify-module="track-click" data-track-category="cookieSettings" data-track-action="Back to previous page">
           Go back to the page you were looking at
         </a>
       </div>
@@ -53,7 +53,7 @@ describe("Cookie settings", () => {
       </div>
       <h2 class="heading-medium">Analytics cookies (optional)</h2>
       <div class="cookie-settings__form-wrapper">
-        <form data-module="cookie-settings">
+        <form data-notify-module="cookie-settings">
           <div class="govuk-form-group govuk-!-margin-top-6">
             <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
               <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/tests/javascripts/copyToClipboard.test.js
+++ b/tests/javascripts/copyToClipboard.test.js
@@ -24,7 +24,7 @@ describe('copy to clipboard', () => {
       <h2 class="copy-to-clipboard__name">
         ${options.thing}
       </h2>
-      <div data-module="copy-to-clipboard" data-value="${apiKey}" data-thing="${options.thing}" data-name="${options.name}">
+      <div data-notify-module="copy-to-clipboard" data-value="${apiKey}" data-thing="${options.thing}" data-name="${options.name}">
         <span class="copy-to-clipboard__value" aria-live="assertive">${(options.name === options.thing) ? '<span class="govuk-visually-hidden">' + options.thing + ': </span>' : ''}${apiKey}</span>
         <span class="copy-to-clipboard__notice" aria-live="assertive"></span>
       </div>`;
@@ -60,7 +60,7 @@ describe('copy to clipboard', () => {
 
     setUpDOM({ 'thing': 'Some Thing', 'name': 'Some Thing' });
 
-    component = document.querySelector('[data-module=copy-to-clipboard]');
+    component = document.querySelector('[data-notify-module=copy-to-clipboard]');
 
     // start the module
     window.GOVUK.notifyModules.start();
@@ -97,11 +97,11 @@ describe('copy to clipboard', () => {
 
           setUpDOM({ 'thing': 'Some Thing', 'name': 'Some Thing' });
 
-          component = document.querySelector('[data-module=copy-to-clipboard]');
+          component = document.querySelector('[data-notify-module=copy-to-clipboard]');
 
           // set default style for component height (queried by jQuery before checking DOM APIs)
           const stylesheet = document.createElement('style');
-          stylesheet.innerHTML = '[data-module=copy-to-clipboard] { height: auto; }'; // set to browser default
+          stylesheet.innerHTML = '[data-notify-module=copy-to-clipboard] { height: auto; }'; // set to browser default
           document.getElementsByTagName('head')[0].appendChild(stylesheet);
 
           componentHeightOnLoad = 50;
@@ -166,7 +166,7 @@ describe('copy to clipboard', () => {
           // different, it will be one of others called the same 'thing'.
           setUpDOM({ 'thing': 'ID', 'name': 'Default' });
 
-          component = document.querySelector('[data-module=copy-to-clipboard]');
+          component = document.querySelector('[data-notify-module=copy-to-clipboard]');
 
           // start the module
           window.GOVUK.notifyModules.start();
@@ -202,7 +202,7 @@ describe('copy to clipboard', () => {
           // the only one of its type there
           setUpDOM({ 'thing': 'Some Thing', 'name': 'Some Thing' });
 
-          component = document.querySelector('[data-module=copy-to-clipboard]');
+          component = document.querySelector('[data-notify-module=copy-to-clipboard]');
 
           // start the module
           window.GOVUK.notifyModules.start();
@@ -235,7 +235,7 @@ describe('copy to clipboard', () => {
           // start the module
           window.GOVUK.notifyModules.start();
 
-          component = document.querySelector('[data-module=copy-to-clipboard]');
+          component = document.querySelector('[data-notify-module=copy-to-clipboard]');
           keyEl = component.querySelector('.copy-to-clipboard__value');
 
           helpers.triggerEvent(component.querySelector('button'), 'click');
@@ -334,7 +334,7 @@ describe('copy to clipboard', () => {
           // start the module
           window.GOVUK.notifyModules.start();
 
-          component = document.querySelector('[data-module=copy-to-clipboard]');
+          component = document.querySelector('[data-notify-module=copy-to-clipboard]');
 
           helpers.triggerEvent(component.querySelector('button'), 'click');
 
@@ -377,7 +377,7 @@ describe('copy to clipboard', () => {
           // start the module
           window.GOVUK.notifyModules.start();
 
-          component = document.querySelector('[data-module=copy-to-clipboard]');
+          component = document.querySelector('[data-notify-module=copy-to-clipboard]');
 
           helpers.triggerEvent(component.querySelector('button'), 'click');
 

--- a/tests/javascripts/copyToClipboard.test.js
+++ b/tests/javascripts/copyToClipboard.test.js
@@ -63,7 +63,7 @@ describe('copy to clipboard', () => {
     component = document.querySelector('[data-module=copy-to-clipboard]');
 
     // start the module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(component.querySelector('button')).toBeNull();
 
@@ -120,7 +120,7 @@ describe('copy to clipboard', () => {
           });
 
           // start the module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
         });
 
@@ -169,7 +169,7 @@ describe('copy to clipboard', () => {
           component = document.querySelector('[data-module=copy-to-clipboard]');
 
           // start the module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
         });
 
@@ -205,7 +205,7 @@ describe('copy to clipboard', () => {
           component = document.querySelector('[data-module=copy-to-clipboard]');
 
           // start the module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
         });
 
@@ -233,7 +233,7 @@ describe('copy to clipboard', () => {
           setUpDOM({ 'thing': 'Some Thing', 'name': 'Some Thing' });
 
           // start the module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
           component = document.querySelector('[data-module=copy-to-clipboard]');
           keyEl = component.querySelector('.copy-to-clipboard__value');
@@ -332,7 +332,7 @@ describe('copy to clipboard', () => {
           setUpDOM({ 'thing': 'ID', 'name': 'Default' });
 
           // start the module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
           component = document.querySelector('[data-module=copy-to-clipboard]');
 
@@ -375,7 +375,7 @@ describe('copy to clipboard', () => {
           setUpDOM({ 'thing': 'Some Thing', 'name': 'Some Thing' });
 
           // start the module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
           component = document.querySelector('[data-module=copy-to-clipboard]');
 

--- a/tests/javascripts/enhancedTextbox.test.js
+++ b/tests/javascripts/enhancedTextbox.test.js
@@ -65,7 +65,7 @@ describe('Enhanced textbox', () => {
       beforeEach(() => {
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
       });
 
@@ -100,7 +100,7 @@ describe('Enhanced textbox', () => {
       beforeEach(() => {
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
       });
 
@@ -137,7 +137,7 @@ describe('Enhanced textbox', () => {
 
         setDisplayPropertyOfFormGroups('none');
 
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         setDisplayPropertyOfFormGroups('block');
 
@@ -165,7 +165,7 @@ describe('Enhanced textbox', () => {
         textarea.textContent  = "Dear ((title)) ((name))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -182,7 +182,7 @@ describe('Enhanced textbox', () => {
         input.value = "Dear ((title)) ((name))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = input.nextElementSibling;
 
@@ -200,7 +200,7 @@ describe('Enhanced textbox', () => {
         textarea.setAttribute('data-highlight-placeholders', 'false')
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -219,7 +219,7 @@ describe('Enhanced textbox', () => {
         textarea.textContent = "When you arrive, please go to the ((weekday??main entrance))((weekend??side entrance))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -236,7 +236,7 @@ describe('Enhanced textbox', () => {
         input.value = "When you arrive, please go to the ((weekday??main entrance))((weekend??side entrance))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = input.nextElementSibling;
 
@@ -272,7 +272,7 @@ describe('Enhanced textbox', () => {
       `;
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       backgroundEl = textarea.nextElementSibling;
 
@@ -290,7 +290,7 @@ describe('Enhanced textbox', () => {
 
     test("If a resize changes the textarea's width, the width of the element below should still match", () => {
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       backgroundEl = textarea.nextElementSibling;
 
@@ -312,7 +312,7 @@ describe('Enhanced textbox', () => {
         textarea.textContent = "Dear ((title)) ((name))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -332,7 +332,7 @@ describe('Enhanced textbox', () => {
         input.value = "Hospital appointment for ((name))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = input.nextElementSibling;
 
@@ -357,7 +357,7 @@ describe('Enhanced textbox', () => {
         textarea.textContent = "Dear ((title)) ((name))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -380,7 +380,7 @@ describe('Enhanced textbox', () => {
         input.value = "Hospital appointment";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = input.nextElementSibling;
 
@@ -407,7 +407,7 @@ describe('Enhanced textbox', () => {
           Ref: ((reference))`;
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -428,7 +428,7 @@ describe('Enhanced textbox', () => {
         input.value = "Hospital appointment for ((name)), ref: ((reference))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = input.nextElementSibling;
 
@@ -455,7 +455,7 @@ describe('Enhanced textbox', () => {
           Your appointment will be on ((date)). When you arrive, please go to the ((weekday??main entrance))((weekend??side entrance)).`;
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = textarea.nextElementSibling;
 
@@ -484,7 +484,7 @@ describe('Enhanced textbox', () => {
         input.value = "Hospital appointment for ((name))((important?? - IMPORTANT))";
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         backgroundEl = input.nextElementSibling;
 

--- a/tests/javascripts/enhancedTextbox.test.js
+++ b/tests/javascripts/enhancedTextbox.test.js
@@ -39,11 +39,11 @@ describe('Enhanced textbox', () => {
     document.body.innerHTML = `
       <div class="form-group">
         <label for="subject">Subject</label>
-        <input class="form-control textbox-highlight-textbox" data-module="enhanced-textbox" type="text" name="subject" id="subject" />
+        <input class="form-control textbox-highlight-textbox" data-notify-module="enhanced-textbox" type="text" name="subject" id="subject" />
       </div>
       <div class="form-group">
         <label for="template_content">Message</label>
-        <textarea class="form-control form-control-1-1 textbox-highlight-textbox" data-module="enhanced-textbox" id="template_content" name="template_content" rows="8">
+        <textarea class="form-control form-control-1-1 textbox-highlight-textbox" data-notify-module="enhanced-textbox" id="template_content" name="template_content" rows="8">
         </textarea>
       </div>`;
 

--- a/tests/javascripts/errorTracking.test.js
+++ b/tests/javascripts/errorTracking.test.js
@@ -29,7 +29,7 @@ describe('Error tracking', () => {
     };
 
     // start the module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(window.GOVUK.analytics.trackEvent).toHaveBeenCalled();
     expect(window.GOVUK.analytics.trackEvent.mock.calls[0]).toEqual(['Error', 'validation', {

--- a/tests/javascripts/errorTracking.test.js
+++ b/tests/javascripts/errorTracking.test.js
@@ -11,7 +11,7 @@ describe('Error tracking', () => {
   beforeEach(() => {
 
     // set up DOM
-    document.body.innerHTML = `<div data-module="track-error" data-error-type="validation" data-error-label="missing field"></div>`;
+    document.body.innerHTML = `<div data-notify-module="track-error" data-error-type="validation" data-error-label="missing field"></div>`;
 
   });
 

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -28,7 +28,7 @@ describe('File upload', () => {
 
     // set up DOM
     document.body.innerHTML = `
-      <form method="post" enctype="multipart/form-data" class="" data-module="file-upload">
+      <form method="post" enctype="multipart/form-data" class="" data-notify-module="file-upload">
         <label class="file-upload-label" for="file">
           Upload a PNG logo
         </label>

--- a/tests/javascripts/fileUpload.test.js
+++ b/tests/javascripts/fileUpload.test.js
@@ -54,7 +54,7 @@ describe('File upload', () => {
     form.reset = jest.fn(() => {});
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     helpers.triggerEvent(window, 'pageshow');
 
@@ -65,7 +65,7 @@ describe('File upload', () => {
   test("An 'upload' button should be added", () => {
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     var uploadButton = form.querySelector('button[type=button]');
 
@@ -82,7 +82,7 @@ describe('File upload', () => {
     uploadLabel.innerHTML += '<span class="error-message">PNG images only!</span>';
 
     // start module
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     buttonLabel = form.querySelector('label.file-upload-button-label');
 
@@ -110,7 +110,7 @@ describe('File upload', () => {
       form.submit = jest.fn(() => {});
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       uploadControl.addEventListener('click', fileUploadClickCallback);
 

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -121,7 +121,7 @@ describe('FullscreenTable', () => {
     test("it fixes the number column for each row without changing the semantics", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       tableFrame = document.querySelector('.fullscreen-scrollable-table');
       numberColumnFrame = document.querySelector('.fullscreen-fixed-table');
@@ -137,7 +137,7 @@ describe('FullscreenTable', () => {
       const stickyJSSpy = jest.spyOn(window.GOVUK.stickAtBottomWhenScrolling, 'recalculate');
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       expect(stickyJSSpy.mock.calls.length).toBe(1);
 
@@ -148,7 +148,7 @@ describe('FullscreenTable', () => {
     test("the scrolling section is focusable and has an accessible name matching the table caption", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       tableFrame = document.querySelector('.fullscreen-scrollable-table');
       caption = tableFrame.querySelector('caption');
@@ -163,7 +163,7 @@ describe('FullscreenTable', () => {
     test("the section providing the fixed row headers is not focusable and is hidden from assistive tech'", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       fixedRowHeaders = document.querySelector('.fullscreen-fixed-table');
 
@@ -194,7 +194,7 @@ describe('FullscreenTable', () => {
       });
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       tableFrame = document.querySelector('.fullscreen-scrollable-table');
       numberColumnFrame = document.querySelector('.fullscreen-fixed-table');
@@ -254,7 +254,7 @@ describe('FullscreenTable', () => {
       rowNumberColumnCell.setAttribute('style', 'width: 40px');
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       tableFrame = document.querySelector('.fullscreen-scrollable-table');
       numberColumnFrame = document.querySelector('.fullscreen-fixed-table');
@@ -301,7 +301,7 @@ describe('FullscreenTable', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       tableFrame = document.querySelector('.fullscreen-scrollable-table');
       table = tableFrame.querySelector('table');
@@ -352,7 +352,7 @@ describe('FullscreenTable', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       tableFrame = document.querySelector('.fullscreen-scrollable-table');
       tableFrame.focus();

--- a/tests/javascripts/fullscreenTable.test.js
+++ b/tests/javascripts/fullscreenTable.test.js
@@ -89,7 +89,7 @@ describe('FullscreenTable', () => {
     // set up DOM
     document.body.innerHTML =
       `<main>
-        <div class="fullscreen-content" data-module="fullscreen-table">
+        <div class="fullscreen-content" data-notify-module="fullscreen-table">
           <table class="table table-font-xsmall">
             <caption class="heading-medium table-heading visuallyhidden">
               people.csv

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -70,7 +70,7 @@ describe("List entry", () => {
         <span id="domains-hint" class="govuk-hint">
           For example cabinet-office.gov.uk
         </span>
-        <div class="input-list" data-module="list-entry" data-list-item-name="domain" id="list-entry-domains">
+        <div class="input-list" data-notify-module="list-entry" data-list-item-name="domain" id="list-entry-domains">
           ${entries()} }
         </div>
       </fieldset>`;

--- a/tests/javascripts/listEntry.test.js
+++ b/tests/javascripts/listEntry.test.js
@@ -90,7 +90,7 @@ describe("List entry", () => {
     test("Should remove all the fields except the first 2 if no values are present", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       expect(inputList.querySelectorAll('.list-entry').length).toEqual(2);
 
@@ -104,7 +104,7 @@ describe("List entry", () => {
       fields[0].setAttribute('value', domains[0]);
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       // re-select fields, based on updated DOM
       fields = inputList.querySelectorAll('.list-entry input[type=text]');
@@ -122,7 +122,7 @@ describe("List entry", () => {
       fields[1].setAttribute('value', domains[1]);
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       // re-select fields, based on updated DOM
       fields = inputList.querySelectorAll('.list-entry input[type=text]');
@@ -140,7 +140,7 @@ describe("List entry", () => {
       fourDomains.forEach((domain, idx) => { fields[idx].setAttribute('value', domain) });
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       // re-select fields, based on updated DOM
       fields = inputList.querySelectorAll('.list-entry input[type=text]');
@@ -156,7 +156,7 @@ describe("List entry", () => {
     test("Should add 'remove' buttons to all fields except the first", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       inputList.querySelectorAll('.list-entry').forEach((listEntry, idx) => {
 
@@ -173,7 +173,7 @@ describe("List entry", () => {
     test("Should add an 'add feature' button to the bottom of the list", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       const listItems = inputList.children;
 
@@ -194,7 +194,7 @@ describe("List entry", () => {
       });
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       // re-select fields, based on updated DOM
       fields = inputList.querySelectorAll('.list-entry input[type=text]').forEach((field, idx) => {
@@ -216,7 +216,7 @@ describe("List entry", () => {
       });
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       // re-select fields, based on updated DOM
       fields = inputList.querySelectorAll('.list-entry input[type=text]');
@@ -232,7 +232,7 @@ describe("List entry", () => {
       setFieldValues(10);
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
     });
 
     test("Should remove the associated field", () => {
@@ -309,7 +309,7 @@ describe("List entry", () => {
     test("Should add a new field", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       triggerEvent(inputList.querySelector('.input-list__button--add'), 'click');
 
@@ -320,7 +320,7 @@ describe("List entry", () => {
     test("Should update the number of fields users are allowed to enter if one is removed", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       triggerEvent(inputList.querySelectorAll('.input-list__button--remove')[0], 'click');
 
@@ -331,7 +331,7 @@ describe("List entry", () => {
     test("Should update the number of fields users are allowed to enter if one is added", () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       triggerEvent(inputList.querySelector('.input-list__button--add'), 'click');
 
@@ -344,7 +344,7 @@ describe("List entry", () => {
       setFieldValues(9);
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       triggerEvent(inputList.querySelector('.input-list__button--add'), 'click');
 

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -64,7 +64,7 @@ describe('Live search', () => {
 
       // set up DOM
       document.body.innerHTML = `
-        <div class="live-search js-header" data-module="live-search" data-targets=".govuk-radios__item">
+        <div class="live-search js-header" data-notify-module="live-search" data-targets=".govuk-radios__item">
           <div class="govuk-form-group">
             <label class="govuk-label" for="search">
               ${searchLabelText}
@@ -262,7 +262,7 @@ describe('Live search', () => {
 
       // set up DOM
       document.body.innerHTML = `
-        <div class="live-search js-header" data-module="live-search" data-targets="#template-list .template-list-item">
+        <div class="live-search js-header" data-notify-module="live-search" data-targets="#template-list .template-list-item">
           <div class="form-group">
             <label class="form-label" for="search">
                 ${searchLabelText}
@@ -553,12 +553,12 @@ describe('Live search', () => {
 
       // set up DOM
       document.body.innerHTML = `
-        <div class="live-search js-header" data-module="live-search" data-targets=".user-list-item">
-          <div class="form-group" data-module="">
+        <div class="live-search js-header" data-notify-module="live-search" data-targets=".user-list-item">
+          <div class="form-group" data-notify-module="">
             <label class="form-label" for="search">
                 ${searchLabelText}
             </label>
-            <input autocomplete="off" class="form-control form-control-1-1 " data-module="" id="search" name="search" rows="8" type="search" value="">
+            <input autocomplete="off" class="form-control form-control-1-1 " data-notify-module="" id="search" name="search" rows="8" type="search" value="">
             <div role="region" aria-live="polite" class="live-search__status govuk-visually-hidden"></div>
           </div>
         </div>

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -90,7 +90,7 @@ describe('Live search', () => {
       test("If there is no search term, the results should be unchanged", () => {
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.govuk-radios__item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -105,7 +105,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Department';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.govuk-radios__item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -121,7 +121,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Department for Work';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.govuk-radios__item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -141,7 +141,7 @@ describe('Live search', () => {
         checkedItem.checked = true;
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         expect(window.getComputedStyle(checkedItem).display).not.toEqual('none');
 
@@ -156,7 +156,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Department';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate the input of new search text
         searchTextbox.value = '';
@@ -175,7 +175,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Department';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate the input of new search text
         searchTextbox.value = 'Home';
@@ -194,7 +194,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Department';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate the input of new search text
         searchTextbox.value = 'Department for';
@@ -217,7 +217,7 @@ describe('Live search', () => {
         checkedItem.checked = true;
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate the input of new search text
         searchTextbox.value = 'Home Office';
@@ -288,7 +288,7 @@ describe('Live search', () => {
       test("If there is no search term, the results should be unchanged", () => {
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.template-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -303,7 +303,7 @@ describe('Live search', () => {
         searchTextbox.value = 'New';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.template-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -320,7 +320,7 @@ describe('Live search', () => {
         searchTextbox.value = 'New patient';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.template-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -340,7 +340,7 @@ describe('Live search', () => {
         checkedItem.checked = true;
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // should show despite not matching
         expect(window.getComputedStyle(checkedItem).display).not.toEqual('none');
@@ -352,7 +352,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Email template';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.template-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -373,7 +373,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Appointments';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = '';
@@ -392,7 +392,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Appointments';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'Prescriptions';
@@ -411,7 +411,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Appointments';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'New doctor';
@@ -434,7 +434,7 @@ describe('Live search', () => {
         checkedItem.checked = true;
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'Prescriptions';
@@ -450,7 +450,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Appointments';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'Email template';
@@ -577,7 +577,7 @@ describe('Live search', () => {
       test("If there is no search term, the results should be unchanged", () => {
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.user-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -592,7 +592,7 @@ describe('Live search', () => {
         searchTextbox.value = 'admin';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.user-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -608,7 +608,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Administrator (admin@nhs.uk)';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.user-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -624,7 +624,7 @@ describe('Live search', () => {
         searchTextbox.value = "Add and edit templates";
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         const listItems = list.querySelectorAll('.user-list-item');
         const listItemsShowing = Array.from(listItems).filter(item => window.getComputedStyle(item).display !== 'none');
@@ -645,7 +645,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Admin';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = '';
@@ -663,7 +663,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Admin';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'Administrator';
@@ -682,7 +682,7 @@ describe('Live search', () => {
         searchTextbox.value = 'Admin';
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'Administrator (admin@nhs.uk)';
@@ -701,7 +701,7 @@ describe('Live search', () => {
         searchTextbox.value = "Admin";
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         // simulate input of new search text
         searchTextbox.value = 'Add and edit templates';

--- a/tests/javascripts/previewPane.test.js
+++ b/tests/javascripts/previewPane.test.js
@@ -66,8 +66,8 @@ describe('Preview pane', () => {
         <div class="govuk-grid-row"></div>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            <div data-module="autofocus">
-              <div class="live-search js-header" data-module="live-search" data-targets=".govuk-radios__item">
+            <div data-notify-module="autofocus">
+              <div class="live-search js-header" data-notify-module="live-search" data-targets=".govuk-radios__item">
                 <div class="form-group">
                   <label class="form-label" for="search">
                       Search branding styles by name

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -128,7 +128,7 @@ describe('RadioSelect', () => {
         // default is for it to be set to true
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         expect(document.querySelectorAll('.radio-select__column').length).toEqual(2);
 
@@ -139,7 +139,7 @@ describe('RadioSelect', () => {
         document.querySelector('.radio-select').setAttribute('data-show-now-as-default', 'false');
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         expect(document.querySelectorAll('.radio-select__column').length).toEqual(1);
 
@@ -154,7 +154,7 @@ describe('RadioSelect', () => {
       beforeEach(() => {
 
         // start module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
         categoryButtons = document.querySelectorAll('.radio-select__column:nth-child(2) .radio-select__button--category');
 
@@ -202,7 +202,7 @@ describe('RadioSelect', () => {
           originalOptionsForCategory = originalOptionsForAllCategories.filter(option => categoryRegExp.test(option.label));
 
           // start module
-          window.GOVUK.modules.start();
+          window.GOVUK.notifyModules.start();
 
           clickButtonForCategory(category);
 
@@ -237,7 +237,7 @@ describe('RadioSelect', () => {
     test(`clicking the button for a category should add a 'Done' button below its options`, () => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       clickButtonForCategory(CATEGORIES[0]);
 
@@ -256,7 +256,7 @@ describe('RadioSelect', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       clickButtonForCategory(CATEGORIES[0]);
 

--- a/tests/javascripts/radioSelect.test.js
+++ b/tests/javascripts/radioSelect.test.js
@@ -100,7 +100,7 @@ describe('RadioSelect', () => {
         <legend class="form-label">
           When should Notify send these messages?
         </legend>
-        <div class="radio-select" data-module="radio-select" data-categories="${CATEGORIES.join(',')}" data-show-now-as-default="true">
+        <div class="radio-select" data-notify-module="radio-select" data-categories="${CATEGORIES.join(',')}" data-show-now-as-default="true">
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" checked="" id="scheduled_for-0" name="scheduled_for" type="radio" value="">
             <label class="govuk-label govuk-radios__label" for="scheduled_for-0">

--- a/tests/javascripts/registerSecurityKey.test.js
+++ b/tests/javascripts/registerSecurityKey.test.js
@@ -44,7 +44,7 @@ describe('Register security key', () => {
       </a>`
 
     button = document.querySelector('[data-module="register-security-key"]')
-    window.GOVUK.modules.start()
+    window.GOVUK.notifyModules.start()
   })
 
   afterEach(() => {

--- a/tests/javascripts/registerSecurityKey.test.js
+++ b/tests/javascripts/registerSecurityKey.test.js
@@ -39,11 +39,11 @@ describe('Register security key', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
 
     document.body.innerHTML = `
-      <a href="#" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="register-security-key">
+      <a href="#" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-notify-module="register-security-key">
         Register a key
       </a>`
 
-    button = document.querySelector('[data-module="register-security-key"]')
+    button = document.querySelector('[data-notify-module="register-security-key"]')
     window.GOVUK.notifyModules.start()
   })
 

--- a/tests/javascripts/stick-to-window-when-scrolling.test.js
+++ b/tests/javascripts/stick-to-window-when-scrolling.test.js
@@ -82,11 +82,11 @@ describe("Stick to top/bottom of window when scrolling", () => {
             <form method="post" autocomplete="off">
               <div class="govuk-grid-row js-stick-at-top-when-scrolling">
                 <div class="govuk-grid-column-two-thirds ">
-                  <div class="form-group" data-module="">
+                  <div class="form-group" data-notify-module="">
                     <label class="form-label" for="placeholder_value">
                       name
                     </label>
-                    <input class="form-control form-control-1-1 " data-module="" id="placeholder_value" name="placeholder_value" required="" rows="8" type="text" value="">
+                    <input class="form-control form-control-1-1 " data-notify-module="" id="placeholder_value" name="placeholder_value" required="" rows="8" type="text" value="">
                   </div>
                 </div>
               </div>

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -252,7 +252,7 @@ describe('TemplateFolderForm', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
       visibleCounter = getVisibleCounter();
@@ -321,7 +321,7 @@ describe('TemplateFolderForm', () => {
       templateFolderForm = document.querySelector('form[data-module=template-folder-form]');
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
 
@@ -351,7 +351,7 @@ describe('TemplateFolderForm', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
 
@@ -475,7 +475,7 @@ describe('TemplateFolderForm', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       formControls = templateFolderForm.querySelector('#sticky_template_forms');
 
@@ -582,7 +582,7 @@ describe('TemplateFolderForm', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       templateFolderCheckboxes = getTemplateFolderCheckboxes();
 
@@ -908,7 +908,7 @@ describe('TemplateFolderForm', () => {
     beforeEach(() => {
 
       // start module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       templateFolderCheckboxes = getTemplateFolderCheckboxes();
       visibleCounterText = getVisibleCounter().textContent.trim();

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -123,7 +123,7 @@ function setFixtures (hierarchy, newTemplateDataModules = "") {
   };
 
   document.body.innerHTML = `
-    <form method="post" data-module="template-folder-form">
+    <form method="post" data-notify-module="template-folder-form">
       ${helpers.templatesAndFoldersCheckboxes(hierarchy)}
       ${controlsHTML(newTemplateDataModules)}
     </form>`;
@@ -209,7 +209,7 @@ describe('TemplateFolderForm', () => {
 
     setFixtures(hierarchy);
 
-    templateFolderForm = document.querySelector('form[data-module=template-folder-form]');
+    templateFolderForm = document.querySelector('form[data-notify-module=template-folder-form]');
 
   });
 
@@ -318,7 +318,7 @@ describe('TemplateFolderForm', () => {
   describe("Click 'New template' for single channel service", () => {
     test("should redirect to new template page", () => {
       setFixtures(hierarchy, "data-channel='sms' data-service='123'")
-      templateFolderForm = document.querySelector('form[data-module=template-folder-form]');
+      templateFolderForm = document.querySelector('form[data-notify-module=template-folder-form]');
 
       // start module
       window.GOVUK.notifyModules.start();

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -47,7 +47,7 @@ afterAll(() => {
 describe('Update content', () => {
 
   const getInitialHTMLString = partial => `
-    <div data-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
+    <div data-notify-module="update-content" data-resource="${resourceURL}" data-key="${updateKey}">
       ${partial}
     </div>`;
 
@@ -58,7 +58,7 @@ describe('Update content', () => {
       // Intentionally basic example because we're not testing changes to the partial
       document.body.innerHTML = getInitialHTMLString(`<p class="notification-status">Sending</p>`);
 
-      // default the response to match the content inside div[data-module]
+      // default the response to match the content inside div[data-notify-module]
       responseObj[updateKey] = `<p class="notification-status">Sending</p>`;
 
     });
@@ -135,7 +135,7 @@ describe('Update content', () => {
           </form>`;
 
         // Link the component to the form
-        document.querySelector('[data-module=update-content]').setAttribute('data-form', 'service');
+        document.querySelector('[data-notify-module=update-content]').setAttribute('data-form', 'service');
 
         // start the module
         window.GOVUK.notifyModules.start();
@@ -221,7 +221,7 @@ describe('Update content', () => {
 
     test("It should replace the original HTML with that of the partial, to match that returned from AJAX responses", () => {
 
-      // default the response to match the content inside div[data-module]
+      // default the response to match the content inside div[data-notify-module]
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
@@ -233,7 +233,7 @@ describe('Update content', () => {
 
     test("It should make requests to the URL specified in the data-resource attribute", () => {
 
-      // default the response to match the content inside div[data-module]
+      // default the response to match the content inside div[data-notify-module]
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
@@ -404,7 +404,7 @@ describe('Update content', () => {
       // remove the last item
       partialData.pop();
 
-      // default the response to match the content inside div[data-module]
+      // default the response to match the content inside div[data-notify-module]
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module

--- a/tests/javascripts/updateContent.test.js
+++ b/tests/javascripts/updateContent.test.js
@@ -68,7 +68,7 @@ describe('Update content', () => {
       beforeEach(() => {
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
       });
 
@@ -115,7 +115,7 @@ describe('Update content', () => {
         [24000, 10000],
       ]).test('It calculates a delay of %dms if the API responds in %dms', (waitTime, responseTime) => {
           expect(
-            window.GOVUK.Modules.UpdateContent.calculateBackoff(responseTime)
+            window.GOVUK.NotifyModules.UpdateContent.calculateBackoff(responseTime)
           ).toBe(
             waitTime
           );
@@ -138,7 +138,7 @@ describe('Update content', () => {
         document.querySelector('[data-module=update-content]').setAttribute('data-form', 'service');
 
         // start the module
-        window.GOVUK.modules.start();
+        window.GOVUK.notifyModules.start();
 
       });
 
@@ -225,7 +225,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
 
       expect(document.querySelector('.ajax-block-container').parentNode.hasAttribute('data-resource')).toBe(false);
 
@@ -237,7 +237,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       expect($.ajax.mock.calls[0][0]).toEqual(resourceURL);
@@ -250,7 +250,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // check a sample DOM node is unchanged
@@ -266,7 +266,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // check the right DOM node is updated
@@ -349,7 +349,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // check it has the same number of items
@@ -376,7 +376,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // check the node has been added
@@ -408,7 +408,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // check the node has been removed
@@ -442,7 +442,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // check the class is still there
@@ -480,7 +480,7 @@ describe('Update content', () => {
       responseObj[updateKey] = getPartial(partialData);
 
       // start the module
-      window.GOVUK.modules.start();
+      window.GOVUK.notifyModules.start();
       jest.advanceTimersByTime(2000);
 
       // re-select in case nodes in partialsInPage have changed

--- a/tests/javascripts/updateStatus.test.js
+++ b/tests/javascripts/updateStatus.test.js
@@ -47,7 +47,7 @@ describe('Update content', () => {
         <span id="example-hint-text">Example hint text</span>
         <textarea name="template_content" id="template_content" aria-describedby="example-hint-text">Content of message</textarea>
       </form>
-      <div data-module="update-status" data-updates-url="${updatesURL}" data-target="template_content">
+      <div data-notify-module="update-status" data-updates-url="${updatesURL}" data-target="template_content">
         Initial content
       </div>
     `;
@@ -71,7 +71,7 @@ describe('Update content', () => {
     window.GOVUK.notifyModules.start();
 
     expect(
-      document.querySelectorAll('[data-module=update-status]')[0].id
+      document.querySelectorAll('[data-notify-module=update-status]')[0].id
     ).toEqual(
       "update-status"
     );
@@ -118,7 +118,7 @@ describe('Update content', () => {
     responseObj = {'html': 'Updated content'}
 
     expect(
-      document.querySelectorAll('[data-module=update-status]')[0].textContent.trim()
+      document.querySelectorAll('[data-notify-module=update-status]')[0].textContent.trim()
     ).toEqual(
       "Initial content"
     );
@@ -126,7 +126,7 @@ describe('Update content', () => {
     window.GOVUK.notifyModules.start();
 
     expect(
-      document.querySelectorAll('[data-module=update-status]')[0].textContent.trim()
+      document.querySelectorAll('[data-notify-module=update-status]')[0].textContent.trim()
     ).toEqual(
       "Updated content"
     );

--- a/tests/javascripts/updateStatus.test.js
+++ b/tests/javascripts/updateStatus.test.js
@@ -68,7 +68,7 @@ describe('Update content', () => {
 
   test("It should add attributes to the elements", () => {
 
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(
       document.querySelectorAll('[data-module=update-status]')[0].id
@@ -88,7 +88,7 @@ describe('Update content', () => {
 
     document.getElementById('template_content').removeAttribute('aria-describedby');
 
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(
       document.getElementById('template_content').getAttribute('aria-describedby')
@@ -100,7 +100,7 @@ describe('Update content', () => {
 
   test("It should make requests to the URL specified in the data-updates-url attribute", () => {
 
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect($.ajax.mock.calls[0][0]).toEqual(updatesURL);
     expect($.ajax.mock.calls[0]).toEqual([
@@ -123,7 +123,7 @@ describe('Update content', () => {
       "Initial content"
     );
 
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
 
     expect(
       document.querySelectorAll('[data-module=update-status]')[0].textContent.trim()
@@ -138,7 +138,7 @@ describe('Update content', () => {
     let textarea = document.getElementById('template_content');
 
     // Initial update triggered
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
     expect($.ajax.mock.calls.length).toEqual(1);
 
     // 150ms of inactivity
@@ -154,7 +154,7 @@ describe('Update content', () => {
     let textarea = document.getElementById('template_content');
 
     // Initial update triggered
-    window.GOVUK.modules.start();
+    window.GOVUK.notifyModules.start();
     expect($.ajax.mock.calls.length).toEqual(1);
 
     helpers.triggerEvent(textarea, 'input');


### PR DESCRIPTION
This changes the name of [the JS modules pattern](https://github.com/alphagov/notifications-manuals/wiki/GOVUK-Modules-pattern) we use to be specific to Notify so it doesn't clash with the one GOVUK Frontend uses.

https://trello.com/c/CWddqvWb/33-rewrite-our-js-modules-to-work-with-govuk-frontend

We identify the elements in our HTML we want to have JS behaviours by giving them a `data-module` attribute, set to the name of the JS we want to run for it. From version 3, GOVUK Frontend does the same so we won't be able to have components associated with both GOVUK Frontend and Notify JS.

GOVUK Frontend 3 also [hard-codes it into the HTML in their templates](https://github.com/alphagov/govuk-frontend/blob/v3.0.0/src/govuk/components/button/template.njk#L36) so any `data-module` attributes passed in are ignored. We already have JS, like `GOVUK.Modules.RegisterSecurityKey.js` which is added to a GOVUK Frontend button component, that would be broken by this.

This proposes changing the names used by our JS modules pattern to avoid the clash.

To that end, this pull request changes the following name changes:

|Current name|New name|Description|
|---|---|---|
|`GOVUK.Modules`|`GOVUK.NotifyModules`|The namespace[^1] used to hold the different module scripts|
|`GOVUK.modules`|`GOVUK.notifyModules`|The code that matches HTML to module script and provides methods to intialise them|
|`data-module`|`data-notify-module`|Attribute used to bind HTML to Notify's JS modules|

[^1]: Note that in client-side JS, the `window` object **is** the global scope. Because of this JavaScripts tend to expose their public interfaces through objects attached to it, like `window.GOVUK`, to avoid naming clashes. This is usually referred to as 'namespacing'.