### PR TITLE
Set org default branding if conditions are met

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1199,6 +1199,7 @@ def email_branding_request(service_id):
                     ".email_branding_choose_banner_type",
                     service_id=current_service.id,
                     back_link=".email_branding_request",
+                    branding_choice=branding_choice,
                 )
             )
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1504,7 +1504,7 @@ def email_branding_set_alt_text(service_id):
         )
 
         if _should_set_default_org_branding(branding_choice):
-            current_service.organisation.update(email_branding_id=new_email_branding.id)
+            current_service.organisation.update(email_branding_id=new_email_branding.id, delete_services_cache=True)
 
         flash(
             "You’ve changed your email branding. Send yourself an email to make sure it looks OK.", "default_with_tick"

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1464,7 +1464,7 @@ def _should_set_default_org_branding(branding_choice):
     org_not_central = current_service.organisation_type != Organisation.TYPE_CENTRAL
     # 4. and the organisation has no other live services
     no_other_live_services_in_org = not any(
-        service["id"] != current_service.id for service in current_service.organisation.live_services
+        service.id != current_service.id for service in current_service.organisation.live_services
     )
 
     return (

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -146,19 +146,21 @@ class Organisation(JSONModel):
 
     @cached_property
     def services(self):
-        return organisations_client.get_organisation_services(self.id)
+        from app.models.service import Services
+
+        return Services(organisations_client.get_organisation_services(self.id))
 
     @cached_property
     def service_ids(self):
-        return [s["id"] for s in self.services]
+        return [s.id for s in self.services]
 
     @property
     def live_services(self):
-        return [s for s in self.services if s["active"] and not s["restricted"]]
+        return [s for s in self.services if s.active and s.live]
 
     @property
     def trial_services(self):
-        return [s for s in self.services if not s["active"] or s["restricted"]]
+        return [s for s in self.services if not s.active or s.trial_mode]
 
     @cached_property
     def invited_users(self):

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -345,49 +345,43 @@ def test_email_branding_request_page_back_link(
     "data, org_type, endpoint, extra_args",
     (
         (
-            {
-                "options": "govuk",
-            },
+            {"options": "govuk"},
             "central",
             "main.email_branding_govuk",
             {},
         ),
         (
-            {
-                "options": "govuk_and_org",
-            },
+            {"options": "govuk_and_org"},
             "central",
             "main.email_branding_choose_logo",
             {"branding_choice": "govuk_and_org"},
         ),
         (
-            {
-                "options": "organisation",
-            },
+            {"options": "organisation"},
             "central",
             "main.email_branding_choose_logo",
             {"branding_choice": "organisation"},
         ),
         (
-            {
-                "options": "something_else",
-            },
+            {"options": "something_else"},
             "central",
             "main.email_branding_choose_logo",
             {"branding_choice": "something_else"},
         ),
         (
-            {
-                "options": "something_else",
-            },
+            {"options": "something_else"},
             "local",
             "main.email_branding_choose_banner_type",
-            {"back_link": ".email_branding_request"},
+            {"back_link": ".email_branding_request", "branding_choice": "something_else"},
         ),
         (
-            {
-                "options": EmailBranding.NHS_ID,
-            },
+            {"options": "organisation"},
+            "local",
+            "main.email_branding_choose_banner_type",
+            {"back_link": ".email_branding_request", "branding_choice": "organisation"},
+        ),
+        (
+            {"options": EmailBranding.NHS_ID},
             "nhs_local",
             "main.email_branding_nhs",
             {},

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4337,6 +4337,7 @@ def test_POST_email_branding_set_alt_text_creates_branding_sets_org_default_if_a
     active_user_with_permissions,
     mock_update_service,
     mock_get_organisation,
+    mock_get_organisation_services,
     mock_update_organisation,
     fake_uuid,
     mocker,

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -8,12 +8,14 @@ from urllib.parse import parse_qs, urlparse
 from uuid import UUID, uuid4
 
 import pytest
-from flask import url_for
+from flask import g, url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket
 
 import app
+from app.main.views.service_settings import _should_set_default_org_branding
+from app.models.service import Service
 from tests import (
     find_element_by_tag_and_partial_text,
     invite_json,
@@ -4291,6 +4293,9 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
     expected_name,
 ):
     mock_flash = mocker.patch("app.main.views.service_settings.flash")
+    mock_should_set_default_org_branding = mocker.patch(
+        "app.main.views.service_settings._should_set_default_org_branding", return_value=False
+    )
     mock_add_to_branding_pool = mocker.patch(
         "app.organisations_client.add_brandings_to_email_branding_pool", return_value=None
     )
@@ -4320,6 +4325,52 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
     mock_flash.assert_called_once_with(
         "You’ve changed your email branding. Send yourself an email to make sure it looks OK.",
         "default_with_tick",
+    )
+    mock_should_set_default_org_branding.assert_called_once_with(None)
+
+
+def test_POST_email_branding_set_alt_text_creates_branding_sets_org_default_if_appropriate(
+    client_request,
+    service_one,
+    mock_create_email_branding,
+    mock_get_email_branding_name_for_alt_text,
+    active_user_with_permissions,
+    mock_update_service,
+    mock_get_organisation,
+    mock_update_organisation,
+    fake_uuid,
+    mocker,
+):
+    service_one["organisation"] = ORGANISATION_ID
+    mock_should_set_default_org_branding = mocker.patch(
+        "app.main.views.service_settings._should_set_default_org_branding", return_value=True
+    )
+    mock_add_to_branding_pool = mocker.patch(
+        "app.organisations_client.add_brandings_to_email_branding_pool", return_value=None
+    )
+    client_request.post(
+        "main.email_branding_set_alt_text",
+        service_id=service_one["id"],
+        brand_type="org",
+        logo="example.png",
+        branding_choice="organisation",
+        _data={"alt_text": "some alt text"},
+        _expected_status=302,
+        _expected_redirect=url_for("main.service_settings", service_id=SERVICE_ONE_ID),
+    )
+    mock_create_email_branding.assert_called_once_with(
+        logo="example.png",
+        name="some alt text",
+        alt_text="some alt text",
+        text=None,
+        colour=None,
+        brand_type="org",
+        created_by_id=active_user_with_permissions["id"],
+    )
+    mock_add_to_branding_pool.assert_called_once_with(service_one["organisation"], [fake_uuid])
+    mock_should_set_default_org_branding.assert_called_once_with("organisation")
+    mock_update_organisation.assert_called_once_with(
+        ORGANISATION_ID, cached_service_ids=ANY, email_branding_id=fake_uuid
     )
 
 
@@ -5949,3 +6000,77 @@ def test_service_set_broadcast_channel_makes_you_choose(
         _expected_status=200,
     )
     assert "Error: Select mode or channel" in page.select_one(".govuk-error-message").text
+
+
+@pytest.mark.parametrize("branding_choice", [None, "govuk_and_org", "something_else"])
+def test_should_set_default_org_branding_fails_if_branding_choice_is_not_org(client_request, mocker, branding_choice):
+    organisation = organisation_json(email_branding_id=None, organisation_type="local")
+    service = service_json(organisation_id=organisation["id"], organisation_type="local")
+    mocker.patch(
+        "app.organisations_client.get_organisation_services",
+        return_value=[service, service_json(id_="5678", restricted=True)],
+    )
+
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
+    g.current_service = Service(service)
+
+    assert _should_set_default_org_branding(branding_choice) is False
+
+
+def test_should_set_default_org_branding_fails_if_org_already_has_a_default_branding(client_request, mocker):
+    organisation = organisation_json(email_branding_id="12345", organisation_type="local")
+    service = service_json(organisation_id=organisation["id"], organisation_type="local")
+    mocker.patch(
+        "app.organisations_client.get_organisation_services",
+        return_value=[service, service_json(id_="5678", restricted=True)],
+    )
+
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
+    g.current_service = Service(service)
+
+    assert _should_set_default_org_branding("organisation") is False
+
+
+def test_should_set_default_org_branding_fails_if_org_is_central(client_request, mocker):
+    organisation = organisation_json(email_branding_id=None, organisation_type="central")
+    service = service_json(organisation_id=organisation["id"], organisation_type="central")
+    mocker.patch(
+        "app.organisations_client.get_organisation_services",
+        return_value=[service, service_json(id_="5678", restricted=True)],
+    )
+
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
+    g.current_service = Service(service)
+
+    assert _should_set_default_org_branding("organisation") is False
+
+
+def test_should_set_default_org_branding_fails_if_other_live_services_in_org(client_request, mocker):
+    organisation = organisation_json(email_branding_id=None, organisation_type="local")
+    service = service_json(organisation_id=organisation["id"], organisation_type="local")
+    mocker.patch(
+        "app.organisations_client.get_organisation_services",
+        return_value=[service, service_json(id_="5678", restricted=False)],
+    )
+
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
+    g.current_service = Service(service)
+
+    assert _should_set_default_org_branding("organisation") is False
+
+
+# regardless of whether this service is live, we're only interested in other services with
+# different ids when checking for other live services
+@pytest.mark.parametrize("is_service_trial", [True, False])
+def test_should_set_default_org_branding_succeeds_if_all_conditions_are_met(client_request, mocker, is_service_trial):
+    organisation = organisation_json(email_branding_id=None, organisation_type="local")
+    service = service_json(organisation_id=organisation["id"], organisation_type="local", restricted=is_service_trial)
+    mocker.patch(
+        "app.organisations_client.get_organisation_services",
+        return_value=[service, service_json(id_="5678", restricted=True)],
+    )
+
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
+    g.current_service = Service(service)
+
+    assert _should_set_default_org_branding("organisation") is True


### PR DESCRIPTION
1. The user set organisation on the very first page
2. the org doesn't have a default set yet
3. the org isn't central govt (keep govuk as default in that case)
4. the org has no other live services (so we dont change any settings for them)