### PR TITLE
Remove unused Jinja imports

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,5 +1,4 @@
 {% extends "govuk_frontend_jinja/template.html"%}
-{% from "components/banner.html" import banner %}
 {% from "components/cookie-banner.html" import cookie_banner %}
 
 {% block headIcons %}

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -1,4 +1,4 @@
-{% from "components/select-input.html" import select, select_list, select_nested, select_wrapper, select_input %}
+{% from "components/select-input.html" import select, select_list, select_nested, select_input %}
 
 {% macro radios(field, hint=None, disable=[], option_hints={}, hide_legend=False, inline=False) %}
   {{ select(field, hint, disable, option_hints, hide_legend, input="radio", inline=inline) }}

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
 
 {% from "components/sub-navigation.html" import sub_navigation %}
-{% from "components/page-header.html" import page_header %}
 
 {% block per_page_title %}
   {{ content_page_title }}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, notification_status_field %}
+{% from "components/table.html" import list_table, row_heading, notification_status_field %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 

--- a/app/templates/partials/notifications/notifications.html
+++ b/app/templates/partials/notifications/notifications.html
@@ -1,5 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, notification_status_field %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/table.html" import list_table, row_heading, notification_status_field %}
 
 <div class="ajax-block-container" aria-labelledby='pill-selected-item'>
   <div class="dashboard-table bottom-gutter-3-2">

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -13,7 +13,7 @@
     data={
       "Published": "23 September 2020",
       "Last updated": "4 January 2023",
-      "Next review due": "21 March 2022"
+      "Next review due": "21 March 2023"
     }
     ) }}
 

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -12,7 +12,7 @@
   {{ content_metadata(
     data={
       "Published": "23 September 2020",
-      "Last updated": "20 December 2022",
+      "Last updated": "4 January 2023",
       "Next review due": "21 March 2022"
     }
     ) }}

--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -1,5 +1,4 @@
 {% extends "content_template.html" %}
-{% from "components/service-link.html" import service_link %}
 {% from "components/content-metadata.html" import content_metadata %}
 
 {% block per_page_title %}

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -1,6 +1,5 @@
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, notification_status_field %}
+{% from "components/table.html" import list_table, row_heading, notification_status_field %}
 
 <div class="ajax-block-container" id='pill-selected-item'>
 

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
   Download the GOV.UK Notify data sharing and financial agreement

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/api/guest-list.html
+++ b/app/templates/views/api/guest-list.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list-entry.html" import list_entry %}

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, hidden_field_heading %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% block service_page_title %}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,5 +1,3 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
-
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in broadcasts|sort|reverse|list %}
   <div class="keyline-block">

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -1,9 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radio_select %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -1,4 +1,3 @@
-{% from 'components/ajax-block.html' import ajax_block %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% extends "withnav_template.html" %}

--- a/app/templates/views/broadcast/tour/1.html
+++ b/app/templates/views/broadcast/tour/1.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/2.html
+++ b/app/templates/views/broadcast/tour/2.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/3.html
+++ b/app/templates/views/broadcast/tour/3.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/4.html
+++ b/app/templates/views/broadcast/tour/4.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import navigation_service_name %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import service_navigation %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/tour/live/1.html
+++ b/app/templates/views/broadcast/tour/live/1.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import service_navigation %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/tour/live/2.html
+++ b/app/templates/views/broadcast/tour/live/2.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import service_navigation %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,7 +1,6 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/skip-link/macro.html" import govukSkipLink %}

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import mapping_table, row, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import mapping_table, row, field, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/cookies.html
+++ b/app/templates/views/cookies.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/banner.html" import banner %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% block per_page_title %}

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, hidden_field_heading, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 
 <div class="ajax-block-container">

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 {% from "components/big-number.html" import big_number -%}
 
 <div class='dashboard-table ajax-block-container'>

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -1,6 +1,3 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
-{% from "components/show-more.html" import show_more %}
-
 <div class="ajax-block-container">
   {% if current_service.scheduled_job_stats.count %}
     <h2 class="heading-medium heading-upcoming-jobs">

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -1,6 +1,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/pill.html" import pill %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
+{% from "components/table.html" import list_table, row_heading, spark_bar_field %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 
 {% from "components/show-more.html" import show_more %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, hidden_field_heading %}
 {% from "components/ajax-block.html" import ajax_block %}
 
 {% block service_page_title %}

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -1,7 +1,7 @@
 {% from "components/page-header.html" import page_header %}
-{% from "components/big-number.html" import big_number_with_status, big_number %}
+{% from "components/big-number.html" import big_number %}
 {% from "components/pill.html" import pill %}
-{% from "components/table.html" import list_table, field, hidden_field_heading, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -1,6 +1,4 @@
-{% from "components/big-number.html" import big_number %}
-{% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
+{% from "components/table.html" import list_table, row_heading, spark_bar_field %}
 {% from "components/show-more.html" import show_more %}
 
 <div class="ajax-block-container">

--- a/app/templates/views/email-branding/government-identity-options-colour.html
+++ b/app/templates/views/email-branding/government-identity-options-colour.html
@@ -1,6 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/file-upload.html" import file_upload %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/email-branding/government-identity-options.html
+++ b/app/templates/views/email-branding/government-identity-options.html
@@ -1,6 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/file-upload.html" import file_upload %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Invalid email link

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -1,8 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   {{ user.name }}

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -1,8 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
-
 {% block per_page_title %}
   Get started
 {% endblock %}

--- a/app/templates/views/guidance/index.html
+++ b/app/templates/views/guidance/index.html
@@ -1,8 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}
 

--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/service-link.html" import service_link %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -1,4 +1,3 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% extends "withoutnav_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/make-service-live.html
+++ b/app/templates/views/make-service-live.html
@@ -2,7 +2,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
-{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set title = "Make service live" %}
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -1,8 +1,6 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/organisations/organisation/settings/edit-can-approve-own-go-live-requests.html
+++ b/app/templates/views/organisations/organisation/settings/edit-can-approve-own-go-live-requests.html
@@ -1,8 +1,6 @@
 {% extends "org_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/page-header.html" import page_header %}
-{% from "components/textbox.html" import textbox %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block org_page_title %}

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -1,5 +1,4 @@
 {% extends "org_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper%}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -1,6 +1,5 @@
 {% extends "org_template.html" %}
-{% from "components/table.html" import list_table, row, field, hidden_field_heading %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/banner.html" import banner %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block main %}
 <div class="govuk-width-container {{ mainClasses }}">

--- a/app/templates/views/platform-admin/complaints.html
+++ b/app/templates/views/platform-admin/complaints.html
@@ -1,7 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, link_field %}
 
 {% block per_page_title %}
   Email complaints

--- a/app/templates/views/platform-admin/get-billing-report.html
+++ b/app/templates/views/platform-admin/get-billing-report.html
@@ -1,5 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import mapping_table, row, text_field %}
 
 {% block per_page_title %}

--- a/app/templates/views/platform-admin/notifications_by_service.html
+++ b/app/templates/views/platform-admin/notifications_by_service.html
@@ -1,5 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Monthly notification statuses for live services

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -1,7 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
-{% from "components/big-number.html" import big_number, big_number_with_status %}
-{% from "components/table.html" import mapping_table, field, stats_fields, row_group, row, right_aligned_field_heading, hidden_field_heading, text_field %}
+{% from "components/big-number.html" import big_number %}
+{% from "components/table.html" import mapping_table, field, row_group, row, right_aligned_field_heading %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}

--- a/app/templates/views/providers/provider.html
+++ b/app/templates/views/providers/provider.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}

--- a/app/templates/views/providers/providers.html
+++ b/app/templates/views/providers/providers.html
@@ -1,5 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, optional_text_field %}
+{% from "components/table.html" import list_table, text_field, link_field, optional_text_field %}
 
 {% block per_page_title %}
 Providers

--- a/app/templates/views/resend-email-verification.html
+++ b/app/templates/views/resend-email-verification.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Check your email

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/content-metadata.html" import content_metadata %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/send-contact-list.html
+++ b/app/templates/views/send-contact-list.html
@@ -2,7 +2,7 @@
 {% from "components/big-number.html" import big_number -%}
 {% from "components/list.html" import list_of_placeholders %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -1,8 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/table.html" import mapping_table, row, settings_row, text_field, optional_text_field, edit_field, field, boolean_field with context %}
 {% from "service_navigation.html" import broadcast_service_name_tag %}
 

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radio, radios_with_images %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
@@ -1,7 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radio %}
-{% from "components/select-input.html" import select_wrapper %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-upload-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-upload-logo.html
@@ -1,9 +1,6 @@
 {% extends "withnav_template.html" %}
-{% from "components/form.html" import form_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/error-summary.html" import errorSummary %}
 

--- a/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
+++ b/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "components/branding-preview.html" import email_branding_preview %}

--- a/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
@@ -2,10 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/page-header.html" import page_header %}
-{% from "components/branding-preview.html" import email_branding_preview %}
-{% from "components/textbox.html" import textbox %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radio %}
-{% from "components/select-input.html" import select_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/branding/email-branding-something-else.html
+++ b/app/templates/views/service-settings/branding/email-branding-something-else.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/textbox.html" import textbox %}
 
 {% block service_page_title %}
   Describe the branding you want

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import mapping_table, row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
-{% from "components/form.html" import form_wrapper %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -1,8 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radio %}
-{% from "components/select-input.html" import select_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer, sticky_page_footer %}
+{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/error-summary.html" import errorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/set-branding.html
+++ b/app/templates/views/service-settings/set-branding.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer, sticky_page_footer %}
+{% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/set-message-limit.html
+++ b/app/templates/views/service-settings/set-message-limit.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context%}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/support/thanks.html
+++ b/app/templates/views/support/thanks.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, field %}
 {% from "components/pill.html" import pill %}
 
 {% block service_page_title %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list.html" import list_of_placeholders, list_of_code_snippets %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -3,7 +3,6 @@
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -1,4 +1,4 @@
-{% from "components/folder-path.html" import copy_folder_path, page_title_folder_path %}
+{% from "components/folder-path.html" import copy_folder_path %}
 {% from "components/live-search.html" import live_search %}
 
 {% extends "withnav_template.html" %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/banner.html" import banner_wrapper %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -1,10 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/big-number.html" import big_number %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading, row, row_heading %}
+{% from "components/table.html" import list_table, field, text_field, row_heading %}
 {% from "components/page-header.html" import page_header %}
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/uploads/contact-list/ok.html
+++ b/app/templates/views/uploads/contact-list/ok.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -2,7 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -1,5 +1,5 @@
 {% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, hidden_field_heading, row_heading, text_field %}
+{% from "components/table.html" import list_table, field, hidden_field_heading, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/pill.html" import pill %}
 

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
+{% from "components/table.html" import edit_field, mapping_table, row, field %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 

--- a/tests/app/test_accessibility_statement.py
+++ b/tests/app/test_accessibility_statement.py
@@ -11,15 +11,19 @@ def test_last_review_date():
         [f"git diff --exit-code origin/main -- {statement_file_path}"], stdout=subprocess.PIPE, shell=True
     )
 
+    date_format = "%d %B %Y"
+
     # if statement has changed, test the review date was part of those changes
     if statement_diff.returncode == 1:
         raw_diff = statement_diff.stdout.decode("utf-8")
-        today = datetime.now().strftime("%d %B %Y")
+        today = datetime.now().strftime(date_format)
         with open(statement_file_path, "r") as statement_file:
-            current_review_date = re.search(
-                (r'"Last updated": "(\d{1,2} [A-Z]{1}[a-z]+ \d{4})"'), statement_file.read()
-            ).group(1)
+            contents = statement_file.read()
+            current_review_date = re.search((r'"Last updated": "(\d{1,2} [A-Z]{1}[a-z]+ \d{4})"'), contents).group(1)
+            next_review_due = re.search((r'"Next review due": "(\d{1,2} [A-Z]{1}[a-z]+ \d{4})"'), contents).group(1)
 
         # guard against changes that don't need to update the review date
         if current_review_date != today:
             assert '"Last updated": "' in raw_diff
+
+        assert datetime.strptime(next_review_due, date_format) > datetime.strptime(current_review_date, date_format)

--- a/tests/app/test_jinja_templates.py
+++ b/tests/app/test_jinja_templates.py
@@ -1,0 +1,29 @@
+from itertools import chain
+from pathlib import Path
+
+import pytest
+from flask import current_app
+from jinja2.nodes import Call, FromImport, Name
+from orderedset import OrderedSet
+
+
+class UnusedJinjaImports(Exception):
+    def __init__(self, unused_imports, file):
+        separator = "\n  • "
+        formatted_unused_imports = separator.join(unused_imports)
+        super().__init__(f"\n\nUnused Jinja imports:{separator}{formatted_unused_imports}\n\nFound in {file}")
+
+
+templates_dir = Path(__file__).parent.parent.parent.resolve() / "app/templates"
+files = sorted(templates_dir.glob("**/*.html"))
+
+
+@pytest.mark.parametrize("file", files, ids=[str(path.relative_to(templates_dir)) for path in files])
+def test_for_unused_jinja_imports(client_request, file):
+    parse_tree = current_app.jinja_env.parse(file.read_text())
+
+    calls = set(node.node.name for node in parse_tree.find_all(Call) if isinstance(node.node, Name))
+    imports = OrderedSet(chain.from_iterable(node.names for node in parse_tree.find_all(FromImport)))
+
+    if unused_imports := imports - calls:
+        raise UnusedJinjaImports(unused_imports, file)


### PR DESCRIPTION
This pull request adds a test which checks for any unused Jinja imports. If it finds any it outputs an error like this:

<img width="812" alt="image" src="https://user-images.githubusercontent.com/355079/208901228-6162828c-dbe4-4d99-aaa3-950bf8ccaad3.png">

This pull request then fixes all these errors across our templates.