### PR TITLE
Re-label the ‘upload logo’ radio button

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2193,7 +2193,7 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
             },
         },
         "org": {
-            "label": "Upload a logo",
+            "label": "Use your own logo",
             "image": {
                 "url": asset_fingerprinter.get_url("images/branding/org.png"),
                 "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -853,7 +853,7 @@ def test_email_branding_choose_logo_page(client_request, service_one):
         for i, radio in enumerate(page.select("input[type=radio]"))
     ] == [
         ("single_identity", "Create a government identity logo"),
-        ("org", "Upload a logo"),
+        ("org", "Use your own logo"),
     ]
 
 


### PR DESCRIPTION
At the moment this options takes you to the existing journey, where you write some text and raise a ticket.

In the future this option will take you to the upload pages, but for now the label should reflect what the subsequent page is currently.

Before | After 
---|---
<img width="783" alt="image" src="https://user-images.githubusercontent.com/355079/201366243-7d84e298-2f7c-4e92-acd6-376289f09437.png"> | <img width="793" alt="image" src="https://user-images.githubusercontent.com/355079/201366356-7c476b5a-983a-4555-aa85-91274b78a257.png">
<img width="777" alt="image" src="https://user-images.githubusercontent.com/355079/201366418-d9da2b37-d003-47c9-aee6-2d9123a0764a.png"> | <img width="777" alt="image" src="https://user-images.githubusercontent.com/355079/201366418-d9da2b37-d003-47c9-aee6-2d9123a0764a.png">

