### PR TITLE
Add a make command to bump utils, using the tooling from utils version 59.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ freeze-requirements: ## create static requirements.txt
 	${PYTHON_EXECUTABLE_PREFIX}pip3 install --upgrade pip-tools
 	${PYTHON_EXECUTABLE_PREFIX}pip-compile requirements.in
 
+.PHONY: bump-utils
+bump-utils:  # Bump notifications-utils package to latest version
+	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
+
 .PHONY: clean
 clean:
 	rm -rf node_modules cache target ${CF_MANIFEST_PATH}

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ pyproj==3.4.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 itsdangerous==2.1.2
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
 govuk-frontend-jinja==2.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,7 +122,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.4.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
     # via -r requirements.in
 openpyxl==3.0.10
     # via pyexcel-xlsx


### PR DESCRIPTION
59.3.0
---
* Add tooling to bump utils version in apps (which is then used by the `make` command)

59.2.0
---
* Add support for creating redis cache keys for a specific notification type.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/59.1.1...59.3.0