### PR TITLE
Choose letter branding from pool options

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1997,7 +1997,7 @@ class ChooseLetterBrandingForm(ChooseBrandingForm):
     def __init__(self, service):
         super().__init__()
 
-        self.options.choices = tuple(list(branding.get_letter_choices(service)) + [self.FALLBACK_OPTION])
+        self.options.choices = tuple(OrderedSet(list(branding.get_letter_choices(service)) + [self.FALLBACK_OPTION]))
 
         if self.something_else_is_only_option:
             self.options.data = self.FALLBACK_OPTION_VALUE

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1603,30 +1603,30 @@ def letter_branding_request(service_id):
             return redirect(
                 url_for(".letter_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)
             )
-        else:
-            ticket_message = render_template(
-                "support-tickets/branding-request.txt",
-                current_branding=current_service.letter_branding.name or "no",
-                branding_requested=dict(form.options.choices)[form.options.data],
-                detail=form.something_else.data,
-            )
-            ticket = NotifySupportTicket(
-                subject=f"Letter branding request - {current_service.name}",
-                message=ticket_message,
-                ticket_type=NotifySupportTicket.TYPE_QUESTION,
-                user_name=current_user.name,
-                user_email=current_user.email_address,
-                org_id=current_service.organisation_id,
-                org_type=current_service.organisation_type,
-                service_id=current_service.id,
-            )
-            zendesk_client.send_ticket_to_zendesk(ticket)
-            flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
-            return redirect(
-                url_for(".view_template", service_id=current_service.id, template_id=from_template)
-                if from_template
-                else url_for(".service_settings", service_id=current_service.id)
-            )
+
+        ticket_message = render_template(
+            "support-tickets/branding-request.txt",
+            current_branding=current_service.letter_branding.name or "no",
+            branding_requested=dict(form.options.choices)[form.options.data],
+            detail=form.something_else.data,
+        )
+        ticket = NotifySupportTicket(
+            subject=f"Letter branding request - {current_service.name}",
+            message=ticket_message,
+            ticket_type=NotifySupportTicket.TYPE_QUESTION,
+            user_name=current_user.name,
+            user_email=current_user.email_address,
+            org_id=current_service.organisation_id,
+            org_type=current_service.organisation_type,
+            service_id=current_service.id,
+        )
+        zendesk_client.send_ticket_to_zendesk(ticket)
+        flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
+        return redirect(
+            url_for(".view_template", service_id=current_service.id, template_id=from_template)
+            if from_template
+            else url_for(".service_settings", service_id=current_service.id)
+        )
 
     return render_template(
         "views/service-settings/branding/letter-branding-options.html",

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1638,7 +1638,22 @@ def letter_branding_request(service_id):
 @user_has_permissions("manage_service")
 @main.route("/services/<uuid:service_id>/service-settings/letter-branding/pool", methods=["GET", "POST"])
 def letter_branding_pool_option(service_id):
-    return "WIP"
+    try:
+        chosen_branding = current_service.letter_branding_pool.get_item_by_id(request.args.get("branding_option"))
+    except current_service.letter_branding_pool.NotFound:
+        flash("No branding found for this id.")
+        return redirect(url_for(".letter_branding_request", service_id=current_service.id))
+
+    if request.method == "POST":
+        current_service.update(letter_branding=chosen_branding.id)
+
+        flash("You’ve updated your letter branding", "default")
+        return redirect(url_for(".service_settings", service_id=current_service.id))
+
+    return render_template(
+        "views/service-settings/branding/letter-branding-pool-option.html",
+        chosen_branding=chosen_branding,
+    )
 
 
 @main.route("/services/<uuid:service_id>/data-retention", methods=["GET"])

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1597,35 +1597,48 @@ def letter_branding_request(service_id):
     form = ChooseLetterBrandingForm(current_service)
     from_template = request.args.get("from_template")
     if form.validate_on_submit():
-        ticket_message = render_template(
-            "support-tickets/branding-request.txt",
-            current_branding=current_service.letter_branding.name or "no",
-            branding_requested=dict(form.options.choices)[form.options.data],
-            detail=form.something_else.data,
-        )
-        ticket = NotifySupportTicket(
-            subject=f"Letter branding request - {current_service.name}",
-            message=ticket_message,
-            ticket_type=NotifySupportTicket.TYPE_QUESTION,
-            user_name=current_user.name,
-            user_email=current_user.email_address,
-            org_id=current_service.organisation_id,
-            org_type=current_service.organisation_type,
-            service_id=current_service.id,
-        )
-        zendesk_client.send_ticket_to_zendesk(ticket)
-        flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
-        return redirect(
-            url_for(".view_template", service_id=current_service.id, template_id=from_template)
-            if from_template
-            else url_for(".service_settings", service_id=current_service.id)
-        )
+        branding_choice = form.options.data
+
+        if branding_choice in current_service.letter_branding_pool.ids:
+            return redirect(
+                url_for(".letter_branding_pool_option", service_id=current_service.id, branding_option=branding_choice)
+            )
+        else:
+            ticket_message = render_template(
+                "support-tickets/branding-request.txt",
+                current_branding=current_service.letter_branding.name or "no",
+                branding_requested=dict(form.options.choices)[form.options.data],
+                detail=form.something_else.data,
+            )
+            ticket = NotifySupportTicket(
+                subject=f"Letter branding request - {current_service.name}",
+                message=ticket_message,
+                ticket_type=NotifySupportTicket.TYPE_QUESTION,
+                user_name=current_user.name,
+                user_email=current_user.email_address,
+                org_id=current_service.organisation_id,
+                org_type=current_service.organisation_type,
+                service_id=current_service.id,
+            )
+            zendesk_client.send_ticket_to_zendesk(ticket)
+            flash((THANKS_FOR_BRANDING_REQUEST_MESSAGE), "default")
+            return redirect(
+                url_for(".view_template", service_id=current_service.id, template_id=from_template)
+                if from_template
+                else url_for(".service_settings", service_id=current_service.id)
+            )
 
     return render_template(
         "views/service-settings/branding/letter-branding-options.html",
         form=form,
         from_template=from_template,
     )
+
+
+@user_has_permissions("manage_service")
+@main.route("/services/<uuid:service_id>/service-settings/letter-branding/pool", methods=["GET", "POST"])
+def letter_branding_pool_option(service_id):
+    return "WIP"
 
 
 @main.route("/services/<uuid:service_id>/data-retention", methods=["GET"])

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -70,6 +70,7 @@ class EmailBranding(Branding):
 
 class LetterBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {"filename"}
+    NHS_ID = "2cd354bb-6b85-eda3-c0ad-6b613150459f"
 
     @classmethod
     def from_id(cls, id):

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -238,6 +238,7 @@ class MainNavigation(Navigation):
             "email_branding_something_else",
             "email_branding_upload_logo",
             "estimate_usage",
+            "letter_branding_pool_option",
             "letter_branding_request",
             "link_service_to_organisation",
             "request_to_go_live",

--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -47,10 +47,7 @@
         ) }}
       {% endcall %}
     {% endif %}
-    <p class="form-group">
-      We’ll email you once your branding’s ready to use, or if we need any
-      more information.
-    </p>
+
     {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -51,7 +51,7 @@
       We’ll email you once your branding’s ready to use, or if we need any
       more information.
     </p>
-    {{ page_footer('Request new branding') }}
+    {{ page_footer('Continue') }}
   {% endcall %}
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/letter-branding-pool-option.html
+++ b/app/templates/views/service-settings/branding/letter-branding-pool-option.html
@@ -1,0 +1,35 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/branding-preview.html" import letter_branding_preview %}
+
+{% set page_title = "Change letter branding" %}
+
+{% block service_page_title %}
+  {{  page_title }}
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    "href": url_for('.letter_branding_request', service_id=current_service.id)
+  }) }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  {{ page_header(page_title) }}
+
+  <p class="govuk-body">
+    If you confirm, your letters will come with {{ chosen_branding.name }} branding.
+  </p>
+
+  {{ letter_branding_preview(chosen_branding.id) }}
+
+
+  {% call form_wrapper() %}
+    {{ page_footer('Change letter branding') }}
+  {% endcall %}
+
+{% endblock %}

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -28,9 +28,13 @@ def get_email_choices(service):
 def get_letter_choices(service):
 
     if service.is_nhs and not service.letter_branding.is_nhs:
-        yield ("nhs", "NHS")
+        yield (EmailBranding.NHS_ID, "NHS")
 
-    if (
+    if service.letter_branding_pool:
+        for branding in service.letter_branding_pool.excluding(service.letter_branding_id):
+            yield (branding.id, branding.name)
+
+    elif (
         service.organisation
         and not service.is_nhs
         and (not service.letter_branding_id or service.letter_branding_id != service.organisation.letter_branding_id)

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -1,4 +1,4 @@
-from app.models.branding import EmailBranding
+from app.models.branding import EmailBranding, LetterBranding
 
 
 def get_email_choices(service):
@@ -28,7 +28,7 @@ def get_email_choices(service):
 def get_letter_choices(service):
 
     if service.is_nhs and not service.letter_branding.is_nhs:
-        yield (EmailBranding.NHS_ID, "NHS")
+        yield (LetterBranding.NHS_ID, "NHS")
 
     if service.letter_branding_pool:
         for branding in service.letter_branding_pool.excluding(service.letter_branding_id):

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -4,7 +4,7 @@ import pytest
 from flask import url_for
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket
 
-from app.models.branding import EmailBranding
+from app.models.branding import LetterBranding
 from tests import organisation_json, sample_uuid
 from tests.conftest import (
     ORGANISATION_ID,
@@ -25,7 +25,7 @@ from tests.conftest import (
                 {"id": "5678", "name": "Brand 2", "filename": "brand_2"},
             ],
             [
-                (EmailBranding.NHS_ID, "NHS"),
+                (LetterBranding.NHS_ID, "NHS"),
                 ("1234", "Brand 1"),
                 ("5678", "Brand 2"),
                 ("something_else", "Something else"),
@@ -36,7 +36,7 @@ from tests.conftest import (
             False,
             [],
             [
-                (EmailBranding.NHS_ID, "NHS"),
+                (LetterBranding.NHS_ID, "NHS"),
                 ("something_else", "Something else"),
             ],
         ),

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -77,7 +77,7 @@ def test_letter_branding_request_page_when_no_branding_is_set(
     assert normalize_spaces(page.select_one("main p").text) == "Your letters currently have no branding."
 
     button_text = normalize_spaces(page.select_one(".page-footer button").text)
-    assert button_text == "Request new branding"
+    assert button_text == "Continue"
 
     if expected_options:
         assert [

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -128,6 +128,35 @@ def test_letter_branding_request_page_back_link(
     assert back_link[0].attrs["href"] == back_link_url
 
 
+def test_letter_branding_request_redirects_to_branding_preview_for_a_branding_pool_option(
+    client_request,
+    service_one,
+    mocker,
+    mock_get_letter_branding_pool,
+):
+    mocker.patch(
+        "app.models.service.Service.organisation_id",
+        new_callable=PropertyMock,
+        return_value=ORGANISATION_ID,
+    )
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_json(id_=ORGANISATION_ID, name="Org 1"),
+    )
+
+    client_request.post(
+        ".letter_branding_request",
+        service_id=SERVICE_ONE_ID,
+        _data={"options": "1234"},
+        _expected_status=302,
+        _expected_redirect=url_for(
+            "main.letter_branding_pool_option",
+            service_id=SERVICE_ONE_ID,
+            branding_option="1234",
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "org_name, expected_organisation",
     (
@@ -135,7 +164,7 @@ def test_letter_branding_request_page_back_link(
         ("Test Organisation", "Test Organisation"),
     ),
 )
-def test_letter_branding_request_submit(
+def test_letter_branding_request_submit_choose_something_else(
     client_request,
     service_one,
     mocker,

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -166,6 +166,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "invite_org_user",
             "invite_user",
             "letter_branding",
+            "letter_branding_pool_option",
             "letter_branding_request",
             "letter_spec",
             "letter_specification",

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -2,7 +2,7 @@ from unittest.mock import PropertyMock
 
 import pytest
 
-from app.models.branding import EmailBranding
+from app.models.branding import EmailBranding, LetterBranding
 from app.models.service import Service
 from app.utils.branding import get_email_choices, get_letter_choices
 from tests import organisation_json
@@ -17,7 +17,7 @@ from tests.conftest import create_email_branding
         (get_email_choices, "local", []),
         (get_letter_choices, "local", []),
         (get_email_choices, "nhs_central", [(EmailBranding.NHS_ID, "NHS")]),
-        (get_letter_choices, "nhs_central", [(EmailBranding.NHS_ID, "NHS")]),
+        (get_letter_choices, "nhs_central", [(LetterBranding.NHS_ID, "NHS")]),
     ],
 )
 def test_get_choices_service_not_assigned_to_org(
@@ -237,7 +237,7 @@ def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
         ("central", None, [("organisation", "Test Organisation")]),
         ("local", None, [("organisation", "Test Organisation")]),
         ("local", "some-random-branding", [("organisation", "Test Organisation")]),
-        ("nhs_central", None, [(EmailBranding.NHS_ID, "NHS")]),
+        ("nhs_central", None, [(LetterBranding.NHS_ID, "NHS")]),
     ],
 )
 def test_get_letter_choices_service_assigned_to_org(
@@ -309,7 +309,7 @@ def test_get_letter_choices_org_has_default_branding(
         (
             "NHS something else",
             [
-                (EmailBranding.NHS_ID, "NHS"),
+                (LetterBranding.NHS_ID, "NHS"),
             ],
         ),
         (


### PR DESCRIPTION
Allow user to choose a new letter branding from pool options.

Ssome of this code (notably `.letter_branding_pool_option` view and its template) is very similar to the one for email branding option preview.

We could consolidate them when we are doing the clean-up after both features are finished.