### PR TITLE
Remove `Service.default_letter_contact_block_html`

### DIFF
--- a/app/models/service.py
+++ b/app/models/service.py
@@ -365,15 +365,6 @@ class Service(JSONModel):
             None,
         )
 
-    @property
-    def default_letter_contact_block_html(self):
-        # import in the function to prevent cyclical imports
-        from app import nl2br
-
-        if self.default_letter_contact_block:
-            return nl2br(self.default_letter_contact_block["contact_block"])
-        return ""
-
     def edit_letter_contact_block(self, id, contact_block, is_default):
         service_api_client.update_letter_contact(
             self.id,

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -233,7 +233,7 @@
             {{ text_field('Sender addresses') }}
             {% call field(status='' if current_service.count_letter_contact_details else 'default') %}
               {% if current_service.default_letter_contact_block %}
-                {{ current_service.default_letter_contact_block_html }}
+                {{ current_service.default_letter_contact_block.contact_block | nl2br }}
               {% elif current_service.count_letter_contact_details %}
                 Blank
               {% else %}


### PR DESCRIPTION
Rather than doing formatting in the model layer, let’s save some lines of code and do it in the template layer, where we can use the existing formatter without any importing.

This uses the formatter in the admin app, which deals with escaping unsafe HTML:
https://github.com/alphagov/notifications-admin/blob/41e211d365c66dffc269f95b61733e937b7488d4/app/formatters.py#L271-L281