### PR TITLE
favour descriptionText over descriptionHtml

### DIFF
--- a/app/templates/views/two-factor-webauthn.html
+++ b/app/templates/views/two-factor-webauthn.html
@@ -31,7 +31,7 @@
   {{ govukErrorSummary({
     "classes": "webauthn__no-js",
     "titleText": "There’s a problem",
-    "descriptionHtml": "JavaScript is not available for this page. Security keys need JavaScript to work."
+    "descriptionText": "JavaScript is not available for this page. Security keys need JavaScript to work."
   }) }}
 
   {% set keyProblemDescription %}

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -45,7 +45,7 @@
   {{ govukErrorSummary({
     "classes": "webauthn__no-js",
     "titleText": "There’s a problem",
-    "descriptionHtml": "JavaScript is not available for this page. Security keys need JavaScript to work."
+    "descriptionText": "JavaScript is not available for this page. Security keys need JavaScript to work."
   }) }}
 
   {% set keyProblemDescription %}


### PR DESCRIPTION
something that slipped in in the 2fa webauthn error message stuff the other day

descriptionHtml content is assumed to be safe to render, so is inherently riskier. We should only use this when we have actual HTML content we need to render rather than just plain text (for example when we have a link to the support page)