### PR TITLE
Tidy up inbound sms code

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -626,10 +626,8 @@ def service_set_inbound_number(service_id):
     form = AdminServiceInboundNumberForm(inbound_number_choices=inbound_numbers_value_and_label)
 
     if form.validate_on_submit():
-        service_api_client.add_sms_sender(
+        inbound_number_client.add_inbound_number_to_service(
             current_service.id,
-            sms_sender=form.inbound_number.data,
-            is_default=True,
             inbound_number_id=form.inbound_number.data,
         )
         current_service.force_permission("inbound_sms", on=True)

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -695,7 +695,6 @@ def service_set_international_letters(service_id):
     )
 
 
-@main.route("/services/<uuid:service_id>/service-settings/set-inbound-sms", methods=["GET"])
 @main.route("/services/<uuid:service_id>/service-settings/receive-text-messages", methods=["GET"])
 @user_has_permissions("manage_service")
 def service_receive_text_messages(service_id):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -403,11 +403,10 @@ class ServiceAPIClient(NotifyAdminAPIClient):
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")
-    def add_sms_sender(self, service_id, sms_sender, is_default=False, inbound_number_id=None):
+    def add_sms_sender(self, service_id, sms_sender, is_default=False):
         data = {"sms_sender": sms_sender, "is_default": is_default}
-        if inbound_number_id:
-            data["inbound_number_id"] = inbound_number_id
-        return self.post("/service/{}/sms-sender".format(service_id), data=data)
+
+        return self.post(f"/service/{service_id}/sms-sender", data=data)
 
     @cache.delete("service-{service_id}")
     @cache.delete_by_pattern("service-{service_id}-template-*")

--- a/tests/app/main/views/service_settings/test_inbound_sms_setting.py
+++ b/tests/app/main/views/service_settings/test_inbound_sms_setting.py
@@ -3,12 +3,12 @@ from tests.conftest import SERVICE_ONE_ID, normalize_spaces
 
 def test_set_inbound_sms_sets_a_number_for_service(
     client_request,
-    mock_add_sms_sender,
     multiple_available_inbound_numbers,
     fake_uuid,
     mock_no_inbound_number_for_service,
     mocker,
 ):
+    mock_add_inbound_number = mocker.patch("app.inbound_number_client.add_inbound_number_to_service")
     mocker.patch("app.service_api_client.update_service")
     data = {
         "inbound_number": "781d9c60-7a7e-46b7-9896-7b045b992fa5",
@@ -21,10 +21,8 @@ def test_set_inbound_sms_sets_a_number_for_service(
         _expected_status=302,
     )
 
-    mock_add_sms_sender.assert_called_once_with(
+    mock_add_inbound_number.assert_called_once_with(
         SERVICE_ONE_ID,
-        sms_sender="781d9c60-7a7e-46b7-9896-7b045b992fa5",
-        is_default=True,
         inbound_number_id="781d9c60-7a7e-46b7-9896-7b045b992fa5",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -451,7 +451,7 @@ def get_non_default_sms_sender(mocker):
 
 @pytest.fixture(scope="function")
 def mock_add_sms_sender(mocker):
-    def _add_sms_sender(service_id, sms_sender, is_default=False, inbound_number_id=None):
+    def _add_sms_sender(service_id, sms_sender, is_default=False):
         return
 
     return mocker.patch("app.service_api_client.add_sms_sender", side_effect=_add_sms_sender)


### PR DESCRIPTION
This ensures we always use the new api route that was added for inbound SMS and simplifies the `add_sms_sender` since it's no longer used for inbound SMS.