### PR TITLE
Update fido2 from 0.9.3 to 1.1.0

### DIFF
--- a/app/main/views/webauthn_credentials.py
+++ b/app/main/views/webauthn_credentials.py
@@ -1,6 +1,5 @@
 from fido2 import cbor
-from fido2.client import ClientData
-from fido2.ctap2 import AuthenticatorData
+from fido2.webauthn import AuthenticatorData, CollectedClientData
 from flask import abort, current_app, flash, redirect, request, session, url_for
 from flask_login import current_user
 
@@ -119,7 +118,7 @@ def _verify_webauthn_authentication(user):
             state=state,
             credentials=user.webauthn_credentials.as_cbor,
             credential_id=request_data["credentialId"],
-            client_data=ClientData(request_data["clientDataJSON"]),
+            client_data=CollectedClientData(request_data["clientDataJSON"]),
             auth_data=AuthenticatorData(request_data["authenticatorData"]),
             signature=request_data["signature"],
         )

--- a/app/models/webauthn_credential.py
+++ b/app/models/webauthn_credential.py
@@ -1,9 +1,12 @@
 import base64
 
 from fido2 import cbor
-from fido2.client import ClientData
 from fido2.cose import UnsupportedKey
-from fido2.ctap2 import AttestationObject, AttestedCredentialData
+from fido2.webauthn import (
+    AttestationObject,
+    AttestedCredentialData,
+    CollectedClientData,
+)
 from flask import current_app
 
 from app.models import JSONModel, ModelList
@@ -33,7 +36,7 @@ class WebAuthnCredential(JSONModel):
         try:
             auth_data = server.register_complete(
                 state,
-                ClientData(response["clientDataJSON"]),
+                CollectedClientData(response["clientDataJSON"]),
                 AttestationObject(response["attestationObject"]),
             )
         except ValueError as e:

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ pytz==2022.2.1
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 notifications-python-client==6.3.0
 rtreelib==0.2.0
-fido2==0.9.3
+fido2==1.1.0
 pyproj==3.3.1
 
 # PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ et-xmlfile==1.1.0
     # via openpyxl
 eventlet==0.33.1
     # via gunicorn
-fido2==0.9.3
+fido2==1.1.0
     # via -r requirements.in
 flask==2.1.2
     # via
@@ -202,7 +202,6 @@ six==1.16.0
     # via
     #   awscli-cwlogs
     #   eventlet
-    #   fido2
     #   python-dateutil
 smartypants==2.0.1
     # via notifications-utils

--- a/tests/app/models/test_webauthn_credential.py
+++ b/tests/app/models/test_webauthn_credential.py
@@ -3,6 +3,7 @@ import base64
 import pytest
 from fido2 import cbor
 from fido2.cose import ES256
+from fido2.webauthn import Aaguid
 
 from app.models.webauthn_credential import RegistrationError, WebAuthnCredential
 
@@ -33,7 +34,8 @@ def test_from_registration_verifies_response(webauthn_dev_server):
 
     credential_data = credential.to_credential_data()
     assert type(credential_data.credential_id) is bytes
-    assert type(credential_data.aaguid) is bytes
+    assert type(credential_data.aaguid) is Aaguid
+    assert isinstance(credential_data.aaguid, bytes)
     assert credential_data.public_key[3] == ES256.ALGORITHM
 
 


### PR DESCRIPTION
Split from https://github.com/alphagov/notifications-admin/pull/4411 because some code changes were required, specifically:
- moved imports
- new, custom `Aaguid` type instead of `bytes` (I’ve modified the affect test to assert for both)

I’ve run this locally and checked that I can still sign in with a key.