### PR TITLE
Tweak email branding journey to make it smoother

### DIFF
--- a/app/assets/stylesheets/components/radios-with-images.scss
+++ b/app/assets/stylesheets/components/radios-with-images.scss
@@ -1,5 +1,6 @@
 .notify-radios-with-images {
   display: flex;
+  margin-top: govuk-spacing(3);
 }
 
 .notify-radios-with-images__item {

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2113,33 +2113,33 @@ class EmailBrandingChooseLogoForm(StripWhitespaceForm):
 
 class EmailBrandingChooseBanner(Form):
     BANNER_CHOICES_DATA = {
-        "org": {
-            "label": "No banner",
-            "image": {
-                "url": asset_fingerprinter.get_url("images/branding/org.png"),
-                "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',
-                "dimensions": {"width": 404, "height": 454},
-            },
-        },
         "org_banner": {
-            "label": "Coloured banner",
+            "label": "Yes",
             "image": {
                 "url": asset_fingerprinter.get_url("images/branding/org_banner.png"),
                 "alt_text": "An example of an email with a logo on a blue banner.",
                 "dimensions": {"width": 404, "height": 454},
             },
         },
+        "org": {
+            "label": "No",
+            "image": {
+                "url": asset_fingerprinter.get_url("images/branding/org.png"),
+                "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',
+                "dimensions": {"width": 404, "height": 454},
+            },
+        },
     }
 
     banner = GovukRadiosWithImagesField(
-        "Add a banner to your logo",
+        "Does your logo appear on a coloured background?",
         choices=tuple((key, value["label"]) for key, value in BANNER_CHOICES_DATA.items()),
         image_data={key: value["image"] for key, value in BANNER_CHOICES_DATA.items()},
     )
 
 
 class EmailBrandingChooseBannerColour(StripWhitespaceForm):
-    hex_colour = HexColourCodeField("Choose a colour for your banner", validators=[DataRequired()])
+    hex_colour = HexColourCodeField("Choose a background colour", validators=[DataRequired()])
 
 
 class EmailBrandingAltTextForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -2125,7 +2125,7 @@ class EmailBrandingChooseBanner(Form):
             "label": "No",
             "image": {
                 "url": asset_fingerprinter.get_url("images/branding/org.png"),
-                "alt_text": 'An example of an email with the heading "Your logo" in blue text on a white background.',
+                "alt_text": "An example of an email with a logo on a clear background.",
                 "dimensions": {"width": 404, "height": 454},
             },
         },

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1199,7 +1199,6 @@ def email_branding_request(service_id):
             url_for(
                 ".email_branding_choose_banner_type",
                 service_id=current_service.id,
-                back_link=".email_branding_request",
                 branding_choice="something_else",
             )
         )
@@ -1606,13 +1605,19 @@ def email_branding_choose_banner_type(service_id):
             )
 
     org_type = current_service.organisation_type
-    back_link_fallback = ".email_branding_choose_logo" if org_type == "central" else ".service_settings"
+
+    if any(get_email_branding_choices(current_service)):
+        back_view_fallback = ".email_branding_choose_logo" if org_type == "central" else ".email_branding_request"
+        back_view = request.args.get("back_link", back_view_fallback)
+    else:
+        back_view = ".email_branding_request"
+
     return (
         render_template(
             "views/service-settings/branding/add-new-branding/email-branding-choose-banner.html",
             form=form,
             back_link=url_for(
-                request.args.get("back_link", back_link_fallback),
+                back_view,
                 service_id=current_service.id,
                 **_email_branding_flow_query_params(request),
             ),

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1193,10 +1193,17 @@ def create_email_branding_zendesk_ticket(form_option_selected, detail=None):
 @user_has_permissions("manage_service")
 def email_branding_request(service_id):
     form = ChooseEmailBrandingForm(current_service)
-    if form.something_else_is_only_option:
+
+    if form.something_else_is_only_option and request.method == "POST":
         return redirect(
-            url_for(".email_branding_choose_banner_type", service_id=current_service.id, back_link=".service_settings")
+            url_for(
+                ".email_branding_choose_banner_type",
+                service_id=current_service.id,
+                back_link=".email_branding_request",
+                branding_choice="something_else",
+            )
         )
+
     if form.validate_on_submit():
 
         branding_choice = form.options.data

--- a/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
+++ b/app/templates/views/service-settings/branding/add-new-branding/email-branding-choose-banner-colour.html
@@ -30,7 +30,7 @@
   {% endcall %}
 
   <p class="govuk-body">
-    <a class="govuk-link" href="{{ abandon_flow_link }}">I do not know the hex colour code for my banner</a>
+    <a class="govuk-link" href="{{ abandon_flow_link }}">I do not know the hex colour code</a>
   </p>
 
 {% endblock %}

--- a/app/templates/views/service-settings/branding/email-branding-options.html
+++ b/app/templates/views/service-settings/branding/email-branding-options.html
@@ -36,7 +36,9 @@
   {% endif %}
 
   {% call form_wrapper() %}
-    {{ form.options }}
+    {% if not form.something_else_is_only_option %}
+      {{ form.options }}
+    {% endif %}
     {{ page_footer('Continue') }}
   {% endcall %}
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -201,6 +201,31 @@ def test_email_branding_request_does_not_show_nhs_branding_twice(
     ]
 
 
+def test_email_branding_request_page_shows_preview_if_something_else_is_only_option(
+    mocker,
+    service_one,
+    client_request,
+    mock_get_email_branding,
+    mock_get_empty_email_branding_pool,
+):
+    service_one["organisation_type"] = "other"
+    mocker.patch(
+        "app.models.service.Service.email_branding_id",
+        new_callable=PropertyMock,
+        return_value="some-random-branding",
+    )
+
+    page = client_request.get(
+        ".email_branding_request",
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert normalize_spaces(page.select_one("h1").text) == "Change email branding"
+    assert page.select("iframe.branding-preview")
+    assert not page.select("input[type=radio]")
+    assert normalize_spaces(page.select_one("form[method=post] button").text) == "Continue"
+
+
 def test_email_branding_request_page_redirects_to_choose_banner_type_page_if_something_else_is_only_option(
     mocker,
     service_one,
@@ -215,12 +240,15 @@ def test_email_branding_request_page_redirects_to_choose_banner_type_page_if_som
         return_value="some-random-branding",
     )
 
-    client_request.get(
+    client_request.post(
         ".email_branding_request",
         service_id=SERVICE_ONE_ID,
         _expected_status=302,
         _expected_redirect=url_for(
-            "main.email_branding_choose_banner_type", service_id=SERVICE_ONE_ID, back_link=".service_settings"
+            "main.email_branding_choose_banner_type",
+            service_id=SERVICE_ONE_ID,
+            back_link=".email_branding_request",
+            branding_choice="something_else",
         ),
     )
 

--- a/tests/app/main/views/service_settings/test_email_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_email_branding_requests.py
@@ -247,7 +247,6 @@ def test_email_branding_request_page_redirects_to_choose_banner_type_page_if_som
         _expected_redirect=url_for(
             "main.email_branding_choose_banner_type",
             service_id=SERVICE_ONE_ID,
-            back_link=".email_branding_request",
             branding_choice="something_else",
         ),
     )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -3987,11 +3987,11 @@ def test_email_branding_choose_banner_type_page(
     submit_button = page.select_one("button.page-footer__button")
     back_button = page.select_one("a.govuk-back-link")
 
-    assert page.select_one("h1").text.strip() == "Add a banner to your logo"
+    assert page.select_one("h1").text.strip() == "Does your logo appear on a coloured background?"
 
     assert form["method"] == "post"
     assert "Continue" in submit_button.text
-    assert [radio["value"] for radio in page.select("input[type=radio]")] == ["org", "org_banner"]
+    assert [radio["value"] for radio in page.select("input[type=radio]")] == ["org_banner", "org"]
 
     assert back_button["href"] == url_for(back_button_url, service_id=SERVICE_ONE_ID)
 
@@ -4459,7 +4459,7 @@ def test_GET_email_branding_choose_banner_colour(client_request, service_one):
         back_link=".email_branding_choose_banner_colour",
         brand_type="org_banner",
     )
-    assert skip_link.text == "I do not know the hex colour code for my banner"
+    assert skip_link.text == "I do not know the hex colour code"
 
 
 def test_POST_email_branding_choose_banner_colour(client_request, service_one):


### PR DESCRIPTION
If we jump people straight into the new upload journey from the settings page they don’t have much context about what they are doing.

This happens when:
- they don’t have an organisation
- or there is nothing in the pool for their organisation
- and we can’t show any magic options

This commit shows them the preview of the current branding, which also gives them the ‘You should change your branding’ line if they are using GOV.UK.

They should only go into the upload journey once they’ve pressed the continue button.

***

Then the banner page needs to change so that it still makes sense in context. ‘Adding’ a banner doesn’t feel quite right:
- adding it to what
- and in addition to what?

This commit rewords the page to be about how the branding should appear, which feels better.

I’ve swapped the order of the radios because yes/no is more intuitive than no/yes, even if no will be the more likely option.

Words by @karlchillmaid 

Before | After
---|---
<img width="755" alt="image" src="https://user-images.githubusercontent.com/355079/209974369-aa065cd8-f67d-4d5e-86f8-7255d30bf869.png"> | <img width="755" alt="image" src="https://user-images.githubusercontent.com/355079/209974369-aa065cd8-f67d-4d5e-86f8-7255d30bf869.png">
— | <img width="788" alt="image" src="https://user-images.githubusercontent.com/355079/209974402-cf4fee09-d469-4323-b162-e8a495864349.png">
<img width="769" alt="image" src="https://user-images.githubusercontent.com/355079/209974589-6e29112f-dab6-4a9e-b464-01673b136711.png"> | <img width="773" alt="image" src="https://user-images.githubusercontent.com/355079/209977255-8349de89-5382-40c4-942c-4b0417a7bf7c.png">
<img width="759" alt="image" src="https://user-images.githubusercontent.com/355079/209974550-6dcd6dd4-b8d1-46f9-b9d3-cde770cbb7dc.png"> | <img width="764" alt="image" src="https://user-images.githubusercontent.com/355079/209974506-b2113e21-d35f-4f3c-b5fe-982d2f1507d9.png">



