### PR TITLE
Fix visible hidden content in letter logo preview

### DIFF
--- a/app/templates/views/service-settings/letter-preview.html
+++ b/app/templates/views/service-settings/letter-preview.html
@@ -17,7 +17,7 @@
         height: auto;
       }
       .letter-postage,
-      .visually-hidden {
+      .govuk-visually-hidden {
         display: none;
       }
     </style>


### PR DESCRIPTION
Presumably the `{{ template }}` is now using new GOV.UK Design System classes, so is no longer targeted by `.visually` hidden

Means that the `<iframe>` temporarily looks like this: 

<img width="795" alt="image" src="https://user-images.githubusercontent.com/355079/198988542-2fe2b0ba-203b-436e-aecc-2f7cd8d97dd3.png">
