### PR TITLE
Add a page title for submit returned letters page

### DIFF
--- a/app/templates/views/platform-admin/returned-letters.html
+++ b/app/templates/views/platform-admin/returned-letters.html
@@ -3,13 +3,15 @@
 {% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/form.html" import form_wrapper %}
 
+{% set page_title = 'Submit returned letters' %}
+
 {% block per_page_title %}
-  {{ page_title|capitalize }}
+  {{ page_title }}
 {% endblock %}
 
 {% block platform_admin_content %}
 
-  <h1 class="heading-medium">Submit returned letters</h1>
+  <h1 class="heading-medium">{{ page_title }}</h1>
   {% call form_wrapper() %}
     {{ textbox(form.references, width='1-1', rows=8, autosize=True) }}
     {{ sticky_page_footer("Submit") }}

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -657,6 +657,14 @@ def test_platform_admin_displays_stats_in_right_boxes_and_with_correct_styling(
     )
 
 
+def test_platform_admin_show_submit_returned_letters_page(
+    client_request,
+    platform_admin_user,
+):
+    client_request.login(platform_admin_user)
+    client_request.get("main.platform_admin_returned_letters")
+
+
 def test_platform_admin_submit_returned_letters(
     mocker,
     client_request,


### PR DESCRIPTION
The page title for this page was showing as `– GOV.UK Notify`. A test to GET the page has been added since includes a check that the title matches the H1 and will fail if the title is not set. We were only testing POST requests before.