### PR TITLE
Set name based on alt-text

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1452,9 +1452,9 @@ def email_branding_set_alt_text(service_id):
     form = EmailBrandingAltTextForm()
 
     if form.validate_on_submit():
+        name = email_branding_client.get_email_branding_name_for_alt_text(form.alt_text.data)
         email_branding_client.create_email_branding(
-            # TODO: handle if this name already exists in the db
-            name=form.alt_text.data,
+            name=name,
             alt_text=form.alt_text.data,
             text=None,
             created_by_id=current_user.id,

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -10,6 +10,12 @@ class EmailBrandingClient(NotifyAdminAPIClient):
     def get_all_email_branding(self):
         return self.get(url="/email-branding")["email_branding"]
 
+    def get_email_branding_name_for_alt_text(self, alt_text):
+        # a post rather than a get so we dont have to worry about URL/query param encoding for what could be
+        # a relatively long and arbitrary unicode string full of spaces etc.
+        resp = self.post(url="/email-branding/get-name-for-alt-text", data={"alt_text": alt_text})
+        return resp["name"]
+
     @cache.delete("email_branding")
     def create_email_branding(self, *, logo, name, alt_text, text, colour, brand_type, created_by_id: str):
         data = {

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4126,6 +4126,7 @@ def test_POST_email_branding_set_alt_text_creates_branding_and_redirects_to_serv
     client_request,
     service_one,
     mock_create_email_branding,
+    mock_get_email_branding_name_for_alt_text,
     active_user_with_permissions,
     mocker,
 ):

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -157,3 +157,12 @@ def test_update_email_branding_sends_none_values(mocker, fake_uuid):
     EmailBrandingClient().update_email_branding(**form_data)
 
     mock_post.assert_called_once_with(url=f"/email-branding/{fake_uuid}", data=expected_data)
+
+
+def test_get_email_branding_name_for_alt_text(mocker):
+    mock_post = mocker.patch(
+        "app.notify_client.email_branding_client.EmailBrandingClient.post", return_value={"name": "bar"}
+    )
+    resp = EmailBrandingClient().get_email_branding_name_for_alt_text("foo")
+    assert resp == "bar"
+    mock_post.assert_called_once_with(url="/email-branding/get-name-for-alt-text", data={"alt_text": "foo"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2601,6 +2601,17 @@ def mock_create_email_branding(mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_get_email_branding_name_for_alt_text(mocker):
+    def _get_email_branding_name_for_alt_text(alt_text):
+        return alt_text
+
+    return mocker.patch(
+        "app.email_branding_client.get_email_branding_name_for_alt_text",
+        side_effect=_get_email_branding_name_for_alt_text,
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_update_email_branding(mocker):
     def _update_email_branding(branding_id, logo, name, alt_text, text, colour, brand_type, updated_by_id):
         return


### PR DESCRIPTION
- [x] https://github.com/alphagov/notifications-admin/pull/4472
- [x] https://github.com/alphagov/notifications-api/pull/3651

See [0631d3d](https://github.com/alphagov/notifications-admin/pull/4473/commits/0631d3df53836802b575e4fe0f49627edd21158a). Given an alt text "My Department", checks if that exists as a name in the DB, and if so, returns a new name along the lines of `"My Department (alternate 1)"`.