### PR TITLE
Add profiling header to API requests

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -23,12 +23,20 @@ class NotifyAdminAPIClient(BaseAPIClient):
         self.api_key = app.config["ADMIN_CLIENT_SECRET"]
         self.route_secret = app.config["ROUTE_SECRET_KEY_1"]
 
+    @staticmethod
+    def _notify_profile():
+        if not has_request_context() or not current_user:
+            return "0"
+
+        return "1" if "debug" in request.args and current_user.platform_admin else "0"
+
     def generate_headers(self, api_token):
         headers = {
             "Content-type": "application/json",
             "Authorization": "Bearer {}".format(api_token),
             "X-Custom-Forwarder": self.route_secret,
             "User-agent": "NOTIFY-API-PYTHON-CLIENT/{}".format(__version__),
+            "X-Notify-Profile": self._notify_profile(),
         }
         return self._add_request_id_header(headers)
 

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -78,11 +78,18 @@ def test_generate_headers_sets_standard_headers(notify_admin):
     # with patch('app.notify_client.has_request_context', return_value=False):
     headers = api_client.generate_headers("api_token")
 
-    assert set(headers.keys()) == {"Authorization", "Content-type", "User-agent", "X-Custom-Forwarder"}
+    assert set(headers.keys()) == {
+        "Authorization",
+        "Content-type",
+        "User-agent",
+        "X-Custom-Forwarder",
+        "X-Notify-Profile",
+    }
     assert headers["Authorization"] == "Bearer api_token"
     assert headers["Content-type"] == "application/json"
     assert headers["User-agent"].startswith("NOTIFY-API-PYTHON-CLIENT")
     assert headers["X-Custom-Forwarder"] == "proxy-secret"
+    assert headers["X-Notify-Profile"] == "0"
 
 
 def test_generate_headers_sets_request_id_if_in_request_context(notify_admin):
@@ -97,6 +104,7 @@ def test_generate_headers_sets_request_id_if_in_request_context(notify_admin):
         "Content-type",
         "User-agent",
         "X-Custom-Forwarder",
+        "X-Notify-Profile",
         "X-B3-TraceId",
         "X-B3-SpanId",
     }


### PR DESCRIPTION
Allow platform admins to add a `?debug` query param to a URL to enable profiling the request through to the API.

This and the sister api PR https://github.com/alphagov/notifications-api/pull/3681 are both likely to just get fully reverted after a while, so don't expect this code to live forever.