### PR TITLE
Convert the rest of the elements to govuk frontend jinja macros

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "govuk_frontend_jinja/template.html"%}
 {% from "components/banner.html" import banner %}
 {% from "components/cookie-banner.html" import cookie_banner %}
 

--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -1,5 +1,4 @@
 {% from "vendor/govuk-frontend/components/fieldset/macro.njk" import govukFieldset %}
-{% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
 
 {% macro list_entry(
   field,

--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -1,4 +1,4 @@
-{% from "vendor/govuk-frontend/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk_frontend_jinja/components/fieldset/macro.html" import govukFieldset %}
 
 {% macro list_entry(
   field,

--- a/app/templates/partials/templates/guidance-formatting-letters.html
+++ b/app/templates/partials/templates/guidance-formatting-letters.html
@@ -1,4 +1,4 @@
-{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
 <h2 class="heading-medium">Formatting</h2>
 <p class="govuk-body">

--- a/app/templates/partials/templates/guidance-formatting.html
+++ b/app/templates/partials/templates/guidance-formatting.html
@@ -1,4 +1,4 @@
-{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
 <h2 class="heading-medium">Formatting</h2>
 <p class="bottom-gutter-1-3">

--- a/app/templates/partials/templates/guidance-links.html
+++ b/app/templates/partials/templates/guidance-links.html
@@ -1,4 +1,4 @@
-{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
 <h2 class="heading-medium">Links and URLs</h2>
 <p class="bottom-gutter-1-3">

--- a/app/templates/partials/templates/guidance-optional-content.html
+++ b/app/templates/partials/templates/guidance-optional-content.html
@@ -1,4 +1,4 @@
-{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
 <h2 class="heading-medium">
   Optional content

--- a/app/templates/partials/templates/guidance-personalisation.html
+++ b/app/templates/partials/templates/guidance-personalisation.html
@@ -1,4 +1,4 @@
-{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
 <h2 class="heading-medium">
   Personalisation

--- a/app/templates/partials/templates/guidance-send-a-document.html
+++ b/app/templates/partials/templates/guidance-send-a-document.html
@@ -1,4 +1,4 @@
-{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk_frontend_jinja/components/inset-text/macro.html" import govukInsetText %}
 
 <h2 class="heading-medium">
   Send a document by email

--- a/app/templates/views/agreement/agreement-accept.html
+++ b/app/templates/views/agreement/agreement-accept.html
@@ -4,7 +4,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Accept our data sharing and financial agreement

--- a/app/templates/views/agreement/agreement-confirm.html
+++ b/app/templates/views/agreement/agreement-confirm.html
@@ -2,7 +2,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Confirm that you accept the agreement

--- a/app/templates/views/agreement/service-agreement-choose.html
+++ b/app/templates/views/agreement/service-agreement-choose.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Accept the data sharing and financial agreement

--- a/app/templates/views/agreement/service-agreement-signed.html
+++ b/app/templates/views/agreement/service-agreement-signed.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Your organisation has already accepted the agreement

--- a/app/templates/views/agreement/service-agreement.html
+++ b/app/templates/views/agreement/service-agreement.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Accept our data sharing and financial agreement

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field with context %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Callbacks

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Callbacks for delivery receipts

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Callbacks for received text messages

--- a/app/templates/views/api/guest-list.html
+++ b/app/templates/views/api/guest-list.html
@@ -5,7 +5,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list-entry.html" import list_entry %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Guest list

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/details/macro.njk" import govukDetails %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% block service_page_title %}
   API integration

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -2,7 +2,7 @@
 {% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   API keys

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Create an API key

--- a/app/templates/views/broadcast/areas-with-sub-areas.html
+++ b/app/templates/views/broadcast/areas-with-sub-areas.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/broadcast/areas.html
+++ b/app/templates/views/broadcast/areas.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/live-search.html" import live_search %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/broadcast/counties.html
+++ b/app/templates/views/broadcast/counties.html
@@ -3,7 +3,7 @@
 {% from "components/live-search.html" import live_search %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/broadcast/libraries.html
+++ b/app/templates/views/broadcast/libraries.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Choose where to send this alert

--- a/app/templates/views/broadcast/new-broadcast.html
+++ b/app/templates/views/broadcast/new-broadcast.html
@@ -1,4 +1,4 @@
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Choose where to send this alert

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -4,7 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radio_select %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Preview message

--- a/app/templates/views/broadcast/sub-areas.html
+++ b/app/templates/views/broadcast/sub-areas.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/live-search.html" import live_search %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,11 +1,10 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/details/macro.njk" import govukDetails %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
-{% from "components/details/macro.njk" import govukDetails %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,4 +1,4 @@
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/details/macro.njk" import govukDetails %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}

--- a/app/templates/views/broadcast/write-new-broadcast.html
+++ b/app/templates/views/broadcast/write-new-broadcast.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   New alert

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Error

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -4,7 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/skip-link/macro.njk" import govukSkipLink %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set file_contents_header_id = 'file-preview' %}
 

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -3,7 +3,7 @@
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/skip-link/macro.njk" import govukSkipLink %}
+{% from "govuk_frontend_jinja/components/skip-link/macro.html" import govukSkipLink %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set file_contents_header_id = 'file-preview' %}

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import mapping_table, row, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Error

--- a/app/templates/views/conversations/conversation.html
+++ b/app/templates/views/conversations/conversation.html
@@ -1,5 +1,5 @@
 {% from "components/ajax-block.html" import ajax_block %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/dashboard/inbox.html
+++ b/app/templates/views/dashboard/inbox.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Received text messages

--- a/app/templates/views/edit-broadcast-template.html
+++ b/app/templates/views/edit-broadcast-template.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ heading_action }} template

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ heading_action }} email template

--- a/app/templates/views/edit-letter-template.html
+++ b/app/templates/views/edit-letter-template.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ heading_action }} letter template

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ heading_action }} text message template

--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/banner.html" import banner %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ user.name or user.email_localpart }}

--- a/app/templates/views/email-branding/government-identity-options-colour.html
+++ b/app/templates/views/email-branding/government-identity-options-colour.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ form.colour.label.text }}

--- a/app/templates/views/email-branding/government-identity-options.html
+++ b/app/templates/views/email-branding/government-identity-options.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ form.coat_of_arms_or_insignia.label.text }}

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ '{} email branding'.format('Update' if email_branding else 'Add')}}

--- a/app/templates/views/find-users/auth_type.html
+++ b/app/templates/views/find-users/auth_type.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Set auth type for {{ user.name }}

--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -1,7 +1,7 @@
 {% extends "content_template.html" %}
 
 {% from "components/service-link.html" import service_link %}
-{% from "components/details/macro.njk" import govukDetails %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}

--- a/app/templates/views/invite-user.html
+++ b/app/templates/views/invite-user.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Invite a team member

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -3,7 +3,7 @@
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ job.original_file_name }}

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ '{} letter branding'.format('Update' if is_update else 'Add')}}

--- a/app/templates/views/manage-users/confirm-edit-user-email.html
+++ b/app/templates/views/manage-users/confirm-edit-user-email.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Confirm change of email address

--- a/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
+++ b/app/templates/views/manage-users/confirm-edit-user-mobile-number.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Confirm change of mobile number

--- a/app/templates/views/manage-users/edit-user-email.html
+++ b/app/templates/views/manage-users/edit-user-email.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Change team member’s email address

--- a/app/templates/views/manage-users/edit-user-mobile.html
+++ b/app/templates/views/manage-users/edit-user-mobile.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Change team member’s mobile number

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/button/macro.njk" import govukButton %}
 
 {% block service_page_title %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -3,7 +3,7 @@
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ 1|message_count_label(template.template_type, suffix='') | capitalize }}

--- a/app/templates/views/organisations/add-gp-organisation.html
+++ b/app/templates/views/organisations/add-gp-organisation.html
@@ -4,7 +4,7 @@
 {% from "components/radios.html" import radio, conditional_radio_panel %}
 {% from "components/select-input.html" import select_wrapper %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Accept our data sharing and financial agreement

--- a/app/templates/views/organisations/add-nhs-local-organisation.html
+++ b/app/templates/views/organisations/add-nhs-local-organisation.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Accept our data sharing and financial agreement" %}
 

--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Add email branding options

--- a/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Add letter branding options

--- a/app/templates/views/organisations/organisation/settings/edit-agreement.html
+++ b/app/templates/views/organisations/organisation/settings/edit-agreement.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block backLink %}
   {{ govukBackLink({ "href": url_for('.organisation_settings', org_id=current_org.id) }) }}

--- a/app/templates/views/organisations/organisation/settings/edit-crown-status.html
+++ b/app/templates/views/organisations/organisation/settings/edit-crown-status.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Crown organisation

--- a/app/templates/views/organisations/organisation/settings/edit-domains.html
+++ b/app/templates/views/organisations/organisation/settings/edit-domains.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/list-entry.html" import list_entry %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/banner.html" import banner_wrapper %}
 
 {% block org_page_title %}

--- a/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-go-live-notes.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Edit request to go live notes

--- a/app/templates/views/organisations/organisation/settings/edit-name.html
+++ b/app/templates/views/organisations/organisation/settings/edit-name.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Change organisation name

--- a/app/templates/views/organisations/organisation/settings/edit-organisation-billing-details.html
+++ b/app/templates/views/organisations/organisation/settings/edit-organisation-billing-details.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Edit organisation billing details

--- a/app/templates/views/organisations/organisation/settings/edit-organisation-notes.html
+++ b/app/templates/views/organisations/organisation/settings/edit-organisation-notes.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Edit organisation notes

--- a/app/templates/views/organisations/organisation/settings/edit-type.html
+++ b/app/templates/views/organisations/organisation/settings/edit-type.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}
   Organisation sector

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper%}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/button/macro.njk" import govukButton %}
 {%  from "components/branding-preview.html" import email_branding_preview %}
 

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -1,7 +1,7 @@
 {% extends "org_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {%  from "components/branding-preview.html" import letter_branding_preview %}
 
 {% block org_page_title %}

--- a/app/templates/views/organisations/organisation/settings/set-letter-branding.html
+++ b/app/templates/views/organisations/organisation/settings/set-letter-branding.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Default letter branding" %}
 

--- a/app/templates/views/organisations/organisation/users/invite-org-user.html
+++ b/app/templates/views/organisations/organisation/users/invite-org-user.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Invite a team member

--- a/app/templates/views/platform-admin/index.html
+++ b/app/templates/views/platform-admin/index.html
@@ -2,7 +2,7 @@
 {% from "components/big-number.html" import big_number_simple %}
 {% from "components/status-box.html" import status_box %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/details/macro.njk" import govukDetails %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 {% from "components/button/macro.njk" import govukButton %}
 
 {% block per_page_title %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -4,7 +4,7 @@
 {% from "components/table.html" import mapping_table, field, stats_fields, row_group, row, right_aligned_field_heading, hidden_field_heading, text_field %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/details/macro.njk" import govukDetails %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% macro services_table(services, caption) %}
   {% call(item, row_number) mapping_table(

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -3,7 +3,7 @@
 {% from "components/content-metadata.html" import content_metadata %}
 {% from "components/table.html" import mapping_table, row, text_field, field, row_heading %}
 {% from "components/live-search.html" import live_search %}
-{% from "components/details/macro.njk" import govukDetails %}
+{% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Pricing information' %}

--- a/app/templates/views/providers/provider.html
+++ b/app/templates/views/providers/provider.html
@@ -2,7 +2,7 @@
 {% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ provider_versions[0].display_name }}

--- a/app/templates/views/returned-letter-summary.html
+++ b/app/templates/views/returned-letter-summary.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/table.html" import list_table, row_heading %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Returned letters

--- a/app/templates/views/returned-letters.html
+++ b/app/templates/views/returned-letters.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/table.html" import list_table, field %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Returned letters for {{ reported_at|format_date_normal }}

--- a/app/templates/views/send-contact-list.html
+++ b/app/templates/views/send-contact-list.html
@@ -3,7 +3,7 @@
 {% from "components/list.html" import list_of_placeholders %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Choose an emergency contact list

--- a/app/templates/views/send-one-off-letter-address.html
+++ b/app/templates/views/send-one-off-letter-address.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ page_title }}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Upload a list of {{ 999|recipient_count_label(template.template_type) }}

--- a/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
@@ -4,7 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set page_title = form.options.label %}

--- a/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/government-branding-or-own-logo.html
@@ -5,7 +5,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% set page_title = form.options.label %}
 

--- a/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
+++ b/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}

--- a/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/branding-preview.html" import email_branding_preview %}

--- a/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
@@ -6,7 +6,7 @@
 {% from "components/branding-preview.html" import email_branding_preview %}
 {% from "components/textbox.html" import textbox %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% block service_page_title %}
   Enter the text that will appear in your logo

--- a/app/templates/views/service-settings/branding/email-branding-govuk-org.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk-org.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 

--- a/app/templates/views/service-settings/branding/email-branding-govuk.html
+++ b/app/templates/views/service-settings/branding/email-branding-govuk.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/branding-preview.html" import email_branding_preview %}

--- a/app/templates/views/service-settings/branding/email-branding-nhs.html
+++ b/app/templates/views/service-settings/branding/email-branding-nhs.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/branding-preview.html" import email_branding_preview %}

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -4,7 +4,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/branding/email-branding-organisation.html
+++ b/app/templates/views/service-settings/branding/email-branding-organisation.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 

--- a/app/templates/views/service-settings/branding/email-branding-pool-option.html
+++ b/app/templates/views/service-settings/branding/email-branding-pool-option.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/branding-preview.html" import email_branding_preview %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/branding/email-branding-something-else.html
+++ b/app/templates/views/service-settings/branding/email-branding-something-else.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/textbox.html" import textbox %}
 

--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -5,7 +5,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Change letter branding

--- a/app/templates/views/service-settings/confirm.html
+++ b/app/templates/views/service-settings/confirm.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ heading }}

--- a/app/templates/views/service-settings/data-retention/add.html
+++ b/app/templates/views/service-settings/data-retention/add.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Set data retention

--- a/app/templates/views/service-settings/data-retention/edit.html
+++ b/app/templates/views/service-settings/data-retention/edit.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Set data retention

--- a/app/templates/views/service-settings/edit-service-billing-details.html
+++ b/app/templates/views/service-settings/edit-service-billing-details.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/textbox.html" import textbox %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/edit-service-notes.html
+++ b/app/templates/views/service-settings/edit-service-notes.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Edit service notes

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Add reply-to email address

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
  Change reply-to email address

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/ajax-block.html" import ajax_block %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ verb }} email reply-to address

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Reply-to email addresses

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -3,7 +3,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Tell us how many messages you expect to send

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Sender addresses

--- a/app/templates/views/service-settings/letter-contact/add.html
+++ b/app/templates/views/service-settings/letter-contact/add.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Add a new address

--- a/app/templates/views/service-settings/letter-contact/edit.html
+++ b/app/templates/views/service-settings/letter-contact/edit.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Change sender address

--- a/app/templates/views/service-settings/link-service-to-organisation.html
+++ b/app/templates/views/service-settings/link-service-to-organisation.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Link service to organisation" %}
 

--- a/app/templates/views/service-settings/name-local.html
+++ b/app/templates/views/service-settings/name-local.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Change your service name

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Change your service name

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/task-list.html" import task_list_wrapper, task_list_item %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Before you request to go live

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -4,7 +4,7 @@
 {% from "components/radios.html" import radio %}
 {% from "components/select-input.html" import select_wrapper %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Send files by email

--- a/app/templates/views/service-settings/service-confirm-broadcast-account-type.html
+++ b/app/templates/views/service-settings/service-confirm-broadcast-account-type.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Confirm emergency alert settings

--- a/app/templates/views/service-settings/service-set-broadcast-channel.html
+++ b/app/templates/views/service-settings/service-set-broadcast-channel.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Emergency alerts settings

--- a/app/templates/views/service-settings/service-set-broadcast-network.html
+++ b/app/templates/views/service-settings/service-set-broadcast-network.html
@@ -4,7 +4,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/radios.html" import radio, conditional_radio_panel %}
 {% from "components/select-input.html" import select_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Choose a mobile network

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Sign-in method

--- a/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-email-branding-add-to-branding-pool-step.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer, sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Apply ‘{}’ branding".format(email_branding_name) %}
 
@@ -24,4 +24,3 @@
     {% endcall %}
 
 {% endblock %}
-

--- a/app/templates/views/service-settings/set-email-branding.html
+++ b/app/templates/views/service-settings/set-email-branding.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import page_footer, sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Set email branding" %}
 

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -2,7 +2,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Send emails

--- a/app/templates/views/service-settings/set-free-sms-allowance.html
+++ b/app/templates/views/service-settings/set-free-sms-allowance.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Free text message allowance

--- a/app/templates/views/service-settings/set-inbound-number.html
+++ b/app/templates/views/service-settings/set-inbound-number.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = 'Set inbound number' %}
 

--- a/app/templates/views/service-settings/set-inbound-sms.html
+++ b/app/templates/views/service-settings/set-inbound-sms.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Receive text messages

--- a/app/templates/views/service-settings/set-international-letters.html
+++ b/app/templates/views/service-settings/set-international-letters.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Send international letters

--- a/app/templates/views/service-settings/set-international-sms.html
+++ b/app/templates/views/service-settings/set-international-sms.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Send international text messages

--- a/app/templates/views/service-settings/set-letter-branding.html
+++ b/app/templates/views/service-settings/set-letter-branding.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = "Set letter branding" %}
 

--- a/app/templates/views/service-settings/set-letter.html
+++ b/app/templates/views/service-settings/set-letter.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Send letters

--- a/app/templates/views/service-settings/set-message-limit.html
+++ b/app/templates/views/service-settings/set-message-limit.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Daily message limit

--- a/app/templates/views/service-settings/set-rate-limit.html
+++ b/app/templates/views/service-settings/set-rate-limit.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Rate limit

--- a/app/templates/views/service-settings/set-service-setting.html
+++ b/app/templates/views/service-settings/set-service-setting.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ title }}

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -2,7 +2,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Send text messages

--- a/app/templates/views/service-settings/sms-prefix.html
+++ b/app/templates/views/service-settings/sms-prefix.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Start text messages with service name

--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Add text message sender

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Change text message sender

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -3,7 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context%}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Text message senders

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Out of hours emergencies

--- a/app/templates/views/support/form.html
+++ b/app/templates/views/support/form.html
@@ -3,7 +3,7 @@
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ page_title }}

--- a/app/templates/views/support/public.html
+++ b/app/templates/views/support/public.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   The GOV.UK Notify service is for people who work in the government

--- a/app/templates/views/support/thanks.html
+++ b/app/templates/views/support/thanks.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Thanks for contacting us

--- a/app/templates/views/support/triage.html
+++ b/app/templates/views/support/triage.html
@@ -2,7 +2,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   {{ page_title }}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ notification_type.capitalize() }} are disabled

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -4,7 +4,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list.html" import list_of_placeholders, list_of_code_snippets %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Confirm changes

--- a/app/templates/views/templates/edit-template-postage.html
+++ b/app/templates/views/templates/edit-template-postage.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Change postage

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ sender_context.title }}

--- a/app/templates/views/templates/set-template-sender.html
+++ b/app/templates/views/templates/set-template-sender.html
@@ -1,7 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = 'Set letter contact block' %}
 

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -3,7 +3,7 @@
 {% from "components/button/macro.njk" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
 
 {% set page_title = 'Get your security key' %}
 

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
 

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -2,7 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Upload a letter

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Error

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -5,7 +5,7 @@
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading, row, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ contact_list.original_file_name }}

--- a/app/templates/views/uploads/contact-list/ok.html
+++ b/app/templates/views/uploads/contact-list/ok.html
@@ -4,7 +4,7 @@
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   {{ original_file_name }}

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Error

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -3,7 +3,7 @@
 {% from "components/radios.html" import radio_select %}
 {% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Error

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -3,7 +3,7 @@
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Upload an emergency contact list

--- a/app/templates/views/uploads/preview.html
+++ b/app/templates/views/uploads/preview.html
@@ -2,7 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/file-upload.html" import file_upload %}
 
 {% block service_page_title %}

--- a/app/templates/views/uploads/uploaded-letters.html
+++ b/app/templates/views/uploads/uploaded-letters.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   Uploaded letters

--- a/app/templates/views/user-already-invited.html
+++ b/app/templates/views/user-already-invited.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   This person has already received an invite

--- a/app/templates/views/user-already-team-member.html
+++ b/app/templates/views/user-already-team-member.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}
   This person is already a team member

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -1,5 +1,5 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList %}
 
 {% block per_page_title %}
   Your profile

--- a/app/templates/views/user-profile/authenticate.html
+++ b/app/templates/views/user-profile/authenticate.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Change your {{ thing }}

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Change your password

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Change your {{ thing }}

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}
   Change your {{ thing }}

--- a/app/templates/views/user-profile/disable-platform-admin-view.html
+++ b/app/templates/views/user-profile/disable-platform-admin-view.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = 'Use platform admin view' %}
 

--- a/app/templates/views/user-profile/manage-security-key.html
+++ b/app/templates/views/user-profile/manage-security-key.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set page_title = 'Manage ' + '‘' + security_key.name + '’' %}
 

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -1,7 +1,7 @@
 {% extends "withoutnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/button/macro.njk" import govukButton %}
-{% from "components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -4,7 +4,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "vendor/govuk-frontend/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,12 +57,6 @@ const copy = {
     templates: (cb) => {
       // Put names of GOVUK Frontend templates here
       const _templates = [
-        'template',
-        // skip-link, header and footer are used by template
-        'skip-link',
-        'header',
-        'footer',
-
         'button',
       ];
       let done = 0;
@@ -74,12 +68,6 @@ const copy = {
           paths.govuk_frontend + 'govuk/components/' + name + '/template.njk'
         ];
         let _dest = paths.templates + 'vendor/govuk-frontend/components/' + name;
-
-        // template.njk isn't a component
-        if (name === 'template') {
-          _src = paths.govuk_frontend + 'govuk/template.njk';
-          _dest = paths.templates + 'vendor/govuk-frontend';
-        }
 
         src(_src)
         .pipe(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,6 @@ const copy = {
         'footer',
 
         'button',
-        'fieldset',
       ];
       let done = 0;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,9 +58,11 @@ const copy = {
       // Put names of GOVUK Frontend templates here
       const _templates = [
         'template',
+        // skip-link, header and footer are used by template
         'skip-link',
         'header',
         'footer',
+
         'details',
         'button',
         'error-summary',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,19 +61,10 @@ const copy = {
         'skip-link',
         'header',
         'footer',
-        'back-link',
         'details',
         'button',
-        'error-message',
         'error-summary',
         'fieldset',
-        'hint',
-        'label',
-        'checkboxes',
-        'radios',
-        'input',
-        'inset-text',
-        'textarea',
         'summary-list'
       ];
       let done = 0;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,7 +63,6 @@ const copy = {
         'header',
         'footer',
 
-        'details',
         'button',
         'error-summary',
         'fieldset',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,6 @@ const copy = {
         'footer',
 
         'button',
-        'error-summary',
         'fieldset',
       ];
       let done = 0;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,6 @@ const copy = {
         'button',
         'error-summary',
         'fieldset',
-        'summary-list'
       ];
       let done = 0;
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -2377,7 +2377,7 @@ def test_service_verify_reply_to_address(
     )
     assert page.select_one("h1").text == "{} email reply-to address".format(expected_header)
     back_link = page.select_one(".govuk-back-link")
-    assert back_link.text == "Back"
+    assert back_link.text.strip() == "Back"
     if replace:
         assert "/email-reply-to/123/edit" in back_link["href"]
     else:
@@ -3745,7 +3745,7 @@ def test_GET_email_branding_enter_government_identity_logo_text(client_request, 
     assert back_button["href"] == url_for(
         "main.email_branding_request_government_identity_logo", service_id=service_one["id"]
     )
-    assert back_button.text == "Back"
+    assert back_button.text.strip() == "Back"
     assert form["method"] == "post"
     assert "Request new branding" in submit_button.text
     assert text_input["name"] == "logo_text"

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -665,7 +665,7 @@ def test_bat_email_page(
     client_request.logout()
     page = client_request.get(bat_phone_page)
 
-    assert page.select_one(".govuk-back-link").text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select_one(".govuk-back-link")["href"] == url_for("main.support")
     assert page.select("main a")[1].text == "Fill in this form"
     assert page.select("main a")[1]["href"] == url_for("main.feedback", ticket_type=PROBLEM_TICKET_TYPE, severe="no")

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -252,9 +252,9 @@ def test_resources_that_use_asset_path_variable_have_correct_path(client_request
 
     page = client_request.get("main.documentation")  # easy static page
 
-    logo_svg_fallback = page.select_one(".govuk-header__logotype-crown-fallback-image")
+    favicon = page.select_one('link[type="image/x-icon"]')
 
-    assert logo_svg_fallback["src"].startswith("https://static.example.com/images/govuk-logotype-crown.png")
+    assert favicon.attrs["href"].startswith("https://static.example.com/images/favicon.ico")
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -270,7 +270,7 @@ def test_should_not_allow_files_to_be_uploaded_without_the_correct_permission(
     )
 
     assert page.select("main p")[0].text.strip() == "Sending text messages has been disabled for your service."
-    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select(".govuk-back-link")[0]["href"] == url_for(
         ".view_template",
         service_id=service_one["id"],
@@ -1228,7 +1228,7 @@ def test_send_one_off_does_not_send_without_the_correct_permissions(
     )
 
     assert page.select("main p")[0].text.strip() == "Sending text messages has been disabled for your service."
-    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select(".govuk-back-link")[0]["href"] == url_for(
         ".view_template",
         service_id=service_one["id"],
@@ -3496,7 +3496,7 @@ def test_send_one_off_letter_errors_in_trial_mode(
     assert len(page.select(".letter img")) == 5
 
     assert not page.select("main [type=submit]")
-    assert page.select_one(".govuk-back-link").text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select_one("a[download]").text == "Download as a PDF"
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1508,7 +1508,7 @@ def test_should_not_allow_creation_of_template_through_form_without_correct_perm
         _expected_status=403,
     )
     assert normalize_spaces(page.select("main p")[0].text) == expected_error
-    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select(".govuk-back-link")[0]["href"] == url_for(
         ".choose_template",
         service_id=SERVICE_ONE_ID,
@@ -1543,7 +1543,7 @@ def test_should_not_allow_creation_of_a_template_without_correct_permission(
         _expected_status=403,
     )
     assert page.select("main p")[0].text.strip() == expected_error
-    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select(".govuk-back-link")[0]["href"] == url_for(
         ".choose_template",
         service_id=service_one["id"],
@@ -1665,7 +1665,7 @@ def test_should_not_allow_template_edits_without_correct_permission(
     )
 
     assert page.select("main p")[0].text.strip() == "Sending text messages has been disabled for your service."
-    assert page.select(".govuk-back-link")[0].text == "Back"
+    assert page.select_one(".govuk-back-link").text.strip() == "Back"
     assert page.select(".govuk-back-link")[0]["href"] == url_for(
         ".view_template",
         service_id=SERVICE_ONE_ID,


### PR DESCRIPTION
these ones are all pretty simple and didn't need any code changes apart from where they're referenced in imports

* back-link - used in loads of places but we don't do anything exciting with it - we only ever pass in an href, the generated html is identical to the old one.
* inset text - used in guidance, very simple
* govukTextarea - we only use this in one place
* govukErrorMessage - only used in webauthn sign in/adding keys (though used in two different ways)
* govukSummaryList - only used on the user profile page
* govukSkiplink - we only invoke directly on the csv check page (it's also used in the main template on every page though)
* govukDetails - used in a few places for detail/summary components. 
* govukErrorSummary - only used in the new email branding flow
* govukFieldset - used in the list view for org email domains and api key guestlists
* [template.html](https://github.com/LandRegistry/govuk-frontend-jinja/blob/main/govuk_frontend_jinja/templates/template.html) - used on every single page as the base that we build from. Take a look at the source code linked to see what it does

as ever, take a look at each commit for a simpler diff

requires the checkboxes PR:

- [x] https://github.com/alphagov/notifications-admin/pull/4429