### PR TITLE
Only show ‘not set up’ message when user has chosen organisation branding

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1420,6 +1420,7 @@ def email_branding_choose_logo(service_id):
             "views/service-settings/branding/add-new-branding/email-branding-choose-logo.html",
             form=form,
             branding_options=form,
+            branding_choice=branding_choice,
         ),
         400 if form.errors else 200,
     )

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-logo.html
@@ -19,19 +19,27 @@
   }) }}
 {% endblock %}
 
+{% set prompt_text -%}
+  {% if branding_choice == "org" %}
+    {{ current_service.organisation_name }} branding is not set up yet.
+  {% elif branding_choice == "govuk_and_org" %}
+    GOV.UK and {{ current_service.organisation_name }} branding is not set up yet.
+  {% endif %}
+{%- endset %}
+
 {% block maincolumn_content %}
   {{ errorSummary(form) }}
 
   {% call form_wrapper() %}
-    {% if current_service.email_branding_id %}
-      {% set param_extensions = {} %}
-    {% else %}
+    {% if prompt_text %}
       {% set param_extensions = {
         "hint":{
-          "text": current_service.name + " branding is not set up yet.",
+          "text": prompt_text,
           "classes": "notify-hint--paragraph",
         }
       } %}
+    {% else %}
+      {% set param_extensions = {} %}
     {% endif %}
     {{ form.branding_options(param_extensions=param_extensions) }}
     {{ page_footer('Continue') }}

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -773,16 +773,60 @@ def test_email_branding_choose_logo_page(client_request, service_one):
     ]
 
 
-def test_email_branding_choose_logo_page_prevents_xss_attacks(client_request, service_one):
-    service_one["name"] = "<script>evil</script>"
+@pytest.mark.parametrize(
+    "branding_choice, expected_hint",
+    (
+        ("org", "Test organisation branding is not set up yet."),
+        ("govuk_and_org", "GOV.UK and Test organisation branding is not set up yet."),
+        ("something_else", ""),
+        ("", ""),
+    ),
+)
+def test_email_branding_choose_logo_page_shows_not_setup_message(
+    client_request,
+    service_one,
+    fake_uuid,
+    mock_get_organisation,
+    branding_choice,
+    expected_hint,
+):
+    service_one["organisation"] = fake_uuid
     page = client_request.get(
         "main.email_branding_choose_logo",
         service_id=SERVICE_ONE_ID,
+        branding_choice=branding_choice,
+    )
+
+    hint = page.select_one("#branding_options-hint")
+
+    if expected_hint:
+        assert normalize_spaces(hint.text) == expected_hint
+    else:
+        assert not hint
+
+
+def test_email_branding_choose_logo_page_prevents_xss_attacks(
+    mocker,
+    client_request,
+    service_one,
+    organisation_one,
+):
+    service_one["organisation"] = organisation_one
+    organisation_one["name"] = "<script>evil</script>"
+    mocker.patch(
+        "app.organisations_client.get_organisation",
+        return_value=organisation_one,
+    )
+
+    page = client_request.get(
+        "main.email_branding_choose_logo",
+        service_id=SERVICE_ONE_ID,
+        branding_choice="org",
     )
 
     hint = page.select_one("form .govuk-hint")
     assert not hint.select_one("script")
-    assert service_one["name"] in normalize_spaces(hint.text)
+    assert organisation_one["name"] in normalize_spaces(hint.text)
 
 
 def test_only_central_org_services_can_see_email_branding_choose_logo_page(client_request, service_one):


### PR DESCRIPTION
If the user has chosen their organisation’s branding but we don’t have it then we should let them know that they’re going to need to set it up.

I can’t remember if we did this and it changed to talk about the service<sup>1</sup> or if it was never like this.

Anyway, talking about the service’s branding not being set up doesn’t make sense when the user has pick an option labelled with the name of their organisation, so let’s fix it.


Before | After
---|---
<img width="770" alt="image" src="https://user-images.githubusercontent.com/355079/209970217-ea7f67da-e2af-49df-a776-321461bb1ff1.png"> | <img width="800" alt="image" src="https://user-images.githubusercontent.com/355079/209970137-570d867c-4107-49b9-9851-db2c11e5f92d.png">


***

1. `git blame` got me back as far as https://github.com/alphagov/notifications-admin/commit/7dafb91fb3bca38248236849e0b6b9fce7ecada4#diff-626679b981f01eb2e5471518344e7d131ef28b01b8d0aafbf2bc31d2f704ccabR35-R39 which doesn’t explain why the line was added