### PR TITLE
Fix back_links when dropping out of new brand flow

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1294,11 +1294,21 @@ def email_branding_something_else(service_id):
         flash(THANKS_FOR_BRANDING_REQUEST_MESSAGE, "default")
         return redirect(url_for(".service_settings", service_id=current_service.id))
 
+    branding_options = ChooseEmailBrandingForm(current_service)
+    if branding_options.something_else_is_only_option:
+        back_link = url_for(".service_settings", service_id=current_service.id)
+    else:
+        back_link = url_for(
+            request.args.get("back_link", ".email_branding_request"),
+            service_id=current_service.id,
+            **_email_branding_flow_query_params(request),
+        )
+
     return render_template(
         "views/service-settings/branding/email-branding-something-else.html",
         form=form,
-        branding_options=ChooseEmailBrandingForm(current_service),
-        back_link=request.args.get("back_link", ".email_branding_request"),
+        branding_options=branding_options,
+        back_link=back_link,
     )
 
 
@@ -1417,6 +1427,12 @@ def email_branding_upload_logo(service_id):
             )
         )
 
+    abandon_flow_link = url_for(
+        "main.email_branding_something_else",
+        service_id=current_service.id,
+        back_link=".email_branding_upload_logo",
+        **_email_branding_flow_query_params(request),
+    )
     if request.args.get("brand_type") == "org_banner":
         back_link = url_for(
             ".email_branding_choose_banner_colour",
@@ -1432,7 +1448,10 @@ def email_branding_upload_logo(service_id):
 
     return (
         render_template(
-            "views/service-settings/branding/add-new-branding/upload-logo.html", form=form, back_link=back_link
+            "views/service-settings/branding/add-new-branding/upload-logo.html",
+            form=form,
+            back_link=back_link,
+            abandon_flow_link=abandon_flow_link,
         ),
         400 if form.errors else 200,
     )
@@ -1557,11 +1576,18 @@ def email_branding_choose_banner_colour(service_id):
             )
         )
 
+    abandon_flow_link = url_for(
+        ".email_branding_something_else",
+        service_id=current_service.id,
+        back_link=".email_branding_choose_banner_colour",
+        **_email_branding_flow_query_params(request),
+    )
     return (
         render_template(
             "views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html",
             form=form,
             back_link=url_for(".email_branding_choose_banner_type", service_id=service_id),
+            abandon_flow_link=abandon_flow_link,
         ),
         400 if form.errors else 200,
     )

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1295,19 +1295,17 @@ def email_branding_something_else(service_id):
         return redirect(url_for(".service_settings", service_id=current_service.id))
 
     branding_options = ChooseEmailBrandingForm(current_service)
-    if branding_options.something_else_is_only_option:
-        back_link = url_for(".service_settings", service_id=current_service.id)
-    else:
-        back_link = url_for(
-            request.args.get("back_link", ".email_branding_request"),
-            service_id=current_service.id,
-            **_email_branding_flow_query_params(request),
-        )
-
+    default_back_view = (
+        ".service_settings" if branding_options.something_else_is_only_option else ".email_branding_request"
+    )
+    back_link = url_for(
+        request.args.get("back_link", default_back_view),
+        service_id=current_service.id,
+        **_email_branding_flow_query_params(request),
+    )
     return render_template(
         "views/service-settings/branding/email-branding-something-else.html",
         form=form,
-        branding_options=branding_options,
         back_link=back_link,
     )
 

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
@@ -30,7 +30,7 @@
   {% endcall %}
 
   <p class="govuk-body">
-    <a class="govuk-link" href="{{ url_for(".email_branding_something_else", service_id=current_service.id) }}">I do not know the hex colour code for my banner</a>
+    <a class="govuk-link" href="{{ abandon_flow_link }}">I do not know the hex colour code for my banner</a>
   </p>
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
@@ -32,7 +32,7 @@
       </p>
       {{ file_upload(form.logo, allowed_file_extensions=[form.EXPECTED_LOGO_FORMAT], button_text='Upload logo') }}
       <p class="govuk-body govuk-!-margin-top-4">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.email_branding_something_else', service_id=current_service.id) }}">I do not have a file to upload</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ abandon_flow_link }}">I do not have a file to upload</a>
       </p>
     </div>
 

--- a/app/templates/views/service-settings/branding/email-branding-something-else.html
+++ b/app/templates/views/service-settings/branding/email-branding-something-else.html
@@ -8,14 +8,8 @@
   Describe the branding you want
 {% endblock %}
 
-{% if branding_options.something_else_is_only_option %}
-  {% set back_url = url_for('.service_settings', service_id=current_service.id) %}
-{% else %}
-  {% set back_url = url_for(back_link, service_id=current_service.id) %}
-{% endif %}
-
 {% block backLink %}
-  {{ govukBackLink({"href": back_url}) }}
+  {{ govukBackLink({"href": back_link}) }}
 {% endblock %}
 
 {% block maincolumn_content %}

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -533,6 +533,29 @@ def test_email_branding_something_else_page(client_request, service_one, mock_ge
     )
 
 
+@pytest.mark.parametrize(
+    "back_view, back_view_args",
+    (
+        (".email_branding_choose_banner_type", {}),
+        (".email_branding_choose_banner_colour", {"brand_type": "org"}),
+        (".email_branding_upload_logo", {"brand_type": "org", "colour": "1ce"}),
+    ),
+)
+def test_email_branding_something_else_back_to_new_email_branding_query_params(
+    client_request, service_one, mock_get_empty_email_branding_pool, back_view, back_view_args
+):
+    service_one["organisation_type"] = "nhs_central"
+
+    page = client_request.get(
+        "main.email_branding_something_else",
+        service_id=SERVICE_ONE_ID,
+        back_link=back_view,
+        **back_view_args,
+    )
+    back_link = page.select_one(".govuk-back-link")
+    assert back_link["href"] == url_for(back_view, service_id=SERVICE_ONE_ID, **back_view_args)
+
+
 @pytest.mark.parametrize("back_link", [".service_settings", ".email_branding_request", ".email_branding_choose_logo"])
 def test_email_branding_something_else_page_back_link_from_args(
     client_request, service_one, mock_get_empty_email_branding_pool, back_link

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3859,20 +3859,37 @@ def test_email_branding_choose_banner_type_shows_error_summary_on_invalid_data(c
 
 
 @pytest.mark.parametrize(
-    "query_params, expected_back_link",
+    "query_params, expected_back_link, expected_skip_link",
     (
-        ({}, "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner"),
+        (
+            {},
+            "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner",
+            (
+                "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/something-else"
+                "?back_link=.email_branding_upload_logo"
+            ),
+        ),
         (
             {"brand_type": "org"},
             "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/add-banner",
+            (
+                "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/something-else"
+                "?back_link=.email_branding_upload_logo&brand_type=org"
+            ),
         ),
         (
             {"brand_type": "org_banner"},
             "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/choose-banner-colour?brand_type=org_banner",  # noqa
+            (
+                "/services/596364a0-858e-42c8-9062-a8fe822260eb/service-settings/email-branding/something-else"
+                "?back_link=.email_branding_upload_logo&brand_type=org_banner"
+            ),
         ),
     ),
 )
-def test_GET_email_branding_upload_logo(client_request, service_one, query_params, expected_back_link):
+def test_GET_email_branding_upload_logo(
+    client_request, service_one, query_params, expected_back_link, expected_skip_link
+):
     page = client_request.get(
         "main.email_branding_upload_logo",
         service_id=service_one["id"],
@@ -3891,7 +3908,7 @@ def test_GET_email_branding_upload_logo(client_request, service_one, query_param
     assert file_input["name"] == "logo"
 
     assert skip_link is not None
-    assert skip_link["href"] == url_for("main.email_branding_something_else", service_id=service_one["id"])
+    assert skip_link["href"] == expected_skip_link
     assert skip_link.text == "I do not have a file to upload"
 
 
@@ -4184,7 +4201,12 @@ def test_GET_email_branding_choose_banner_colour(client_request, service_one):
     assert text_input["name"] == "hex_colour"
 
     assert skip_link is not None
-    assert skip_link["href"] == url_for("main.email_branding_something_else", service_id=service_one["id"])
+    assert skip_link["href"] == url_for(
+        "main.email_branding_something_else",
+        service_id=service_one["id"],
+        back_link=".email_branding_choose_banner_colour",
+        brand_type="org_banner",
+    )
     assert skip_link.text == "I do not know the hex colour code for my banner"
 
 


### PR DESCRIPTION
If a user bails out of the new email branding flow, we take them to the page where they can submit a zendesk ticket with details on the brand they want. This page has a back link, and it should take the user back to the correct place in the previous flow. We need to pass through URL query params and the correct back links to build the right URL.