### PR TITLE
Hard-code the HTML for the 2-factor webauth error

### DIFF
--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -21,20 +21,12 @@
 
 {% block maincolumn_content %}
 
-    {{ govukErrorMessage({
-      "classes": "banner-dangerous govuk-!-display-none",
-      "html": (
-        'There’s a problem with your security key' +
-        '<p class="govuk-body">Check you have the right key and try again. ' +
-        'If this does not work, ' +
-        '<a class="govuk-link govuk-link--no-visited-state" href=' + url_for('main.support') + ">contact us</a>." +
-        '</p>'
-      ),
-      "attributes": {
-        "aria-live": "polite",
-        "tabindex": '-1'
-      }
-    }) }}
+  <span class="govuk-error-message banner-dangerous govuk-!-display-none" aria-live="polite" tabindex="-1">
+    <span class="govuk-visually-hidden">Error:</span> There’s a problem with your security key
+    <p class="govuk-body">
+      Check you have the right key and try again. If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="/support">contact us</a>.
+    </p>
+  </span>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">


### PR DESCRIPTION
We used the GOVUK Frontend error message component for this. Recent updates to our version of GOVUK
Frontend changed the elements used for this
message from `<span>`s to `<p>`s. This broke our
code, meaning part of it is now showing:

![image](https://user-images.githubusercontent.com/87140/203831319-740e7932-d687-486b-9474-337cabc45232.png)

This hard-codes the original HTML, to unblock
deployment of a recent bump to the latest GOVUK
Frontend until we can fix it properly.