### PR TITLE
Upload a logo

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -469,6 +469,11 @@ class HexColourCodeField(GovukTextInputField):
     def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
         if validators is None:
             validators = []
+        else:
+            # Make a copy of the validators list, as field validators are usually instantiated at the class-level,
+            # meaning the list is shared between all instances. We want to potentially modify the validators, so we need
+            # to create a new list.
+            validators = validators[:]
 
         validators.append(Regexp(regex="^$|^#?(?:[0-9a-fA-F]{3}){1,2}$", message="Must be a valid hex colour code"))
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1949,6 +1949,17 @@ class SVGFileUpload(StripWhitespaceForm):
     )
 
 
+class PNGFileUpload(StripWhitespaceForm):
+    file = VirusScannedFileField(
+        "Upload a logo",
+        validators=[
+            DataRequired(message="You need to upload a file to submit"),
+            FileSize(max_size=(2 * 1024 * 1024), message="File must be smaller than 2MB"),
+            FileAllowed(["png"], "That is not a PNG file"),
+        ],
+    )
+
+
 class PDFUploadForm(StripWhitespaceForm):
     file = VirusScannedFileField(
         "Upload a letter in PDF format",

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -33,7 +33,6 @@ from app import (
     service_api_client,
     upload_api_client,
 )
-from app.extensions import antivirus_client
 from app.main import main
 from app.main.forms import CsvUploadForm, LetterUploadPostageForm, PDFUploadForm
 from app.models.contact_list import ContactList
@@ -151,11 +150,6 @@ def upload_letter(service_id):
         pdf_file_bytes = form.file.data.read()
         original_filename = form.file.data.filename
 
-        if current_app.config["ANTIVIRUS_ENABLED"]:
-            virus_free = antivirus_client.scan(BytesIO(pdf_file_bytes))
-            if not virus_free:
-                return invalid_upload_error("Your file contains a virus")
-
         if len(pdf_file_bytes) > MAX_FILE_UPLOAD_SIZE:
             return invalid_upload_error("Your file is too big", "Files must be smaller than 2MB.")
 
@@ -227,7 +221,7 @@ def upload_letter(service_id):
     if form.file.errors:
         error = _get_error_from_upload_form(form.file.errors[0])
 
-    return render_template("views/uploads/choose-file.html", error=error, form=form)
+    return render_template("views/uploads/choose-file.html", error=error, form=form), 400 if error else 200
 
 
 def invalid_upload_error(error_title, error_detail=None):

--- a/app/s3_client/s3_logo_client.py
+++ b/app/s3_client/s3_logo_client.py
@@ -43,9 +43,12 @@ def get_letter_filename_with_no_path_or_extension(filename):
     return filename[len(LETTER_PREFIX) : -4]
 
 
-def upload_email_logo(filename, filedata, region, user_id):
+def upload_email_logo(filename, filedata, region, user_id, unique_id: str = None):
+    if not unique_id:
+        unique_id = str(uuid.uuid4())
+
     upload_file_name = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=str(uuid.uuid4()), filename=filename
+        temp=TEMP_TAG.format(user_id=user_id), unique_id=unique_id, filename=filename
     )
     bucket_name = current_app.config["LOGO_UPLOAD_BUCKET_NAME"]
     utils_s3upload(
@@ -59,8 +62,11 @@ def upload_email_logo(filename, filedata, region, user_id):
     return upload_file_name
 
 
-def upload_letter_temp_logo(filename, filedata, region, user_id):
-    upload_filename = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=str(uuid.uuid4()), filename=filename)
+def upload_letter_temp_logo(filename, filedata, region, user_id, unique_id: str = None):
+    if not unique_id:
+        unique_id = str(uuid.uuid4())
+
+    upload_filename = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=unique_id, filename=filename)
     bucket_name = current_app.config["LOGO_UPLOAD_BUCKET_NAME"]
     utils_s3upload(
         filedata=filedata,

--- a/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
@@ -1,0 +1,49 @@
+{% extends "withnav_template.html" %}
+{% from "components/form.html" import form_wrapper %}
+{% from "components/file-upload.html" import file_upload %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
+
+{% block service_page_title %}
+  {{ form.file.label.text }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({"href": back_link }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {% if form.file.errors %}
+    {% set params = {
+        "titleText": "There is a problem",
+        "errorList": [{"href": "#" + form.file.id, "text": form.file.errors[0]}]
+      }
+    %}
+    {{ govukErrorSummary(params) }}
+  {% endif %}
+
+  {{ page_header(form.file.label.text) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>a landscape image</li>
+        <li>at least 108 pixels high</li>
+        <li>saved as a PNG file</li>
+        <li>with a transparent background</li>
+      </ul>
+      <p class="govuk-body">
+        We do not recommend portrait images because they’ll look very small. This is because the space for email branding has a fixed height.
+      </p>
+        {{ file_upload(form.file, allowed_file_extensions=['png'], button_text='Upload logo') }}
+      <p class="govuk-body govuk-!-margin-top-4">
+        If you do not have a file, you can
+        <a class="govuk-link" href="{{ url_for('main.email_branding_name_logo', service_id=current_service.id) }}">skip this step</a>.
+      </p>
+    </div>
+
+{% endblock %}

--- a/tests/app/s3_client/test_s3_logo_client.py
+++ b/tests/app/s3_client/test_s3_logo_client.py
@@ -51,12 +51,41 @@ def test_upload_email_logo_calls_correct_args(client_request, mocker, fake_uuid,
     )
 
 
+def test_upload_email_logo_allows_passing_unique_id(client_request, mocker, fake_uuid, upload_filename):
+    mocker.patch.dict("flask.current_app.config", {"LOGO_UPLOAD_BUCKET_NAME": bucket})
+    mocked_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
+
+    upload_email_logo(filename=filename, user_id=fake_uuid, filedata=data, region=region, unique_id=upload_id)
+
+    mocked_s3_upload.assert_called_once_with(
+        filedata=data, region=region, file_location=upload_filename, bucket_name=bucket, content_type="image/png"
+    )
+
+
 def test_upload_letter_temp_logo_calls_correct_args(mocker, fake_uuid, letter_upload_filename):
     mocker.patch("uuid.uuid4", return_value=upload_id)
     mocker.patch.dict("flask.current_app.config", {"LOGO_UPLOAD_BUCKET_NAME": bucket})
     mocked_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
 
     new_filename = upload_letter_temp_logo(filename=svg_filename, user_id=fake_uuid, filedata=data, region=region)
+
+    mocked_s3_upload.assert_called_once_with(
+        filedata=data,
+        region=region,
+        bucket_name=bucket,
+        file_location=letter_upload_filename,
+        content_type="image/svg+xml",
+    )
+    assert new_filename == "letters/static/images/letter-template/temp-{}_test_uuid-test.svg".format(fake_uuid)
+
+
+def test_upload_letter_temp_logo_allows_passing_unique_id(mocker, fake_uuid, letter_upload_filename):
+    mocker.patch.dict("flask.current_app.config", {"LOGO_UPLOAD_BUCKET_NAME": bucket})
+    mocked_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
+
+    new_filename = upload_letter_temp_logo(
+        filename=svg_filename, user_id=fake_uuid, filedata=data, region=region, unique_id=upload_id
+    )
 
     mocked_s3_upload.assert_called_once_with(
         filedata=data,

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -1,12 +1,23 @@
 import json
+from importlib import metadata
+
+from packaging.version import Version
 
 
 def test_govuk_frontend_jinja_overrides_on_design_system_v3():
     with open("package.json") as package_file:
         package_json = json.load(package_file)
+        govuk_frontend_version = Version(package_json["dependencies"]["govuk-frontend"])
 
-    assert package_json["dependencies"]["govuk-frontend"].startswith("3."), (
-        "After upgrading the Design System, manually validate that "
+    govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
+
+    # This should be checking govuk_frontend_version == 3.14.x, but we're not there yet. Update this when we are.
+    # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
+    correct_govuk_frontend_version = Version("3.0.0") <= govuk_frontend_version < Version("4.0.0")
+    correct_govuk_frontend_jinja_version = Version("1.5.0") <= govuk_frontend_jinja_version < Version("1.6.0")
+
+    assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
+        "After upgrading either of the Design System packages, you must validate that "
         "`app/templates/govuk_frontend_jinja_overrides/templates/components/*/template.html`"
         "are all structurally-correct and up-to-date macros. If not, update the macros or retire them and update the "
         "rendering process."

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -7,7 +7,7 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
 
     assert package_json["dependencies"]["govuk-frontend"].startswith("3."), (
         "After upgrading the Design System, manually validate that "
-        "`app/templates/govuk_frontend_jinja_overrides/templates/components/*/template.njk`"
+        "`app/templates/govuk_frontend_jinja_overrides/templates/components/*/template.html`"
         "are all structurally-correct and up-to-date macros. If not, update the macros or retire them and update the "
         "rendering process."
     )


### PR DESCRIPTION
Builds out the page for the 'new email branding' flow where a user can upload the logo they want to use for their brand.

We only cover off the basic validation cases here:

* Virus free
* A PNG
* Smaller than 2MB

More advanced validation will be handled as part of a separate ticket.

Ticket: https://trello.com/c/pmbh1vVQ/82-build-a-page-where-user-can-upload-a-new-logo

## DRYing stuff
As part of this ticket I've created a new file field and validator: VirusScannedFileField and FileIsVirusFree. These can be used to automatically virus scan the uploaded file before any other validation happens.

## Gif
Error page is expected - the redirected view hasn't been implemented yet.

![2022-11-10 09 19 41](https://user-images.githubusercontent.com/2920760/201050783-e95a86b3-d643-49ee-ace0-5cabdcee0ac3.gif)

