### PR TITLE
Stop NHS domains being added to organisation list

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -72,6 +72,7 @@ from app.main.validators import (
     NoPlaceholders,
     NoTextInSVG,
     OnlySMSCharacters,
+    StringsNotAllowed,
     ValidEmail,
     ValidGovEmail,
 )
@@ -1049,6 +1050,7 @@ class AdminOrganisationDomainsForm(StripWhitespaceForm):
             "",
             validators=[
                 CharactersNotAllowed("@"),
+                StringsNotAllowed("nhs.uk", "nhs.net"),
                 Optional(),
             ],
             default="",

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -206,6 +206,21 @@ class CharactersNotAllowed:
             )
 
 
+class StringsNotAllowed:
+    def __init__(self, *args, message=None, match_on_substrings=False):
+        self.strings_not_allowed = OrderedSet(string.lower() for string in args)
+        self.match_on_substrings = match_on_substrings
+        self.message = message
+
+    def __call__(self, form, field):
+        normalised = field.data.lower()
+        for not_allowed in self.strings_not_allowed:
+            if normalised == not_allowed or (self.match_on_substrings and not_allowed in normalised):
+                if self.message:
+                    raise ValidationError(self.message)
+                raise ValidationError(f"Cannot {'contain' if self.match_on_substrings else 'be'} ‘{not_allowed}’")
+
+
 class FileIsVirusFree:
     def __call__(self, form, field):
         if field.data:


### PR DESCRIPTION
I noticed in [one of our runbooks](https://docs.google.com/document/d/12zofU5AKerOUDEEKpDFtz7GQETBQ1GH0oT7j42ELMTQ/edit#heading=h.n9ei2rpz58py) there is this warning:

> IMPORTANT! If the domain is nhs.net, don’t assign it to any organisation! Otherwise, from that point on, every single service created by new Notify users with an nhs.net email domain will be assigned to that one organisation.

Rather than hope people find this warning, let’s make it automatic:

<img width="767" alt="image" src="https://user-images.githubusercontent.com/355079/206167338-d62472da-175b-4f25-aff2-2eae68423dc7.png">
