### PR TITLE
Show notification processor to platform admins

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -121,6 +121,7 @@ from app.url_converters import (
     TemplateTypeConverter,
     TicketTypeConverter,
 )
+from app.utils import format_provider
 
 login_manager = LoginManager()
 csrf = CSRFProtect()
@@ -574,3 +575,5 @@ def init_jinja(application):
             jinja2.PrefixLoader({"govuk_frontend_jinja": jinja2.PackageLoader("govuk_frontend_jinja")}),
         ]
     )
+
+    application.jinja_env.filters["format_provider"] = format_provider

--- a/app/templates/partials/notifications/status.html
+++ b/app/templates/partials/notifications/status.html
@@ -11,6 +11,9 @@
     {% if status_url %}
       </a>
     {% endif %}
+    {% if current_user.platform_admin and notification.sent_by %}
+      via {{ notification.sent_by | format_provider }}
+    {% endif %}
     {% if sent_with_test_key %}
       (test)
     {% endif %}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -157,3 +157,10 @@ def merge_jsonlike(source, destination):
                 source[key] = value
 
     merge_items(source, destination)
+
+
+def format_provider(provider):
+    if provider == "firetext":
+        return provider.title()
+
+    return provider.upper()


### PR DESCRIPTION
Adds `via <provider>` to the delivery status section - only visible to platform admins.

![2022-12-30 15 57 59](https://user-images.githubusercontent.com/2920760/210089168-ef78a40c-9ac0-4b0f-84e5-b73ad2b28055.gif)

![2022-12-30 15 57 04](https://user-images.githubusercontent.com/2920760/210089112-23a455a8-cbef-40a9-b494-7e4e2a4b7dd3.gif)
