### PR TITLE
Bump GOVUK Frontend to 4.2.0

### DIFF
--- a/app/assets/javascripts/esm/all.mjs
+++ b/app/assets/javascripts/esm/all.mjs
@@ -13,6 +13,7 @@ import Details from 'govuk-frontend/govuk/components/details/details';
 import Button from 'govuk-frontend/govuk/components/button/button';
 import Radios from 'govuk-frontend/govuk/components/radios/radios';
 import ErrorSummary from 'govuk-frontend/govuk/components/error-summary/error-summary';
+import SkipLink from 'govuk-frontend/govuk/components/skip-link/skip-link';
 
 // Modules from 3rd party vendors
 import morphdom from 'morphdom';
@@ -59,8 +60,13 @@ function initAll (options) {
     new Radios($radio).init()
   })
 
+  // There will only every be one error-summary per page
   var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]')
   new ErrorSummary($errorSummary).init()
+
+  // There will only ever be one skip-link per page
+  var skipLink = scope.querySelector('[data-module="govuk-skip-link"]')
+  new SkipLink(skipLink).init()
 }
 
 // Create separate namespace for GOVUK Frontend.
@@ -68,6 +74,9 @@ var Frontend = {
   "Header": Header,
   "Details": Details,
   "Button": Button,
+  "Radios": Radios,
+  "ErrorSummary": ErrorSummary,
+  "SkipLink": SkipLink,
   "initAll": initAll
 }
 

--- a/app/assets/javascripts/esm/all.mjs
+++ b/app/assets/javascripts/esm/all.mjs
@@ -8,12 +8,7 @@
 // For example, `export { Frontend }` will assign `Frontend` to `window.Frontend`
 
 // GOVUK Frontend modules
-import Header from 'govuk-frontend/govuk/components/header/header';
-import Details from 'govuk-frontend/govuk/components/details/details';
-import Button from 'govuk-frontend/govuk/components/button/button';
-import Radios from 'govuk-frontend/govuk/components/radios/radios';
-import ErrorSummary from 'govuk-frontend/govuk/components/error-summary/error-summary';
-import SkipLink from 'govuk-frontend/govuk/components/skip-link/skip-link';
+import { Header, Details, Button, Radios, ErrorSummary, SkipLink } from 'govuk-frontend';
 
 // Modules from 3rd party vendors
 import morphdom from 'morphdom';

--- a/app/assets/javascripts/esm/all.mjs
+++ b/app/assets/javascripts/esm/all.mjs
@@ -55,13 +55,14 @@ function initAll (options) {
     new Radios($radio).init()
   })
 
+  var $skipLinks = scope.querySelectorAll('[data-module="govuk-skip-link"]')
+  nodeListForEach($skipLinks, function ($skipLink) {
+    new SkipLink($skipLink).init()
+  })
+
   // There will only every be one error-summary per page
   var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]')
   new ErrorSummary($errorSummary).init()
-
-  // There will only ever be one skip-link per page
-  var skipLink = scope.querySelector('[data-module="govuk-skip-link"]')
-  new SkipLink(skipLink).init()
 }
 
 // Create separate namespace for GOVUK Frontend.

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -70,6 +70,8 @@
 
     &:focus {
       text-decoration: none; // override the :hover style (the focus style has its own underline)
+      // hack to make the focus style fit in the navigation bar
+      box-shadow: inset 0 -3px $govuk-focus-text-colour, 0 1px $govuk-focus-text-colour;
     }
 
   }
@@ -98,8 +100,6 @@
 
       &:focus {
         padding: $padding-top 0px $padding-bottom + 1px govuk-spacing(3) + 10;
-        /* override default focus style to inset bottom underline */
-        box-shadow: inset 0 -4px $govuk-focus-text-colour;
       }
 
     }
@@ -141,11 +141,6 @@
 
     &:focus:before {
       border-color: $govuk-focus-text-colour;
-    }
-
-    // hack to make the focus style fit in the navigation bar
-    &:focus {
-      box-shadow: inset 0 -3px $govuk-focus-text-colour, 0 1px $govuk-focus-text-colour;
     }
 
   }

--- a/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
+++ b/app/assets/stylesheets/govuk-elements/forms/_form-validation.scss
@@ -15,7 +15,7 @@
 
 // Use .form-control-error to add a red border to .form-control
 .form-control-error {
-  border: 4px solid $govuk-error-colour;
+  border: 2px solid $govuk-error-colour;
 
   // Hack to give GOVUK Frontend styling
   &:focus {

--- a/app/assets/stylesheets/govuk-frontend/overrides.scss
+++ b/app/assets/stylesheets/govuk-frontend/overrides.scss
@@ -13,34 +13,6 @@ $notify-secondary-button-hover-colour: govuk-shade(govuk-colour("light-grey"), 1
   }
 }
 
-.govuk-footer__navigation {
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
-.govuk-footer__section {
-  -webkit-flex-basis: 200px;
-  -ms-flex-preferred-size: 200px;
-  flex-basis: 100%;
-}
-
-@include govuk-media-query($from: tablet) {
-
-  .govuk-footer__navigation {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap
-  }
-
-  .govuk-footer__section {
-    -webkit-flex-basis: 200px;
-    -ms-flex-preferred-size: 200px;
-    flex-basis: 200px;
-  }
-
-}
-
 // Make column headings smaller to prevent wrapping
 .govuk-footer__heading {
   @include govuk-font($size: 19, $weight: bold);

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -165,6 +165,7 @@
       {
         "title": "Support",
         "columns": 1,
+        "width": "one-quarter",
         "items": [
           {
             "href": url_for('main.support'),
@@ -187,6 +188,7 @@
       {
         "title": "About Notify",
         "columns": 1,
+        "width": "one-quarter",
         "items": [
           {
             "href": url_for("main.features"),
@@ -217,6 +219,7 @@
       {
         "title": "Pricing and payment",
         "columns": 1,
+        "width": "one-quarter",
         "items": [
           {
             "href": url_for("main.pricing"),
@@ -235,6 +238,7 @@
       {
         "title": "Using Notify",
         "columns": 1,
+        "width": "one-quarter",
         "items": [
           {
             "href": url_for("main.get_started"),

--- a/app/templates/components/cookie-banner.html
+++ b/app/templates/components/cookie-banner.html
@@ -1,6 +1,6 @@
 {% macro cookie_banner(id='global-cookie-message') %}
 
-<div id="{{ id }}" class="notify-cookie-banner" data-notify-module="cookie-banner" role="region" aria-label="cookie banner">
+<div id="{{ id }}" class="notify-cookie-banner" data-nosnippet data-notify-module="cookie-banner" role="region" aria-label="cookie banner">
   <div class="notify-cookie-banner__wrapper govuk-width-container">
     <h2 class="notify-cookie-banner__heading govuk-heading-m" id="notify-cookie-banner__heading">Can we store analytics cookies on your device?</h2>
     <p class="govuk-body">Analytics cookies help us understand how our website is being used.</p>

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -144,7 +144,7 @@
         ) }}
       {% endif %}
     </div>
-    <a href="#content" class="govuk-link govuk-link--no-visited-state back-to-top-link">Back to top</a>
+    <a href="#main-content" class="govuk-link govuk-link--no-visited-state back-to-top-link" data-module="govuk-skip-link">Back to top</a>
   </div>
 
   {% if not request.args.from_test %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,6 @@
 // 1. LIBRARIES
 // - - - - - - - - - - - - - - -
 const { src, pipe, dest, series, parallel, watch } = require('gulp');
-const rollupPluginCommonjs = require('rollup-plugin-commonjs');
 const rollupPluginNodeResolve = require('rollup-plugin-node-resolve');
 const streamqueue = require('streamqueue');
 const stylish = require('jshint-stylish');
@@ -79,11 +78,6 @@ const javascripts = () => {
           // determine module entry points from either 'module' or 'main' fields in package.json
           rollupPluginNodeResolve({
             mainFields: ['module', 'main']
-          }),
-          // gulp rollup runs on nodeJS so reads modules in commonJS format
-          // this adds node_modules to the require path so it can find the GOVUK Frontend modules
-          rollupPluginCommonjs({
-            include: 'node_modules/**'
           })
         ]
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cbor-js": "0.1.0",
-        "govuk-frontend": "3.14.0",
+        "govuk-frontend": "4.2.0",
         "hogan": "1.0.2",
         "jquery": "3.5.0",
         "leaflet": "1.6.0",
@@ -6415,9 +6415,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -21200,9 +21200,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/alphagov/notifications-admin#readme",
   "dependencies": {
     "cbor-js": "0.1.0",
-    "govuk-frontend": "3.14.0",
+    "govuk-frontend": "4.2.0",
     "hogan": "1.0.2",
     "jquery": "3.5.0",
     "leaflet": "1.6.0",

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ pyproj==3.4.0
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58.1.0
-govuk-frontend-jinja==1.5.1
+govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ govuk-bank-holidays==0.11
     # via
     #   -r requirements.in
     #   notifications-utils
-govuk-frontend-jinja==1.5.1
+govuk-frontend-jinja==2.3.0
     # via -r requirements.in
 greenlet==1.1.2
     # via eventlet

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -545,7 +545,7 @@ def test_service_name_change_fails_if_new_name_fails_validation(
         _expected_status=200,
     )
     assert not mock_update_service.called
-    assert error_message in page.select_one("span.govuk-error-message").text
+    assert error_message in page.select_one(".govuk-error-message").text
 
 
 @pytest.mark.parametrize(
@@ -5693,4 +5693,4 @@ def test_service_set_broadcast_channel_makes_you_choose(
         service_id=SERVICE_ONE_ID,
         _expected_status=200,
     )
-    assert "Error: Select mode or channel" in page.select_one("span.govuk-error-message").text
+    assert "Error: Select mode or channel" in page.select_one(".govuk-error-message").text

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -308,7 +308,7 @@ def test_add_service_fails_if_service_name_fails_validation(
         _data={"name": name},
         _expected_status=200,
     )
-    assert error_message in page.select_one("span.govuk-error-message").text
+    assert error_message in page.select_one(".govuk-error-message").text
 
 
 @freeze_time("2021-01-01")

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -274,7 +274,7 @@ def test_email_address_must_be_valid_if_provided_to_support_form(
         _expected_status=200,
     )
 
-    assert normalize_spaces(page.select_one("span.govuk-error-message").text) == ("Error: Enter a valid email address")
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == ("Error: Enter a valid email address")
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_find_services.py
+++ b/tests/app/main/views/test_find_services.py
@@ -49,7 +49,7 @@ def test_find_services_by_name_validates_against_empty_search_submission(client_
     document = client_request.post("main.find_services_by_name", _data={"search": ""}, _expected_status=200)
 
     expected_message = "Error: You need to enter full or partial name to search by."
-    assert document.select_one("span.govuk-error-message").text.strip() == expected_message
+    assert document.select_one(".govuk-error-message").text.strip() == expected_message
 
 
 def test_find_services_by_name_redirects_for_uuid(client_request, platform_admin_user, mocker, fake_uuid):

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -1505,7 +1505,7 @@ def test_broadcast_user_cant_invite_themselves_or_their_aliases(
         _data={"email_address": email_address, "permissions_field": []},
         _expected_status=200,
     )
-    assert normalize_spaces(page.select_one("span.govuk-error-message").text) == (
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == (
         "Error: You cannot send an invitation to yourself"
     )
     assert mock_create_invite.called is False
@@ -1535,7 +1535,7 @@ def test_platform_admin_cant_invite_themselves_to_broadcast_services(
         _data={"email_address": platform_admin_user["email_address"], "permissions_field": []},
         _expected_status=200,
     )
-    assert normalize_spaces(page.select_one("span.govuk-error-message").text) == (
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == (
         "Error: You cannot send an invitation to yourself"
     )
     assert mock_create_invite.called is False

--- a/tests/templates/components/test_radios_with_images.py
+++ b/tests/templates/components/test_radios_with_images.py
@@ -12,8 +12,8 @@ def test_govuk_frontend_jinja_overrides_on_design_system_v3():
     govuk_frontend_jinja_version = Version(metadata.version("govuk-frontend-jinja"))
 
     # Compatibility between these two libs is defined at https://github.com/LandRegistry/govuk-frontend-jinja/
-    correct_govuk_frontend_version = Version("3.14.0") == govuk_frontend_version
-    correct_govuk_frontend_jinja_version = Version("1.5.1") == govuk_frontend_jinja_version
+    correct_govuk_frontend_version = Version("4.2.0") == govuk_frontend_version
+    correct_govuk_frontend_jinja_version = Version("2.3.0") == govuk_frontend_jinja_version
 
     assert correct_govuk_frontend_version and correct_govuk_frontend_jinja_version, (
         "After upgrading either of the Design System packages, you must validate that "


### PR DESCRIPTION
Bump GOVUK Frontend to 4.2.0 (the latest version GOVUK Frontend Jinja Macros has parity with[^1])

Part of https://trello.com/c/n3OI2lt6/39-bump-govuk-frontend-from-v3-to-latest-version-v42

## Notes for reviewers

These changes are intended to be reviewed commit-by-commit.

[^1]: See [the table of compatibility table on GOVUK Frontend Jinja's repo](https://github.com/LandRegistry/govuk-frontend-jinja#compatibility).