### PR TITLE
Make errors on webauth pages use the Error Summary component

### DIFF
--- a/app/assets/javascripts/errorBanner.js
+++ b/app/assets/javascripts/errorBanner.js
@@ -6,11 +6,11 @@
   sure the banner has an appropriate aria-live attribute, and a tabindex of -1 so that screenreaders and keyboard users
   are alerted to the change respectively.
 
-  This may behave in unexpected ways if you have more than one element with the `banner-dangerous` class on your page.
+  This may behave in unexpected ways if you have more than one element with the `govuk-error-summary` class on your page.
   */
   window.GOVUK.ErrorBanner = {
-    hideBanner: () => $('.banner-dangerous').addClass('govuk-!-display-none'),
-    showBanner: () => $('.banner-dangerous')
+    hideBanner: () => $('.govuk-error-summary').addClass('govuk-!-display-none'),
+    showBanner: () => $('.govuk-error-summary')
       .removeClass('govuk-!-display-none')
       .trigger('focus'),
   };

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -47,9 +47,9 @@
   }) }}
 {% endset %}
 
+  {{ errorSummaries }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
-      {{ errorSummaries }}
       {{ page_header(page_title) }}
 
       <p class="govuk-body">

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -3,7 +3,7 @@
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% set page_title = 'Get your security key' %}
 
@@ -21,15 +21,35 @@
 
 {% block maincolumn_content %}
 
-  <span class="govuk-error-message banner-dangerous govuk-!-display-none" aria-live="polite" tabindex="-1">
-    <span class="govuk-visually-hidden">Error:</span> There’s a problem with your security key
-    <p class="govuk-body">
-      Check you have the right key and try again. If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="/support">contact us</a>.
-    </p>
-  </span>
+{% set errorSummaries %}
+  {{ govukErrorSummary({
+    "classes": "webauthn__api-missing",
+    "titleText": "There's a problem",
+    "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser."
+  }) }}
+
+  {{ govukErrorSummary({
+    "classes": "webauthn__no-js",
+    "titleText": "There's a problem",
+    "descriptionHtml": "JavaScript is not available for this page. Security keys need JavaScript to work."
+  }) }}
+
+  {% set keyProblemDescription %}
+    Check you have the right key and try again. If this does not work,
+     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
+  {% endset %}
+
+  {{ govukErrorSummary({
+    "classes": "govuk-!-display-none",
+    "attributes": { "aria-live": "polite", "tabindex":"-1" },
+    "titleText": "There's a problem with your security keys",
+    "descriptionHtml": keyProblemDescription
+  }) }}
+{% endset %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
+      {{ errorSummaries }}
       {{ page_header(page_title) }}
 
       <p class="govuk-body">
@@ -44,16 +64,6 @@
           "data-notify-module": "authenticate-security-key",
           "data-csrf-token": csrf_token(),
         }
-      }) }}
-
-      {{ govukErrorMessage({
-        "classes": "webauthn__api-missing",
-        "text": "Your browser does not support security keys. Try signing in to Notify using a different browser."
-      }) }}
-
-      {{ govukErrorMessage({
-        "classes": "webauthn__no-js",
-        "text": "JavaScript is not available for this page. Security keys need JavaScript to work."
       }) }}
     </div>
     <div class="govuk-grid-column-one-quarter">

--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -24,13 +24,13 @@
 {% set errorSummaries %}
   {{ govukErrorSummary({
     "classes": "webauthn__api-missing",
-    "titleText": "There's a problem",
+    "titleText": "There’s a problem",
     "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser."
   }) }}
 
   {{ govukErrorSummary({
     "classes": "webauthn__no-js",
-    "titleText": "There's a problem",
+    "titleText": "There’s a problem",
     "descriptionHtml": "JavaScript is not available for this page. Security keys need JavaScript to work."
   }) }}
 
@@ -42,7 +42,7 @@
   {{ govukErrorSummary({
     "classes": "govuk-!-display-none",
     "attributes": { "aria-live": "polite", "tabindex":"-1" },
-    "titleText": "There's a problem with your security keys",
+    "titleText": "There’s a problem with your security keys",
     "descriptionHtml": keyProblemDescription
   }) }}
 {% endset %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -4,7 +4,7 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
-{% from "govuk_frontend_jinja/components/error-message/macro.html" import govukErrorMessage %}
+{% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 
 {% set page_title = 'Security keys' %}
 {% set credentials = current_user.webauthn_credentials %}
@@ -33,39 +33,39 @@
       "data-csrf-token": csrf_token(),
     }
   }) }}
-
-  {{ govukErrorMessage({
-    "classes": "webauthn__api-missing",
-    "text": "Your browser does not support security keys. Try signing in to Notify using a different browser."
-  }) }}
-
-  {{ govukErrorMessage({
-    "classes": "webauthn__no-js",
-    "text": "JavaScript is not available for this page. Security keys need JavaScript to work."
-  }) }}
 {% endset %}
 
-  {% set html %}
-    There’s a problem with your security key
-    <p class="govuk-body">
-      Check you have the right key and try again.
-      If this does not work,
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
-    </p>
-  {% endset %}
-  {{ govukErrorMessage({
-    "classes": "banner-dangerous govuk-!-display-none",
-    "html": html,
-    "attributes": {
-      "aria-live": "polite",
-      "tabindex": '-1'
-    }
+{% set errorSummaries %}
+  {{ govukErrorSummary({
+    "classes": "webauthn__api-missing",
+    "titleText": "There's a problem",
+    "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser."
   }) }}
+
+  {{ govukErrorSummary({
+    "classes": "webauthn__no-js",
+    "titleText": "There's a problem",
+    "descriptionHtml": "JavaScript is not available for this page. Security keys need JavaScript to work."
+  }) }}
+
+  {% set keyProblemDescription %}
+    Check you have the right key and try again. If this does not work,
+     <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
+  {% endset %}
+
+  {{ govukErrorSummary({
+    "classes": "govuk-!-display-none",
+    "attributes": { "aria-live": "polite", "tabindex":"-1" },
+    "titleText": "There's a problem with your security keys",
+    "descriptionHtml": keyProblemDescription
+  }) }}
+{% endset %}
 
   <div class="govuk-grid-row">
 
     {% if credentials %}
       <div class="govuk-grid-column-five-sixths">
+        {{ errorSummaries }}
         {{ page_header(page_title) }}
         <div class="body-copy-table">
           {% call mapping_table(

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -38,13 +38,13 @@
 {% set errorSummaries %}
   {{ govukErrorSummary({
     "classes": "webauthn__api-missing",
-    "titleText": "There's a problem",
+    "titleText": "There’s a problem",
     "descriptionText": "Your browser does not support security keys. Try signing in to Notify using a different browser."
   }) }}
 
   {{ govukErrorSummary({
     "classes": "webauthn__no-js",
-    "titleText": "There's a problem",
+    "titleText": "There’s a problem",
     "descriptionHtml": "JavaScript is not available for this page. Security keys need JavaScript to work."
   }) }}
 
@@ -56,7 +56,7 @@
   {{ govukErrorSummary({
     "classes": "govuk-!-display-none",
     "attributes": { "aria-live": "polite", "tabindex":"-1" },
-    "titleText": "There's a problem with your security keys",
+    "titleText": "There’s a problem with your security keys",
     "descriptionHtml": keyProblemDescription
   }) }}
 {% endset %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2798,6 +2798,7 @@ def client_request(_logged_in_client, mocker, service_one):  # noqa (C901 too co
                         element
                         and not element.has_attr("style")  # Elements with inline CSS are exempt
                         and element.text.strip()  # Empty elements are exempt
+                        and "govuk-error-summary__body" not in element.parent["class"]
                     ):
                         raise AssertionError(
                             f"Found a <{tag}> without a class attribute:\n"

--- a/tests/javascripts/errorBanner.test.js
+++ b/tests/javascripts/errorBanner.test.js
@@ -14,24 +14,24 @@ describe("Error Banner", () => {
   describe("The `hideBanner` method", () => {
     test("Will hide the element", () => {
       document.body.innerHTML = `
-      <span class="govuk-error-message banner-dangerous js-error-visible">
-      </span>`;
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" aria-live="polite" tabindex="-1" data-module="govuk-error-summary">
+      </div>`;
       window.GOVUK.ErrorBanner.hideBanner();
-      expect(document.querySelector('.banner-dangerous').classList).toContain('govuk-!-display-none')
+      expect(document.querySelector('.govuk-error-summary').classList).toContain('govuk-!-display-none')
     });
   });
 
   describe("The `showBanner` method", () => {
     beforeEach(() => {
       document.body.innerHTML = `
-        <span class="govuk-error-message banner-dangerous js-error-visible govuk-!-display-none">
-        </span>`;
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" aria-live="polite" tabindex="-1" data-module="govuk-error-summary">
+      </div>`;
 
       window.GOVUK.ErrorBanner.showBanner('Some Err');
     });
 
     test("Will show the element", () => {
-      expect(document.querySelector('.banner-dangerous').classList).not.toContain('govuk-!-display-none')
+      expect(document.querySelector('.govuk-error-summary').classList).not.toContain('govuk-!-display-none')
     });
   });
 });


### PR DESCRIPTION
We used the GOVUK Frontend error message component for this. Recent updates to our version of GOVUK
Frontend changed the elements used for this
message from `<span>`s to `<p>`s. This broke our
code, meaning part of it is now showing:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/87140/207324707-ee020d67-7a29-4447-af48-9fa7d1ac8678.png">

~~Basically the same as https://github.com/alphagov/notifications-admin/pull/4469 and this should have been done then but wasn't.~~

~~Note: This is a temporary fix but I've added [a story to fix this properly](https://trello.com/c/byv6y7Wa/133-fix-webauth-error-messages) to the longer backlog.~~

Edit: putting in a temporary fix that wasn't horrible proved about as much effort as playing the story to fix this properly (the coding at least) so I did that instead.

This now replaces all the error messages with the Error Summary component, which is what the visual design was doing anyway.