### PR TITLE
Email branding query arg refactor

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1443,22 +1443,14 @@ def email_branding_upload_logo(service_id):
 @user_has_permissions("manage_service")
 def email_branding_confirm_upload_logo(service_id):
     email_branding_data = _email_branding_flow_query_params(request)
-    if "brand_type" not in email_branding_data:
+    if not email_branding_data["brand_type"]:
         return redirect(url_for("main.email_branding_choose_banner_type", service_id=service_id))
-    elif "logo" not in email_branding_data:
+    elif not email_branding_data["logo"]:
         return redirect(url_for("main.email_branding_upload_logo", service_id=service_id, **email_branding_data))
 
     if request.method == "POST":
         # Can't create the branding yet - need to extend this page to accept and handle the logo name/alt text
         pass
-
-    # Translate new brand form data into query params expected by the `/_email` endpoint
-    email_preview_data = {
-        "brand_type": email_branding_data["brand_type"],
-        "logo": email_branding_data["logo"],
-    }
-    if "colour" in email_branding_data:
-        email_preview_data["colour"] = email_branding_data["colour"]
 
     return render_template(
         "views/service-settings/branding/add-new-branding/confirm.html",
@@ -1467,7 +1459,7 @@ def email_branding_confirm_upload_logo(service_id):
             service_id=service_id,
             **_email_branding_flow_query_params(request, logo=None),
         ),
-        email_preview_data=email_preview_data,
+        email_preview_data=email_branding_data,
     )
 
 
@@ -1490,8 +1482,7 @@ def _email_branding_flow_query_params(request, **kwargs):
 
     These values can get passed to the `/_email` endpoint to generate a preview of a new brand.
     """
-    email_branding_data = {k: kwargs.get(k, request.args.get(k)) for k in ("brand_type", "colour", "logo")}
-    return {k: v for k, v in email_branding_data.items() if v}
+    return {k: kwargs.get(k, request.args.get(k)) for k in ("brand_type", "colour", "logo")}
 
 
 @main.route("/services/<uuid:service_id>/service-settings/email-branding/add-banner", methods=["GET", "POST"])

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1416,7 +1416,7 @@ def email_branding_upload_logo(service_id):
             )
         )
 
-    if request.args.get("type") == "org_banner":
+    if request.args.get("brand_type") == "org_banner":
         back_link = url_for(
             ".email_branding_choose_banner_colour",
             service_id=service_id,
@@ -1426,7 +1426,7 @@ def email_branding_upload_logo(service_id):
         back_link = url_for(
             ".email_branding_choose_banner_type",
             service_id=service_id,
-            **_email_branding_flow_query_params(request, type=None),
+            **_email_branding_flow_query_params(request, brand_type=None),
         )
 
     return (
@@ -1443,7 +1443,7 @@ def email_branding_upload_logo(service_id):
 @user_has_permissions("manage_service")
 def email_branding_confirm_upload_logo(service_id):
     email_branding_data = _email_branding_flow_query_params(request)
-    if "type" not in email_branding_data:
+    if "brand_type" not in email_branding_data:
         return redirect(url_for("main.email_branding_choose_banner_type", service_id=service_id))
     elif "logo" not in email_branding_data:
         return redirect(url_for("main.email_branding_upload_logo", service_id=service_id, **email_branding_data))
@@ -1454,7 +1454,7 @@ def email_branding_confirm_upload_logo(service_id):
 
     # Translate new brand form data into query params expected by the `/_email` endpoint
     email_preview_data = {
-        "brand_type": email_branding_data["type"],
+        "brand_type": email_branding_data["brand_type"],
         "logo": email_branding_data["logo"],
     }
     if "colour" in email_branding_data:
@@ -1483,14 +1483,14 @@ def _email_branding_flow_query_params(request, **kwargs):
     URL, and optionally allows the caller to update or remove some of the options.
 
     To set a new value:
-        _email_branding_flow_query_params(request, type='org')
+        _email_branding_flow_query_params(request, brand_type='org')
 
     To remove a value:
-        _email_branding_flow_query_params(request, type=None)
+        _email_branding_flow_query_params(request, brand_type=None)
 
     These values can get passed to the `/_email` endpoint to generate a preview of a new brand.
     """
-    email_branding_data = {k: kwargs.get(k, request.args.get(k)) for k in ("type", "colour", "logo")}
+    email_branding_data = {k: kwargs.get(k, request.args.get(k)) for k in ("brand_type", "colour", "logo")}
     return {k: v for k, v in email_branding_data.items() if v}
 
 
@@ -1505,7 +1505,7 @@ def email_branding_choose_banner_type(service_id):
                 url_for(
                     ".email_branding_upload_logo",
                     service_id=service_id,
-                    **_email_branding_flow_query_params(request, type=form.banner.data),
+                    **_email_branding_flow_query_params(request, brand_type=form.banner.data),
                 )
             )
 
@@ -1514,7 +1514,7 @@ def email_branding_choose_banner_type(service_id):
                 url_for(
                     ".email_branding_choose_banner_colour",
                     service_id=service_id,
-                    **_email_branding_flow_query_params(request, type=form.banner.data),
+                    **_email_branding_flow_query_params(request, brand_type=form.banner.data),
                 )
             )
 

--- a/app/templates/components/branding-preview.html
+++ b/app/templates/components/branding-preview.html
@@ -3,9 +3,7 @@
 {% endmacro %}
 
 {% macro custom_email_branding_preview(preview_settings) %}
-  {% set query_params = (preview_settings | urlencode) %}
-  {% set query_params = 'branding_style=custom' + ('&' + query_params if query_params else '') %}
-  <iframe src="{{ url_for('main.email_template') }}?{{ query_params }}" class="branding-preview" scrolling="no"></iframe>
+  <iframe src="{{ url_for('main.email_template', branding_style='custom', **preview_settings) }}" class="branding-preview" scrolling="no"></iframe>
 {% endmacro %}
 
 {% macro email_branding_preview(branding_style, classes='') %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3827,8 +3827,8 @@ def test_any_org_type_can_see_email_branding_choose_banner_type_page(
 @pytest.mark.parametrize(
     "selected_option, expected_endpoint, url_for_kwargs",
     [
-        ("org", ".email_branding_upload_logo", {"type": "org"}),
-        ("org_banner", ".email_branding_choose_banner_colour", {"type": "org_banner"}),
+        ("org", ".email_branding_upload_logo", {"brand_type": "org"}),
+        ("org_banner", ".email_branding_choose_banner_colour", {"brand_type": "org_banner"}),
     ],
 )
 def test_email_branding_choose_banner_type_redirects_to_right_page(
@@ -3863,12 +3863,12 @@ def test_email_branding_choose_banner_type_shows_error_summary_on_invalid_data(c
     (
         ({}, "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner"),
         (
-            {"type": "org"},
+            {"brand_type": "org"},
             "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner",
         ),
         (
-            {"type": "org_banner"},
-            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/choose-banner-colour?type=org_banner",  # noqa
+            {"brand_type": "org_banner"},
+            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/choose-banner-colour?brand_type=org_banner",  # noqa
         ),
     ),
 )
@@ -3899,8 +3899,8 @@ def test_GET_email_branding_upload_logo(client_request, service_one, query_param
     "email_branding_data",
     (
         {},
-        {"type": "org"},
-        {"type": "org_banner", "colour": "#abcdef"},
+        {"brand_type": "org"},
+        {"brand_type": "org_banner", "colour": "#abcdef"},
     ),
 )
 def test_POST_email_branding_upload_logo_success(mocker, client_request, service_one, email_branding_data):
@@ -4040,7 +4040,10 @@ def test_POST_email_branding_upload_logo_resizes_and_pads_wide_short_logo(mocker
 
 def test_GET_email_branding_confirm_upload_logo(client_request, service_one):
     page = client_request.get(
-        "main.email_branding_confirm_upload_logo", service_id=service_one["id"], type="org_banner", logo="example.png"
+        "main.email_branding_confirm_upload_logo",
+        service_id=service_one["id"],
+        brand_type="org_banner",
+        logo="example.png",
     )
     form = page.select_one("main form")
     email_preview = page.select_one("iframe")
@@ -4057,8 +4060,8 @@ def test_GET_email_branding_confirm_upload_logo(client_request, service_one):
     "request_params, expected_location",
     (
         (
-            {"type": "org"},
-            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/upload-logo?type=org",
+            {"brand_type": "org"},
+            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/upload-logo?brand_type=org",
         ),
         ({}, "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner"),
     ),
@@ -4078,7 +4081,7 @@ def test_GET_email_branding_confirm_upload_logo_redirects_on_missing_query_param
 def test_GET_email_branding_choose_banner_colour(client_request, service_one):
     page = client_request.get(
         "main.email_branding_choose_banner_colour",
-        type="org_banner",
+        brand_type="org_banner",
         service_id=service_one["id"],
     )
 
@@ -4102,11 +4105,11 @@ def test_POST_email_branding_choose_banner_colour(client_request, service_one):
     client_request.post(
         "main.email_branding_choose_banner_colour",
         service_id=service_one["id"],
-        type="org_banner",
+        brand_type="org_banner",
         _data={"hex_colour": "#abcdef"},
         _expected_status=302,
         _expected_redirect=url_for(
-            "main.email_branding_upload_logo", service_id=service_one["id"], type="org_banner", colour="#abcdef"
+            "main.email_branding_upload_logo", service_id=service_one["id"], brand_type="org_banner", colour="#abcdef"
         ),
     )
 

--- a/tests/app/main/views/test_email_preview.py
+++ b/tests/app/main/views/test_email_preview.py
@@ -105,7 +105,7 @@ def test_displays_custom_brand_through_query_params(client_request, mocker):
         text="Some text",
         colour="#abcdef",
         logo="example.png",
-        type="org",
+        brand_type="org",
     )
 
     assert mock_get_email_branding.called is False


### PR DESCRIPTION
Some small refactors around how we handle query params.

By renaming `type` to `brand_type` in the admin endpoints, we keep that consistent with the model they'll eventually populate, and also the email_preview endpoint.

By using url_for to generate query params for the email preview, we can avoid constructing query params ourselves, and we can also take advantage of url_for stripping None values to tidy up our code a bit