### PR TITLE
remove misleading aria-expanded attribute on New template button

### DIFF
--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -299,7 +299,7 @@
     this.nothingSelectedButtons = $(`
       <div id="nothing_selected">
         <div class="js-stick-at-bottom-when-scrolling">
-          <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="add-new-template">
+          <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="add-new-template" ${!this.$singleNotificationChannel ? 'aria-expanded="false"' : ''}>
             New template
           </button>
           <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="add-new-folder" aria-expanded="false">New folder</button>

--- a/app/assets/javascripts/templateFolderForm.js
+++ b/app/assets/javascripts/templateFolderForm.js
@@ -299,7 +299,7 @@
     this.nothingSelectedButtons = $(`
       <div id="nothing_selected">
         <div class="js-stick-at-bottom-when-scrolling">
-          <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="add-new-template" aria-expanded="false">
+          <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-right-3 govuk-!-margin-bottom-1" value="add-new-template">
             New template
           </button>
           <button type="button" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" value="add-new-folder" aria-expanded="false">New folder</button>

--- a/tests/javascripts/templateFolderForm.test.js
+++ b/tests/javascripts/templateFolderForm.test.js
@@ -275,6 +275,15 @@ describe('TemplateFolderForm', () => {
 
     });
 
+    // Single Channel Broadcasting uses the 'New template' button as a link to another page, not an expanding
+    // element, as is the case with Notify. This test ensures that the 'aria-expanded' attribute does not
+    // appear in the case of Single Channel Broadcasting, removing screen-reader ambiguity.
+    test("the 'New folder' button should not have an aria-expanded attribute", () => {
+      setFixtures(hierarchy, "data-channel='sms' data-service='123'")
+
+      expect(document.querySelector('button[value=add-new-template]').getAttribute('aria-expanded')).toBeNull();
+    });
+
     // Our counter needs to be wrapped in an ARIA live region so changes to its content are
     // communicated to assistive tech'.
     // ARIA live regions need to be in the HTML before JS loads.


### PR DESCRIPTION
Remove "aria-expanded=false" from the "New template" button when adding templates. The attribute is unnecessary on button elements.