### PR TITLE
Bump Flask/Flask-Login/Werkzeug

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -294,7 +294,7 @@ def load_service_before_request():
 
     if service_id:
         try:
-            g.current_service = Service(service_api_client.get_service(service_id)["data"])
+            g.current_service = Service.from_id(service_id)
         except HTTPError as exc:
             # if service id isn't real, then 404 rather than 500ing later because we expect service to be set
             if exc.status_code == 404:

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -44,7 +44,6 @@ def manage_users(service_id):
 @main.route("/services/<uuid:service_id>/users/invite/<uuid:user_id>", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def invite_user(service_id, user_id=None):
-
     if current_service.has_permission("broadcast"):
         form_class = BroadcastInviteUserForm
     else:

--- a/requirements.in
+++ b/requirements.in
@@ -4,11 +4,11 @@
 ago==0.0.95
 govuk-bank-holidays==0.11
 humanize==4.4.0
-Flask==2.1.2
+Flask==2.2.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
 Flask-Login==0.6.2
-Werkzeug==2.1.2
+Werkzeug==2.2.2
 jinja2==3.1.2
 
 blinker==1.5

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ humanize==4.4.0
 Flask==2.1.2
 Flask-WTF==1.0.1
 wtforms==3.0.1
-Flask-Login==0.6.1
+Flask-Login==0.6.2
 Werkzeug==2.1.2
 jinja2==3.1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ flask==2.1.2
     #   flask-wtf
     #   gds-metrics
     #   notifications-utils
-flask-login==0.6.1
+flask-login==0.6.2
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2694,9 +2694,7 @@ def test_organisation_billing_page_when_the_agreement_is_signed_by_a_known_perso
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
 
     client_request.login(platform_admin_user)
-
-    mocker.patch("app.user_api_client.get_user", side_effect=[platform_admin_user, api_user_active])
-
+    mocker.patch("app.user_api_client.get_user", return_value=api_user_active)
     page = client_request.get(
         ".organisation_billing",
         org_id=ORGANISATION_ID,

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -1,5 +1,6 @@
 import pytest
 from flask import url_for
+from flask_login import current_user
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 
@@ -11,7 +12,7 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 def test_non_gov_user_cannot_see_add_service_button(
     client_request,
     mock_login,
-    mock_get_non_govuser,
+    login_non_govuser,
     api_nongov_user_active,
     mock_get_organisations,
     mock_get_organisations_and_services_for_user,
@@ -337,11 +338,11 @@ def test_should_return_form_errors_with_duplicate_service_name_regardless_of_cas
 
 def test_non_government_user_cannot_access_create_service_page(
     client_request,
-    mock_get_non_govuser,
+    login_non_govuser,
     api_nongov_user_active,
     mock_get_organisations,
 ):
-    assert is_gov_user(api_nongov_user_active["email_address"]) is False
+    assert is_gov_user(current_user.email_address) is False
     client_request.get(
         "main.add_service",
         _expected_status=403,
@@ -350,11 +351,11 @@ def test_non_government_user_cannot_access_create_service_page(
 
 def test_non_government_user_cannot_create_service(
     client_request,
-    mock_get_non_govuser,
+    login_non_govuser,
     api_nongov_user_active,
     mock_get_organisations,
 ):
-    assert is_gov_user(api_nongov_user_active["email_address"]) is False
+    assert is_gov_user(current_user.email_address) is False
     client_request.post(
         "main.add_service",
         _data={"name": "SERVICE TWO"},

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -121,10 +121,9 @@ def test_redirect_from_old_dashboard(
 
 def test_redirect_caseworkers_to_templates(
     client_request,
-    mocker,
     active_caseworking_user,
 ):
-    mocker.patch("app.user_api_client.get_user", return_value=active_caseworking_user)
+    client_request.login(active_caseworking_user)
     client_request.get(
         "main.service_dashboard",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -82,7 +82,7 @@ def test_user_information_page_shows_information_about_user(
     user_service_two = uuid.uuid4()
     mocker.patch(
         "app.user_api_client.get_user",
-        side_effect=[platform_admin_user, user_json(name="Apple Bloom", services=[user_service_one, user_service_two])],
+        return_value=user_json(name="Apple Bloom", services=[user_service_one, user_service_two]),
         autospec=True,
     )
 
@@ -129,10 +129,7 @@ def test_user_information_page_shows_change_auth_type_link(
     client_request.login(platform_admin_user)
     mocker.patch(
         "app.user_api_client.get_user",
-        side_effect=[
-            platform_admin_user,
-            user_json(id_=api_user_active["id"], name="Apple Bloom", auth_type="sms_auth"),
-        ],
+        return_value=user_json(id_=api_user_active["id"], name="Apple Bloom", auth_type="sms_auth"),
         autospec=True,
     )
 
@@ -170,10 +167,7 @@ def test_change_user_auth_preselects_current_auth_type(
 
     mocker.patch(
         "app.user_api_client.get_user",
-        side_effect=[
-            platform_admin_user,
-            user_json(id_=api_user_active["id"], name="Apple Bloom", auth_type=current_auth_type),
-        ],
+        return_value=user_json(id_=api_user_active["id"], name="Apple Bloom", auth_type=current_auth_type),
         autospec=True,
     )
 
@@ -192,10 +186,7 @@ def test_change_user_auth(client_request, platform_admin_user, api_user_active, 
 
     mocker.patch(
         "app.user_api_client.get_user",
-        side_effect=[
-            platform_admin_user,
-            user_json(id_=api_user_active["id"], name="Apple Bloom", auth_type="sms_auth"),
-        ],
+        return_value=user_json(id_=api_user_active["id"], name="Apple Bloom", auth_type="sms_auth"),
         autospec=True,
     )
 
@@ -223,7 +214,7 @@ def test_user_information_page_displays_if_there_are_failed_login_attempts(
     client_request.login(platform_admin_user)
     mocker.patch(
         "app.user_api_client.get_user",
-        side_effect=[platform_admin_user, user_json(name="Apple Bloom", failed_login_count=2)],
+        return_value=user_json(name="Apple Bloom", failed_login_count=2),
         autospec=True,
     )
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1345,11 +1345,11 @@ def test_send_one_off_has_skip_link(
     expected_link_url,
     user,
 ):
-    mocker.patch("app.user_api_client.get_user", return_value=user)
     template_data = create_template(template_id=fake_uuid, template_type=template_type)
     mocker.patch("app.service_api_client.get_service_template", return_value={"data": template_data})
     mocker.patch("app.main.views.send.get_page_count_for_letter", return_value=9)
 
+    client_request.login(user)
     page = client_request.get(
         "main.send_one_off_step",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -660,9 +660,10 @@ def test_get_manage_folder_viewing_permissions_for_users_not_visible_when_no_man
     ]
     mocker.patch(
         "app.models.user.Users.client_method",
-        return_value=[active_user_with_permissions, team_member, team_member_2],
+        return_value=[team_member, team_member_2],
     )
 
+    client_request.login(active_user_with_permissions)
     page = client_request.get(
         "main.manage_template_folder",
         service_id=service_one["id"],
@@ -875,9 +876,10 @@ def test_manage_folder_users_doesnt_change_permissions_current_user_cannot_manag
     ]
     mocker.patch(
         "app.models.user.Users.client_method",
-        return_value=[active_user_with_permissions, team_member],
+        return_value=[team_member],
     )
 
+    client_request.login(active_user_with_permissions)
     client_request.post(
         "main.manage_template_folder",
         service_id=service_one["id"],

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -548,13 +548,10 @@ def test_caseworker_redirected_to_set_sender_for_one_off(
     client_request,
     mock_get_service_templates,
     mock_get_service_template,
-    mocker,
     fake_uuid,
     active_caseworking_user,
 ):
-
-    mocker.patch("app.user_api_client.get_user", return_value=active_caseworking_user)
-
+    client_request.login(active_caseworking_user)
     client_request.get(
         "main.view_template",
         service_id=SERVICE_ONE_ID,
@@ -908,8 +905,8 @@ def test_view_broadcast_template(
     fake_uuid,
     active_user_create_broadcasts_permission,
 ):
-    client_request.login(active_user_create_broadcasts_permission)
     active_user_create_broadcasts_permission["permissions"][SERVICE_ONE_ID].append("manage_templates")
+    client_request.login(active_user_create_broadcasts_permission)
     page = client_request.get(
         ".view_template",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -190,10 +190,10 @@ def test_should_show_mobile_number_page(
 
 
 def test_change_your_mobile_number_page_shows_delete_link_if_user_on_email_auth(
-    client_request, api_user_active_email_auth, mocker
+    client_request, api_user_active_email_auth
 ):
-    mocker.patch("app.user_api_client.get_user", return_value=api_user_active_email_auth)
-    page = client_request.get(("main.user_profile_mobile_number"))
+    client_request.login(api_user_active_email_auth)
+    page = client_request.get("main.user_profile_mobile_number")
     assert "Change your mobile number" in page.text
     assert "Delete your number" in page.text
 
@@ -224,9 +224,9 @@ def test_confirm_delete_mobile_number(client_request, api_user_active_email_auth
 
 
 def test_delete_mobile_number(client_request, api_user_active_email_auth, mocker):
-    mocker.patch("app.user_api_client.get_user", return_value=api_user_active_email_auth)
     mock_delete = mocker.patch("app.user_api_client.update_user_attribute")
 
+    client_request.login(api_user_active_email_auth)
     client_request.post(
         ".user_profile_mobile_number_delete",
         _expected_redirect=url_for(
@@ -322,7 +322,8 @@ def test_should_redirect_after_mobile_number_confirm(
     user_after["current_session_id"] = str(uuid.UUID(int=2))
 
     # first time (login decorator) return normally, second time (after 2FA return with new session id)
-    mocker.patch("app.user_api_client.get_user", side_effect=[user_before, user_after])
+    client_request.login(user_before)
+    mocker.patch("app.user_api_client.get_user", return_value=user_after)
 
     with client_request.session_transaction() as session:
         session["new-mob-password-confirmed"] = True

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import werkzeug
+from flask import g
 
 from app.models.service import Service
 from app.notify_client import NotifyAdminAPIClient
@@ -28,9 +29,9 @@ from tests.conftest import (
 def test_active_service_can_be_modified(notify_admin, method, user, service):
     api_client = NotifyAdminAPIClient()
 
-    with notify_admin.test_request_context() as request_context, notify_admin.test_client() as client:
+    with notify_admin.test_request_context(), notify_admin.test_client() as client:
         client.login(user)
-        request_context.service = Service(service)
+        g.current_service = Service(service)
 
         with patch.object(api_client, "request") as request:
             ret = getattr(api_client, method)("url", "data")
@@ -43,9 +44,9 @@ def test_active_service_can_be_modified(notify_admin, method, user, service):
 def test_inactive_service_cannot_be_modified_by_normal_user(notify_admin, api_user_active, method):
     api_client = NotifyAdminAPIClient()
 
-    with notify_admin.test_request_context() as request_context, notify_admin.test_client() as client:
+    with notify_admin.test_request_context(), notify_admin.test_client() as client:
         client.login(api_user_active)
-        request_context.service = Service(service_json(active=False))
+        g.current_service = Service(service_json(active=False))
 
         with patch.object(api_client, "request") as request:
             with pytest.raises(werkzeug.exceptions.Forbidden):
@@ -58,9 +59,9 @@ def test_inactive_service_cannot_be_modified_by_normal_user(notify_admin, api_us
 def test_inactive_service_can_be_modified_by_platform_admin(notify_admin, platform_admin_user, method):
     api_client = NotifyAdminAPIClient()
 
-    with notify_admin.test_request_context() as request_context, notify_admin.test_client() as client:
+    with notify_admin.test_request_context(), notify_admin.test_client() as client:
         client.login(platform_admin_user)
-        request_context.service = Service(service_json(active=False))
+        g.current_service = Service(service_json(active=False))
 
         with patch.object(api_client, "request") as request:
             ret = getattr(api_client, method)("url", "data")

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -10,6 +10,11 @@ from tests.conftest import SERVICE_ONE_ID
 FAKE_TEMPLATE_ID = uuid4()
 
 
+@pytest.fixture(autouse=True)
+def mock_notify_client_check_inactive_service(mocker):
+    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
+
+
 def test_client_posts_archived_true_when_deleting_template(mocker):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -524,7 +524,6 @@ def test_navigation_urls(
 
 
 def test_navigation_for_services_with_broadcast_permission(
-    mocker,
     client_request,
     service_one,
     mock_get_service_templates,
@@ -533,7 +532,7 @@ def test_navigation_for_services_with_broadcast_permission(
     active_user_create_broadcasts_permission,
 ):
     service_one["permissions"] += ["broadcast"]
-    mocker.patch("app.user_api_client.get_user", return_value=active_user_create_broadcasts_permission)
+    client_request.login(active_user_create_broadcasts_permission)
 
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert [a["href"] for a in page.select(".navigation a")] == [
@@ -546,7 +545,6 @@ def test_navigation_for_services_with_broadcast_permission(
 
 
 def test_navigation_for_services_with_broadcast_permission_platform_admin(
-    mocker,
     client_request,
     service_one,
     mock_get_service_templates,
@@ -555,11 +553,8 @@ def test_navigation_for_services_with_broadcast_permission_platform_admin(
     platform_admin_user,
 ):
     service_one["permissions"] += ["broadcast"]
-    mocker.patch(
-        "app.user_api_client.get_user",
-        return_value=platform_admin_user,
-    )
 
+    client_request.login(platform_admin_user)
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert [a["href"] for a in page.select(".navigation a")] == [
         "/services/{}/current-alerts".format(SERVICE_ONE_ID),
@@ -574,14 +569,13 @@ def test_navigation_for_services_with_broadcast_permission_platform_admin(
 
 def test_caseworkers_get_caseworking_navigation(
     client_request,
-    mocker,
     mock_get_template_folders,
     mock_get_service_templates,
     mock_has_no_jobs,
     mock_get_api_keys,
     active_caseworking_user,
 ):
-    mocker.patch("app.user_api_client.get_user", return_value=active_caseworking_user)
+    client_request.login(active_caseworking_user)
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one("header + .govuk-width-container nav").text) == (
         "Templates Sent messages Uploads Team members"
@@ -590,14 +584,13 @@ def test_caseworkers_get_caseworking_navigation(
 
 def test_caseworkers_see_jobs_nav_if_jobs_exist(
     client_request,
-    mocker,
     mock_get_service_templates,
     mock_get_template_folders,
     mock_has_jobs,
     active_caseworking_user,
     mock_get_api_keys,
 ):
-    mocker.patch("app.user_api_client.get_user", return_value=active_caseworking_user)
+    client_request.login(active_caseworking_user)
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one("header + .govuk-width-container nav").text) == (
         "Templates Sent messages Uploads Team members"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1158,14 +1158,10 @@ def mock_register_user(mocker, api_user_pending):
 
 
 @pytest.fixture(scope="function")
-def mock_get_non_govuser(mocker, api_user_active):
+def login_non_govuser(client_request, api_user_active):
     api_user_active["email_address"] = "someuser@example.com"
 
-    def _get_user(id_):
-        api_user_active["id"] = id_
-        return api_user_active
-
-    return mocker.patch("app.user_api_client.get_user", side_effect=_get_user)
+    client_request.login(api_user_active)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Summary
Moves us away from deprecated Flask/Flask-Login implementation details onto the new supported interface (mostly `g` for Flask), so that we can then update our Flask/Flask-Login/Werkzeug packages to newer versions.

Good to review commit-by-commit.

Updates most of the tests to use the `client.login` function rather than manually patching `get_user`. The `login` function patches this as needed by default, as well as patching a number of other functions as needed so let's just use `client.login` to be consistent and centralise that logic from now on.