### PR TITLE
Enforce `page.select` over `page.find` in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 import freezegun
 import pytest
+from bs4 import BeautifulSoup
 from flask import session as flask_session
 from flask import url_for
 from flask.testing import FlaskClient
@@ -41,6 +42,21 @@ class TestClient(FlaskClient):
 
     def logout(self, user):
         self.get(url_for("main.sign_out"))
+
+
+class NotifyBeautifulSoup(BeautifulSoup):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.override_method("find", "select_one")
+        self.override_method("find_all", "select")
+
+    def override_method(self, method_name, preferred_method_name):
+        def overridden_method(*args, **kwargs):
+            raise AttributeError(
+                f"Don’t use BeautifulSoup.{method_name}" f" – try BeautifulSoup.{preferred_method_name} instead"
+            )
+
+        setattr(self, method_name, overridden_method)
 
 
 def sample_uuid():

--- a/tests/app/main/test_errorhandlers.py
+++ b/tests/app/main/test_errorhandlers.py
@@ -9,8 +9,8 @@ def test_bad_url_returns_page_not_found(client_request):
         "/bad_url",
         _expected_status=404,
     )
-    assert page.h1.string.strip() == "Page not found"
-    assert page.title.string.strip() == "Page not found – GOV.UK Notify"
+    assert page.select_one("h1").string.strip() == "Page not found"
+    assert page.select_one("title").string.strip() == "Page not found – GOV.UK Notify"
 
 
 def test_load_service_before_request_handles_404(client_request, mocker):
@@ -31,10 +31,10 @@ def test_load_service_before_request_handles_404(client_request, mocker):
 def test_malformed_token_returns_page_not_found(client_request, url):
     page = client_request.get_url(url, _expected_status=404)
 
-    assert page.h1.string.strip() == "Page not found"
+    assert page.select_one("h1").string.strip() == "Page not found"
     flash_banner = page.select_one("div.banner-dangerous").string.strip()
     assert flash_banner == "There’s something wrong with the link you’ve used."
-    assert page.title.string.strip() == "Page not found – GOV.UK Notify"
+    assert page.select_one("title").string.strip() == "Page not found – GOV.UK Notify"
 
 
 def test_csrf_returns_400(client_request, mocker):
@@ -48,8 +48,8 @@ def test_csrf_returns_400(client_request, mocker):
         _test_page_title=False,
     )
 
-    assert page.h1.string.strip() == "Sorry, there’s a problem with GOV.UK Notify"
-    assert page.title.string.strip() == "Sorry, there’s a problem with the service – GOV.UK Notify"
+    assert page.select_one("h1").string.strip() == "Sorry, there’s a problem with GOV.UK Notify"
+    assert page.select_one("title").string.strip() == "Sorry, there’s a problem with the service – GOV.UK Notify"
 
 
 def test_csrf_redirects_to_sign_in_page_if_not_signed_in(client_request, mocker):
@@ -66,5 +66,5 @@ def test_csrf_redirects_to_sign_in_page_if_not_signed_in(client_request, mocker)
 def test_405_returns_something_went_wrong_page(client_request, mocker):
     page = client_request.post_url("/", _expected_status=405)
 
-    assert page.h1.string.strip() == "Sorry, there’s a problem with GOV.UK Notify"
-    assert page.title.string.strip() == "Sorry, there’s a problem with the service – GOV.UK Notify"
+    assert page.select_one("h1").string.strip() == "Sorry, there’s a problem with GOV.UK Notify"
+    assert page.select_one("title").string.strip() == "Sorry, there’s a problem with the service – GOV.UK Notify"

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -78,9 +78,9 @@ def test_choose_account_should_show_choose_accounts_page(
     mock_get_organisation,
 ):
     resp = client_request.get("main.choose_account")
-    page = resp.find("main", {"id": "main-content"})
+    page = resp.select_one("main#main-content")
 
-    assert normalize_spaces(page.h1.text) == "Choose service"
+    assert normalize_spaces(page.select_one("h1").text) == "Choose service"
     outer_list_items = page.select("nav ul")[0].select("li")
     headings = page.select("main h2")
 

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -70,7 +70,7 @@ def test_cancel_invited_org_user_cancels_user_invitations(
         invited_user_id=sample_org_invite["id"],
         _follow_redirects=True,
     )
-    assert normalize_spaces(page.h1.text) == "Team members"
+    assert normalize_spaces(page.select_one("h1").text) == "Team members"
     flash_banner = normalize_spaces(page.select_one("div.banner-default-with-tick").text)
     assert flash_banner == f"Invitation cancelled for {sample_org_invite['email_address']}"
     mock_cancel.assert_called_once_with(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2312,7 +2312,7 @@ def test_add_organisation_email_branding_options_calls_api_client_with_chosen_br
     )
 
     assert page.select_one("h1").text == "Email branding"
-    assert normalize_spaces(page.find("div", class_="banner-default-with-tick").text) == flash_message
+    assert normalize_spaces(page.select_one("div.banner-default-with-tick").text) == flash_message
     mock_update_pool.assert_called_once_with(organisation_one["id"], branding_ids_added)
 
 
@@ -2558,8 +2558,8 @@ def test_add_organisation_letter_branding_options_calls_api_client_with_chosen_b
         _follow_redirects=True,
     )
 
-    assert page.h1.text == "Letter branding"
-    assert normalize_spaces(page.find("div", class_="banner-default-with-tick").text) == flash_message
+    assert page.select_one("h1").text == "Letter branding"
+    assert normalize_spaces(page.select_one("div.banner-default-with-tick").text) == flash_message
     mock_update_pool.assert_called_once_with(organisation_one["id"], branding_ids_added)
 
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -865,7 +865,7 @@ def test_edit_organisation_user_shows_the_delete_confirmation_banner(
         ".edit_organisation_user", org_id=ORGANISATION_ID, user_id=active_user_with_permissions["id"]
     )
 
-    assert normalize_spaces(page.h1) == "Team members"
+    assert normalize_spaces(page.select_one("h1").text) == "Team members"
 
     banner = page.select_one(".banner-dangerous")
     assert "Are you sure you want to remove Test User?" in normalize_spaces(banner.contents[0])
@@ -1824,7 +1824,7 @@ def test_organisation_email_branding_page_shows_all_branding_pool_options(
 
     page = client_request.get(".organisation_email_branding", org_id=organisation_one["id"])
 
-    assert page.h1.text == "Email branding"
+    assert page.select_one("h1").text == "Email branding"
     assert (
         set(normalize_spaces(heading.text) for heading in page.select(".govuk-heading-s")) == expected_branding_options
     )
@@ -2248,7 +2248,7 @@ def test_add_organisation_email_branding_options_shows_branding_not_in_branding_
 
     client_request.login(platform_admin_user)
     page = client_request.get(".add_organisation_email_branding_options", org_id=organisation_one["id"])
-    assert page.h1.text == "Add email branding options"
+    assert page.select_one("h1").text == "Add email branding options"
     assert page.select_one("[data-notify-module=live-search]")["data-targets"] == (".govuk-checkboxes__item")
 
     assert [
@@ -2311,7 +2311,7 @@ def test_add_organisation_email_branding_options_calls_api_client_with_chosen_br
         _follow_redirects=True,
     )
 
-    assert page.h1.text == "Email branding"
+    assert page.select_one("h1").text == "Email branding"
     assert normalize_spaces(page.find("div", class_="banner-default-with-tick").text) == flash_message
     mock_update_pool.assert_called_once_with(organisation_one["id"], branding_ids_added)
 
@@ -2330,7 +2330,7 @@ def test_organisation_letter_branding_page_shows_all_branding_pool_options(
     client_request.login(platform_admin_user)
     page = client_request.get("main.organisation_letter_branding", org_id=organisation_one["id"])
 
-    assert page.h1.text == "Letter branding"
+    assert page.select_one("h1").text == "Letter branding"
     assert [normalize_spaces(heading.text) for heading in page.select(".govuk-heading-s")] == [
         "No branding (default)",
         "Cabinet Office",
@@ -2496,7 +2496,7 @@ def test_add_organisation_letter_branding_options_shows_branding_not_in_branding
 
     client_request.login(platform_admin_user)
     page = client_request.get(".add_organisation_letter_branding_options", org_id=organisation_one["id"])
-    assert page.h1.text == "Add letter branding options"
+    assert page.select_one("h1").text == "Add letter branding options"
     assert page.select_one("[data-notify-module=live-search]")["data-targets"] == (".govuk-checkboxes__item")
 
     assert [
@@ -2702,7 +2702,7 @@ def test_organisation_billing_page_when_the_agreement_is_signed_by_a_known_perso
         org_id=ORGANISATION_ID,
     )
 
-    assert page.h1.string == "Billing"
+    assert page.select_one("h1").string == "Billing"
     assert "2.5 of the GOV.UK Notify data sharing and financial agreement on 20 February 2020" in normalize_spaces(
         page.text
     )
@@ -2725,7 +2725,7 @@ def test_organisation_billing_page_when_the_agreement_is_signed_by_an_unknown_pe
         org_id=ORGANISATION_ID,
     )
 
-    assert page.h1.string == "Billing"
+    assert page.select_one("h1").string == "Billing"
     assert (
         f'{organisation_one["name"]} has accepted the GOV.UK Notify data ' "sharing and financial agreement."
     ) in page.text
@@ -2756,7 +2756,7 @@ def test_organisation_billing_page_when_the_agreement_is_not_signed(
         org_id=ORGANISATION_ID,
     )
 
-    assert page.h1.string == "Billing"
+    assert page.select_one("h1").string == "Billing"
     assert f'{organisation_one["name"]} {expected_content}' in page.text
 
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -820,7 +820,7 @@ def test_email_branding_choose_logo_page(client_request, service_one):
     )
 
     assert [
-        (radio["value"], page.find_all("label", {"class": "block-label", "for": f"options-{i}"})[0].text.strip())
+        (radio["value"], page.select_one(f"label.block-label[for=options-{i}]").text.strip())
         for i, radio in enumerate(page.select("input[type=radio]"))
     ] == [
         ("single_identity", "Create a government identity logo"),

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -303,7 +303,7 @@ def test_email_branding_pool_option_changes_email_branding_when_user_confirms(
         SERVICE_ONE_ID,
         email_branding="email-branding-1-id",
     )
-    assert page.h1.text == "Settings"
+    assert page.select_one("h1").text == "Settings"
     assert normalize_spaces(page.select_one(".banner-default").text) == "You’ve updated your email branding"
 
 
@@ -428,7 +428,7 @@ def test_email_branding_request_submit_when_no_radio_button_is_selected(
         _data={"options": ""},
         _follow_redirects=True,
     )
-    assert page.h1.text == "Change email branding"
+    assert page.select_one("h1").text == "Change email branding"
     assert normalize_spaces(page.select_one(".error-message").text) == "Select an option"
 
 
@@ -461,7 +461,7 @@ def test_email_branding_description_pages_for_org_branding(
         endpoint,
         service_id=SERVICE_ONE_ID,
     )
-    assert page.h1.text == expected_heading
+    assert page.select_one("h1").text == expected_heading
     assert normalize_spaces(page.select_one(".page-footer button").text) == "Request new branding"
 
 
@@ -496,7 +496,7 @@ def test_email_branding_govuk_and_nhs_pages(
         endpoint,
         service_id=SERVICE_ONE_ID,
     )
-    assert page.h1.text == "Check your new branding"
+    assert page.select_one("h1").text == "Check your new branding"
     assert "Emails from service one will look like this" in normalize_spaces(page.text)
     assert page.select_one("iframe")["src"] == url_for("main.email_template", branding_style=branding_preview_id)
     assert normalize_spaces(page.select_one(".page-footer button").text) == "Use this branding"
@@ -511,7 +511,7 @@ def test_email_branding_something_else_page(client_request, service_one, mock_ge
         "main.email_branding_something_else",
         service_id=SERVICE_ONE_ID,
     )
-    assert normalize_spaces(page.h1.text) == "Describe the branding you want"
+    assert normalize_spaces(page.select_one("h1").text) == "Describe the branding you want"
     assert page.select_one("textarea")["name"] == ("something_else")
     assert normalize_spaces(page.select_one(".page-footer button").text) == "Request new branding"
     assert page.select_one(".govuk-back-link")["href"] == url_for(
@@ -588,7 +588,7 @@ def test_email_branding_govuk_submit(
         SERVICE_ONE_ID,
         email_branding=None,
     )
-    assert page.h1.text == "Settings"
+    assert page.select_one("h1").text == "Settings"
     assert normalize_spaces(page.select_one(".banner-default").text) == "You’ve updated your email branding"
 
 
@@ -676,7 +676,7 @@ def test_email_branding_nhs_submit(
         SERVICE_ONE_ID,
         email_branding=EmailBranding.NHS_ID,
     )
-    assert page.h1.text == "Settings"
+    assert page.select_one("h1").text == "Settings"
     assert normalize_spaces(page.select_one(".banner-default").text) == "You’ve updated your email branding"
 
 
@@ -802,7 +802,7 @@ def test_email_branding_something_else_submit_shows_error_if_textbox_is_empty(
         _data={"something_else": ""},
         _follow_redirects=True,
     )
-    assert normalize_spaces(page.h1.text) == "Describe the branding you want"
+    assert normalize_spaces(page.select_one("h1").text) == "Describe the branding you want"
     assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Cannot be empty"
 
 
@@ -812,7 +812,7 @@ def test_email_branding_choose_logo_page(client_request, service_one):
         service_id=SERVICE_ONE_ID,
     )
 
-    assert page.h1.text == "Choose a logo for your emails"
+    assert page.select_one("h1").text == "Choose a logo for your emails"
 
     assert page.select_one(".govuk-back-link")["href"] == url_for(
         "main.email_branding_request",

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -199,7 +199,7 @@ def test_letter_branding_request_submit_when_form_has_missing_data(
         _data=data,
         _follow_redirects=True,
     )
-    assert page.h1.text == "Change letter branding"
+    assert page.select_one("h1").text == "Change letter branding"
     assert normalize_spaces(page.select_one(".error-message").text) == error_message
 
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -185,7 +185,7 @@ def test_service_setting_links_not_displayed_for_archived_services(
     link_texts = ["Delete this service", "Service history"]
     service_one.update({"active": False})
     page = get_service_settings_page()
-    toggles = page.find_all("a", {"class": "govuk-link"})
+    toggles = page.select("a.govuk-link")
     assert not any(link for link in toggles if link.text.strip() in link_texts)
 
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3706,7 +3706,7 @@ def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
     if add_to_pool == "yes":
         mock_add_to_branding_pool.assert_called_with(organisation_one["id"], [email_branding_id])
         assert (
-            normalize_spaces(page.find("div", class_="banner-default-with-tick").text)
+            normalize_spaces(page.select_one("div.banner-default-with-tick").text)
             == f"The email branding has been set to {email_branding_name} "
             f"and it has been added to {organisation_one['name']}'s email branding pool"
         )
@@ -3714,7 +3714,7 @@ def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
     elif add_to_pool == "no":
         mock_add_to_branding_pool.assert_not_called()
         assert (
-            normalize_spaces(page.find("div", class_="banner-default-with-tick").text)
+            normalize_spaces(page.select_one("div.banner-default-with-tick").text)
             == f"The email branding has been set to {email_branding_name}"
         )
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -805,7 +805,7 @@ def test_should_check_if_estimated_volumes_provided(
     )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
 
     assert normalize_spaces(page.select_one(".task-list .task-list-item").text) == (expected_estimated_volumes_item)
 
@@ -855,7 +855,7 @@ def test_should_check_for_reply_to_on_go_live(
         )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
 
     checklist_items = page.select(".task-list .task-list-item")
     assert normalize_spaces(checklist_items[3].text) == expected_reply_to_checklist_item
@@ -927,7 +927,7 @@ def test_should_check_for_sending_things_right(
     )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
 
     checklist_items = page.select(".task-list .task-list-item")
     assert normalize_spaces(checklist_items[1].text) == expected_user_checklist_item
@@ -980,7 +980,7 @@ def test_should_not_show_go_live_button_if_checklist_not_complete(
         )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
 
     if expected_button:
         assert page.select_one("form")["method"] == "post"
@@ -1022,7 +1022,7 @@ def test_request_to_go_live_redirects_if_service_already_live(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert page.h1.text == "Your service is already live"
+    assert page.select_one("h1").text == "Your service is already live"
     assert normalize_spaces(page.select_one("main p").text) == message
 
 
@@ -1146,7 +1146,7 @@ def test_should_check_for_sms_sender_on_go_live(
         )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
 
     checklist_items = page.select(".task-list .task-list-item")
     assert normalize_spaces(checklist_items[3].text) == expected_sms_sender_checklist_item
@@ -1206,7 +1206,7 @@ def test_should_check_for_mou_on_request_to_go_live(
         "app.organisations_client.get_organisation", return_value=organisation_json(agreement_signed=agreement_signed)
     )
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
 
     checklist_items = page.select(".task-list .task-list-item")
     assert normalize_spaces(checklist_items[3].text) == expected_item
@@ -1261,7 +1261,7 @@ def test_gp_without_organisation_is_shown_agreement_step(
     )
 
     page = client_request.get("main.request_to_go_live", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Before you request to go live"
+    assert page.select_one("h1").text == "Before you request to go live"
     assert normalize_spaces(page.select(".task-list .task-list-item")[3].text) == (
         "Accept our data sharing and financial agreement Not completed"
     )
@@ -1344,7 +1344,7 @@ def test_should_show_estimate_volumes(
         return_value=consent_to_research,
     )
     page = client_request.get("main.estimate_usage", service_id=SERVICE_ONE_ID)
-    assert page.h1.text == "Tell us how many messages you expect to send"
+    assert page.select_one("h1").text == "Tell us how many messages you expect to send"
     for channel, label, hint, value in (
         (
             "email",
@@ -3643,7 +3643,7 @@ def test_get_service_set_email_branding_add_to_branding_pool_step(
         service_id=SERVICE_ONE_ID,
         email_branding_id=email_branding_id,
     )
-    assert f"Apply ‘{email_branding_name}’ branding" in normalize_spaces(page.find("title").text)
+    assert f"Apply ‘{email_branding_name}’ branding" in normalize_spaces(page.select_one("title").text)
 
 
 def test_service_set_email_branding_add_to_branding_pool_step_is_platform_admin_only(
@@ -3737,14 +3737,15 @@ def test_email_branding_create_government_identity_logo(client_request, service_
 def test_GET_email_branding_enter_government_identity_logo_text(client_request, service_one):
     page = client_request.get("main.email_branding_enter_government_identity_logo_text", service_id=service_one["id"])
 
-    back_button = page.find("a", text="Back")
-    form = page.find("form")
-    submit_button = form.find("button")
-    text_input = form.find("input")
+    back_button = page.select_one("a.govuk-back-link")
+    form = page.select_one("form")
+    submit_button = form.select_one("button")
+    text_input = form.select_one("input")
 
     assert back_button["href"] == url_for(
         "main.email_branding_request_government_identity_logo", service_id=service_one["id"]
     )
+    assert back_button.text == "Back"
     assert form["method"] == "post"
     assert "Request new branding" in submit_button.text
     assert text_input["name"] == "logo_text"
@@ -4306,7 +4307,7 @@ def test_send_files_by_email_contact_details_updates_contact_details_and_redirec
         _follow_redirects=True,
     )
 
-    assert page.h1.text == "Settings"
+    assert page.select_one("h1").text == "Settings"
     mock_update_service.assert_called_once_with(SERVICE_ONE_ID, contact_link=new_value)
 
 
@@ -4333,7 +4334,7 @@ def test_send_files_by_email_contact_details_uses_the_selected_field_when_multip
         _follow_redirects=True,
     )
 
-    assert page.h1.text == "Settings"
+    assert page.select_one("h1").text == "Settings"
     mock_update_service.assert_called_once_with(SERVICE_ONE_ID, contact_link="http://www.new-url.com")
 
 
@@ -4371,7 +4372,7 @@ def test_send_files_by_email_contact_details_displays_error_message_when_no_radi
         _follow_redirects=True,
     )
     assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Select an option"
-    assert normalize_spaces(page.h1.text) == "Send files by email"
+    assert normalize_spaces(page.select_one("h1").text) == "Send files by email"
 
 
 @pytest.mark.parametrize(
@@ -4404,7 +4405,7 @@ def test_send_files_by_email_contact_details_does_not_update_invalid_contact_det
     )
 
     assert error in page.select_one(".govuk-error-message").text
-    assert normalize_spaces(page.h1.text) == "Send files by email"
+    assert normalize_spaces(page.select_one("h1").text) == "Send files by email"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -163,7 +163,7 @@ def test_if_existing_user_accepts_twice_they_redirect_to_sign_in(
         _follow_redirects=True,
     )
 
-    assert (page.h1.string, page.select("main p")[0].text.strip(),) == (
+    assert (page.select_one("h1").string, page.select("main p")[0].text.strip(),) == (
         "You need to sign in again",
         "We signed you out because you have not used Notify for a while.",
     )
@@ -271,7 +271,7 @@ def test_existing_user_of_service_get_redirected_to_signin(
         _follow_redirects=True,
     )
 
-    assert (page.h1.string, page.select("main p")[0].text.strip(),) == (
+    assert (page.select_one("h1").string, page.select("main p")[0].text.strip(),) == (
         "You need to sign in again",
         "We signed you out because you have not used Notify for a while.",
     )
@@ -347,7 +347,7 @@ def test_existing_signed_out_user_accept_invite_redirects_to_sign_in(
         expected_service, api_user_active["id"], expected_permissions, sample_invite["folder_permissions"]
     )
     assert mock_accept_invite.call_count == 1
-    assert (page.h1.string, page.select("main p")[0].text.strip(),) == (
+    assert (page.select_one("h1").string, page.select("main p")[0].text.strip(),) == (
         "You need to sign in again",
         "We signed you out because you have not used Notify for a while.",
     )
@@ -397,7 +397,7 @@ def test_new_user_accept_invite_calls_api_and_views_registration_page(
     mock_dont_get_user_by_email.assert_called_with("invited_user@test.gov.uk")
     mock_get_invited_user_by_id.assert_called_once_with(sample_invite["id"])
 
-    assert page.h1.string.strip() == "Create an account"
+    assert page.select_one("h1").string.strip() == "Create an account"
 
     assert normalize_spaces(page.select_one("main p").text) == (
         "Your account will be created with this email address: " "invited_user@test.gov.uk"
@@ -432,7 +432,7 @@ def test_cancelled_invited_user_accepts_invited_redirect_to_cancelled_invitation
 
     app.invite_api_client.check_token.assert_called_with("thisisnotarealtoken")
 
-    assert page.h1.string.strip() == "The invitation you were sent has been cancelled"
+    assert page.select_one("h1").string.strip() == "The invitation you were sent has been cancelled"
     # We don’t let people update `email_access_validated_at` using an
     # cancelled invite
     assert mock_update_user_attribute.called is False
@@ -550,7 +550,7 @@ def test_signed_in_existing_user_cannot_use_anothers_invite(
         _follow_redirects=True,
         _expected_status=403,
     )
-    assert page.h1.string.strip() == "You’re not allowed to see this page"
+    assert page.select_one("h1").string.strip() == "You’re not allowed to see this page"
     flash_banners = page.select("div.banner-dangerous")
     assert len(flash_banners) == 1
     banner_contents = normalize_spaces(flash_banners[0].text)

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -155,7 +155,7 @@ def test_can_show_notifications(
         "Delivered 1 January at 1:01am"
     )
 
-    assert page_title in page.h1.text.strip()
+    assert page_title in page.select_one("h1").text.strip()
 
     path_to_json = page.select_one("div[data-key=notifications]")["data-resource"]
 
@@ -199,7 +199,7 @@ def test_can_show_notifications_if_data_retention_not_available(
         service_id=SERVICE_ONE_ID,
         status="sending,delivered,failed",
     )
-    assert page.h1.text.strip() == "Messages"
+    assert page.select_one("h1").text.strip() == "Messages"
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -16,7 +16,7 @@ def test_should_show_api_page(
         "main.api_integration",
         service_id=SERVICE_ONE_ID,
     )
-    assert page.h1.string.strip() == "API integration"
+    assert page.select_one("h1").string.strip() == "API integration"
     rows = page.select("details")
     assert len(rows) == 5
     for row in rows:
@@ -454,7 +454,7 @@ def test_should_validate_guestlist_items(
         _expected_status=200,
     )
 
-    assert page.h1.string.strip() == "There was a problem with your guest list"
+    assert page.select_one("h1").string.strip() == "There was a problem with your guest list"
     jump_links = page.select(".banner-dangerous a")
 
     assert jump_links[0].string.strip() == "Enter valid email addresses"

--- a/tests/app/main/views/test_code_not_received.py
+++ b/tests/app/main/views/test_code_not_received.py
@@ -16,7 +16,7 @@ def test_should_render_email_verification_resend_show_email_address_and_resend_v
         session["user_details"] = {"id": api_user_active["id"], "email": api_user_active["email_address"]}
     page = client_request.get("main.resend_email_verification")
 
-    assert page.h1.string == "Check your email"
+    assert page.select_one("h1").string == "Check your email"
     expected = "A new confirmation email has been sent to {}".format(api_user_active["email_address"])
 
     message = page.select("main p")[0].text
@@ -39,7 +39,7 @@ def test_should_render_correct_resend_template_for_active_user(
         session["user_details"] = {"id": api_user_active["id"], "email": api_user_active["email_address"]}
     page = client_request.get("main.check_and_resend_text_code", next=redirect_url)
 
-    assert page.h1.string == "Resend security code"
+    assert page.select_one("h1").string == "Resend security code"
     # there shouldn't be a form for updating mobile number
     assert page.select_one("form") is None
     assert page.select_one("a.govuk-button")["href"] == url_for(
@@ -60,7 +60,7 @@ def test_should_render_correct_resend_template_for_pending_user(
         session["user_details"] = {"id": api_user_pending["id"], "email": api_user_pending["email_address"]}
     page = client_request.get("main.check_and_resend_text_code")
 
-    assert page.h1.string == "Check your mobile number"
+    assert page.select_one("h1").string == "Check your mobile number"
 
     expected = "Check your mobile phone number is correct and then resend the security code."
     message = page.select("main p")[0].text
@@ -193,7 +193,7 @@ def test_should_render_correct_email_not_received_template_for_active_user(
         session["user_details"] = {"id": api_user_active["id"], "email": api_user_active["email_address"]}
     page = client_request.get("main.email_not_received", next=redirect_url)
 
-    assert page.h1.string == "Resend email link"
+    assert page.select_one("h1").string == "Resend email link"
     # there shouldn't be a form for updating mobile number
     assert page.select_one("form") is None
     assert page.select_one("a.govuk-button")["href"] == url_for("main.resend_email_link", next=redirect_url)

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -67,7 +67,7 @@ def test_choose_support_type(
         _data={"support_type": support_type},
         _follow_redirects=True,
     )
-    assert page.h1.string.strip() == expected_h1
+    assert page.select_one("h1").string.strip() == expected_h1
     assert not page.select_one("input[name=name]")
     assert not page.select_one("input[name=email_address]")
     assert page.select_one("form").find("p").text.strip() == ("We’ll reply to test@user.gov.uk")
@@ -670,7 +670,7 @@ def test_bat_email_page(
     assert page.select("main a")[1].text == "Fill in this form"
     assert page.select("main a")[1]["href"] == url_for("main.feedback", ticket_type=PROBLEM_TICKET_TYPE, severe="no")
     next_page = client_request.get_url(page.select("main a")[1]["href"])
-    assert next_page.h1.text.strip() == "Report a problem"
+    assert next_page.select_one("h1").text.strip() == "Report a problem"
 
     client_request.login(active_user_with_permissions)
     client_request.get(bat_phone_page, _expected_redirect=url_for("main.feedback", ticket_type=PROBLEM_TICKET_TYPE))

--- a/tests/app/main/views/test_find_services.py
+++ b/tests/app/main/views/test_find_services.py
@@ -7,7 +7,7 @@ def test_find_services_by_name_page_loads_correctly(client_request, platform_adm
     client_request.login(platform_admin_user)
     document = client_request.get("main.find_services_by_name")
 
-    assert document.h1.text.strip() == "Find services by name"
+    assert document.select_one("h1").text.strip() == "Find services by name"
     assert len(document.select("input[type=search]")) > 0
 
 

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -12,7 +12,7 @@ def test_find_users_by_email_page_loads_correctly(client_request, platform_admin
     client_request.login(platform_admin_user)
     document = client_request.get("main.find_users_by_email")
 
-    assert document.h1.text.strip() == "Find users by email"
+    assert document.select_one("h1").text.strip() == "Find users by email"
     assert len(document.select("input[type=search]")) > 0
 
 

--- a/tests/app/main/views/test_inbound_sms_admin.py
+++ b/tests/app/main/views/test_inbound_sms_admin.py
@@ -39,4 +39,4 @@ def test_inbound_sms_admin(
     mocker.patch("app.inbound_number_client.get_all_inbound_sms_number_service", return_value=sample_inbound_sms)
     client_request.login(platform_admin_user)
     page = client_request.get("main.inbound_sms_admin")
-    assert page.h1.string.strip() == "Inbound SMS"
+    assert page.select_one("h1").string.strip() == "Inbound SMS"

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -16,7 +16,7 @@ def test_non_logged_in_user_can_see_homepage(
     client_request.logout()
     page = client_request.get("main.index", _test_page_title=False)
 
-    assert page.h1.text.strip() == ("Send emails, text messages and letters to your users")
+    assert page.select_one("h1").text.strip() == ("Send emails, text messages and letters to your users")
 
     assert page.select_one("a[role=button][draggable=false]")["href"] == url_for("main.register")
 
@@ -281,7 +281,7 @@ def test_email_branding_preview(
     email_branding_retrieved,
 ):
     page = client_request.get("main.email_template", _test_page_title=False, **extra_args)
-    assert page.title.text == "Email branding preview"
+    assert page.select_one("title").text == "Email branding preview"
     assert mock_get_email_branding.called is email_branding_retrieved
 
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -91,7 +91,7 @@ def test_should_show_page_for_one_job(
 
     page = client_request.get("main.view_job", service_id=SERVICE_ONE_ID, job_id=fake_uuid, status=status_argument)
 
-    assert page.h1.text.strip() == "thisisatest.csv"
+    assert page.select_one("h1").text.strip() == "thisisatest.csv"
     assert page.select_one(".govuk-back-link")["href"] == url_for(
         "main.uploads",
         service_id=SERVICE_ONE_ID,
@@ -324,7 +324,7 @@ def test_should_show_letter_job(
         service_id=SERVICE_ONE_ID,
         job_id=fake_uuid,
     )
-    assert normalize_spaces(page.h1.text) == "thisisatest.csv"
+    assert normalize_spaces(page.select_one("h1").text) == "thisisatest.csv"
     assert normalize_spaces(page.select("p.bottom-gutter")[0].text) == (
         "Sent by Test User on 1 January at 11:09am Printing starts today at 5:30pm"
     )

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1171,7 +1171,7 @@ def test_invite_user(
         },
         _follow_redirects=True,
     )
-    assert page.h1.string.strip() == "Team members"
+    assert page.select_one("h1").string.strip() == "Team members"
     flash_banner = page.select_one("div.banner-default-with-tick").string.strip()
     assert flash_banner == f"Invite sent to {email_address}"
 
@@ -1267,7 +1267,7 @@ def test_invite_user_with_email_auth_service(
         _expected_status=200,
     )
 
-    assert page.h1.string.strip() == "Team members"
+    assert page.select_one("h1").string.strip() == "Team members"
     flash_banner = page.select_one("div.banner-default-with-tick").string.strip()
     assert flash_banner == "Invite sent to test@example.gov.uk"
 
@@ -1382,7 +1382,7 @@ def test_cancel_invited_user_cancels_user_invitations(
         _follow_redirects=True,
     )
 
-    assert normalize_spaces(page.h1.text) == "Team members"
+    assert normalize_spaces(page.select_one("h1").text) == "Team members"
     flash_banner = normalize_spaces(page.select_one("div.banner-default-with-tick").text)
     assert flash_banner == f"Invitation cancelled for {sample_invite['email_address']}"
     mock_cancel.assert_called_once_with(
@@ -1449,7 +1449,7 @@ def test_manage_users_shows_invited_user(
     mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])
 
     page = client_request.get("main.manage_users", service_id=SERVICE_ONE_ID)
-    assert page.h1.string.strip() == "Team members"
+    assert page.select_one("h1").string.strip() == "Team members"
     assert normalize_spaces(page.select(".user-list-item")[0].text) == expected_text
 
 
@@ -1468,7 +1468,7 @@ def test_manage_users_does_not_show_accepted_invite(
 
     page = client_request.get("main.manage_users", service_id=SERVICE_ONE_ID)
 
-    assert page.h1.string.strip() == "Team members"
+    assert page.select_one("h1").string.strip() == "Team members"
     user_lists = page.select("div.user-list")
     assert len(user_lists) == 1
     assert "invited_user@test.gov.uk" not in page.text
@@ -1491,7 +1491,7 @@ def test_user_cant_invite_themselves(
         _follow_redirects=True,
         _expected_status=200,
     )
-    assert page.h1.string.strip() == "Invite a team member"
+    assert page.select_one("h1").string.strip() == "Invite a team member"
     form_error = page.select_one(".govuk-error-message").text.strip()
     assert form_error == "Error: You cannot send an invitation to yourself"
     assert not mock_create_invite.called

--- a/tests/app/main/views/test_returned_letters.py
+++ b/tests/app/main/views/test_returned_letters.py
@@ -14,7 +14,7 @@ def test_returned_letter_summary(client_request, mocker):
 
     mock.assert_called_once_with(SERVICE_ONE_ID)
 
-    assert page.h1.string.strip() == "Returned letters"
+    assert page.select_one("h1").string.strip() == "Returned letters"
     assert normalize_spaces(page.select_one(".table-field").text) == ("24 December 2019 " "1,234 letters")
     assert page.select_one(".table-field a")["href"] == url_for(
         ".returned_letters",
@@ -31,7 +31,7 @@ def test_returned_letter_summary_with_one_letter(client_request, mocker):
 
     mock.assert_called_once_with(SERVICE_ONE_ID)
 
-    assert page.h1.string.strip() == "Returned letters"
+    assert page.select_one("h1").string.strip() == "Returned letters"
     assert normalize_spaces(page.select_one(".table-field").text) == ("24 December 2019 " "1 letter")
 
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -495,7 +495,7 @@ def test_upload_csv_file_with_errors_shows_check_page_with_errors(
     assert "There’s a problem with example.csv" in page.text
     assert "+447700900986" in page.text
     assert "Missing" in page.text
-    assert normalize_spaces(page.find("input", {"type": "file"})["data-button-text"]) == "Upload your file again"
+    assert normalize_spaces(page.select_one("input[type=file]")["data-button-text"]) == "Upload your file again"
 
 
 def test_upload_csv_file_with_empty_message_shows_check_page_with_errors(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -986,7 +986,7 @@ def test_upload_valid_csv_shows_preview_and_table(
         original_file_name="example.csv",
     )
 
-    assert page.h1.text.strip() == "Preview of Two week reminder"
+    assert page.select_one("h1").text.strip() == "Preview of Two week reminder"
     assert page.select_one(".sms-message-recipient").text.strip() == expected_recipient
     assert page.select_one(".sms-message-wrapper").text.strip() == expected_message
 
@@ -1264,7 +1264,7 @@ def test_send_one_off_has_correct_page_title(
         step_index=0,
         _follow_redirects=True,
     )
-    assert page.h1.text.strip() == "Send ‘Two week reminder’"
+    assert page.select_one("h1").text.strip() == "Send ‘Two week reminder’"
 
     assert len(page.select(".banner-tour")) == 0
 
@@ -3605,7 +3605,7 @@ def test_check_notification_shows_preview(client_request, service_one, fake_uuid
 
     page = client_request.get("main.check_notification", service_id=service_one["id"], template_id=fake_uuid)
 
-    assert page.h1.text.strip() == "Preview of ‘Two week reminder’"
+    assert page.select_one("h1").text.strip() == "Preview of ‘Two week reminder’"
     assert (page.select_one("a.govuk-back-link")["href"]) == url_for(
         "main.send_one_off_step",
         service_id=service_one["id"],
@@ -3617,7 +3617,7 @@ def test_check_notification_shows_preview(client_request, service_one, fake_uuid
     assert not page.select(".banner-tour")
 
     # post to send_notification with help=0 to ensure no back link is then shown
-    assert page.form.attrs["action"] == url_for(
+    assert page.select_one("form")["action"] == url_for(
         "main.send_notification", service_id=service_one["id"], template_id=fake_uuid, help="0"
     )
 
@@ -3657,7 +3657,7 @@ def test_check_notification_shows_back_link(mocker, client_request, service_one,
         template_id=fake_uuid,
     )
 
-    assert page.h1.text.strip() == "Preview of ‘Awkward letter’"
+    assert page.select_one("h1").text.strip() == "Preview of ‘Awkward letter’"
     back_link = page.select_one("a.govuk-back-link")["href"]
     assert back_link == url_for(
         "main.send_one_off_step",

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1787,7 +1787,7 @@ def test_should_show_interstitial_when_making_breaking_change(
         _expected_status=200,
     )
 
-    assert page.h1.string.strip() == "Confirm changes"
+    assert page.select_one("h1").string.strip() == "Confirm changes"
     assert page.select_one("a.govuk-back-link")["href"] == url_for(
         ".edit_service_template",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3,12 +3,16 @@ from functools import partial
 from unittest.mock import ANY, Mock
 
 import pytest
-from bs4 import BeautifulSoup
 from flask import url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 
-from tests import sample_uuid, template_json, validate_route_permission
+from tests import (
+    NotifyBeautifulSoup,
+    sample_uuid,
+    template_json,
+    validate_route_permission,
+)
 from tests.app.main.views.test_template_folders import (
     CHILD_FOLDER_ID,
     FOLDER_TWO_ID,
@@ -2737,7 +2741,7 @@ def test_content_count_json_endpoint(
     )
 
     html = json.loads(response.get_data(as_text=True))["html"]
-    snippet = BeautifulSoup(html, "html.parser").select_one("span")
+    snippet = NotifyBeautifulSoup(html, "html.parser").select_one("span")
 
     assert normalize_spaces(snippet.text) == expected_message
 

--- a/tests/app/main/views/test_tour.py
+++ b/tests/app/main/views/test_tour.py
@@ -477,7 +477,7 @@ def test_should_200_for_check_tour_notification(
     assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == ("service one: hello hi howdy")
 
     # post to send_notification keeps help argument
-    assert page.form.attrs["action"] == url_for(
+    assert page.select_one("form").attrs["action"] == url_for(
         "main.send_notification", service_id=SERVICE_ONE_ID, template_id=fake_uuid, help="3"
     )
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -25,7 +25,7 @@ def test_two_factor_email_sent_page(client_request, email_resent, page_title, re
         email_resent=email_resent,
     )
 
-    assert page.h1.string == page_title
+    assert page.select_one("h1").string == page_title
     # there shouldn't be a form for updating mobile number
     assert page.select_one("form") is None
     resend_email_link = page.select_one("a.govuk-link.govuk-link--no-visited-state.page-footer-secondary-link")
@@ -391,7 +391,7 @@ def test_two_factor_email_link_has_expired(
             _follow_redirects=True,
         )
 
-    assert page.h1.text.strip() == "The link has expired"
+    assert page.select_one("h1").text.strip() == "The link has expired"
     assert page.select_one('a:contains("Sign in again")')["href"] == url_for("main.sign_in", next=redirect_url)
 
     assert mock_send_verify_code.called is False
@@ -431,7 +431,7 @@ def test_two_factor_email_link_is_already_used(
         _follow_redirects=True,
     )
 
-    assert page.h1.text.strip() == "The link has expired"
+    assert page.select_one("h1").text.strip() == "The link has expired"
     assert page.select_one('a:contains("Sign in again")')["href"] == url_for("main.sign_in", next=redirect_url)
 
     assert mock_send_verify_code.called is False
@@ -446,7 +446,7 @@ def test_two_factor_email_link_when_user_is_locked_out(client_request, valid_tok
         _follow_redirects=True,
     )
 
-    assert page.h1.text.strip() == "The link has expired"
+    assert page.select_one("h1").text.strip() == "The link has expired"
     assert mock_send_verify_code.called is False
 
 

--- a/tests/app/main/views/test_verify.py
+++ b/tests/app/main/views/test_verify.py
@@ -23,7 +23,7 @@ def test_should_return_verify_template(
         session["user_details"] = {"email_address": api_user_active["email_address"], "id": api_user_active["id"]}
     page = client_request.get("main.verify")
 
-    assert page.h1.text == "Check your phone"
+    assert page.select_one("h1").text == "Check your phone"
     message = page.select("main p")[0].text
     assert message == "We’ve sent you a text message with a security code."
 
@@ -179,7 +179,7 @@ def test_verify_email_redirects_to_sign_in_if_user_active(
 
     page = client_request.get("main.verify_email", token="notreal", _follow_redirects=True)
 
-    assert page.h1.text == "Sign in"
+    assert page.select_one("h1").text == "Sign in"
     flash_banner = page.select_one("div.banner-dangerous").string.strip()
     assert flash_banner == "That verification link has expired."
 

--- a/tests/app/utils/test_letters.py
+++ b/tests/app/utils/test_letters.py
@@ -1,5 +1,4 @@
 import pytest
-from bs4 import BeautifulSoup
 from flask import url_for
 from freezegun import freeze_time
 
@@ -8,6 +7,7 @@ from app.utils.letters import (
     get_letter_validation_error,
     printing_today_or_tomorrow,
 )
+from tests import NotifyBeautifulSoup
 
 
 @pytest.mark.parametrize(
@@ -204,8 +204,8 @@ def test_get_letter_validation_error_for_known_errors(
     expected_summary,
 ):
     error = get_letter_validation_error(error_message, invalid_pages=invalid_pages, page_count=13)
-    detail = BeautifulSoup(error["detail"], "html.parser")
-    summary = BeautifulSoup(error["summary"], "html.parser")
+    detail = NotifyBeautifulSoup(error["detail"], "html.parser")
+    summary = NotifyBeautifulSoup(error["summary"], "html.parser")
 
     assert error["title"] == expected_title
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from notifications_utils.url_safe_token import generate_token
 from app import create_app, webauthn_server
 
 from . import (
+    NotifyBeautifulSoup,
     TestClient,
     api_key_json,
     assert_url_expected,
@@ -2750,9 +2751,8 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             if _expected_redirect:
                 assert resp.location == _expected_redirect
 
-            page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
-            block_method(page, "find", preferred_method_name="select_one")
-            block_method(page, "find_all", preferred_method_name="select")
+            page = NotifyBeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+
             if _test_page_title:
                 count_of_h1s = len(page.select("h1"))
                 if count_of_h1s != 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2752,6 +2752,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
 
             page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
             block_method(page, "find", preferred_method_name="select_one")
+            block_method(page, "find_all", preferred_method_name="select")
             if _test_page_title:
                 count_of_h1s = len(page.select("h1"))
                 if count_of_h1s != 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from unittest.mock import Mock, PropertyMock
 from uuid import UUID, uuid4
 
 import pytest
-from bs4 import BeautifulSoup
 from flask import Flask, url_for
 from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import generate_token
@@ -2817,7 +2816,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             if _expected_redirect:
                 assert_url_expected(resp.location, _expected_redirect)
 
-            return BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
+            return NotifyBeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
         @staticmethod
         def get_response(endpoint, _expected_status=200, _optional_args="", **endpoint_kwargs):

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_BeautifulSoup_methods_are_overridden(
+    client_request,
+    mock_get_service_and_organisation_counts,
+):
+    client_request.logout()
+    page = client_request.get("main.index", _test_page_title=False)
+
+    with pytest.raises(AttributeError) as exception:
+        page.find("h1")
+
+    assert str(exception.value) == "Don’t use BeautifulSoup.find – try BeautifulSoup.select_one instead"
+
+    with pytest.raises(AttributeError) as exception:
+        page.find_all("h1")
+
+    assert str(exception.value) == "Don’t use BeautifulSoup.find_all – try BeautifulSoup.select instead"


### PR DESCRIPTION
In https://github.com/alphagov/notifications-admin/pull/4308 we replaced uses of `page.find` with `page.select`, to standardise on one way of doing things.

However I’ve seen uses of `page.find` creeping back in. This commit prevents `page.find` by raising an exception when someone tries to use it.

This also has the (welcome) side effect of removing the third way of selecting things with BeautifulSoup, the magic (in a bad way) attribute access, for example `page.form` or `page.h1`.

<img width="847" alt="image" src="https://user-images.githubusercontent.com/355079/199720225-97e684df-f205-47bc-ba0b-dffef4aafea3.png">
