### PR TITLE
Reflect selection of ’GOV.UK and `organisation name`’ throughout new branding journey

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1343,9 +1343,22 @@ def email_branding_enter_government_identity_logo_text(service_id):
 @service_belongs_to_org_type("central")
 def email_branding_choose_logo(service_id):
     form = EmailBrandingChooseLogoForm()
+    branding_choice = request.args.get("branding_choice")
 
     if form.validate_on_submit():
         if form.branding_options.data == "org":
+
+            if branding_choice == "govuk_and_org":
+                return redirect(
+                    url_for(
+                        ".email_branding_upload_logo",
+                        service_id=current_service.id,
+                        branding_choice=branding_choice,
+                        brand_type="both",
+                        back_link=".email_branding_choose_logo",
+                    )
+                )
+
             return redirect(
                 url_for(
                     ".email_branding_choose_banner_type",

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1462,6 +1462,10 @@ def email_branding_set_alt_text(service_id):
         del email_branding_data["branding_choice"]
 
         name = email_branding_client.get_email_branding_name_for_alt_text(form.alt_text.data)
+
+        if email_branding_data["brand_type"] == "both":
+            name = f"GOV.UK and {name}"
+
         new_email_branding = email_branding_client.create_email_branding(
             name=name,
             alt_text=form.alt_text.data,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1461,25 +1461,17 @@ def email_branding_set_alt_text(service_id):
         # we use this key to keep track of user choices through the journey but we don't use it to save the branding
         del email_branding_data["branding_choice"]
 
-        name = email_branding_client.get_email_branding_name_for_alt_text(form.alt_text.data)
-
-        if email_branding_data["brand_type"] == "both":
-            name = f"GOV.UK and {name}"
-
-        new_email_branding = email_branding_client.create_email_branding(
-            name=name,
+        new_email_branding = EmailBranding.create(
             alt_text=form.alt_text.data,
-            text=None,
-            created_by_id=current_user.id,
             **email_branding_data,
         )
 
         # set as service branding
-        current_service.update(email_branding=new_email_branding["id"])
+        current_service.update(email_branding=new_email_branding.id)
 
         # add to org pool
         organisations_client.add_brandings_to_email_branding_pool(
-            current_service.organisation.id, [new_email_branding["id"]]
+            current_service.organisation.id, [new_email_branding.id]
         )
 
         flash(

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from flask import current_app
+from flask_login import current_user
 
 from app import asset_fingerprinter
 from app.formatters import email_safe
@@ -42,6 +43,30 @@ class EmailBranding(Branding):
     @classmethod
     def govuk_branding(cls):
         return cls.from_id(None)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        logo,
+        alt_text,
+        colour,
+        brand_type,
+    ):
+        name = email_branding_client.get_email_branding_name_for_alt_text(alt_text)
+        if brand_type == "both":
+            name = f"GOV.UK and {name}"
+
+        new_email_branding = email_branding_client.create_email_branding(
+            name=name,
+            alt_text=alt_text,
+            text=None,
+            created_by_id=current_user.id,
+            logo=logo,
+            colour=colour,
+            brand_type=brand_type,
+        )
+        return cls(new_email_branding)
 
     @property
     def is_nhs(self):

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -736,18 +736,48 @@ def test_only_central_org_services_can_see_email_branding_choose_logo_page(clien
 
 
 @pytest.mark.parametrize(
-    "selected_option, expected_endpoint, extra_url_args",
+    "branding_choice, selected_option, expected_endpoint, extra_url_args",
     [
-        ("org", ".email_branding_choose_banner_type", {"back_link": ".email_branding_choose_logo"}),
-        ("single_identity", ".email_branding_request_government_identity_logo", {}),
+        (
+            "something_else",
+            "org",
+            ".email_branding_choose_banner_type",
+            {"back_link": ".email_branding_choose_logo", "branding_choice": "something_else"},
+        ),
+        (
+            "something_else",
+            "single_identity",
+            ".email_branding_request_government_identity_logo",
+            {"branding_choice": "something_else"},
+        ),
+        (
+            "org",
+            "org",
+            ".email_branding_choose_banner_type",
+            {"back_link": ".email_branding_choose_logo", "branding_choice": "org"},
+        ),
+        ("org", "single_identity", ".email_branding_request_government_identity_logo", {"branding_choice": "org"}),
+        (
+            "govuk_and_org",
+            "org",
+            ".email_branding_upload_logo",
+            {"back_link": ".email_branding_choose_logo", "branding_choice": "govuk_and_org", "brand_type": "both"},
+        ),
+        (
+            "govuk_and_org",
+            "single_identity",
+            ".email_branding_request_government_identity_logo",
+            {"branding_choice": "govuk_and_org"},
+        ),
     ],
 )
 def test_email_branding_choose_logo_redirects_to_right_page(
-    client_request, service_one, selected_option, expected_endpoint, extra_url_args
+    client_request, service_one, branding_choice, selected_option, expected_endpoint, extra_url_args
 ):
     client_request.post(
         ".email_branding_choose_logo",
         service_id=SERVICE_ONE_ID,
+        branding_choice=branding_choice,
         _data={"branding_options": selected_option},
         _expected_status=302,
         _expected_redirect=url_for(expected_endpoint, service_id=SERVICE_ONE_ID, **extra_url_args),

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4148,6 +4148,13 @@ def test_POST_email_branding_set_alt_text_shows_error(client_request, service_on
     assert normalize_spaces(page.select_one("#alt_text-error").text) == expected_error
 
 
+@pytest.mark.parametrize(
+    "brand_type, expected_name",
+    (
+        ("org", "some alt text"),
+        ("both", "GOV.UK and some alt text"),
+    ),
+)
 def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redirects(
     client_request,
     service_one,
@@ -4157,6 +4164,8 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
     mock_update_service,
     fake_uuid,
     mocker,
+    brand_type,
+    expected_name,
 ):
     mock_flash = mocker.patch("app.main.views.service_settings.flash")
     mock_add_to_branding_pool = mocker.patch(
@@ -4165,7 +4174,7 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
     client_request.post(
         "main.email_branding_set_alt_text",
         service_id=service_one["id"],
-        brand_type="org",
+        brand_type=brand_type,
         logo="example.png",
         _data={"alt_text": "some alt text"},
         _expected_status=302,
@@ -4173,11 +4182,11 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
     )
     mock_create_email_branding.assert_called_once_with(
         logo="example.png",
-        name="some alt text",
+        name=expected_name,
         alt_text="some alt text",
         text=None,
         colour=None,
-        brand_type="org",
+        brand_type=brand_type,
         created_by_id=active_user_with_permissions["id"],
     )
     mock_add_to_branding_pool.assert_called_once_with(service_one["organisation"], [fake_uuid])


### PR DESCRIPTION
If someone selects ‘GOV.UK and `organisation name`’ in the first part of the journey this should be respected when:
- they preview the branding they have upload
- they save the branding they have upload

To achieve this we need to make sure we are passing the info on via the query string.

Unfortunately we do call this different names so the code is a bit of a combination of both:

— | variable name | variable value
---|---|---
UI code | `branding_choice` | `govuk_and_org`
Database | `brand_type` | `both`

When we auto-generate the `name` of the branding this also needs to reflect the choice of GOV.UK and organisation name.