### PR TITLE
Email an organisation’s users when one of its service requests to go live

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -210,6 +210,8 @@ def submit_request_to_go_live(service_id):
         has_active_go_live_request=True,
     )
 
+    current_service.notify_organisation_users_of_request_to_go_live()
+
     flash("Thanks for your request to go live. We’ll get back to you within one working day.", "default")
     return redirect(url_for(".service_settings", service_id=service_id))
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -430,6 +430,10 @@ class Service(JSONModel):
     def go_live_user(self):
         return User.from_id(self._dict["go_live_user"])
 
+    def notify_organisation_users_of_request_to_go_live(self):
+        if self.organisation.can_approve_own_go_live_requests:
+            return organisations_client.notify_users_of_request_to_go_live_for_service(self.id)
+
     @cached_property
     def free_sms_fragment_limit(self):
         return billing_api_client.get_free_sms_fragment_limit_for_year(self.id) or 0

--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -128,5 +128,11 @@ class OrganisationsClient(NotifyAdminAPIClient):
     def remove_letter_branding_from_pool(self, org_id, branding_id):
         self.delete(f"/organisations/{org_id}/letter-branding-pool/{branding_id}")
 
+    def notify_users_of_request_to_go_live_for_service(self, service_id):
+        self.post(
+            url=f"/organisations/notify-users-of-request-to-go-live/{service_id}",
+            data=None,
+        )
+
 
 organisations_client = OrganisationsClient()

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -1786,32 +1786,16 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
 def test_request_to_go_live_is_sent_to_organiation_if_can_be_approved_by_organisation(
     client_request,
     mocker,
-    single_reply_to_email_address,
-    single_letter_contact_block,
-    single_sms_sender,
     mock_get_organisations_and_services_for_user,
     mock_get_service_organisation,
-    mock_get_service_templates,
-    mock_get_users_by_service,
     mock_update_service,
-    mock_get_invites_without_manage_permission,
     mock_notify_users_of_request_to_go_live_for_service,
-    service_one,
     organisation_one,
     can_approve_own_go_live_requests,
     expected_call_args,
 ):
     organisation_one["can_approve_own_go_live_requests"] = can_approve_own_go_live_requests
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
-
-    for channel in {"email", "sms", "letter"}:
-        mocker.patch(
-            "app.models.service.Service.volume_{}".format(channel),
-            create=True,
-            new_callable=PropertyMock,
-            return_value=1,
-        )
-
     mocker.patch("app.main.views.service_settings.index.zendesk_client.send_ticket_to_zendesk", autospec=True)
 
     client_request.post("main.request_to_go_live", service_id=SERVICE_ONE_ID)

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -1777,6 +1777,49 @@ def test_should_be_able_to_request_to_go_live_with_no_organisation(
 
 
 @pytest.mark.parametrize(
+    "can_approve_own_go_live_requests, expected_call_args",
+    (
+        (True, [call(SERVICE_ONE_ID)]),
+        (False, []),
+    ),
+)
+def test_request_to_go_live_is_sent_to_organiation_if_can_be_approved_by_organisation(
+    client_request,
+    mocker,
+    single_reply_to_email_address,
+    single_letter_contact_block,
+    single_sms_sender,
+    mock_get_organisations_and_services_for_user,
+    mock_get_service_organisation,
+    mock_get_service_templates,
+    mock_get_users_by_service,
+    mock_update_service,
+    mock_get_invites_without_manage_permission,
+    mock_notify_users_of_request_to_go_live_for_service,
+    service_one,
+    organisation_one,
+    can_approve_own_go_live_requests,
+    expected_call_args,
+):
+    organisation_one["can_approve_own_go_live_requests"] = can_approve_own_go_live_requests
+    mocker.patch("app.organisations_client.get_organisation", return_value=organisation_one)
+
+    for channel in {"email", "sms", "letter"}:
+        mocker.patch(
+            "app.models.service.Service.volume_{}".format(channel),
+            create=True,
+            new_callable=PropertyMock,
+            return_value=1,
+        )
+
+    mocker.patch("app.main.views.service_settings.index.zendesk_client.send_ticket_to_zendesk", autospec=True)
+
+    client_request.post("main.request_to_go_live", service_id=SERVICE_ONE_ID)
+
+    assert mock_notify_users_of_request_to_go_live_for_service.call_args_list == expected_call_args
+
+
+@pytest.mark.parametrize(
     (
         "has_team_members,"
         "has_templates,"

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -373,3 +373,14 @@ def test_remove_letter_branding_from_organisation_pool(mocker):
 
     assert mock_redis_delete.call_args_list == [call(f"organisation-{org_id}-letter-branding-pool")]
     mock_delete.assert_called_with(f"/organisations/{org_id}/letter-branding-pool/{branding_id}")
+
+
+def test_notify_users_of_request_to_go_live_for_service(mocker, fake_uuid):
+    mock_post = mocker.patch("app.notify_client.organisations_api_client.OrganisationsClient.post")
+
+    organisations_client.notify_users_of_request_to_go_live_for_service(fake_uuid)
+
+    mock_post.assert_called_with(
+        url=f"/organisations/notify-users-of-request-to-go-live/{fake_uuid}",
+        data=None,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3198,6 +3198,17 @@ def mock_get_organisation_services(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
+def mock_notify_users_of_request_to_go_live_for_service(mocker, api_user_active):
+    def _notify_users_of_request_to_go_live_for_service(service_id):
+        return
+
+    return mocker.patch(
+        "app.organisations_client.notify_users_of_request_to_go_live_for_service",
+        side_effect=_notify_users_of_request_to_go_live_for_service,
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_get_users_for_organisation(mocker):
     def _get_users_for_organisation(org_id):
         return [


### PR DESCRIPTION
If an organisation can approve its own go-live requests then we should let them know when there’s a new service that wants to go live.

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/4538
- [x] https://github.com/alphagov/notifications-api/pull/3682