### PR TITLE
Make failed messages links fill their block

### DIFF
--- a/app/assets/stylesheets/components/big-number.scss
+++ b/app/assets/stylesheets/components/big-number.scss
@@ -141,6 +141,31 @@
 
   }
 
+  // TODO: when the :has() pseudo-class gets enough support we can remove the
+  // .big-number-status--with-link and just do .big-number-status:has(> .govuk-link)
+  .big-number-status--with-link {
+    padding: 0;
+
+    & > .govuk-link {
+      display: block;
+      padding: 15px;
+
+      // override the default focus style to inset the underline
+      &:active,
+      &:focus {
+        box-shadow: inset 0 -4px $govuk-focus-text-colour;
+      }
+
+      // For Safari, which doesn't fire :focus when :active
+      &:active {
+        text-decoration: none;
+        background-color: $govuk-focus-colour;
+        color: $govuk-focus-text-colour;
+      }
+
+    }
+  }
+
   .big-number-status-failing {
     @extend %big-number-status;
     background: $govuk-error-colour;

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -39,7 +39,7 @@
   <span class="big-number-with-status">
     {{ big_number(number, label, link=link, smaller=smaller, smallest=smallest) }}
     {% if show_failures %}
-      <span class="big-number-status{% if danger_zone %}-failing{% endif %}">
+      <span class="big-number-status{% if danger_zone %}-failing{% endif %}{% if failures and failure_link %} big-number-status--with-link{% endif %}">
         {% if failures %}
           {% if failure_link %}
             <a class="govuk-link govuk-link--inverse" href="{{ failure_link }}">


### PR DESCRIPTION
The link for failed messages on the main dashboard page doesn't fill it's container and it should.

This fixes it.

## Before

<img width="246" alt="failure_message_link_focused_before" src="https://user-images.githubusercontent.com/87140/206480056-2953c2ac-cebe-4bc9-9b81-ca727bd35073.png">

## After

<img width="244" alt="failure_message_link_focused_after" src="https://user-images.githubusercontent.com/87140/206480090-15460adb-22db-487e-b14d-ca18fea150ff.png">
