### PR TITLE
Various fixes

### DIFF
--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -381,7 +381,6 @@
       background: transparent;
     }
 
-    &:active:before,
     &:focus:before {
       box-shadow: inset 0px -4px $govuk-focus-text-colour, inset 0px 15px $govuk-focus-colour, inset 15px 0px $govuk-focus-colour, inset 0px -11px $govuk-focus-colour;
     }

--- a/app/assets/stylesheets/components/textbox.scss
+++ b/app/assets/stylesheets/components/textbox.scss
@@ -14,7 +14,7 @@
   &-background,
   &-foreground,
   &-mask {
-    font-size: 19px;
+    @include govuk-font(19);
     display: block;
     box-sizing: border-box;
     position: relative;

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -29,7 +29,6 @@
 //
 
 .breadcrumbs {
-  @include govuk-width-container;
   @include govuk-font(16, $line-height: (25 / 16));
 
   padding: govuk-spacing(2) 0;

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -113,6 +113,11 @@ $govuk-grid-widths: (
 .notify-summary-list {
 
   border-top: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: 0;
+  }
 
 }
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1513,7 +1513,6 @@ class SupportRedirect(StripWhitespaceForm):
             ("public-sector", "I work in the public sector and need to send emails, text messages or letters"),
             ("public", "I’m a member of the public with a question for the government"),
         ],
-        param_extensions={"fieldset": {"legend": {"classes": "govuk-visually-hidden"}}},
     )
 
 

--- a/app/templates/views/support/index.html
+++ b/app/templates/views/support/index.html
@@ -15,9 +15,6 @@
     {% if current_user.is_authenticated %}
       {{ form.support_type }}
     {% else %}
-      <p class="govuk-body">
-        What do you need help with?
-      </p>
       {{ form.who }}
     {% endif %}
     {{ page_footer('Continue') }}


### PR DESCRIPTION
Fixes for these issues found while testing changes in https://github.com/alphagov/notifications-admin/pull/4405

## Remove not needed paragraph from support page

The support triage page (signed out) had a paragraph duplicating the legend of the radios fieldset:

<img width="1112" alt="support_triage_before" src="https://user-images.githubusercontent.com/87140/198550310-9d58f486-f7b6-44f1-b145-934c985c2516.png">

### How to test this change

Compare the HTML of the support page on production (to see the duplicate) to the version here and check how both look.

## Fix :active state for links in tables

Links in tables look like this in Safari when you click them with a cursor:

<img width="254" alt="table_link_active_safari_before" src="https://user-images.githubusercontent.com/87140/198402786-767f87e4-fd22-48fb-9cc2-5bfd047dee8a.png">

### How to test this change

Try clicking a 'Change' link on the settings page in Safari on production and compare with this branch.

## Fix highlight textbox text size on mobile

The text in our 'highlight textboxes' is too big on smaller screens:

<img width="398" alt="textbox_before" src="https://user-images.githubusercontent.com/87140/198403243-49e2ab95-9558-43b3-839a-a6dee49e720e.png">

### How to test this change

Compare the textboxes on the 'Edit template' page on production with this branch.

## Add padding at top of summary list

The top row on our version of the summary list component is missing some space above the text:

<img width="253" alt="profile_before" src="https://user-images.githubusercontent.com/87140/198404090-07705bba-d48f-468f-977d-b3c0a5460247.png">

### How to test this change

Compare the summary list on the profile page on production with this branch.

## Remove extra margins from the product page breadcrumb on mobile

The product page breadcrumb has too much spacing on either side on smaller screens:

<img width="243" alt="product_page_breadcrumb_before" src="https://user-images.githubusercontent.com/87140/198404369-7497c1b3-5db7-4d69-a790-f9d1690f1517.png">

### How to test this change

Compare the breadcrumb on the product page on production with this branch.
