### PR TITLE
change aria/focusable attributes on remove areas SVG icon as suggeste…

### DIFF
--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -32,7 +32,7 @@
         <li class="area-list-item">
           {{ area.name }}
           <a class="area-list-item-remove govuk-button" data-module="govuk-button" role="button" href="{{ url_for('.remove_broadcast_area', service_id=current_service.id, broadcast_message_id=broadcast_message.id, area_slug=area.id) }}">
-            <svg id="area-list-item-remove__icon" width="11" height="11" viewbox="0 0 10 10" aria-labelledby="area__{{ loop.index }}" role="img" xmlns="http://www.w3.org/2000/svg">
+            <svg id="area-list-item-remove__icon" width="11" height="11" viewbox="0 0 10 10" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
               <title id="area__{{ loop.index }}">Remove {{ area.name }}</title>
               <g transform="rotate(45),translate(1, -6)">
                 <line stroke-width="1.75" id="svg_1" y2="0" x2="6" y1="12" x1="6" stroke="currentColor" fill="none"/>


### PR DESCRIPTION
Change the following HTML attributes of the remove area SVG icon:

Remove "aria-labelledby", "role=img",
Add "aria-hidden=true", "focusable=false",

As advised by the Digital Accessibility Centre.