### PR TITLE
lookup insignias in compiled assets path

### DIFF
--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from app import asset_fingerprinter
 from app.models import JSONModel, ModelList
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.letter_branding_client import letter_branding_client
@@ -141,7 +142,7 @@ GOVERNMENT_IDENTITY_SYSTEM_COLOURS = {
     "Wales Office": "#a33038",
 }
 
-INSIGNIA_ASSETS_PATH = Path(__file__) / "../../assets/images/branding/insignia/"
+INSIGNIA_ASSETS_PATH = Path(asset_fingerprinter._filesystem_path) / "images/branding/insignia/"
 
 GOVERNMENT_IDENTITY_SYSTEM_CRESTS_OR_INSIGNIA = tuple(
     item.stem for item in INSIGNIA_ASSETS_PATH.resolve().iterdir() if item.is_file()


### PR DESCRIPTION
the normal app/assets path is only for dev (ie: unminified js, uncompiled scss, etc). When we build artifacts to deploy, we move the files in to app/static (and minify, compile, etc) using our gulpfile.

Make sure the new government insignia lookup uses this path rather than the assets path