### PR TITLE
Remove grid column from add email branding page

### DIFF
--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -17,19 +17,16 @@
   {{ page_header("Add email branding options") }}
   {{ live_search(target_selector='.govuk-checkboxes__item', show=True, form=search_form, autofocus=True) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-five-sixths">
-      {% call form_wrapper(module='add-branding-options-form') %}
-        <div class="brand-pool">
-            {{ form.branding_field }}
-        </div>
-      <div class="js-stick-at-bottom-when-scrolling">
-        {{ page_footer('Add options') }}
-        <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
-          Nothing selected
-        </div>
-      </div>
-      {% endcall %}
+  {% call form_wrapper(module='add-branding-options-form') %}
+    <div class="brand-pool">
+        {{ form.branding_field }}
+    </div>
+  <div class="js-stick-at-bottom-when-scrolling">
+    {{ page_footer('Add options') }}
+    <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
+      Nothing selected
     </div>
   </div>
+  {% endcall %}
+
 {% endblock %}

--- a/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
@@ -17,19 +17,16 @@
   {{ page_header("Add letter branding options") }}
   {{ live_search(target_selector='.govuk-checkboxes__item', show=True, form=search_form, autofocus=True) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-five-sixths">
-      {% call form_wrapper(module='add-branding-options-form') %}
-        <div class="brand-pool">
-            {{ form.branding_field }}
-        </div>
-      <div class="js-stick-at-bottom-when-scrolling">
-        {{ page_footer('Add options') }}
-        <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
-          Nothing selected
-        </div>
-      </div>
-      {% endcall %}
+  {% call form_wrapper(module='add-branding-options-form') %}
+    <div class="brand-pool">
+        {{ form.branding_field }}
+    </div>
+  <div class="js-stick-at-bottom-when-scrolling">
+    {{ page_footer('Add options') }}
+    <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
+      Nothing selected
     </div>
   </div>
+  {% endcall %}
+
 {% endblock %}


### PR DESCRIPTION
This should be full width; it doesn’t need to be in a column.

Before:

<img width="766" alt="image" src="https://user-images.githubusercontent.com/355079/199771866-ffa09f15-e488-4729-91ff-0de9c9c03e3b.png">

After:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/355079/199771987-c0a3c94c-8680-4ec3-84cc-5201d825f7c2.png">
