### PR TITLE
bump utils to v58

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -78,7 +78,7 @@ def email_template():
         source = email_branding_client.get_email_branding(branding_style)["email_branding"]
 
     brand_type = source.get("brand_type")
-    brand_name = source.get("name")
+    brand_alt_text = source.get("alt_text")
     brand_text = source.get("text")
     brand_colour = source.get("colour")
     brand_logo = f"https://{current_app.config['LOGO_CDN_DOMAIN']}/{source.get('logo')}" if source.get("logo") else None
@@ -104,7 +104,7 @@ def email_template():
                     brand_colour=brand_colour,
                     brand_logo=brand_logo,
                     brand_banner=brand_banner,
-                    brand_name=brand_name,
+                    brand_alt_text=brand_alt_text,
                 )
             )
         )

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ pyproj==3.4.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58.1.0
 govuk-frontend-jinja==1.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,7 +122,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.4.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58.1.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -58,6 +58,7 @@ def test_displays_org_branding(client_request, mock_get_email_branding):
 
     assert not any(a["href"] == "https://www.gov.uk" for a in page.select("a"))
     assert page.select_one("img")["src"] == "https://static-logos.test.com/example.png"
+    assert page.select_one("img")["alt"] == ""  # no alt text cos brand text is present
     assert not page.select("body > table > tr > td[bgcolor='#f00']")  # banner colour is not set
     assert (
         page.select("body > table:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(2)")[0].get_text().strip()
@@ -89,6 +90,7 @@ def test_displays_org_branding_with_banner_without_brand_text(
 
     assert not any(a["href"] == "https://www.gov.uk" for a in page.select("a"))
     assert page.select_one("img")["src"] == "https://static-logos.test.com/example.png"
+    assert page.select_one("img")["alt"] == "Alt text"
     assert page.select("body > table > tr > td[bgcolor='#f00']")  # banner colour is set
     assert not page.select("body > table table > tr > td > span") == 0  # brand text is not set
 


### PR DESCRIPTION
uses brand_alt_text rather than brand_name in the email template code

Note that when we pass in params, currently, we're only passing in type, colour and logo. `text`, `name` and `alt_text` are only populated in the email_template endpoint if it's called with a UUID for an existing branding option