### PR TITLE
Clear letter branding pool cache when updating an organisation

### DIFF
--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -58,6 +58,9 @@ class OrganisationsClient(NotifyAdminAPIClient):
         if "email_branding_id" in kwargs and kwargs["email_branding_id"]:
             redis_client.delete(f"organisation-{org_id}-email-branding-pool")
 
+        if kwargs.get("letter_branding_id"):
+            redis_client.delete(f"organisation-{org_id}-letter-branding-pool")
+
         return api_response
 
     @cache.delete("organisation-{org_id}-email-branding-pool")

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -145,6 +145,21 @@ def test_deletes_domain_cache(
                 call("domains"),
             ],
         ),
+        (
+            {"letter_branding_id": "new id"},
+            [
+                call("organisation-6ce466d0-fd6a-11e5-82f5-e0accb9d11a6-letter-branding-pool"),
+                call("organisations"),
+                call("domains"),
+            ],
+        ),
+        (
+            {"letter_branding_id": None},
+            [
+                call("organisations"),
+                call("domains"),
+            ],
+        ),
     ),
 )
 def test_update_organisation_when_not_updating_org_type(


### PR DESCRIPTION
Updating an organisation's default letter branding in api can now add that branding to the letter branding pool. This means that we need to clear the cache when an organisation's branding is updated.