### PR TITLE
Add page for adding to letter branding pool

### DIFF
--- a/app/assets/javascripts/addBrandingOptionsForm.js
+++ b/app/assets/javascripts/addBrandingOptionsForm.js
@@ -1,10 +1,10 @@
 (function(Modules) {
   "use strict";
 
-  Modules.AddEmailBrandingOptionsForm = function() {
+  Modules.AddBrandingOptionsForm = function() {
 
-    this.start = function(addEmailBrandingOptionsForm) {
-      this.$form = $(addEmailBrandingOptionsForm);
+    this.start = function(addBrandingOptionsForm) {
+      this.$form = $(addBrandingOptionsForm);
 
       this.$liveRegionCounter = this.$form.find('.selection-counter');
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1785,6 +1785,14 @@ class AddEmailBrandingOptionsForm(StripWhitespaceForm):
     )
 
 
+class AddLetterBrandingOptionsForm(StripWhitespaceForm):
+    branding_field = GovukCheckboxesField(
+        "Branding options",
+        validators=[DataRequired(message="Select at least 1 letter branding option")],
+        param_extensions={"fieldset": {"legend": {"classes": "govuk-visually-hidden"}}},
+    )
+
+
 class AdminSetEmailBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
     def __init__(self, *args, org_name, service_name, **kwargs):
         super().__init__(*args, **kwargs)

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -339,6 +339,7 @@ class OrgNavigation(Navigation):
         "settings": {
             "archive_organisation",
             "add_organisation_email_branding_options",
+            "add_organisation_letter_branding_options",
             "edit_organisation_agreement",
             "edit_organisation_billing_details",
             "edit_organisation_crown_status",

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -64,6 +64,10 @@ class OrganisationsClient(NotifyAdminAPIClient):
     def add_brandings_to_email_branding_pool(self, org_id, branding_ids):
         return self.post(url=f"/organisations/{org_id}/email-branding-pool", data={"branding_ids": branding_ids})
 
+    @cache.delete("organisation-{org_id}-letter-branding-pool")
+    def add_brandings_to_letter_branding_pool(self, org_id, branding_ids):
+        return self.post(url=f"/organisations/{org_id}/letter-branding-pool", data={"branding_ids": branding_ids})
+
     @cache.delete("service-{service_id}")
     @cache.delete("live-service-and-organisation-counts")
     @cache.delete("organisations")

--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -19,7 +19,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
-      {% call form_wrapper(module='add-email-branding-options-form') %}
+      {% call form_wrapper(module='add-branding-options-form') %}
         <div class="brand-pool">
             {{ form.branding_field }}
         </div>

--- a/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
@@ -1,0 +1,35 @@
+{% extends "org_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/live-search.html" import live_search %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/back-link/macro.njk" import govukBackLink %}
+
+{% block org_page_title %}
+  Add letter branding options
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({ "href": url_for('.organisation_settings', org_id=current_org.id) }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+  {{ page_header("Add letter branding options") }}
+  {{ live_search(target_selector='.govuk-checkboxes__item', show=True, form=search_form, autofocus=True) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-five-sixths">
+      {% call form_wrapper(module='add-branding-options-form') %}
+        <div class="brand-pool">
+            {{ form.branding_field }}
+        </div>
+      <div class="js-stick-at-bottom-when-scrolling">
+        {{ page_footer('Add options') }}
+        <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
+          Nothing selected
+        </div>
+      </div>
+      {% endcall %}
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -1,5 +1,6 @@
 {% extends "org_template.html" %}
 {% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
 {% from "components/back-link/macro.njk" import govukBackLink %}
 {%  from "components/branding-preview.html" import letter_branding_preview %}
 
@@ -20,5 +21,16 @@
     </h2>
     {{ letter_branding_preview(option.id) }}
   {% endfor %}
+
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />
+
+  <div class="js-stick-at-bottom-when-scrolling">
+    {{ page_footer(
+        button_text='Add branding options',
+        secondary_button=True,
+        secondary_button_url=url_for('.add_organisation_letter_branding_options', org_id=current_org.id)
+      )
+    }}
+  </div>
 
 {% endblock %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -178,7 +178,7 @@ const javascripts = () => {
     paths.src + 'javascripts/previewPane.js',
     paths.src + 'javascripts/colourPreview.js',
     paths.src + 'javascripts/templateFolderForm.js',
-    paths.src + 'javascripts/addEmailBrandingOptionsForm.js',
+    paths.src + 'javascripts/addBrandingOptionsForm.js',
     paths.src + 'javascripts/collapsibleCheckboxes.js',
     paths.src + 'javascripts/registerSecurityKey.js',
     paths.src + 'javascripts/authenticateSecurityKey.js',

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -289,3 +289,17 @@ def test_get_letter_branding_pool(mocker):
         f"organisation-{org_id}-letter-branding-pool", '{"filename": "gov.svg"}', ex=604800
     )
     mock_get.assert_called_with(url=f"/organisations/{org_id}/letter-branding-pool")
+
+
+def test_add_brandings_to_letter_branding_pool(mocker, fake_uuid):
+    mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
+    mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
+
+    organisations_client.add_brandings_to_letter_branding_pool(
+        fake_uuid,
+        branding_ids=["abcd", "efgh"],
+    )
+    mock_post.assert_called_with(
+        url=f"/organisations/{fake_uuid}/letter-branding-pool", data={"branding_ids": ["abcd", "efgh"]}
+    )
+    mock_redis_delete.assert_called_once_with(f"organisation-{fake_uuid}-letter-branding-pool")

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -24,6 +24,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "add_organisation_email_branding_options",
             "add_organisation_from_gp_service",
             "add_organisation_from_nhs_local_service",
+            "add_organisation_letter_branding_options",
             "add_service",
             "add_service_template",
             "api_callbacks",

--- a/tests/javascripts/addEmailBrandingOptionsForm.test.js
+++ b/tests/javascripts/addEmailBrandingOptionsForm.test.js
@@ -1,16 +1,16 @@
   const helpers = require('./support/helpers');
 
 beforeAll(() => {
-  require('../../app/assets/javascripts/addEmailBrandingOptionsForm.js');
+  require('../../app/assets/javascripts/addBrandingOptionsForm.js');
 });
 
 afterAll(() => {
   require('./support/teardown.js');
 });
 
-describe('AddEmailBrandingOptionsForm', () => {
+describe('AddBrandingOptionsForm', () => {
 
-  let addEmailBrandingOptionsForm;
+  let addBrandingOptionsForm;
   let formControls;
   let visibleCounter;
   let hiddenCounter;
@@ -18,7 +18,7 @@ describe('AddEmailBrandingOptionsForm', () => {
   beforeEach(() => {
 
     const htmlFragment = `
-      <form method="post" autocomplete="off" data-notify-module="add-email-branding-options-form" novalidate="">
+      <form method="post" autocomplete="off" data-notify-module="add-branding-options-form" novalidate="">
         <div class="brand-pool">
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset" id="branding_field">
@@ -61,7 +61,7 @@ describe('AddEmailBrandingOptionsForm', () => {
 
     document.body.innerHTML = htmlFragment;
 
-    addEmailBrandingOptionsForm = document.querySelector('form[data-notify-module=add-email-branding-options-form]');
+    addBrandingOptionsForm = document.querySelector('form[data-notify-module=add-branding-options-form]');
 
   });
 
@@ -71,8 +71,8 @@ describe('AddEmailBrandingOptionsForm', () => {
 
   });
 
-  function getEmailBrandingOptionsCheckboxes () {
-    return addEmailBrandingOptionsForm.querySelectorAll('input[type=checkbox]');
+  function getBrandingOptionsCheckboxes () {
+    return addBrandingOptionsForm.querySelectorAll('input[type=checkbox]');
   };
 
   function getVisibleCounter () {
@@ -90,7 +90,7 @@ describe('AddEmailBrandingOptionsForm', () => {
       // start module
       window.GOVUK.notifyModules.start();
 
-      formControls = addEmailBrandingOptionsForm.querySelector('.js-stick-at-bottom-when-scrolling');
+      formControls = addBrandingOptionsForm.querySelector('.js-stick-at-bottom-when-scrolling');
       visibleCounter = getVisibleCounter();
 
     });
@@ -136,19 +136,19 @@ describe('AddEmailBrandingOptionsForm', () => {
 
     describe("When some branding options are selected", () => {
 
-      let EmailBrandingOptionsCheckboxes;
+      let BrandingOptionsCheckboxes;
 
       beforeEach(() => {
 
         // start module
         window.GOVUK.notifyModules.start();
 
-        EmailBrandingOptionsCheckboxes = getEmailBrandingOptionsCheckboxes();
+        BrandingOptionsCheckboxes = getBrandingOptionsCheckboxes();
 
-        formControls = addEmailBrandingOptionsForm.querySelector('.js-stick-at-bottom-when-scrolling');
+        formControls = addBrandingOptionsForm.querySelector('.js-stick-at-bottom-when-scrolling');
 
-        helpers.triggerEvent(EmailBrandingOptionsCheckboxes[0], 'click');
-        helpers.triggerEvent(EmailBrandingOptionsCheckboxes[2], 'click');
+        helpers.triggerEvent(BrandingOptionsCheckboxes[0], 'click');
+        helpers.triggerEvent(BrandingOptionsCheckboxes[2], 'click');
 
       });
 
@@ -173,7 +173,7 @@ describe('AddEmailBrandingOptionsForm', () => {
 
           helpers.triggerEvent(clearLink, 'click');
 
-          const checkedCheckboxes = Array.from(EmailBrandingOptionsCheckboxes).filter(checkbox => checkbox.checked);
+          const checkedCheckboxes = Array.from(BrandingOptionsCheckboxes).filter(checkbox => checkbox.checked);
 
           expect(checkedCheckboxes.length === 0).toBe(true);
 
@@ -183,7 +183,7 @@ describe('AddEmailBrandingOptionsForm', () => {
 
           helpers.triggerEvent(clearLink, 'click');
 
-          const firstCheckbox = EmailBrandingOptionsCheckboxes[0];
+          const firstCheckbox = BrandingOptionsCheckboxes[0];
 
           expect(document.activeElement).toBe(firstCheckbox);
 


### PR DESCRIPTION
This new platform admin page matches the equivalent page for email branding. It shows a form with all letter branding that is not already in the branding pool for an organisation and allows you to select some and add them to the pool.

<img width="500" alt="Screenshot 2022-10-28 at 13 59 36" src="https://user-images.githubusercontent.com/12881990/198595818-9694c772-5133-45e3-b524-aa6ab1856429.png">

<img width="500" alt="Screenshot 2022-10-28 at 13 59 46" src="https://user-images.githubusercontent.com/12881990/198595895-b5cbdeae-3adf-4648-8961-8c54ab2d40da.png">

## Merge after
- [ ] https://github.com/alphagov/notifications-api/pull/3629
