### PR TITLE
Clear cache when updating an organisation

### DIFF
--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -342,14 +342,13 @@ def edit_organisation_crown_status(org_id):
     )
 
     if form.validate_on_submit():
-        organisations_client.update_organisation(
-            current_organisation.id,
-            crown={
-                "crown": True,
-                "non-crown": False,
-                "unknown": None,
-            }.get(form.crown_status.data),
-        )
+        crown_data = {
+            "crown": True,
+            "non-crown": False,
+            "unknown": None,
+        }.get(form.crown_status.data)
+
+        current_organisation.update(crown=crown_data, delete_services_cache=True)
         return redirect(url_for(".organisation_settings", org_id=org_id))
 
     return render_template(

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -55,10 +55,18 @@ class OrganisationsClient(NotifyAdminAPIClient):
         if "name" in kwargs:
             redis_client.delete(f"organisation-{org_id}-name")
 
-        if "email_branding_id" in kwargs and kwargs["email_branding_id"]:
+        if kwargs.get("email_branding_id"):
             redis_client.delete(f"organisation-{org_id}-email-branding-pool")
 
         if kwargs.get("letter_branding_id"):
+            redis_client.delete(f"organisation-{org_id}-letter-branding-pool")
+
+        from app.models.organisation import Organisation
+
+        if kwargs.get("organisation_type") in Organisation.NHS_TYPES:
+            # If an org gets set to an NHS org type we add NHS branding to the branding pools, so need
+            # to clear those caches
+            redis_client.delete(f"organisation-{org_id}-email-branding-pool")
             redis_client.delete(f"organisation-{org_id}-letter-branding-pool")
 
         return api_response

--- a/tests/app/main/views/organisations/test_organisations.py
+++ b/tests/app/main/views/organisations/test_organisations.py
@@ -1330,17 +1330,17 @@ def test_view_organisation_settings(
         (
             ".edit_organisation_crown_status",
             {"crown_status": "crown"},
-            {"crown": True},
+            {"cached_service_ids": [], "crown": True},
         ),
         (
             ".edit_organisation_crown_status",
             {"crown_status": "non-crown"},
-            {"crown": False},
+            {"cached_service_ids": [], "crown": False},
         ),
         (
             ".edit_organisation_crown_status",
             {"crown_status": "unknown"},
-            {"crown": None},
+            {"cached_service_ids": [], "crown": None},
         ),
         (
             ".edit_organisation_agreement",


### PR DESCRIPTION
This clears the cache when updating an organisation for two scenarios that were missed previously:

**Clear services cache when updating org's crown status**
Updating an organisation's crown status also changes the crown status [for all of its services](https://github.com/alphagov/notifications-api/blob/b21868aa0c82147e3b94928a37733de5efd24e26/app/dao/organisation_dao.py#L116-L117).

This means we should be clearing the services cache too, which we hadn't been doing.

**Clear branding pool caches if org type is set to NHS**
If we update an organisation's type in api to be an NHS org, we also add the NHS branding to the email and letter branding pools. This means that we should clear the pool caches in this case.