### PR TITLE
Clear branding pool caches when updating branding

### DIFF
--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -31,6 +31,7 @@ class EmailBrandingClient(NotifyAdminAPIClient):
 
     @cache.delete("email_branding")
     @cache.delete("email_branding-{branding_id}")
+    @cache.delete_by_pattern("organisation-*-email-branding-pool")
     def update_email_branding(self, *, branding_id, logo, name, alt_text, text, colour, brand_type, updated_by_id: str):
         data = {
             "logo": logo or None,

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -20,6 +20,7 @@ class LetterBrandingClient(NotifyAdminAPIClient):
 
     @cache.delete("letter_branding")
     @cache.delete("letter_branding-{branding_id}")
+    @cache.delete_by_pattern("organisation-*-letter-branding-pool")
     def update_letter_branding(self, branding_id, filename, name):
         data = {
             "filename": filename,

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -86,6 +86,7 @@ def test_update_email_branding(mocker, fake_uuid):
 
     mock_post = mocker.patch("app.notify_client.email_branding_client.EmailBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
+    mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")
     EmailBrandingClient().update_email_branding(
         branding_id=fake_uuid,
         logo=org_data["logo"],
@@ -102,6 +103,7 @@ def test_update_email_branding(mocker, fake_uuid):
         call("email_branding-{}".format(fake_uuid)),
         call("email_branding"),
     ]
+    assert mock_redis_delete_by_pattern.call_args_list == [call("organisation-*-email-branding-pool")]
 
 
 def test_create_email_branding_sends_none_values(mocker, fake_uuid):

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -57,6 +57,7 @@ def test_update_letter_branding(mocker, fake_uuid):
 
     mock_post = mocker.patch("app.notify_client.letter_branding_client.LetterBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
+    mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")
     LetterBrandingClient().update_letter_branding(
         branding_id=fake_uuid, filename=branding["filename"], name=branding["name"]
     )
@@ -66,3 +67,4 @@ def test_update_letter_branding(mocker, fake_uuid):
         call("letter_branding-{}".format(fake_uuid)),
         call("letter_branding"),
     ]
+    assert mock_redis_delete_by_pattern.call_args_list == [call("organisation-*-letter-branding-pool")]


### PR DESCRIPTION
If we update email or letter branding, we need to clear the branding pool caches to avoid them still containing the old branding details. Finding out which branding pools (if any) contain the branding we're updating would require an extra api request, so this just clears all the branding pool caches.