### PR TITLE
Fix backlinks to notification dashboard

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -280,6 +280,7 @@ def get_notifications(service_id, message_type, status_override=None):
                 url_for,
                 ".view_notification",
                 service_id=current_service.id,
+                from_statuses=request.args.get("status"),
             ),
         ),
     }

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -140,7 +140,7 @@ def view_notification(service_id, notification_id):
             "main.view_notifications",
             service_id=current_service.id,
             message_type=template.template_type,
-            status="sending,delivered,failed",
+            status=request.args.get("from_statuses", "sending,delivered,failed"),
         )
 
     if notification["notification_type"] == "letter":

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -186,6 +186,15 @@ def test_can_show_notifications(
     json_content = json.loads(json_response.get_data(as_text=True))
     assert json_content.keys() == {"counts", "notifications", "service_data_retention_days"}
 
+    # All links to view individual notifications should pass through the statuses for the current view,
+    # so that backlinks can be generated correctly.
+    view_notification_links = page.select(".file-list-filename")
+    assert all(
+        parse_qs(urlparse(view_notification_link["href"]).query, keep_blank_values=True)["from_statuses"]
+        == [status_argument]
+        for view_notification_link in view_notification_links
+    )
+
 
 def test_can_show_notifications_if_data_retention_not_available(
     client_request,

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -139,6 +139,14 @@ def test_notification_status_page_respects_redaction(
             partial(url_for, "main.view_notifications", message_type="sms", status="sending,delivered,failed"),
         ),
         (
+            {"from_statuses": "sending"},
+            partial(url_for, "main.view_notifications", message_type="sms", status="sending"),
+        ),
+        (
+            {"from_statuses": "failed"},
+            partial(url_for, "main.view_notifications", message_type="sms", status="failed"),
+        ),
+        (
             {"from_job": "job_id"},
             partial(url_for, "main.view_job", job_id="job_id"),
         ),


### PR DESCRIPTION
The notifications dashboard shows an overview of how many notifications are in each state, and below that a table containing links to the latest notifications in each state.

When clicking a notification, the page shown has a back link that returns the user to the notifications dashboard. However, that link didn't take the user back to the previous filtered state (eg only failed notifications), which could be confusing. This patch updates the links so that they correctly record and return the user to the filtered dashboard view.

## Before
![2022-12-19 10 13 12](https://user-images.githubusercontent.com/2920760/208402244-6e3cca29-bf05-494a-8a4d-958049080e94.gif)

## After
![2022-12-19 10 13 48](https://user-images.githubusercontent.com/2920760/208402262-f5e0caf9-3134-455f-a998-0cd9c85b9447.gif)