### PR TITLE
Direct central org service users towards government identity journey

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -125,6 +125,7 @@ def create_email_branding_government_identity_logo():
                 ".create_email_branding_government_identity_colour",
                 text=request.args.get("text"),
                 filename=form.coat_of_arms_or_insignia.data,
+                brand_type=request.args.get("brand_type"),
             )
         )
 
@@ -160,6 +161,7 @@ def create_email_branding_government_identity_colour():
                 text=request.args.get("text"),
                 colour=form.colour.data,
                 logo=upload_filename,
+                brand_type=request.args.get("brand_type"),
             )
         )
 
@@ -177,7 +179,7 @@ def create_email_branding(logo=None):
         name=request.args.get("name"),
         text=request.args.get("text"),
         colour=request.args.get("colour"),
-        brand_type="org",
+        brand_type=request.args.get("brand_type", "org"),
     )
 
     if form.validate_on_submit():

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1151,7 +1151,9 @@ def create_email_branding_zendesk_ticket(form_option_selected, detail=None):
 def email_branding_request(service_id):
     form = ChooseEmailBrandingForm(current_service)
     if form.something_else_is_only_option:
-        return redirect(url_for(".email_branding_something_else", service_id=current_service.id))
+        return redirect(
+            url_for(".email_branding_something_else", service_id=current_service.id, back_link=".service_settings")
+        )
     if form.validate_on_submit():
 
         branding_choice = form.options.data
@@ -1167,11 +1169,18 @@ def email_branding_request(service_id):
             return redirect(
                 url_for(".email_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)
             )
+        if branding_choice == "govuk":
+            return redirect(url_for(".email_branding_govuk", service_id=current_service.id))
+
+        if current_service.organisation_type == "central":
+            return redirect(url_for(".email_branding_choose_logo", service_id=current_service.id))
         else:
+            # TODO: change this to redirect to new logo upload flow once it's ready
             return redirect(
                 url_for(
                     f".email_branding_{branding_choice}",
                     service_id=current_service.id,
+                    back_link=".email_branding_request",
                 )
             )
 
@@ -1282,6 +1291,7 @@ def email_branding_something_else(service_id):
         "views/service-settings/branding/email-branding-something-else.html",
         form=form,
         branding_options=ChooseEmailBrandingForm(current_service),
+        back_link=request.args.get("back_link", ".email_branding_request"),
     )
 
 
@@ -1341,9 +1351,21 @@ def email_branding_choose_logo(service_id):
 
     if form.validate_on_submit():
         if form.branding_options.data == "org":
-            return redirect(url_for(".email_branding_something_else", service_id=current_service.id))
+            return redirect(
+                url_for(
+                    ".email_branding_something_else",
+                    service_id=current_service.id,
+                    back_link=".email_branding_choose_logo",
+                )
+            )
         elif form.branding_options.data == "single_identity":
-            return redirect(url_for(".email_branding_request_government_identity_logo", service_id=current_service.id))
+            return redirect(
+                url_for(
+                    ".email_branding_request_government_identity_logo",
+                    service_id=current_service.id,
+                    branding_choice=request.args.get("branding_choice"),
+                )
+            )
 
     return (
         render_template(

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1173,7 +1173,9 @@ def email_branding_request(service_id):
             return redirect(url_for(".email_branding_govuk", service_id=current_service.id))
 
         if current_service.organisation_type == "central":
-            return redirect(url_for(".email_branding_choose_logo", service_id=current_service.id))
+            return redirect(
+                url_for(".email_branding_choose_logo", service_id=current_service.id, branding_choice=branding_choice)
+            )
         else:
             # TODO: change this to redirect to new logo upload flow once it's ready
             return redirect(
@@ -1301,10 +1303,12 @@ def email_branding_something_else(service_id):
 )
 @user_has_permissions("manage_service")
 def email_branding_request_government_identity_logo(service_id):
+    branding_choice = request.args.get("branding_choice")
     return render_template(
         "views/service-settings/branding/email-branding-create-government-identity-logo.html",
         service_id=service_id,
-        back_link=url_for(".email_branding_choose_logo", service_id=service_id),
+        back_link=url_for(".email_branding_choose_logo", service_id=service_id, branding_choice=branding_choice),
+        branding_choice=branding_choice,
         example=AllEmailBranding().example_government_identity_branding,
     )
 
@@ -1316,11 +1320,13 @@ def email_branding_request_government_identity_logo(service_id):
 @user_has_permissions("manage_service")
 def email_branding_enter_government_identity_logo_text(service_id):
     form = GovernmentIdentityLogoForm(organisation=current_service.organisation)
+    branding_choice = request.args.get("branding_choice")
 
     if form.validate_on_submit():
         ticket_message = render_template(
             "support-tickets/government-logo-branding-request.txt",
             logo_text=form.logo_text.data,
+            branding_choice=branding_choice,
         )
         ticket = NotifySupportTicket(
             subject=f"Email branding request - {current_service.name}",
@@ -1339,7 +1345,9 @@ def email_branding_enter_government_identity_logo_text(service_id):
     return render_template(
         "views/service-settings/branding/email-branding-enter-government-identity-logo-text.html",
         form=form,
-        back_link=url_for(".email_branding_request_government_identity_logo", service_id=service_id),
+        back_link=url_for(
+            ".email_branding_request_government_identity_logo", service_id=service_id, branding_choice=branding_choice
+        ),
     )
 
 

--- a/app/templates/support-tickets/government-logo-branding-request.txt
+++ b/app/templates/support-tickets/government-logo-branding-request.txt
@@ -8,7 +8,15 @@ Service: {{ current_service.name }}
 
 ---
 Government logo text requested: {{ logo_text }}
+{% set create_logo_url = url_for(
+  'main.create_email_branding_government_identity_logo', text=logo_text, _external=True
+) %}
+{% if branding_choice == "govuk_and_org" %}This service requested for both GOV.UK and organisation logo to be visible.
+{% set create_logo_url = url_for(
+  'main.create_email_branding_government_identity_logo', text=logo_text, brand_type="both", _external=True
+) %}
+{% elif branding_choice == "organisation" %}This service requested organisation branding.
 
-Create this logo: {{ url_for('main.create_email_branding_government_identity_logo', text=logo_text, _external=True) }}
+{% endif %}Create this logo: {{ create_logo_url }}
 
 Apply branding to this service: {{ url_for('main.service_set_email_branding', service_id=current_service.id, _external=True) }}

--- a/app/templates/views/email-branding/government-identity-options-colour.html
+++ b/app/templates/views/email-branding/government-identity-options-colour.html
@@ -11,7 +11,11 @@
 
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('.email_branding') }) }}
+  {{ govukBackLink({ "href": url_for(
+    '.create_email_branding_government_identity_logo',
+    text=request.args.get("text"),
+    brand_type=request.args.get("brand_type")
+  ) }) }}
 {% endblock %}
 
 {% block platform_admin_content %}

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
@@ -23,7 +23,7 @@
   {% if form.branding_options.errors %}
     {% set params = {
         "titleText": "There is a problem",
-        "errorList": [{"href": "#" + form.options.id, "text": form.options.errors[0]}]
+        "errorList": [{"href": "#" + form.branding_options.id, "text": form.branding_options.errors[0]}]
       }
     %}
     {{ govukErrorSummary(params) }}

--- a/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
+++ b/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
@@ -45,7 +45,11 @@
   {{ govukButton({
     "element": "a",
     "text": "Continue",
-    "href": url_for('.email_branding_enter_government_identity_logo_text', service_id=service_id)
+    "href": url_for(
+      '.email_branding_enter_government_identity_logo_text',
+      service_id=service_id,
+      branding_choice=branding_choice
+    )
   }) }}
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/email-branding-something-else.html
+++ b/app/templates/views/service-settings/branding/email-branding-something-else.html
@@ -11,7 +11,7 @@
 {% if branding_options.something_else_is_only_option %}
   {% set back_url = url_for('.service_settings', service_id=current_service.id) %}
 {% else %}
-  {% set back_url = url_for('.email_branding_request', service_id=current_service.id) %}
+  {% set back_url = url_for(back_link, service_id=current_service.id) %}
 {% endif %}
 
 {% block backLink %}

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -341,7 +341,7 @@ def test_email_branding_request_page_back_link(
 
 
 @pytest.mark.parametrize(
-    "data, org_type, endpoint",
+    "data, org_type, endpoint, extra_args",
     (
         (
             {
@@ -349,6 +349,7 @@ def test_email_branding_request_page_back_link(
             },
             "central",
             "main.email_branding_govuk",
+            {},
         ),
         (
             {
@@ -356,6 +357,7 @@ def test_email_branding_request_page_back_link(
             },
             "central",
             "main.email_branding_choose_logo",
+            {"branding_choice": "govuk_and_org"},
         ),
         (
             {
@@ -363,6 +365,7 @@ def test_email_branding_request_page_back_link(
             },
             "central",
             "main.email_branding_choose_logo",
+            {"branding_choice": "organisation"},
         ),
         (
             {
@@ -370,6 +373,7 @@ def test_email_branding_request_page_back_link(
             },
             "central",
             "main.email_branding_choose_logo",
+            {"branding_choice": "something_else"},
         ),
         (
             {
@@ -377,6 +381,7 @@ def test_email_branding_request_page_back_link(
             },
             "local",
             "main.email_branding_something_else",
+            {"back_link": ".email_branding_request"},
         ),
         (
             {
@@ -384,6 +389,7 @@ def test_email_branding_request_page_back_link(
             },
             "nhs_local",
             "main.email_branding_nhs",
+            {},
         ),
     ),
 )
@@ -397,6 +403,7 @@ def test_email_branding_request_submit(
     data,
     org_type,
     endpoint,
+    extra_args,
 ):
     organisation_one["organisation_type"] = org_type
     service_one["email_branding"] = sample_uuid()
@@ -407,20 +414,16 @@ def test_email_branding_request_submit(
         return_value=organisation_one,
     )
 
-    if org_type == "local" and data["options"] == "something_else":
-        expected_url = url_for(endpoint, service_id=SERVICE_ONE_ID, back_link=".email_branding_request")
-    else:
-        expected_url = url_for(
-            endpoint,
-            service_id=SERVICE_ONE_ID,
-        )
-
     client_request.post(
         ".email_branding_request",
         service_id=SERVICE_ONE_ID,
         _data=data,
         _expected_status=302,
-        _expected_redirect=expected_url,
+        _expected_redirect=url_for(
+            endpoint,
+            service_id=SERVICE_ONE_ID,
+            **extra_args,
+        ),
     )
 
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -154,7 +154,6 @@ def test_email_branding_request_page_redirects_to_something_else_page_if_that_is
     mock_get_email_branding,
     mock_get_empty_email_branding_pool,
 ):
-
     service_one["organisation_type"] = "other"
     mocker.patch(
         "app.models.service.Service.email_branding_id",
@@ -167,8 +166,7 @@ def test_email_branding_request_page_redirects_to_something_else_page_if_that_is
         service_id=SERVICE_ONE_ID,
         _expected_status=302,
         _expected_redirect=url_for(
-            "main.email_branding_something_else",
-            service_id=SERVICE_ONE_ID,
+            "main.email_branding_something_else", service_id=SERVICE_ONE_ID, back_link=".service_settings"
         ),
     )
 
@@ -357,20 +355,27 @@ def test_email_branding_request_page_back_link(
                 "options": "govuk_and_org",
             },
             "central",
-            "main.email_branding_govuk_and_org",
+            "main.email_branding_choose_logo",
         ),
         (
             {
                 "options": "organisation",
             },
             "central",
-            "main.email_branding_organisation",
+            "main.email_branding_choose_logo",
         ),
         (
             {
                 "options": "something_else",
             },
             "central",
+            "main.email_branding_choose_logo",
+        ),
+        (
+            {
+                "options": "something_else",
+            },
+            "local",
             "main.email_branding_something_else",
         ),
         (
@@ -402,15 +407,20 @@ def test_email_branding_request_submit(
         return_value=organisation_one,
     )
 
+    if org_type == "local" and data["options"] == "something_else":
+        expected_url = url_for(endpoint, service_id=SERVICE_ONE_ID, back_link=".email_branding_request")
+    else:
+        expected_url = url_for(
+            endpoint,
+            service_id=SERVICE_ONE_ID,
+        )
+
     client_request.post(
         ".email_branding_request",
         service_id=SERVICE_ONE_ID,
         _data=data,
         _expected_status=302,
-        _expected_redirect=url_for(
-            endpoint,
-            service_id=SERVICE_ONE_ID,
-        ),
+        _expected_redirect=expected_url,
     )
 
 
@@ -516,6 +526,22 @@ def test_email_branding_something_else_page(client_request, service_one, mock_ge
     assert normalize_spaces(page.select_one(".page-footer button").text) == "Request new branding"
     assert page.select_one(".govuk-back-link")["href"] == url_for(
         "main.email_branding_request",
+        service_id=SERVICE_ONE_ID,
+    )
+
+
+@pytest.mark.parametrize("back_link", [".service_settings", ".email_branding_request", ".email_branding_choose_logo"])
+def test_email_branding_something_else_page_back_link_from_args(
+    client_request, service_one, mock_get_empty_email_branding_pool, back_link
+):
+    # expect to have a "NHS" option as well as the
+    # fallback, so "something else" is not an only option
+    service_one["organisation_type"] = "nhs_central"
+
+    page = client_request.get("main.email_branding_something_else", service_id=SERVICE_ONE_ID, back_link=back_link)
+    assert normalize_spaces(page.select_one("h1").text) == "Describe the branding you want"
+    assert page.select_one(".govuk-back-link")["href"] == url_for(
+        back_link,
         service_id=SERVICE_ONE_ID,
     )
 
@@ -839,19 +865,19 @@ def test_only_central_org_services_can_see_email_branding_choose_logo_page(clien
 
 
 @pytest.mark.parametrize(
-    "selected_option, expected_endpoint",
+    "selected_option, expected_endpoint, extra_url_args",
     [
-        ("org", ".email_branding_something_else"),
-        ("single_identity", ".email_branding_request_government_identity_logo"),
+        ("org", ".email_branding_something_else", {"back_link": ".email_branding_choose_logo"}),
+        ("single_identity", ".email_branding_request_government_identity_logo", {}),
     ],
 )
 def test_email_branding_choose_logo_redirects_to_right_page(
-    client_request, service_one, selected_option, expected_endpoint
+    client_request, service_one, selected_option, expected_endpoint, extra_url_args
 ):
     client_request.post(
         ".email_branding_choose_logo",
         service_id=SERVICE_ONE_ID,
         _data={"branding_options": selected_option},
         _expected_status=302,
-        _expected_redirect=url_for(expected_endpoint, service_id=SERVICE_ONE_ID),
+        _expected_redirect=url_for(expected_endpoint, service_id=SERVICE_ONE_ID, **extra_url_args),
     )

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -73,7 +73,7 @@ def test_create_email_branding_does_not_show_any_branding_info(
     assert page.select_one("#colour").attrs.get("value") is None
 
 
-def test_create_email_branding_does_can_be_populated_from_querystring(
+def test_create_email_branding_can_be_populated_from_querystring(
     client_request, platform_admin_user, mock_no_email_branding
 ):
     client_request.login(platform_admin_user)
@@ -82,11 +82,13 @@ def test_create_email_branding_does_can_be_populated_from_querystring(
         name="Example name",
         text="Example text",
         colour="Example colour",
+        brand_type="both",
     )
 
     assert page.select_one("#name")["value"] == "Example name"
     assert page.select_one("#text")["value"] == "Example text"
     assert page.select_one("#colour")["value"] == "Example colour"
+    assert page.select_one("#brand_type input")["value"] == "both"
 
 
 def test_create_new_email_branding_without_logo(


### PR DESCRIPTION
In this PR, we are direct central org service users towards government identity journey. We also make sure that back link on the Something Else page is correct.

Needs to go in after: https://github.com/alphagov/notifications-admin/pull/4426

### To consider:
- do we still need `.email_branding_organisation` and `.email_branding_govuk_and_org` views?
- if users select `organisation` or `govuk_and_org` as their branding choice, should we somehow take this into consideration? If not, should we even still have those options? They seem potentially confusing in the new journey.