### PR TITLE
Freeze dependencies to bump flask/werkzeug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ fix-imports: ## Fix imports using isort
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip-tools
+	${VIRTUALENV_ROOT}/bin/pip3 install --upgrade pip-tools
 	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,14 @@ $(eval export CF_HOME)
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
+PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
 
 
 ## DEVELOPMENT
 
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
-	pip3 install -r requirements_for_test.txt
+	${PYTHON_EXECUTABLE_PREFIX}pip3 install -r requirements_for_test.txt
 
 	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci --no-audit
 	. environment.sh; source $(HOME)/.nvm/nvm.sh && npm run build
@@ -51,7 +52,7 @@ virtualenv:
 
 .PHONY: upgrade-pip
 upgrade-pip: virtualenv
-	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
+	${PYTHON_EXECUTABLE_PREFIX}pip3 install --upgrade pip
 
 .PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
@@ -71,8 +72,8 @@ fix-imports: ## Fix imports using isort
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip3 install --upgrade pip-tools
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
+	${PYTHON_EXECUTABLE_PREFIX}pip3 install --upgrade pip-tools
+	${PYTHON_EXECUTABLE_PREFIX}pip-compile requirements.in
 
 .PHONY: clean
 clean:

--- a/app/main/views/uploads.py
+++ b/app/main/views/uploads.py
@@ -567,6 +567,6 @@ def download_contact_list(service_id, contact_list_id):
     contact_list = ContactList.from_id(contact_list_id, service_id=service_id)
     return send_file(
         path_or_file=BytesIO(contact_list.contents.encode("utf-8")),
-        attachment_filename=contact_list.saved_file_name,
+        download_name=contact_list.saved_file_name,
         as_attachment=True,
     )

--- a/app/s3_client/s3_mou_client.py
+++ b/app/s3_client/s3_mou_client.py
@@ -14,7 +14,7 @@ def get_mou(organisation_is_crown):
         key = get_s3_object(bucket, filename)
         return {
             "path_or_file": key.get()["Body"],
-            "attachment_filename": attachment_filename,
+            "download_name": attachment_filename,
             "as_attachment": True,
         }
     except botocore.exceptions.ClientError as exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ eventlet==0.33.1
     # via gunicorn
 fido2==1.1.0
     # via -r requirements.in
-flask==2.1.2
+flask==2.2.2
     # via
     #   -r requirements.in
     #   flask-login
@@ -116,6 +116,7 @@ lxml==4.9.1
 markupsafe==2.1.1
     # via
     #   jinja2
+    #   werkzeug
     #   wtforms
 mistune==0.8.4
     # via notifications-utils
@@ -215,7 +216,7 @@ urllib3==1.26.9
     # via
     #   botocore
     #   requests
-werkzeug==2.1.2
+werkzeug==2.2.2
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
I didn't commit a freeze-requirements for the Flask/Werkzeug bump to 2.2.2 :(

This actually installs the updates and makes the required compatibility changes, which is just a renamed argument to send_file: attachment_filename is now download_name.

Update to Makefile related to new CI step to make sure that requirements.txt gets updated: https://github.com/alphagov/notifications-aws/pull/1207