### PR TITLE
Remove old csv logic

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -192,14 +192,14 @@ def view_notifications(service_id, message_type=None):
 @main.route("/services/<uuid:service_id>/notifications/<template_type:message_type>.json", methods=["GET", "POST"])
 @user_has_permissions()
 def get_notifications_as_json(service_id, message_type=None):
-    return jsonify(get_notifications(service_id, message_type, status_override=request.args.get("status")))
+    return jsonify(get_notifications(service_id, message_type))
 
 
 @main.route(
     "/services/<uuid:service_id>/notifications/<template_type:message_type>.csv", endpoint="view_notifications_csv"
 )
 @user_has_permissions()
-def get_notifications(service_id, message_type, status_override=None):
+def get_notifications(service_id, message_type):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()
     if page is None:

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -194,10 +194,6 @@ def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(service_id, message_type))
 
 
-@main.route(
-    "/services/<uuid:service_id>/notifications/<template_type:message_type>.csv", endpoint="view_notifications_csv"
-)
-@user_has_permissions()
 def get_notifications(service_id, message_type):
     # TODO get the api to return count of pages as well.
     page = get_page_from_request()

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -195,7 +195,6 @@ def get_notifications_as_json(service_id, message_type=None):
     return jsonify(get_notifications(service_id, message_type, status_override=request.args.get("status")))
 
 
-@main.route("/services/<uuid:service_id>/notifications.csv", endpoint="view_notifications_csv")
 @main.route(
     "/services/<uuid:service_id>/notifications/<template_type:message_type>.csv", endpoint="view_notifications_csv"
 )

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -243,16 +243,6 @@ def get_notifications(service_id, message_type, status_override=None):
     if "links" in notifications and notifications["links"].get("next", None):
         next_page = generate_next_dict("main.view_notifications", service_id, page, url_args)
 
-    if message_type:
-        download_link = url_for(
-            ".view_notifications_csv",
-            service_id=current_service.id,
-            message_type=message_type,
-            status=request.args.get("status"),
-        )
-    else:
-        download_link = None
-
     return {
         "service_data_retention_days": service_data_retention_days,
         "counts": render_template(
@@ -267,14 +257,10 @@ def get_notifications(service_id, message_type, status_override=None):
         "notifications": render_template(
             "views/activity/notifications.html",
             notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
-            page=page,
             limit_days=service_data_retention_days,
             prev_page=prev_page,
             next_page=next_page,
             show_pagination=(not search_term),
-            status=request.args.get("status"),
-            message_type=message_type,
-            download_link=download_link,
             single_notification_url=partial(
                 url_for,
                 ".view_notification",

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -158,7 +158,7 @@ def view_job_updates(service_id, job_id):
 def view_notifications(service_id, message_type=None):
     return render_template(
         "views/notifications.html",
-        partials=get_notifications(service_id, message_type),
+        partials=_get_notifications_dashboard_partials_data(service_id, message_type),
         message_type=message_type,
         status=request.args.get("status") or "sending,delivered,failed",
         page=request.args.get("page", 1),
@@ -190,12 +190,11 @@ def view_notifications(service_id, message_type=None):
 @main.route("/services/<uuid:service_id>/notifications.json", methods=["GET", "POST"])
 @main.route("/services/<uuid:service_id>/notifications/<template_type:message_type>.json", methods=["GET", "POST"])
 @user_has_permissions()
-def get_notifications_as_json(service_id, message_type=None):
-    return jsonify(get_notifications(service_id, message_type))
+def get_notifications_page_partials_as_json(service_id, message_type=None):
+    return jsonify(_get_notifications_dashboard_partials_data(service_id, message_type))
 
 
-def get_notifications(service_id, message_type):
-    # TODO get the api to return count of pages as well.
+def _get_notifications_dashboard_partials_data(service_id, message_type):
     page = get_page_from_request()
     if page is None:
         abort(404, "Invalid page argument ({}).".format(request.args.get("page")))

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -14,7 +14,6 @@ from flask import (
     stream_with_context,
     url_for,
 )
-from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 from notifications_utils.template import (
     EmailPreviewTemplate,
@@ -212,19 +211,6 @@ def get_notifications(service_id, message_type):
     if message_type is not None:
         service_data_retention_days = current_service.get_days_of_retention(message_type)
 
-    if request.path.endswith("csv") and current_user.has_permissions("view_activity"):
-        return Response(
-            generate_notifications_csv(
-                service_id=service_id,
-                page=page,
-                page_size=5000,
-                template_type=[message_type],
-                status=filter_args.get("status"),
-                limit_days=service_data_retention_days,
-            ),
-            mimetype="text/csv",
-            headers={"Content-Disposition": 'inline; filename="notifications.csv"'},
-        )
     notifications = notification_api_client.get_notifications_for_service(
         service_id=service_id,
         page=page,

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -27,7 +27,7 @@
 
     {{ ajax_block(
       partials,
-      url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
+      url_for('.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status),
       'counts'
     ) }}
 
@@ -74,7 +74,7 @@
 
   {{ ajax_block(
     partials,
-    url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),
+    url_for('.get_notifications_page_partials_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),
     'notifications',
     form='search-form'
   ) }}

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -181,7 +181,10 @@ def test_can_show_notifications(
     )
 
     json_response = client_request.get_response(
-        "main.get_notifications_as_json", service_id=service_one["id"], status=status_argument, **extra_args
+        "main.get_notifications_page_partials_as_json",
+        service_id=service_one["id"],
+        status=status_argument,
+        **extra_args
     )
     json_content = json.loads(json_response.get_data(as_text=True))
     assert json_content.keys() == {"counts", "notifications", "service_data_retention_days"}

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -145,7 +145,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "get_daily_sms_provider_volumes",
             "get_volumes_by_service",
             "get_example_csv",
-            "get_notifications_as_json",
+            "get_notifications_page_partials_as_json",
             "get_started",
             "get_started_old",
             "go_to_dashboard_after_tour",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -357,7 +357,6 @@ EXCLUDED_ENDPOINTS = tuple(
             "view_notification",
             "view_notification_updates",
             "view_notifications",
-            "view_notifications_csv",
             "view_previous_broadcast",
             "view_provider",
             "view_providers",


### PR DESCRIPTION
While fixing the backlinks for viewing notifications I spotted that this CSV endpoint seems to no longer be in use (replaced by `download_notifications_csv`). So this attempts to clean that up and rename it as what it actually is a - helper for the refreshing dashboard ajax blocks.

Athena says the removed route hasn't been used:
<img width="2661" alt="image" src="https://user-images.githubusercontent.com/2920760/208425202-72c3ceaa-2e6d-4504-a0f4-ede70bbf6c76.png">
