### PR TITLE
Fix the HTML for lists of templates

### DIFF
--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -24,10 +24,6 @@
   <div id="template-list" class="{{ 'govuk-!-margin-top-1' if (not show_template_nav and not show_search_box) else 'govuk-!-margin-top-6' }}">
     {% set checkboxes_data = [] %}
 
-    {% if not current_user.has_permissions('manage_templates') %}
-    <ul>
-    {% endif %}
-
     {% for item in template_list %}
 
       {% set item_link_content %}
@@ -80,18 +76,14 @@
       {% set _ = checkboxes_data.append(checkbox_config) %}
 
       {% if not current_user.has_permissions('manage_templates') %}
-        <li class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
+        <div class="template-list-item {%- if item.ancestors %} template-list-item-hidden-by-default {%- else %} template-list-item-without-ancestors{%- endif %}">
           {{ item_link_content }}
           <p class="template-list-item-hint govuk-!-margin-bottom-4">
             {{ item.hint }}
           </p>
-        </li>
+        </div>
       {% endif %}
     {% endfor %}
-
-    {% if not current_user.has_permissions('manage_templates') %}
-    </ul>
-    {% endif %}
 
     {% if current_user.has_permissions('manage_templates') %}
       {{ templates_and_folders_form.templates_and_folders(param_extensions={

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -38,9 +38,8 @@
     {{ live_search(target_selector='#template-list .template-list-item', show=True, form=search_form) }}
 
     <div id="template-list">
-      <ul class="govuk-list">
       {% for item in templates_and_folders %}
-        <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
+        <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
           {% for ancestor in item.ancestors %}
               <a href="{{ url_for('.conversation_reply', service_id=current_service.id, notification_id=notification_id, from_folder=ancestor.id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
               {{ ancestor.name }}
@@ -58,9 +57,8 @@
           <p class="template-list-item-hint govuk-hint">
             {{ item.hint }}
           </p>
-        </li>
+        </div>
       {% endfor %}
-      </ul>
     </div>
 
 

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -37,7 +37,7 @@
 
     {{ live_search(target_selector='#template-list .template-list-item', show=True, form=search_form) }}
 
-    <nav id="template-list">
+    <div id="template-list">
       <ul class="govuk-list">
       {% for item in templates_and_folders %}
         <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
@@ -61,7 +61,7 @@
         </li>
       {% endfor %}
       </ul>
-    </nav>
+    </div>
 
 
   {% endif %}

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -26,9 +26,8 @@
         autofocus=True
       ) }}
       <div id="template-list">
-        <ul>
         {% for item in services_templates_and_folders %}
-          <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
+          <div class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
             {% for ancestor in item.ancestors %}
               {% if ancestor.is_service %}
                 <a href="{{ url_for('.choose_template_to_copy', service_id=current_service.id, from_service=ancestor.service_id) }}" class="govuk-link govuk-link--no-visited-state template-list-folder">
@@ -54,9 +53,8 @@
             <p class="template-list-item-hint govuk-hint">
               {{ item.hint }}
             </p>
-          </li>
+          </div>
         {% endfor %}
-        </ul>
       </div>
     {% endif %}
 

--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -25,7 +25,7 @@
         form=search_form,
         autofocus=True
       ) }}
-      <nav id="template-list">
+      <div id="template-list">
         <ul>
         {% for item in services_templates_and_folders %}
           <li class="template-list-item {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
@@ -57,7 +57,7 @@
           </li>
         {% endfor %}
         </ul>
-      </nav>
+      </div>
     {% endif %}
 
 {% endblock %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1200,7 +1200,7 @@ def test_choose_a_template_to_copy(
     for actual, expected in zip(actual, expected):  # noqa: B020
         assert normalize_spaces(actual.text) == expected
 
-    links = page.select("main nav a")
+    links = page.select(".template-list-item a")
     assert links[0]["href"] == url_for(
         "main.choose_template_to_copy",
         service_id=SERVICE_ONE_ID,
@@ -1248,7 +1248,7 @@ def test_choose_a_template_to_copy_when_user_has_one_service(
     for actual, expected in zip(actual, expected):  # noqa: B020
         assert normalize_spaces(actual.text) == expected
 
-    assert page.select("main nav a")[0]["href"] == url_for(
+    assert page.select(".template-list-item a")[0]["href"] == url_for(
         "main.copy_template",
         service_id=SERVICE_ONE_ID,
         template_id=TEMPLATE_ONE_ID,
@@ -1319,7 +1319,7 @@ def test_choose_a_template_to_copy_from_folder_within_service(
     for actual, expected in zip(actual, expected):  # noqa: B020
         assert normalize_spaces(actual.text) == expected
 
-    links = page.select("main nav a")
+    links = page.select(".template-list-item a")
     assert links[0]["href"] == url_for(
         "main.choose_template_to_copy",
         service_id=SERVICE_ONE_ID,

--- a/tests/javascripts/liveSearch.test.js
+++ b/tests/javascripts/liveSearch.test.js
@@ -272,9 +272,9 @@ describe('Live search', () => {
           </div>
         </div>
         <form method="post" autocomplete="off" novalidate>
-          <nav id="template-list">
+          <div id="template-list">
             ${helpers.templatesAndFoldersCheckboxes(templatesAndFolders)}
-          </nav>
+          </div>
         </form>`;
 
       searchTextbox = document.getElementById('search');


### PR DESCRIPTION
**Remove template lists from `<nav>`s**

We removed the `<nav>` around template list items on the templates page, but there are a couple of other places where we show a template list that still needed updating - the copy template page and the page to choose a template to reply to a received text message with. Changing the tag used doesn't affect the appearance of the pages.

**Stop using list tags for templates**

This replaces list tags with navs when displaying a list of templates in the following places:
- The main templates page when the user doesn't have `manage_templates` permission
- The pages to copy a template
- The page to pick a template to use to reply to a received text message

This should keep the pages looking the same, though there were a couple of places where we were had forgotten to add the `govuk-list` class to the list of templates so makes the templates display as expected (without visible bullet points).

---

**Templates list before (the bullet points should not have been visible)**

<img width="450" alt="Screenshot 2023-01-04 at 14 27 38" src="https://user-images.githubusercontent.com/12881990/210580976-73ed6f88-8c85-4a2a-b9b2-80e7b2a898a1.png">

**Templates list after**

<img width="450" alt="Screenshot 2023-01-04 at 14 29 26" src="https://user-images.githubusercontent.com/12881990/210581002-4529426f-80d9-4df8-becc-5ae5d3d4c470.png">
