### PR TITLE
Let organisation users see all template folders

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -882,10 +882,22 @@ class BasePermissionsForm(StripWhitespaceForm):
         return set(self.permissions_field.data)
 
     @classmethod
-    def from_user(cls, user, service_id, **kwargs):
+    def from_user_and_service(cls, user, service):
+        if user.platform_admin:
+            all_template_folders = None
+            folder_permissions = None
+        else:
+            all_template_folders = service.all_template_folders
+            folder_permissions = [
+                folder["id"]
+                for folder in all_template_folders
+                if user.has_template_folder_permission(folder, service=service)
+            ]
+
         form = cls(
-            **kwargs,
-            **{"permissions_field": (user.permissions_for_service(service_id) & all_ui_permissions)},
+            folder_permissions=folder_permissions,
+            all_template_folders=all_template_folders,
+            permissions_field=user.permissions_for_service(service.id) & all_ui_permissions,
             login_authentication=user.auth_type,
         )
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -115,7 +115,11 @@ def edit_user_permissions(service_id, user_id):
         service_id,
         folder_permissions=None
         if user.platform_admin
-        else [f["id"] for f in current_service.all_template_folders if user.has_template_folder_permission(f)],
+        else [
+            f["id"]
+            for f in current_service.all_template_folders
+            if user.has_template_folder_permission(f, service=current_service)
+        ],
         all_template_folders=None if user.platform_admin else current_service.all_template_folders,
     )
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -110,18 +110,7 @@ def edit_user_permissions(service_id, user_id):
     else:
         form_class = PermissionsForm
 
-    form = form_class.from_user(
-        user,
-        service_id,
-        folder_permissions=None
-        if user.platform_admin
-        else [
-            f["id"]
-            for f in current_service.all_template_folders
-            if user.has_template_folder_permission(f, service=current_service)
-        ],
-        all_template_folders=None if user.platform_admin else current_service.all_template_folders,
-    )
+    form = form_class.from_user_and_service(user, current_service)
 
     if form.validate_on_submit():
         user.set_permissions(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -49,7 +49,7 @@ def view_template(service_id, template_id):
     template = current_service.get_template(template_id)
     template_folder = current_service.get_template_folder(template["folder"])
 
-    user_has_template_permission = current_user.has_template_folder_permission(template_folder)
+    user_has_template_permission = current_user.has_template_folder_permission(template_folder, service=current_service)
     if should_skip_template_page(template):
         return redirect(url_for(".set_sender", service_id=service_id, template_id=template_id))
 
@@ -89,8 +89,9 @@ def view_template(service_id, template_id):
 @user_has_permissions(allow_org_user=True)
 def choose_template(service_id, template_type="all", template_folder_id=None):
     template_folder = current_service.get_template_folder(template_folder_id)
-    user_has_template_folder_permission = current_user.has_template_folder_permission(template_folder)
-
+    user_has_template_folder_permission = current_user.has_template_folder_permission(
+        template_folder, service=current_service
+    )
     template_list = UserTemplateList(
         service=current_service, template_type=template_type, template_folder_id=template_folder_id, user=current_user
     )
@@ -355,7 +356,7 @@ def copy_template(service_id, template_id):
     template = service_api_client.get_service_template(from_service, template_id)["data"]
 
     template_folder = template_folder_api_client.get_template_folder(from_service, template["folder"])
-    if not current_user.has_template_folder_permission(template_folder):
+    if not current_user.has_template_folder_permission(template_folder, service=current_service):
         abort(403)
 
     if request.method == "POST":

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -216,7 +216,7 @@ class Service(JSONModel):
     def get_template_folder_with_user_permission_or_403(self, folder_id, user):
         template_folder = self.get_template_folder(folder_id)
 
-        if not user.has_template_folder_permission(template_folder):
+        if not user.has_template_folder_permission(template_folder, service=self):
             abort(403)
 
         return template_folder

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -248,8 +248,9 @@ class User(BaseUser, UserMixin):
     def has_permission_for_service(self, service_id, permission):
         return permission in self._permissions.get(service_id, [])
 
-    def has_template_folder_permission(self, template_folder, service=None):
-        if self.platform_admin:
+    def has_template_folder_permission(self, template_folder, *, service):
+        # These users can see all folders
+        if self.platform_admin or self.belongs_to_organisation(service.organisation_id):
             return True
 
         # Top-level templates are always visible

--- a/app/templates/components/folder-path.html
+++ b/app/templates/components/folder-path.html
@@ -1,6 +1,6 @@
 {% macro folder_path(
   folders,
-  service_id,
+  service,
   template_type,
   current_user,
   link_current_item=False,
@@ -16,13 +16,13 @@
         {% endif %}
       {% else %}
         {% if folder.id %}
-          {% if current_user.has_template_folder_permission(folder) %}
-            <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
+          {% if current_user.has_template_folder_permission(folder, service=service) %}
+            <a href="{{ url_for('.choose_template', service_id=service.id, template_type=template_type, template_folder_id=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder {% if loop.index < (loop.length - 1) %}folder-heading-folder-truncated{% endif %}" title="{{ folder.name }}">{{ folder.name }}</a>
           {% else %}
             <span class="folder-heading-folder">{{ folder.name }}</span>
           {% endif %}
         {% else %}
-          <a href="{{ url_for('.choose_template', service_id=service_id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
+          <a href="{{ url_for('.choose_template', service_id=service.id, template_type=template_type) }}" title="Templates" class="govuk-link govuk-link--no-visited-state {% if loop.length > 2 %}folder-heading-folder-root-truncated{% endif %}">Templates</a>
         {% endif %}
         {% if not loop.last %}{{ folder_path_separator() }}{% endif %}
       {% endif %}
@@ -50,7 +50,7 @@
           </span>
         {% else %}
           {% if folder.id %}
-            {% if current_user.has_template_folder_permission(folder) %}
+            {% if current_user.has_template_folder_permission(folder, service=from_service) %}
               <a href="{{ url_for('.choose_template_to_copy', service_id=current_service_id, from_service=from_service.id, from_folder=folder.id) }}" class="govuk-link govuk-link--no-visited-state folder-heading-folder">{{ folder.name }}</a>
              {% else %}
               <span class="folder-heading-folder">{{ folder.name }}</span>

--- a/app/templates/views/templates/choose-reply.html
+++ b/app/templates/views/templates/choose-reply.html
@@ -12,7 +12,7 @@
 
 <div class="bottom-gutter-1-2">
   <h1 class="heading-large">Choose a template</h1>
-  {{ folder_path(template_folder_path, current_service.id, template_type, current_user, root_element='h2') }}
+  {{ folder_path(template_folder_path, current_service, template_type, current_user, root_element='h2') }}
 </div>
 
   {% if not templates_and_folders.templates_to_show %}

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -37,7 +37,7 @@
       <div class="{% if current_user.has_permissions('manage_templates') %} govuk-grid-column-five-sixths {% else %} govuk-grid-column-full {% endif %}">
         {{ folder_path(
           folders=template_folder_path,
-          service_id=current_service.id,
+          service=current_service,
           template_type=template_type,
           current_user=current_user
         ) }}

--- a/app/templates/views/templates/manage-template-folder.html
+++ b/app/templates/views/templates/manage-template-folder.html
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-full">
       {{ folder_path(
         folders=template_folder_path,
-        service_id=current_service.id,
+        service=current_service,
         template_type='all',
         current_user=current_user,
         link_current_item=True

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -32,7 +32,7 @@
       <div class="govuk-grid-column-full">
         {{ folder_path(
           folders=current_service.get_template_path(template._template),
-          service_id=current_service.id,
+          service=current_service,
           template_type='all',
           current_user=current_user
         ) }}

--- a/tests/app/main/test_permissions.py
+++ b/tests/app/main/test_permissions.py
@@ -11,6 +11,7 @@ from tests.conftest import (
     ORGANISATION_TWO_ID,
     SERVICE_ONE_ID,
     SERVICE_TWO_ID,
+    create_folder,
 )
 
 
@@ -35,6 +36,7 @@ from tests.conftest import (
         ("main.usage", {}),
         ("main.manage_users", {}),
         ("main.choose_template", {"template_id": sample_uuid()}),
+        ("main.choose_template", {"template_folder_id": sample_uuid()}),
         ("main.view_template", {"template_id": sample_uuid()}),
         ("main.view_template_versions", {"template_id": sample_uuid()}),
         ("main.view_template_version", {"template_id": sample_uuid(), "version": 1}),
@@ -51,7 +53,6 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     mock_get_service,
     mock_get_invites_for_service,
     mock_get_users_by_service,
-    mock_get_template_folders,
     mock_get_organisation,
     mock_has_jobs,
     mock_get_service_templates,
@@ -80,6 +81,8 @@ def test_services_pages_that_org_users_are_allowed_to_see(
     mock_get_service = mocker.patch(
         "app.notify_client.service_api_client.service_api_client.get_service", return_value={"data": service}
     )
+    mocker.patch("app.template_folder_api_client.get_template_folders", return_value=[create_folder(id=sample_uuid())])
+
     client_request.login(
         api_user_active,
         service=service if SERVICE_ONE_ID in user_services else None,


### PR DESCRIPTION
We already let organisation users see all templates in their service: https://github.com/alphagov/notifications-admin/pull/4494

However if the template is in a folder then the user won’t be able to see it, since the user also needs permission to see the folder in order to see the template.

This defeats the objective of letting organisation users see all templates.

This commit effectively gives organisation users permission to see all folders in a service, and by extension all templates no matter which folder they are in.

Before | After
---|---
<img width="700" alt="image" src="https://user-images.githubusercontent.com/355079/210773350-5f5aadd4-6db5-4d23-97ca-c84c364e725d.png"> | <img width="714" alt="image" src="https://user-images.githubusercontent.com/355079/210773456-ab177b3e-dfcc-4bb1-9139-7a2eb9cbb1d9.png">

***

There’s a small amount of refactoring which is in a second commit.