### PR TITLE
Announce letter price increases

### DIFF
--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -267,8 +267,7 @@
   </div>
 
   <div class="panel panel-border-wide">  
-    <p class="govuk-body">These prices were updated on 1 March 2022.</p>
-    <p class="govuk-body">On 23 January 2023:</p>
+    <p class="govuk-body">From Monday 23 January 2023:</p>
     <ul class="list list-bullet">
     <li>second class postage will go up by 6 pence, plus VAT</li>
     <li>first class postage will go up by 9 pence, plus VAT</li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -266,7 +266,7 @@
     {% endcall %}
   </div>
 
-  <div class="panel panel-border-wide">  
+  <div class="govuk-inset-text"  
     <p class="govuk-body">From Monday 23 January 2023:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>second class postage will go up by 6 pence, plus VAT</li>

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -268,11 +268,11 @@
 
   <div class="panel panel-border-wide">  
     <p class="govuk-body">From Monday 23 January 2023:</p>
-    <ul class="list list-bullet">
-    <li>second class postage will go up by 6 pence, plus VAT</li>
-    <li>first class postage will go up by 9 pence, plus VAT</li>
-    <li>international postage will go up by 9 pence, plus VAT</li>
-  </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>second class postage will go up by 6 pence, plus VAT</li>
+      <li>first class postage will go up by 9 pence, plus VAT</li>
+      <li>international postage will go up by 9 pence, plus VAT</li>
+    </ul>
   </div>
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -266,4 +266,14 @@
     {% endcall %}
   </div>
 
+  <div class="panel panel-border-wide">  
+    <p class="govuk-body">These prices were updated on 1 March 2022.</p>
+    <p class="govuk-body">On 23 January 2023:</p>
+    <ul class="list list-bullet">
+    <li>second class postage will go up by 6 pence, plus VAT</li>
+    <li>first class postage will go up by 9 pence, plus VAT</li>
+    <li>international postage will go up by 9 pence, plus VAT</li>
+  </ul>
+  </div>
+
 {% endblock %}


### PR DESCRIPTION
This PR adds an announcement to the pricing page of forthcoming price increases.

It follows the same pattern we used in 2021, with slightly updated content.