### PR TITLE
Fix redaction box not covering all of hidden text

### DIFF
--- a/app/assets/stylesheets/components/placeholder.scss
+++ b/app/assets/stylesheets/components/placeholder.scss
@@ -48,7 +48,7 @@
   top: 0.1em;
 
   .sms-message-wrapper & {
-    box-shadow: inset 0 -0.35em 0 0 govuk-shade(govuk-colour("light-grey"), 7%);
+    box-shadow: inset 0 0.05em 0 0 govuk-shade(govuk-colour("light-grey"), 7%), inset 0 -0.25em 0 0 govuk-shade(govuk-colour("light-grey"), 7%);
   }
 
   *:focus + p & {


### PR DESCRIPTION
I suspect this broke in the recent font change but our current redaction box is not fully covering the word 'hidden' and the bottom part of it sticks out slightly. Whilst it does not expose anything sensitive, it is not quite right.

I've manually chosen a value for the CSS which does cover all the text.

I've also checked and this is not an issue for email templates.

The only bit I'm not sure on is whether a similar change from `0.35em` to `0.25em` is required for the bit of CSS below for `*:focus + p &`. I couldn't figure out what it was for but was interested as the value of 0.35em is the same so could be related.

## Before
<img width="504" alt="image" src="https://user-images.githubusercontent.com/7228605/201972031-3fd54d49-09c7-46d1-b9d5-551daaf2d63c.png">

## After
<img width="493" alt="image" src="https://user-images.githubusercontent.com/7228605/201972118-e7c6c5e7-eead-45ef-aa83-14a01c103be1.png">

## After on a multiline message
<img width="500" alt="image" src="https://user-images.githubusercontent.com/7228605/201972267-0fef02fa-ae05-44c0-b08e-6ecf4d30aaae.png">

## After with multiple placeholders
<img width="495" alt="image" src="https://user-images.githubusercontent.com/7228605/201972660-c131fc86-0ada-4a61-97f0-0c7df65c30cf.png">

## After on small screen size
<img width="523" alt="image" src="https://user-images.githubusercontent.com/7228605/201972869-73a286d5-96c3-438f-bc9e-86012d73bac6.png">

## Proof that email was not affected by this issue
<img width="731" alt="image" src="https://user-images.githubusercontent.com/7228605/201971942-4e611730-3ee4-4401-bebd-2dfff3e3cda5.png">
