### PR TITLE
Fix message when service has no letter branding

### DIFF
--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -22,7 +22,7 @@
   {{ page_header('Change letter branding') }}
 
   <p class="govuk-body">
-    Your letters currently have {{ current_service.letter_branding.name }} branding.
+    Your letters currently have {{ current_service.letter_branding.name or 'no' }} branding.
   </p>
 
   {% call form_wrapper() %}

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -42,6 +42,8 @@ def test_letter_branding_request_page_when_no_branding_is_set(
     assert mock_get_email_branding.called is False
     assert mock_get_letter_branding_by_id.called is False
 
+    assert normalize_spaces(page.select_one("main p").text) == "Your letters currently have no branding."
+
     button_text = normalize_spaces(page.select_one(".page-footer button").text)
     assert button_text == "Request new branding"
 
@@ -54,6 +56,17 @@ def test_letter_branding_request_page_when_no_branding_is_set(
     else:
         assert page.select_one("textarea")["name"] == ("something_else")
         assert not page.select(".conditional-radios-panel")
+
+
+def test_letter_branding_request_page_when_branding_is_set_already(
+    client_request,
+    service_one,
+    fake_uuid,
+    mock_get_letter_branding_by_id,
+):
+    service_one["letter_branding"] = fake_uuid
+    page = client_request.get(".letter_branding_request", service_id=SERVICE_ONE_ID)
+    assert normalize_spaces(page.select_one("main p").text) == "Your letters currently have HM Government branding."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This was broken by 245f1b9524aba8aeff540f056d0cbd44aaf43dfe because the default value for letter branding name was changed from `'no branding'` to `None`.

This commit fixes the bug by checking for a `None` value in the template and makes sure the message has test coverage.