### PR TITLE
Update link styles

### DIFF
--- a/app/assets/stylesheets/_app.scss
+++ b/app/assets/stylesheets/_app.scss
@@ -72,11 +72,6 @@ td {
   }
 }
 
-details summary {
-  text-decoration: underline;
-  margin-bottom: govuk-spacing(3);
-}
-
 .spreadsheet {
 
   margin-bottom: -1 * govuk-spacing(6);

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -132,20 +132,12 @@
     padding: 0 ;
     margin: 0 0 govuk-spacing(6) 0;
 
-    &:link,
-    &:visited {
-      color: govuk-colour("white");
-    }
-
     &:hover {
-      color: govuk-colour("white");
       background-color: $govuk-link-hover-colour;
       box-shadow: 0 0 0 10px $govuk-link-hover-colour;
     }
 
-    &:focus,
-    &:active {
-      color: $govuk-focus-text-colour;
+    &:focus {
       background-color: $govuk-focus-colour;
       box-shadow: 0 0 0 10px $govuk-focus-colour, 0 4px 0 10px $govuk-focus-text-colour;
     }

--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -178,9 +178,19 @@
   margin-bottom: govuk-spacing(6);
   text-decoration: none;
 
+  &:hover {
+    .banner-dashboard-count-label {
+      @include govuk-link-hover-decoration;
+    }
+  }
+
   &:focus {
     border-top: 1px solid transparent;
     border-bottom: 1px solid transparent;
+
+    .banner-dashboard-count-label {
+      text-decoration: none;
+    }
   }
 
   &-count,
@@ -200,7 +210,7 @@
 
   &-count-label {
     @include govuk-font(24, $weight: bold);
-    text-decoration: underline;
+    @include govuk-link-decoration;
     padding-right: govuk-spacing(6);
     margin: 10px 0px 5px; // 10px includes 5px extra to counter the -5px margin-top on the count item
     flex: 2 1 auto;

--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -90,21 +90,15 @@
   .big-number-link {
 
     text-decoration: none;
-    background: $govuk-link-colour;
-    color: govuk-colour("white");
+    background: $govuk-link-colour; // text colour is set in the HTML, with the govuk-link--inverse class
     display: block;
     border: 2px solid $govuk-link-colour;
     margin-bottom: 5px;
 
     &:hover {
 
-      color: govuk-tint(govuk-colour("light-blue"), 75);
-
-      .big-number,
-      .big-number-number,
-      .big-number-smaller,
       .big-number-label {
-        color: govuk-tint(govuk-colour("light-blue"), 75);
+        @include govuk-link-hover-decoration;
       }
 
     }
@@ -131,7 +125,7 @@
     }
 
     .big-number-label {
-      text-decoration: underline;
+      @include govuk-link-decoration;
     }
 
   }
@@ -144,23 +138,6 @@
     background: govuk-colour("green");
     color: govuk-colour("white");
     padding: 15px;
-
-    a {
-
-      &:link,
-      &:visited,
-      &:active,
-      &:hover {
-        color: govuk-colour("white");
-        text-decoration: underline;
-      }
-
-      &:active,
-      &:focus {
-        color: $govuk-focus-text-colour;
-      }
-
-    }
 
   }
 

--- a/app/assets/stylesheets/components/message.scss
+++ b/app/assets/stylesheets/components/message.scss
@@ -108,8 +108,7 @@ a {
           }
         }
 
-        &:focus,
-        &:active {
+        &:focus {
 
           &,
           &::before {

--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -59,15 +59,6 @@
   &-service-back-to,
   &-organisation-link {
 
-    &:link,
-    &:visited {
-      text-decoration: none;
-    }
-
-    &:hover {
-      text-decoration: underline;
-    }
-
     &:focus {
       text-decoration: none; // override the :hover style (the focus style has its own underline)
       // hack to make the focus style fit in the navigation bar
@@ -151,24 +142,10 @@
   }
 
   a {
-
     display: block;
     padding: 5px 0;
     position: relative;
     top: 5px;
-
-    &:link,
-    &:visited {
-      text-decoration: none;
-    }
-
-    &:hover {
-      text-decoration: underline;
-    }
-
-    &:focus { // override the :hover style (the focus style has its own underline)
-      text-decoration: none;
-    }
 
     &.selected {
       @include govuk-font(19, $weight: bold);
@@ -208,15 +185,6 @@
     border-bottom: 1px govuk-shade(govuk-colour("light-grey"), 7%) solid;
     display: block;
     padding: govuk-spacing(2) 0;
-
-    a:link {
-      text-decoration: none;
-    }
-
-    a:hover,
-    a:active {
-      text-decoration: underline;
-    }
 
     ol ol & {
       padding-left: govuk-spacing(6);

--- a/app/assets/stylesheets/components/pill.scss
+++ b/app/assets/stylesheets/components/pill.scss
@@ -36,26 +36,18 @@
 
   &-item {
     $background: $govuk-link-colour;
-    background: $background;
-    color: govuk-colour("white");
+    background: $background; // text colour is set in the HTML by the govuk-link--inverse class
     border: 2px solid $background;
     position: relative;
     text-decoration: none;
     cursor: pointer;
 
-    &:link,
-    &:visited {
-      color: govuk-colour("white");
-    }
-
-    &:hover {
-      color: govuk-tint(govuk-colour("light-blue"), 75);
-    }
-
+    // give :active links the :focus style
     &:active,
     &:focus {
       z-index: 10;
-      color: $govuk-focus-text-colour;
+      background-color: $govuk-focus-colour;
+      color: $govuk-focus-text-colour; // required for Safari, which doesn't fire :focus on :active
       /* override default focus styles to inset bottom underline */
       box-shadow: inset 0 -4px $govuk-focus-text-colour;
       border: none;
@@ -79,10 +71,11 @@
       color: govuk-tint($govuk-text-colour, 25%);
     }
 
+    // give :active links the :focus style
     &:active,
     &:focus {
       z-index: 1000;
-      color: $govuk-focus-text-colour;
+      color: $govuk-focus-text-colour; // required for Safari, which doesn't fire :focus on :active
       border: solid 2px $govuk-focus-text-colour;
       padding: 10px 0px; /* reset padding to default */
       box-shadow: inset 0 -2px $govuk-focus-text-colour; /* remove bottom border from underline */
@@ -92,7 +85,7 @@
 
   &-item__label {
 
-    text-decoration: underline;
+    @include govuk-link-decoration;
     // reduce padding until screen is above 420px / zoomed below 300%
     padding-left: govuk-spacing(1);
 
@@ -104,6 +97,11 @@
 
   &-item,
   &-item--selected {
+    &:hover .pill-item__label {
+      @include govuk-link-hover-decoration;
+    }
+
+    &:active .pill-item__label,
     &:focus .pill-item__label {
       text-decoration: none;
     }
@@ -122,26 +120,17 @@
 
     display: block;
     text-align: left;
+    background-color: $govuk-link-colour; // text colour is set in the HTML by govuk-link--inverse
     padding: 9px (govuk-spacing(3) - 1);
     border: 1px solid transparent;
     text-align: center;
 
-    &:link,
-    &:visited {
-      background: $govuk-link-colour;
-      color: govuk-colour("white");
-      text-decoration: underline;
-    }
-
-    &:hover {
-      color: govuk-tint(govuk-colour("light-blue"), 75);
-    }
-
-    &:focus,
-    &:link:focus {
-      color: $govuk-focus-text-colour;
-      text-decoration: none;
-      background: $govuk-focus-colour;
+    // give :active links the :focus style
+    &:active,
+    &:focus {
+      background-color: $govuk-focus-colour;
+      color: $govuk-focus-text-colour; // required for Safari, which doesn't fire :focus on :active
+      text-decoration: none; // required for Safari, which doesn't fire :focus on :active
       /* override default focus style to inset bottom underline */
       box-shadow: inset 0 -4px $govuk-focus-text-colour;
     }

--- a/app/assets/stylesheets/components/show-more.scss
+++ b/app/assets/stylesheets/components/show-more.scss
@@ -1,40 +1,88 @@
-%show-more,
+// container for the link which
+// - contains the absolutely positioned child pseudo elements
+// - sets text size and so line height
+// - allows alignment and vertical spacing
 .show-more {
-
   @include govuk-font(16);
-  display: block;
-  padding: 0 0;
-  margin: govuk-spacing(3) 0 govuk-spacing(3) 0;
+  position: relative; // contain all
   text-align: center;
-  border-top: 1px solid $govuk-border-colour;
+  margin: govuk-spacing(1) 0 govuk-spacing(5) 0;
+}
+
+.show-more__link {
+
+  // create the separator line the link sits in front of
+  &::before {
+
+    content: "";
+    position: absolute;
+    top: 11px;
+    left: 0;
+    width: 100%;
+    height: 0;
+    border-top: 1px solid $govuk-border-colour;
+
+  }
+
+  // create a click area matching the size of the containing div + 16px extra height
+  &::after {
+
+    content: "";
+    position: absolute;
+    top: govuk-spacing(1) * -1;
+    left: 0;
+    bottom: govuk-spacing(1) * -1;
+    width: 100%;
+
+  }
+
+  // make the link text sit in front of the separator line, with a gap on either side
+  span {
+
+    position: relative; // required for z-index
+    z-index: 1; // place above ::after pseudo-element
+    padding: 0 10px;
+    background: govuk-colour('white');
+
+  }
 
   &:focus {
 
-    border-color: transparent;
-    /* override default focus style to increase top yellow box-shadow */
-    box-shadow: 0 -15px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+    box-shadow: none; // turn off the focus style (::after handles this)
 
+    &::before {
+
+      border-color: transparent; // hide the separator line
+
+    }
+
+    // make focus style fill click area
+    &::after {
+
+      box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+      background: $govuk-focus-colour;
+      outline: 3px solid transparent; // for forced-colour modes
+
+    }
+
+    // hide all styling around link text
     span {
-      outline: none;
-      border-color: transparent;
-      background-color: transparent;
+
+      background: transparent;
+
     }
 
   }
 
-  span {
-    position: relative;
-    top: -11px;
-    outline: 10px solid white;
-    background: govuk-colour("white");
-    display: inline-block;
-    border-bottom: 1px solid govuk-colour("light-blue");
-  }
-
 }
 
-.show-more-no-border {
-  @extend %show-more;
-  border-top: 1px solid transparent;
-  margin-top: -5px;
+.show-more--no-border {
+
+  margin-top: govuk-spacing(3) * -1;
+
+  & > .show-more__link::before {
+
+    border-color: transparent;
+
+  }
 }

--- a/app/assets/stylesheets/components/vendor/breadcrumbs.scss
+++ b/app/assets/stylesheets/components/vendor/breadcrumbs.scss
@@ -88,16 +88,15 @@
     border-bottom: 1px govuk-colour("white") solid;
     border-bottom-color: rgba(govuk-colour("white"), 0.25);
 
-    .breadcrumbs__item {
-      &--active,
-      a:link,
-      a:hover,
-      a:active,
-      a:visited {
+    .govuk-link--inverse {
+      &:link,
+      &:hover,
+      &:active,
+      &:visited {
         color: govuk-colour("white");
       }
 
-      a:focus {
+      &:focus {
         color: $govuk-focus-text-colour;
       }
     }

--- a/app/assets/stylesheets/govuk-frontend/extensions.scss
+++ b/app/assets/stylesheets/govuk-frontend/extensions.scss
@@ -1,5 +1,13 @@
 @use "sass:map";
 
+// Custom colours for our destructive link
+// Based on the error colour in:
+// https://github.com/alphagov/govuk-frontend/blob/v4.2.0/src/govuk/settings/_colours-applied.scss
+// with :hover and :active variants based on those for links
+$govuk-destructive-link-colour: $govuk-error-colour;
+$govuk-destructive-link-hover-colour: #990a00;
+$govuk-destructive-link-active-colour: $govuk-text-colour;
+
 // Gives access to the Sass variables used in the GOVUK Frontend typographic styles
 // See: https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-typography-scale
 @function get-govuk-typography-style($size, $breakpoint, $property) {
@@ -25,17 +33,17 @@
 
 // Extends govuk-link to create a class of link that causes a destructive action
 // Based on styles of link in:
-// https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/helpers/_links.scss
+// https://github.com/alphagov/govuk-frontend/blob/v4.2.0/src/govuk/helpers/_links.scss
 //
 // Note: all destructive actions must have a confirmation step these links navigate to
 @mixin govuk-link-style-destructive-no-visited-state {
   &:link,
   &:visited {
-    color: $govuk-error-colour;
+    color: $govuk-destructive-link-colour;
   }
 
   &:hover {
-    color: govuk-tint($govuk-error-colour, 25%);
+    color: $govuk-destructive-link-hover-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -43,7 +51,7 @@
   // Activated links are usually focused so this applies to them as well
   &:active,
   &:focus {
-    color: $govuk-focus-text-colour;
+    color: $govuk-destructive-link-active-colour;
   }
 }
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -9,6 +9,7 @@ $path: '/static/images/';
 @import './globals';
 
 // Dependencies from GOV.UK Frontend, packaged to be specific to this application
+$govuk-new-link-styles: true;
 @import './govuk-frontend/all';
 
 // Dependencies from GOV.UK Elements, moved here until all components are migrated

--- a/app/assets/stylesheets/views/api.scss
+++ b/app/assets/stylesheets/views/api.scss
@@ -25,6 +25,11 @@
       &::before {
         top: -1.3em;
       }
+
+      // stretch focus style to fill containing row
+      &:focus {
+        box-shadow: 0 -10px $govuk-focus-colour, 0 11px $govuk-focus-colour, 0 15px $govuk-focus-text-colour;
+      }
     }
 
     &__meta {

--- a/app/assets/stylesheets/views/product-page.scss
+++ b/app/assets/stylesheets/views/product-page.scss
@@ -48,24 +48,6 @@ $button-shadow-size: $govuk-border-width-form-element;
       margin: govuk-spacing(3) 0 govuk-spacing(6);
     }
 
-    .govuk-link {
-
-      &:link,
-      &:visited {
-        color: govuk-colour("white");
-      }
-
-      &:hover {
-        color: govuk-tint(govuk-colour("light-blue"), 75);
-      }
-
-      &:active,
-      &:focus {
-        color: $govuk-focus-text-colour;
-      }
-
-    }
-
   }
 
   &-section {

--- a/app/assets/stylesheets/views/template.scss
+++ b/app/assets/stylesheets/views/template.scss
@@ -7,22 +7,9 @@
 
   @include govuk-font(19);
   position: absolute;
-  background: $govuk-link-colour;
-  color: govuk-colour("white");
+  background-color: $govuk-link-colour; // text colour is set in the HTML by the govuk-link--inverse class
   padding: 10px govuk-spacing(3);
   z-index: 10000;
-
-  &:link, &:visited {
-    color: govuk-colour("white");
-  }
-
-  &:hover {
-    color: govuk-tint(govuk-colour("light-blue"), 75);
-  }
-
-  &:focus {
-    color: $govuk-text-colour;
-  }
 
 }
 

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -1,6 +1,6 @@
 {% macro big_number(number, label, link=None, currency='', smaller=False, smallest=False) %}
   {% if link %}
-    <a class="govuk-link govuk-link--no-visited-state big-number-link" href="{{ link }}">
+    <a class="govuk-link govuk-link--inverse big-number-link" href="{{ link }}">
   {% endif %}
       <span class="big-number{% if smaller %}-smaller{% endif %}{% if smallest %}-smallest{% endif %}">
         <span class="big-number-number">
@@ -42,7 +42,7 @@
       <span class="big-number-status{% if danger_zone %}-failing{% endif %}">
         {% if failures %}
           {% if failure_link %}
-            <a class="govuk-link govuk-link--no-visited-state" href="{{ failure_link }}">
+            <a class="govuk-link govuk-link--inverse href="{{ failure_link }}">
               {{ "{:,}".format(failures) }}
               failed – {{ failure_percentage }}%
             </a>

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -13,7 +13,7 @@
         {% if current_value == option %}
           <a id="pill-selected-item" class="pill-item pill-item--selected govuk-link govuk-link--no-visited-state{% if not show_count %} pill-item--centered{% endif %}" href="{{ link }}" aria-current="page">
         {% else %}
-          <a class="pill-item govuk-link govuk-link--no-visited-state" href="{{ link }}">
+          <a class="pill-item govuk-link govuk-link--inverse" href="{{ link }}">
         {% endif %}
           {% if show_count %}
             {{ big_number(count, **big_number_args) }}

--- a/app/templates/components/show-more.html
+++ b/app/templates/components/show-more.html
@@ -1,6 +1,10 @@
 {% macro show_more(url, label, with_border=True) %}
-  <a
-    href="{{ url }}"
-    class="govuk-link govuk-link--no-visited-state show-more{% if not with_border %}-no-border{% endif %}"
-  ><span>{{ label }}</span></a>
+  <div class="show-more{% if not with_border %}-no-border{% endif %}">
+      <a
+        href="{{ url }}"
+        class="govuk-link govuk-link--no-visited-state show-more__link"
+      >
+        <span>{{ label }}</span>
+      </a>
+  </div>
 {% endmacro %}

--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -4,7 +4,7 @@
       itemscope
       itemtype="http://schema.org/ListItem"
   >
-    <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for(item['link']) }}" itemprop="item">
+    <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url_for(item['link']) }}" itemprop="item">
       <span itemprop="name">{{item['name']}}</span>
     </a>
     {% if caller %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -5,36 +5,36 @@
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Past alerts</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('rejected-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_rejected', service_id=current_service.id) }}">Rejected alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Past alerts</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('rejected-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_rejected', service_id=current_service.id) }}">Rejected alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
     {% if not current_user.has_permissions('view_activity') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
     {% endif %}
     {% if not current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     {% if current_user.has_permissions('manage_service', allow_org_user=True) and not current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-      <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
+      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys') %}
       {% if current_service.has_permission('broadcast') %}
-        <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API integration</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API integration</a></li>
       {% else %}
-        <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
+        <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
       {% endif %}
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
-    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -1,11 +1,11 @@
 <nav class="navigation" aria-label="Organisation">
   <ul>
-    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('dashboard') }}" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Usage</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('dashboard') }}" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
     {% if current_user.platform_admin %}
-    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('settings') }}" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}">Settings</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('trial-services') }}" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}">Trial mode services</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state{{ org_navigation.is_selected('billing') }}" href="{{ url_for('.organisation_billing', org_id=current_org.id) }}">Billing</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('settings') }}" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}">Settings</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('trial-services') }}" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}">Trial mode services</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('billing') }}" href="{{ url_for('.organisation_billing', org_id=current_org.id) }}">Billing</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_template.html
+++ b/app/templates/org_template.html
@@ -8,12 +8,12 @@
   <div class="govuk-width-container">
     <div class="navigation-service">
       {% if current_user.platform_admin %}
-        <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state navigation-organisation-link">Organisations</a>
+        <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-organisation-link">Organisations</a>
       {% endif %}
       <div class="navigation-service-name govuk-!-font-weight-bold">
         {{ current_org.name }}
       </div>
-      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
     </div>
     <div class="govuk-grid-row govuk-!-padding-bottom-12">
       <div class="govuk-grid-column-one-quarter">

--- a/app/templates/service_navigation.html
+++ b/app/templates/service_navigation.html
@@ -35,10 +35,10 @@
   {% if service.organisation_id %}
     {% if user.platform_admin or
       (user.belongs_to_organisation(service.organisation_id) and service.live) %}
-      <a href="{{ url_for('.organisation_dashboard', org_id=service.organisation_id) }}" class="govuk-link govuk-link--no-visited-state navigation-organisation-link">{{ service.organisation_name }}</a>
+      <a href="{{ url_for('.organisation_dashboard', org_id=service.organisation_id) }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-organisation-link">{{ service.organisation_name }}</a>
     {% endif %}
   {% endif %}
   {{ navigation_service_name(service) }}
-  <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
+  <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
 </div>
 {% endmacro %}

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -15,13 +15,13 @@
 
   <nav class="govuk-grid-row bottom-gutter-1-2">
     <div class="govuk-grid-column-one-third">
-      <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
+      <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API keys</a>
     </div>
     <div class="govuk-grid-column-one-third">
-      <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.guest_list', service_id=current_service.id) }}">Guest list</a>
+      <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for('.guest_list', service_id=current_service.id) }}">Guest list</a>
     </div>
     <div class="govuk-grid-column-one-third">
-      <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">Callbacks</a>
+      <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">Callbacks</a>
     </div>
   </nav>
 

--- a/app/templates/views/broadcast/tour/1.html
+++ b/app/templates/views/broadcast/tour/1.html
@@ -21,7 +21,7 @@
           imminent risk to life.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=2) }}'>
+          <a class="govuk-link govuk-link--inverse" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=2) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/2.html
+++ b/app/templates/views/broadcast/tour/2.html
@@ -19,7 +19,7 @@
           the affected area at exactly the same time.
         </h1>
         <p class="govuk-body heading-medium govuk-!-margin-bottom-6">
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=3) }}'>
+          <a class="govuk-link govuk-link--inverse" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=3) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/3.html
+++ b/app/templates/views/broadcast/tour/3.html
@@ -17,7 +17,7 @@
           The phone will make a loud alarm noise, even if it’s set on silent.
         </h1>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=4) }}'>
+          <a class="govuk-link govuk-link--inverse" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=4) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/4.html
+++ b/app/templates/views/broadcast/tour/4.html
@@ -21,7 +21,7 @@
           need to know anyone’s phone number.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=5) }}'>
+          <a class="govuk-link govuk-link--inverse" href='{{ url_for(".broadcast_tour", service_id=current_service.id, step_index=5) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -31,7 +31,7 @@
           When you’re ready, you can ask for access to the live system.
         </p>
         <p class="govuk-body heading-medium">
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
+          <a class="govuk-link govuk-link--inverse" href='{{ url_for(".service_dashboard", service_id=current_service.id) }}'>
             Continue
           </a>
         </p>

--- a/app/templates/views/dashboard/write-first-messages.html
+++ b/app/templates/views/dashboard/write-first-messages.html
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">Get started</h2>
 
 <nav>
-  <a class="govuk-link govuk-link--no-visited-state pill-separate-item" href="{{ url_for('.choose_template', service_id=current_service.id) }}">
+  <a class="govuk-link govuk-link--inverse pill-separate-item" href="{{ url_for('.choose_template', service_id=current_service.id) }}">
     {% if 'letter' in current_service.permissions %}
       Write an email, text message or letter
     {% else %}

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -10,8 +10,8 @@
 {% block main %}
   <div class="govuk-width-container">
     <div class="navigation-service">
-      <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state navigation-service-back-to">All organisations</a>
-      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('.organisations') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-back-to">All organisations</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
     </div>
 
     <div class="govuk-grid-row">

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -7,7 +7,7 @@
       <div class="navigation-service-name govuk-!-font-weight-bold">
         Platform admin
       </div>
-      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state navigation-service-switch">Switch service</a>
+      <a href="{{ url_for('main.choose_account') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-switch">Switch service</a>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
@@ -29,7 +29,7 @@
             ('Clear cache', url_for('main.clear_cache')),
           ] %}
             <li>
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ url }}">
+              <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="{{ url }}">
                 {{ link_text }}
               </a>
             </li>

--- a/app/templates/views/providers/providers.html
+++ b/app/templates/views/providers/providers.html
@@ -1,6 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, optional_text_field %}
-{% from "components/show-more.html" import show_more %}
 
 {% block per_page_title %}
 Providers

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -16,10 +16,10 @@
       <nav class="breadcrumbs breadcrumbs--inverse" aria-label="Breadcrumbs">
        <ol itemscope itemtype="http://schema.org/BreadcrumbList">
          <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-           <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
+           <a class="govuk-link govuk-link--inverse" href="https://www.gov.uk/service-toolkit#gov-uk-services" itemprop="item"><span itemprop="name">GOV.UK services</span></a>
          </li>
          <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-           <a class="govuk-link govuk-link--no-visited-state" href="#main" itemprop="item"><span itemprop="name">GOV.UK Notify</span></a>
+           <a class="govuk-link govuk-link--inverse" href="#main" itemprop="item"><span itemprop="name">GOV.UK Notify</span></a>
          </li>
        </ol>
       </nav>
@@ -38,7 +38,7 @@
               "classes": "product-page-button button-container__button govuk-!-margin-right-3",
               "href": url_for('main.register' )
             }) }}
-            or <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.sign_in' )}}">sign in</a> if you’ve used
+            or <a class="govuk-link govuk-link--inverse" href="{{ url_for('.sign_in' )}}">sign in</a> if you’ve used
             it before
           </div>
         </div>

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -65,14 +65,14 @@
 <div class="govuk-grid-column-full template-container">
   {% if current_user.has_permissions('manage_templates') and template.template_type == 'letter' %}
     {% if not current_service.letter_branding_id %}
-      <a href="{{ url_for(".letter_branding_request", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-branding">Add logo</a>
+      <a href="{{ url_for(".letter_branding_request", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-branding">Add logo</a>
     {% endif %}
-    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-postage">Change<span class="govuk-visually-hidden"> postage</span></a>
-    <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> letter template</span></a>
+    <a href="{{ url_for(".edit_template_postage", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-postage">Change<span class="govuk-visually-hidden"> postage</span></a>
+    <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-body">Edit<span class="govuk-visually-hidden"> letter template</span></a>
     {% if current_service.count_letter_contact_details %}
-      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
+      <a href="{{ url_for(".set_template_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
     {% else %}
-      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--no-visited-state edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
+      <a href="{{ url_for(".service_add_letter_contact", service_id=current_service.id, from_template=template.id) }}" class="govuk-link govuk-link--inverse edit-template-link-letter-contact">Edit<span class="govuk-visually-hidden"> letter contact block</span></a>
     {% endif %}
   {% endif %}
   {{ template|string }}

--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -22,7 +22,7 @@
           {% endif %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) and not letter_too_long %}
             <div class="govuk-grid-column-one-half">
-              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
+              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
                 Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
               </a>
             </div>
@@ -30,14 +30,14 @@
         {% elif template.template_type == 'broadcast' %}
           {% if current_user.has_permissions('create_broadcasts') %}
             <div class="govuk-grid-column-one-half">
-              <a href="{{ url_for(".broadcast", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
+              <a href="{{ url_for(".broadcast", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
                 Get ready to send
               </a>
             </div>
           {% endif %}
           {% if current_user.has_permissions('manage_templates') %}
             <div class="govuk-grid-column-one-half">
-              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
+              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
                 Edit<span class="govuk-visually-hidden"> this template</span>
               </a>
             </div>
@@ -45,14 +45,14 @@
         {% else %}
           {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
             <div class="govuk-grid-column-one-half">
-              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
+              <a href="{{ url_for(".set_sender", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
                 Get ready to send<span class="govuk-visually-hidden"> a message using this template</span>
               </a>
             </div>
           {% endif %}
           {% if current_user.has_permissions('manage_templates') %}
             <div class="govuk-grid-column-one-half">
-              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--no-visited-state pill-separate-item">
+              <a href="{{ url_for(".edit_service_template", service_id=current_service.id, template_id=template.id) }}" class="govuk-link govuk-link--inverse pill-separate-item">
                 Edit
               </a>
             </div>

--- a/app/templates/withoutnav_template.html
+++ b/app/templates/withoutnav_template.html
@@ -5,7 +5,7 @@
 {% block beforeContent %}
     {% if current_service and current_service.active and current_user.is_authenticated and current_user.belongs_to_service(current_service.id) %}
     <div class="navigation-service">
-      <a href="{{ url_for('main.show_accounts_or_dashboard') }}" class="govuk-link govuk-link--no-visited-state navigation-service-back-to">Back to {{ current_service.name }}</a>
+      <a href="{{ url_for('main.show_accounts_or_dashboard') }}" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline navigation-service-back-to">Back to {{ current_service.name }}</a>
     </div>
     {% endif %}
     {% block backLink %}{% endblock %}


### PR DESCRIPTION
Updates the links using the new link styles:
- [pull request explaining their design](https://github.com/alphagov/govuk-frontend/pull/2183)
- [release note explaining the new classes and Sass mixins you can use to implement them](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0)

Story: https://trello.com/c/jDtuwHih/116-change-links-in-admin-app-to-new-design-system-style

The old style changed colour on hover. The new one thickens the underline so doesn't rely on colour (which is a WCAG win[^1])

This 'just works' for any normal links, like in our guidance, but we have quite a few custom links so the majority of these changes are making them work.

## Our custom links

|Example|Description|Notes on changes|
|---|---|---|
|<img width="224" alt="image" src="https://user-images.githubusercontent.com/87140/205260806-a09f7ccd-92a1-43a3-b18e-5b99ed51b340.png">|Navigation links, including the different side navigations but also the service navigation at the top of pages|Uses the `govuk-link--no-underline` class provided as part of the new styles so we can delete any CSS we wrote to remove underlines by default|
|<img width="232" alt="image" src="https://user-images.githubusercontent.com/87140/205261607-8ca785bb-83dc-446e-be48-ff8bda283ce4.png">|Big number links on the dashboard|Uses the `govuk-link--inverse` class to make them white for all states, except focus, so we could remove CSS we wrote for this. Only the text gets an underline so we needed to turn underlines off for the parent element and use the `govuk-link-decoration` and `govuk-link-hover-decoration` mixins provided as part of the new styles to apply it to the text alone.|
|<img width="247" alt="image" src="https://user-images.githubusercontent.com/87140/205262207-61a04e21-6eeb-44e3-b5a1-09b7349cce0e.png">|Pill links on dashboardy pages|Same as big numbers. Uses the `govuk-link--underline` class for colour and only the last line of text gets an underline.|
|<img width="442" alt="image" src="https://user-images.githubusercontent.com/87140/205271134-9e8549b5-2311-4919-a7bf-101a867de22e.png">|Dashboard big count link|Only the text after the number is underlined so we use the same approach as big numbers and pills, turning it off on the parent element and on for a specific child.|
|<img width="311" alt="image" src="https://user-images.githubusercontent.com/87140/205271030-607affd6-41c8-48a3-8c90-09785b4abccd.png">|'Show more' link on dashboard|Was hacked to make the text look like a link when it was a `<span>` so required a rewrite to make it a real link so it could inherit the new styles.|
|<img width="265" alt="image" src="https://user-images.githubusercontent.com/87140/205264256-af4df79d-929a-4ec8-b9b0-a8a28bceca45.png">|'Edit' links on letter template page|Used the `govuk-link--inverse` class to make them white for all states, except focus, so could remove CSS we wrote for this.|
|<img width="279" alt="image" src="https://user-images.githubusercontent.com/87140/205265301-3096124b-630e-4dc8-92d8-458811d7a4c5.png">|Big links on broadcast tour pages|Used the `govuk-link--inverse` class to make them white for all states, except focus, so could remove CSS we wrote for this.|
|<img width="177" alt="image" src="https://user-images.githubusercontent.com/87140/205265605-bc05dfda-55d9-43f9-9c5d-48f146a3e751.png">|Links in the blue section of the product page|Used the `govuk-link--inverse` class to make them white for all states, except focus, so could remove CSS we wrote for this. Required some extra CSS sadly, to let the new styles override some existing ones.|

## Other fixes

I also rolled a few other fixes for issues with links spotted along the way:
- changes to the hover colour for our custom 'destructive' links
- fixes for how some links look when clicked in Safari (which doesn't fire a focus event like other browsers so you don't see the focus styles by default)
- removal of some redundant styles for `<details>` elements which interfered with the new styles

## Notes for reviewers

This pull request is made to be reviewed commit by commit. It's all been tested across our browser matrix and in forced-colour mode. The CSS is a bit complex in some places too so it's ok to just review that the changes make sense.

[^1]: [WCAG success criteria 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) states that information shouldn't be conveyed by colour alone.