### PR TITLE
Check for valid HTML as part of running the tests

### DIFF
--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -58,5 +58,6 @@
       {% endfor %}
     </div>
   {% endcall %}
+  </div>
 
 {% endmacro %}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -49,9 +49,11 @@
 {%- endmacro %}
 
 {% macro row_group(id=None) %}
+  </tbody>
   <tbody class="table-row-group" {% if id %}id="{{id}}"{% endif %}>
     {{ caller() }}
   </tbody>
+  <tbody>
 {%- endmacro %}
 
 {% macro settings_row(if_has_permission='') -%}

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -1,4 +1,4 @@
-{% macro mapping_table(caption='', field_headings=[], field_headings_visible=True, caption_visible=True, equal_length=False) -%}
+{% macro mapping_table(caption='', field_headings=[], field_headings_visible=True, caption_visible=True, equal_length=False, output_tbody_tags=True) -%}
   <table class="table table-font-xsmall">
     <caption class="heading-medium table-heading{{ ' govuk-visually-hidden' if not caption_visible}}">
       {{ caption }}
@@ -16,9 +16,13 @@
         {% endfor %}
       </tr>
     </thead>
+    {% if output_tbody_tags %}
     <tbody>
+    {% endif %}
       {{ caller() }}
+    {% if output_tbody_tags %}
     </tbody>
+    {% endif %}
   </table>
 {%- endmacro %}
 
@@ -49,11 +53,9 @@
 {%- endmacro %}
 
 {% macro row_group(id=None) %}
-  </tbody>
   <tbody class="table-row-group" {% if id %}id="{{id}}"{% endif %}>
     {{ caller() }}
   </tbody>
-  <tbody>
 {%- endmacro %}
 
 {% macro settings_row(if_has_permission='') -%}

--- a/app/templates/partials/jobs/status.html
+++ b/app/templates/partials/jobs/status.html
@@ -1,25 +1,29 @@
 <div class="ajax-block-container">
-  <p class='bottom-gutter'>
     {% if job.scheduled_for %}
       {% if job.processing_started %}
-        Sent by {{ job.created_by.name }} on {{ job.processing_started|format_datetime_short }}
+        <p class='bottom-gutter'>
+          Sent by {{ job.created_by.name }} on {{ job.processing_started|format_datetime_short }}
+        </p>
         {% if job.template.template_type == "letter" %}
           <p class="govuk-body" id="printing-info">
             {{ letter_print_day }}
           </p>
         {% endif %}
       {% else %}
-        Uploaded by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
+        <p class='bottom-gutter'>
+          Uploaded by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
+        </p>
       {% endif %}
-   {% else %}
-      Sent by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
+    {% else %}
+      <p class='bottom-gutter'>
+        Sent by {{ job.created_by.name }} on {{ job.created_at|format_datetime_short }}
+      </p>
       {% if job.template.template_type == "letter" %}
         <p class="govuk-body" id="printing-info">
           {{ letter_print_day }}
         </p>
       {% endif %}
     {% endif %}
-  </p>
   {% if job.status == 'sending limits exceeded'%}
     <p class="govuk-error-message">
         Notify cannot send these messages because you have reached your daily limit. You can only send {{ current_service.message_limit|format_thousands }} messages per day.
@@ -27,5 +31,5 @@
     <p class="govuk-error-message govuk-!-margin-bottom-6">
         Upload this spreadsheet again tomorrow or <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a> to raise the limit.
     </p>
-    {% endif %}
+  {% endif %}
 </div>

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -196,8 +196,8 @@
           {% endfor %}
         {% endif %}
       {% endcall %}
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 
   {% if recipients.too_many_rows %}
     <p class="table-show-more-link">

--- a/app/templates/views/dashboard/_inbox.html
+++ b/app/templates/views/dashboard/_inbox.html
@@ -1,6 +1,6 @@
 <div class="ajax-block">
   {% if current_service.inbound_sms_summary != None %}
-    <a id="total-received" class="govuk-link govuk-link--no-visited-state banner-dashboard" class="banner-dashboard" href="{{ url_for('.inbox', service_id=current_service.id) }}">
+    <a id="total-received" class="govuk-link govuk-link--no-visited-state banner-dashboard" href="{{ url_for('.inbox', service_id=current_service.id) }}">
       <span class="banner-dashboard-count">
         {{ current_service.inbound_sms_summary.count|format_thousands }}
       </span>

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -46,6 +46,7 @@
             {% else %}
               Not used yet
             {% endif %}
+          </span>
         {% elif item.upload_type == 'letter_day' %}
           <span class="file-list-hint-large">
             {{ item.letter_printing_statement }}

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -46,5 +46,6 @@
         </div>
       {% endcall %}
     </div>
+  </div>
 
 {% endblock %}

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -34,7 +34,7 @@
   <p class="govuk-body">When you send a text message with Notify, the sender name tells people who it’s from.</p>
   <p class="govuk-body">See <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.guidance_text_message_sender') }}">how to change the text message sender</a>.</p>
 
-  <h2 class="heading heading-medium">Pricing<h2>
+  <h2 class="heading heading-medium">Pricing</h2>
     <p class="govuk-body">Each service you add has an annual allowance of free text messages.</p>
     <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing', _anchor='text-messages') }}">See pricing</a> for more details.</p>
 

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -29,13 +29,13 @@ Inbound SMS
           <col style="width:20%">
           <col style="width:17%">
           <col style="width:30%">
-          <thread>
+          <thead>
               <tr>
                 <th>{{table_headings.field_headings[0]}}</th>
                 <th>{{table_headings.field_headings[1]}}</th>
                 <th>{{table_headings.field_headings[2]}}</th>
               </tr>
-          </thread>
+          </thead>
           <tbody>
 
           {% for value in inbound_num_list.data: %}

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -14,7 +14,7 @@
     <p class="govuk-body">This information has moved.</p>
 
     <p class="govuk-body">
-      Refer to the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation
+      Refer to the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.documentation') }}">documentation</a>
       for the client library you are using.
     </p>
 

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -33,6 +33,8 @@
           <span class="page-footer-link page-footer-delete-link-without-button">
             <a class="govuk-link govuk-link--destructive" href="{{ url_for('main.cancel_letter_job', service_id=current_service.id, job_id=job.id) }}">Cancel sending these letters</a>
           </span>
+        </div>
+      </div>
     {% else %}
       <div>&nbsp;</div>
     {% endif %}

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -40,5 +40,6 @@
         </div>
       {% endcall %}
     </div>
+  </div>
 
 {% endblock %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -60,7 +60,7 @@
   {% endcall %}
 
   {% call form_wrapper(id="search-form") %}
-    <input type="hidden" name="to" {% if search_form.to.data %}value="{{ search_form.to.data }}{%  endif %}">
+    <input type="hidden" name="to" {% if search_form.to.data %}value="{{ search_form.to.data }}"{%  endif %}>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% endcall %}
 

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -12,7 +12,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
         <nav class="navigation" aria-label="Platform admin">
-            {% for link_text, url in [
+          <ul class="govuk-list">
+          {% for link_text, url in [
             ('Summary', url_for('main.platform_admin')),
             ('Live services', url_for('main.live_services')),
             ('Trial mode services', url_for('main.trial_services')),
@@ -34,6 +35,7 @@
               </a>
             </li>
           {% endfor %}
+          </ul>
         </nav>
       </div>
       <div class="govuk-grid-column-three-quarters">

--- a/app/templates/views/platform-admin/index.html
+++ b/app/templates/views/platform-admin/index.html
@@ -19,7 +19,7 @@
     {% call form_wrapper(method="get") %}
       {{ form.start_date(param_extensions={"hint": {"text":"Enter start date in format YYYY-MM-DD"}}) }}
       {{ form.end_date(param_extensions={"hint": {"text":"Enter end date in format YYYY-MM-DD"}}) }}
-      </br>
+      <br>
       {{ govukButton({ "text": "Filter" }) }}
     {% endcall %}
   {% endset %}

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -16,6 +16,7 @@
     right_aligned_field_heading('Letters')
     ],
     field_headings_visible=False,
+    output_tbody_tags=False,
   ) %}
 
     {% for service in services %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -32,7 +32,7 @@
 
   <p class="govuk-body">
     {% if not current_user.is_authenticated %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many unique services as you need to.</p>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many unique services as you need to.
     {% else %}
       You can add as many unique services as you need to.
     {% endif %}
@@ -266,7 +266,7 @@
     {% endcall %}
   </div>
 
-  <div class="govuk-inset-text"  
+  <div class="govuk-inset-text">
     <p class="govuk-body">From Monday 23 January 2023:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>second class postage will go up by 6 pence, plus VAT</li>

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -155,7 +155,7 @@
     <p class="govuk-body">
     Information Commissioner’s Office<br>
     <a class="govuk-link govuk-link--no-visited-state" href="mailto:icocasework@ico.org.uk">icocasework@ico.org.uk</a><br>
-    0303 123 1113</br>
+    0303 123 1113<br>
     Wycliffe House<br>
     Water Lane<br>
     Wilmslow<br>

--- a/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
@@ -35,5 +35,6 @@
         <a class="govuk-link govuk-link--no-visited-state" href="{{ abandon_flow_link }}">I do not have a file to upload</a>
       </p>
     </div>
+  </div>
 
 {% endblock %}

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -37,7 +37,7 @@
           </div>
           <div class="govuk-grid-column-one-quarter">
             {% if current_user.has_permissions('manage_service') %}
-              <a class="govuk-link govuk-link--no-visited-state user-list-edit-link"href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">
+              <a class="govuk-link govuk-link--no-visited-state user-list-edit-link" href="{{ url_for('.service_edit_email_reply_to', service_id =current_service.id, reply_to_email_id = item.id) }}">
                 Change<span class="govuk-visually-hidden"> {{ item.email_address }}</span>
               </a>
             {% endif %}

--- a/app/templates/views/service-settings/name.html
+++ b/app/templates/views/service-settings/name.html
@@ -37,7 +37,6 @@
 
   {% if organisation_type != 'central' %}
     <p class="govuk-body">You should only use an acronym or initialism if your users are already familiar with it.</p>
-    <div class="form-group">
     {% if current_service.prefix_sms %}
       <p class="govuk-body">Users will see your service name:</p>
       <ul class="govuk-list govuk-list--bullet">

--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -44,6 +44,7 @@
             <div class="govuk-grid-column-two-thirds">
               {{ event }}
             </div>
+          </div>
         </li>
       {% endfor%}
     </ul>

--- a/app/templates/views/templates/set-sender.html
+++ b/app/templates/views/templates/set-sender.html
@@ -29,7 +29,6 @@
         {{ page_footer('Continue') }}
       </div>
     {% endcall %}
-    </div>
   </div>
 
 {% endblock %}

--- a/app/templates/views/uploads/choose-file.html
+++ b/app/templates/views/uploads/choose-file.html
@@ -30,7 +30,7 @@
     <p class="govuk-body">You can use this feature if you send a lot of one-off letters or if our reusable letter templates do not meet your needs.</p>
     {% endif %}
 
-  <p class="govuk-body">
+  <div class="govuk-body">
     {{ file_upload(
       form.file,
       allowed_file_extensions=['pdf'],
@@ -38,7 +38,7 @@
       button_text='Upload your file again' if error else 'Choose file',
       show_errors=False
     )}}
-  </p>
+  </div>
 
     <p class="govuk-body">Your file must meet our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.guidance_letter_specification') }}">letter specification</a>.</p>
   </div>

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -109,7 +109,6 @@
       <div class="govuk-grid-column-one-quarter">
         <img src="{{ asset_url('images/security-key.svg') }}" alt="" class="webauthn-illustration" width="149" height="150">
       </div>
-      {% endif %}
-    </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/app/templates/views/verification-not-received.html
+++ b/app/templates/views/verification-not-received.html
@@ -29,7 +29,5 @@
     </ul>
   </div>
 </div>
-  </div>
-</div>
 
 {% endblock %}

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -14,3 +14,4 @@ moto==4.0.9
 requests-mock==1.10.0
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.8.2
+html5lib==1.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 import freezegun
 import pytest
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Doctype
 from flask import session as flask_session
 from flask import url_for
 from flask.testing import FlaskClient
@@ -57,6 +57,13 @@ class NotifyBeautifulSoup(BeautifulSoup):
             )
 
         setattr(self, method_name, overridden_method)
+
+    @property
+    def doctype(self):
+        return next(
+            (item for item in self.contents if isinstance(item, Doctype)),
+            "",
+        )
 
 
 def sample_uuid():

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -325,9 +325,8 @@ def test_should_show_letter_job(
         job_id=fake_uuid,
     )
     assert normalize_spaces(page.select_one("h1").text) == "thisisatest.csv"
-    assert normalize_spaces(page.select("p.bottom-gutter")[0].text) == (
-        "Sent by Test User on 1 January at 11:09am Printing starts today at 5:30pm"
-    )
+    assert normalize_spaces(page.select("p.bottom-gutter")[0].text) == ("Sent by Test User on 1 January at 11:09am")
+    assert normalize_spaces(page.select("p#printing-info")[0].text) == ("Printing starts today at 5:30pm")
     assert page.select(".banner-default-with-tick") == []
     assert normalize_spaces(page.select("tbody tr")[0].text) == (
         "1 Example Street template subject 1 January at 11:09am"

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -299,8 +299,8 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
         {"detailed": True, "include_from_test_key": True, "only_active": ANY}
     )
 
-    table_body = page.select("table tbody")[0]
-    service_row_group = table_body.select_one("tbody").select("tr")
+    table = page.select_one("table")
+    service_row_group = table.select("tbody")[1].select("tr")
     email_stats = service_row_group[1].select(".big-number-number")[0]
     sms_stats = service_row_group[1].select(".big-number-number")[1]
 
@@ -335,8 +335,7 @@ def test_should_show_archived_services_last(
         {"detailed": True, "include_from_test_key": True, "only_active": ANY}
     )
 
-    table_body = page.select_one("table tbody")
-    services = [service.tr for service in table_body.select("tbody")]
+    services = page.select("table tbody tr:first-child")
     assert len(services) == 3
     assert normalize_spaces(services[0].td.text) == "A"
     assert normalize_spaces(services[1].td.text) == "B"
@@ -380,7 +379,7 @@ def test_should_order_services_by_usage_with_inactive_last(
         {"detailed": True, "include_from_test_key": True, "only_active": ANY}
     )
 
-    services = page.select("table tbody tbody tr:first-child")
+    services = page.select("table tbody tr:first-child")
     assert len(services) == 3
     assert normalize_spaces(services[0].td.text) == "My Service 2"
     assert normalize_spaces(services[1].td.text) == "My Service 1"

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -300,7 +300,7 @@ def test_should_show_email_and_sms_stats_for_all_service_types(
     )
 
     table = page.select_one("table")
-    service_row_group = table.select("tbody")[1].select("tr")
+    service_row_group = table.select_one("tbody").select("tr")
     email_stats = service_row_group[1].select(".big-number-number")[0]
     sms_stats = service_row_group[1].select(".big-number-number")[1]
 

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3276,7 +3276,7 @@ def test_check_messages_adds_sender_id_in_session_to_metadata(
     fake_uuid,
 ):
     mocker.patch("app.main.views.send.s3download", return_value=("phone number,\n07900900321"))
-    mocker.patch("app.main.views.send.get_sms_sender_from_session")
+    mocker.patch("app.main.views.send.get_sms_sender_from_session", return_value="Fake Sender")
 
     with client_request.session_transaction() as session:
         session["file_uploads"] = {fake_uuid: {"template_id": fake_uuid}}


### PR DESCRIPTION
HTMl is a forgiving language, so valid markup is not always needed in order for a page to render properly.

But invalid markup can:
- cause problems with spacing or layout where elements are improperly nested (for example mismatched closing tags, or `<p>` inside `<p>`)
- cause problems for users of assistive technology, if element names are misspelled (for example `<thread>` will be ignored whereas `<thead>` has  semantic meaning)
- by symptomatic of code that is hard to follow because it’s not indented properly

This commit adds a step to `client_request.get()` which checks for valid HTML. If invalid HTML is found then an exception will be raised.

It only runs on HTML documents. Almost all of our pages are HTML, the only exception being the email template, which is nominally XHTML (and hard to validate because of all the tricks we use to get around email client rendering issues).

Examples of output:

<img width="824" alt="image" src="https://user-images.githubusercontent.com/355079/208728422-df11623a-c284-4eb7-8b1c-e23ca981b947.png">

<img width="810" alt="image" src="https://user-images.githubusercontent.com/355079/208728053-29201c11-6a6a-46a9-9a29-226994f3413b.png">

