### PR TITLE
Create new logo flow: Let users choose type of logo

### DIFF
--- a/app/assets/stylesheets/components/preview-pane.scss
+++ b/app/assets/stylesheets/components/preview-pane.scss
@@ -17,3 +17,8 @@
     display: block;
   }
 }
+
+#responsive-image {
+  width: 100%;
+  height: auto;
+}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2101,6 +2101,19 @@ class GovernmentIdentityLogoForm(StripWhitespaceForm):
         )
 
 
+class GovBrandingOrOwnLogoForm(StripWhitespaceForm):
+    branding_options = (
+        ("single_identity", "Create a government identity logo"),
+        ("org", "Upload a logo"),
+    )
+
+    options = GovukRadiosField(
+        "Choose a logo for your emails",
+        choices=branding_options,
+        validators=[DataRequired()],
+    )
+
+
 class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
     notification_type = GovukRadiosField(
         "What notification type?",

--- a/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
@@ -5,6 +5,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set page_title = form.options.label %}
 
@@ -21,6 +22,15 @@
 {% block maincolumn_content %}
 
   {{ page_header(page_title) }}
+
+  {% if form.options.errors %}
+    {% set params = {
+        "titleText": "There is a problem",
+        "errorList": [{"href": "#" + form.options.id, "text": form.options.errors[0]}]
+      }
+    %}
+    {{ govukErrorSummary(params) }}
+  {% endif %}
 
   {% call form_wrapper() %}
     <fieldset class="form-group {% if form.options.errors %}form-group-error{% endif %} top-gutter">

--- a/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
@@ -1,0 +1,46 @@
+{% extends "withnav_template.html" %}
+{% from "components/radios.html" import radio %}
+{% from "components/select-input.html" import select_wrapper %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
+{% set page_title = form.options.label %}
+
+{% block service_page_title %}
+  {{ page_title }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    "href": url_for('.email_branding_request', service_id=current_service.id)
+  }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(page_title) }}
+
+  {% call form_wrapper() %}
+    <fieldset class="form-group {% if form.options.errors %}form-group-error{% endif %} top-gutter">
+      <div class="govuk-grid-row">
+        {% for option in form.options %}
+          <div class="govuk-grid-column-one-half">
+            <label for="{{ option.id }}">
+              <img
+                src="{{ asset_url('images/branding/{}.png'.format(option.data)) }}"
+                alt=""
+                class="bordered-image bottom-gutter-1-3"
+                id="responsive-image"
+              >
+            </label>
+            {{ radio(option) }}
+          </div>
+        {% endfor %}
+      </div>
+    </fieldset>
+    {{ page_footer('Continue') }}
+  {% endcall %}
+
+{% endblock %}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -39,6 +39,22 @@ def service_has_permission(permission):
     return wrap
 
 
+def service_belongs_to_org_type(org_type):
+
+    from app import current_service
+
+    def wrap(func):
+        @wraps(func)
+        def wrap_func(*args, **kwargs):
+            if not current_service or not current_service.organisation_type == org_type:
+                abort(403)
+            return func(*args, **kwargs)
+
+        return wrap_func
+
+    return wrap
+
+
 def get_help_argument():
     return request.args.get("help") if request.args.get("help") in ("1", "2", "3") else None
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3721,14 +3721,12 @@ def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
 def test_email_branding_create_government_identity_logo(client_request, service_one):
     page = client_request.get("main.email_branding_create_government_identity_logo", service_id=service_one["id"])
 
-    expected_href = (
-        "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings"
-        "/email-branding/create-government-identity-logo/enter-text"
-    )
     back_button = page.find("a", text="Back")
-    continue_button = page.find("a", href=expected_href)
+    continue_button = page.find(
+        "a", href=url_for(".email_branding_enter_government_identity_logo_text", service_id=SERVICE_ONE_ID)
+    )
 
-    assert back_button["href"] == "#"  # TODO: update this when we know the right back link
+    assert back_button["href"] == url_for(".email_branding_choose_logo", service_id=SERVICE_ONE_ID)
     assert "Continue" in continue_button.text
 
 

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -115,6 +115,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "edit_user_mobile_number",
             "edit_user_permissions",
             "email_branding",
+            "email_branding_choose_logo",
             "email_branding_create_government_identity_logo",
             "email_branding_enter_government_identity_logo_text",
             "email_branding_govuk",


### PR DESCRIPTION
### Story ticket: 
https://trello.com/c/GDnrFbse/69-build-the-page-where-a-user-can-choose-if-they-want-a-banner-or-not

### Page looks like: 
<img width="1106" alt="Screenshot 2022-10-26 at 18 47 17" src="https://user-images.githubusercontent.com/20957548/198099204-b5d2cbbf-4e78-4484-b838-3aa35d98e2d9.png">
