### PR TITLE
Revert "Re-label the ‘upload logo’ radio button"

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2062,7 +2062,7 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
             },
         },
         "org": {
-            "label": "Use your own logo",
+            "label": "Upload a logo",
             "image": {
                 "url": asset_fingerprinter.get_url("images/branding/org.png"),
                 "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -721,7 +721,7 @@ def test_email_branding_choose_logo_page(client_request, service_one):
         for i, radio in enumerate(page.select("input[type=radio]"))
     ] == [
         ("single_identity", "Create a government identity logo"),
-        ("org", "Use your own logo"),
+        ("org", "Upload a logo"),
     ]
 
 


### PR DESCRIPTION
This reverts commit 0816e445ea9faa12b60592eac5789679dcd03f2c.

Now that the second option does let you upload a logo, we should label it as such.

Before | After
---|---
<img width="761" alt="image" src="https://user-images.githubusercontent.com/355079/207033895-20e8ee99-b92f-478b-8cfc-2f67ab334963.png"> | <img width="756" alt="image" src="https://user-images.githubusercontent.com/355079/207033797-29c98de4-5c1d-487c-b70d-86093a2281ad.png">
