### PR TITLE
Bump govuk frontend to v3.14.0

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -3,16 +3,14 @@
 .banner-default {
 
   @include govuk-font(19, $weight: bold);
-  // TODO: replace with `$govuk-success-colour` when GOV.UK Frontend version >= 3.10.0
-  color: govuk-colour("green");
+  color: $govuk-success-colour;
   display: block;
   padding: govuk-spacing(3);
   margin: govuk-spacing(3) 0 govuk-spacing(6) 0;
   text-align: left;
   position: relative;
   clear: both;
-  // TODO: replace with `$govuk-success-colour` when GOV.UK Frontend version >= 3.10.0
-  border: 5px solid govuk-colour("green");
+  border: 5px solid $govuk-success-colour;
 
   &-title {
     @include govuk-font(24, $weight: bold);

--- a/app/assets/stylesheets/govuk-frontend/_all.scss
+++ b/app/assets/stylesheets/govuk-frontend/_all.scss
@@ -5,26 +5,24 @@
 // set asset URL root to match that of application
 $govuk-assets-path: "/static/";
 
-@import "govuk/settings/all";
-@import "govuk/tools/all";
-@import "govuk/helpers/all";
+@import "govuk/base";
 @import "govuk/core/all";
 @import "govuk/objects/all";
 
 // section replacing @import "components/all", specifying which components to include
-@import "govuk/components/skip-link/_skip-link";
-@import "govuk/components/header/_header";
-@import "govuk/components/footer/_footer";
-@import "govuk/components/back-link/_back-link";
-@import "govuk/components/button/_button";
-@import "govuk/components/details/_details";
-@import "govuk/components/error-summary/_error-summary";
-@import "govuk/components/radios/_radios";
-@import "govuk/components/checkboxes/_checkboxes";
-@import "govuk/components/input/_input";
-@import "govuk/components/inset-text/_inset-text";
-@import "govuk/components/textarea/_textarea";
-@import "govuk/components/summary-list/_summary-list";
+@import "govuk/components/skip-link/index";
+@import "govuk/components/header/index";
+@import "govuk/components/footer/index";
+@import "govuk/components/back-link/index";
+@import "govuk/components/button/index";
+@import "govuk/components/details/index";
+@import "govuk/components/error-summary/index";
+@import "govuk/components/radios/index";
+@import "govuk/components/checkboxes/index";
+@import "govuk/components/input/index";
+@import "govuk/components/inset-text/index";
+@import "govuk/components/textarea/index";
+@import "govuk/components/summary-list/index";
 
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -95,19 +95,6 @@ $govuk-grid-widths: (
   }
 }
 
-// We can delete this code when we upgrade to a version >=3.14
-.govuk-\!-text-align-left {
-  text-align: left !important;
-}
-
-.govuk-\!-text-align-centre {
-  text-align: center !important;
-}
-
-.govuk-\!-text-align-right {
-  text-align: right !important;
-}
-
 // Extensions to the GOVUK Frontend summary-list component, to apply to all
 // summary-lists on Notify
 .notify-summary-list {

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 // Gives access to the Sass variables used in the GOVUK Frontend typographic styles
 // See: https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-typography-scale
 @function get-govuk-typography-style($size, $breakpoint, $property) {
@@ -48,19 +50,18 @@
 .govuk-link--destructive {
   @include govuk-link-style-destructive-no-visited-state;
 }
-$govuk-grid-widths: (
+
+// GOVUK Frontend's grid-column classes are built from the $govuk-grid-widths map
+// that means we can extend the map to get extra classes
+$notify-grid-widths: (
   one-eighth: 12.5%,
   one-sixth: 16.6666%,
-  one-quarter: 25%,
-  one-third: 33.3333%,
-  one-half: 50%,
   five-eighths: 62.5%,
-  two-thirds: 66.6666%,
-  three-quarters: 75%,
   five-sixths: 83.3333%,
-  seven-eighths: 87.5%,
-  full: 100%
+  seven-eighths: 87.5%
 );
+
+$govuk-grid-widths: map.merge($govuk-grid-widths, $notify-grid-widths);
 
 .govuk-input--width-6 {
   max-width: 14ex;

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -63,12 +63,6 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
   }
 }
 
-// Add override from future version of GOV.UK Frontend
-// TODO: remove this once we’ve upgraded past v3.11.0
-.govuk-\!-display-none {
-  display: none !important;
-}
-
 // Give footer links back their underline
 // TODO: remove this once we've upgraded past v3.12.0
 .govuk-footer__list,

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -76,9 +76,3 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
 
   }
 }
-
-// Fix issue with skiplink solved in v3.7.0
-// TODO: remove this once we've upgraded past v3.7.0
-.govuk-skip-link:focus {
-  outline-offset: 0;
-}

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -62,17 +62,3 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
     background-color: $notify-secondary-button-hover-colour;
   }
 }
-
-// Give footer links back their underline
-// TODO: remove this once we've upgraded past v3.12.0
-.govuk-footer__list,
-.govuk-footer__inline-list {
-  .govuk-footer__link {
-    text-decoration: underline;
-
-    &:focus {
-      text-decoration: none;
-    }
-
-  }
-}

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -238,7 +238,7 @@ class GovukPasswordField(GovukTextInputFieldMixin, PasswordField):
 
 class GovukEmailField(GovukTextInputFieldMixin, EmailField):
     input_type = "email"
-    param_extensions = {"attributes": {"spellcheck": "false"}}  # email addresses don't need to be spellchecked
+    param_extensions = {"spellcheck": False}  # email addresses don't need to be spellchecked
 
 
 class GovukSearchField(GovukTextInputFieldMixin, SearchField):

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "3.0.0",
+        "govuk-frontend": "3.14.0",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
         "leaflet": "1.6.0",
@@ -6415,9 +6415,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
-      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
+      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -21200,9 +21200,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
-      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
+      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "3.0.0",
+    "govuk-frontend": "3.14.0",
     "hogan": "1.0.2",
     "jquery": "3.5.0",
     "leaflet": "1.6.0",

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -11,10 +11,9 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
 
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
-    # This should be checking govuk_frontend_version == 3.14.x, but we're not there yet. Update this when we are.
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("3.0.0") <= govuk_frontend_version < Version("4.0.0")
-    correct_govuk_frontend_jinja_version = Version("1.5.0") <= govuk_frontend_jinja_version < Version("1.6.0")
+    correct_govuk_frontend_version = Version("3.14.0") == govuk_frontend_version
+    correct_govuk_frontend_jinja_version = Version("1.5.1") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
         "After upgrading either of the Design System packages, you must validate that "


### PR DESCRIPTION
Bumps GOVUK Frontend to v3.14.0 so it has parity with the version of GOVUK Frontend Jinja Macros, our templating library, we currently use[^1].

Part of https://trello.com/c/n3OI2lt6/39-bump-govuk-frontend-from-v3-to-latest-version-v44

## Notes for reviewers

Bumping to v3.14.0 doesn't break anything but does bring in some features and remove the need for some hacks we wrote for GOVUK Frontend features we wanted ahead of time.

If you want to understand all the changes, go commit by commit but it's also ok to just check in your browser.

Worth saying v3.12.0 introduced changes to the way links look but the work to include this is complex enough that I've put it in a separate story: https://trello.com/c/jDtuwHih/116-change-links-in-admin-app-to-new-design-system-style so isn't in these changes.

[^1]: We use v1.5.1 of GOVUK Frontend Jinja Macros which has parity with v3.14.0 of GOVUK Frontend, as defined in [this comparison table of versions](https://github.com/LandRegistry/govuk-frontend-jinja#compatibility).