### PR TITLE
Re-add removed imports

### DIFF
--- a/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-sms-provider-volumes-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Daily SMS provider volumes Report

--- a/app/templates/views/platform-admin/daily-volumes-report.html
+++ b/app/templates/views/platform-admin/daily-volumes-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Daily volumes report

--- a/app/templates/views/platform-admin/volumes-by-service-report.html
+++ b/app/templates/views/platform-admin/volumes-by-service-report.html
@@ -1,6 +1,7 @@
 {% extends "views/platform-admin/_base_template.html" %}
 {% from "components/form.html" import form_wrapper %}
 {% from "components/table.html" import mapping_table, row, text_field %}
+{% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
   Volumes by service report

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1020,6 +1020,14 @@ def test_get_notifications_sent_by_service_calls_api_and_downloads_data(
     )
 
 
+def test_get_volumes_by_service_report_page(client_request, platform_admin_user, mocker):
+    client_request.login(platform_admin_user)
+    client_request.get(
+        "main.get_volumes_by_service",
+        _test_page_title=False,
+    )
+
+
 def test_get_volumes_by_service_report_calls_api_and_download_data(client_request, platform_admin_user, mocker):
     mocker.patch(
         "app.main.views.platform_admin.billing_api_client.get_data_for_volumes_by_service_report",
@@ -1070,6 +1078,14 @@ def test_get_volumes_by_service_report_calls_api_and_download_data(client_reques
     )
 
 
+def test_get_daily_volumes_report_page(client_request, platform_admin_user, mocker):
+    client_request.login(platform_admin_user)
+    client_request.get(
+        "main.get_daily_volumes",
+        _test_page_title=False,
+    )
+
+
 def test_get_daily_volumes_report_calls_api_and_download_data(client_request, platform_admin_user, mocker):
     mocker.patch(
         "app.main.views.platform_admin.billing_api_client.get_data_for_daily_volumes_report",
@@ -1109,6 +1125,11 @@ def test_get_daily_volumes_report_calls_api_and_download_data(client_request, pl
         + "20"
         + "\r\n"
     )
+
+
+def test_get_daily_sms_provider_volumes_report_page(client_request, platform_admin_user, mocker):
+    client_request.login(platform_admin_user)
+    client_request.get("main.get_daily_sms_provider_volumes")
 
 
 def test_get_daily_sms_provider_volumes_report_calls_api_and_download_data(client_request, platform_admin_user, mocker):


### PR DESCRIPTION
These were over-zealously removed and the page won’t load without them.

I’ve added some very basic test coverage for these pages which would have caught this.