### PR TITLE
Link to user profile for platform admins

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -35,6 +35,10 @@ def _get_org_id_from_view_args():
 class BaseUser(JSONModel):
     __sort_attribute__ = "email_address"
 
+    @property
+    def is_invited_user(self):
+        return self.__class__ is InvitedUser
+
 
 class User(BaseUser, UserMixin):
 

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -25,28 +25,28 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
             <h2 class="user-list-item-heading" title="{{ user.email_address }}">
-              {% if current_user.platform_admin and not user.is_invited_user %}
-              <a
-                class="govuk-link govuk-link--text-colour"
-                href="{{ url_for('.user_information', user_id=user.id) }}">
+              {%- if user.name -%}
+                <span class="heading-small live-search-relevant">
+                  {% if current_user.platform_admin and not user.is_invited_user %}
+                    <a class="govuk-link govuk-link--text-colour" href="{{ url_for('.user_information', user_id=user.id) }}">
+                      {{ user.name }}
+                    </a>
+                  {% else %}
+                    {{ user.name }}
+                  {% endif %}
+                </span>&ensp;
+              {%- endif -%}
+              <span class="hint">
+              {%- if user.status == 'pending' -%}
+                <span class="live-search-relevant">{{ user.email_address }}</span> (invited)
+              {%- elif user.status == 'cancelled' -%}
+                <span class="live-search-relevant">{{ user.email_address }}</span> (cancelled invite)
+              {%- elif user.id == current_user.id -%}
+                <span class="live-search-relevant">(you)</span>
+              {% else %}
+                <span class="live-search-relevant">{{ user.email_address }}</span>
               {% endif %}
-                {%- if user.name -%}
-                <span class="heading-small live-search-relevant">{{ user.name }}</span>&ensp;
-                {%- endif -%}
-                <span class="hint">
-                {%- if user.status == 'pending' -%}
-                  <span class="live-search-relevant">{{ user.email_address }}</span> (invited)
-                {%- elif user.status == 'cancelled' -%}
-                  <span class="live-search-relevant">{{ user.email_address }}</span> (cancelled invite)
-                {%- elif user.id == current_user.id -%}
-                  <span class="live-search-relevant">(you)</span>
-                {% else %}
-                  <span class="live-search-relevant">{{ user.email_address }}</span>
-                {% endif %}
-                </span>
-              {% if current_user.platform_admin and not user.is_invited_user %}
-              </a>
-              {% endif %}
+              </span>
             </h2>
             <ul class="tick-cross-list-permissions">
               {% for permission, label in permissions %}

--- a/app/templates/views/manage-users.html
+++ b/app/templates/views/manage-users.html
@@ -25,20 +25,28 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
             <h2 class="user-list-item-heading" title="{{ user.email_address }}">
-              {%- if user.name -%}
-              <span class="heading-small live-search-relevant">{{ user.name }}</span>&ensp;
-              {%- endif -%}
-              <span class="hint">
-              {%- if user.status == 'pending' -%}
-                <span class="live-search-relevant">{{ user.email_address }}</span> (invited)
-              {%- elif user.status == 'cancelled' -%}
-                <span class="live-search-relevant">{{ user.email_address }}</span> (cancelled invite)
-              {%- elif user.id == current_user.id -%}
-                <span class="live-search-relevant">(you)</span>
-              {% else %}
-                <span class="live-search-relevant">{{ user.email_address }}</span>
+              {% if current_user.platform_admin and not user.is_invited_user %}
+              <a
+                class="govuk-link govuk-link--text-colour"
+                href="{{ url_for('.user_information', user_id=user.id) }}">
               {% endif %}
-              </span>
+                {%- if user.name -%}
+                <span class="heading-small live-search-relevant">{{ user.name }}</span>&ensp;
+                {%- endif -%}
+                <span class="hint">
+                {%- if user.status == 'pending' -%}
+                  <span class="live-search-relevant">{{ user.email_address }}</span> (invited)
+                {%- elif user.status == 'cancelled' -%}
+                  <span class="live-search-relevant">{{ user.email_address }}</span> (cancelled invite)
+                {%- elif user.id == current_user.id -%}
+                  <span class="live-search-relevant">(you)</span>
+                {% else %}
+                  <span class="live-search-relevant">{{ user.email_address }}</span>
+                {% endif %}
+                </span>
+              {% if current_user.platform_admin and not user.is_invited_user %}
+              </a>
+              {% endif %}
             </h2>
             <ul class="tick-cross-list-permissions">
               {% for permission, label in permissions %}

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -196,3 +196,11 @@ def test_add_to_service(client_request, mocker, api_user_active, fake_uuid):
         invited_by_id=fake_uuid,
         ui_permissions={"manage_templates"},
     )
+
+
+def test_is_invited_user(client_request, mocker, api_user_active, mock_get_invited_user_by_id):
+    session_dict = {"invited_user_id": USER_ONE_ID}
+    mocker.patch.dict("app.models.user.session", values=session_dict, clear=True)
+
+    assert User(api_user_active).is_invited_user is False
+    assert InvitedUser.from_session().is_invited_user is True


### PR DESCRIPTION
On the team members page of a service, add a link on the name to take platform admins to the user's profile page so that we can jump to their other services or see other profile information.

By keeping it the same black colour I'm hoping to make it relatively inconspicuous - available but not distracting. Another option might be to have a 'View profile' link beneath the 'Change details' link, but that felt crowded.

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/2920760/210074698-08a758a9-08b5-4f45-8b7c-97946c52a3c2.png">
