### PR TITLE
Fix a variety of service and org name XSS scripts

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2050,26 +2050,7 @@ class GovernmentIdentityLogoForm(StripWhitespaceForm):
     logo_text = GovukTextInputField(
         "Enter the text that will appear in your logo",
         validators=[DataRequired("Cannot be empty")],
-        param_extensions={
-            "label": {
-                "isPageHeading": True,
-                "classes": "govuk-label--l",
-            },
-            "hint": {
-                "html": (
-                    "This is usually the full name of your organisation.<br/><br/>For example, {organisation_name}"
-                )
-            },
-        },
     )
-
-    def __init__(self, organisation=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        organisation_name = organisation.name if organisation else "Department of Education"
-        self.logo_text.param_extensions["hint"]["html"] = self.logo_text.param_extensions["hint"]["html"].format(
-            organisation_name=organisation_name
-        )
 
 
 class EmailBrandingChooseLogoForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1728,42 +1728,18 @@ class AddLetterBrandingOptionsForm(StripWhitespaceForm):
 
 
 class AdminSetBrandingAddToBrandingPoolStepForm(StripWhitespaceForm):
-    def __init__(self, *args, org_name, service_name, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.add_to_pool.label.text = f"Should other teams in {org_name} have the option to use this branding?"
-
-        self.add_to_pool.param_extensions = {
+    add_to_pool = GovukRadiosField(
+        choices=[("yes", "Yes"), ("no", "No")],
+        thing="yes or no",
+        param_extensions={
             "fieldset": {
                 "legend": {
                     # This removes the `govuk-fieldset__legend--s` class, thereby
                     # making the form label font regular weight, not bold
                     "classes": "",
                 },
-            },
-            "items": [
-                {"hint": {}},
-                {"hint": {}},
-            ],
-        }
-        self.add_to_pool.param_extensions["items"][0]["hint"]["html"] = Markup(
-            f"""
-            <ul class="govuk-list govuk-hint govuk-!-margin-bottom-0">
-                <li>Apply this branding to ‘{service_name}’</li>
-                <li class="govuk-!-margin-bottom-0">Let other {org_name} teams apply this branding themselves</li>
-            </ul>
-        """
-        )
-        self.add_to_pool.param_extensions["items"][1]["hint"]["html"] = Markup(
-            f"""
-            <ul class="govuk-list govuk-hint govuk-!-margin-bottom-0">
-                <li class="govuk-!-margin-bottom-0">Only apply this branding to ‘{service_name}’</li>
-            </ul>
-        """
-        )
-
-    add_to_pool = GovukRadiosField(
-        choices=[("yes", "Yes"), ("no", "No")],
-        thing="yes or no",
+            }
+        },
     )
 
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1062,9 +1062,9 @@ class OrganisationAgreementSignedForm(StripWhitespaceForm):
         thing="whether this organisation has signed the agreement",
         param_extensions={
             "items": [
-                {"hint": {"html": "Users will be told their organisation has already signed the agreement"}},
-                {"hint": {"html": "Users will be prompted to sign the agreement before they can go live"}},
-                {"hint": {"html": "Users will not be prompted to sign the agreement"}},
+                {"hint": {"text": "Users will be told their organisation has already signed the agreement"}},
+                {"hint": {"text": "Users will be prompted to sign the agreement before they can go live"}},
+                {"hint": {"text": "Users will not be prompted to sign the agreement"}},
             ]
         },
     )

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1315,7 +1315,7 @@ def email_branding_request_government_identity_logo(service_id):
 @user_has_permissions("manage_service")
 @service_belongs_to_org_type("central")
 def email_branding_enter_government_identity_logo_text(service_id):
-    form = GovernmentIdentityLogoForm(organisation=current_service.organisation)
+    form = GovernmentIdentityLogoForm()
     branding_choice = request.args.get("branding_choice")
 
     if form.validate_on_submit():

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1039,10 +1039,7 @@ def service_set_branding_add_to_branding_pool_step(service_id, notification_type
     branding_name = branding.name
     org_id = current_service.organisation.id
 
-    form = AdminSetBrandingAddToBrandingPoolStepForm(
-        org_name=current_service.organisation.name,
-        service_name=current_service.name,
-    )
+    form = AdminSetBrandingAddToBrandingPoolStepForm()
 
     if form.validate_on_submit():
         # The service’s branding gets updated either way

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -22,11 +22,14 @@
     </p>
     {% endif %}
     {% if delete_button %}
+      {% set html %}
+        {{ delete_button }}<span class="govuk-visually-hidden"> ‘{{ thing }}’</span>
+      {% endset %}
       {% call form_wrapper(action=action) %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {{ govukButton({
           "text": "" if thing else delete_button,
-          "html": delete_button + "<span class=\"govuk-visually-hidden\"> ‘" + thing + "’</span>" if thing else "",
+          "html": html if thing else "",
           "name": "delete",
           "classes": "govuk-button--warning govuk-!-margin-top-2",
         }) }}

--- a/app/templates/components/list-entry.html
+++ b/app/templates/components/list-entry.html
@@ -40,11 +40,14 @@
             {% set label_classes = "govuk-input--numbered__label" %}
           {% endif %}
           {% set field_name = field.name + "-" + loop.index|string %}
+          {% set html -%}
+            <span class="govuk-visually-hidden">{{ item_name }} number </span> + {{ loop.index }}.
+          {%- endset%}
           {{ entry(param_extensions={
             "id": "input-" + field_name,
             "name": field_name,
             "label": {
-              "html": '<span class="govuk-visually-hidden">' + item_name + ' number </span>' + loop.index|string + '.',
+              "html": html,
               "classes": label_classes
             },
             "classes": "govuk-input--numbered govuk-!-width-full",

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -28,8 +28,12 @@
       {% if button_name %}{% set _ = button_data.update({"name": button_name}) %}{% endif %}
       {% if button_value %}{% set _ = button_data.update({"value": button_value}) %}{% endif %}
       {% if button_text_hidden_suffix %}
+        {% set html %}
+          {{ button_text }}<span class="govuk-visually-hidden"> {{button_text_hidden_suffix}}</span>
+        {% endset %}
         {% set _ = button_data.update({
-          "text": "", "html": button_text + "<span class=\"govuk-visually-hidden\"> " + button_text_hidden_suffix + "</span>"
+          "text": "",
+          "html": html
         }) %}
       {% endif %}
 

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
@@ -23,7 +23,7 @@
               "isPageHeading": True,
               "classes": "govuk-label--l",
           },
-          "hint": {"html": "Enter a hex colour code. For example, #1d70b8"}
+          "hint": {"text": "Enter a hex colour code. For example, #1d70b8"}
         })
       }}
     {{ page_footer('Continue') }}

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
@@ -28,7 +28,7 @@
     {% else %}
       {% set param_extensions = {
         "hint":{
-          "html": current_service.name + " branding is not set up yet.",
+          "text": current_service.name + " branding is not set up yet.",
           "classes": "notify-hint--paragraph",
         }
       } %}

--- a/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
@@ -20,7 +20,23 @@
   {{ errorSummary(form) }}
 
   {% call form_wrapper() %}
-    {{ form.logo_text }}
+    {% set html %}
+      This is usually the full name of your organisation.
+      <br/>
+      <br/>
+      For example, {{ current_service.organisation.name }}
+    {% endset %}
+    {{
+      form.logo_text(
+        param_extensions={
+          "label": {
+            "isPageHeading": True,
+            "classes": "govuk-label--l",
+          },
+          "hint": {"html": html},
+        },
+      )
+    }}
     {{ page_footer('Request new branding') }}
   {% endcall %}
 

--- a/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
@@ -20,7 +20,34 @@
     {{ page_header(page_title) }}
 
     {% call form_wrapper() %}
-      {{ form.add_to_pool }}
+      {% set hint_1 %}
+        <ul class="govuk-list govuk-hint govuk-!-margin-bottom-0">
+          <li>Apply this branding to ‘{{current_service.name}}’</li>
+          <li class="govuk-!-margin-bottom-0">Let other {{current_service.organisation.name}} teams apply this branding themselves</li>
+        </ul>
+      {% endset %}
+      {% set hint_2 %}
+        <ul class="govuk-list govuk-hint govuk-!-margin-bottom-0">
+          <li class="govuk-!-margin-bottom-0">Only apply this branding to ‘{{current_service.name}}’</li>
+        </ul>
+      {% endset %}
+      {% set label_text %}
+        Should other teams in {{current_service.organisation.name}} have the option to use this branding?
+      {% endset %}
+
+      {{
+        form.add_to_pool(
+          param_extensions={
+            "fieldset": {
+              "legend": {"text": label_text}
+            },
+            "items": [
+              {"hint": {"html": hint_1} },
+              {"hint": {"html": hint_2} },
+            ]
+          }
+        )
+      }}
       {{ page_footer('Continue') }}
     {% endcall %}
 

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -45,15 +45,17 @@
   }) }}
 {% endset %}
 
+  {% set html %}
+    There’s a problem with your security key
+    <p class="govuk-body">
+      Check you have the right key and try again.
+      If this does not work,
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
+    </p>
+  {% endset %}
   {{ govukErrorMessage({
     "classes": "banner-dangerous govuk-!-display-none",
-    "html": (
-      'There’s a problem with your security key' +
-      '<p class="govuk-body">Check you have the right key and try again. ' +
-      'If this does not work, ' +
-      '<a class="govuk-link govuk-link--no-visited-state" href=' + url_for('main.support') + ">contact us</a>." +
-      '</p>'
-    ),
+    "html": html,
     "attributes": {
       "aria-live": "polite",
       "tabindex": '-1'

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -773,6 +773,18 @@ def test_email_branding_choose_logo_page(client_request, service_one):
     ]
 
 
+def test_email_branding_choose_logo_page_prevents_xss_attacks(client_request, service_one):
+    service_one["name"] = "<script>evil</script>"
+    page = client_request.get(
+        "main.email_branding_choose_logo",
+        service_id=SERVICE_ONE_ID,
+    )
+
+    hint = page.select_one("form .govuk-hint")
+    assert not hint.select_one("script")
+    assert service_one["name"] in normalize_spaces(hint.text)
+
+
 def test_only_central_org_services_can_see_email_branding_choose_logo_page(client_request, service_one):
     service_one["organisation_type"] = "local"
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3837,6 +3837,20 @@ def test_GET_email_branding_enter_government_identity_logo_text(client_request, 
     assert text_input["name"] == "logo_text"
 
 
+def test_GET_email_branding_enter_government_identity_logo_text_protects_against_xss(
+    client_request, service_one, organisation_one, mocker
+):
+    organisation_one["name"] = "<script>evil</script>"
+    service_one["organisation"] = organisation_one["id"]
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
+
+    page = client_request.get("main.email_branding_enter_government_identity_logo_text", service_id=service_one["id"])
+
+    hint = page.select_one("form .govuk-hint")
+    assert not hint.select("script")
+    assert organisation_one["name"] in normalize_spaces(hint.text)
+
+
 @pytest.mark.parametrize(
     "extra_url_args,expected_ticket_content,expected_extra_url_args",
     [

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3674,6 +3674,28 @@ def test_get_service_set_letter_branding_add_to_branding_pool_step(
     assert f"Apply ‘{letter_branding_name}’ branding" in normalize_spaces(page.select_one("title").text)
 
 
+def test_get_service_set_letter_branding_add_to_branding_pool_step_protects_against_xss(
+    mocker, client_request, platform_admin_user, service_one, organisation_one
+):
+    service_one["organisation"] = organisation_one
+    service_one["name"] = "<script>evil</script>"
+    client_request.login(platform_admin_user)
+    mocker.patch("app.letter_branding_client.get_letter_branding", return_value={"name": "branding 1"})
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
+
+    page = client_request.get(
+        "main.service_set_branding_add_to_branding_pool_step",
+        _expected_status=200,
+        service_id=SERVICE_ONE_ID,
+        notification_type="letter",
+        branding_id="234",
+    )
+    form = page.select_one("form")
+    for hint in form.select(".govuk-hint"):
+        assert not hint.select("script")
+        assert "apply this branding to ‘<script>evil</script>’" in normalize_spaces(hint.text).lower()
+
+
 def test_service_set_letter_branding_add_to_branding_pool_step_is_platform_admin_only(
     mocker, client_request, service_one, organisation_one
 ):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -2020,6 +2020,19 @@ def test_should_show_delete_template_page_with_never_used_block(
     mock_get_service_template.assert_called_with(SERVICE_ONE_ID, fake_uuid, None)
 
 
+def test_should_show_delete_template_page_with_escaped_template_name(client_request, mocker, fake_uuid):
+    template = template_json(SERVICE_ONE_ID, fake_uuid, name="<script>evil</script>")
+
+    mocker.patch("app.template_statistics_client.get_last_used_date_for_template", return_value=None)
+    mocker.patch("app.service_api_client.get_service_template", return_value={"data": template})
+
+    page = client_request.get(
+        ".delete_service_template", service_id=SERVICE_ONE_ID, template_id=fake_uuid, _test_page_title=False
+    )
+    banner = page.select_one(".banner-dangerous")
+    assert banner.select("script") == []
+
+
 @pytest.mark.parametrize("parent", (PARENT_FOLDER_ID, None))
 def test_should_redirect_when_deleting_a_template(
     mocker,


### PR DESCRIPTION
The first example we found was:

specifically this can be seen when deleting a template - if you name your template `<script>alert(1)</script>` for example, that html will be rendered and the alert will happen

jinja treats all variables as unsafe unless we declare them safe (Note that all jinja macros are considered to return fully formed HTML, thus are declared as safe internaly automatically). To mark a variable as containing HTML you wish to render, you pass it through the `safe` filter `{{ foo | safe }}`. This is what the govuk-frontend-jinja does to any html you pass in through the html property.

When showing a delete prompt we use this html field to wrap the name of the thing with a visually hidden span so it is read out by screen readers but not visible to the user (we do this because the name's already above in the `body` variable normally).

However, we had an [XSS](https://owasp.org/www-community/attacks/xss/) vulnerability where the name of the template isn't escaped, and then it's marked as safe. It's not safe, as it's untrusted user input.

To fix this, rather than concatenating the string in python inside the macro invocation, we can create the string in html in a set block above. By calling `{{ thing }}`, jinja automatically escapes any HTML contained within.

--------------
All these are fixed, also, Tom and I have gone through all the places where we pass html in to govuk frontend components and ensured that we:

* are escaping user provided values by taking advantage of jinja's escape-by-default `{{foo}}` syntax
* only use html where necessary, using text by default
* are declaring html with user provided data in templates rather than in forms (which also avoids weird form state issues)

## Screenshots of pages where XSS vulnerabilities were found

|||
|-|-|
| ![image](https://user-images.githubusercontent.com/5020841/208139058-c41b9268-747c-44db-9835-8aa697187b90.png) | ![image](https://user-images.githubusercontent.com/5020841/208139077-7ac026fa-409e-4263-9b82-903663d73b06.png) | 
![image](https://user-images.githubusercontent.com/5020841/208139106-32be9fc9-143b-4bd0-9e43-3218be9df7de.png) | ![image](https://user-images.githubusercontent.com/5020841/208140409-bf733c55-d264-4914-90d6-6ce250916993.png) |
