### PR TITLE
Fixed the closing HTML tag at `<p class="govuk-body">`

### DIFF
--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -23,7 +23,7 @@
     <li>create reusable text message templates</li>
     <li>personalise the content of your texts</li>
     <li>send and schedule bulk messages</li></ul>
-  <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send text messages automatically.<p class="govuk-body">
+  <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">integrate with our API</a> to send text messages automatically.</p>
 
   <h3 class="heading heading-small" id="receive">Receive text messages</h3>
   <p class="govuk-body">Let people send messages to your service or reply to your texts.</p>

--- a/app/templates/views/message-status.html
+++ b/app/templates/views/message-status.html
@@ -16,7 +16,7 @@
   <p class="govuk-body">Notify’s real-time dashboard lets you check the status of any message, to see when it was delivered.</p>
   <p class="govuk-body">For <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for("main.security") }}">security</a>, this information is only available for 7 days after a message has been sent. You can download a report, including a list of sent messages, for your own records.</p>
   <p class="govuk-body">This page describes the statuses you’ll see when you’re signed in to Notify.</p>
-  <p class="govuk-body">If you’re using the Notify API, read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.<p class="govuk-body">
+  <p class="govuk-body">If you’re using the Notify API, read our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.documentation') }}">documentation</a> for a list of API statuses.</p>
 
   <h2 id="email-statuses" class="heading-medium">Emails</h2>
   <div class="bottom-gutter-3-2">

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -104,7 +104,7 @@
   <h3 class="heading-small" id="accents">Accents and accented characters</h3>
   <p class="govuk-body">Some languages, such as Welsh, use accented characters.</p>
   <p class="govuk-body">The following accented characters do not affect the cost of sending text messages: Ä, É, Ö, Ü, à, ä, é, è, ì, ò, ö, ù, ü.</p>
-  <p class="govuk-body">Using other accented characters can increase the cost of sending text messages.<p class="govuk-body">
+  <p class="govuk-body">Using other accented characters can increase the cost of sending text messages.</p>
   {% set accentedChars %}
     <div class="bottom-gutter-3-2">
       {% call mapping_table(


### PR DESCRIPTION
Hi @quis,
I found some syntax typo at `app/templates/views`. This patch is tiny and simple to fix, thanks.

Signed-off-by: Toomore Chiang <toomore0929@gmail.com>