### PR TITLE
Add a new page for making a service live

### DIFF
--- a/app/assets/stylesheets/components/navigation.scss
+++ b/app/assets/stylesheets/components/navigation.scss
@@ -136,11 +136,6 @@
 
   }
 
-  li {
-    margin: 0;
-    list-style-type: none;
-  }
-
   a {
     display: block;
     padding: 5px 0;
@@ -154,6 +149,19 @@
       // between selected and unselected states
       left: -0.5px;
       letter-spacing: -0.01em;
+    }
+
+  }
+
+  &__item {
+
+    margin: 0;
+    list-style-type: none;
+
+    &--with-separator {
+      margin-top: govuk-spacing(3);
+      border-top: 1px solid $govuk-border-colour;
+      padding-top: govuk-spacing(1);
     }
 
   }

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -23,6 +23,7 @@ from app.main.views import (  # noqa
     invites,
     jobs,
     letter_branding,
+    make_service_live,
     manage_users,
     new_password,
     notifications,

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -753,7 +753,7 @@ class OptionalGovukRadiosField(GovukRadiosField):
 
 
 class OnOffField(GovukRadiosField):
-    def __init__(self, label, choices=None, thing=None, *args, **kwargs):
+    def __init__(self, label, choices=None, choices_for_error_message=None, *args, **kwargs):
         choices = choices or [
             (True, "On"),
             (False, "Off"),
@@ -761,7 +761,7 @@ class OnOffField(GovukRadiosField):
         super().__init__(
             label,
             choices=choices,
-            thing=thing or f"{choices[0][1].lower()} or {choices[1][1].lower()}",
+            thing=choices_for_error_message or f"{choices[0][1].lower()} or {choices[1][1].lower()}",
             *args,
             **kwargs,
         )
@@ -1612,15 +1612,15 @@ class ServiceLetterContactBlockForm(StripWhitespaceForm):
 
 
 class OnOffSettingForm(StripWhitespaceForm):
-    def __init__(self, name, *args, truthy="On", falsey="Off", thing=None, **kwargs):
+    def __init__(self, name, *args, truthy="On", falsey="Off", choices_for_error_message=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.enabled.label.text = name
         self.enabled.choices = [
             (True, truthy),
             (False, falsey),
         ]
-        if thing:
-            self.enabled.thing = thing
+        if choices_for_error_message:
+            self.enabled.thing = choices_for_error_message
 
     enabled = OnOffField("Choices")
 

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -753,7 +753,7 @@ class OptionalGovukRadiosField(GovukRadiosField):
 
 
 class OnOffField(GovukRadiosField):
-    def __init__(self, label, choices=None, *args, **kwargs):
+    def __init__(self, label, choices=None, thing=None, *args, **kwargs):
         choices = choices or [
             (True, "On"),
             (False, "Off"),
@@ -761,7 +761,7 @@ class OnOffField(GovukRadiosField):
         super().__init__(
             label,
             choices=choices,
-            thing=f"{choices[0][1].lower()} or {choices[1][1].lower()}",
+            thing=thing or f"{choices[0][1].lower()} or {choices[1][1].lower()}",
             *args,
             **kwargs,
         )
@@ -1612,13 +1612,15 @@ class ServiceLetterContactBlockForm(StripWhitespaceForm):
 
 
 class OnOffSettingForm(StripWhitespaceForm):
-    def __init__(self, name, *args, truthy="On", falsey="Off", **kwargs):
+    def __init__(self, name, *args, truthy="On", falsey="Off", thing=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.enabled.label.text = name
         self.enabled.choices = [
             (True, truthy),
             (False, falsey),
         ]
+        if thing:
+            self.enabled.thing = thing
 
     enabled = OnOffField("Choices")
 

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -21,7 +21,7 @@ def make_service_live(service_id):
         name="What would you like to do?",
         truthy="Approve the request and make this service live",
         falsey="Reject the request",
-        thing="approve or reject",
+        choices_for_error_message="approve or reject",
     )
 
     if form.validate_on_submit():

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -1,4 +1,4 @@
-from flask import abort, redirect, render_template, url_for
+from flask import abort, flash, redirect, render_template, url_for
 from flask_login import current_user
 
 from app import current_service
@@ -23,6 +23,12 @@ def make_service_live(service_id):
 
     if form.validate_on_submit():
         current_service.update_status(live=form.enabled.data)
+
+        if form.enabled.data:
+            flash(f"‘{current_service.name}’ is now live", "default_with_tick")
+        else:
+            flash("Request to go live rejected", "default")
+
         return redirect(url_for(".organisation_dashboard", org_id=current_service.organisation_id))
 
     return render_template(

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -1,0 +1,27 @@
+from flask import abort, redirect, render_template, url_for
+from flask_login import current_user
+
+from app import current_service
+from app.main import main
+from app.main.forms import OnOffSettingForm
+from app.utils.user import user_has_permissions
+
+
+@main.route("/services/<uuid:service_id>/make-service-live", methods=["GET", "POST"])
+@user_has_permissions(allow_org_user=True)
+def make_service_live(service_id):
+
+    if not current_user.can_make_service_live(current_service):
+        abort(403)
+
+    form = OnOffSettingForm(name="Make service live", enabled=not current_service.trial_mode)
+
+    if form.validate_on_submit():
+        current_service.update_status(live=form.enabled.data)
+        return redirect(url_for(".organisation_dashboard", org_id=current_service.organisation_id))
+
+    return render_template(
+        "views/service-settings/set-service-setting.html",
+        form=form,
+        title="Make service live",
+    )

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -14,7 +14,11 @@ def make_service_live(service_id):
     if not current_user.can_make_service_live(current_service):
         abort(403)
 
-    form = OnOffSettingForm(name="Make service live")
+    form = OnOffSettingForm(
+        name="What would you like to do?",
+        truthy="Approve the request and make this service live",
+        falsey="Reject the request",
+    )
 
     if form.validate_on_submit():
         current_service.update_status(live=form.enabled.data)

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -18,6 +18,7 @@ def make_service_live(service_id):
         name="What would you like to do?",
         truthy="Approve the request and make this service live",
         falsey="Reject the request",
+        thing="approve or reject",
     )
 
     if form.validate_on_submit():

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -12,7 +12,7 @@ from app.utils.user import user_has_permissions
 def make_service_live(service_id):
 
     if current_service.live:
-        return render_template("views/service-settings/service-already-live.html"), 410
+        return render_template("views/service-settings/service-already-live.html", prompt_to_switch_service=False), 410
 
     if not current_user.can_make_service_live(current_service):
         abort(403)

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -14,14 +14,14 @@ def make_service_live(service_id):
     if not current_user.can_make_service_live(current_service):
         abort(403)
 
-    form = OnOffSettingForm(name="Make service live", enabled=not current_service.trial_mode)
+    form = OnOffSettingForm(name="Make service live")
 
     if form.validate_on_submit():
         current_service.update_status(live=form.enabled.data)
         return redirect(url_for(".organisation_dashboard", org_id=current_service.organisation_id))
 
     return render_template(
-        "views/service-settings/set-service-setting.html",
+        "views/make-service-live.html",
         form=form,
         title="Make service live",
     )

--- a/app/main/views/make_service_live.py
+++ b/app/main/views/make_service_live.py
@@ -11,6 +11,9 @@ from app.utils.user import user_has_permissions
 @user_has_permissions(allow_org_user=True)
 def make_service_live(service_id):
 
+    if current_service.live:
+        return render_template("views/service-settings/service-already-live.html"), 410
+
     if not current_user.can_make_service_live(current_service):
         abort(403)
 

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -181,7 +181,7 @@ def estimate_usage(service_id):
 @user_has_permissions("manage_service")
 def request_to_go_live(service_id):
     if current_service.live:
-        return render_template("views/service-settings/service-already-live.html")
+        return render_template("views/service-settings/service-already-live.html", prompt_to_switch_service=True)
 
     return render_template("views/service-settings/request-to-go-live.html")
 

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -121,6 +121,7 @@ class Organisation(JSONModel):
             self.request_to_go_live_notes = None
             self.email_branding_id = None
             self.letter_branding_id = None
+            self.can_approve_own_go_live_requests = False
 
     @property
     def organisation_type_label(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -33,7 +33,6 @@ class Service(JSONModel):
         "count_as_live",
         "email_from",
         "go_live_at",
-        "go_live_user",
         "has_active_go_live_request",
         "id",
         "inbound_api",
@@ -408,6 +407,10 @@ class Service(JSONModel):
         )
 
     @property
+    def volumes_by_channel(self):
+        return ((channel, getattr(self, f"volume_{channel}")) for channel in ("email", "sms", "letter"))
+
+    @property
     def go_live_checklist_completed(self):
         return all(
             (
@@ -422,6 +425,10 @@ class Service(JSONModel):
     @property
     def go_live_checklist_completed_as_yes_no(self):
         return "Yes" if self.go_live_checklist_completed else "No"
+
+    @property
+    def go_live_user(self):
+        return User.from_id(self._dict["go_live_user"])
 
     @cached_property
     def free_sms_fragment_limit(self):

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -34,6 +34,7 @@ class Service(JSONModel):
         "email_from",
         "go_live_at",
         "go_live_user",
+        "has_active_go_live_request",
         "id",
         "inbound_api",
         "message_limit",

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -438,6 +438,15 @@ class User(BaseUser, UserMixin):
             return True
         return False
 
+    def can_make_service_live(self, service):
+        return (
+            self.platform_admin
+            or (
+                self.belongs_to_organisation(service.organisation_id)
+                and service.organisation.can_approve_own_go_live_requests
+            )
+        ) and service.has_active_go_live_request
+
 
 class InvitedUser(BaseUser):
 

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -294,6 +294,9 @@ class MainNavigation(Navigation):
             "guest_list",
             "old_guest_list",
         },
+        "make-service-live": {
+            "make_service_live",
+        },
     }
 
 

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -37,6 +37,9 @@
     <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
     <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
+  {% if current_user.can_make_service_live(current_service) %}
+    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('make-service-live') }}" href="{{ url_for('.make_service_live', service_id=current_service.id) }}">Make service live</a></li>
+  {% endif %}
   </ul>
 </nav>
 {% endif %}

--- a/app/templates/main_nav.html
+++ b/app/templates/main_nav.html
@@ -5,40 +5,40 @@
   <ul>
   {% if current_user.has_permissions() %}
     {% if current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Past alerts</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('rejected-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_rejected', service_id=current_service.id) }}">Rejected alerts</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('current-broadcasts') }}" href="{{ url_for('.broadcast_dashboard', service_id=current_service.id) }}">Current alerts</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('previous-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_previous', service_id=current_service.id) }}">Past alerts</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('rejected-broadcasts') }}" href="{{ url_for('.broadcast_dashboard_rejected', service_id=current_service.id) }}">Rejected alerts</a></li>
     {% elif current_user.has_permissions('view_activity') %}
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('dashboard') }}" href="{{ url_for('.service_dashboard', service_id=current_service.id) }}">Dashboard</a></li>
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
     {% if not current_user.has_permissions('view_activity') %}
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ casework_navigation.is_selected('sent-messages') }}" href="{{ url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed') }}">Sent messages</a></li>
     {% endif %}
     {% if not current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('uploads') }}" href="{{ url_for('main.uploads', service_id=current_service.id) }}">Uploads</a></li>
     {% endif %}
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
     {% if current_user.has_permissions('manage_service', allow_org_user=True) and not current_service.has_permission('broadcast') %}
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-      <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
+      <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('settings') }}" href="{{ url_for('.service_settings', service_id=current_service.id) }}">Settings</a></li>
     {% endif %}
     {% if current_user.has_permissions('manage_api_keys') %}
       {% if current_service.has_permission('broadcast') %}
-        <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API integration</a></li>
+        <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_keys', service_id=current_service.id) }}">API integration</a></li>
       {% else %}
-        <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
+        <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('api-integration') }}" href="{{ url_for('.api_integration', service_id=current_service.id) }}">API integration</a></li>
       {% endif %}
     {% endif %}
   {% elif current_user.has_permissions(allow_org_user=True) %}
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('usage') }}" href="{{ url_for('.usage', service_id=current_service.id) }}">Usage</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('templates') }}" href="{{ url_for('.choose_template', service_id=current_service.id) }}">Templates</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_users', service_id=current_service.id) }}">Team members</a></li>
   {% endif %}
   {% if current_user.can_make_service_live(current_service) %}
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('make-service-live') }}" href="{{ url_for('.make_service_live', service_id=current_service.id) }}">Make service live</a></li>
+    <li class="navigation__item navigation__item--with-separator"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ main_navigation.is_selected('make-service-live') }}" href="{{ url_for('.make_service_live', service_id=current_service.id) }}">Make service live</a></li>
   {% endif %}
   </ul>
 </nav>

--- a/app/templates/org_nav.html
+++ b/app/templates/org_nav.html
@@ -1,11 +1,11 @@
 <nav class="navigation" aria-label="Organisation">
   <ul>
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('dashboard') }}" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Usage</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('dashboard') }}" href="{{ url_for('.organisation_dashboard', org_id=current_org.id) }}">Usage</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('team-members') }}" href="{{ url_for('.manage_org_users', org_id=current_org.id) }}">Team members</a></li>
     {% if current_user.platform_admin %}
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('settings') }}" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}">Settings</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('trial-services') }}" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}">Trial mode services</a></li>
-    <li><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('billing') }}" href="{{ url_for('.organisation_billing', org_id=current_org.id) }}">Billing</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('settings') }}" href="{{ url_for('.organisation_settings', org_id=current_org.id) }}">Settings</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('trial-services') }}" href="{{ url_for('.organisation_trial_mode_services', org_id=current_org.id) }}">Trial mode services</a></li>
+    <li class="navigation__item"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline{{ org_navigation.is_selected('billing') }}" href="{{ url_for('.organisation_billing', org_id=current_org.id) }}">Billing</a></li>
     {% endif %}
   </ul>
 </nav>

--- a/app/templates/views/make-service-live.html
+++ b/app/templates/views/make-service-live.html
@@ -1,0 +1,31 @@
+{% extends "withnav_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set title = "Make service live" %}
+
+{% block service_page_title %}
+  {{ title }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-five-sixths">
+      {% call form_wrapper() %}
+        {{ form.enabled(param_extensions={
+          "fieldset": {
+            "classes": "govuk-!-margin-top-3",
+            "legend": {
+              "isPageHeading": True,
+              "classes": "govuk-fieldset__legend--m"
+            }
+          }
+        }) }}
+        {{ page_footer('Save') }}
+      {% endcall %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/templates/views/make-service-live.html
+++ b/app/templates/views/make-service-live.html
@@ -1,4 +1,5 @@
 {% extends "withnav_template.html" %}
+{% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
@@ -11,20 +12,40 @@
 
 {% block maincolumn_content %}
 
+  {{ page_header(title) }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
+
+      <p class="govuk-body">
+        {{ current_service.go_live_user.name }} has requested for this service to be made live.
+      </p>
+
+      <p class="govuk-body">
+        They estimate this service will send:
+      </p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        {% for channel, volumes in current_service.volumes_by_channel %}
+          <li>
+            {% if volumes %}
+              {{ volumes|message_count(channel) }} per year
+            {% else %}
+              No {{ 0|message_count_noun(channel) }}
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+
       {% call form_wrapper() %}
         {{ form.enabled(param_extensions={
-          "fieldset": {
-            "classes": "govuk-!-margin-top-3",
-            "legend": {
-              "isPageHeading": True,
-              "classes": "govuk-fieldset__legend--m"
-            }
-          }
+          "items": [
+            {"hint": {"text": "We’ll email this service’s team members to let them know"} },
+            {"hint": {"html": "You should contact " + current_service.go_live_user.name + " to explain why the request has not been approved"} },
+          ]
         }) }}
-        {{ page_footer('Save') }}
+        {{ page_footer('Confirm') }}
       {% endcall %}
+
     </div>
   </div>
 

--- a/app/templates/views/service-settings/service-already-live.html
+++ b/app/templates/views/service-settings/service-already-live.html
@@ -1,14 +1,16 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
 
+{% set title = "Your service is already live" if current_user.belongs_to_service(current_service.id) else "This service is already live" %}
+
 {% block service_page_title %}
-  Your service is already live
+  {{ title }}
 {% endblock %}
 
 {% block maincolumn_content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      {{ page_header('Your service is already live') }}
+      {{ page_header(title) }}
 
       <p class="govuk-body">
         {% if current_service.go_live_at %}
@@ -18,10 +20,12 @@
         {% endif %}
         </p>
 
+      {% if prompt_to_switch_service %}
       <p class="govuk-body">
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.choose_account') }}">Switch service</a>
          if you want to make a different service live.
       </p>
+      {% endif %}
 
     </div>
   </div>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -191,6 +191,7 @@ def service_json(
     purchase_order_number=None,
     broadcast_channel=None,
     allowed_broadcast_provider=None,
+    has_active_go_live_request=False,
 ):
     if users is None:
         users = []
@@ -239,6 +240,7 @@ def service_json(
         "purchase_order_number": purchase_order_number,
         "broadcast_channel": broadcast_channel,
         "allowed_broadcast_provider": allowed_broadcast_provider,
+        "has_active_go_live_request": has_active_go_live_request,
     }
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -192,6 +192,7 @@ def service_json(
     broadcast_channel=None,
     allowed_broadcast_provider=None,
     has_active_go_live_request=False,
+    go_live_user=None,
 ):
     if users is None:
         users = []
@@ -241,6 +242,7 @@ def service_json(
         "broadcast_channel": broadcast_channel,
         "allowed_broadcast_provider": allowed_broadcast_provider,
         "has_active_go_live_request": has_active_go_live_request,
+        "go_live_user": go_live_user,
     }
 
 

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -77,7 +77,7 @@ def test_get_make_service_live_page(
         _expected_status=expected_status,
     )
 
-    if expected_status < 300:
+    if expected_status == 200:
         assert (
             normalize_spaces(page.select_one("main p")) == "Test User has requested for this service to be made live."
         )

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -147,3 +147,27 @@ def test_post_make_service_live_page(
         SERVICE_ONE_ID,
         **expected_arguments_to_update_service,
     )
+
+
+def test_post_make_service_live_page_error(
+    mocker,
+    client_request,
+    platform_admin_user,
+    service_one,
+    mock_get_organisation,
+    mock_update_service,
+):
+
+    service_one["has_active_go_live_request"] = True
+    service_one["organisation"] = ORGANISATION_ID
+
+    client_request.login(platform_admin_user)
+
+    page = client_request.post(
+        "main.make_service_live",
+        service_id=SERVICE_ONE_ID,
+        _data={},
+        _expected_status=200,
+    )
+    assert normalize_spaces(page.select_one(".govuk-error-message")) == "Error: Select approve or reject"
+    assert mock_update_service.called is False

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -1,0 +1,139 @@
+import pytest
+from flask import url_for
+from freezegun import freeze_time
+
+from tests.conftest import (
+    ORGANISATION_ID,
+    SERVICE_ONE_ID,
+    create_user,
+    normalize_spaces,
+    sample_uuid,
+)
+
+
+@pytest.mark.parametrize(
+    "user, organisation_can_approve_own_go_live_requests, service_has_active_go_live_request, expected_status",
+    (
+        (
+            # A user who is a member of the organisation
+            create_user(id=sample_uuid(), organisations=[ORGANISATION_ID]),
+            True,
+            True,
+            200,
+        ),
+        (
+            # A platform admin users who is not a member of the organisation
+            create_user(id=sample_uuid(), platform_admin=True),
+            True,
+            True,
+            200,
+        ),
+        (
+            # User who is a not an organisation team member can’t approve go live requests
+            create_user(id=sample_uuid()),
+            True,
+            True,
+            403,
+        ),
+        (
+            # If the organisation can’t approve its own go live requests then the user is blocked
+            create_user(id=sample_uuid(), organisations=[ORGANISATION_ID]),
+            False,
+            True,
+            403,
+        ),
+        (
+            # If the service doesn’t have an active go live request then the user is blocked
+            create_user(id=sample_uuid(), organisations=[ORGANISATION_ID]),
+            False,
+            True,
+            403,
+        ),
+    ),
+)
+def test_get_make_service_live_page(
+    mocker,
+    client_request,
+    service_one,
+    organisation_one,
+    user,
+    organisation_can_approve_own_go_live_requests,
+    service_has_active_go_live_request,
+    expected_status,
+):
+    organisation_one["can_approve_own_go_live_requests"] = organisation_can_approve_own_go_live_requests
+
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
+
+    service_one["has_active_go_live_request"] = service_has_active_go_live_request
+    service_one["organisation"] = ORGANISATION_ID
+
+    client_request.login(user)
+
+    page = client_request.get(
+        "main.make_service_live",
+        service_id=SERVICE_ONE_ID,
+        _expected_status=expected_status,
+    )
+
+    if expected_status < 300:
+        assert [
+            (radio.select_one("input[type=radio]")["value"], normalize_spaces(radio.select_one("label").text))
+            for radio in page.select(".govuk-radios__item")
+        ] == [
+            ("True", "On"),
+            ("False", "Off"),
+        ]
+
+
+@pytest.mark.parametrize(
+    "post_data, expected_arguments_to_update_service",
+    (
+        (
+            True,
+            {
+                "message_limit": 250000,
+                "restricted": False,
+                "go_live_at": "2022-12-22 12:12:12",
+                "has_active_go_live_request": False,
+            },
+        ),
+        (
+            False,
+            {
+                "message_limit": 50,
+                "restricted": True,
+                "go_live_at": None,
+                "has_active_go_live_request": False,
+            },
+        ),
+    ),
+)
+@freeze_time("2022-12-22 12:12:12")
+def test_post_make_service_live_page(
+    client_request,
+    platform_admin_user,
+    service_one,
+    mock_get_organisation,
+    mock_update_service,
+    post_data,
+    expected_arguments_to_update_service,
+):
+    service_one["has_active_go_live_request"] = True
+    service_one["organisation"] = ORGANISATION_ID
+
+    client_request.login(platform_admin_user)
+
+    client_request.post(
+        "main.make_service_live",
+        service_id=SERVICE_ONE_ID,
+        _data={
+            "enabled": post_data,
+        },
+        _expected_redirect=url_for("main.organisation_dashboard", org_id=ORGANISATION_ID),
+    )
+
+    mock_update_service.assert_called_once_with(
+        SERVICE_ONE_ID,
+        **expected_arguments_to_update_service,
+    )

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -45,8 +45,8 @@ from tests.conftest import (
         (
             # If the service doesn’t have an active go live request then the user is blocked
             create_user(id=sample_uuid(), organisations=[ORGANISATION_ID]),
-            False,
             True,
+            False,
             403,
         ),
     ),

--- a/tests/app/main/views/test_make_service_live.py
+++ b/tests/app/main/views/test_make_service_live.py
@@ -67,6 +67,7 @@ def test_get_make_service_live_page(
 
     service_one["has_active_go_live_request"] = service_has_active_go_live_request
     service_one["organisation"] = ORGANISATION_ID
+    service_one["volume_letter"] = None
 
     client_request.login(user)
 
@@ -77,12 +78,21 @@ def test_get_make_service_live_page(
     )
 
     if expected_status < 300:
+        assert (
+            normalize_spaces(page.select_one("main p")) == "Test User has requested for this service to be made live."
+        )
+        assert [normalize_spaces(li) for li in page.select("main li")] == [
+            "111,111 emails per year",
+            "222,222 text messages per year",
+            "No letters",
+        ]
+
         assert [
             (radio.select_one("input[type=radio]")["value"], normalize_spaces(radio.select_one("label").text))
             for radio in page.select(".govuk-radios__item")
         ] == [
-            ("True", "On"),
-            ("False", "Off"),
+            ("True", "Approve the request and make this service live"),
+            ("False", "Reject the request"),
         ]
 
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -971,6 +971,7 @@ def test_should_show_page_for_inviting_user_with_email_prefilled(
     active_user_with_permissions,
     active_user_with_permission_to_other_service,
     mock_get_organisation_by_domain,
+    mock_get_organisation,
     mock_get_invites_for_service,
 ):
     service_one["organisation"] = ORGANISATION_ID

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -619,10 +619,11 @@ def test_make_service_live_link_is_shown_in_limited_circumstances(
 
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
 
-    last_navigation_item = page.select(".navigation a")[-1]
+    last_navigation_item = page.select(".navigation li")[-1]
 
+    assert last_navigation_item["class"] == ["navigation__item", "navigation__item--with-separator"]
     assert normalize_spaces(last_navigation_item.text) == "Make service live"
-    assert last_navigation_item["href"] == url_for(
+    assert last_navigation_item.select_one("a")["href"] == url_for(
         "main.make_service_live",
         service_id=SERVICE_ONE_ID,
     )


### PR DESCRIPTION
Unlike the service settings page this page is usable by both platform admins and members of the organisation (if the organisation is allowed to approve its own go live requests).

For some organisations we want to let them make their own services live. This is because:
- we think they are better informed to make decisions about which services should be live
- it will reduce our support burden

To facilitate this, this pull requests adds:
- a page where organisation team members can make a service live
- a link to this page from the left hand navigation

The link is styled so that it stands out from the rest of the links in the navigation, and so that it feels like a different/separate thing.

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/355079/209144427-0c15f7c4-a6aa-4018-a4bb-3cd1c282cb65.png">
