### PR TITLE
Add new daily limits to bulk sending guidance

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -34,9 +34,11 @@ class Config(object):
     ASSETS_DEBUG = False
     AWS_REGION = "eu-west-1"
     DEFAULT_SERVICE_LIMIT = 50
-    DEFAULT_LIVE_SERVICE_EMAIL_RATE_LIMIT = 250_000
-    DEFAULT_LIVE_SERVICE_SMS_RATE_LIMIT = 250_000
-    DEFAULT_LIVE_SERVICE_LETTER_RATE_LIMIT = 20_000
+    DEFAULT_LIVE_SERVICE_RATE_LIMITS = {
+        "email": 250_000,
+        "sms": 250_000,
+        "letter": 20_000,
+    }
 
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,8 +1,18 @@
-from flask import abort, make_response, redirect, render_template, request, url_for
+from flask import (
+    abort,
+    current_app,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from flask_login import current_user
+from notifications_utils.recipients import RecipientCSV
 from notifications_utils.template import HTMLEmailTemplate, LetterImageTemplate
 
 from app import letter_branding_client, status_api_client
+from app.formatters import message_count
 from app.main import main
 from app.main.forms import FieldWithNoneOption
 from app.main.views.pricing import CURRENT_SMS_RATE
@@ -253,6 +263,11 @@ def guidance_index():
 def guidance_bulk_sending():
     return render_template(
         "views/guidance/bulk-sending.html",
+        max_spreadsheet_rows=RecipientCSV.max_rows,
+        rate_limits=[
+            message_count(current_app.config[f"DEFAULT_LIVE_SERVICE_{channel.upper()}_RATE_LIMIT"], channel)
+            for channel in ("email", "sms", "letter")
+        ],
         navigation_links=using_notify_nav(),
     )
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -265,8 +265,8 @@ def guidance_bulk_sending():
         "views/guidance/bulk-sending.html",
         max_spreadsheet_rows=RecipientCSV.max_rows,
         rate_limits=[
-            message_count(current_app.config[f"DEFAULT_LIVE_SERVICE_{channel.upper()}_RATE_LIMIT"], channel)
-            for channel in ("email", "sms", "letter")
+            message_count(limit, channel)
+            for channel, limit in current_app.config["DEFAULT_LIVE_SERVICE_RATE_LIMITS"].items()
         ],
         navigation_links=using_notify_nav(),
     )

--- a/app/templates/views/guidance/bulk-sending.html
+++ b/app/templates/views/guidance/bulk-sending.html
@@ -13,9 +13,9 @@
 
   <h1 class="heading-large">Bulk sending</h1>
 
-  <p class="govuk-body">You can send a batch of up to 100,000 messages at once.</p>
+  <p class="govuk-body">You can send a batch of up to {{ max_spreadsheet_rows|format_thousands }} messages at once.</p>
 
-  <!-- <p class="govuk-body">There’s a maximum daily limit of 250,000 emails, 250,000 text messages and 20,000 letters. If you need to discuss these limits, <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact us</a>.</p> -->
+  <p class="govuk-body">There’s a maximum daily limit of {{ rate_limits|formatted_list(before_each="", after_each="") }}. If you need to discuss these limits, <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact us</a>.</p>
 
   <p class="govuk-body">To send a batch of messages:</p>
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -438,3 +438,14 @@ def test_sms_price(
         f"{expected_rate} pence (plus VAT) for each text message you "
         f"send."
     )
+
+
+def test_bulk_sending_limits(client_request):
+    page = client_request.get("main.guidance_bulk_sending")
+    paragraphs = page.select("main p")
+
+    assert normalize_spaces(paragraphs[0].text) == "You can send a batch of up to 100,000 messages at once."
+    assert normalize_spaces(paragraphs[1].text) == (
+        "There’s a maximum daily limit of 250,000 emails, 250,000 text messages and 20,000 letters. "
+        "If you need to discuss these limits, contact us."
+    )


### PR DESCRIPTION
We removed these temporarily while we migrated from the old, non-channel-specific limit.

I’ve made these dynamic so that if we ever change the values we know to update the guidance.

# Before

<img width="644" alt="image" src="https://user-images.githubusercontent.com/355079/211338879-2da096e8-d5c6-4247-8e36-6df3963d5547.png">

# After

<img width="613" alt="image" src="https://user-images.githubusercontent.com/355079/211338707-0164b614-ab58-4cb5-b7d6-c3af90f44c40.png">


***

Depends on:
- [ ] https://github.com/alphagov/notifications-api/pull/3696