### PR TITLE
Forward limited headers from template-preview

### DIFF
--- a/tests/app/test_template_previews.py
+++ b/tests/app/test_template_previews.py
@@ -68,7 +68,7 @@ def test_from_database_object_makes_request(
     # `service` is in the `_request_ctx_stack` to avoid an error
     load_service_before_request()
 
-    resp = Mock(content="a", status_code="b", headers={"c": "d"})
+    resp = Mock(content="a", status_code="b", headers={"content-type": "image/png"})
     request_mock = mocker.patch("app.template_previews.requests.post", return_value=resp)
     mocker.patch("app.template_previews.current_service", letter_branding=letter_branding)
     template = mock_get_service_letter_template("123", "456")["data"]
@@ -77,7 +77,7 @@ def test_from_database_object_makes_request(
 
     assert ret[0] == "a"
     assert ret[1] == "b"
-    assert list(ret[2]) == [("c", "d")]
+    assert list(ret[2]) == [("content-type", "image/png")]
 
     data = {
         "letter_contact_block": None,
@@ -100,12 +100,13 @@ def test_from_database_object_makes_request(
 def test_from_valid_pdf_file_makes_request(mocker, page_number, expected_url):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
     request_mock = mocker.patch(
-        "app.template_previews.requests.post", return_value=Mock(content="a", status_code="b", headers={"c": "d"})
+        "app.template_previews.requests.post",
+        return_value=Mock(content="a", status_code="b", headers={"content-type": "image/png"}),
     )
 
     response = TemplatePreview.from_valid_pdf_file(b"pdf file", page_number)
 
-    assert response == ("a", "b", {"c": "d"}.items())
+    assert response == ("a", "b", {"content-type": "image/png"}.items())
     request_mock.assert_called_once_with(
         expected_url,
         data=base64.b64encode(b"pdf page").decode("utf-8"),
@@ -116,12 +117,13 @@ def test_from_valid_pdf_file_makes_request(mocker, page_number, expected_url):
 def test_from_invalid_pdf_file_makes_request(mocker):
     mocker.patch("app.template_previews.extract_page_from_pdf", return_value=b"pdf page")
     request_mock = mocker.patch(
-        "app.template_previews.requests.post", return_value=Mock(content="a", status_code="b", headers={"c": "d"})
+        "app.template_previews.requests.post",
+        return_value=Mock(content="a", status_code="b", headers={"content-type": "image/png"}),
     )
 
     response = TemplatePreview.from_invalid_pdf_file(b"pdf file", "1")
 
-    assert response == ("a", "b", {"c": "d"}.items())
+    assert response == ("a", "b", {"content-type": "image/png"}.items())
     request_mock.assert_called_once_with(
         "http://localhost:9999/precompiled/overlay.png?page_number=1",
         data=b"pdf page",


### PR DESCRIPTION
We have experienced issues locally with template-preview responses to the admin app because they include a Transfer-Encoding:chunked header that indicates the response is a streaming response. By including these in the response from admin to the browser, the browser gets confused, because it receives a standard non-streamed HTTP response but has a header telling it to expect chunks. This leads to issues and doesn't render the template preview correctly in the iframe.

Let's only forward specific headers (eg the Content-Type) and allow flask on the admin app to set the rest as it sees fit.