### PR TITLE
Minor content updates for platform admin branding content

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -410,14 +410,14 @@ def _handle_remove_branding(remove_branding_id) -> Optional[Response]:
     else:
         confirmation_question = Markup(
             render_template(
-                "partials/flash_messages/email_branding_confirm_remove_brand.html",
+                "partials/flash_messages/branding_confirm_remove_brand.html",
                 branding_name=remove_branding.name,
             )
         )
 
         flash(
             confirmation_question,
-            "delete",
+            "remove",
         )
 
     return None
@@ -635,7 +635,15 @@ def organisation_letter_branding(org_id):
             abort(400, f"Invalid letter branding ID {remove_branding_id} for {current_organisation}")
 
         if request.method == "GET":
-            flash(f"Are you sure you want to remove the letter brand ‘{remove_branding.name}’?", "delete")
+            flash(
+                Markup(
+                    render_template(
+                        "partials/flash_messages/branding_confirm_remove_brand.html",
+                        branding_name=remove_branding.name,
+                    )
+                ),
+                "remove",
+            )
         else:
             organisations_client.remove_letter_branding_from_pool(current_organisation.id, remove_branding_id)
             flash(f"Letter branding ‘{remove_branding.name}’ removed.", "default_with_tick")

--- a/app/templates/partials/check/letter-too-long.html
+++ b/app/templates/partials/check/letter-too-long.html
@@ -1,4 +1,4 @@
-<h1 h1 class="banner-title" data-notify-module="track-error" data-error-type="letter-too-long" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
+<h1 class="banner-title" data-notify-module="track-error" data-error-type="letter-too-long" data-error-label="precompiled letter validation failed for service_id: {{ current_service.id }}">
   Your letter is too long
 </h1>
 <p class="govuk-body">

--- a/app/templates/partials/flash_messages/branding_confirm_remove_brand.html
+++ b/app/templates/partials/flash_messages/branding_confirm_remove_brand.html
@@ -1,0 +1,4 @@
+<h2 class="banner-title">
+  Are you sure you want to remove ‘{{ branding_name }}’ branding?
+</h2>
+<p class="govuk-body"> {{ current_org.name}} services will no longer see this option.</p>

--- a/app/templates/partials/flash_messages/email_branding_confirm_remove_brand.html
+++ b/app/templates/partials/flash_messages/email_branding_confirm_remove_brand.html
@@ -1,3 +1,0 @@
-<h2 class="banner-title">
-  Are you sure you want to remove the email brand ‘{{ branding_name }}’?
-</h2>

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -50,7 +50,7 @@
       <h2 class="heading-medium">Authentication</h2>
       <p class="govuk-body">{{ user.auth_type | format_auth_type }}</p>
       {% if user.auth_type != 'webauthn_auth' %}
-        <a class="govuk-link govuk-link" href="{{ url_for('main.change_user_auth', user_id=user.id) }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.change_user_auth', user_id=user.id) }}">
           Change authentication for this user
         </a>
       {% endif %}

--- a/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-email-branding-options.html
@@ -22,7 +22,7 @@
         {{ form.branding_field }}
     </div>
   <div class="js-stick-at-bottom-when-scrolling">
-    {{ page_footer('Add options') }}
+    {{ page_footer('Add selected options') }}
     <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
       Nothing selected
     </div>

--- a/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/add-letter-branding-options.html
@@ -22,7 +22,7 @@
         {{ form.branding_field }}
     </div>
   <div class="js-stick-at-bottom-when-scrolling">
-    {{ page_footer('Add options') }}
+    {{ page_footer('Add selected options') }}
     <div class="selection-counter govuk-visually-hidden" role="status" aria-live="polite">
       Nothing selected
     </div>

--- a/app/templates/views/organisations/organisation/settings/index.html
+++ b/app/templates/views/organisations/organisation/settings/index.html
@@ -121,7 +121,7 @@
           {{ email_branding_html }}
         {% endcall %}
         {{ edit_field(
-            'Change',
+            'Manage',
             url_for('.organisation_email_branding', org_id=current_org.id),
             suffix='email branding options for the organisation'
           )
@@ -144,7 +144,7 @@
         {{ text_field('Letter branding options') }}
         {{ optional_text_field(letter_branding_pool_names, default="None") }}
         {{ edit_field(
-            'Change',
+            'Manage',
             url_for('.organisation_letter_branding', org_id=current_org.id),
             suffix='letter branding options for the organisation'
             )

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -922,9 +922,9 @@ def test_organisation_settings_for_platform_admin(
         "Request to go live notes None Change go live notes for the organisation",
         "Billing details None Change billing details for the organisation",
         "Notes None Change the notes for the organisation",
-        "Email branding options GOV.UK Default Change email branding options for the organisation",
+        "Email branding options GOV.UK Default Manage email branding options for the organisation",
         "Default letter branding No branding Change default letter branding for the organisation",
-        "Letter branding options None Change letter branding options for the organisation",
+        "Letter branding options None Manage letter branding options for the organisation",
         "Known email domains None Change known email domains for the organisation",
     ]
 
@@ -957,7 +957,7 @@ def test_organisation_settings_table_shows_email_branding_pool(
         "GOV.UK Default "
         "Email branding name 1 "
         "Email branding name 2 "
-        "Change email branding options for the organisation"
+        "Manage email branding options for the organisation"
     )
 
 
@@ -979,7 +979,7 @@ def test_organisation_settings_table_shows_letter_branding_pool(
         "Cabinet Office "
         "Department for Education "
         "Government Digital Service "
-        "Change letter branding options for the organisation"
+        "Manage letter branding options for the organisation"
     )
 
 
@@ -1017,7 +1017,7 @@ def test_organisation_settings_table_shows_email_branding_pool_non_govuk_default
         "Email branding options "
         "Email branding name 1 Default "
         "Email branding name 2 "
-        "Change email branding options for the organisation"
+        "Manage email branding options for the organisation"
     )
 
 
@@ -1035,7 +1035,7 @@ def test_organisation_settings_table_shows_email_branding_pool_govuk_default(
     email_branding_options_row = page.select("tr")[8]
 
     assert normalize_spaces(email_branding_options_row.text) == (
-        "Email branding options GOV.UK Default Change email branding options for the organisation"
+        "Email branding options GOV.UK Default Manage email branding options for the organisation"
     )
 
 

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1913,8 +1913,8 @@ def test_get_organisation_email_branding_page_with_remove_param(
         remove_branding_id="email-branding-1-id",
     )
 
-    assert "Are you sure you want to remove the email brand ‘Email branding name 1’?" in page.text
-    assert normalize_spaces(page.select_one(".banner-dangerous form button").text) == "Yes, delete"
+    assert "Are you sure you want to remove ‘Email branding name 1’ branding?" in page.text
+    assert normalize_spaces(page.select_one(".banner-dangerous form button").text) == "Yes, remove"
 
 
 def test_post_organisation_email_branding_page_with_remove_param(
@@ -2399,8 +2399,8 @@ def test_get_organisation_letter_branding_page_with_remove_param_shows_confirmat
         remove_branding_id="1234",
     )
 
-    assert "Are you sure you want to remove the letter brand ‘Cabinet Office’?" in page.text
-    assert normalize_spaces(page.select_one(".banner-dangerous form button").text) == "Yes, delete"
+    assert "Are you sure you want to remove ‘Cabinet Office’ branding?" in page.text
+    assert normalize_spaces(page.select_one(".banner-dangerous form button").text) == "Yes, remove"
 
 
 def test_post_organisation_letter_branding_page_with_remove_param_calls_client_and_redirects(

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2259,7 +2259,7 @@ def test_add_organisation_email_branding_options_shows_branding_not_in_branding_
         ("org 4", "4", False),
         ("org 5", "5", False),
     ]
-    assert normalize_spaces(page.select_one(".page-footer__button").text) == "Add options"
+    assert normalize_spaces(page.select_one(".page-footer__button").text) == "Add selected options"
 
 
 def test_add_organisation_email_branding_options_shows_error_if_no_branding_selected(
@@ -2506,7 +2506,7 @@ def test_add_organisation_letter_branding_options_shows_branding_not_in_branding
         ("Animal and Plant Health Agency", "efgh", False),
         ("Land Registry", "abcd", False),
     ]
-    assert normalize_spaces(page.select_one(".page-footer__button").text) == "Add options"
+    assert normalize_spaces(page.select_one(".page-footer__button").text) == "Add selected options"
 
 
 def test_add_organisation_letter_branding_options_shows_error_if_no_branding_selected(


### PR DESCRIPTION
This makes a few small changes to the platform admin content for both letter branding and email branding that were discussed with @karlchillmaid 

Also fixes two really minor HTML / stying things

---

## Use the word "Manage" on the organisation settings page instead of "Change"
We want to start using the term "Manage" when you have the option to change or manage more than one thing, for example email reply-to addresses. This changes the branding rows in the org settings table to fit the new pattern. Other parts of the settings table and app will be looked at later.

Settings page before             |  Settings page after
:-------------------------:|:-------------------------:
<img alt="Screenshot 2022-11-11 at 08 52 20" src="https://user-images.githubusercontent.com/12881990/201306947-b8864b39-e003-4cc3-bf67-f2684898055b.png">  |  <img alt="Screenshot 2022-11-11 at 08 52 35" src="https://user-images.githubusercontent.com/12881990/201306966-a2a9407e-45a0-41f1-a056-86ac2e164e51.png">

## Change button text when adding to branding pools
This updates the button content on the pages where a platform admin user can new email or letter brands to a branding pool from "Add options" to "Add selected options".

Button before             |  Button after
:-------------------------:|:-------------------------:
<img alt="Screenshot 2022-11-11 at 08 55 38" src="https://user-images.githubusercontent.com/12881990/201307782-348f72ea-3cfe-4420-801e-606f832e83ea.png">  |  <img alt="Screenshot 2022-11-11 at 08 55 47" src="https://user-images.githubusercontent.com/12881990/201307798-e071539f-a2c8-43fd-957c-c4971b8a970c.png">

## Update the flash confirmation when removing a brand from the pool

Flash message before             |  Flash message after
:-------------------------:|:-------------------------:
<img alt="Screenshot 2022-11-11 at 08 56 39" src="https://user-images.githubusercontent.com/12881990/201308152-63d6c5f0-c7b6-439d-8a86-60b561e8f88f.png">  |  <img  alt="Screenshot 2022-11-11 at 08 57 17" src="https://user-images.githubusercontent.com/12881990/201308172-ad69d7fa-7fe2-41b1-9924-d57a2f2dcf9e.png">




