### PR TITLE
Redirect to existing request logo pages

### DIFF
--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
@@ -35,7 +35,7 @@
   {% endcall %}
 
   <p class="govuk-body">
-    <a class="govuk-link" href="{{ url_for(".email_branding_upload_logo", service_id=current_service.id) }}">I do not know the hex colour code for my banner</a>
+    <a class="govuk-link" href="{{ url_for(".email_branding_something_else", service_id=current_service.id) }}">I do not know the hex colour code for my banner</a>
   </p>
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
@@ -39,10 +39,9 @@
       <p class="govuk-body">
         We do not recommend portrait images because they’ll look very small. This is because the space for email branding has a fixed height.
       </p>
-        {{ file_upload(form.file, allowed_file_extensions=['png'], button_text='Upload logo') }}
+      {{ file_upload(form.file, allowed_file_extensions=['png'], button_text='Upload logo') }}
       <p class="govuk-body govuk-!-margin-top-4">
-        If you do not have a file, you can
-        <a class="govuk-link" href="{{ url_for('main.email_branding_name_logo', service_id=current_service.id) }}">skip this step</a>.
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.email_branding_something_else', service_id=current_service.id) }}">I do not have a file to upload</a>
       </p>
     </div>
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3890,11 +3890,16 @@ def test_GET_email_branding_upload_logo(client_request, service_one, query_param
     form = page.select_one("form")
     submit_button = form.select_one("button")
     file_input = form.select_one("input")
+    skip_link = page.select("main a")[-1]
 
     assert back_button["href"] == expected_back_link
     assert form["method"] == "post"
     assert "Submit" in submit_button.text
     assert file_input["name"] == "file"
+
+    assert skip_link is not None
+    assert skip_link["href"] == url_for("main.email_branding_something_else", service_id=service_one["id"])
+    assert skip_link.text == "I do not have a file to upload"
 
 
 def test_POST_email_branding_upload_logo_success(mocker, client_request, service_one):
@@ -3965,10 +3970,7 @@ def test_GET_email_branding_choose_banner_colour(client_request, service_one):
     form = page.select_one("form")
     submit_button = form.select_one("button")
     text_input = form.select_one("input")
-    page_links = page.select("a")
-    skip_link = next(
-        filter(lambda link: link.text == "I do not know the hex colour code for my banner", page_links), None
-    )
+    skip_link = page.select("main a")[-1]
 
     assert back_button["href"] == url_for("main.email_branding_choose_banner_type", service_id=service_one["id"])
     assert form["method"] == "post"
@@ -3976,7 +3978,8 @@ def test_GET_email_branding_choose_banner_colour(client_request, service_one):
     assert text_input["name"] == "hex_colour"
 
     assert skip_link is not None
-    assert skip_link["href"] == url_for("main.email_branding_upload_logo", service_id=service_one["id"])
+    assert skip_link["href"] == url_for("main.email_branding_something_else", service_id=service_one["id"])
+    assert skip_link.text == "I do not know the hex colour code for my banner"
 
 
 def test_POST_email_branding_choose_banner_colour(client_request, service_one):


### PR DESCRIPTION
If the user doesn't know their hex code or logo, they will need to log a support ticket as we can't handle their request automatically.