### PR TITLE
Email branding - government logo

### DIFF
--- a/app/assets/javascripts/esm/all.mjs
+++ b/app/assets/javascripts/esm/all.mjs
@@ -12,6 +12,7 @@ import Header from 'govuk-frontend/components/header/header';
 import Details from 'govuk-frontend/components/details/details';
 import Button from 'govuk-frontend/components/button/button';
 import Radios from 'govuk-frontend/components/radios/radios';
+import ErrorSummary from 'govuk-frontend/components/error-summary/error-summary';
 
 // Modules from 3rd party vendors
 import morphdom from 'morphdom';
@@ -57,6 +58,9 @@ function initAll (options) {
   nodeListForEach($radios, function ($radio) {
     new Radios($radio).init()
   })
+
+  var $errorSummary = scope.querySelector('[data-module="error-summary"]')
+  new ErrorSummary($errorSummary).init()
 }
 
 // Create separate namespace for GOVUK Frontend.

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -31,6 +31,7 @@ $govuk-assets-path: "/static/";
 @import "components/back-link/_back-link";
 @import "components/button/_button";
 @import "components/details/_details";
+@import "components/error-summary/_error-summary";
 @import "components/radios/_radios";
 @import "components/checkboxes/_checkboxes";
 @import "components/input/_input";

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2075,6 +2075,32 @@ class SomethingElseBrandingForm(StripWhitespaceForm):
     )
 
 
+class GovernmentIdentityLogoForm(StripWhitespaceForm):
+    logo_text = GovukTextInputField(
+        "Enter the text that will appear in your logo",
+        validators=[DataRequired("Cannot be empty")],
+        param_extensions={
+            "label": {
+                "isPageHeading": True,
+                "classes": "govuk-label--l",
+            },
+            "hint": {
+                "html": (
+                    "This is usually the full name of your organisation.<br/><br/>For example, {organisation_name}"
+                )
+            },
+        },
+    )
+
+    def __init__(self, organisation=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        organisation_name = organisation.name if organisation else "Department of Education"
+        self.logo_text.param_extensions["hint"]["html"] = self.logo_text.param_extensions["hint"]["html"].format(
+            organisation_name=organisation_name
+        )
+
+
 class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
     notification_type = GovukRadiosField(
         "What notification type?",

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -223,6 +223,8 @@ class MainNavigation(Navigation):
         "settings": {
             "add_organisation_from_gp_service",
             "add_organisation_from_nhs_local_service",
+            "email_branding_create_government_identity_logo",
+            "email_branding_enter_government_identity_logo_text",
             "email_branding_govuk",
             "email_branding_govuk_and_org",
             "email_branding_nhs",

--- a/app/templates/support-tickets/government-logo-branding-request.txt
+++ b/app/templates/support-tickets/government-logo-branding-request.txt
@@ -1,0 +1,13 @@
+Organisation: {% if current_service.organisation -%}
+  {{ current_service.organisation.name }}
+{%- else -%}
+  Can’t tell (domain is {{ current_user.email_domain }})
+{%- endif %}
+Service: {{ current_service.name }}
+{{ url_for('main.service_dashboard', service_id=current_service.id, _external=True) }}
+
+---
+Government logo text requested: {{ logo_text }}
+{% if detail %}
+{{ detail }}
+{% endif %}

--- a/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
+++ b/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
@@ -1,0 +1,48 @@
+{% extends "withnav_template.html" %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/button/macro.njk" import govukButton %}
+{% from "components/branding-preview.html" import email_branding_preview %}
+
+{% block service_page_title %}
+  Create a government identity logo
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({"href": back_link }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header('Create a government identity logo') }}
+
+  {{ email_branding_preview('__NONE__') }}
+
+  <p class="govuk-body">
+    A government identity logo is made up of:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>text, usually the organisation name</li>
+      <li>a symbol, for example the Royal Coat of Arms</li>
+      <li>a coloured line</li>
+    </ul>
+  </p>
+
+  <p class="govuk-body">
+    You will need to enter the text that will appear in the logo.
+  </p>
+  <p class="govuk-body">
+    We will select the appropriate symbol and coloured line for you.
+  </p>
+  <p class="govuk-body">
+    It can take up to 1 working day for us to create a new logo.
+  </p>
+
+  {{ govukButton({
+    "element": "a",
+    "text": "Continue",
+    "href": url_for('.email_branding_enter_government_identity_logo_text', service_id=service_id)
+  }) }}
+
+{% endblock %}

--- a/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
@@ -1,0 +1,30 @@
+{% extends "withnav_template.html" %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/branding-preview.html" import email_branding_preview %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/banner.html" import banner_wrapper %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block service_page_title %}
+  Enter the text that will appear in your logo
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({"href": back_link }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+  {% if form.logo_text.errors %}
+    {% set params = {"titleText": "There is a problem", "errorList": [{"href": "#" + form.logo_text.id, "text": form.logo_text.errors[0]}]} %}
+    {{ govukErrorSummary(params) }}
+  {% endif %}
+
+  {% call form_wrapper() %}
+    {{ form.logo_text }}
+    {{ page_footer('Request new branding') }}
+  {% endcall %}
+
+{% endblock %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,6 +65,7 @@ const copy = {
         'details',
         'button',
         'error-message',
+        'error-summary',
         'fieldset',
         'hint',
         'label',

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -115,6 +115,8 @@ EXCLUDED_ENDPOINTS = tuple(
             "edit_user_mobile_number",
             "edit_user_permissions",
             "email_branding",
+            "email_branding_create_government_identity_logo",
+            "email_branding_enter_government_identity_logo_text",
             "email_branding_govuk",
             "email_branding_govuk_and_org",
             "email_branding_nhs",


### PR DESCRIPTION
We want users to be able to request new government logo email brandings
through the Notify admin app. These pages will show what the branding
will look like and ask the user for the logo text they want as part of
the brand, then submits their request to Zendesk to be actioned by
support.

## Flow
![2022-10-27 13 34 50](https://user-images.githubusercontent.com/2920760/198292010-50c23cce-ffb1-4cde-896e-42ba10363692.gif)
