### PR TITLE
remove all unused imports from jinja templates

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -1,5 +1,4 @@
 {% extends "govuk_frontend_jinja/template.html"%}
-{% from "components/banner.html" import banner %}
 {% from "components/cookie-banner.html" import cookie_banner %}
 
 {% block headIcons %}

--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -1,12 +1,7 @@
-{% from "components/select-input.html" import select, select_list, select_nested, select_wrapper, select_input %}
+{% from "components/select-input.html" import select, select_nested, select_input %}
 
 {% macro radios(field, hint=None, disable=[], option_hints={}, hide_legend=False, inline=False) %}
   {{ select(field, hint, disable, option_hints, hide_legend, input="radio", inline=inline) }}
-{% endmacro %}
-
-
-{% macro radio_list(options, child_map, disable=[], option_hints={}) %}
-  {{ select_list(options, child_map, disable, option_hints, input="radio") }}
 {% endmacro %}
 
 
@@ -17,44 +12,6 @@
 
 {% macro radio(option, disable=[], option_hints={}, data_target=None, as_list_item=False) %}
   {{ select_input(option, disable, option_hints, data_target, as_list_item, input="radio") }}
-{% endmacro %}
-
-
-{% macro radio_select(
- field,
- hint=None,
- wrapping_class='form-group',
- show_now_as_default=True,
- bold_legend=False
-) %}
- <div class="{{ wrapping_class }} {% if field.errors %} form-group-error{% endif %}">
-   <fieldset>
-     <legend class="form-label {% if bold_legend %}govuk-!-font-weight-bold{% endif %}">
-       {{ field.label.text }}
-       {% if field.errors %}
-         <span class="error-message" data-notify-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
-           {{ field.errors[0] }}
-         </span>
-       {% endif %}
-     </legend>
-     <div class="radio-select" data-notify-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default|string|lower }}">
-       <div class="radio-select-column">
-       {% for option in field %}
-         <div class="multiple-choice">
-           {{ option }}
-           <label for="{{ option.id }}">
-             {{ option.label.text }}
-           </label>
-         </div>
-         {% if loop.first %}
-       </div>
-       <div class="radio-select-column">
-         {% endif %}
-       {% endfor %}
-       </div>
-     </div>
-   </fieldset>
- </div>
 {% endmacro %}
 
 

--- a/app/templates/components/tick-cross.html
+++ b/app/templates/components/tick-cross.html
@@ -13,7 +13,3 @@
     {% endif %}
   </li>
 {% endmacro %}
-
-{% macro tick_cross_done_not_done(yes, label) %}
-  {{ tick_cross(yes, label, truthy_hint='Done: ', falsey_hint='Not done: ') }}
-{% endmacro %}

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
 
 {% from "components/sub-navigation.html" import sub_navigation %}
-{% from "components/page-header.html" import page_header %}
 
 {% block per_page_title %}
   {{ content_page_title }}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, notification_status_field %}
+{% from "components/table.html" import list_table, row_heading, notification_status_field %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 

--- a/app/templates/partials/notifications/notifications.html
+++ b/app/templates/partials/notifications/notifications.html
@@ -1,5 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, notification_status_field %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/table.html" import list_table, row_heading, notification_status_field %}
 
 <div class="ajax-block-container" aria-labelledby='pill-selected-item'>
   <div class="dashboard-table bottom-gutter-3-2">

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -1,6 +1,5 @@
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, row_heading, notification_status_field %}
+{% from "components/table.html" import list_table, row_heading, notification_status_field %}
 
 <div class="ajax-block-container" id='pill-selected-item'>
 

--- a/app/templates/views/agreement/agreement-public.html
+++ b/app/templates/views/agreement/agreement-public.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/sub-navigation.html" import sub_navigation %}
 
 {% block per_page_title %}
   Download the GOV.UK Notify data sharing and financial agreement

--- a/app/templates/views/api/callbacks.html
+++ b/app/templates/views/api/callbacks.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import mapping_table, row, text_field, edit_field, optional_text_field with context %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/api/guest-list.html
+++ b/app/templates/views/api/guest-list.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, field, hidden_field_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list-entry.html" import list_entry %}

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, hidden_field_heading %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {% block service_page_title %}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import list_table, field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/broadcast/partials/dashboard-table.html
+++ b/app/templates/views/broadcast/partials/dashboard-table.html
@@ -1,5 +1,3 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
-
 <div class="ajax-block-container js-mark-focus-on-parent" data-classes-to-persist="js-child-has-focus">
 {% for item in broadcasts|sort|reverse|list %}
   <div class="keyline-block">

--- a/app/templates/views/broadcast/preview-areas.html
+++ b/app/templates/views/broadcast/preview-areas.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/broadcast/preview-message.html
+++ b/app/templates/views/broadcast/preview-message.html
@@ -1,9 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radio_select %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/broadcast/previous-broadcasts.html
+++ b/app/templates/views/broadcast/previous-broadcasts.html
@@ -1,4 +1,3 @@
-{% from 'components/ajax-block.html' import ajax_block %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% extends "withnav_template.html" %}

--- a/app/templates/views/broadcast/tour/1.html
+++ b/app/templates/views/broadcast/tour/1.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/2.html
+++ b/app/templates/views/broadcast/tour/2.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/3.html
+++ b/app/templates/views/broadcast/tour/3.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/4.html
+++ b/app/templates/views/broadcast/tour/4.html
@@ -1,5 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
-
 {% extends "admin_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/broadcast/tour/5.html
+++ b/app/templates/views/broadcast/tour/5.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import navigation_service_name %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/tour/6.html
+++ b/app/templates/views/broadcast/tour/6.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import service_navigation %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/tour/live/1.html
+++ b/app/templates/views/broadcast/tour/live/1.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import service_navigation %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/tour/live/2.html
+++ b/app/templates/views/broadcast/tour/live/2.html
@@ -1,4 +1,3 @@
-{% from "components/banner.html" import banner_wrapper %}
 {% from "service_navigation.html" import service_navigation %}
 
 {% extends "admin_template.html" %}

--- a/app/templates/views/broadcast/view-message.html
+++ b/app/templates/views/broadcast/view-message.html
@@ -1,7 +1,6 @@
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 {% from "components/form.html" import form_wrapper %}
-{% from "components/banner.html" import banner %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "views/broadcast/macros/area-map.html" import map %}

--- a/app/templates/views/check/column-errors.html
+++ b/app/templates/views/check/column-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/skip-link/macro.html" import govukSkipLink %}

--- a/app/templates/views/check/row-errors.html
+++ b/app/templates/views/check/row-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import mapping_table, row, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import mapping_table, row, field, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, hidden_field_heading, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
 
 <div class="ajax-block-container">

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -1,4 +1,4 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 {% from "components/big-number.html" import big_number -%}
 
 <div class='dashboard-table ajax-block-container'>

--- a/app/templates/views/dashboard/_upcoming.html
+++ b/app/templates/views/dashboard/_upcoming.html
@@ -1,6 +1,3 @@
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
-{% from "components/show-more.html" import show_more %}
-
 <div class="ajax-block-container">
   {% if current_service.scheduled_job_stats.count %}
     <h2 class="heading-medium heading-upcoming-jobs">

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -1,6 +1,6 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/pill.html" import pill %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
+{% from "components/table.html" import list_table, row_heading, spark_bar_field %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 
 {% from "components/show-more.html" import show_more %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, hidden_field_heading %}
 {% from "components/ajax-block.html" import ajax_block %}
 
 {% block service_page_title %}

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -1,7 +1,7 @@
 {% from "components/page-header.html" import page_header %}
-{% from "components/big-number.html" import big_number_with_status, big_number %}
+{% from "components/big-number.html" import big_number %}
 {% from "components/pill.html" import pill %}
-{% from "components/table.html" import list_table, field, hidden_field_heading, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/dashboard/template-statistics.html
+++ b/app/templates/views/dashboard/template-statistics.html
@@ -1,6 +1,4 @@
-{% from "components/big-number.html" import big_number %}
-{% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading, spark_bar_field %}
+{% from "components/table.html" import list_table, row_heading, spark_bar_field %}
 {% from "components/show-more.html" import show_more %}
 
 <div class="ajax-block-container">

--- a/app/templates/views/email-branding/government-identity-options-colour.html
+++ b/app/templates/views/email-branding/government-identity-options-colour.html
@@ -1,6 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/file-upload.html" import file_upload %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/email-branding/government-identity-options.html
+++ b/app/templates/views/email-branding/government-identity-options.html
@@ -1,6 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/file-upload.html" import file_upload %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/email-link-invalid.html
+++ b/app/templates/views/email-link-invalid.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Invalid email link

--- a/app/templates/views/features.html
+++ b/app/templates/views/features.html
@@ -1,8 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/features/emails.html
+++ b/app/templates/views/features/emails.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/features/letters.html
+++ b/app/templates/views/features/letters.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/features/text-messages.html
+++ b/app/templates/views/features/text-messages.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/find-services/find-services-by-name.html
+++ b/app/templates/views/find-services/find-services-by-name.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/find-users/find-users-by-email.html
+++ b/app/templates/views/find-users/find-users-by-email.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   {{ user.name }}

--- a/app/templates/views/get-started.html
+++ b/app/templates/views/get-started.html
@@ -1,8 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
-
 {% block per_page_title %}
   Get started
 {% endblock %}

--- a/app/templates/views/guidance/index.html
+++ b/app/templates/views/guidance/index.html
@@ -1,8 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-{% from "components/sub-navigation.html" import sub_navigation %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'Using Notify' %}
 

--- a/app/templates/views/guidance/letter-specification.html
+++ b/app/templates/views/guidance/letter-specification.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/service-link.html" import service_link %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}

--- a/app/templates/views/inbound-sms-admin.html
+++ b/app/templates/views/inbound-sms-admin.html
@@ -45,7 +45,7 @@ Inbound SMS
 
               {% if value.active %}
                 Active
-              {% elif not value.service.name  %}
+              {% elif not value.service.name %}
                   Not used
               {% else %}
                 Inactive

--- a/app/templates/views/integration-testing.html
+++ b/app/templates/views/integration-testing.html
@@ -1,4 +1,3 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% extends "withoutnav_template.html" %}
 
 {% block per_page_title %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -1,5 +1,4 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
@@ -60,7 +59,7 @@
   {% endcall %}
 
   {% call form_wrapper(id="search-form") %}
-    <input type="hidden" name="to" {% if search_form.to.data %}value="{{ search_form.to.data }}{%  endif %}">
+    <input type="hidden" name="to" {% if search_form.to.data %}value="{{ search_form.to.data }}{% endif %}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% endcall %}
 

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -1,8 +1,6 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/organisations/organisation/settings/email-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/email-branding-options.html
@@ -1,10 +1,9 @@
 {% extends "org_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/form.html" import form_wrapper%}
+{% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
-{%  from "components/branding-preview.html" import email_branding_preview %}
+{% from "components/branding-preview.html" import email_branding_preview %}
 
 {% set page_title = "Email branding" %}
 
@@ -14,7 +13,7 @@
 
 {% block backLink %}
     {{ govukBackLink({ "href": url_for('.organisation_settings', org_id=current_org.id) }) }}
-{%  endblock %}
+{% endblock %}
 
 {% block maincolumn_content %}
     <h1 class="govuk-heading-l">{{ page_title }}</h1>

--- a/app/templates/views/organisations/organisation/settings/letter-branding-options.html
+++ b/app/templates/views/organisations/organisation/settings/letter-branding-options.html
@@ -1,10 +1,10 @@
 {% extends "org_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/form.html" import form_wrapper%}
+{% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
-{%  from "components/branding-preview.html" import letter_branding_preview %}
+{% from "components/branding-preview.html" import letter_branding_preview %}
 
 {% block org_page_title %}
   Letter branding
@@ -12,7 +12,7 @@
 
 {% block backLink %}
   {{ govukBackLink({ "href": url_for('.organisation_settings', org_id=current_org.id) }) }}
-{%  endblock %}
+{% endblock %}
 
 {% block maincolumn_content %}
   {{ page_header("Letter branding") }}

--- a/app/templates/views/organisations/organisation/users/index.html
+++ b/app/templates/views/organisations/organisation/users/index.html
@@ -1,6 +1,5 @@
 {% extends "org_template.html" %}
-{% from "components/table.html" import list_table, row, field, hidden_field_heading %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/banner.html" import banner %}
 {% from "components/live-search.html" import live_search %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block main %}
 <div class="govuk-width-container {{ mainClasses }}">

--- a/app/templates/views/platform-admin/complaints.html
+++ b/app/templates/views/platform-admin/complaints.html
@@ -1,7 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/previous-next-navigation.html" import previous_next_navigation %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, link_field %}
 
 {% block per_page_title %}
   Email complaints

--- a/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Daily SMS provider volumes Report

--- a/app/templates/views/platform-admin/daily-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-volumes-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Daily volumes report

--- a/app/templates/views/platform-admin/get-billing-report.html
+++ b/app/templates/views/platform-admin/get-billing-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Billing Report

--- a/app/templates/views/platform-admin/notifications_by_service.html
+++ b/app/templates/views/platform-admin/notifications_by_service.html
@@ -1,5 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Monthly notification statuses for live services

--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -1,7 +1,6 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
-{% from "components/big-number.html" import big_number, big_number_with_status %}
-{% from "components/table.html" import mapping_table, field, stats_fields, row_group, row, right_aligned_field_heading, hidden_field_heading, text_field %}
+{% from "components/big-number.html" import big_number %}
+{% from "components/table.html" import mapping_table, field, row_group, row, right_aligned_field_heading %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/details/macro.html" import govukDetails %}

--- a/app/templates/views/platform-admin/volumes-by-service-report.html
+++ b/app/templates/views/platform-admin/volumes-by-service-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Volumes by service report

--- a/app/templates/views/providers/provider.html
+++ b/app/templates/views/providers/provider.html
@@ -1,7 +1,6 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block per_page_title %}

--- a/app/templates/views/providers/providers.html
+++ b/app/templates/views/providers/providers.html
@@ -1,5 +1,5 @@
 {% extends "views/platform-admin/_base_template.html" %}
-{% from "components/table.html" import list_table, field, text_field, link_field, right_aligned_field_heading, hidden_field_heading, optional_text_field %}
+{% from "components/table.html" import list_table, text_field, link_field, optional_text_field %}
 
 {% block per_page_title %}
 Providers

--- a/app/templates/views/resend-email-verification.html
+++ b/app/templates/views/resend-email-verification.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Check your email

--- a/app/templates/views/roadmap.html
+++ b/app/templates/views/roadmap.html
@@ -1,6 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 {% from "components/content-metadata.html" import content_metadata %}
 
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
@@ -48,14 +47,14 @@
   <h3 class="heading-small" id="january-to-march">January to March 2023</h3>
 
   <ul class="govuk-list govuk-list--bullet">
-    
+
     <li>Add multilingual letter templates so services can provide information in several languages</li>
     <li>Test reusable content patterns for text messages</li>
     <li>Review our <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.edit_and_format_messages') }}">email formatting options</a></li>
     <li>Migrate a second application from GOV.UK PaaS to Amazon ECS</li>
 
 </ul>
-    
+
 
   <h3 class="heading-small" id="april-to-june">April 2023 onwards</h3>
 
@@ -70,29 +69,29 @@
   <h2 class="heading-medium" id="things-we-have-done">Things we’ve done</h2>
 
   <h3 class="heading-small">Improved email branding</h3>
-  
+
   <p class="govuk-body">When a service team needs to update their email branding, they can now:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    
+
     <li>choose new branding from a set of existing options</li>
     <li>preview their branding on the Notify website</li>
-    
+
   </ul>
 
   <h3 class="heading-small">Made sending files by email more secure</h3>
-  
+
   <p class="govuk-body">To protect files sent by email, service teams can now:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    
+
     <li>ask recipients to enter their email address before they can download a file</li>
     <li>choose the length of time that a file is available to download</li>
-    
+
   </ul>
 
   <h3 class="heading-small">Pair writing with service teams</h3>
-  
+
   <p class="govuk-body">We wrote a blog post about this work, called ‘<a class="govuk-link govuk-link--no-visited-state" href="https://gds.blog.gov.uk/2022/07/20/how-rewriting-text-messages-can-help-services-to-save-money/">how rewriting text messages can help services to save money</a>’.</p>
 
 {% endblock %}

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/send-contact-list.html
+++ b/app/templates/views/send-contact-list.html
@@ -2,7 +2,7 @@
 {% from "components/big-number.html" import big_number -%}
 {% from "components/list.html" import list_of_placeholders %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
+{% from "components/table.html" import list_table, field, row_heading %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/send.html
+++ b/app/templates/views/send.html
@@ -1,8 +1,7 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
-{% from "components/table.html" import mapping_table, row, settings_row, text_field, optional_text_field, edit_field, field, boolean_field with context %}
 {% from "service_navigation.html" import broadcast_service_name_tag %}
+{% from "components/table.html" import mapping_table, row, settings_row, text_field, optional_text_field, edit_field, field, boolean_field with context%}
 
 {% block service_page_title %}
   Settings

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radio, radios_with_images %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
@@ -1,7 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radio %}
-{% from "components/select-input.html" import select_wrapper %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/upload-logo.html
@@ -1,9 +1,6 @@
 {% extends "withnav_template.html" %}
-{% from "components/form.html" import form_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/error-summary.html" import errorSummary %}
 

--- a/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
+++ b/app/templates/views/service-settings/branding/email-branding-create-government-identity-logo.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "components/branding-preview.html" import email_branding_preview %}

--- a/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
+++ b/app/templates/views/service-settings/branding/email-branding-enter-government-identity-logo-text.html
@@ -2,10 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/page-header.html" import page_header %}
-{% from "components/branding-preview.html" import email_branding_preview %}
-{% from "components/textbox.html" import textbox %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/error-summary.html" import errorSummary %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -1,6 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/radios.html" import radio %}
-{% from "components/select-input.html" import select_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/branding/email-branding-something-else.html
+++ b/app/templates/views/service-settings/branding/email-branding-something-else.html
@@ -2,7 +2,6 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/textbox.html" import textbox %}
 
 {% block service_page_title %}
   Describe the branding you want

--- a/app/templates/views/service-settings/branding/letter-branding-pool-option.html
+++ b/app/templates/views/service-settings/branding/letter-branding-pool-option.html
@@ -8,7 +8,7 @@
 {% set page_title = "Change letter branding" %}
 
 {% block service_page_title %}
-  {{  page_title }}
+  {{ page_title }}
 {% endblock %}
 
 {% block backLink %}

--- a/app/templates/views/service-settings/data-retention.html
+++ b/app/templates/views/service-settings/data-retention.html
@@ -1,5 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/table.html" import mapping_table, row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/data-retention/edit.html
+++ b/app/templates/views/service-settings/data-retention/edit.html
@@ -17,7 +17,7 @@
     {{ page_header('Set data retention') }}
     {% call form_wrapper() %}
       {{ notification_type | capitalize}}
-      {{  form.days_of_retention }}
+      {{ form.days_of_retention }}
       {{ page_footer('Save') }}
     {% endcall %}
 

--- a/app/templates/views/service-settings/email-reply-to/edit.html
+++ b/app/templates/views/service-settings/email-reply-to/edit.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/email-reply-to/verify.html
+++ b/app/templates/views/service-settings/email-reply-to/verify.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
-{% from "components/form.html" import form_wrapper %}
 {% from "components/ajax-block.html" import ajax_block %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/email_reply_to.html
+++ b/app/templates/views/service-settings/email_reply_to.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/letter-contact-details.html
+++ b/app/templates/views/service-settings/letter-contact-details.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/send-files-by-email.html
+++ b/app/templates/views/service-settings/send-files-by-email.html
@@ -1,8 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
-{% from "components/radios.html" import radio %}
-{% from "components/select-input.html" import select_wrapper %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/service-settings/set-auth-type.html
+++ b/app/templates/views/service-settings/set-auth-type.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
+++ b/app/templates/views/service-settings/set-branding-add-to-branding-pool-step.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer, sticky_page_footer %}
+{% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/error-summary.html" import errorSummary %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/set-branding.html
+++ b/app/templates/views/service-settings/set-branding.html
@@ -1,6 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer, sticky_page_footer %}
+{% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/set-message-limit.html
+++ b/app/templates/views/service-settings/set-message-limit.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/service-settings/sms-sender/edit.html
+++ b/app/templates/views/service-settings/sms-sender/edit.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}

--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import row_group, row, text_field, edit_field, field, boolean_field, list_table with context%}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/support/bat-phone.html
+++ b/app/templates/views/support/bat-phone.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/support/thanks.html
+++ b/app/templates/views/support/thanks.html
@@ -1,5 +1,4 @@
 {% extends "withoutnav_template.html" %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/temp-history.html
+++ b/app/templates/views/temp-history.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, field %}
 {% from "components/pill.html" import pill %}
 
 {% block service_page_title %}

--- a/app/templates/views/templates/action_blocked.html
+++ b/app/templates/views/templates/action_blocked.html
@@ -1,6 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/templates/breaking-change.html
+++ b/app/templates/views/templates/breaking-change.html
@@ -1,5 +1,4 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/list.html" import list_of_placeholders, list_of_code_snippets %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -3,7 +3,6 @@
 {% from "components/live-search.html" import live_search %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
 
 {% extends "withnav_template.html" %}
 

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -1,4 +1,4 @@
-{% from "components/folder-path.html" import copy_folder_path, page_title_folder_path %}
+{% from "components/folder-path.html" import copy_folder_path %}
 {% from "components/live-search.html" import live_search %}
 
 {% extends "withnav_template.html" %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
-{% from "components/page-footer.html" import page_footer %}
 {% from "components/copy-to-clipboard.html" import copy_to_clipboard %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 

--- a/app/templates/views/terms-of-use.html
+++ b/app/templates/views/terms-of-use.html
@@ -1,7 +1,5 @@
 {% extends "content_template.html" %}
 
-{% from "components/banner.html" import banner_wrapper %}
-
 {# Used by the content_template.html layout, prefixes the "navigation" accessible name #}
 {% set navigation_label_prefix = 'About Notify' %}
 

--- a/app/templates/views/uploads/contact-list/column-errors.html
+++ b/app/templates/views/uploads/contact-list/column-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/uploads/contact-list/contact-list.html
+++ b/app/templates/views/uploads/contact-list/contact-list.html
@@ -1,10 +1,7 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
 {% from "components/big-number.html" import big_number %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading, row, row_heading %}
+{% from "components/table.html" import list_table, field, text_field, row_heading %}
 {% from "components/page-header.html" import page_header %}
-{% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/uploads/contact-list/ok.html
+++ b/app/templates/views/uploads/contact-list/ok.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
-{% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}

--- a/app/templates/views/uploads/contact-list/row-errors.html
+++ b/app/templates/views/uploads/contact-list/row-errors.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, field, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/uploads/contact-list/too-many-columns.html
+++ b/app/templates/views/uploads/contact-list/too-many-columns.html
@@ -1,7 +1,6 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
-{% from "components/radios.html" import radio_select %}
-{% from "components/table.html" import list_table, field, text_field, index_field, hidden_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 

--- a/app/templates/views/uploads/contact-list/upload.html
+++ b/app/templates/views/uploads/contact-list/upload.html
@@ -2,7 +2,7 @@
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/file-upload.html" import file_upload %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/table.html" import list_table, text_field, index_field, index_field_heading %}
+{% from "components/table.html" import list_table, text_field, index_field %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% block service_page_title %}

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -1,5 +1,5 @@
 {% from "components/big-number.html" import big_number %}
-{% from "components/table.html" import list_table, field, hidden_field_heading, row_heading, text_field %}
+{% from "components/table.html" import list_table, field, hidden_field_heading, row_heading %}
 {% from "components/page-header.html" import page_header %}
 {% from "components/pill.html" import pill %}
 

--- a/app/templates/views/user-profile/security-keys.html
+++ b/app/templates/views/user-profile/security-keys.html
@@ -2,7 +2,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "govuk_frontend_jinja/components/button/macro.html" import govukButton %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
-{% from "components/table.html" import edit_field, mapping_table, row, field, row_heading %}
+{% from "components/table.html" import edit_field, mapping_table, row, field %}
 {% from "components/webauthn-api-check.html" import webauthn_api_check %}
 {% from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary %}
 


### PR DESCRIPTION
i hacked together a script that parses all jinja files, identifies macro declarations, then finds any files that import those macros but don't use them

the only unused import i didn't remove was from the accessibility statement because then it wanted me to update the last reviewed date for the unit test

the script wasn't perfect, there were some false positives when words like `select` and are sometimes a macro, and are sometimes just the word select. but all the things i removed were legitimate

```python
import re
import pathlib
import logging


all_macros = {}
# read all files to find macro definitions
for template_path in pathlib.Path("app/templates").glob("**/*.html"):
    with open(template_path, "r") as f:
        lines = f.readlines()
    for line in lines:
        if match := re.search(r"\{%\s+macro\s+(.+?)\(", line):
            all_macros[match.group(1)] = 0

# read all files again to find usage
for template_path in pathlib.Path("app/templates").glob("**/*.html"):
    with open(template_path, "r") as f:
        lines = f.readlines()

    imports = set()
    used_macros = set()
    defined_macros = set()

    for line in lines:
        line = line.strip()

        # find imports. theres a bit of nuance - they can look as complex as
        # {% from "components/page-footer.html" import a, b, c, d with context -%}
        if match := re.search(r"""\{%\s*from\s+['"](.+?)['"]\s+import\s+(.+?)( with context)?\s*-?%\}""", line):
            imported_things = [x.strip() for x in match.group(2).split(",")]
            for imported_thing in imported_things:
                if imported_thing not in all_macros and "govuk_frontend_jinja/components" in line:
                    # make sure we dont have unused frontend macros (that have no definition in our code)
                    all_macros[imported_thing] = 0
                imports.add(imported_thing)
        elif match := re.search(r"\{%\s+macro\s+(.+?)\(", line):
            defined_macros.add(match.group(1))
        # its not a macro definition OR an import. just a normal template line
        else:
            # split into tokens on spaces, commas, brackets etc
            tokens = re.split(r"[%{\s,(]", line)
            for token in tokens:
                if token in all_macros:
                    used_macros.add(token)
                    all_macros[token] += 1

    if unused_macros := imports - used_macros:
        logging.error(f" {template_path} unused: {' '.join(unused_macros)}")
    if undeclared_macros := used_macros - defined_macros - imports:
        logging.error(f" {template_path} undeclared {' '.join(undeclared_macros)}")

for macro in all_macros:
    if all_macros[macro] == 0:
        # this is okay if its a govuk-jinja component as we dont import them directly (but render them as a widget)
        logging.error(f"globally unused macro {macro}")
```