### PR TITLE
Show whichever set of daily limits is the applicable one

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -292,14 +292,19 @@
       {% else %}
         <h2 class="heading-medium top-gutter-0">Your service is live</h2>
 
-        <p class="govuk-body">
-          You can send up to
-          {{ "{:,}".format(current_service.message_limit) }} messages
-          per day.
-        </p>
-
-        {# TODO: Remove this check when we go-live with new limits - and probably the paragraph above #}
-        {% if current_user.platform_admin %}
+        {% if (
+            current_service.email_message_limit > current_service.message_limit
+          ) and (
+            current_service.sms_message_limit > current_service.message_limit
+          ) and (
+            current_service.letter_message_limit > current_service.message_limit
+        ) %}
+          <p class="govuk-body">
+            You can send up to
+            {{ "{:,}".format(current_service.message_limit) }} messages
+            per day.
+          </p>
+          {% else %}
           <p class="govuk-body">
             You can send up to:
             </p>
@@ -307,10 +312,10 @@
                 <li>{{ "{:,}".format(current_service.email_message_limit) }} {{ current_service.email_message_limit | message_count_noun('email') }} per day
                 </li>
                 <li>{{ "{:,}".format(current_service.sms_message_limit) }} {{ current_service.sms_message_limit | message_count_noun('sms') }} per day
-               </li>
-               <li>{{ "{:,}".format(current_service.letter_message_limit) }} {{ current_service.letter_message_limit | message_count_noun('letter') }} per day
-               </li>
-           </ul>
+              </li>
+              <li>{{ "{:,}".format(current_service.letter_message_limit) }} {{ current_service.letter_message_limit | message_count_noun('letter') }} per day
+              </li>
+          </ul>
         {% endif %}
 
         <p class="govuk-body">

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -601,6 +601,42 @@ def test_show_restricted_service(
         assert not request_to_live_link
 
 
+@pytest.mark.parametrize(
+    "message_limit, email_message_limit, sms_message_limit, letter_message_limit, selector, expected_text",
+    (
+        (1_000, 9_999, 9_999, 9_999, "p", "You can send up to 1,000 messages per day."),
+        (9_999, 1_000, 2_000, 3_000, "ul", "1,000 emails per day 2,000 text messages per day 3,000 letters per day"),
+    ),
+)
+def test_show_limits_for_live_service(
+    client_request,
+    service_one,
+    single_reply_to_email_address,
+    single_letter_contact_block,
+    single_sms_sender,
+    mock_get_service_settings_page_common,
+    message_limit,
+    email_message_limit,
+    sms_message_limit,
+    letter_message_limit,
+    selector,
+    expected_text,
+):
+    service_one["restricted"] = False
+    service_one["message_limit"] = message_limit
+    service_one["email_message_limit"] = email_message_limit
+    service_one["sms_message_limit"] = sms_message_limit
+    service_one["letter_message_limit"] = letter_message_limit
+
+    page = client_request.get(
+        "main.service_settings",
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert page.select_one("main h2").text == "Your service is live"
+    assert normalize_spaces(page.select_one(f"main {selector}")) == expected_text
+
+
 def test_broadcast_service_in_training_mode_doesnt_show_trial_mode_content(
     client_request,
     service_one,


### PR DESCRIPTION
Assumes that `email_message_limit`, `sms_message_limit`, `letter_message_limit` will all be reduced from 999,999,999 in one go