### PR TITLE
Fix failing big number link

### DIFF
--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -42,7 +42,7 @@
       <span class="big-number-status{% if danger_zone %}-failing{% endif %}">
         {% if failures %}
           {% if failure_link %}
-            <a class="govuk-link govuk-link--inverse href="{{ failure_link }}">
+            <a class="govuk-link govuk-link--inverse" href="{{ failure_link }}">
               {{ "{:,}".format(failures) }}
               failed – {{ failure_percentage }}%
             </a>


### PR DESCRIPTION
The links for getting to 'failed notification' dashboards are currently broken due to malformed HTML.

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/2920760/206135339-cc7e3379-ccc0-4e02-9cc2-722e2ae85e9e.png">
