### PR TITLE
Increase height of placeholder redaction mask

### DIFF
--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -43,7 +43,7 @@
   background: currentColor;
   padding: 0 0.5em;
   opacity: 0.8;
-  box-shadow: inset 0 -0.35em 0 0 govuk-colour("white");
+  box-shadow: inset 0 -0.25em 0 0 govuk-colour("white");
   position: relative;
   top: 0.1em;
 

--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -43,7 +43,7 @@
   background: currentColor;
   padding: 0 0.5em;
   opacity: 0.8;
-  box-shadow: inset 0 -0.25em 0 0 govuk-colour("white");
+  box-shadow: inset 0 0.05em 0 0 govuk-colour("white"), inset 0 -0.25em 0 0 govuk-colour("white");
   position: relative;
   top: 0.1em;
 


### PR DESCRIPTION
The GDS Transport font, which we moved to recently, sits slightly lower on the line which seems to have resulted in the text we display for redacted placeholders poking out from below the bottom of the mask we cover it with.

This increases the height of the mask so it covers its text again.

Note: We also replace the text of any placeholders with 'hidden' so this issue will not have
disclosed any information set as redacted.

## Before these changes

<img width="557" alt="redacted_content_fix_before" src="https://user-images.githubusercontent.com/87140/200817099-02057d15-a602-4bf6-8ef9-68a3c065c7bd.png">

## With these changes

<img width="539" alt="redacted_content_fix_after" src="https://user-images.githubusercontent.com/87140/200817147-e048a1ba-df03-435f-8783-ba7240c66434.png">
