### PR TITLE
Offer ‘GOV.UK and `organisation name`’ branding more widely

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -2,7 +2,7 @@ import re
 import unicodedata
 import urllib
 from datetime import datetime, timedelta, timezone
-from functools import partial
+from functools import lru_cache, partial
 from math import floor, log10
 from numbers import Number
 
@@ -309,6 +309,7 @@ def format_thousands(value):
     return value
 
 
+@lru_cache(maxsize=4)
 def email_safe(string, whitespace="."):
     # strips accents, diacritics etc
     string = "".join(c for c in unicodedata.normalize("NFD", string) if unicodedata.category(c) != "Mn")

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -106,6 +106,9 @@ class AllBranding(ModelList):
     def excluding(self, *ids_to_exclude):
         return tuple(branding for branding in self if branding.id not in ids_to_exclude)
 
+    def contains_name(self, name):
+        return any(branding.name_like(name) for branding in self)
+
 
 class AllEmailBranding(AllBranding):
     client_method = email_branding_client.get_all_email_branding

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -21,6 +21,9 @@ class Branding(JSONModel):
     def with_default_values(cls, **kwargs):
         return cls({key: None for key in cls.ALLOWED_PROPERTIES} | kwargs)
 
+    def name_like(self, name):
+        return email_safe(name, whitespace="") == email_safe(self.name, whitespace="")
+
 
 class EmailBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {
@@ -111,7 +114,7 @@ class AllEmailBranding(AllBranding):
     @property
     def example_government_identity_branding(self):
         for branding in self:
-            if email_safe(branding.name, whitespace="") == "departmentforeducation":
+            if branding.name_like("Department for Education"):
                 return branding
 
 

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -19,10 +19,8 @@ def get_email_choices(service):
     if service.email_branding_pool:
         for branding in service.email_branding_pool.excluding(service.email_branding_id):
             yield (branding.id, branding.name)
-    elif (
-        service.organisation
-        and not service.is_nhs
-        and (not service.email_branding_id or service.email_branding_id != service.organisation.email_branding_id)
+    elif service.organisation and (
+        not service.email_branding_id or service.email_branding_id != service.organisation.email_branding_id
     ):
         yield ("organisation", service.organisation.name)
 

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -19,9 +19,7 @@ def get_email_choices(service):
     if service.email_branding_pool:
         for branding in service.email_branding_pool.excluding(service.email_branding_id):
             yield (branding.id, branding.name)
-    elif service.organisation and (
-        not service.email_branding_id or service.email_branding_id != service.organisation.email_branding_id
-    ):
+    elif service.organisation:
         yield ("organisation", service.organisation.name)
 
 

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -5,24 +5,26 @@ def get_email_choices(service):
     if service.can_use_govuk_branding and not service.email_branding.is_govuk:
         yield ("govuk", "GOV.UK")
 
+    if (
+        service.organisation
+        and service.can_use_govuk_branding
+        and not service.email_branding.name_like(f"GOV.UK and {service.organisation.name}")
+        and not service.email_branding_pool.contains_name(f"GOV.UK and {service.organisation.name}")
+    ):
+        yield ("govuk_and_org", f"GOV.UK and {service.organisation.name}")
+
     if service.is_nhs and not service.email_branding.is_nhs:
         yield (EmailBranding.NHS_ID, "NHS")
 
     if service.email_branding_pool:
         for branding in service.email_branding_pool.excluding(service.email_branding_id):
             yield (branding.id, branding.name)
-    elif service.organisation:
-        # fake branding options
-        if (
-            service.can_use_govuk_branding
-            and service.email_branding.name.lower() != f"GOV.UK and {service.organisation.name}".lower()
-        ):
-            yield ("govuk_and_org", f"GOV.UK and {service.organisation.name}")
-
-        if not service.is_nhs and (
-            not service.email_branding_id or service.email_branding_id != service.organisation.email_branding_id
-        ):
-            yield ("organisation", service.organisation.name)
+    elif (
+        service.organisation
+        and not service.is_nhs
+        and (not service.email_branding_id or service.email_branding_id != service.organisation.email_branding_id)
+    ):
+        yield ("organisation", service.organisation.name)
 
 
 def get_letter_choices(service):

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -2,16 +2,16 @@ from app.models.branding import EmailBranding
 
 
 def get_email_choices(service):
-    if service.can_use_govuk_branding and not service.email_branding.is_govuk:
-        yield ("govuk", "GOV.UK")
+    if service.can_use_govuk_branding:
 
-    if (
-        service.organisation
-        and service.can_use_govuk_branding
-        and not service.email_branding.name_like(f"GOV.UK and {service.organisation.name}")
-        and not service.email_branding_pool.contains_name(f"GOV.UK and {service.organisation.name}")
-    ):
-        yield ("govuk_and_org", f"GOV.UK and {service.organisation.name}")
+        if not service.email_branding.is_govuk:
+            yield ("govuk", "GOV.UK")
+
+        if service.organisation and not (
+            service.email_branding.name_like(f"GOV.UK and {service.organisation.name}")
+            or service.email_branding_pool.contains_name(f"GOV.UK and {service.organisation.name}")
+        ):
+            yield ("govuk_and_org", f"GOV.UK and {service.organisation.name}")
 
     if service.is_nhs and not service.email_branding.is_nhs:
         yield (EmailBranding.NHS_ID, "NHS")

--- a/app/utils/branding.py
+++ b/app/utils/branding.py
@@ -16,10 +16,10 @@ def get_email_choices(service):
     if service.is_nhs and not service.email_branding.is_nhs:
         yield (EmailBranding.NHS_ID, "NHS")
 
-    if service.email_branding_pool:
-        for branding in service.email_branding_pool.excluding(service.email_branding_id):
-            yield (branding.id, branding.name)
-    elif service.organisation:
+    for branding in service.email_branding_pool.excluding(service.email_branding_id):
+        yield (branding.id, branding.name)
+
+    if service.organisation and not service.email_branding_pool:
         yield ("organisation", service.organisation.name)
 
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -67,6 +67,7 @@ def test_email_branding_request_page_when_no_branding_is_set(
             "central",
             [
                 ("govuk", "GOV.UK"),
+                ("govuk_and_org", "GOV.UK and organisation one"),
                 ("email-branding-1-id", "Email branding name 1"),
                 ("email-branding-2-id", "Email branding name 2"),
                 ("something_else", "Something else"),

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -56,12 +56,20 @@ def test_get_choices_service_not_assigned_to_org(
         ),
         ("local", None, [("organisation", "Test Organisation")]),
         ("local", "some-branding-id", [("organisation", "Test Organisation")]),
-        ("nhs_central", None, [(EmailBranding.NHS_ID, "NHS")]),
+        (
+            "nhs_central",
+            None,
+            [
+                (EmailBranding.NHS_ID, "NHS"),
+                ("organisation", "Test Organisation"),
+            ],
+        ),
         (
             "nhs_central",
             EmailBranding.NHS_ID,
             [
                 # don't show NHS if it's the current branding
+                ("organisation", "Test Organisation"),
             ],
         ),
     ],

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -96,28 +96,20 @@ def test_get_email_choices_service_assigned_to_org(
 
 
 @pytest.mark.parametrize(
-    "org_type, branding_id, expected_options",
+    "org_type, expected_options",
     [
         (
             "central",
-            "some-branding-id",
             [
-                # don't show GOV.UK options as org default supersedes it
+                ("govuk", "GOV.UK"),
+                ("govuk_and_org", "GOV.UK and Test Organisation"),
                 ("organisation", "Test Organisation"),
             ],
         ),
         (
-            "central",
-            "org-branding-id",
-            [
-                # also don't show org option if it's the current branding
-            ],
-        ),
-        (
             "local",
-            "org-branding-id",
             [
-                # don't show org option if it's the current branding
+                ("organisation", "Test Organisation"),
             ],
         ),
     ],
@@ -126,7 +118,6 @@ def test_get_email_choices_org_has_default_branding(
     mocker,
     service_one,
     org_type,
-    branding_id,
     expected_options,
     mock_get_empty_email_branding_pool,
     mock_get_service_organisation,
@@ -136,9 +127,9 @@ def test_get_email_choices_org_has_default_branding(
 
     mocker.patch(
         "app.organisations_client.get_organisation",
-        return_value=organisation_json(organisation_type=org_type, email_branding_id="org-branding-id"),
+        return_value=organisation_json(organisation_type=org_type),
     )
-    mocker.patch("app.models.service.Service.email_branding_id", new_callable=PropertyMock, return_value=branding_id)
+    mocker.patch("app.models.service.Service.email_branding_id")
 
     options = get_email_choices(service)
     assert list(options) == expected_options

--- a/tests/app/utils/test_branding.py
+++ b/tests/app/utils/test_branding.py
@@ -184,12 +184,60 @@ def test_get_email_choices_branding_name_in_use(
     assert list(options) == expected_options
 
 
+@pytest.mark.parametrize(
+    "branding_pool, expected_options",
+    (
+        (
+            [
+                {
+                    "logo": "example_1.png",
+                    "name": "Email branding name 1",
+                    "text": "Email branding text 1",
+                    "id": "email-branding-1-id",
+                    "colour": "#f00",
+                    "brand_type": "org",
+                },
+                {
+                    "logo": "example_2.png",
+                    "name": "Email branding name 2",
+                    "text": "Email branding text 2",
+                    "id": "email-branding-2-id",
+                    "colour": "#f00",
+                    "brand_type": "org",
+                },
+            ],
+            [
+                ("govuk", "GOV.UK"),
+                ("govuk_and_org", "GOV.UK and Test Organisation"),
+                ("email-branding-2-id", "Email branding name 2"),
+            ],
+        ),
+        (
+            [
+                {
+                    "logo": "example_1.png",
+                    "name": "GOV.UK and test organisation",
+                    "text": "test organisation",
+                    "id": "govuk-and-org-id",
+                    "colour": None,
+                    "brand_type": "both",
+                },
+            ],
+            [
+                ("govuk", "GOV.UK"),
+                ("govuk-and-org-id", "GOV.UK and test organisation"),
+            ],
+        ),
+    ),
+)
 def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
     mocker,
     service_one,
     mock_get_email_branding_pool,
     mock_get_service_organisation,
     mock_get_email_branding,
+    branding_pool,
+    expected_options,
 ):
     service = Service(service_one)
 
@@ -202,29 +250,6 @@ def test_current_email_branding_is_not_displayed_in_email_branding_pool_options(
         return_value="email-branding-1-id",
     )
 
-    branding_pool = [
-        {
-            "logo": "example_1.png",
-            "name": "Email branding name 1",
-            "text": "Email branding text 1",
-            "id": "email-branding-1-id",
-            "colour": "#f00",
-            "brand_type": "org",
-        },
-        {
-            "logo": "example_2.png",
-            "name": "Email branding name 2",
-            "text": "Email branding text 2",
-            "id": "email-branding-2-id",
-            "colour": "#f00",
-            "brand_type": "org",
-        },
-    ]
-
-    expected_options = [
-        ("govuk", "GOV.UK"),
-        ("email-branding-2-id", "Email branding name 2"),
-    ]
     mocker.patch("app.models.branding.EmailBrandingPool.client_method", return_value=branding_pool)
 
     options = get_email_choices(service)


### PR DESCRIPTION
Now that we have the branding pool a lot of services won’t get shown the ’GOV.UK and `organisation name’ option.

This isn’t great because
- we don’t already have this branding set up for a lot of organisations
- it’s not possible for people to know this is something we can offer if we don’t make it discoverable

So this pull request makes the magic option available to anyone who might be eligible to use it, not just those who have empty branding pools.

***

There’s also a fair bit of refactoring and attempts at simplification in here, so best reviewed commit by commit.
