### PR TITLE
Say ‘or something else’ if there are lots of items in the branding pool

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2005,7 +2005,10 @@ class ChooseEmailBrandingForm(ChooseBrandingForm):
 
     def __init__(self, service):
         super().__init__()
-        self.options.choices = tuple(OrderedSet(branding.get_email_choices(service)) | {self.FALLBACK_OPTION})
+        choices = OrderedSet(branding.get_email_choices(service))
+        if len(choices) > 2:
+            choices = choices | {GovukRadiosField.Divider("or")}
+        self.options.choices = tuple(choices | {self.FALLBACK_OPTION})
 
 
 class ChooseLetterBrandingForm(ChooseBrandingForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2001,7 +2001,7 @@ class ChooseBrandingForm(StripWhitespaceForm):
 
 
 class ChooseEmailBrandingForm(ChooseBrandingForm):
-    options = RadioField("Choose your new email branding")
+    options = GovukRadiosField("Choose your new email branding")
 
     def __init__(self, service):
         super().__init__()

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -687,7 +687,21 @@ class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
     govuk_frontend_component_name = "radios"
 
     class Divider(str):
-        pass
+        """
+        Behaves like a normal string but can be used instead of a `(value, label)`
+        pair as one of the items in `GovukRadiosField.choices`, for example:
+
+            numbers = GovukRadiosField(choices=(
+                (1, "One"),
+                (2, "Two"),
+                GovukRadiosField.Divider("or")
+                (3, "Three"),
+            ))
+
+        When rendered it won’t appear as a choice the user can click, but instead
+        as text in between the choices, as per:
+        https://design-system.service.gov.uk/components/radios/#radio-items-with-a-text-divider
+        """
 
         def __iter__(self):
             # This is what WTForms will use as the value of the choice. We will

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2001,7 +2001,18 @@ class ChooseBrandingForm(StripWhitespaceForm):
 
 
 class ChooseEmailBrandingForm(ChooseBrandingForm):
-    options = GovukRadiosField("Choose your new email branding")
+    options = GovukRadiosField(
+        "Choose your new email branding",
+        param_extensions={
+            "fieldset": {
+                "legend": {
+                    # This removes the `govuk-fieldset__legend--s` class, thereby
+                    # making the form label font regular weight, not bold
+                    "classes": "",
+                },
+            },
+        },
+    )
 
     def __init__(self, service):
         super().__init__()

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -686,7 +686,23 @@ class GovukCollapsibleNestedCheckboxesField(NestedFieldMixin, GovukCollapsibleCh
 class GovukRadiosField(GovukFrontendWidgetMixin, RadioField):
     govuk_frontend_component_name = "radios"
 
+    class Divider(str):
+        pass
+
+        def __iter__(self):
+            # This is what WTForms will use as the value of the choice. We will
+            # throw this away, but needs to be unique, unguessable and impossible
+            # to confuse with a real choice
+            yield object()
+            # This is what WTForms will use as the label, which we can later
+            # use to see if the choice is actually a divider
+            yield self
+
     def get_item_from_option(self, option):
+        if isinstance(option.label.text, self.Divider):
+            return {
+                "divider": option.label.text,
+            }
         return {
             "name": option.name,
             "id": option.id,

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -36,11 +36,7 @@
   {% endif %}
 
   {% call form_wrapper() %}
-      {% call select_wrapper(form.options) %}
-        {% for option in form.options %}
-          {{ radio(option) }}
-        {% endfor %}
-      {% endcall %}
+    {{ form.options }}
     {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/tests/app/main/forms/test_govuk_radios_field.py
+++ b/tests/app/main/forms/test_govuk_radios_field.py
@@ -1,0 +1,40 @@
+from bs4 import BeautifulSoup
+from flask_wtf import FlaskForm as Form
+
+from app.main.forms import GovukRadiosField
+from tests.conftest import normalize_spaces
+
+
+def test_GovukRadiosField_supports_dividers(client_request):
+    class FakeForm(Form):
+        field = GovukRadiosField(
+            choices=(
+                ("1", "Aa"),
+                ("2", "Bb"),
+                GovukRadiosField.Divider("C to Y"),
+                ("26", "Zz"),
+            )
+        )
+
+    html = BeautifulSoup(FakeForm().field())
+
+    assert [item["class"] for item in html.select(".govuk-radios>div")] == [
+        ["govuk-radios__item"],
+        ["govuk-radios__item"],
+        ["govuk-radios__divider"],
+        ["govuk-radios__item"],
+    ]
+
+    assert [
+        (
+            normalize_spaces(item.select_one("label").text),
+            item.select_one("input")["value"],
+        )
+        for item in html.select(".govuk-radios__item")
+    ] == [
+        ("Aa", "1"),
+        ("Bb", "2"),
+        ("Zz", "26"),
+    ]
+
+    assert str(html.select_one(".govuk-radios__divider")) == '<div class="govuk-radios__divider">C to Y</div>'

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -117,6 +117,59 @@ def test_email_branding_request_page_shows_branding_pool_options_if_branding_poo
     ] == expected_options
 
 
+@pytest.mark.parametrize(
+    "pool_contents, expected_options",
+    (
+        (
+            [],
+            [
+                ("govuk-radios__item", "GOV.UK and organisation one"),
+                ("govuk-radios__item", "organisation one"),
+                ("govuk-radios__item", "Something else"),
+            ],
+        ),
+        (
+            create_email_branding_pool(),
+            [
+                ("govuk-radios__item", "GOV.UK and organisation one"),
+                ("govuk-radios__item", "Email branding name 1"),
+                ("govuk-radios__item", "Email branding name 2"),
+                ("govuk-radios__divider", "or"),
+                ("govuk-radios__item", "Something else"),
+            ],
+        ),
+    ),
+)
+def test_email_branding_request_page_shows_divider_if_there_are_lots_of_options(
+    mocker,
+    service_one,
+    organisation_one,
+    client_request,
+    mock_get_email_branding,
+    mock_get_email_branding_pool,
+    pool_contents,
+    expected_options,
+):
+    service_one["organisation"] = organisation_one
+
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_one,
+    )
+
+    mocker.patch(
+        "app.models.branding.EmailBrandingPool.client_method",
+        return_value=pool_contents,
+    )
+
+    page = client_request.get(".email_branding_request", service_id=SERVICE_ONE_ID)
+
+    assert [
+        (item["class"][0], normalize_spaces(item))
+        for item in page.select(".govuk-radios__item, .govuk-radios__divider")
+    ] == expected_options
+
+
 def test_email_branding_request_does_not_show_nhs_branding_twice(
     mocker,
     service_one,

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -443,7 +443,7 @@ def test_email_branding_request_submit_when_no_radio_button_is_selected(
         _follow_redirects=True,
     )
     assert page.select_one("h1").text == "Change email branding"
-    assert normalize_spaces(page.select_one(".error-message").text) == "Select an option"
+    assert normalize_spaces(page.select_one(".govuk-error-message").text) == "Error: Select an option"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If there are lots of items in the pool, it’s handy to flag that _Something else_ is a separate, special option, without making you scan the whole list.

We can do this by putting a divider ahead of it.

We don’t need to do this when the list is very short, which is also the case where there are no items in the pool and all the choices are magic options.

The divider is created by implementing [Radio items with a text divider](https://design-system.service.gov.uk/components/radios/#radio-items-with-a-text-divider) from the GOV.UK Design System.

Before | After
---|---
<img width="793" alt="image" src="https://user-images.githubusercontent.com/355079/207856374-6cfbe2e8-16e1-447b-8917-70ad1833bbb6.png"> | <img width="784" alt="image" src="https://user-images.githubusercontent.com/355079/207857550-e6af2ea2-0cb2-4162-9fcd-53c69184e361.png">
