### PR TITLE
Be stricter at looking up example of government identity branding

### DIFF
--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -111,7 +111,7 @@ class AllEmailBranding(AllBranding):
     @property
     def example_government_identity_branding(self):
         for branding in self:
-            if "departmentforeducation" in email_safe(branding.name, whitespace=""):
+            if email_safe(branding.name, whitespace="") == "departmentforeducation":
                 return branding
 
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3638,7 +3638,11 @@ def test_service_set_email_branding_add_to_branding_pool_step_choices_yes_or_no(
             None,
         ),
         (
-            [{"idx": 3, "id": "dfe1234", "name": "The Department for EDUCATION"}],
+            [{"idx": 3, "id": "dfe1234", "name": "Department for Education - National Apprenticeship Service"}],
+            None,
+        ),
+        (
+            [{"idx": 3, "id": "dfe1234", "name": "Department for EDUCATION"}],
             "dfe1234",
         ),
     ),


### PR DESCRIPTION
When we show an example of government identity branding we try to find the DfE one from the database.

Because there are several brands on production with "Department for Education" in the name this doesn’t always match the right one.

This commit makes the matching stricter, so that the right one will be shown.

Before | After
---|---
<img width="806" alt="image" src="https://user-images.githubusercontent.com/355079/207078090-742735e5-12af-494f-a824-346e59f7676e.png"> | <img width="780" alt="image" src="https://user-images.githubusercontent.com/355079/207078280-ac7b6a96-f8c2-48cc-9bd8-cc648e54b4fc.png">
