### PR TITLE
Allow a letter branding in the pool for an organisation to be made the default

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1861,6 +1861,13 @@ class AdminChangeOrganisationDefaultEmailBrandingForm(StripWhitespaceForm):
     )
 
 
+class AdminChangeOrganisationDefaultLetterBrandingForm(StripWhitespaceForm):
+    letter_branding_id = HiddenField(
+        "Letter branding id",
+        validators=[DataRequired()],
+    )
+
+
 class AddEmailBrandingOptionsForm(StripWhitespaceForm):
     branding_field = GovukCheckboxesField(
         "Branding options",

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -652,13 +652,42 @@ def _handle_remove_letter_branding(remove_branding_id):
         )
 
 
+def _handle_change_default_letter_branding_to_none():
+    """
+    This handles settings an organisation's default letter branding to None.
+    If we're in here, then the user has either clicked the 'Use no branding as default instead' link
+    or they're clicking the button in the confirmation dialog.
+    """
+    if request.method == "POST":
+        organisations_client.update_organisation(
+            current_organisation.id,
+            letter_branding_id=None,
+        )
+        return redirect(url_for("main.organisation_letter_branding", org_id=current_organisation.id))
+
+    else:
+        flash(
+            Markup(
+                render_template(
+                    "partials/flash_messages/letter_branding_confirm_change_default_to_none.html",
+                )
+            ),
+            "remove",
+        )
+
+
 @main.route("/organisations/<uuid:org_id>/settings/letter-branding", methods=["GET", "POST"])
 @user_is_platform_admin
 def organisation_letter_branding(org_id):
     remove_branding_id = request.args.get("remove_branding_id")
+    change_default_branding_to_none = "change_default_branding_to_none" in request.args
 
     if remove_branding_id:
         if response := _handle_remove_letter_branding(remove_branding_id):
+            return response
+
+    elif change_default_branding_to_none:
+        if response := _handle_change_default_letter_branding_to_none():
             return response
 
     return render_template(

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -435,10 +435,7 @@ def _handle_change_default_email_branding_to_govuk(is_central_government) -> Opt
         return None
 
     if request.method == "POST":
-        organisations_client.update_organisation(
-            current_organisation.id,
-            email_branding_id=None,
-        )
+        current_organisation.update(email_branding_id=None)
         return redirect(url_for("main.organisation_email_branding", org_id=current_organisation.id))
 
     else:
@@ -481,10 +478,7 @@ def _handle_change_default_email_branding(form, new_default_branding_id) -> Opti
         email_branding_name = __get_email_branding_name(new_default_branding_id)
 
         if request.method == "POST":
-            organisations_client.update_organisation(
-                current_organisation.id,
-                email_branding_id=new_default_branding_id,
-            )
+            current_organisation.update(delete_services_cache=True, email_branding_id=new_default_branding_id)
             return redirect(url_for("main.organisation_email_branding", org_id=current_organisation.id))
 
         confirmation_question = Markup(
@@ -514,10 +508,7 @@ def _handle_change_default_email_branding(form, new_default_branding_id) -> Opti
                 )
             )
 
-        organisations_client.update_organisation(
-            current_organisation.id,
-            email_branding_id=form.email_branding_id.data,
-        )
+        current_organisation.update(email_branding_id=form.email_branding_id.data)
         return redirect(url_for("main.organisation_email_branding", org_id=current_organisation.id))
 
     return None
@@ -660,10 +651,7 @@ def _handle_change_default_letter_branding_to_none():
     or they're clicking the button in the confirmation dialog.
     """
     if request.method == "POST":
-        organisations_client.update_organisation(
-            current_organisation.id,
-            letter_branding_id=None,
-        )
+        current_organisation.update(letter_branding_id=None)
         return redirect(url_for("main.organisation_letter_branding", org_id=current_organisation.id))
 
     else:
@@ -703,10 +691,7 @@ def _handle_change_default_letter_branding(form, new_default_branding_id):
         letter_branding_name = __get_letter_branding_name(new_default_branding_id)
 
         if request.method == "POST":
-            organisations_client.update_organisation(
-                current_organisation.id,
-                letter_branding_id=new_default_branding_id,
-            )
+            current_organisation.update(delete_services_cache=True, letter_branding_id=new_default_branding_id)
             return redirect(url_for("main.organisation_letter_branding", org_id=current_organisation.id))
 
         confirmation_question = Markup(
@@ -735,10 +720,7 @@ def _handle_change_default_letter_branding(form, new_default_branding_id):
                 )
             )
 
-        organisations_client.update_organisation(
-            current_organisation.id,
-            letter_branding_id=form.letter_branding_id.data,
-        )
+        current_organisation.update(letter_branding_id=form.letter_branding_id.data)
         return redirect(url_for("main.organisation_letter_branding", org_id=current_organisation.id))
 
 

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -661,7 +661,7 @@ def _handle_change_default_letter_branding_to_none():
                     "partials/flash_messages/letter_branding_confirm_change_default_to_none.html",
                 )
             ),
-            "remove",
+            "remove default letter branding",
         )
 
 

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -391,7 +391,7 @@ def edit_organisation_agreement(org_id):
     )
 
 
-def _handle_remove_branding(remove_branding_id) -> Optional[Response]:
+def _handle_remove_email_branding(remove_branding_id) -> Optional[Response]:
     """
     The user has clicked 'remove' on a brand and is either going to see a confirmation flash message
     or has clicked to confirm that flash message.
@@ -423,7 +423,7 @@ def _handle_remove_branding(remove_branding_id) -> Optional[Response]:
     return None
 
 
-def _handle_change_default_branding_to_govuk(is_central_government) -> Optional[Response]:
+def _handle_change_default_email_branding_to_govuk(is_central_government) -> Optional[Response]:
     """
     This handles changing a central government organisation from a custom brand back to the default GOV.UK brand.
     If we're in here, then the user has either clicked the 'Reset to GOV.UK' link or they're clicking the
@@ -454,7 +454,7 @@ def _handle_change_default_branding_to_govuk(is_central_government) -> Optional[
     return None
 
 
-def _handle_change_default_branding(form, new_default_branding_id) -> Optional[Response]:
+def _handle_change_default_email_branding(form, new_default_branding_id) -> Optional[Response]:
     """
     Handle any change of branding to a non-default (GOV.UK) brand. This includes going from GOV.UK to a custom
     brand, and going from a custom brand to another custom brand. When moving from GOV.UK to a custom brand,
@@ -532,14 +532,14 @@ def organisation_email_branding(org_id):
     form = AdminChangeOrganisationDefaultEmailBrandingForm()
 
     if remove_branding_id:
-        if response := _handle_remove_branding(remove_branding_id):
+        if response := _handle_remove_email_branding(remove_branding_id):
             return response
 
     elif change_default_branding_to_govuk:
-        if response := _handle_change_default_branding_to_govuk(is_central_government):
+        if response := _handle_change_default_email_branding_to_govuk(is_central_government):
             return response
 
-    elif response := _handle_change_default_branding(form, new_default_branding_id):
+    elif response := _handle_change_default_email_branding(form, new_default_branding_id):
         return response
 
     # We only show this link to central government organisations.

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -208,10 +208,9 @@ class Organisation(JSONModel):
             return User.from_id(self.agreement_signed_by_id)
 
     def update(self, delete_services_cache=False, **kwargs):
-        response = organisations_client.update_organisation(
+        organisations_client.update_organisation(
             self.id, cached_service_ids=self.service_ids if delete_services_cache else None, **kwargs
         )
-        self.__init__(response)
 
     def associate_service(self, service_id):
         organisations_client.update_service_organisation(service_id, self.id)

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -2,11 +2,19 @@
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
     {% for category, message in messages %}
-      {% if category in ['cancel', 'delete', 'suspend', 'resume', 'remove', 'revoke this API key', 'stop broadcasting'] %}
+      {% if category in [
+        'cancel',
+        'delete',
+        'suspend',
+        'resume',
+        'remove',
+        'revoke this API key',
+        'stop broadcasting',
+        'make this email branding the default',
+        'make this letter branding the default',
+      ] %}
         {% set delete_button_text = "Yes, {}".format(category) %}
       {% elif category == 'try again' %}
-        {% set delete_button_text = category|capitalize %}
-      {% elif category == 'yes, make this email branding the default' %}
         {% set delete_button_text = category|capitalize %}
       {% else %}
         {% set delete_button_text = None %}

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -8,6 +8,7 @@
         'suspend',
         'resume',
         'remove',
+        'remove default letter branding',
         'revoke this API key',
         'stop broadcasting',
         'make this email branding the default',

--- a/app/templates/partials/flash_messages/letter_branding_confirm_change_brand_from_none.html
+++ b/app/templates/partials/flash_messages/letter_branding_confirm_change_brand_from_none.html
@@ -1,0 +1,12 @@
+<h2 class="banner-title">
+  Are you sure you want to make ‘{{ branding_name }}’ the default letter branding?
+</h2>
+
+<p class="govuk-body">
+  {{ current_org.name }} services that currently have no branding:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>will have their default letter branding changed</li>
+  <li>will no longer be able to send letters with no branding</li>
+</ul>

--- a/app/templates/partials/flash_messages/letter_branding_confirm_change_default_to_none.html
+++ b/app/templates/partials/flash_messages/letter_branding_confirm_change_default_to_none.html
@@ -1,0 +1,7 @@
+<h2 class="banner-title">
+  Are you sure you want to remove the default letter branding?
+</h2>
+
+<p class="govuk-body">
+  This will not change the current branding of any {{ current_org.name }} services.
+</p>

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -1,7 +1,9 @@
 {% extends "org_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper%}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {%  from "components/branding-preview.html" import letter_branding_preview %}
 
 {% block org_page_title %}
@@ -35,11 +37,20 @@
 
   {% for option in current_org.letter_branding_pool_excluding_default %}
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-        {{ option.name }}
+      {{ option.name }}
     </h2>
-    {{ letter_branding_preview(option.id) }}
+    {{ letter_branding_preview(option.id, classes='govuk-!-margin-bottom-0') }}
     <div class="govuk-grid-row govuk-!-margin-top-2 govuk-!-margin-bottom-6">
-      <div class="govuk-grid-column-one-half">&nbsp;
+      <div class="govuk-grid-column-one-half">
+        {% call form_wrapper(action=url_for('main.organisation_letter_branding', org_id=current_org.id)) %}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {{ form.letter_branding_id(value=option.id) }}
+          {{ govukButton({
+            "element": "input",
+            "text": "Make default",
+            "classes": "govuk-button--secondary"
+          }) }}
+        {% endcall %}
       </div>
       <div class="govuk-grid-column-one-half">
         <p class="govuk-body govuk-!-text-align-right">

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -19,7 +19,19 @@
     {{ current_org.letter_branding.name or "No branding" }}<span class="hint govuk-!-font-weight-regular">&ensp;(default)</span>
   </h2>
 
-  {{ letter_branding_preview(current_org.letter_branding_id, classes='govuk-!-margin-bottom-8') }}
+  {% if current_org.letter_branding_id %}
+    {{ letter_branding_preview(current_org.letter_branding_id, classes='govuk-!-margin-bottom-2') }}
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="{{ url_for('main.organisation_letter_branding', org_id=current_org.id) }}?change_default_branding_to_none"
+      >
+        Use no branding as default instead
+      </a>
+    </p>
+  {% else %}
+    {{ letter_branding_preview(current_org.letter_branding_id, classes='govuk-!-margin-bottom-8') }}
+  {% endif %}
 
   {% for option in current_org.letter_branding_pool_excluding_default %}
     <h2 class="govuk-heading-s govuk-!-margin-bottom-2">

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -2072,7 +2072,7 @@ def test_reset_org_email_branding_to_govuk_successfully(
 
     expected_calls = []
     if should_succeed:
-        expected_calls.append(mocker.call(organisation_one["id"], email_branding_id=None))
+        expected_calls.append(mocker.call(organisation_one["id"], cached_service_ids=None, email_branding_id=None))
 
     assert mock_update_organisation.call_args_list == expected_calls
 
@@ -2139,6 +2139,7 @@ def test_change_default_org_email_branding_successfully_from_govuk(
     platform_admin_user,
     organisation_one,
     mock_get_email_branding_pool,
+    mock_get_organisation_services,
     mock_update_organisation,
 ):
     mocker.patch(
@@ -2159,7 +2160,11 @@ def test_change_default_org_email_branding_successfully_from_govuk(
     )
 
     assert mock_update_organisation.call_args_list == [
-        mocker.call(organisation_one["id"], email_branding_id="email-branding-1-id")
+        mocker.call(
+            organisation_one["id"],
+            cached_service_ids=["12345", "67890", SERVICE_ONE_ID],
+            email_branding_id="email-branding-1-id",
+        )
     ]
 
 
@@ -2203,7 +2208,7 @@ def test_change_default_org_email_branding_successfully_from_explicit_brand(
     )
 
     assert mock_update_organisation.call_args_list == [
-        mocker.call(organisation_one["id"], email_branding_id="email-branding-1-id")
+        mocker.call(organisation_one["id"], cached_service_ids=None, email_branding_id="email-branding-1-id")
     ]
 
 
@@ -2492,7 +2497,7 @@ def test_organisation_letter_branding_page_makes_none_default_on_post_request(
     url = url_for(".organisation_letter_branding", org_id=organisation_one["id"]) + "?change_default_branding_to_none"
     client_request.post_url(url)
 
-    update_mock.assert_called_once_with(organisation_one["id"], letter_branding_id=None)
+    update_mock.assert_called_once_with(organisation_one["id"], cached_service_ids=None, letter_branding_id=None)
 
 
 def test_add_organisation_letter_branding_options_is_platform_admin_only(
@@ -2567,6 +2572,7 @@ def test_change_default_org_letter_branding_successfully_from_no_branding(
     platform_admin_user,
     organisation_one,
     mock_get_letter_branding_pool,
+    mock_get_organisation_services,
     mock_update_organisation,
 ):
     mocker.patch(
@@ -2586,7 +2592,11 @@ def test_change_default_org_letter_branding_successfully_from_no_branding(
         new_default_branding_id="1234",
     )
 
-    assert mock_update_organisation.call_args_list == [mocker.call(organisation_one["id"], letter_branding_id="1234")]
+    assert mock_update_organisation.call_args_list == [
+        mocker.call(
+            organisation_one["id"], cached_service_ids=["12345", "67890", SERVICE_ONE_ID], letter_branding_id="1234"
+        )
+    ]
 
 
 def test_change_default_org_letter_branding_successfully_from_explicit_brand(
@@ -2614,7 +2624,9 @@ def test_change_default_org_letter_branding_successfully_from_explicit_brand(
         _data={"letter_branding_id": "5678"},
     )
 
-    assert mock_update_organisation.call_args_list == [mocker.call(organisation_one["id"], letter_branding_id="5678")]
+    assert mock_update_organisation.call_args_list == [
+        mocker.call(organisation_one["id"], cached_service_ids=None, letter_branding_id="5678")
+    ]
 
 
 def test_add_organisation_letter_branding_options_shows_branding_not_in_branding_pool(


### PR DESCRIPTION
This change allows one of the letter brandings in the pool for an organisation (or no branding) to be set as the default.

If the organisation doesn't originally have no branding as the default, we show a "Use no branding as default instead" link under the current default. Each non-default brand has a "Make default" button under it. For consistency, this is all very similar to the code for email branding except that the no branding option replaces the GOVUK option.

We show a confirmation message if changing the default brand to or from no branding, but no message if you are changing the brand from one set brand to another.

## Page with no branding as the default branding
![Screenshot 2022-11-14 at 15 54 43](https://user-images.githubusercontent.com/12881990/201706629-34a03cd1-e6d1-49c0-b0a2-84ed4f62991d.png)

## Page with a set branding as the default
![Screenshot 2022-11-14 at 15 53 55](https://user-images.githubusercontent.com/12881990/201706685-1cea73ed-cf37-428b-8b7a-63cf29af4c2e.png)

## Confirmation message before changing from no branding to a brand
![Screenshot 2022-11-14 at 15 55 03](https://user-images.githubusercontent.com/12881990/201707140-ff0033f6-4290-4507-befe-d3c9a9877bec.png)

## Confirmation message before changing from a set brand to no branding
![Screenshot 2022-11-14 at 15 54 28](https://user-images.githubusercontent.com/12881990/201707065-bdce7e2d-5da1-4297-8e57-b10346829f8b.png)


