### PR TITLE
Always cf-target before cf-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ upload-static:
 	aws s3 cp --region eu-west-1 --recursive --cache-control max-age=315360000,immutable ./app/static s3://${DNS_NAME}-static
 
 .PHONY: cf-deploy
-cf-deploy: ## Deploys the app to Cloud Foundry
+cf-deploy: cf-target ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	@cf app --guid notify-admin || exit 1
 	# cancel any existing deploys to ensure we can apply manifest (if a deploy is in progress you'll see ScaleDisabledDuringDeployment)


### PR DESCRIPTION
I accidentally did `make preview cf-deploy` while targetting `production` (from a previous dig into the DB), expecting it to target the correct paas space automatically.

It did not and we got an alert in prod. Fortunately the deploy was rejected because of a config mismatch so nothing went wrong, but let's protect ourselves from my stupidity anyway...