### PR TITLE
Remove old, non-channel-specific, rate limit

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -291,33 +291,14 @@
 
       {% else %}
         <h2 class="heading-medium top-gutter-0">Your service is live</h2>
-
-        {% if (
-            current_service.email_message_limit > current_service.message_limit
-          ) and (
-            current_service.sms_message_limit > current_service.message_limit
-          ) and (
-            current_service.letter_message_limit > current_service.message_limit
-        ) %}
-          <p class="govuk-body">
-            You can send up to
-            {{ "{:,}".format(current_service.message_limit) }} messages
-            per day.
-          </p>
-          {% else %}
-          <p class="govuk-body">
-            You can send up to:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>{{ "{:,}".format(current_service.email_message_limit) }} {{ current_service.email_message_limit | message_count_noun('email') }} per day
-                </li>
-                <li>{{ "{:,}".format(current_service.sms_message_limit) }} {{ current_service.sms_message_limit | message_count_noun('sms') }} per day
-              </li>
-              <li>{{ "{:,}".format(current_service.letter_message_limit) }} {{ current_service.letter_message_limit | message_count_noun('letter') }} per day
-              </li>
-          </ul>
-        {% endif %}
-
+        <p class="govuk-body">
+          You can send up to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>{{ current_service.email_message_limit | message_count('email') }} per day</li>
+          <li>{{ current_service.sms_message_limit | message_count('sms') }} per day</li>
+          <li>{{ current_service.letter_message_limit | message_count('letter') }} per day</li>
+        </ul>
         <p class="govuk-body">
           Problems or comments?
           <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Give feedback</a>.

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -275,8 +275,9 @@
           <p class="govuk-body">You can only:</p>
 
           <ul class="govuk-list govuk-list--bullet">
-            <li>send {{ current_service.message_limit }} text messages and emails per day</li>
             <li>send messages to yourself and other people in your team</li>
+            <li>send {{ current_service.email_message_limit | message_count('email') }} per day</li>
+            <li>send {{ current_service.sms_message_limit | message_count('sms') }} per day</li>
             <li>create letter templates, but not send them</li>
           </ul>
 

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -581,6 +581,9 @@ def test_show_restricted_service(
     expected_text,
     expected_link,
 ):
+    service_one["email_message_limit"] = 50
+    service_one["sms_message_limit"] = 51
+
     client_request.login(user)
     page = client_request.get(
         "main.service_settings",
@@ -589,6 +592,13 @@ def test_show_restricted_service(
 
     assert page.select_one("h1").text == "Settings"
     assert page.select("main h2")[0].text == "Your service is in trial mode"
+
+    assert [normalize_spaces(li.text) for li in page.select("main ul li")] == [
+        "send messages to yourself and other people in your team",
+        "send 50 emails per day",
+        "send 51 text messages per day",
+        "create letter templates, but not send them",
+    ]
 
     request_to_live = page.select("main p")[1]
     request_to_live_link = request_to_live.select_one("a")


### PR DESCRIPTION
Now that the non-channel-specific rate limit has been increased to an impossibly high number we don’t ever need to show it in place of the new channel-specific rate limits.

***

Depends on:
- [x] https://github.com/alphagov/notifications-api/pull/3696