### PR TITLE
Generate param_extensions in init

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2218,17 +2218,17 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
         "Choose a logo for your emails",
         choices=tuple((key, value["label"]) for key, value in BRANDING_OPTIONS_DATA.items()),
         image_data={key: value["image"] for key, value in BRANDING_OPTIONS_DATA.items()},
-        param_extensions={
-            "classes": "govuk-radios--inline",
-            "fieldset": {"legend": {"classes": "govuk-fieldset__legend--l", "isPageHeading": True}},
-        },
     )
 
     def __init__(self, service, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.branding_options.param_extensions = {
+            "classes": "govuk-radios--inline",
+            "fieldset": {"legend": {"classes": "govuk-fieldset__legend--l", "isPageHeading": True}},
+        }
         if not service.email_branding_id:
             self.branding_options.param_extensions["hint"] = {
-                "html": (f"{service.name} branding is not set up yet."),
+                "html": f"{service.name} branding is not set up yet.",
                 "classes": "notify-hint--paragraph",
             }
 


### PR DESCRIPTION
We are editing a dictionary in the __init__ method for EmailBrandingChooseLogoForm, which is stored on the class. This can lead to data being mutated between requests on the same worker.

Let's build a whole new param_extensions dict every time we instantiate the form, rather than injecting into an existing dict.