### PR TITLE
Let organisation users see the templates for their services

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -44,7 +44,7 @@ form_objects = {
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>")
-@user_has_permissions()
+@user_has_permissions(allow_org_user=True)
 def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
     template_folder = current_service.get_template_folder(template["folder"])
@@ -86,7 +86,7 @@ def view_template(service_id, template_id):
     "/services/<uuid:service_id>/templates/<template_type:template_type>/folders/<uuid:template_folder_id>",
     methods=["GET", "POST"],
 )
-@user_has_permissions()
+@user_has_permissions(allow_org_user=True)
 def choose_template(service_id, template_type="all", template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
     user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
@@ -205,7 +205,7 @@ def get_template_nav_items(template_folder_id):
 
 
 @no_cookie.route("/services/<uuid:service_id>/templates/<uuid:template_id>.<filetype>")
-@user_has_permissions()
+@user_has_permissions(allow_org_user=True)
 def view_letter_template_preview(service_id, template_id, filetype):
     if filetype not in ("pdf", "png"):
         abort(404)
@@ -262,7 +262,7 @@ def _view_template_version(service_id, template_id, version, letters_as_pdf=Fals
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>")
-@user_has_permissions()
+@user_has_permissions(allow_org_user=True)
 def view_template_version(service_id, template_id, version):
     return render_template(
         "views/templates/template_history.html",
@@ -271,7 +271,7 @@ def view_template_version(service_id, template_id, version):
 
 
 @no_cookie.route("/services/<uuid:service_id>/templates/<uuid:template_id>/version/<int:version>.<filetype>")
-@user_has_permissions()
+@user_has_permissions(allow_org_user=True)
 def view_template_version_preview(service_id, template_id, version, filetype):
     db_template = current_service.get_template(template_id, version=version)
     return TemplatePreview.from_database_object(db_template, filetype)
@@ -785,7 +785,7 @@ def redact_template(service_id, template_id):
 
 
 @main.route("/services/<uuid:service_id>/templates/<uuid:template_id>/versions")
-@user_has_permissions("view_activity")
+@user_has_permissions(allow_org_user=True)
 def view_template_versions(service_id, template_id):
     return render_template(
         "views/templates/choose_history.html",

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -34,6 +34,7 @@
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
     <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
   </ul>

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -107,6 +107,7 @@ def test_service_navigation_for_org_user(
     )
     assert [item.text.strip() for item in page.select("nav.navigation a")] == [
         "Usage",
+        "Templates",
         "Team members",
     ]
 

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -42,10 +42,17 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     mock_get_template_folders,
     mock_get_organisation,
     mock_has_jobs,
+    mock_get_service_templates,
+    mock_get_service_template,
+    mock_get_template_versions,
+    mock_get_template_version,
+    mock_get_api_keys,
+    mock_template_preview,
     user_services,
     user_organisations,
     expected_status,
     organisation_checked,
+    fake_uuid,
 ):
     api_user_active["services"] = user_services
     api_user_active["organisations"] = user_organisations
@@ -66,15 +73,18 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     )
 
     endpoints = (
-        "main.usage",
-        "main.manage_users",
+        ("main.usage", {}),
+        ("main.manage_users", {}),
+        ("main.choose_template", {"template_id": fake_uuid}),
+        ("main.view_template", {"template_id": fake_uuid}),
+        ("main.view_template_versions", {"template_id": fake_uuid}),
+        ("main.view_template_version", {"template_id": fake_uuid, "version": 1}),
+        ("no_cookie.view_letter_template_preview", {"template_id": fake_uuid, "filetype": "pdf"}),
     )
 
-    for endpoint in endpoints:
+    for endpoint, extra_args in endpoints:
         client_request.get(
-            endpoint,
-            service_id=SERVICE_ONE_ID,
-            _expected_status=expected_status,
+            endpoint, service_id=SERVICE_ONE_ID, _expected_status=expected_status, _test_page_title=False, **extra_args
         )
 
     assert mock_get_service.called is organisation_checked


### PR DESCRIPTION
We want to let organisation users approve go live requests for teams in their organisation.

As part of reviewing these requests, we think that being able to see the templates a team has set up will be important.

For a user of an organisation viewing a service, this pull request:
- makes the ‘Templates’ navigation item visible
- gives them permission to view the various pages under the ‘Templates’ navigation item