### PR TITLE
Make colour picker work when there is whitespace

### DIFF
--- a/app/assets/javascripts/colourPreview.js
+++ b/app/assets/javascripts/colourPreview.js
@@ -25,7 +25,7 @@
     };
 
     this.update = () => this.$preview.css(
-      'background', colourOrWhite(this.$input.val())
+      'background', colourOrWhite(this.$input.val().trim())
     );
 
   };

--- a/tests/javascripts/colourPreview.test.js
+++ b/tests/javascripts/colourPreview.test.js
@@ -167,6 +167,16 @@ describe('Colour preview', () => {
 
     });
 
+    test("If there is leading and trailing space the preview still works", () => {
+
+      textbox.setAttribute('value', '  #00FF00 ');
+
+      helpers.triggerEvent(textbox, 'input');
+
+      expect(swatchEl.style.background).toEqual('rgb(0, 255, 0)');
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Sometimes when you copy and paste a hex code from another place you end up with leading and/or trailing whitespace.

Our Python code will handle this automatically and strip the whitespace before sending the data to the API:
https://github.com/alphagov/notifications-admin/blob/main/app/main/forms.py#L476-L490

This commit makes the Javascript strip the whitespace before using the value of the hex colour preview.