### PR TITLE
Record creator/updater for email branding

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -18,6 +18,7 @@ EVENT_SCHEMAS = {
         "provider_restriction",
     },  # noqa: E501 (length)
     "archive_service": {"service_id", "archived_by_id"},
+    "update_email_branding": {"email_branding_id", "updated_by_id", "old_email_branding"},
 }
 
 
@@ -55,6 +56,10 @@ def create_broadcast_account_type_change_event(**kwargs):
 
 def create_archive_service_event(**kwargs):
     _send_event("archive_service", **kwargs)
+
+
+def create_update_email_branding_event(**kwargs):
+    _send_event("update_email_branding", **kwargs)
 
 
 def _send_event(event_type, **kwargs):

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -1,7 +1,9 @@
 from flask import current_app, redirect, render_template, session, url_for
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import email_branding_client
+from app.event_handlers import create_update_email_branding_event
 from app.main import main
 from app.main.forms import AdminEditEmailBrandingForm, SearchByNameForm
 from app.s3_client.s3_logo_client import (
@@ -61,6 +63,10 @@ def update_email_branding(branding_id, logo=None):
                 text=form.text.data,
                 colour=form.colour.data,
                 brand_type=form.brand_type.data,
+                updated_by_id=current_user.id,
+            )
+            create_update_email_branding_event(
+                email_branding_id=branding_id, updated_by_id=str(current_user.id), old_email_branding=email_branding
             )
         except HTTPError as e:
             if e.status_code == 400 and "name" in e.response.json().get("message", {}):
@@ -114,6 +120,7 @@ def create_email_branding(logo=None):
                 text=form.text.data,
                 colour=form.colour.data,
                 brand_type=form.brand_type.data,
+                created_by_id=current_user.id,
             )
         except HTTPError as e:
             if e.status_code == 400 and "name" in e.response.json().get("message", {}):

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -14,14 +14,28 @@ class EmailBrandingClient(NotifyAdminAPIClient):
         return brandings
 
     @cache.delete("email_branding")
-    def create_email_branding(self, logo, name, text, colour, brand_type):
-        data = {"logo": logo, "name": name, "text": text, "colour": colour, "brand_type": brand_type}
+    def create_email_branding(self, logo, name, text, colour, brand_type, created_by_id: str):
+        data = {
+            "logo": logo,
+            "name": name,
+            "text": text,
+            "colour": colour,
+            "brand_type": brand_type,
+            "created_by": created_by_id,
+        }
         return self.post(url="/email-branding", data=data)
 
     @cache.delete("email_branding")
     @cache.delete("email_branding-{branding_id}")
-    def update_email_branding(self, branding_id, logo, name, text, colour, brand_type):
-        data = {"logo": logo, "name": name, "text": text, "colour": colour, "brand_type": brand_type}
+    def update_email_branding(self, branding_id, logo, name, text, colour, brand_type, updated_by_id: str):
+        data = {
+            "logo": logo,
+            "name": name,
+            "text": text,
+            "colour": colour,
+            "brand_type": brand_type,
+            "updated_by": updated_by_id,
+        }
         return self.post(url="/email-branding/{}".format(branding_id), data=data)
 
 

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -45,13 +45,25 @@ def test_get_all_email_branding(mocker):
     )
 
 
-def test_create_email_branding(mocker):
-    org_data = {"logo": "test.png", "name": "test name", "text": "test name", "colour": "red", "brand_type": "org"}
+def test_create_email_branding(mocker, fake_uuid):
+    org_data = {
+        "logo": "test.png",
+        "name": "test name",
+        "text": "test name",
+        "colour": "red",
+        "brand_type": "org",
+        "created_by": fake_uuid,
+    }
 
     mock_post = mocker.patch("app.notify_client.email_branding_client.EmailBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
     EmailBrandingClient().create_email_branding(
-        logo=org_data["logo"], name=org_data["name"], text=org_data["text"], colour=org_data["colour"], brand_type="org"
+        logo=org_data["logo"],
+        name=org_data["name"],
+        text=org_data["text"],
+        colour=org_data["colour"],
+        brand_type="org",
+        created_by_id=org_data["created_by"],
     )
 
     mock_post.assert_called_once_with(url="/email-branding", data=org_data)
@@ -60,7 +72,14 @@ def test_create_email_branding(mocker):
 
 
 def test_update_email_branding(mocker, fake_uuid):
-    org_data = {"logo": "test.png", "name": "test name", "text": "test name", "colour": "red", "brand_type": "org"}
+    org_data = {
+        "logo": "test.png",
+        "name": "test name",
+        "text": "test name",
+        "colour": "red",
+        "brand_type": "org",
+        "updated_by": fake_uuid,
+    }
 
     mock_post = mocker.patch("app.notify_client.email_branding_client.EmailBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
@@ -71,6 +90,7 @@ def test_update_email_branding(mocker, fake_uuid):
         text=org_data["text"],
         colour=org_data["colour"],
         brand_type="org",
+        updated_by_id=org_data["updated_by"],
     )
 
     mock_post.assert_called_once_with(url="/email-branding/{}".format(fake_uuid), data=org_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2555,7 +2555,7 @@ def mock_get_email_branding_without_brand_text(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_create_email_branding(mocker):
-    def _create_email_branding(logo, name, text, colour, brand_type):
+    def _create_email_branding(logo, name, text, colour, brand_type, created_by_id):
         return
 
     return mocker.patch("app.email_branding_client.create_email_branding", side_effect=_create_email_branding)
@@ -2563,7 +2563,7 @@ def mock_create_email_branding(mocker):
 
 @pytest.fixture(scope="function")
 def mock_update_email_branding(mocker):
-    def _update_email_branding(branding_id, logo, name, text, colour, brand_type):
+    def _update_email_branding(branding_id, logo, name, text, colour, brand_type, updated_by_id):
         return
 
     return mocker.patch("app.email_branding_client.update_email_branding", side_effect=_update_email_branding)


### PR DESCRIPTION
When a user creates or updates an email brand, let's send across the user id to the API so it can be recorded in the database.

On updates, let's also record an event including the old email branding, in case we ever need to look back in time.