### PR TITLE
Create `OnOffSettingForm` and `YesNoSettingForm` instead of `ServiceOnOffSettingForm`

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1613,6 +1613,11 @@ class OnOffSettingForm(StripWhitespaceForm):
     enabled = OnOffField("Choices")
 
 
+class YesNoSettingForm(OnOffSettingForm):
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(name, *args, truthy="Yes", falsey="No", **kwargs)
+
+
 class ServiceSwitchChannelForm(OnOffSettingForm):
     def __init__(self, channel, *args, **kwargs):
         name = "Send {}".format(

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1601,7 +1601,7 @@ class ServiceLetterContactBlockForm(StripWhitespaceForm):
             raise ValidationError("Contains {} lines, maximum is 10".format(line_count + 1))
 
 
-class ServiceOnOffSettingForm(StripWhitespaceForm):
+class OnOffSettingForm(StripWhitespaceForm):
     def __init__(self, name, *args, truthy="On", falsey="Off", **kwargs):
         super().__init__(*args, **kwargs)
         self.enabled.label.text = name
@@ -1613,7 +1613,7 @@ class ServiceOnOffSettingForm(StripWhitespaceForm):
     enabled = OnOffField("Choices")
 
 
-class ServiceSwitchChannelForm(ServiceOnOffSettingForm):
+class ServiceSwitchChannelForm(OnOffSettingForm):
     def __init__(self, channel, *args, **kwargs):
         name = "Send {}".format(
             {

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -56,6 +56,7 @@ from app.main.forms import (
     EmailBrandingLogoUpload,
     EstimateUsageForm,
     GovernmentIdentityLogoForm,
+    OnOffSettingForm,
     RenameServiceForm,
     SearchByNameForm,
     ServiceBroadcastAccountTypeForm,
@@ -64,7 +65,6 @@ from app.main.forms import (
     ServiceContactDetailsForm,
     ServiceEditInboundNumberForm,
     ServiceLetterContactBlockForm,
-    ServiceOnOffSettingForm,
     ServiceReplyToEmailForm,
     ServiceSmsSenderForm,
     ServiceSwitchChannelForm,
@@ -219,7 +219,7 @@ def submit_request_to_go_live(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/switch-live", methods=["GET", "POST"])
 @user_is_platform_admin
 def service_switch_live(service_id):
-    form = ServiceOnOffSettingForm(name="Make service live", enabled=not current_service.trial_mode)
+    form = OnOffSettingForm(name="Make service live", enabled=not current_service.trial_mode)
 
     if form.validate_on_submit():
         current_service.update_status(live=form.enabled.data)
@@ -236,7 +236,7 @@ def service_switch_live(service_id):
 @user_is_platform_admin
 def service_switch_count_as_live(service_id):
 
-    form = ServiceOnOffSettingForm(
+    form = OnOffSettingForm(
         name="Count in list of live services",
         enabled=current_service.count_as_live,
         truthy="Yes",
@@ -261,7 +261,7 @@ def service_set_permission(service_id, permission):
         abort(404)
 
     title = PLATFORM_ADMIN_SERVICE_PERMISSIONS[permission]["title"]
-    form = ServiceOnOffSettingForm(name=title, enabled=current_service.has_permission(permission))
+    form = OnOffSettingForm(name=title, enabled=current_service.has_permission(permission))
 
     if form.validate_on_submit():
         current_service.force_permission(permission, on=form.enabled.data)
@@ -666,7 +666,7 @@ def service_set_sms_prefix(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/set-international-sms", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def service_set_international_sms(service_id):
-    form = ServiceOnOffSettingForm(
+    form = OnOffSettingForm(
         "Send text messages to international phone numbers",
         enabled=current_service.has_permission("international_sms"),
     )
@@ -685,7 +685,7 @@ def service_set_international_sms(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/set-international-letters", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def service_set_international_letters(service_id):
-    form = ServiceOnOffSettingForm(
+    form = OnOffSettingForm(
         "Send letters to international addresses",
         enabled=current_service.has_permission("international_letters"),
     )

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -70,6 +70,7 @@ from app.main.forms import (
     ServiceSwitchChannelForm,
     SMSPrefixForm,
     SomethingElseBrandingForm,
+    YesNoSettingForm,
 )
 from app.main.views.pricing import CURRENT_SMS_RATE
 from app.models.branding import (
@@ -236,11 +237,9 @@ def service_switch_live(service_id):
 @user_is_platform_admin
 def service_switch_count_as_live(service_id):
 
-    form = OnOffSettingForm(
+    form = YesNoSettingForm(
         name="Count in list of live services",
         enabled=current_service.count_as_live,
-        truthy="Yes",
-        falsey="No",
     )
 
     if form.validate_on_submit():

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -23,8 +23,8 @@ from app.main.forms import (
     ChangePasswordForm,
     ChangeSecurityKeyNameForm,
     ConfirmPasswordForm,
-    OnOffSettingForm,
     TwoFactorForm,
+    YesNoSettingForm,
 )
 from app.models.user import User
 from app.utils.user import user_is_gov_user, user_is_logged_in
@@ -214,11 +214,9 @@ def user_profile_disable_platform_admin_view():
     if not current_user.platform_admin and not session.get("disable_platform_admin_view"):
         abort(403)
 
-    form = OnOffSettingForm(
+    form = YesNoSettingForm(
         name="Use platform admin view",
         enabled=not session.get("disable_platform_admin_view"),
-        truthy="Yes",
-        falsey="No",
     )
 
     form.enabled.param_extensions = {"hint": {"text": "Signing in again clears this setting"}}

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -23,7 +23,7 @@ from app.main.forms import (
     ChangePasswordForm,
     ChangeSecurityKeyNameForm,
     ConfirmPasswordForm,
-    ServiceOnOffSettingForm,
+    OnOffSettingForm,
     TwoFactorForm,
 )
 from app.models.user import User
@@ -214,7 +214,7 @@ def user_profile_disable_platform_admin_view():
     if not current_user.platform_admin and not session.get("disable_platform_admin_view"):
         abort(403)
 
-    form = ServiceOnOffSettingForm(
+    form = OnOffSettingForm(
         name="Use platform admin view",
         enabled=not session.get("disable_platform_admin_view"),
         truthy="Yes",


### PR DESCRIPTION
We also use `ServiceOnOffSettingForm` this form on the user profile page, so it’s not strictly for service settings. We will also use it on organisations in the future, so it makes sense for it to be more generic.

We often use the `OnOffSettingForm` with ‘Yes’ and ‘No’ as the default choices, so this pull request also makes a reusable thing for doing that.