### PR TITLE
Make pyup only report on security updates

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -2,6 +2,9 @@
 
 schedule: "every week on monday"
 
+# Security updates only - not just any newer version
+update: insecure
+
 search: False
 requirements:
   - requirements.in


### PR DESCRIPTION
We aren't keeping up with dependency bump PRs from PyUp due to incompatibilities, which puts us at risk of missing necessary security bumps. Let's be pragmatic and try to get security dependency bumps under control first. Once we've done that, we could revisit whether we want to pull in all updates.