### PR TITLE
Show when a webauthn key was last used

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -428,8 +428,8 @@ class User(BaseUser, UserMixin):
             self.id,
         )
 
-    def complete_webauthn_login_attempt(self, is_successful=True):
-        return user_api_client.complete_webauthn_login_attempt(self.id, is_successful)
+    def complete_webauthn_login_attempt(self, is_successful=True, webauthn_credential_id=None):
+        return user_api_client.complete_webauthn_login_attempt(self.id, is_successful, webauthn_credential_id)
 
     def is_editable_by(self, other_user):
         if other_user == self:

--- a/app/models/webauthn_credential.py
+++ b/app/models/webauthn_credential.py
@@ -25,6 +25,7 @@ class WebAuthnCredential(JSONModel):
         "registration_response",  # sent to API for later auditing (not used)
         "created_at",
         "updated_at",
+        "logged_in_at",
     }
 
     __sort_attribute__ = "name"

--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -123,8 +123,8 @@ class UserApiClient(NotifyAdminAPIClient):
             raise e
 
     @cache.delete("user-{user_id}")
-    def complete_webauthn_login_attempt(self, user_id, is_successful):
-        data = {"successful": is_successful}
+    def complete_webauthn_login_attempt(self, user_id, is_successful, webauthn_credential_id):
+        data = {"successful": is_successful, "webauthn_credential_id": webauthn_credential_id}
         endpoint = f"/user/{user_id}/complete/webauthn-login"
         try:
             self.post(endpoint, data=data)

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -77,6 +77,13 @@
                 {% call field() %}
                   <div class="govuk-body">{{ credential.name }}</div>
                   <div class="govuk-body hint">Registered {{ credential.created_at|format_delta }}</div>
+                  <div class="govuk-body hint">
+                    {% if credential.logged_in_at %}
+                      Last used {{ credential.logged_in_at|format_delta }}
+                    {% else %}
+                      Never used
+                    {% endif %}
+                  </div>
                 {% endcall %}
                 {{ edit_field('Manage', url_for('.user_profile_manage_security_key', key_id=credential.id)) }}
               {% endcall %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -75,13 +75,12 @@
             {% for credential in credentials %}
               {% call row() %}
                 {% call field() %}
-                  <div class="govuk-body">{{ credential.name }}</div>
-                  <div class="govuk-body hint">Registered {{ credential.created_at|format_delta }}</div>
-                  <div class="govuk-body hint">
+                  <div class="govuk-body govuk-!-margin-bottom-2">{{ credential.name }}</div>
+                  <div class="govuk-hint govuk-!-margin-bottom-2">
                     {% if credential.logged_in_at %}
                       Last used {{ credential.logged_in_at|format_delta }}
                     {% else %}
-                      Never used
+                      Never used (registered {{ credential.created_at|format_delta }})
                     {% endif %}
                   </div>
                 {% endcall %}

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -471,8 +471,8 @@ def test_should_show_security_keys_page(
     cred_1_lhs = cred_1.select_one("td.table-field-left-aligned")
     cred_2_lhs = cred_2.select_one("td.table-field-left-aligned")
 
-    assert normalize_spaces(cred_1_lhs.text) == "Test credential Registered 4 years ago Last used 4 years ago"
-    assert normalize_spaces(cred_2_lhs.text) == "Another test credential Registered 1 year, 4 months ago Never used"
+    assert normalize_spaces(cred_1_lhs.text) == "Test credential Last used 4 years ago"
+    assert normalize_spaces(cred_2_lhs.text) == "Another test credential Never used (registered 1 year, 4 months ago)"
     manage_link = cred_1.select_one("td.table-field-right-aligned a")
     assert normalize_spaces(manage_link.text) == "Manage"
     assert manage_link["href"] == url_for(".user_profile_manage_security_key", key_id=webauthn_credential["id"])

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 from flask import url_for
+from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import generate_token
 
@@ -447,28 +448,34 @@ def test_user_doesnt_see_security_keys_unless_they_can_use_webauthn(client_reque
     )
 
 
+@freeze_time("2022-10-10")
 def test_should_show_security_keys_page(
     mocker,
     client_request,
     platform_admin_user,
     webauthn_credential,
+    webauthn_credential_2,
 ):
     client_request.login(platform_admin_user)
 
     mocker.patch(
         "app.models.webauthn_credential.WebAuthnCredentials.client_method",
-        return_value=[webauthn_credential],
+        return_value=[webauthn_credential, webauthn_credential_2],
     )
 
     page = client_request.get(".user_profile_security_keys")
     assert page.select_one("h1").text.strip() == "Security keys"
 
-    credential_row = page.select("tr")[-1]
-    assert "Test credential" in credential_row.text
-    assert "Manage" in credential_row.find("a").text
-    assert credential_row.find("a")["href"] == url_for(
-        ".user_profile_manage_security_key", key_id=webauthn_credential["id"]
-    )
+    cred_1 = page.select("tr")[1]
+    cred_2 = page.select("tr")[2]
+    cred_1_lhs = cred_1.select_one("td.table-field-left-aligned")
+    cred_2_lhs = cred_2.select_one("td.table-field-left-aligned")
+
+    assert normalize_spaces(cred_1_lhs.text) == "Test credential Registered 4 years ago Last used 4 years ago"
+    assert normalize_spaces(cred_2_lhs.text) == "Another test credential Registered 1 year, 4 months ago Never used"
+    manage_link = cred_1.select_one("td.table-field-right-aligned a")
+    assert normalize_spaces(manage_link.text) == "Manage"
+    assert manage_link["href"] == url_for(".user_profile_manage_security_key", key_id=webauthn_credential["id"])
 
     register_button = page.select_one("[data-notify-module='register-security-key']")
     assert register_button.text.strip() == "Register a key"

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -5,6 +5,11 @@ import pytest
 from app import organisations_client
 
 
+@pytest.fixture(autouse=True)
+def mock_notify_client_check_inactive_service(mocker):
+    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
+
+
 @pytest.mark.parametrize(
     (
         "client_method,"

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -194,7 +194,12 @@ def test_returns_value_from_cache(
         (user_api_client, "update_password", [user_id, "hunter2"], {}),
         (user_api_client, "verify_password", [user_id, "hunter2"], {}),
         (user_api_client, "check_verify_code", [user_id, "", ""], {}),
-        (user_api_client, "complete_webauthn_login_attempt", [user_id], {"is_successful": True}),
+        (
+            user_api_client,
+            "complete_webauthn_login_attempt",
+            [user_id],
+            {"is_successful": True, "webauthn_credential_id": "123"},
+        ),
         (user_api_client, "add_user_to_service", [SERVICE_ONE_ID, user_id, [], []], {}),
         (user_api_client, "add_user_to_organisation", [sample_uuid(), user_id], {}),
         (user_api_client, "set_user_permissions", [user_id, SERVICE_ONE_ID, []], {}),
@@ -263,10 +268,13 @@ def test_create_webauthn_credential_for_user(mocker, webauthn_credential, fake_u
 
 def test_complete_webauthn_login_attempt_returns_true_and_no_message_normally(fake_uuid, mocker):
     mock_post = mocker.patch("app.notify_client.user_api_client.UserApiClient.post")
+    webauthn_credential_id = str(uuid.uuid4())
 
-    resp = user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True)
+    resp = user_api_client.complete_webauthn_login_attempt(
+        fake_uuid, is_successful=True, webauthn_credential_id=webauthn_credential_id
+    )
 
-    expected_data = {"successful": True}
+    expected_data = {"successful": True, "webauthn_credential_id": webauthn_credential_id}
     mock_post.assert_called_once_with(f"/user/{fake_uuid}/complete/webauthn-login", data=expected_data)
     assert resp == (True, "")
 
@@ -276,10 +284,13 @@ def test_complete_webauthn_login_attempt_returns_false_and_message_on_403(fake_u
         "app.notify_client.user_api_client.UserApiClient.post",
         side_effect=HTTPError(response=Mock(status_code=403, json=Mock(return_value={"message": "forbidden"}))),
     )
+    webauthn_credential_id = str(uuid.uuid4())
 
-    resp = user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True)
+    resp = user_api_client.complete_webauthn_login_attempt(
+        fake_uuid, is_successful=True, webauthn_credential_id=webauthn_credential_id
+    )
 
-    expected_data = {"successful": True}
+    expected_data = {"successful": True, "webauthn_credential_id": webauthn_credential_id}
     mock_post.assert_called_once_with(f"/user/{fake_uuid}/complete/webauthn-login", data=expected_data)
 
     assert resp == (False, "forbidden")
@@ -292,7 +303,7 @@ def test_complete_webauthn_login_attempt_raises_on_api_error(fake_uuid, mocker):
     )
 
     with pytest.raises(HTTPError):
-        user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True)
+        user_api_client.complete_webauthn_login_attempt(fake_uuid, is_successful=True, webauthn_credential_id=fake_uuid)
 
 
 def test_reset_password(

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -12,6 +12,11 @@ from tests.conftest import SERVICE_ONE_ID
 user_id = sample_uuid()
 
 
+@pytest.fixture(autouse=True)
+def mock_notify_client_check_inactive_service(mocker):
+    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
+
+
 def test_client_gets_all_users_for_service(
     mocker,
     fake_uuid,
@@ -200,15 +205,7 @@ def test_returns_value_from_cache(
         (invite_api_client, "accept_invite", [SERVICE_ONE_ID, user_id], {}),
     ],
 )
-def test_deletes_user_cache(
-    notify_admin,
-    mock_get_user,
-    mocker,
-    client,
-    method,
-    extra_args,
-    extra_kwargs,
-):
+def test_deletes_user_cache(notify_admin, mock_get_user, mocker, client, method, extra_args, extra_kwargs):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
     mock_request = mocker.patch("notifications_python_client.base.BaseAPIClient.request")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,15 +41,23 @@ class ElementNotFound(Exception):
 
 
 @pytest.fixture(scope="session")
-def notify_admin():
+def notify_admin_without_context():
+    """
+    You probably won't need to use this fixture, unless you need to use the flask.appcontext_pushed hook. Possibly if
+    you're patching something on `g`. https://flask.palletsprojects.com/en/1.1.x/testing/#faking-resources-and-context
+    """
     app = Flask("app")
     create_app(app)
-
-    ctx = app.app_context()
-    ctx.push()
-
     app.test_client_class = TestClient
-    yield app
+
+    return app
+
+
+@pytest.fixture
+def notify_admin(notify_admin_without_context):
+
+    with notify_admin_without_context.app_context():
+        yield notify_admin_without_context
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4120,6 +4120,7 @@ def webauthn_credential():
         "credential_data": "WJ8AAAAAAAAAAAAAAAAAAAAAAECKU1ppjl9gmhHWyDkgHsUvZmhr6oF3/lD3llzLE2SaOSgOGIsIuAQqgp8JQSUu3r/oOaP8RS44dlQjrH+ALfYtpQECAyYgASFYIDGeoB8RJc5iMpRzZYAK5dndyHQkfFXRUWutPKPKMgdcIlggWfHwfzsvhsClHgz6E9xX58d6EQ55b4oLJ3Qf5YZjyzo=",  # noqa
         "registration_response": "anything",
         "created_at": "2017-10-18T16:57:14.154185Z",
+        "logged_in_at": "2017-10-19T00:00:00.000000Z",
     }
 
 
@@ -4131,4 +4132,5 @@ def webauthn_credential_2():
         "credential_data": "WJ0AAAAAAAAAAAAAAAAAAAAAAECKU1jppl9mhgHWyDkgHsUvZmhr6oF3/lD3llzLE2SaOSgOGIsIuAQqgp8JQSUu3r/oOaP8RS44dlQjrH+ALfYtpAECAyYhWCAxnqAfESXOYjKUc2WACuXZ3ch0JHxV0VFrrTyjyjIHXCJYIFnx8L4H87bApR4M+hPcV+fHehEOeW+KCyd0H+WGY8s6",  # noqa
         "registration_response": "stuff",
         "created_at": "2021-05-14T16:57:14.154185Z",
+        "logged_in_at": None,
     }


### PR DESCRIPTION
This was inspired by me having three keys all called "Unknown key" on prod. I still don't know what one of them is 😱 

When a user logs in, work out which key they used to log in, and pass through that key's id to the API so it can set a `logged_in_at` timestamp against that key.

Then, on the security keys page we can show when each key was last used to log in.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/5020841/202283912-ebed9b1e-6869-4b57-9d2b-5d2c55af3024.png">

-------------

- [x] https://github.com/alphagov/notifications-admin/pull/4451
- [x] https://github.com/alphagov/notifications-api/pull/3638