### PR TITLE
Remove unused Jinja macros

### DIFF
--- a/app/templates/components/radios.html
+++ b/app/templates/components/radios.html
@@ -1,12 +1,7 @@
-{% from "components/select-input.html" import select, select_list, select_nested, select_input %}
+{% from "components/select-input.html" import select, select_nested, select_input %}
 
 {% macro radios(field, hint=None, disable=[], option_hints={}, hide_legend=False, inline=False) %}
   {{ select(field, hint, disable, option_hints, hide_legend, input="radio", inline=inline) }}
-{% endmacro %}
-
-
-{% macro radio_list(options, child_map, disable=[], option_hints={}) %}
-  {{ select_list(options, child_map, disable, option_hints, input="radio") }}
 {% endmacro %}
 
 
@@ -17,44 +12,6 @@
 
 {% macro radio(option, disable=[], option_hints={}, data_target=None, as_list_item=False) %}
   {{ select_input(option, disable, option_hints, data_target, as_list_item, input="radio") }}
-{% endmacro %}
-
-
-{% macro radio_select(
- field,
- hint=None,
- wrapping_class='form-group',
- show_now_as_default=True,
- bold_legend=False
-) %}
- <div class="{{ wrapping_class }} {% if field.errors %} form-group-error{% endif %}">
-   <fieldset>
-     <legend class="form-label {% if bold_legend %}govuk-!-font-weight-bold{% endif %}">
-       {{ field.label.text }}
-       {% if field.errors %}
-         <span class="error-message" data-notify-module="track-error" data-error-type="{{ field.errors[0] }}" data-error-label="{{ field.name }}">
-           {{ field.errors[0] }}
-         </span>
-       {% endif %}
-     </legend>
-     <div class="radio-select" data-notify-module="radio-select" data-categories="{{ field.categories|join(',') }}" data-show-now-as-default="{{ show_now_as_default|string|lower }}">
-       <div class="radio-select-column">
-       {% for option in field %}
-         <div class="multiple-choice">
-           {{ option }}
-           <label for="{{ option.id }}">
-             {{ option.label.text }}
-           </label>
-         </div>
-         {% if loop.first %}
-       </div>
-       <div class="radio-select-column">
-         {% endif %}
-       {% endfor %}
-       </div>
-     </div>
-   </fieldset>
- </div>
 {% endmacro %}
 
 

--- a/app/templates/components/tick-cross.html
+++ b/app/templates/components/tick-cross.html
@@ -13,7 +13,3 @@
     {% endif %}
   </li>
 {% endmacro %}
-
-{% macro tick_cross_done_not_done(yes, label) %}
-  {{ tick_cross(yes, label, truthy_hint='Done: ', falsey_hint='Not done: ') }}
-{% endmacro %}


### PR DESCRIPTION
This uses the script from https://github.com/alphagov/notifications-admin/pull/4534 to identify Jinja macros which aren’t imported anywhere.

It then removes them.

There were a couple of false positives, namely:
- `govukRadiosWithImages`
- `govukCheckboxes`

It’s hard to programitically identify where these are because of the way we’ve wrapped the GOV.UK Frontend components, but it is happening: https://github.com/alphagov/notifications-admin/blob/8236a28e9aff6388857335aca388e04a3bcdfdf4/app/utils/govuk_frontend_field.py#L123

***

Closes #4534