### PR TITLE
Fix naming of new service attribute

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -208,7 +208,7 @@ def submit_request_to_go_live(service_id):
 
     current_service.update(
         go_live_user=current_user.id,
-        has_current_request_to_go_live=True,
+        has_active_go_live_request=True,
     )
 
     flash("Thanks for your request to go live. We’ll get back to you within one working day.", "default")

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -84,7 +84,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "free_sms_fragment_limit",
             "go_live_at",
             "go_live_user",
-            "has_current_request_to_go_live",
+            "has_active_go_live_request",
             "letter_branding",
             "letter_contact_block",
             "message_limit",
@@ -119,7 +119,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             message_limit=250000 if live else 50,
             restricted=(not live),
             go_live_at=str(datetime.utcnow()) if live else None,
-            has_current_request_to_go_live=False,
+            has_active_go_live_request=False,
         )
 
     @cache.delete("live-service-and-organisation-counts")

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -637,7 +637,7 @@ def test_switch_service_to_live(
         message_limit=250000,
         restricted=False,
         go_live_at="2017-04-01 11:09:00.061258",
-        has_current_request_to_go_live=False,
+        has_active_go_live_request=False,
     )
 
 
@@ -680,7 +680,7 @@ def test_switch_service_to_restricted(
         message_limit=50,
         restricted=True,
         go_live_at=None,
-        has_current_request_to_go_live=False,
+        has_active_go_live_request=False,
     )
 
 
@@ -1626,7 +1626,7 @@ def test_should_redirect_after_request_to_go_live(
     mock_update_service.assert_called_once_with(
         SERVICE_ONE_ID,
         go_live_user=active_user_with_permissions["id"],
-        has_current_request_to_go_live=True,
+        has_active_go_live_request=True,
     )
 
 


### PR DESCRIPTION
In the database<sup>1</sup> and database model<sup>2</sup> the column is called `has_active_request_to_go_live`

The admin app is currently trying to update the wrong thing.

1. https://github.com/alphagov/notifications-api/pull/3677/files#diff-d2e60dc75e65d1a6ba0b66a7c97c7b2776ae51143d6fc069af8872f8338bae9bR16
2. https://github.com/alphagov/notifications-api/pull/3678/files#diff-90c680eba43456b516da8b4c2573d467ae17d1b0ed4373549f2a593ced3616d5R535