### PR TITLE
vendor govuk-frontend-jinja==1.5.1 to run side by side with the old lib

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
-exclude = venv*,__pycache__,node_modules,cache
+exclude = venv*,__pycache__,node_modules,cache,vendor
 max-complexity = 14
 max-line-length = 120
 

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ environment.sh
 app/version.py
 app/static
 app/templates/vendor
+
+# TODO: remove once CCS govuk_frontend_jinja is removed and we get rid of vendoring hack
+vendor

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$V
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
+
+	# TODO: once CCS govuk_frontend_jinja is removed, replace this with normal reqs.txt (and update PackageLoader)
+	mkdir -p vendor/govuk_frontend_jinja_macros
+	pip3 install govuk-frontend-jinja==1.5.1 --target ./vendor/govuk_frontend_jinja_macros
+
 	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci --no-audit
 	. environment.sh; source $(HOME)/.nvm/nvm.sh && npm run build
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import sys
 from functools import partial
 from time import monotonic
 
@@ -574,5 +575,16 @@ def init_jinja(application):
         os.path.join(repo_root, "app/templates"),
         os.path.join(repo_root, "app/templates/vendor/govuk-frontend"),
     ]
-    jinja_loader = jinja2.FileSystemLoader(template_folders)
-    application.jinja_loader = jinja_loader
+
+    # Add vendor directory to module search path so we can find the new govuk-frontend-jinja macros
+    # TODO: once CCS govuk_frontend_jinja is removed, remove this path hack
+    sys.path.append(str(pathlib.Path("./vendor")))
+
+    application.jinja_loader = jinja2.ChoiceLoader(
+        [
+            jinja2.FileSystemLoader(template_folders),
+            jinja2.PrefixLoader(
+                {"govuk_frontend_jinja": jinja2.PackageLoader("govuk_frontend_jinja_macros.govuk_frontend_jinja")}
+            ),
+        ]
+    )


### PR DESCRIPTION
- [x] https://github.com/alphagov/notifications-admin/pull/4405

------------------------

There's two govuk-frontend-jinjas.

1. The old alphagov library, moved to CrownCommercialServices. This is not maintained and not compatible with newer versions of govuk frontend.

2. The new LandRegistry library. This is maintained, compatible with newer versions of govuk frontend, and hosted on pypi.

The two libraries are not cross-compatible.

We don't want to do a big-bang switch from one to the other - we want to replace one component at a time so we can have small PRs that are easy to review. To help us do so, we need to be able to install both libraries, and then refer to their components under separate aliases.

pip doesn't make this easy. The way we've decided to solve this is to download the library to a separate location (rather than the default site-packages folder that pip targets), and then manually add the parent folder of that to `sys.path` so that python can find it. We create a vendor subfolder so that the path doesn't get anything else accidentally.

We can then import the new file separately to the old file by using that subfolder of vendor we specified in bootstrap

```
>>> import govuk_frontend_jinja as old_lib
>>> old_lib.__file__
'~/.pyenv/versions/admin/lib/python3.9/site-packages/govuk_frontend_jinja/__init__.py'
>>> from govuk_frontend_jinja_macros import govuk_frontend_jinja as new_lib
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'govuk_frontend_jinja_macros'
>>> import sys
>>> sys.path.append('./vendor')
>>> from govuk_frontend_jinja_macros import govuk_frontend_jinja as new_lib
>>> new_lib.__file__
'~/dev/admin/./vendor/govuk_frontend_jinja_macros/govuk_frontend_jinja/__init__.py'
```

Then it's just a case of updating the jinja_loader engine in flask to a ChoiceLoader with the PackageLoader as specified in the new lib's docs, except pointing to the new alias as you would import it.

We have chosen version 1.5.1 of the govuk-frontend-jinja library as it is the last version to support govuk-frontend 3.x.x.

Note, this is just planned as a temporary hack to allow side-by-side running.

Once the migration is complete, we should remove this commit and simply include the new library in our `requirements.in` file as normal. (Then we'll need to update all the references to govuk_frontend_jinja_macros to drop the _macros suffix too)