### PR TITLE
Refactor form widgets

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -5,7 +5,7 @@ from itertools import chain
 from numbers import Number
 
 import pytz
-from flask import Markup, render_template_string, request
+from flask import Markup, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileAllowed
@@ -81,52 +81,13 @@ from app.models.branding import (
 from app.models.feedback import PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE
 from app.models.organisation import Organisation
 from app.utils import branding, merge_jsonlike
+from app.utils.govuk_frontend_field import render_govuk_frontend_macro
 from app.utils.user import distinct_email_addresses
 from app.utils.user_permissions import (
     all_ui_permissions,
     broadcast_permission_options,
     permission_options,
 )
-
-
-def render_govuk_frontend_macro(component, params):
-    """
-    jinja needs a template to render
-
-    This function creates a template string that just calls that macro on its own.
-
-    ```
-    {%- from <path> import <macro> -%}
-
-    {{ macro(params) }}
-    ```
-
-    This function dynamically fills in the path and macro based on the GOVUK_FRONTEND_MACROS dictionary.
-    Then we render that template with any params to produce just the output of that macro.
-    """
-    govuk_frontend_components = {
-        "radios": {"path": "govuk_frontend_jinja/components/radios/macro.html", "macro": "govukRadios"},
-        "radios-with-images": {
-            "path": "govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html",
-            "macro": "govukRadiosWithImages",
-        },
-        "text-input": {"path": "govuk_frontend_jinja/components/input/macro.html", "macro": "govukInput"},
-        "textarea": {"path": "govuk_frontend_jinja/components/textarea/macro.html", "macro": "govukTextarea"},
-        "checkbox": {
-            "path": "govuk_frontend_jinja_overrides/templates/components/checkboxes/macro.html",
-            "macro": "govukCheckboxes",
-        },
-    }
-
-    # we need to duplicate all curly braces to escape them from the f string so jinja still sees them
-    template_string = f"""
-        {{%- from '{govuk_frontend_components[component]['path']}'
-        import {govuk_frontend_components[component]['macro']} -%}}
-
-        {{{{ {govuk_frontend_components[component]['macro']}(params) }}}}
-    """
-
-    return Markup(render_template_string(template_string, params=params))
 
 
 def get_time_value_and_label(future_time):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -80,7 +80,7 @@ from app.models.branding import (
 )
 from app.models.feedback import PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE
 from app.models.organisation import Organisation
-from app.utils import branding, merge_jsonlike
+from app.utils import branding
 from app.utils.govuk_frontend_field import (
     GovukFrontendWidgetMixin,
     render_govuk_frontend_macro,
@@ -193,10 +193,6 @@ class GovukTextInputFieldMixin(GovukFrontendWidgetMixin):
 class UKMobileNumber(GovukTextInputFieldMixin, TelField):
     input_type = "tel"
 
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(UKMobileNumber, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
-
     def pre_validate(self, form):
         try:
             validate_phone_number(self.data)
@@ -233,66 +229,42 @@ def password(label="Password"):
 
 
 class GovukTextInputField(GovukTextInputFieldMixin, StringField):
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukTextInputField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
+    pass
 
 
 class GovukPasswordField(GovukTextInputFieldMixin, PasswordField):
     input_type = "password"
-
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukPasswordField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
 
 
 class GovukEmailField(GovukTextInputFieldMixin, EmailField):
     input_type = "email"
     param_extensions = {"attributes": {"spellcheck": "false"}}  # email addresses don't need to be spellchecked
 
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukEmailField, self).__init__(label, validators=validators, **kwargs)
-        merge_jsonlike(self.param_extensions, param_extensions)
-
 
 class GovukSearchField(GovukTextInputFieldMixin, SearchField):
     input_type = "search"
     param_extensions = {"classes": "govuk-!-width-full"}  # email addresses don't need to be spellchecked
 
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukSearchField, self).__init__(label, validators, **kwargs)
-        merge_jsonlike(self.param_extensions, param_extensions)
-
 
 class GovukDateField(GovukTextInputFieldMixin, DateField):
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukDateField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
+    pass
 
 
 class GovukIntegerField(GovukTextInputFieldMixin, IntegerField):
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukIntegerField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
+    pass
 
 
 class SMSCode(GovukTextInputField):
     # the design system recommends against ever using `type="number"`. "tel" makes mobile browsers
     # show a phone keypad input rather than a full qwerty keyboard.
     input_type = "tel"
+    param_extensions = {"attributes": {"pattern": "[0-9]*"}}
     validators = [
         DataRequired(message="Cannot be empty"),
         Regexp(regex=r"^\d+$", message="Numbers only"),
         Length(min=5, message="Not enough numbers"),
         Length(max=5, message="Too many numbers"),
     ]
-
-    def __call__(self, **kwargs):
-        params = {"attributes": {"pattern": "[0-9]*"}}
-        if "param_extensions" in kwargs:
-            merge_jsonlike(kwargs["param_extensions"], params)
-
-        return super().__call__(**kwargs)
 
     def process_formdata(self, valuelist):
         if valuelist:
@@ -361,7 +333,7 @@ class ForgivingIntegerField(GovukTextInputField):
 
 
 class HexColourCodeField(GovukTextInputField):
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
+    def __init__(self, label="", validators=None, **kwargs):
         if validators is None:
             validators = []
         else:
@@ -372,7 +344,7 @@ class HexColourCodeField(GovukTextInputField):
 
         validators.append(Regexp(regex="^$|^#?(?:[0-9a-fA-F]{3}){1,2}$", message="Must be a valid hex colour code"))
 
-        super().__init__(label, validators, param_extensions=param_extensions, **kwargs)
+        super().__init__(label, validators, **kwargs)
 
     def post_validate(self, form, validation_stopped):
         if not self.errors:
@@ -501,7 +473,7 @@ class StripWhitespaceForm(Form):
 
 
 class StripWhitespaceStringField(GovukTextInputField):
-    def __init__(self, label=None, param_extensions=None, **kwargs):
+    def __init__(self, label=None, **kwargs):
         kwargs["filters"] = tuple(
             chain(
                 kwargs.get("filters", ()),
@@ -509,7 +481,6 @@ class StripWhitespaceStringField(GovukTextInputField):
             )
         )
         super(GovukTextInputField, self).__init__(label, **kwargs)
-        self.param_extensions = param_extensions
 
 
 class PostalAddressField(TextAreaField):
@@ -587,10 +558,6 @@ class RegisterUserFromOrgInviteForm(StripWhitespaceForm):
 class GovukCheckboxField(GovukFrontendWidgetMixin, BooleanField):
     govuk_frontend_component_name = "checkbox"
 
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukCheckboxField, self).__init__(label, validators, false_values=None, **kwargs)
-        self.param_extensions = param_extensions
-
     def prepare_params(self, **kwargs):
         params = {
             "name": self.name,
@@ -602,10 +569,6 @@ class GovukCheckboxField(GovukFrontendWidgetMixin, BooleanField):
 
 class GovukTextareaField(GovukFrontendWidgetMixin, TextAreaField):
     govuk_frontend_component_name = "textarea"
-
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(TextAreaField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
 
     def prepare_params(self, **kwargs):
         # error messages
@@ -629,10 +592,6 @@ class GovukTextareaField(GovukFrontendWidgetMixin, TextAreaField):
 class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
     govuk_frontend_component_name = "checkbox"
     render_as_list = False
-
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukCheckboxesField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
 
     def get_item_from_option(self, option):
         return {
@@ -669,10 +628,9 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
 class GovukCollapsibleCheckboxesField(GovukCheckboxesField):
     param_extensions = {"hint": {"html": '<div class="selection-summary" role="region" aria-live="polite"></div>'}}
 
-    def __init__(self, label="", validators=None, field_label="", param_extensions=None, **kwargs):
-        super(GovukCollapsibleCheckboxesField, self).__init__(label, validators, param_extensions, **kwargs)
+    def __init__(self, *args, field_label="", **kwargs):
         self.field_label = field_label
-        merge_jsonlike(self.param_extensions, param_extensions)
+        super().__init__(*args, **kwargs)
 
     def widget(self, *args, **kwargs):
         checkboxes_string = super().widget(*args, **kwargs)
@@ -699,10 +657,6 @@ class GovukCollapsibleNestedCheckboxesField(NestedFieldMixin, GovukCollapsibleCh
 
 class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
     govuk_frontend_component_name = "radios"
-
-    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
-        super(GovukRadiosField, self).__init__(label, validators, **kwargs)
-        self.param_extensions = param_extensions
 
     def get_item_from_option(self, option):
         return {
@@ -788,13 +742,12 @@ class GovukRadiosFieldWithNoneOption(FieldWithNoneOption, GovukRadiosField):
 class GovukRadiosWithImagesField(GovukRadiosField):
     govuk_frontend_component_name = "radios-with-images"
 
-    def __init__(self, label="", validators=None, param_extensions=None, image_data=None, **kwargs):
+    def __init__(self, label="", validators=None, image_data=None, **kwargs):
         if image_data is None:
             raise RuntimeError("Must provide `image_data` to initialiser")
 
         super(GovukRadiosField, self).__init__(label, validators, **kwargs)
 
-        self.param_extensions = param_extensions
         self.image_data = image_data
 
     def get_item_from_option(self, option):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -174,23 +174,12 @@ class GovukTextInputFieldMixin(GovukFrontendWidgetMixin):
         value = kwargs["value"] if "value" in kwargs else self.data
         value = str(value) if isinstance(value, Number) else value
 
-        # error messages
-        error_message = None
-        if self.errors:
-            error_message_format = "html" if kwargs.get("error_message_with_html") else "text"
-            error_message = {
-                "attributes": {
-                    "data-notify-module": "track-error",
-                    "data-error-type": self.errors[0],
-                    "data-error-label": self.name,
-                },
-                error_message_format: self.errors[0],
-            }
+        error_message_format = "html" if kwargs.get("error_message_with_html") else "text"
 
         # convert to parameters that govuk understands
         params = {
             "classes": "govuk-!-width-two-thirds",
-            "errorMessage": error_message,
+            "errorMessage": self.get_error_message(error_message_format),
             "id": self.id,
             "label": {"text": self.label.text},
             "name": self.name,
@@ -603,20 +592,9 @@ class GovukCheckboxField(GovukFrontendWidgetMixin, BooleanField):
         self.param_extensions = param_extensions
 
     def prepare_params(self, **kwargs):
-        error_message = None
-        if self.errors:
-            error_message = {
-                "attributes": {
-                    "data-notify-module": "track-error",
-                    "data-error-type": self.errors[0],
-                    "data-error-label": self.name,
-                },
-                "text": self.errors[0],
-            }
-
         params = {
             "name": self.name,
-            "errorMessage": error_message,
+            "errorMessage": self.get_error_message(),
             "items": [{"name": self.name, "id": self.id, "text": self.label.text, "value": "y", "checked": self.data}],
         }
         return params
@@ -669,18 +647,6 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
         return [self.get_item_from_option(option) for option in field]
 
     def prepare_params(self, **kwargs):
-        # error messages
-        error_message = None
-        if self.errors:
-            error_message = {
-                "attributes": {
-                    "data-notify-module": "track-error",
-                    "data-error-type": self.errors[0],
-                    "data-error-label": self.name,
-                },
-                "text": self.errors[0],
-            }
-
         # returns either a list or a hierarchy of lists
         # depending on how get_items_from_options is implemented
         items = self.get_items_from_options(self)
@@ -692,7 +658,7 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
                 "legend": {"text": self.label.text, "classes": "govuk-fieldset__legend--s"},
             },
             "asList": self.render_as_list,
-            "errorMessage": error_message,
+            "errorMessage": self.get_error_message(),
             "items": items,
         }
 
@@ -751,19 +717,6 @@ class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
         return [self.get_item_from_option(option) for option in field]
 
     def prepare_params(self, **kwargs):
-
-        # error messages
-        error_message = None
-        if self.errors:
-            error_message = {
-                "attributes": {
-                    "data-notify-module": "track-error",
-                    "data-error-type": self.errors[0],
-                    "data-error-label": self.name,
-                },
-                "text": self.errors[0],
-            }
-
         # returns either a list or a hierarchy of lists
         # depending on how get_items_from_options is implemented
         items = self.get_items_from_options(self)
@@ -774,7 +727,7 @@ class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
                 "attributes": {"id": self.name},
                 "legend": {"text": self.label.text, "classes": "govuk-fieldset__legend--s"},
             },
-            "errorMessage": error_message,
+            "errorMessage": self.get_error_message(),
             "items": items,
         }
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -799,7 +799,7 @@ class GovukTextareaField(GovukFrontendWidgetMixin, TextAreaField):
         super(TextAreaField, self).__init__(label, validators, **kwargs)
         self.param_extensions = param_extensions
 
-    def prepare_params(self, param_extensions=None, **kwargs):
+    def prepare_params(self, **kwargs):
         # error messages
         error_message = None
         if self.errors:
@@ -813,14 +813,6 @@ class GovukTextareaField(GovukFrontendWidgetMixin, TextAreaField):
             "hint": {"text": None},
             "errorMessage": error_message,
         }
-
-        # extend default params with any sent in during instantiation
-        if self.param_extensions:
-            merge_jsonlike(params, self.param_extensions)
-
-        # add any sent in though use in templates
-        if param_extensions:
-            merge_jsonlike(params, param_extensions)
 
         return params
 

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -1,0 +1,41 @@
+from flask import Markup, render_template_string
+
+
+def render_govuk_frontend_macro(component, params):
+    """
+    jinja needs a template to render but govuk_frontend_jinja only provides macros
+
+    This function creates a template string that just calls the macro for `component` and returns the result.
+
+    ```
+    {%- from <path> import <macro> -%}
+
+    {{ macro(params) }}
+    ```
+
+    This function dynamically fills in the path and macro based on the GOVUK_FRONTEND_MACROS dictionary.
+    Then we render that template with any params to produce just the output of that macro.
+    """
+    govuk_frontend_components = {
+        "radios": {"path": "govuk_frontend_jinja/components/radios/macro.html", "macro": "govukRadios"},
+        "radios-with-images": {
+            "path": "govuk_frontend_jinja_overrides/templates/components/radios-with-images/macro.html",
+            "macro": "govukRadiosWithImages",
+        },
+        "text-input": {"path": "govuk_frontend_jinja/components/input/macro.html", "macro": "govukInput"},
+        "textarea": {"path": "govuk_frontend_jinja/components/textarea/macro.html", "macro": "govukTextarea"},
+        "checkbox": {
+            "path": "govuk_frontend_jinja_overrides/templates/components/checkboxes/macro.html",
+            "macro": "govukCheckboxes",
+        },
+    }
+
+    # we need to duplicate all curly braces to escape them from the f string so jinja still sees them
+    template_string = f"""
+        {{%- from '{govuk_frontend_components[component]['path']}'
+        import {govuk_frontend_components[component]['macro']} -%}}
+
+        {{{{ {govuk_frontend_components[component]['macro']}(params) }}}}
+    """
+
+    return Markup(render_template_string(template_string, params=params))

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -1,4 +1,35 @@
+from abc import ABC, abstractmethod
+
 from flask import Markup, render_template_string
+
+
+class GovukFrontendWidgetMixin(ABC):
+    @property
+    @abstractmethod
+    def govuk_frontend_component_name(self):
+        """
+        Should be a string matching a key in the `govuk_frontend_components` dict - which roughly
+        matches up with URLs found in https://design-system.service.gov.uk/components/
+        """
+        pass
+
+    def prepare_params(self, **kwargs):
+        """
+        Should return a dictionary that will be passed through to the macro as `params` for use within the component
+        """
+        return {}
+
+    def widget(self, _field, **kwargs):
+        """
+        override the widget function, which is called from the html template when rendering
+
+        see https://wtforms.readthedocs.io/en/3.0.x/widgets/
+        """
+        # widget always has a `field` param passed in as a positional, however, we're in a member function of a
+        # Field class so can just discard it, `self == _field` is always true
+        params = self.prepare_params(**kwargs)
+
+        return render_govuk_frontend_macro(self.govuk_frontend_component_name, params)
 
 
 def render_govuk_frontend_macro(component, params):

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -8,6 +8,10 @@ from app.utils import merge_jsonlike
 class GovukFrontendWidgetMixin(ABC):
     param_extensions = {}
 
+    def __init__(self, label="", validators=None, param_extensions=None, **kwargs):
+        super().__init__(label, validators, **kwargs)
+        merge_jsonlike(self.param_extensions, param_extensions)
+
     @property
     @abstractmethod
     def govuk_frontend_component_name(self):

--- a/app/utils/govuk_frontend_field.py
+++ b/app/utils/govuk_frontend_field.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 
 from flask import Markup, render_template_string
 
+from app.utils import merge_jsonlike
+
 
 class GovukFrontendWidgetMixin(ABC):
     @property
@@ -28,6 +30,14 @@ class GovukFrontendWidgetMixin(ABC):
         # widget always has a `field` param passed in as a positional, however, we're in a member function of a
         # Field class so can just discard it, `self == _field` is always true
         params = self.prepare_params(**kwargs)
+
+        # extend default params with any sent in during instantiation
+        if self.param_extensions:
+            merge_jsonlike(params, self.param_extensions)
+
+        # add any sent in though use in templates
+        if "param_extensions" in kwargs:
+            merge_jsonlike(params, kwargs["param_extensions"])
 
         return render_govuk_frontend_macro(self.govuk_frontend_component_name, params)
 

--- a/tests/app/main/forms/test_govuk_frontend_field.py
+++ b/tests/app/main/forms/test_govuk_frontend_field.py
@@ -1,0 +1,20 @@
+from flask_wtf import FlaskForm as Form
+from wtforms import StringField
+
+from app.utils.govuk_frontend_field import GovukFrontendWidgetMixin
+
+
+def test_govuk_frontend_widget_mixin_separates_params_properly(client_request):
+    class MyField(GovukFrontendWidgetMixin, StringField):
+        govuk_frontend_component_name = "foo"
+
+    class FormOne(Form):
+        field = MyField("label1", param_extensions={"foo": "bar"})
+
+    class FormTwo(Form):
+        field = MyField("label2", param_extensions={"baz": "waz"})
+
+    form1 = FormOne()
+    form2 = FormTwo()
+    assert form1.field.param_extensions == {"foo": "bar"}
+    assert form2.field.param_extensions == {"baz": "waz"}

--- a/tests/app/main/forms/test_govuk_frontend_field.py
+++ b/tests/app/main/forms/test_govuk_frontend_field.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 from flask_wtf import FlaskForm as Form
 from wtforms import StringField
 
@@ -18,3 +20,71 @@ def test_govuk_frontend_widget_mixin_separates_params_properly(client_request):
     form2 = FormTwo()
     assert form1.field.param_extensions == {"foo": "bar"}
     assert form2.field.param_extensions == {"baz": "waz"}
+
+
+def test_govuk_frontend_widget_mixin_calls_render(client_request, mocker):
+    mock_render = mocker.patch("app.utils.govuk_frontend_field.render_govuk_frontend_macro", return_value="my html")
+
+    class MyField(GovukFrontendWidgetMixin, StringField):
+        govuk_frontend_component_name = "component"
+
+    class MyForm(Form):
+        field = MyField()
+
+    my_form = MyForm()
+
+    rendered_field = my_form.field()
+
+    assert rendered_field == mock_render.return_value
+    mock_render.assert_called_once_with("component", {})
+
+
+def test_govuk_frontend_widget_mixin_takes_instance_params_over_class_params(client_request, mocker):
+    mock_render = mocker.patch("app.utils.govuk_frontend_field.render_govuk_frontend_macro", return_value="my html")
+
+    class MyField(GovukFrontendWidgetMixin, StringField):
+        govuk_frontend_component_name = "component"
+        param_extensions = {"foo": "bar"}
+
+    class MyForm(Form):
+        field = MyField(param_extensions={"foo": "baz"})
+
+    MyForm().field()
+
+    mock_render.assert_called_once_with(ANY, {"foo": "baz"})
+
+
+def test_govuk_frontend_widget_mixin_takes_render_params_over_class_params(client_request, mocker):
+    mock_render = mocker.patch("app.utils.govuk_frontend_field.render_govuk_frontend_macro", return_value="my html")
+
+    class MyField(GovukFrontendWidgetMixin, StringField):
+        govuk_frontend_component_name = "component"
+        param_extensions = {"foo": "bar"}
+
+    class MyForm(Form):
+        field = MyField(param_extensions={"foo": "baz"})
+
+    MyForm().field(param_extensions={"foo": "waz"})
+
+    mock_render.assert_called_once_with(ANY, {"foo": "waz"})
+
+
+def test_govuk_frontend_widget_mixin_constructs_errors(client_request):
+    class MyField(GovukFrontendWidgetMixin, StringField):
+        govuk_frontend_component_name = "component"
+
+    class MyForm(Form):
+        field = MyField("some-name")
+
+    my_form = MyForm()
+    my_form.field.errors = ["some error message"]
+
+    ret = my_form.field.get_error_message(error_message_format="html")
+    assert ret == {
+        "attributes": {
+            "data-error-label": "field",
+            "data-error-type": "some error message",
+            "data-notify-module": "track-error",
+        },
+        "html": "some error message",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2749,12 +2749,13 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
             page = NotifyBeautifulSoup(resp.data.decode("utf-8"), "html.parser")
 
             if _test_page_title:
-                count_of_h1s = len(page.select("h1"))
-                if count_of_h1s != 1:
-                    raise AssertionError("Page should have one H1 ({} found)".format(count_of_h1s))
+                # Page should have one H1
+                assert len(page.select("h1")) == 1
                 page_title, h1 = (normalize_spaces(page.select_one(selector).text) for selector in ("title", "h1"))
-                if not normalize_spaces(page_title).startswith(h1):
-                    raise AssertionError("Page title ‘{}’ does not start with H1 ‘{}’".format(page_title, h1))
+                assert normalize_spaces(page_title).startswith(
+                    h1
+                ), f"Page {url} title '{page_title}' does not start with H1 '{h1}'"
+
             if _test_for_elements_without_class and _expected_status not in (301, 302):
                 for tag, hint in (
                     ("p", "govuk-body"),


### PR DESCRIPTION
Inspired by @CrystalPea asking why we had the same comment 10 times throughout forms.py on the widget function, I took the opportunity to move the govuk frontend component logic out to its own base class, and "simply" use that base class from all the various field options.

The new base class has a `govuk_frontend_component_name` variable which needs to be defined. 

It then has a `prepare_params` function which should be overriden to return a params dictionary. This params dict should contain the `errorMessage` key if relevant, however you can use `GovukFrontendField.get_error_message` to help you build that errorMessage up. Those params are then combined with `param_extensions`. Then the component is rendered as normal.

No actual functionality or implementation has changed here. (Perhaps some fields are marginally more flexible now, if they now handle param_extensions where they didn't previously etc).

This is really really definitely best reviewed commit by commit.