### PR TITLE
Fix unit test scoping

### DIFF
--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -5,6 +5,11 @@ import pytest
 from app import organisations_client
 
 
+@pytest.fixture(autouse=True)
+def mock_notify_client_check_inactive_service(mocker):
+    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
+
+
 @pytest.mark.parametrize(
     (
         "client_method,"

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -12,6 +12,11 @@ from tests.conftest import SERVICE_ONE_ID
 user_id = sample_uuid()
 
 
+@pytest.fixture(autouse=True)
+def mock_notify_client_check_inactive_service(mocker):
+    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
+
+
 def test_client_gets_all_users_for_service(
     mocker,
     fake_uuid,
@@ -200,15 +205,7 @@ def test_returns_value_from_cache(
         (invite_api_client, "accept_invite", [SERVICE_ONE_ID, user_id], {}),
     ],
 )
-def test_deletes_user_cache(
-    notify_admin,
-    mock_get_user,
-    mocker,
-    client,
-    method,
-    extra_args,
-    extra_kwargs,
-):
+def test_deletes_user_cache(notify_admin, mock_get_user, mocker, client, method, extra_args, extra_kwargs):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
     mock_request = mocker.patch("notifications_python_client.base.BaseAPIClient.request")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,15 +41,23 @@ class ElementNotFound(Exception):
 
 
 @pytest.fixture(scope="session")
-def notify_admin():
+def notify_admin_without_context():
+    """
+    You probably won't need to use this fixture, unless you need to use the flask.appcontext_pushed hook. Possibly if
+    you're patching something on `g`. https://flask.palletsprojects.com/en/1.1.x/testing/#faking-resources-and-context
+    """
     app = Flask("app")
     create_app(app)
-
-    ctx = app.app_context()
-    ctx.push()
-
     app.test_client_class = TestClient
-    yield app
+
+    return app
+
+
+@pytest.fixture
+def notify_admin(notify_admin_without_context):
+
+    with notify_admin_without_context.app_context():
+        yield notify_admin_without_context
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
A nasty and frustrating bug to diagnose - test_notify_admin_api_client.py was setting `g.current_service = ...`, and that causes that value to be present on `g` on all tests run after that. However, if the later tests that don't have a request context run without those tests first, they'd fail because the inactive service check was failling.

Patch the inactive service check to fix these tests, and more importantly, move the `notify_admin` fixture to tear down and rebuild the app context every unit test, rather than once per session. This means that `g` is emptied each time.

(Most of our tests operate inside a request context, which sets up `g.current_service` and `g.current_user` etc for you, so won't be impacted by these changes)

Don't worry, the tests are still fast (it's only if that `create_app` call is done every function that things get slow as it loads the config etc every time).