### PR TITLE
Hex colour code input fields using Design System prefixes

### DIFF
--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -11,7 +11,10 @@
 
       this.$input = $(component);
 
-      this.$input.closest('.govuk-form-group').append(
+      // We expect the colour preview module to only ever be applied to a GOV.UK Design System text input with a prefix,
+      // which wraps the text input inside a `govuk-input__wrapper` div.
+      const $appendToElement = this.$input.parent();
+      $appendToElement.append(
         this.$preview = $('<span class="textbox-colour-preview"></span>')
       );
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -363,6 +363,16 @@ class HexColourCodeField(GovukTextInputField, RequiredValidatorsMixin):
     required_validators = [
         Regexp(regex="^$|^#?(?:[0-9a-fA-F]{3}){1,2}$", message="Must be a valid hex colour code"),
     ]
+    param_extensions = {
+        "prefix": {
+            "text": "#",
+        },
+        "classes": "govuk-input--width-6",
+        "attributes": {"data-notify-module": "colour-preview"},
+    }
+
+    def _value(self):
+        return self.data[1:] if self.data and self.data.startswith("#") else self.data
 
     def post_validate(self, form, validation_stopped):
         if not self.errors:
@@ -1618,10 +1628,7 @@ class AdminPreviewBrandingForm(StripWhitespaceForm):
 class AdminEditEmailBrandingForm(StripWhitespaceForm):
     name = GovukTextInputField("Name of brand")
     text = GovukTextInputField("Text")
-    colour = HexColourCodeField(
-        "Colour",
-        param_extensions={"classes": "govuk-input--width-6", "attributes": {"data-notify-module": "colour-preview"}},
-    )
+    colour = HexColourCodeField("Colour")
     file = VirusScannedFileField("Upload a PNG logo", validators=[FileAllowed(["png"], "PNG Images only!")])
     brand_type = GovukRadiosField(
         "Brand type",

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -198,7 +198,7 @@ class GovukTextInputFieldMixin(GovukFrontendWidgetMixin):
     govuk_frontend_component_name = "text-input"
 
     def prepare_params(self, **kwargs):
-        value = kwargs["value"] if "value" in kwargs else self.data
+        value = kwargs["value"] if "value" in kwargs else self._value()
         value = str(value) if isinstance(value, Number) else value
 
         error_message_format = "html" if kwargs.get("error_message_with_html") else "text"
@@ -571,7 +571,15 @@ class GovukCheckboxField(GovukFrontendWidgetMixin, BooleanField):
         params = {
             "name": self.name,
             "errorMessage": self.get_error_message(),
-            "items": [{"name": self.name, "id": self.id, "text": self.label.text, "value": "y", "checked": self.data}],
+            "items": [
+                {
+                    "name": self.name,
+                    "id": self.id,
+                    "text": self.label.text,
+                    "value": self._value(),
+                    "checked": self.data,
+                }
+            ],
         }
         return params
 
@@ -607,7 +615,7 @@ class GovukCheckboxesField(GovukFrontendWidgetMixin, SelectMultipleField):
             "name": option.name,
             "id": option.id,
             "text": option.label.text,
-            "value": str(option.data),  # to protect against non-string types like uuids
+            "value": option._value(),
             "checked": option.checked,
         }
 
@@ -672,7 +680,7 @@ class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
             "name": option.name,
             "id": option.id,
             "text": option.label.text,
-            "value": str(option.data),  # to protect against non-string types like uuids
+            "value": option._value(),
             "checked": option.checked,
         }
 

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
@@ -23,11 +23,9 @@
               "isPageHeading": True,
               "classes": "govuk-label--l",
           },
-          "hint": {"html": ("Enter a hex colour code. For example, #1d70b8")},
-          "classes": "govuk-input--width-6",
-          "attributes": {"data-notify-module": "colour-preview"},
-      })
-    }}
+          "hint": {"html": "Enter a hex colour code. For example, #1d70b8"}
+        })
+      }}
     {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -54,7 +54,7 @@ def test_edit_email_branding_shows_the_correct_branding_info(
     assert page.select_one("#name").attrs.get("value") == "Organisation name"
     assert page.select_one("#file").attrs.get("accept") == ".png"
     assert page.select_one("#text").attrs.get("value") == "Organisation text"
-    assert page.select_one("#colour").attrs.get("value") == "#f00"
+    assert page.select_one("#colour").attrs.get("value") == "f00"
 
 
 def test_create_email_branding_does_not_show_any_branding_info(

--- a/tests/javascripts/colourPreview.test.js
+++ b/tests/javascripts/colourPreview.test.js
@@ -10,9 +10,7 @@ afterAll(() => {
 
 describe('Colour preview', () => {
 
-  let field;
   let textbox;
-  let swatchEl;
 
   beforeEach(() => {
 
@@ -22,10 +20,12 @@ describe('Colour preview', () => {
         <label class="govuk-form-label" for="colour">
           Colour
         </label>
-        <input class="govuk-input govuk-input--width-6" id="colour" name="colour" rows="8" type="text" value="" data-notify-module="colour-preview">
+        <div class="govuk-input__wrapper">
+          <div class="govuk-input__prefix" aria-hidden="true">#</div>
+          <input class="govuk-input govuk-input--width-6" id="colour-2" name="colour" rows="8" type="text" value="" data-notify-module="colour-preview">
+        </div>
       </div>`;
 
-    field = document.querySelector('.govuk-form-group');
     textbox = document.querySelector('input[type=text]');
 
   });
@@ -42,7 +42,6 @@ describe('Colour preview', () => {
 
       // start the module
       window.GOVUK.notifyModules.start();
-
       swatchEl = document.querySelector('.textbox-colour-preview');
 
       expect(swatchEl).not.toBeNull();
@@ -53,22 +52,58 @@ describe('Colour preview', () => {
 
       // start the module
       window.GOVUK.notifyModules.start();
-
       swatchEl = document.querySelector('.textbox-colour-preview');
 
       // textbox defaults to empty
       // colours are output in RGB
-      expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
-
+        expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
     });
 
-    test("If the textbox has a value which is a hex code it should add that colour to the swatch", () => {
+    test("If the textbox has a value which is a 6-character hex code it should add that colour to the swatch", () => {
 
       textbox.setAttribute('value', '#00FF00');
 
       // start the module
       window.GOVUK.notifyModules.start();
+      swatchEl = document.querySelector('.textbox-colour-preview');
 
+      // textbox defaults to empty
+      // colours are output in RGB
+        expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
+    });
+
+    test("If the textbox has a value which is a 3-character hex code it should add that colour to the swatch", () => {
+
+      textbox.setAttribute('value', '#0F0');
+
+      // start the module
+      window.GOVUK.notifyModules.start();
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+      // colours are output in RGB
+      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
+
+    });
+
+    test("The textbox has a value which is a 6-character hex code without a leading # it should add that colour to the swatch", () => {
+
+      textbox.setAttribute('value', '00FF00');
+
+      // start the module
+      window.GOVUK.notifyModules.start();
+      swatchEl = document.querySelector('.textbox-colour-preview');
+
+      // colours are output in RGB
+      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
+
+    });
+
+    test("The textbox has a value which is a 3-character hex code without a leading # it should add that colour to the swatch", () => {
+
+      textbox.setAttribute('value', '0F0');
+
+      // start the module
+      window.GOVUK.notifyModules.start();
       swatchEl = document.querySelector('.textbox-colour-preview');
 
       // colours are output in RGB
@@ -82,39 +117,10 @@ describe('Colour preview', () => {
 
       // start the module
       window.GOVUK.notifyModules.start();
-
       swatchEl = document.querySelector('.textbox-colour-preview');
 
       // colours are output in RGB
       expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
-
-    });
-
-    test("The textbox accepts hex codes without a leading #", () => {
-
-      textbox.setAttribute('value', '00FF00');
-
-      // start the module
-      window.GOVUK.notifyModules.start();
-
-      swatchEl = document.querySelector('.textbox-colour-preview');
-
-      // colours are output in RGB
-      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
-
-    });
-
-    test("The textbox accepts 3-character hex codes", () => {
-
-      textbox.setAttribute('value', '0F0');
-
-      // start the module
-      window.GOVUK.notifyModules.start();
-
-      swatchEl = document.querySelector('.textbox-colour-preview');
-
-      // colours are output in RGB
-      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
 
     });
 
@@ -126,14 +132,13 @@ describe('Colour preview', () => {
 
       // start the module
       window.GOVUK.notifyModules.start();
-
       swatchEl = document.querySelector('.textbox-colour-preview');
 
     });
 
     test("If the textbox is empty it should make the swatch white", () => {
 
-      helpers.triggerEvent(document.querySelector('input[type=text]'), 'input');
+      helpers.triggerEvent(textbox, 'input');
 
       // textbox defaults to empty
       expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');
@@ -144,7 +149,7 @@ describe('Colour preview', () => {
 
       textbox.setAttribute('value', '#00FF00');
 
-      helpers.triggerEvent(document.querySelector('input[type=text]'), 'input');
+      helpers.triggerEvent(textbox, 'input');
 
       // textbox defaults to empty
       expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
@@ -155,7 +160,7 @@ describe('Colour preview', () => {
 
       textbox.setAttribute('value', 'green');
 
-      helpers.triggerEvent(document.querySelector('input[type=text]'), 'input');
+      helpers.triggerEvent(textbox, 'input');
 
       // textbox defaults to empty
       expect(swatchEl.style.background).toEqual('rgb(255, 255, 255)');


### PR DESCRIPTION
## Summary
Updates the hex colour code input fields to use [Design System text input prefixes](https://design-system.service.gov.uk/components/text-input#prefixes-and-suffixes). We therefore always hide the `#` at the start of the code, but do some magic under the hood to make sure it's there to be stored in the DB.


| Before | After |
|---|---|
| <img width="569" alt="Screenshot 2022-11-28 at 09 53 04" src="https://user-images.githubusercontent.com/2920760/204247700-09db4cd2-7966-4e71-bfe6-0cf31d7dafc2.png"> | <img width="591" alt="Screenshot 2022-11-28 at 09 52 24" src="https://user-images.githubusercontent.com/2920760/204247722-7dd1f569-0c04-4277-9991-77418ad21d7e.png"> |


| Before | After | 
|---|---|
| <img width="439" alt="Screenshot 2022-11-28 at 09 54 03" src="https://user-images.githubusercontent.com/2920760/204247914-26dd0cf7-ebc8-45a6-8fd9-6f1d6371928e.png"> | <img width="425" alt="Screenshot 2022-11-28 at 09 54 27" src="https://user-images.githubusercontent.com/2920760/204247992-427d1681-6987-4132-8a1c-537f2f49cc7c.png"> |