### PR TITLE
Refactor email and letter branding into their own models to make `utils/branding.py` simpler

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -65,7 +65,9 @@ def update_email_branding(branding_id, logo=None):
                 updated_by_id=current_user.id,
             )
             create_update_email_branding_event(
-                email_branding_id=branding_id, updated_by_id=str(current_user.id), old_email_branding=email_branding
+                email_branding_id=branding_id,
+                updated_by_id=str(current_user.id),
+                old_email_branding=email_branding.serialize(),
             )
         except HTTPError as e:
             if e.status_code == 400 and "name" in e.response.json().get("message", {}):

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -6,6 +6,7 @@ from app import email_branding_client
 from app.event_handlers import create_update_email_branding_event
 from app.main import main
 from app.main.forms import AdminEditEmailBrandingForm, SearchByNameForm
+from app.models.branding import AllEmailBranding, EmailBranding
 from app.s3_client.s3_logo_client import (
     TEMP_TAG,
     delete_email_temp_file,
@@ -20,10 +21,8 @@ from app.utils.user import user_is_platform_admin
 @main.route("/email-branding", methods=["GET", "POST"])
 @user_is_platform_admin
 def email_branding():
-    brandings = email_branding_client.get_all_email_branding(sort_key="name")
-
     return render_template(
-        "views/email-branding/select-branding.html", email_brandings=brandings, search_form=SearchByNameForm()
+        "views/email-branding/select-branding.html", email_brandings=AllEmailBranding(), search_form=SearchByNameForm()
     )
 
 
@@ -31,16 +30,16 @@ def email_branding():
 @main.route("/email-branding/<uuid:branding_id>/edit/<logo>", methods=["GET", "POST"])
 @user_is_platform_admin
 def update_email_branding(branding_id, logo=None):
-    email_branding = email_branding_client.get_email_branding(branding_id)["email_branding"]
+    email_branding = EmailBranding.from_id(branding_id)
 
     form = AdminEditEmailBrandingForm(
-        name=email_branding["name"],
-        text=email_branding["text"],
-        colour=email_branding["colour"],
-        brand_type=email_branding["brand_type"],
+        name=email_branding.name,
+        text=email_branding.text,
+        colour=email_branding.colour,
+        brand_type=email_branding.brand_type,
     )
 
-    logo = logo if logo else email_branding.get("logo") if email_branding else None
+    logo = logo or email_branding.logo
 
     if form.validate_on_submit():
         if form.file.data:

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -5,6 +5,7 @@ from notifications_python_client.errors import HTTPError
 from app import letter_branding_client
 from app.main import main
 from app.main.forms import AdminEditLetterBrandingForm, SearchByNameForm, SVGFileUpload
+from app.models.branding import AllLetterBranding, LetterBranding
 from app.s3_client.s3_logo_client import (
     LETTER_TEMP_TAG,
     delete_letter_temp_file,
@@ -20,11 +21,10 @@ from app.utils.user import user_is_platform_admin
 @main.route("/letter-branding", methods=["GET"])
 @user_is_platform_admin
 def letter_branding():
-
-    brandings = letter_branding_client.get_all_letter_branding()
-
     return render_template(
-        "views/letter-branding/select-letter-branding.html", letter_brandings=brandings, search_form=SearchByNameForm()
+        "views/letter-branding/select-letter-branding.html",
+        letter_brandings=AllLetterBranding(),
+        search_form=SearchByNameForm(),
     )
 
 
@@ -32,17 +32,17 @@ def letter_branding():
 @main.route("/letter-branding/<uuid:branding_id>/edit/<path:logo>", methods=["GET", "POST"])
 @user_is_platform_admin
 def update_letter_branding(branding_id, logo=None):
-    letter_branding = letter_branding_client.get_letter_branding(branding_id)
+    letter_branding = LetterBranding.from_id(branding_id)
 
     file_upload_form = SVGFileUpload()
     letter_branding_details_form = AdminEditLetterBrandingForm(
-        name=letter_branding["name"],
+        name=letter_branding.name,
     )
 
     file_upload_form_submitted = file_upload_form.file.data
     details_form_submitted = request.form.get("operation") == "branding-details"
 
-    logo = logo if logo else permanent_letter_logo_name(letter_branding["filename"], "svg")
+    logo = logo or permanent_letter_logo_name(letter_branding.filename, "svg")
 
     if file_upload_form_submitted and file_upload_form.validate_on_submit():
         upload_filename = upload_letter_temp_logo(
@@ -61,7 +61,7 @@ def update_letter_branding(branding_id, logo=None):
         db_filename = letter_filename_for_db(logo, session["user_id"])
 
         try:
-            if db_filename == letter_branding["filename"]:
+            if db_filename == letter_branding.filename:
 
                 letter_branding_client.update_letter_branding(
                     branding_id=branding_id,
@@ -90,8 +90,8 @@ def update_letter_branding(branding_id, logo=None):
             # we had a problem saving the file - rollback the db changes
             letter_branding_client.update_letter_branding(
                 branding_id=branding_id,
-                filename=letter_branding["filename"],
-                name=letter_branding["name"],
+                filename=letter_branding.filename,
+                name=letter_branding.name,
             )
             file_upload_form.file.errors = ["Error saving uploaded file - try uploading again"]
 

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -283,16 +283,7 @@ def cancel_invited_org_user(org_id, invited_user_id):
 @main.route("/organisations/<uuid:org_id>/settings/", methods=["GET"])
 @user_is_platform_admin
 def organisation_settings(org_id):
-    other_email_branding_options = [
-        email_branding.name
-        for email_branding in current_organisation.email_branding_pool
-        if email_branding != current_organisation.email_branding
-    ]
-
-    return render_template(
-        "views/organisations/organisation/settings/index.html",
-        other_email_branding_options=other_email_branding_options,
-    )
+    return render_template("views/organisations/organisation/settings/index.html")
 
 
 @main.route("/organisations/<uuid:org_id>/settings/edit-name", methods=["GET", "POST"])
@@ -530,11 +521,6 @@ def _handle_change_default_branding(form, new_default_branding_id) -> Optional[R
 @main.route("/organisations/<uuid:org_id>/settings/email-branding", methods=["GET", "POST"])
 @user_is_platform_admin
 def organisation_email_branding(org_id):
-    # We want to display email branding options apart from an option that has already been set as the default
-    email_branding_pool_options = [
-        option for option in current_organisation.email_branding_pool if option != current_organisation.email_branding
-    ]
-
     is_central_government = current_organisation.organisation_type == Organisation.TYPE_CENTRAL
     remove_branding_id = request.args.get("remove_branding_id")
     change_default_branding_to_govuk = "change_default_branding_to_govuk" in request.args
@@ -557,7 +543,6 @@ def organisation_email_branding(org_id):
 
     return render_template(
         "views/organisations/organisation/settings/email-branding-options.html",
-        email_branding_pool_options=email_branding_pool_options,
         form=form,
         show_use_govuk_as_default_link=show_use_govuk_as_default_link,
     )
@@ -570,8 +555,7 @@ def add_organisation_email_branding_options(org_id):
 
     form.branding_field.choices = [
         (branding.id, branding.name)
-        for branding in AllEmailBranding()
-        if branding not in current_organisation.email_branding_pool
+        for branding in sorted(AllEmailBranding().excluding(*current_organisation.email_branding_pool.ids))
     ]
 
     if form.validate_on_submit():

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -394,7 +394,7 @@ def _handle_remove_branding(remove_branding_id) -> Optional[Response]:
     """
     try:
         remove_branding = current_organisation.email_branding_pool.get_item_by_id(remove_branding_id)
-    except StopIteration:
+    except current_organisation.email_branding_pool.NotFound:
         abort(400, f"Invalid email branding ID {remove_branding_id} for {current_organisation}")
 
     if request.method == "POST":
@@ -461,7 +461,7 @@ def _handle_change_default_branding(form, new_default_branding_id) -> Optional[R
     def __get_email_branding_name(branding_id):
         try:
             return current_organisation.email_branding_pool.get_item_by_id(branding_id).name
-        except StopIteration:
+        except current_organisation.email_branding_pool.NotFound:
             current_app.logger.info(
                 f"Email branding ID {branding_id} is not present in organisation {current_organisation.name}'s "
                 f"email branding pool."

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -21,7 +21,6 @@ from app import (
     current_service,
     email_branding_client,
     inbound_number_client,
-    letter_branding_client,
     notification_api_client,
     organisations_client,
     service_api_client,
@@ -66,8 +65,8 @@ from app.main.forms import (
     SomethingElseBrandingForm,
 )
 from app.main.views.pricing import CURRENT_SMS_RATE
+from app.models.branding import AllEmailBranding, AllLetterBranding, EmailBranding
 from app.utils import DELIVERED_STATUSES, FAILURE_STATUSES, SENDING_STATUSES
-from app.utils.branding import NHS_EMAIL_BRANDING_ID
 from app.utils.branding import get_email_choices as get_email_branding_choices
 from app.utils.user import (
     user_has_permissions,
@@ -958,10 +957,8 @@ def set_rate_limit(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/set-email-branding", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_set_email_branding(service_id):
-    email_branding = email_branding_client.get_all_email_branding()
-
     form = AdminSetEmailBrandingForm(
-        all_branding_options=get_branding_as_value_and_label(email_branding),
+        all_branding_options=AllEmailBranding().as_id_and_name,
         current_branding=current_service.email_branding_id,
     )
 
@@ -1033,7 +1030,7 @@ def service_preview_email_branding(service_id):
         if (
             current_service.organisation
             and email_branding_id
-            and email_branding_id not in current_service.organisation.email_branding_pool_ids
+            and email_branding_id not in current_service.organisation.email_branding_pool.ids
         ):
             return redirect(
                 url_for(
@@ -1057,10 +1054,8 @@ def service_preview_email_branding(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/set-letter-branding", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_set_letter_branding(service_id):
-    letter_branding = letter_branding_client.get_all_letter_branding()
-
     form = AdminSetLetterBrandingForm(
-        all_branding_options=get_branding_as_value_and_label(letter_branding),
+        all_branding_options=AllLetterBranding().as_id_and_name,
         current_branding=current_service.letter_branding_id,
     )
 
@@ -1124,7 +1119,7 @@ def create_email_branding_zendesk_ticket(form_option_selected, detail=None):
 
     ticket_message = render_template(
         "support-tickets/branding-request.txt",
-        current_branding=current_service.email_branding_name,
+        current_branding=current_service.email_branding.name,
         branding_requested=dict(form.options.choices)[form_option_selected],
         detail=detail,
     )
@@ -1147,19 +1142,18 @@ def email_branding_request(service_id):
     form = ChooseEmailBrandingForm(current_service)
     if form.something_else_is_only_option:
         return redirect(url_for(".email_branding_something_else", service_id=current_service.id))
-    branding_name = current_service.email_branding_name
     if form.validate_on_submit():
 
         branding_choice = form.options.data
 
-        if branding_choice == NHS_EMAIL_BRANDING_ID:
+        if branding_choice == EmailBranding.NHS_ID:
             return redirect(
                 url_for(
                     ".email_branding_nhs",
                     service_id=current_service.id,
                 )
             )
-        if branding_choice in current_service.email_branding_pool_ids:
+        if branding_choice in current_service.organisation.email_branding_pool.ids:
             return redirect(
                 url_for(".email_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)
             )
@@ -1174,32 +1168,29 @@ def email_branding_request(service_id):
     return render_template(
         "views/service-settings/branding/email-branding-options.html",
         form=form,
-        branding_name=branding_name,
     )
 
 
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/pool", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def email_branding_pool_option(service_id):
-    chosen_branding_id = request.args.get("branding_option")
-    chosen_brandings = [
-        branding["name"] for branding in current_service.email_branding_pool if branding["id"] == chosen_branding_id
-    ]
-    if not chosen_brandings:
+    try:
+        chosen_branding = current_service.organisation.email_branding_pool.get_item_by_id(
+            request.args.get("branding_option")
+        )
+    except StopIteration:
         flash("No branding found for this id.")
         return redirect(url_for(".email_branding_request", service_id=current_service.id))
 
-    chosen_branding_name = chosen_brandings[0]
-
     if request.method == "POST":
-        current_service.update(email_branding=chosen_branding_id)
+        current_service.update(email_branding=chosen_branding.id)
 
         flash("You’ve updated your email branding", "default")
         return redirect(url_for(".service_settings", service_id=current_service.id))
+
     return render_template(
         "views/service-settings/branding/email-branding-pool-option.html",
-        chosen_branding_id=chosen_branding_id,
-        chosen_branding_name=chosen_branding_name,
+        chosen_branding=chosen_branding,
     )
 
 
@@ -1241,16 +1232,16 @@ def email_branding_govuk_and_org(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/nhs", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def email_branding_nhs(service_id):
-    check_email_branding_allowed_for_service(NHS_EMAIL_BRANDING_ID)
+    check_email_branding_allowed_for_service(EmailBranding.NHS_ID)
 
     if request.method == "POST":
-        current_service.update(email_branding=NHS_EMAIL_BRANDING_ID)
+        current_service.update(email_branding=EmailBranding.NHS_ID)
 
         flash("You’ve updated your email branding", "default")
         return redirect(url_for(".service_settings", service_id=current_service.id))
 
     return render_template(
-        "views/service-settings/branding/email-branding-nhs.html", nhs_branding_id=NHS_EMAIL_BRANDING_ID
+        "views/service-settings/branding/email-branding-nhs.html", nhs_branding_id=EmailBranding.NHS_ID
     )
 
 
@@ -1291,11 +1282,10 @@ def email_branding_something_else(service_id):
 def letter_branding_request(service_id):
     form = ChooseLetterBrandingForm(current_service)
     from_template = request.args.get("from_template")
-    branding_name = current_service.letter_branding_name
     if form.validate_on_submit():
         ticket_message = render_template(
             "support-tickets/branding-request.txt",
-            current_branding=branding_name,
+            current_branding=current_service.letter_branding.name or "no",
             branding_requested=dict(form.options.choices)[form.options.data],
             detail=form.something_else.data,
         )
@@ -1320,7 +1310,6 @@ def letter_branding_request(service_id):
     return render_template(
         "views/service-settings/branding/letter-branding-options.html",
         form=form,
-        branding_name=branding_name,
         from_template=from_template,
     )
 
@@ -1405,10 +1394,6 @@ def edit_service_billing_details(service_id):
         "views/service-settings/edit-service-billing-details.html",
         form=form,
     )
-
-
-def get_branding_as_value_and_label(email_branding):
-    return [(branding["id"], branding["name"]) for branding in email_branding]
 
 
 def convert_dictionary_to_wtforms_choices_format(dictionary, value, label):

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1030,7 +1030,7 @@ def service_preview_email_branding(service_id):
         if (
             current_service.organisation
             and email_branding_id
-            and email_branding_id not in current_service.organisation.email_branding_pool.ids
+            and email_branding_id not in current_service.email_branding_pool.ids
         ):
             return redirect(
                 url_for(
@@ -1153,7 +1153,7 @@ def email_branding_request(service_id):
                     service_id=current_service.id,
                 )
             )
-        if branding_choice in current_service.organisation.email_branding_pool.ids:
+        if branding_choice in current_service.email_branding_pool.ids:
             return redirect(
                 url_for(".email_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)
             )
@@ -1175,10 +1175,8 @@ def email_branding_request(service_id):
 @user_has_permissions("manage_service")
 def email_branding_pool_option(service_id):
     try:
-        chosen_branding = current_service.organisation.email_branding_pool.get_item_by_id(
-            request.args.get("branding_option")
-        )
-    except current_service.organisation.email_branding_pool.NotFound:
+        chosen_branding = current_service.email_branding_pool.get_item_by_id(request.args.get("branding_option"))
+    except current_service.email_branding_pool.NotFound:
         flash("No branding found for this id.")
         return redirect(url_for(".email_branding_request", service_id=current_service.id))
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1178,7 +1178,7 @@ def email_branding_pool_option(service_id):
         chosen_branding = current_service.organisation.email_branding_pool.get_item_by_id(
             request.args.get("branding_option")
         )
-    except StopIteration:
+    except current_service.organisation.email_branding_pool.NotFound:
         flash("No branding found for this id.")
         return redirect(url_for(".email_branding_request", service_id=current_service.id))
 

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -1,0 +1,86 @@
+from app.models import JSONModel, ModelList
+from app.notify_client.email_branding_client import email_branding_client
+from app.notify_client.letter_branding_client import letter_branding_client
+from app.notify_client.organisations_api_client import organisations_client
+
+
+class Branding(JSONModel):
+    ALLOWED_PROPERTIES = {"id", "name"}
+    __sort_attribute__ = "name"
+
+    def __bool__(self):
+        return bool(self.id)
+
+
+class EmailBranding(Branding):
+    ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {
+        "colour",
+        "logo",
+        "text",
+        "brand_type",
+    }
+
+    NHS_ID = "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"
+
+    @classmethod
+    def from_id(cls, id):
+        if id is None:
+            return cls({key: None for key in cls.ALLOWED_PROPERTIES} | {"name": "GOV.UK"})
+        return cls(email_branding_client.get_email_branding(id)["email_branding"])
+
+    @property
+    def is_nhs(self):
+        return self.id == self.NHS_ID
+
+    @property
+    def is_govuk(self):
+        return self.id is None
+
+
+class LetterBranding(Branding):
+    ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {"filename"}
+
+    @classmethod
+    def from_id(cls, id):
+        if id is None:
+            return cls({key: None for key in cls.ALLOWED_PROPERTIES})
+        return cls(letter_branding_client.get_letter_branding(id))
+
+    @property
+    def is_nhs(self):
+        return self.name == "NHS"
+
+
+class AllBranding(ModelList):
+    @property
+    def ids(self):
+        return tuple(branding.id for branding in self)
+
+    @property
+    def as_id_and_name(self):
+        return [(branding.id, branding.name) for branding in self]
+
+    def get_item_by_id(self, id):
+        for branding in self:
+            if branding.id == id:
+                return branding
+        raise StopIteration
+
+
+class AllEmailBranding(AllBranding):
+    client_method = email_branding_client.get_all_email_branding
+    model = EmailBranding
+
+
+class EmailBrandingPool(AllEmailBranding):
+    client_method = organisations_client.get_email_branding_pool
+
+    def __init__(self, id):
+        self.items = tuple()
+        if id:
+            self.items = self.client_method(id)
+
+
+class AllLetterBranding(AllBranding):
+    client_method = letter_branding_client.get_all_letter_branding
+    model = LetterBranding

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -40,6 +40,9 @@ class EmailBranding(Branding):
     def is_govuk(self):
         return self.id is None
 
+    def serialize(self):
+        return self._dict.copy()
+
 
 class LetterBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {"filename"}

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -52,6 +52,9 @@ class LetterBranding(Branding):
 
 
 class AllBranding(ModelList):
+    class NotFound(Exception):
+        pass
+
     @property
     def ids(self):
         return tuple(branding.id for branding in self)
@@ -64,7 +67,7 @@ class AllBranding(ModelList):
         for branding in self:
             if branding.id == id:
                 return branding
-        raise StopIteration
+        raise self.NotFound
 
     def excluding(self, *ids_to_exclude):
         return tuple(branding for branding in self if branding.id not in ids_to_exclude)

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -66,6 +66,9 @@ class AllBranding(ModelList):
                 return branding
         raise StopIteration
 
+    def excluding(self, *ids_to_exclude):
+        return tuple(branding for branding in self if branding.id not in ids_to_exclude)
+
 
 class AllEmailBranding(AllBranding):
     client_method = email_branding_client.get_all_email_branding

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -11,6 +11,10 @@ class Branding(JSONModel):
     def __bool__(self):
         return bool(self.id)
 
+    @classmethod
+    def with_default_values(cls, **kwargs):
+        return cls({key: None for key in cls.ALLOWED_PROPERTIES} | kwargs)
+
 
 class EmailBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {
@@ -25,7 +29,7 @@ class EmailBranding(Branding):
     @classmethod
     def from_id(cls, id):
         if id is None:
-            return cls({key: None for key in cls.ALLOWED_PROPERTIES} | {"name": "GOV.UK"})
+            return cls.with_default_values(name="GOV.UK")
         return cls(email_branding_client.get_email_branding(id)["email_branding"])
 
     @property
@@ -43,7 +47,7 @@ class LetterBranding(Branding):
     @classmethod
     def from_id(cls, id):
         if id is None:
-            return cls({key: None for key in cls.ALLOWED_PROPERTIES})
+            return cls.with_default_values()
         return cls(letter_branding_client.get_letter_branding(id))
 
     @property

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -4,8 +4,7 @@ from flask import abort
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel, ModelList, SerialisedModelCollection
-from app.notify_client.email_branding_client import email_branding_client
-from app.notify_client.letter_branding_client import letter_branding_client
+from app.models.branding import EmailBranding, EmailBrandingPool, LetterBranding
 from app.notify_client.organisations_api_client import organisations_client
 
 
@@ -107,6 +106,7 @@ class Organisation(JSONModel):
         super().__init__(_dict)
 
         if self._dict == {}:
+            self.id = None
             self.name = None
             self.crown = None
             self.agreement_signed = None
@@ -173,31 +173,15 @@ class Organisation(JSONModel):
 
     @cached_property
     def email_branding(self):
-        if self.email_branding_id:
-            return email_branding_client.get_email_branding(self.email_branding_id)["email_branding"]
+        return EmailBranding.from_id(self.email_branding_id)
 
-    @property
-    def email_branding_name(self):
-        if self.email_branding_id:
-            return self.email_branding["name"]
-        return "GOV.UK"
-
-    @property
+    @cached_property
     def email_branding_pool(self):
-        return organisations_client.get_email_branding_pool(self.id)
-
-    @property
-    def email_branding_pool_names(self):
-        return [branding["name"] for branding in self.email_branding_pool]
-
-    @property
-    def email_branding_pool_ids(self):
-        return [branding["id"] for branding in self.email_branding_pool]
+        return EmailBrandingPool(self.id)
 
     @cached_property
     def letter_branding(self):
-        if self.letter_branding_id:
-            return letter_branding_client.get_letter_branding(self.letter_branding_id)
+        return LetterBranding.from_id(self.letter_branding_id)
 
     @cached_property
     def agreement_signed_by(self):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -114,6 +114,7 @@ class Organisation(JSONModel):
             self.organisation_type = None
             self.request_to_go_live_notes = None
             self.email_branding_id = None
+            self.letter_branding_id = None
 
     @property
     def organisation_type_label(self):

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -179,6 +179,10 @@ class Organisation(JSONModel):
     def email_branding_pool(self):
         return EmailBrandingPool(self.id)
 
+    @property
+    def email_branding_pool_excluding_default(self):
+        return self.email_branding_pool.excluding(self.email_branding_id)
+
     @cached_property
     def letter_branding(self):
         return LetterBranding.from_id(self.letter_branding_id)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -586,6 +586,10 @@ class Service(JSONModel):
         return ContactLists(self.id)
 
     @property
+    def email_branding_pool(self):
+        return self.organisation.email_branding_pool
+
+    @property
     def can_use_govuk_branding(self):
         return self.organisation_type == Organisation.TYPE_CENTRAL and not self.organisation.email_branding
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -3,17 +3,16 @@ from notifications_utils.serialised_model import SerialisedModelCollection
 from werkzeug.utils import cached_property
 
 from app.models import JSONModel
+from app.models.branding import EmailBranding, LetterBranding
 from app.models.contact_list import ContactLists
 from app.models.job import ImmediateJobs, PaginatedJobs, PaginatedUploads, ScheduledJobs
 from app.models.organisation import Organisation
 from app.models.user import InvitedUsers, User, Users
 from app.notify_client.api_key_api_client import api_key_api_client
 from app.notify_client.billing_api_client import billing_api_client
-from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
-from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.service_api_client import service_api_client
 from app.notify_client.template_folder_api_client import template_folder_api_client
@@ -442,25 +441,11 @@ class Service(JSONModel):
 
     @cached_property
     def email_branding(self):
-        if self.email_branding_id:
-            return email_branding_client.get_email_branding(self.email_branding_id)["email_branding"]
-        return None
-
-    @cached_property
-    def email_branding_name(self):
-        if self.email_branding is None:
-            return "GOV.UK"
-        return self.email_branding["name"]
-
-    @cached_property
-    def letter_branding_name(self):
-        if self.letter_branding is None:
-            return "no"
-        return self.letter_branding["name"]
+        return EmailBranding.from_id(self.email_branding_id)
 
     @property
     def needs_to_change_email_branding(self):
-        return self.email_branding_id is None and self.organisation_type != Organisation.TYPE_CENTRAL
+        return self.email_branding.is_govuk and self.organisation_type != Organisation.TYPE_CENTRAL
 
     @property
     def letter_branding_id(self):
@@ -468,9 +453,7 @@ class Service(JSONModel):
 
     @cached_property
     def letter_branding(self):
-        if self.letter_branding_id:
-            return letter_branding_client.get_letter_branding(self.letter_branding_id)
-        return None
+        return LetterBranding.from_id(self.letter_branding_id)
 
     @cached_property
     def organisation(self):
@@ -603,15 +586,8 @@ class Service(JSONModel):
         return ContactLists(self.id)
 
     @property
-    def email_branding_pool(self):
-        if self.organisation_id:
-            return self.organisation.email_branding_pool
-        else:
-            return []
-
-    @property
-    def email_branding_pool_ids(self):
-        return [branding["id"] for branding in self.email_branding_pool]
+    def can_use_govuk_branding(self):
+        return self.organisation_type == Organisation.TYPE_CENTRAL and not self.organisation.email_branding
 
 
 class Services(SerialisedModelCollection):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -494,6 +494,10 @@ class Service(JSONModel):
     def organisation_type_label(self):
         return Organisation.TYPE_LABELS.get(self.organisation_type)
 
+    @property
+    def is_nhs(self):
+        return self.organisation_type in Organisation.NHS_TYPES
+
     @cached_property
     def inbound_number(self):
         return inbound_number_client.get_inbound_sms_number_for_service(self.id)["data"].get("number", "")

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -7,11 +7,8 @@ class EmailBrandingClient(NotifyAdminAPIClient):
         return self.get(url="/email-branding/{}".format(branding_id))
 
     @cache.set("email_branding")
-    def get_all_email_branding(self, sort_key=None):
-        brandings = self.get(url="/email-branding")["email_branding"]
-        if sort_key and sort_key in brandings[0]:
-            brandings.sort(key=lambda branding: branding[sort_key].lower())
-        return brandings
+    def get_all_email_branding(self):
+        return self.get(url="/email-branding")["email_branding"]
 
     @cache.delete("email_branding")
     def create_email_branding(self, logo, name, text, colour, brand_type, created_by_id: str):

--- a/app/template_previews.py
+++ b/app/template_previews.py
@@ -21,7 +21,7 @@ class TemplatePreview:
             "letter_contact_block": template.get("reply_to_text", ""),
             "template": template,
             "values": values,
-            "filename": current_service.letter_branding and current_service.letter_branding["filename"],
+            "filename": current_service.letter_branding.filename,
         }
         resp = requests.post(
             "{}/preview.{}{}".format(

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -14,7 +14,7 @@
   <h1 class="heading-medium">{{ page_title }}</h1>
   {{ live_search(target_selector='.email-brand', show=True, form=search_form, autofocus=True) }}
   <nav>
-    {% for brand in email_brandings %}
+    {% for brand in email_brandings|sort %}
       <div class="email-brand">
         <div class="message-name">
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_email_branding', branding_id=brand.id) }}">

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -40,7 +40,7 @@
 
     <!--display the email-branding-pool options and the preview for each one -->
 
-    {% for option in email_branding_pool_options %}
+    {% for option in current_org.email_branding_pool_excluding_default %}
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
         {{ option.name }}
       </h2>

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -21,7 +21,7 @@
 
     <!-- display default branding and it's preview -->
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-      {{ current_org.email_branding_name }}<span class="hint govuk-!-font-weight-regular">&ensp;(default)</span>
+      {{ current_org.email_branding.name }}<span class="hint govuk-!-font-weight-regular">&ensp;(default)</span>
     </h2>
 
     {% if show_use_govuk_as_default_link %}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -101,7 +101,7 @@
       {% call row() %}
         {{ text_field('Email branding options') }}
         {% set email_branding_html %}
-          <div {% if other_email_branding_options %}class="govuk-!-margin-bottom-3"{% endif %}>
+          <div {% if current_org.email_branding_pool_excluding_default %}class="govuk-!-margin-bottom-3"{% endif %}>
             {{ current_org.email_branding.name }}
             <br>
             <div class="table-field-status-default">
@@ -109,15 +109,13 @@
             </div>
           </div>
 
-          {% if other_email_branding_options %}
-            <ul>
-            {% for item in other_email_branding_options %}
+          {% for item in current_org.email_branding_pool_excluding_default %}
+            {% if loop.first %}<ul>{% endif %}
               <li>
-                {{ item }}
+                {{ item.name }}
               </li>
-            {% endfor %}
-            </ul>
-          {% endif %}
+            {% if loop.last %}</ul>{% endif %}
+          {% endfor %}
         {% endset %}
         {% call field() %}
           {{ email_branding_html }}

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -102,7 +102,7 @@
         {{ text_field('Email branding options') }}
         {% set email_branding_html %}
           <div {% if other_email_branding_options %}class="govuk-!-margin-bottom-3"{% endif %}>
-            {{ default_email_branding_name }}
+            {{ current_org.email_branding.name }}
             <br>
             <div class="table-field-status-default">
               Default
@@ -132,7 +132,7 @@
       {% call row() %}
         {{ text_field('Default letter branding') }}
         {{ optional_text_field(
-          current_org.letter_branding.name,
+          current_org.letter_branding.name if current_org.letter_branding else None,
           default='No branding'
         ) }}
         {{ edit_field(

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -96,7 +96,7 @@
 
           {% call settings_row(if_has_permission='email') %}
             {{ text_field('Email branding') }}
-            {{ text_field(current_service.email_branding_name) }}
+            {{ text_field(current_service.email_branding.name) }}
             {{ edit_field(
               'Change',
               email_request_url,
@@ -386,7 +386,7 @@
           {% endcall %}
           {% call row() %}
             {{ text_field('Email branding' )}}
-            {{ text_field(current_service.email_branding_name) }}
+            {{ text_field(current_service.email_branding.name) }}
             {{ edit_field('Change', url_for('.service_set_email_branding', service_id=current_service.id), suffix='email branding (admin view)') }}
           {% endcall %}
           {% call row() %}

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -22,7 +22,7 @@
   {{ page_header('Change email branding') }}
 
   <p class="govuk-body">
-    Your emails currently have {{ branding_name }} branding.
+    Your emails currently have {{ current_service.email_branding.name }} branding.
   </p>
 
   {{ email_branding_preview(

--- a/app/templates/views/service-settings/branding/email-branding-pool-option.html
+++ b/app/templates/views/service-settings/branding/email-branding-pool-option.html
@@ -20,10 +20,10 @@
   {{ page_header('Change email branding') }}
 
   <p class="govuk-body">
-    If you confirm, your emails will come with {{ chosen_branding_name }} branding.
+    If you confirm, your emails will come with {{ chosen_branding.name }} branding.
   </p>
 
-  {{ email_branding_preview(chosen_branding_id) }}
+  {{ email_branding_preview(chosen_branding.id) }}
 
 
   {% call form_wrapper() %}

--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -22,7 +22,7 @@
   {{ page_header('Change letter branding') }}
 
   <p class="govuk-body">
-    Your letters currently have {{ branding_name }} branding.
+    Your letters currently have {{ current_service.letter_branding.name }} branding.
   </p>
 
   {% call form_wrapper() %}

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -6,8 +6,8 @@ NHS_EMAIL_BRANDING_ID = "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"
 def get_email_choices(service):
     if (
         service.organisation_type == Organisation.TYPE_CENTRAL
-        and service.email_branding_id is not None  # GOV.UK is not current branding
-        and service.organisation.email_branding_id is None  # no default to supersede it (GOV.UK)
+        and service.email_branding_id  # GOV.UK is not current branding
+        and not service.organisation.email_branding_id  # no default to supersede it (GOV.UK)
     ):
         yield ("govuk", "GOV.UK")
 
@@ -23,7 +23,7 @@ def get_email_choices(service):
         if (
             service.organisation_type == Organisation.TYPE_CENTRAL
             and service.organisation
-            and service.organisation.email_branding_id is None  # don't offer both if org has default
+            and not service.organisation.email_branding_id  # don't offer both if org has default
             and service.email_branding_name.lower() != f"GOV.UK and {service.organisation.name}".lower()
         ):
             yield ("govuk_and_org", f"GOV.UK and {service.organisation.name}")
@@ -31,10 +31,7 @@ def get_email_choices(service):
         if (
             service.organisation
             and not service.is_nhs
-            and (
-                service.email_branding_id is None  # GOV.UK is current branding
-                or service.email_branding_id != service.organisation.email_branding_id
-            )
+            and (not service.email_branding_id or service.email_branding_id != service.organisation.email_branding_id)
         ):
             yield ("organisation", service.organisation.name)
 
@@ -47,9 +44,6 @@ def get_letter_choices(service):
     if (
         service.organisation
         and not service.is_nhs
-        and (
-            service.letter_branding_id is None  # GOV.UK is current branding
-            or service.letter_branding_id != service.organisation.letter_branding_id
-        )
+        and (not service.letter_branding_id or service.letter_branding_id != service.organisation.letter_branding_id)
     ):
         yield ("organisation", service.organisation.name)

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -13,7 +13,7 @@ def get_email_choices(service):
     ):
         yield ("govuk", "GOV.UK")
 
-    if service.organisation_type in Organisation.NHS_TYPES and service.email_branding_id != NHS_EMAIL_BRANDING_ID:
+    if service.is_nhs and service.email_branding_id != NHS_EMAIL_BRANDING_ID:
         yield (NHS_EMAIL_BRANDING_ID, "NHS")
 
     if service.email_branding_pool:
@@ -32,7 +32,7 @@ def get_email_choices(service):
 
         if (
             service.organisation
-            and service.organisation_type not in Organisation.NHS_TYPES
+            and not service.is_nhs
             and (
                 service.email_branding_id is None  # GOV.UK is current branding
                 or service.email_branding_id != organisation_branding_id
@@ -44,12 +44,12 @@ def get_email_choices(service):
 def get_letter_choices(service):
     organisation_branding_id = service.organisation.letter_branding_id if service.organisation else None
 
-    if service.organisation_type in Organisation.NHS_TYPES and service.letter_branding_name != "NHS":
+    if service.is_nhs and service.letter_branding_name != "NHS":
         yield ("nhs", "NHS")
 
     if (
         service.organisation
-        and service.organisation_type not in Organisation.NHS_TYPES
+        and not service.is_nhs
         and (
             service.letter_branding_id is None  # GOV.UK is current branding
             or service.letter_branding_id != organisation_branding_id

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -9,9 +9,8 @@ def get_email_choices(service):
         yield (EmailBranding.NHS_ID, "NHS")
 
     if service.organisation.email_branding_pool:
-        for branding in service.organisation.email_branding_pool:
-            if branding.id != service.email_branding_id:
-                yield (branding.id, branding.name)
+        for branding in service.organisation.email_branding_pool.excluding(service.email_branding_id):
+            yield (branding.id, branding.name)
     elif service.organisation:
         # fake branding options
         if (

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -8,8 +8,8 @@ def get_email_choices(service):
     if service.is_nhs and not service.email_branding.is_nhs:
         yield (EmailBranding.NHS_ID, "NHS")
 
-    if service.organisation.email_branding_pool:
-        for branding in service.organisation.email_branding_pool.excluding(service.email_branding_id):
+    if service.email_branding_pool:
+        for branding in service.email_branding_pool.excluding(service.email_branding_id):
             yield (branding.id, branding.name)
     elif service.organisation:
         # fake branding options

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -4,12 +4,10 @@ NHS_EMAIL_BRANDING_ID = "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"
 
 
 def get_email_choices(service):
-    organisation_branding_id = service.organisation.email_branding_id if service.organisation else None
-
     if (
         service.organisation_type == Organisation.TYPE_CENTRAL
         and service.email_branding_id is not None  # GOV.UK is not current branding
-        and organisation_branding_id is None  # no default to supersede it (GOV.UK)
+        and service.organisation.email_branding_id is None  # no default to supersede it (GOV.UK)
     ):
         yield ("govuk", "GOV.UK")
 
@@ -25,7 +23,7 @@ def get_email_choices(service):
         if (
             service.organisation_type == Organisation.TYPE_CENTRAL
             and service.organisation
-            and organisation_branding_id is None  # don't offer both if org has default
+            and service.organisation.email_branding_id is None  # don't offer both if org has default
             and service.email_branding_name.lower() != f"GOV.UK and {service.organisation.name}".lower()
         ):
             yield ("govuk_and_org", f"GOV.UK and {service.organisation.name}")
@@ -35,14 +33,13 @@ def get_email_choices(service):
             and not service.is_nhs
             and (
                 service.email_branding_id is None  # GOV.UK is current branding
-                or service.email_branding_id != organisation_branding_id
+                or service.email_branding_id != service.organisation.email_branding_id
             )
         ):
             yield ("organisation", service.organisation.name)
 
 
 def get_letter_choices(service):
-    organisation_branding_id = service.organisation.letter_branding_id if service.organisation else None
 
     if service.is_nhs and service.letter_branding_name != "NHS":
         yield ("nhs", "NHS")
@@ -52,7 +49,7 @@ def get_letter_choices(service):
         and not service.is_nhs
         and (
             service.letter_branding_id is None  # GOV.UK is current branding
-            or service.letter_branding_id != organisation_branding_id
+            or service.letter_branding_id != service.organisation.letter_branding_id
         )
     ):
         yield ("organisation", service.organisation.name)

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1748,7 +1748,7 @@ def test_organisation_email_branding_page_is_not_accessible_by_non_platform_admi
     "default_email_branding, expected_branding_options",
     (
         [None, {"GOV.UK (default)", "Email branding name 1", "Email branding name 2"}],
-        ["2", {"Email branding name 2 (default)", "Email branding name 1"}],
+        ["email-branding-2-id", {"Email branding name 2 (default)", "Email branding name 1"}],
     ),
 )
 def test_organisation_email_branding_page_shows_all_branding_pool_options(
@@ -2198,10 +2198,10 @@ def test_add_organisation_email_branding_options_shows_branding_not_in_branding_
             "brand_type": "org",
         },
         {
-            "logo": "logo4.png",
-            "name": "org 4",
+            "logo": "logo3.png",
+            "name": "org 3",
             "text": None,
-            "id": "4",
+            "id": "3",
             "colour": None,
             "brand_type": "org",
         },
@@ -2218,7 +2218,7 @@ def test_add_organisation_email_branding_options_shows_branding_not_in_branding_
         for checkbox in page.select(".govuk-checkboxes__item")
     ] == [
         ("org 2", "2", False),
-        ("org 3", "3", False),
+        ("org 4", "4", False),
         ("org 5", "5", False),
     ]
     assert normalize_spaces(page.select_one(".page-footer__button").text) == "Add options"

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2206,7 +2206,7 @@ def test_add_organisation_email_branding_options_shows_branding_not_in_branding_
             "brand_type": "org",
         },
     ]
-    mocker.patch("app.organisations_client.get_email_branding_pool", return_value=branding_pool)
+    mocker.patch("app.models.branding.EmailBrandingPool.client_method", return_value=branding_pool)
 
     client_request.login(platform_admin_user)
     page = client_request.get(".add_organisation_email_branding_options", org_id=organisation_one["id"])

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3458,7 +3458,7 @@ def test_should_show_branding_styles(
     assert "checked" not in branding_style_choices[4].attrs
     assert "checked" not in branding_style_choices[5].attrs
 
-    app.email_branding_client.get_all_email_branding.assert_called_once_with()
+    app.models.branding.AllEmailBranding.client_method.assert_called_once_with()
     app.service_api_client.get_service.assert_called_once_with(service_one["id"])
 
 

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -427,6 +427,7 @@ def test_create_letter_branding_persists_logo_when_all_data_is_valid(
     mocker,
     client_request,
     platform_admin_user,
+    mock_get_all_letter_branding,
     fake_uuid,
 ):
     with client_request.session_transaction() as session:

--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -6,6 +6,7 @@ import pytest
 from notifications_utils.template import LetterPreviewTemplate
 
 from app import load_service_before_request
+from app.models.branding import LetterBranding
 from app.template_previews import (
     TemplatePreview,
     get_page_count_for_letter,
@@ -53,7 +54,8 @@ def test_from_utils_template_calls_through(
     ],
 )
 @pytest.mark.parametrize(
-    "letter_branding, expected_filename", [({"filename": "hm-government"}, "hm-government"), (None, None)]
+    "letter_branding, expected_filename",
+    [(LetterBranding({"filename": "hm-government"}), "hm-government"), (LetterBranding.from_id(None), None)],
 )
 def test_from_database_object_makes_request(
     mocker,

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -2,12 +2,9 @@ from unittest.mock import PropertyMock
 
 import pytest
 
+from app.models.branding import EmailBranding
 from app.models.service import Service
-from app.utils.branding import (
-    NHS_EMAIL_BRANDING_ID,
-    get_email_choices,
-    get_letter_choices,
-)
+from app.utils.branding import get_email_choices, get_letter_choices
 from tests import organisation_json
 from tests.conftest import create_email_branding
 
@@ -19,7 +16,7 @@ from tests.conftest import create_email_branding
         (get_letter_choices, "central", []),
         (get_email_choices, "local", []),
         (get_letter_choices, "local", []),
-        (get_email_choices, "nhs_central", [(NHS_EMAIL_BRANDING_ID, "NHS")]),
+        (get_email_choices, "nhs_central", [(EmailBranding.NHS_ID, "NHS")]),
         (get_letter_choices, "nhs_central", [("nhs", "NHS")]),
     ],
 )
@@ -59,10 +56,10 @@ def test_get_choices_service_not_assigned_to_org(
         ),
         ("local", None, [("organisation", "Test Organisation")]),
         ("local", "some-branding-id", [("organisation", "Test Organisation")]),
-        ("nhs_central", None, [(NHS_EMAIL_BRANDING_ID, "NHS")]),
+        ("nhs_central", None, [(EmailBranding.NHS_ID, "NHS")]),
         (
             "nhs_central",
-            NHS_EMAIL_BRANDING_ID,
+            EmailBranding.NHS_ID,
             [
                 # don't show NHS if it's the current branding
             ],
@@ -192,6 +189,7 @@ def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
     service_one,
     mock_get_email_branding_pool,
     mock_get_service_organisation,
+    mock_get_email_branding,
 ):
     service = Service(service_one)
 
@@ -227,7 +225,7 @@ def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
         ("govuk", "GOV.UK"),
         ("email-branding-2-id", "Email branding name 2"),
     ]
-    mocker.patch("app.organisations_client.get_email_branding_pool", return_value=branding_pool)
+    mocker.patch("app.models.branding.EmailBrandingPool.client_method", return_value=branding_pool)
 
     options = get_email_choices(service)
     assert list(options) == expected_options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2404,7 +2404,7 @@ def mock_get_all_email_branding(mocker):
         return create_email_brandings(5, non_standard_values=non_standard_values, shuffle=shuffle)
 
     return mocker.patch(
-        "app.notify_client.email_branding_client.email_branding_client.get_all_email_branding",
+        "app.models.branding.AllEmailBranding.client_method",
         side_effect=_get_all_email_branding,
     )
 
@@ -2430,7 +2430,7 @@ def mock_get_all_letter_branding(mocker):
             },
         ]
 
-    return mocker.patch("app.letter_branding_client.get_all_letter_branding", side_effect=_get_letter_branding)
+    return mocker.patch("app.models.branding.AllLetterBranding.client_method", side_effect=_get_letter_branding)
 
 
 @pytest.fixture
@@ -2500,7 +2500,7 @@ def mock_get_email_branding_pool(mocker):
     def _get_email_branding_pool(org_id):
         return create_email_branding_pool()
 
-    return mocker.patch("app.organisations_client.get_email_branding_pool", side_effect=_get_email_branding_pool)
+    return mocker.patch("app.models.branding.EmailBrandingPool.client_method", side_effect=_get_email_branding_pool)
 
 
 @pytest.fixture(scope="function")
@@ -2508,15 +2508,15 @@ def mock_get_empty_email_branding_pool(mocker):
     def _get_email_branding_pool(org_id):
         return []
 
-    return mocker.patch("app.organisations_client.get_email_branding_pool", side_effect=_get_email_branding_pool)
+    return mocker.patch("app.models.branding.EmailBrandingPool.client_method", side_effect=_get_email_branding_pool)
 
 
 @pytest.fixture(scope="function")
 def mock_get_email_branding(mocker, fake_uuid):
     def _get_email_branding(id):
-        return create_email_branding(fake_uuid)
+        return create_email_branding(id)
 
-    return mocker.patch("app.email_branding_client.get_email_branding", side_effect=_get_email_branding)
+    return mocker.patch("app.models.branding.email_branding_client.get_email_branding", side_effect=_get_email_branding)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This is re-opening https://github.com/alphagov/notifications-admin/pull/4392 by @quis, which was reverted. The original commits are the same, with two new ones added to the end.

**Original PR description**

I noticed in https://github.com/alphagov/notifications-admin/pull/4282#discussion_r913232533 that @leohemsted thought get_email_choices could do with being made less complex.

Feels like now is a good time to do some refactoring, before we get into building a letter branding pool as well.

This pull request broadly moves logic from the view layer and the utils/branding.py file into model classes for email and letter branding.

This generally means we get nicely-named properties, instead of manipulating or introspecting raw data structures.

Best reviewed commit by commit.

**New commits**

1. Since this was merged we've added a new event, so this updates the code for that which would no longer work as expected.
2. We saw an issue when this was deployed, which the second new commit fixes - there was one place where we weren't expecting `LetterBranding` to be a class so there was an error when trying to serialize it