### PR TITLE
Populate new letter columns in letter branding table

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -19,6 +19,7 @@ EVENT_SCHEMAS = {
     },
     "archive_service": {"service_id", "archived_by_id"},
     "update_email_branding": {"email_branding_id", "updated_by_id", "old_email_branding"},
+    "update_letter_branding": {"letter_branding_id", "updated_by_id", "old_letter_branding"},
     "set_inbound_sms_on": {"user_id", "service_id", "inbound_number_id"},
 }
 
@@ -61,6 +62,10 @@ def create_archive_service_event(**kwargs):
 
 def create_update_email_branding_event(**kwargs):
     _send_event("update_email_branding", **kwargs)
+
+
+def create_update_letter_branding_event(**kwargs):
+    _send_event("update_letter_branding", **kwargs)
 
 
 def create_set_inbound_sms_on_event(**kwargs):

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -4,6 +4,7 @@ from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import letter_branding_client
+from app.event_handlers import create_update_letter_branding_event
 from app.main import main
 from app.main.forms import (
     AdminEditLetterBrandingForm,
@@ -56,6 +57,11 @@ def update_letter_branding(branding_id, logo=None):
             current_app.config["AWS_REGION"],
             user_id=session["user_id"],
         )
+        create_update_letter_branding_event(
+            letter_branding_id=branding_id,
+            updated_by_id=current_user.id,
+            old_letter_branding=letter_branding.serialize(),
+        )
 
         if logo.startswith(LETTER_TEMP_TAG.format(user_id=session["user_id"])):
             delete_letter_temp_file(logo)
@@ -75,6 +81,11 @@ def update_letter_branding(branding_id, logo=None):
                 filename=db_filename,
                 name=letter_branding_details_form.name.data,
                 updated_by_id=current_user.id,
+            )
+            create_update_letter_branding_event(
+                letter_branding_id=branding_id,
+                updated_by_id=current_user.id,
+                old_letter_branding=letter_branding.serialize(),
             )
 
             return redirect(url_for("main.letter_branding"))

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -66,16 +66,16 @@ def update_letter_branding(branding_id, logo=None):
         db_filename = letter_filename_for_db(logo, session["user_id"])
 
         try:
+            # If a new file has been uploaded, db_filename and letter_branding.filename will be different
+            if db_filename != letter_branding.filename:
+                upload_letter_svg_logo(logo, db_filename, session["user_id"])
+
             letter_branding_client.update_letter_branding(
                 branding_id=branding_id,
                 filename=db_filename,
                 name=letter_branding_details_form.name.data,
                 updated_by_id=current_user.id,
             )
-
-            # If a new file has been uploaded, db_filename and letter_branding.filename will be different
-            if db_filename != letter_branding.filename:
-                upload_letter_svg_logo(logo, db_filename, session["user_id"])
 
             return redirect(url_for("main.letter_branding"))
 
@@ -85,12 +85,6 @@ def update_letter_branding(branding_id, logo=None):
             else:
                 raise e
         except BotoClientError:
-            # we had a problem saving the file - rollback the db changes
-            letter_branding_client.update_letter_branding(
-                branding_id=branding_id,
-                filename=letter_branding.filename,
-                name=letter_branding.name,
-            )
             file_upload_form.file.errors = ["Error saving uploaded file - try uploading again"]
 
     return render_template(

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -65,25 +65,17 @@ def update_letter_branding(branding_id, logo=None):
         db_filename = letter_filename_for_db(logo, session["user_id"])
 
         try:
-            if db_filename == letter_branding.filename:
+            letter_branding_client.update_letter_branding(
+                branding_id=branding_id,
+                filename=db_filename,
+                name=letter_branding_details_form.name.data,
+            )
 
-                letter_branding_client.update_letter_branding(
-                    branding_id=branding_id,
-                    filename=db_filename,
-                    name=letter_branding_details_form.name.data,
-                )
-
-                return redirect(url_for("main.letter_branding"))
-            else:
-                letter_branding_client.update_letter_branding(
-                    branding_id=branding_id,
-                    filename=db_filename,
-                    name=letter_branding_details_form.name.data,
-                )
-
+            # If a new file has been uploaded, db_filename and letter_branding.filename will be different
+            if db_filename != letter_branding.filename:
                 upload_letter_svg_logo(logo, db_filename, session["user_id"])
 
-                return redirect(url_for("main.letter_branding"))
+            return redirect(url_for("main.letter_branding"))
 
         except HTTPError as e:
             if "name" in e.message:

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -1,5 +1,6 @@
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app, redirect, render_template, request, session, url_for
+from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
 from app import letter_branding_client
@@ -69,6 +70,7 @@ def update_letter_branding(branding_id, logo=None):
                 branding_id=branding_id,
                 filename=db_filename,
                 name=letter_branding_details_form.name.data,
+                updated_by_id=current_user.id,
             )
 
             # If a new file has been uploaded, db_filename and letter_branding.filename will be different
@@ -129,10 +131,7 @@ def create_letter_branding(logo=None):
             db_filename = letter_filename_for_db(logo, session["user_id"])
 
             try:
-                letter_branding_client.create_letter_branding(
-                    filename=db_filename,
-                    name=letter_branding_details_form.name.data,
-                )
+                LetterBranding.create(filename=db_filename, name=letter_branding_details_form.name.data)
 
                 upload_letter_svg_logo(logo, db_filename, session["user_id"])
 

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -57,11 +57,6 @@ def update_letter_branding(branding_id, logo=None):
             current_app.config["AWS_REGION"],
             user_id=session["user_id"],
         )
-        create_update_letter_branding_event(
-            letter_branding_id=branding_id,
-            updated_by_id=current_user.id,
-            old_letter_branding=letter_branding.serialize(),
-        )
 
         if logo.startswith(LETTER_TEMP_TAG.format(user_id=session["user_id"])):
             delete_letter_temp_file(logo)

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -108,7 +108,11 @@ class LetterBranding(Branding):
         filename,
     ):
         # TODO: rename temp to non-temp and clean up temp files
-        new_letter_branding = letter_branding_client.create_letter_branding(name=name, filename=filename)
+        new_letter_branding = letter_branding_client.create_letter_branding(
+            name=name,
+            filename=filename,
+            created_by_id=current_user.id,
+        )
         return cls(new_letter_branding)
 
     @classmethod

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -25,6 +25,9 @@ class Branding(JSONModel):
     def name_like(self, name):
         return email_safe(name, whitespace="") == email_safe(self.name, whitespace="")
 
+    def serialize(self):
+        return self._dict.copy()
+
 
 class EmailBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {
@@ -91,9 +94,6 @@ class EmailBranding(Branding):
     def logo_url(self):
         if self.logo:
             return f"https://{current_app.config['LOGO_CDN_DOMAIN']}/{self.logo}"
-
-    def serialize(self):
-        return self._dict.copy()
 
 
 class LetterBranding(Branding):

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -11,22 +11,24 @@ class LetterBrandingClient(NotifyAdminAPIClient):
         return self.get(url="/letter-branding")
 
     @cache.delete("letter_branding")
-    def create_letter_branding(self, filename, name):
+    def create_letter_branding(self, *, filename, name, created_by_id):
         data = {
             "filename": filename,
             "name": name,
+            "created_by_id": created_by_id,
         }
         return self.post(url="/letter-branding", data=data)
 
     @cache.delete("letter_branding")
     @cache.delete("letter_branding-{branding_id}")
     @cache.delete_by_pattern("organisation-*-letter-branding-pool")
-    def update_letter_branding(self, branding_id, filename, name):
+    def update_letter_branding(self, *, branding_id, filename, name, updated_by_id):
         data = {
             "filename": filename,
             "name": name,
+            "updated_by_id": updated_by_id,
         }
-        return self.post(url="/letter-branding/{}".format(branding_id), data=data)
+        return self.post(url=f"/letter-branding/{branding_id}", data=data)
 
 
 letter_branding_client = LetterBrandingClient()

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -591,6 +591,7 @@ def test_POST_letter_branding_set_name_creates_branding_adds_to_pool_and_redirec
     mock_create_letter_branding.assert_called_once_with(
         filename="temp_example",
         name="some name",
+        created_by_id=fake_uuid,
     )
     mock_add_to_branding_pool.assert_called_once_with(service_one["organisation"], [fake_uuid])
     mock_update_service.assert_called_once_with(SERVICE_ONE_ID, letter_branding=fake_uuid)

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -59,7 +59,7 @@ def test_update_letter_branding_shows_the_current_letter_brand(
     assert page.select_one("#file").attrs.get("accept") == ".svg"
 
 
-def test_update_letter_branding_with_new_valid_file(
+def test_update_letter_branding_with_new_valid_file_shows_page_with_file_preview(
     mocker, client_request, platform_admin_user, mock_get_letter_branding_by_id, fake_uuid
 ):
     with client_request.session_transaction() as session:
@@ -72,9 +72,6 @@ def test_update_letter_branding_with_new_valid_file(
     mocker.patch("app.s3_client.s3_logo_client.uuid.uuid4", return_value=fake_uuid)
     mock_delete_temp_files = mocker.patch("app.main.views.letter_branding.delete_letter_temp_file")
     mocker.patch("app.extensions.antivirus_client.scan", return_value=True)
-    mock_create_update_letter_branding_event = mocker.patch(
-        "app.main.views.letter_branding.create_update_letter_branding_event"
-    )
 
     client_request.login(platform_admin_user)
     page = client_request.post(
@@ -89,12 +86,6 @@ def test_update_letter_branding_with_new_valid_file(
 
     assert mock_s3_upload.called
     assert mock_delete_temp_files.called is False
-
-    mock_create_update_letter_branding_event.assert_called_once_with(
-        letter_branding_id=fake_uuid,
-        updated_by_id=fake_uuid,
-        old_letter_branding={"id": fake_uuid, "name": "HM Government", "filename": "hm-government"},
-    )
 
 
 def test_update_letter_branding_when_uploading_invalid_file(

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -38,7 +38,7 @@ def test_get_all_letter_branding(mocker):
 
 
 def test_create_letter_branding(mocker):
-    new_branding = {"filename": "uuid-test", "name": "my letters"}
+    new_branding = {"filename": "uuid-test", "name": "my letters", "created_by_id": "1234"}
 
     mock_post = mocker.patch("app.notify_client.letter_branding_client.LetterBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
@@ -46,6 +46,7 @@ def test_create_letter_branding(mocker):
     LetterBrandingClient().create_letter_branding(
         filename=new_branding["filename"],
         name=new_branding["name"],
+        created_by_id=new_branding["created_by_id"],
     )
     mock_post.assert_called_once_with(url="/letter-branding", data=new_branding)
 
@@ -53,18 +54,21 @@ def test_create_letter_branding(mocker):
 
 
 def test_update_letter_branding(mocker, fake_uuid):
-    branding = {"filename": "uuid-test", "name": "my letters"}
+    branding = {"filename": "uuid-test", "name": "my letters", "updated_by_id": "1234"}
 
     mock_post = mocker.patch("app.notify_client.letter_branding_client.LetterBrandingClient.post")
     mock_redis_delete = mocker.patch("app.extensions.RedisClient.delete")
     mock_redis_delete_by_pattern = mocker.patch("app.extensions.RedisClient.delete_by_pattern")
     LetterBrandingClient().update_letter_branding(
-        branding_id=fake_uuid, filename=branding["filename"], name=branding["name"]
+        branding_id=fake_uuid,
+        filename=branding["filename"],
+        name=branding["name"],
+        updated_by_id=branding["updated_by_id"],
     )
 
-    mock_post.assert_called_once_with(url="/letter-branding/{}".format(fake_uuid), data=branding)
+    mock_post.assert_called_once_with(url=f"/letter-branding/{fake_uuid}", data=branding)
     assert mock_redis_delete.call_args_list == [
-        call("letter_branding-{}".format(fake_uuid)),
+        call(f"letter_branding-{fake_uuid}"),
         call("letter_branding"),
     ]
     assert mock_redis_delete_by_pattern.call_args_list == [call("organisation-*-letter-branding-pool")]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2526,11 +2526,7 @@ def create_email_branding(id, non_standard_values=None):
 
 
 def create_letter_branding(id, non_standard_values=None):
-    branding = {
-        "id": id,
-        "filename": "example",
-        "name": "Organisation name",
-    }
+    branding = {"id": id, "filename": "example", "name": "Organisation name", "created_by_id": "abcd-1234"}
 
     if non_standard_values:
         branding.update(non_standard_values)
@@ -2644,12 +2640,13 @@ def mock_create_email_branding(mocker, fake_uuid):
 
 @pytest.fixture(scope="function")
 def mock_create_letter_branding(mocker, fake_uuid):
-    def _create_letter_branding(filename, name):
+    def _create_letter_branding(filename, name, created_by_id):
         return create_letter_branding(
             fake_uuid,
             {
                 "name": name,
                 "filename": filename,
+                "created_by_id": created_by_id,
             },
         )["letter_branding"]
 


### PR DESCRIPTION
When we call api to create or update a letter brand we now want to pass the id of the user who created or updated the brand so it can be stored in the database. This makes the changes necessary to pass the new fields through and also creates an event when a brand is updated, matching what we do for email branding.

**Merge after**
- [x] https://github.com/alphagov/notifications-api/pull/3697