### PR TITLE
Revert some deps, freeze requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 ago==0.0.95
 govuk-bank-holidays==0.11
 humanize==4.4.0
-Flask==2.2.2
+Flask==2.1.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
 Flask-Login==0.6.2

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ Flask==2.1.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
 Flask-Login==0.6.2
-Werkzeug==2.2.2
+Werkzeug==2.1.2
 jinja2==3.1.2
 
 blinker==1.5

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ humanize==4.4.0
 Flask==2.1.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
-Flask-Login==0.6.2
+Flask-Login==0.6.1
 Werkzeug==2.1.2
 jinja2==3.1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -172,7 +172,7 @@ python-dateutil==2.8.2
     #   botocore
 python-json-logger==2.0.4
     # via notifications-utils
-pytz==2022.5
+pytz==2022.6
     # via
     #   -r requirements.in
     #   notifications-utils


### PR DESCRIPTION
PyUp changes `requirements.in` and not `requirements.txt` so didn't actually bump the dependencies 🤦 

This freezes them - and reverts the changes to flask(/login)+werkzeug which require code changes to accept.

I want to update the concourse pipelines to add a check so we can't merge PRs that edit requirements.in without editing requirements.txt, but I don't have VPN access right now so that'll come later.