### PR TITLE
Change classes for show-more variant

### DIFF
--- a/app/templates/components/show-more.html
+++ b/app/templates/components/show-more.html
@@ -1,5 +1,5 @@
 {% macro show_more(url, label, with_border=True) %}
-  <div class="show-more{% if not with_border %}-no-border{% endif %}">
+  <div class="show-more {% if not with_border %}show-more--no-border{% endif %}">
       <a
         href="{{ url }}"
         class="govuk-link govuk-link--no-visited-state show-more__link"


### PR DESCRIPTION
The changes in this pull request assumed the
variant of the show-more component where it has no line running through it had these two classes:
1. `show-more`
2. `show-more--no-border`

It instead had just one: `show-more--no-border`,
which meant the CSS was applied incorrectly and
made the link fill the viewport(!).

This rewrites the macro so both classes are
applied so the CSS works as expected.