### PR TITLE
Remove custom hover state from tour links

### DIFF
--- a/app/assets/stylesheets/components/banner.scss
+++ b/app/assets/stylesheets/components/banner.scss
@@ -132,11 +132,6 @@
     padding: 0 ;
     margin: 0 0 govuk-spacing(6) 0;
 
-    &:hover {
-      background-color: $govuk-link-hover-colour;
-      box-shadow: 0 0 0 10px $govuk-link-hover-colour;
-    }
-
     &:focus {
       background-color: $govuk-focus-colour;
       box-shadow: 0 0 0 10px $govuk-focus-colour, 0 4px 0 10px $govuk-focus-text-colour;


### PR DESCRIPTION
Originally these made the background of the link slightly lighter.

When we moved to the Design System colour pallette we used the new hover colour, which is a darker blue that clashes with the light blue.

Since we now have the new link styles with a thicker underline on hover we don’t need to differentiate with colour, solving the clashing problem.

— | Before | After
---|---|---
Default | <img width="344" alt="image" src="https://user-images.githubusercontent.com/355079/205280002-69483229-5e83-4d9e-861a-541c9d65ee7a.png"> | <img width="344" alt="image" src="https://user-images.githubusercontent.com/355079/205280002-69483229-5e83-4d9e-861a-541c9d65ee7a.png">
Hover | <img width="362" alt="image" src="https://user-images.githubusercontent.com/355079/205280387-569db54d-23b0-4c49-91d1-fb60cfcc0696.png"> | <img width="348" alt="image" src="https://user-images.githubusercontent.com/355079/205280260-897b8ce4-cf72-40e2-937f-be4de1d1bc30.png">
