### PR TITLE
allow users of archived services to create new services

### DIFF
--- a/app/notify_client/__init__.py
+++ b/app/notify_client/__init__.py
@@ -1,4 +1,4 @@
-from flask import abort, has_request_context, request
+from flask import has_request_context, request
 from flask_login import current_user
 from notifications_python_client import __version__
 from notifications_python_client.base import BaseAPIClient
@@ -39,28 +39,6 @@ class NotifyAdminAPIClient(BaseAPIClient):
         headers["X-B3-TraceId"] = request.request_id
         headers["X-B3-SpanId"] = request.span_id
         return headers
-
-    def check_inactive_service(self):
-        # this file is imported in app/__init__.py before current_service is initialised, so need to import later
-        # to prevent cyclical imports
-        from app import current_service
-
-        # if the current service is inactive and the user isn't a platform admin, we should block them from making any
-        # stateful modifications to that service
-        if current_service and not current_service.active and not current_user.platform_admin:
-            abort(403)
-
-    def post(self, *args, **kwargs):
-        self.check_inactive_service()
-        return super().post(*args, **kwargs)
-
-    def put(self, *args, **kwargs):
-        self.check_inactive_service()
-        return super().put(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        self.check_inactive_service()
-        return super().delete(*args, **kwargs)
 
 
 class InviteTokenError(Exception):

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1704,16 +1704,12 @@ def test_breadcrumb_shows_if_service_is_suspended(
     mock_get_annual_usage_for_service,
     mock_get_free_sms_fragment_limit,
     mock_get_returned_letter_statistics_with_no_returned_letters,
-    active_user_with_permissions,
+    platform_admin_user,
     client_request,
 ):
-    service_one_json = service_json(
-        SERVICE_ONE_ID,
-        active=False,
-        users=[active_user_with_permissions["id"]],
-    )
+    service_one_json = service_json(SERVICE_ONE_ID, active=False)
+    client_request.login(platform_admin_user, service=service_one_json)
 
-    mocker.patch("app.service_api_client.get_service", return_value={"data": service_one_json})
     page = client_request.get("main.service_dashboard", service_id=SERVICE_ONE_ID)
 
     assert "Suspended" in page.select_one(".navigation-service-name").text

--- a/tests/app/notify_client/test_notify_admin_api_client.py
+++ b/tests/app/notify_client/test_notify_admin_api_client.py
@@ -1,73 +1,8 @@
 from datetime import date
-from unittest.mock import patch
 
-import pytest
-import werkzeug
-from flask import g
-
-from app.models.service import Service
 from app.notify_client import NotifyAdminAPIClient
 from app.notify_client.notification_api_client import notification_api_client
-from tests import service_json
-from tests.conftest import (
-    create_api_user_active,
-    create_platform_admin_user,
-    set_config,
-)
-
-
-@pytest.mark.parametrize("method", ["put", "post", "delete"])
-@pytest.mark.parametrize(
-    "user",
-    [
-        create_api_user_active(),
-        create_platform_admin_user(),
-    ],
-    ids=["api_user", "platform_admin"],
-)
-@pytest.mark.parametrize("service", [service_json(active=True), None], ids=["active_service", "no_service"])
-def test_active_service_can_be_modified(notify_admin, method, user, service):
-    api_client = NotifyAdminAPIClient()
-
-    with notify_admin.test_request_context(), notify_admin.test_client() as client:
-        client.login(user)
-        g.current_service = Service(service)
-
-        with patch.object(api_client, "request") as request:
-            ret = getattr(api_client, method)("url", "data")
-
-    assert request.called
-    assert ret == request.return_value
-
-
-@pytest.mark.parametrize("method", ["put", "post", "delete"])
-def test_inactive_service_cannot_be_modified_by_normal_user(notify_admin, api_user_active, method):
-    api_client = NotifyAdminAPIClient()
-
-    with notify_admin.test_request_context(), notify_admin.test_client() as client:
-        client.login(api_user_active)
-        g.current_service = Service(service_json(active=False))
-
-        with patch.object(api_client, "request") as request:
-            with pytest.raises(werkzeug.exceptions.Forbidden):
-                getattr(api_client, method)("url", "data")
-
-    assert not request.called
-
-
-@pytest.mark.parametrize("method", ["put", "post", "delete"])
-def test_inactive_service_can_be_modified_by_platform_admin(notify_admin, platform_admin_user, method):
-    api_client = NotifyAdminAPIClient()
-
-    with notify_admin.test_request_context(), notify_admin.test_client() as client:
-        client.login(platform_admin_user)
-        g.current_service = Service(service_json(active=False))
-
-        with patch.object(api_client, "request") as request:
-            ret = getattr(api_client, method)("url", "data")
-
-    assert request.called
-    assert ret == request.return_value
+from tests.conftest import set_config
 
 
 def test_generate_headers_sets_standard_headers(notify_admin):

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -5,11 +5,6 @@ import pytest
 from app import organisations_client
 
 
-@pytest.fixture(autouse=True)
-def mock_notify_client_check_inactive_service(mocker):
-    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
-
-
 @pytest.mark.parametrize(
     (
         "client_method,"

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -10,11 +10,6 @@ from tests.conftest import SERVICE_ONE_ID
 FAKE_TEMPLATE_ID = uuid4()
 
 
-@pytest.fixture(autouse=True)
-def mock_notify_client_check_inactive_service(mocker):
-    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
-
-
 def test_client_posts_archived_true_when_deleting_template(mocker):
     mocker.patch("app.notify_client.current_user", id="1")
     mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -12,11 +12,6 @@ from tests.conftest import SERVICE_ONE_ID
 user_id = sample_uuid()
 
 
-@pytest.fixture(autouse=True)
-def mock_notify_client_check_inactive_service(mocker):
-    mocker.patch("app.notify_client.NotifyAdminAPIClient.check_inactive_service")
-
-
 def test_client_gets_all_users_for_service(
     mocker,
     fake_uuid,

--- a/tests/app/utils/test_user.py
+++ b/tests/app/utils/test_user.py
@@ -2,6 +2,7 @@ import pytest
 from flask import request
 from werkzeug.exceptions import Forbidden
 
+from app import load_service_before_request
 from app.utils.user import user_has_permissions
 
 
@@ -50,6 +51,7 @@ def test_permissions(
     def index():
         pass
 
+    load_service_before_request()
     index()
 
 
@@ -64,6 +66,7 @@ def test_restrict_admin_usage(
     def index():
         pass
 
+    load_service_before_request()
     with pytest.raises(Forbidden):
         index()
 
@@ -158,4 +161,5 @@ def test_user_with_no_permissions_to_service_goes_to_templates(
     def index():
         pass
 
+    load_service_before_request()
     index()


### PR DESCRIPTION
Remove check_inactive_service
---------


we added this as a safeguard to prevent people modifying inactive services. However, when a user hits an endpoint that is associated with a service we decorate that service with the `user_has_permissions` decorator.

Among the various checks the `user_has_permissions` decorator does is `user.belongs_to_service` - this checks in the list of services returned from the api in the get_user_by_id blob. In the API we explicitly only return services that are active in that list[^1]. It also later checks that any permissions match (if that endpoint requires specific permissions to hit for that service). Again, the API explicitly filters to only return permissions for active services when returning the user[^2].

Note that platform admins bypass both these checks (unless `restrict_admin_usage` is set).

This means that there's no way a normal user can ever enter the view code at all with an inactive service, be it for a GET or a POST. The only risks are if we don't clear the user cache when updating a service - however we explicitly clear user cache when archiving a service[^3].

This means we can remove the check_inactive_service, as we're confident this code is never tripped legitimately. The only time it can ever be reached is if the user is in an endpoint that has a different decorator (specifically `@user_is_logged_in`) so doesn't look at service permissions etc. Previously we were blocking POST updates on pages with these decorators, and causing bugs where users couldn't create new services or update their name/password/etc if they'd recently viewed an archived service, but now we have fixed that bug properly.

[^1]: https://github.com/alphagov/notifications-api/blob/ef555db14afa96ba0122341154b00d14edf9a98d/app/models.py#L179
[^2]: https://github.com/alphagov/notifications-api/blob/ef555db14afa96ba0122341154b00d14edf9a98d/app/dao/permissions_dao.py#L65-L71
[^3]: https://github.com/alphagov/notifications-admin/blob/b6a16bebea65ca59360261b1b1ee8aab58e54897/app/main/views/service_settings/index.py#L382-L386