### PR TITLE
Allow letter brandings to be removed from pool

### DIFF
--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -113,5 +113,9 @@ class OrganisationsClient(NotifyAdminAPIClient):
     def remove_email_branding_from_pool(self, org_id, branding_id):
         self.delete(f"/organisations/{org_id}/email-branding-pool/{branding_id}")
 
+    @cache.delete("organisation-{org_id}-letter-branding-pool")
+    def remove_letter_branding_from_pool(self, org_id, branding_id):
+        self.delete(f"/organisations/{org_id}/letter-branding-pool/{branding_id}")
+
 
 organisations_client = OrganisationsClient()

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -20,6 +20,18 @@
         {{ option.name }}
     </h2>
     {{ letter_branding_preview(option.id) }}
+    <div class="govuk-grid-row govuk-!-margin-top-2 govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-one-half">&nbsp;
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <p class="govuk-body govuk-!-text-align-right">
+          <a href="{{ url_for('main.organisation_letter_branding', org_id=current_org.id) }}?remove_branding_id={{ option.id }}"
+           class="govuk-link govuk-link govuk-link--destructive govuk-link--no-visited-state">
+            Remove <span class="govuk-visually-hidden">this branding option</span>
+          </a>
+        </p>
+      </div>
+    </div>
   {% endfor %}
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -15,7 +15,13 @@
 {% block maincolumn_content %}
   {{ page_header("Letter branding") }}
 
-  {% for option in current_org.letter_branding_pool %}
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+    {{ current_org.letter_branding.name or "No branding" }}<span class="hint govuk-!-font-weight-regular">&ensp;(default)</span>
+  </h2>
+
+  {{ letter_branding_preview(current_org.letter_branding_id, classes='govuk-!-margin-bottom-8') }}
+
+  {% for option in current_org.letter_branding_pool_excluding_default %}
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
         {{ option.name }}
     </h2>

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2344,6 +2344,99 @@ def test_organisation_letter_branding_page_shows_all_branding_pool_options(
     )
 
 
+def test_organisation_letter_branding_page_shows_remove_links(
+    client_request,
+    platform_admin_user,
+    organisation_one,
+    mock_get_letter_branding_pool,
+    mock_get_organisation,
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get(".organisation_letter_branding", org_id=organisation_one["id"])
+
+    headers_and_remove_links = page.select("h2.govuk-heading-s, .govuk-\\!-text-align-right a")
+    assert [(element.name, normalize_spaces(element.text)) for element in headers_and_remove_links] == [
+        ("h2", "Cabinet Office"),
+        ("a", "Remove this branding option"),
+        ("h2", "Department for Education"),
+        ("a", "Remove this branding option"),
+        ("h2", "Government Digital Service"),
+        ("a", "Remove this branding option"),
+    ]
+
+    assert headers_and_remove_links[1].get("href") == url_for(
+        ".organisation_letter_branding", org_id=organisation_one["id"], remove_branding_id="1234"
+    )
+    assert headers_and_remove_links[3].get("href") == url_for(
+        ".organisation_letter_branding", org_id=organisation_one["id"], remove_branding_id="5678"
+    )
+    assert headers_and_remove_links[5].get("href") == url_for(
+        ".organisation_letter_branding", org_id=organisation_one["id"], remove_branding_id="9abc"
+    )
+
+
+def test_get_organisation_letter_branding_page_with_remove_param_shows_confirmation(
+    client_request,
+    platform_admin_user,
+    organisation_one,
+    mock_get_letter_branding_pool,
+    mock_get_organisation,
+):
+    client_request.login(platform_admin_user)
+
+    page = client_request.get(
+        ".organisation_letter_branding",
+        org_id=organisation_one["id"],
+        remove_branding_id="1234",
+    )
+
+    assert "Are you sure you want to remove the letter brand ‘Cabinet Office’?" in page.text
+    assert normalize_spaces(page.select_one(".banner-dangerous form button").text) == "Yes, delete"
+
+
+def test_post_organisation_letter_branding_page_with_remove_param_calls_client_and_redirects(
+    client_request,
+    platform_admin_user,
+    organisation_one,
+    mock_get_letter_branding_pool,
+    mock_get_organisation,
+    mocker,
+):
+    remove_mock = mocker.patch("app.organisations_client.remove_letter_branding_from_pool")
+
+    client_request.login(platform_admin_user)
+
+    page = client_request.post(
+        ".organisation_letter_branding",
+        org_id=organisation_one["id"],
+        remove_branding_id="1234",
+        _follow_redirects=True,
+    )
+
+    assert remove_mock.call_args_list == [mocker.call(ORGANISATION_ID, "1234")]
+
+    assert page.select_one("h1").text == "Letter branding"
+    assert "Letter branding ‘Cabinet Office’ removed." in page.text
+
+
+def test_organisation_letter_branding_page_when_branding_is_not_in_pool(
+    client_request,
+    platform_admin_user,
+    organisation_one,
+    mock_get_letter_branding_pool,
+    mock_get_organisation,
+    fake_uuid,
+):
+    client_request.login(platform_admin_user)
+
+    client_request.post(
+        ".organisation_letter_branding",
+        org_id=organisation_one["id"],
+        remove_branding_id=fake_uuid,
+        _expected_status=400,
+    )
+
+
 def test_add_organisation_letter_branding_options_is_platform_admin_only(
     client_request,
     organisation_one,

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2332,6 +2332,7 @@ def test_organisation_letter_branding_page_shows_all_branding_pool_options(
 
     assert page.h1.text == "Letter branding"
     assert [normalize_spaces(heading.text) for heading in page.select(".govuk-heading-s")] == [
+        "No branding (default)",
         "Cabinet Office",
         "Department for Education",
         "Government Digital Service",
@@ -2349,29 +2350,37 @@ def test_organisation_letter_branding_page_shows_remove_links(
     platform_admin_user,
     organisation_one,
     mock_get_letter_branding_pool,
-    mock_get_organisation,
+    mocker,
 ):
+    organisation_one["letter_branding_id"] = "9abc"
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
+
+    mocker.patch(
+        "app.models.branding.letter_branding_client.get_letter_branding",
+        return_value={
+            "id": "9abc",
+            "name": "Government Digital Service",
+            "filename": "gds",
+        },
+    )
+
     client_request.login(platform_admin_user)
     page = client_request.get(".organisation_letter_branding", org_id=organisation_one["id"])
 
     headers_and_remove_links = page.select("h2.govuk-heading-s, .govuk-\\!-text-align-right a")
     assert [(element.name, normalize_spaces(element.text)) for element in headers_and_remove_links] == [
+        ("h2", "Government Digital Service (default)"),
         ("h2", "Cabinet Office"),
         ("a", "Remove this branding option"),
         ("h2", "Department for Education"),
         ("a", "Remove this branding option"),
-        ("h2", "Government Digital Service"),
-        ("a", "Remove this branding option"),
     ]
 
-    assert headers_and_remove_links[1].get("href") == url_for(
+    assert headers_and_remove_links[2].get("href") == url_for(
         ".organisation_letter_branding", org_id=organisation_one["id"], remove_branding_id="1234"
     )
-    assert headers_and_remove_links[3].get("href") == url_for(
+    assert headers_and_remove_links[4].get("href") == url_for(
         ".organisation_letter_branding", org_id=organisation_one["id"], remove_branding_id="5678"
-    )
-    assert headers_and_remove_links[5].get("href") == url_for(
-        ".organisation_letter_branding", org_id=organisation_one["id"], remove_branding_id="9abc"
     )
 
 

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -303,3 +303,19 @@ def test_add_brandings_to_letter_branding_pool(mocker, fake_uuid):
         url=f"/organisations/{fake_uuid}/letter-branding-pool", data={"branding_ids": ["abcd", "efgh"]}
     )
     mock_redis_delete.assert_called_once_with(f"organisation-{fake_uuid}-letter-branding-pool")
+
+
+def test_remove_letter_branding_from_organisation_pool(mocker):
+    mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
+    mock_delete = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.delete")
+
+    org_id = "abcd-1234"
+    branding_id = "efgh-5678"
+
+    organisations_client.remove_letter_branding_from_pool(
+        org_id=org_id,
+        branding_id=branding_id,
+    )
+
+    assert mock_redis_delete.call_args_list == [call(f"organisation-{org_id}-letter-branding-pool")]
+    mock_delete.assert_called_with(f"/organisations/{org_id}/letter-branding-pool/{branding_id}")


### PR DESCRIPTION
This adds a "Remove" link beneath each letter branding in the pool apart from the default brand. The default is shown separately at the top of the page.

#### Depends on
- [x] https://github.com/alphagov/notifications-api/pull/3630

### With no branding as the default
<img width="500" alt="Screenshot 2022-11-03 at 16 17 45" src="https://user-images.githubusercontent.com/12881990/199778335-382eebf9-b647-40b9-bd4c-3e60a8e3ad2c.png">

### With a specific branding as the default
<img width="500" alt="Screenshot 2022-11-03 at 16 17 14" src="https://user-images.githubusercontent.com/12881990/199778364-0098cffc-e222-46f2-8622-a82c445caaa1.png">

### Confirmation banner
<img width="450" alt="Screenshot 2022-11-03 at 16 38 10" src="https://user-images.githubusercontent.com/12881990/199780939-7261e22c-679b-4f3b-9aed-0ecc215b70ea.png">

### Flash message after the brand has been removed
<img width="450" alt="Screenshot 2022-11-03 at 16 38 15" src="https://user-images.githubusercontent.com/12881990/199781012-b6bc131e-d74e-438b-b223-0cb8b06cf56f.png">
