### PR TITLE
Use `current_user` in the branding files and remove unused bits from tests

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -1,12 +1,4 @@
-from flask import (
-    abort,
-    current_app,
-    redirect,
-    render_template,
-    request,
-    session,
-    url_for,
-)
+from flask import abort, current_app, redirect, render_template, request, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
@@ -58,17 +50,17 @@ def platform_admin_update_email_branding(branding_id, logo=None):
     if form.validate_on_submit():
         if form.file.data:
             upload_filename = upload_email_logo(
-                form.file.data.filename, form.file.data, current_app.config["AWS_REGION"], user_id=session["user_id"]
+                form.file.data.filename, form.file.data, current_app.config["AWS_REGION"], user_id=current_user.id
             )
 
-            if logo and logo.startswith(TEMP_TAG.format(user_id=session["user_id"])):
+            if logo and logo.startswith(TEMP_TAG.format(user_id=current_user.id)):
                 delete_email_temp_file(logo)
 
             return redirect(
                 url_for(".platform_admin_update_email_branding", branding_id=branding_id, logo=upload_filename)
             )
 
-        updated_logo_name = permanent_email_logo_name(logo, session["user_id"]) if logo else None
+        updated_logo_name = permanent_email_logo_name(logo, current_user.id) if logo else None
 
         try:
             email_branding_client.update_email_branding(
@@ -95,7 +87,7 @@ def platform_admin_update_email_branding(branding_id, logo=None):
         if logo:
             persist_logo(logo, updated_logo_name)
 
-        delete_email_temp_files_created_by(session["user_id"])
+        delete_email_temp_files_created_by(current_user.id)
 
         if not form.errors:
             return redirect(url_for(".email_branding", branding_id=branding_id))
@@ -150,7 +142,7 @@ def create_email_branding_government_identity_colour():
             email_safe(filename),
             image_file.resolve().read_bytes(),
             current_app.config["AWS_REGION"],
-            user_id=session["user_id"],
+            user_id=current_user.id,
         )
         return redirect(
             url_for(
@@ -183,15 +175,15 @@ def platform_admin_create_email_branding(logo=None):
     if form.validate_on_submit():
         if form.file.data:
             upload_filename = upload_email_logo(
-                form.file.data.filename, form.file.data, current_app.config["AWS_REGION"], user_id=session["user_id"]
+                form.file.data.filename, form.file.data, current_app.config["AWS_REGION"], user_id=current_user.id
             )
 
-            if logo and logo.startswith(TEMP_TAG.format(user_id=session["user_id"])):
+            if logo and logo.startswith(TEMP_TAG.format(user_id=current_user.id)):
                 delete_email_temp_file(logo)
 
             return redirect(url_for("main.platform_admin_create_email_branding", logo=upload_filename))
 
-        updated_logo_name = permanent_email_logo_name(logo, session["user_id"]) if logo else None
+        updated_logo_name = permanent_email_logo_name(logo, current_user.id) if logo else None
 
         try:
             email_branding_client.create_email_branding(
@@ -212,7 +204,7 @@ def platform_admin_create_email_branding(logo=None):
         if logo:
             persist_logo(logo, updated_logo_name)
 
-        delete_email_temp_files_created_by(session["user_id"])
+        delete_email_temp_files_created_by(current_user.id)
 
         if not form.errors:
             return redirect(url_for(".email_branding"))

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -1,5 +1,5 @@
 from botocore.exceptions import ClientError as BotoClientError
-from flask import current_app, redirect, render_template, request, session, url_for
+from flask import current_app, redirect, render_template, request, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
@@ -55,21 +55,21 @@ def update_letter_branding(branding_id, logo=None):
             file_upload_form.file.data.filename,
             file_upload_form.file.data,
             current_app.config["AWS_REGION"],
-            user_id=session["user_id"],
+            user_id=current_user.id,
         )
 
-        if logo.startswith(LETTER_TEMP_TAG.format(user_id=session["user_id"])):
+        if logo.startswith(LETTER_TEMP_TAG.format(user_id=current_user.id)):
             delete_letter_temp_file(logo)
 
         return redirect(url_for(".update_letter_branding", branding_id=branding_id, logo=upload_filename))
 
     if details_form_submitted and letter_branding_details_form.validate_on_submit():
-        db_filename = letter_filename_for_db(logo, session["user_id"])
+        db_filename = letter_filename_for_db(logo, current_user.id)
 
         try:
             # If a new file has been uploaded, db_filename and letter_branding.filename will be different
             if db_filename != letter_branding.filename:
-                upload_letter_svg_logo(logo, db_filename, session["user_id"])
+                upload_letter_svg_logo(logo, db_filename, current_user.id)
 
             letter_branding_client.update_letter_branding(
                 branding_id=branding_id,
@@ -118,22 +118,22 @@ def create_letter_branding(logo=None):
             file_upload_form.file.data.filename,
             file_upload_form.file.data,
             current_app.config["AWS_REGION"],
-            user_id=session["user_id"],
+            user_id=current_user.id,
         )
 
-        if logo and logo.startswith(LETTER_TEMP_TAG.format(user_id=session["user_id"])):
+        if logo and logo.startswith(LETTER_TEMP_TAG.format(user_id=current_user.id)):
             delete_letter_temp_file(logo)
 
         return redirect(url_for(".create_letter_branding", logo=upload_filename))
 
     if details_form_submitted and letter_branding_details_form.validate_on_submit():
         if logo:
-            db_filename = letter_filename_for_db(logo, session["user_id"])
+            db_filename = letter_filename_for_db(logo, current_user.id)
 
             try:
                 LetterBranding.create(filename=db_filename, name=letter_branding_details_form.name.data)
 
-                upload_letter_svg_logo(logo, db_filename, session["user_id"])
+                upload_letter_svg_logo(logo, db_filename, current_user.id)
 
                 return redirect(url_for("main.letter_branding"))
 

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -59,9 +59,7 @@ def test_edit_email_branding_shows_the_correct_branding_info(
     assert page.select_one("#colour").attrs.get("value") == "f00"
 
 
-def test_create_email_branding_does_not_show_any_branding_info(
-    client_request, platform_admin_user, mock_no_email_branding
-):
+def test_create_email_branding_does_not_show_any_branding_info(client_request, platform_admin_user):
     client_request.login(platform_admin_user)
     page = client_request.get(
         "main.platform_admin_create_email_branding",
@@ -75,9 +73,7 @@ def test_create_email_branding_does_not_show_any_branding_info(
     assert page.select_one("#colour").attrs.get("value") is None
 
 
-def test_create_email_branding_can_be_populated_from_querystring(
-    client_request, platform_admin_user, mock_no_email_branding
-):
+def test_create_email_branding_can_be_populated_from_querystring(client_request, platform_admin_user):
     client_request.login(platform_admin_user)
     page = client_request.get(
         "main.platform_admin_create_email_branding",
@@ -394,7 +390,7 @@ def test_deletes_previous_temp_logo_after_uploading_logo(
 
     client_request.login(platform_admin_user)
     client_request.post(
-        "main.platform_admin_create_email_branding",
+        endpoint,
         logo=temp_old_filename,
         branding_id=fake_uuid,
         _data={"file": (BytesIO("".encode("utf-8")), "test.png")},
@@ -622,7 +618,7 @@ def test_logo_persisted_when_organisation_saved(
 
 
 def test_logo_does_not_get_persisted_if_updating_email_branding_client_throws_an_error(
-    client_request, platform_admin_user, mock_create_email_branding, mocker, fake_uuid
+    client_request, platform_admin_user, mocker, fake_uuid
 ):
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
         temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename="test.png"
@@ -654,7 +650,7 @@ def test_logo_does_not_get_persisted_if_updating_email_branding_client_throws_an
     ],
 )
 def test_colour_regex_validation(
-    client_request, platform_admin_user, mocker, fake_uuid, colour_hex, expected_status_code, mock_create_email_branding
+    client_request, platform_admin_user, mocker, colour_hex, expected_status_code, mock_create_email_branding
 ):
     data = {"logo": None, "colour": colour_hex, "text": "new text", "name": "new name", "brand_type": "org"}
 
@@ -726,7 +722,7 @@ def test_create_email_branding_government_identity_logo_form(client_request, pla
         assert normalize_spaces(page.select_one("label[for=" + input["id"] + "]").text) == input["value"]
 
 
-def test_post_create_email_branding_government_identity_logo_form(mocker, client_request, platform_admin_user):
+def test_post_create_email_branding_government_identity_logo_form(client_request, platform_admin_user):
     client_request.login(platform_admin_user)
     client_request.post(
         ".create_email_branding_government_identity_logo",

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -260,9 +260,6 @@ def test_create_new_email_branding_when_branding_saved(
     text,
     alt_text,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     data = {
         "operation": "email-branding-details",
         "logo": "test.png",
@@ -274,7 +271,7 @@ def test_create_new_email_branding_when_branding_saved(
     }
 
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename=data["logo"]
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename=data["logo"]
     )
 
     mocker.patch("app.main.views.email_branding.persist_logo")
@@ -381,15 +378,12 @@ def test_deletes_previous_temp_logo_after_uploading_logo(
     if has_data:
         mocker.patch("app.email_branding_client.get_email_branding", return_value=create_email_branding(fake_uuid))
 
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     temp_old_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename="old_test.png"
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename="old_test.png"
     )
 
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename="test.png"
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename="test.png"
     )
 
     mocked_upload_email_logo = mocker.patch(
@@ -420,20 +414,17 @@ def test_update_existing_branding(
     mock_get_email_branding,
     mock_update_email_branding,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     data = {
         "logo": "test.png",
         "colour": "#0000ff",
         "text": "new text",
         "name": "new name",
         "brand_type": "both",
-        "updated_by_id": user_id,
+        "updated_by_id": fake_uuid,
     }
 
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename=data["logo"]
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename=data["logo"]
     )
 
     mocker.patch("app.main.views.email_branding.persist_logo")
@@ -474,7 +465,7 @@ def test_update_existing_branding(
     assert mock_create_update_email_branding_event.call_args_list == [
         mocker.call(
             email_branding_id=fake_uuid,
-            updated_by_id=user_id,
+            updated_by_id=fake_uuid,
             old_email_branding=mock_get_email_branding(fake_uuid)["email_branding"],
         )
     ]
@@ -586,11 +577,8 @@ def test_temp_logo_is_shown_after_uploading_logo(
     mocker,
     fake_uuid,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename="test.png"
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename="test.png"
     )
 
     mocker.patch("app.main.views.email_branding.upload_email_logo", return_value=temp_filename)
@@ -611,11 +599,8 @@ def test_temp_logo_is_shown_after_uploading_logo(
 def test_logo_persisted_when_organisation_saved(
     client_request, platform_admin_user, mock_create_email_branding, mocker, fake_uuid
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename="test.png"
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename="test.png"
     )
 
     mocked_upload_email_logo = mocker.patch("app.main.views.email_branding.upload_email_logo")
@@ -632,18 +617,15 @@ def test_logo_persisted_when_organisation_saved(
     assert not mocked_upload_email_logo.called
     assert mocked_persist_logo.called
     assert mocked_delete_email_temp_files_by.called
-    assert mocked_delete_email_temp_files_by.call_args == call(user_id)
+    assert mocked_delete_email_temp_files_by.call_args == call(fake_uuid)
     assert mock_create_email_branding.called
 
 
 def test_logo_does_not_get_persisted_if_updating_email_branding_client_throws_an_error(
     client_request, platform_admin_user, mock_create_email_branding, mocker, fake_uuid
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id), unique_id=fake_uuid, filename="test.png"
+        temp=TEMP_TAG.format(user_id=fake_uuid), unique_id=fake_uuid, filename="test.png"
     )
 
     mocked_persist_logo = mocker.patch("app.main.views.email_branding.persist_logo")

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -391,7 +391,6 @@ def test_create_letter_branding_fails_validation_when_uploading_SVG_with_bad_ele
     mocker,
     client_request,
     platform_admin_user,
-    fake_uuid,
     svg_contents,
     expected_error,
 ):
@@ -455,7 +454,7 @@ def test_create_letter_branding_deletes_temp_files_when_uploading_a_new_file(
     assert page.select_one("h1").text == "Add letter branding"
 
 
-def test_create_new_letter_branding_shows_preview_of_logo(mocker, client_request, platform_admin_user, fake_uuid):
+def test_create_new_letter_branding_shows_preview_of_logo(client_request, platform_admin_user, fake_uuid):
     temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="temp.svg")
 
     client_request.login(platform_admin_user)
@@ -469,7 +468,7 @@ def test_create_new_letter_branding_shows_preview_of_logo(mocker, client_request
 
 
 def test_create_letter_branding_shows_an_error_when_submitting_details_with_no_logo(
-    client_request, platform_admin_user, fake_uuid
+    client_request, platform_admin_user
 ):
     client_request.login(platform_admin_user)
     page = client_request.post(

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -62,11 +62,8 @@ def test_update_letter_branding_shows_the_current_letter_brand(
 def test_update_letter_branding_with_new_valid_file_shows_page_with_file_preview(
     mocker, client_request, platform_admin_user, mock_get_letter_branding_by_id, fake_uuid
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     filename = "new_file.svg"
-    expected_temp_filename = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename=filename)
+    expected_temp_filename = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename=filename)
 
     mock_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
     mocker.patch("app.s3_client.s3_logo_client.uuid.uuid4", return_value=fake_uuid)
@@ -116,10 +113,7 @@ def test_update_letter_branding_deletes_any_temp_files_when_uploading_a_file(
     mock_get_letter_branding_by_id,
     fake_uuid,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
-    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename="temp.svg")
+    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="temp.svg")
 
     mock_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
     mock_delete_temp_files = mocker.patch("app.main.views.letter_branding.delete_letter_temp_file")
@@ -303,11 +297,8 @@ def test_create_letter_branding_does_not_show_branding_info(
 
 
 def test_create_letter_branding_when_uploading_valid_file(mocker, client_request, platform_admin_user, fake_uuid):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     filename = "test.svg"
-    expected_temp_filename = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename=filename)
+    expected_temp_filename = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename=filename)
 
     mock_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
     mocker.patch("app.s3_client.s3_logo_client.uuid.uuid4", return_value=fake_uuid)
@@ -446,10 +437,7 @@ def test_create_letter_branding_deletes_temp_files_when_uploading_a_new_file(
     platform_admin_user,
     fake_uuid,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
-    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename="temp.svg")
+    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="temp.svg")
 
     mock_s3_upload = mocker.patch("app.s3_client.s3_logo_client.utils_s3upload")
     mock_delete_temp_files = mocker.patch("app.main.views.letter_branding.delete_letter_temp_file")
@@ -468,10 +456,7 @@ def test_create_letter_branding_deletes_temp_files_when_uploading_a_new_file(
 
 
 def test_create_new_letter_branding_shows_preview_of_logo(mocker, client_request, platform_admin_user, fake_uuid):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
-    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename="temp.svg")
+    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="temp.svg")
 
     client_request.login(platform_admin_user)
     page = client_request.get(
@@ -505,10 +490,7 @@ def test_create_letter_branding_persists_logo_when_all_data_is_valid(
     fake_uuid,
     mock_create_letter_branding,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
-    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename="test.svg")
+    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="test.svg")
 
     mock_persist_logo = mocker.patch("app.main.views.letter_branding.persist_logo")
     mock_delete_temp_files = mocker.patch("app.main.views.letter_branding.delete_letter_temp_files_created_by")
@@ -529,14 +511,11 @@ def test_create_letter_branding_persists_logo_when_all_data_is_valid(
     mock_persist_logo.assert_called_once_with(
         temp_logo, "letters/static/images/letter-template/{}-test.svg".format(fake_uuid)
     )
-    mock_delete_temp_files.assert_called_once_with(user_id)
+    mock_delete_temp_files.assert_called_once_with(fake_uuid)
 
 
 def test_create_letter_branding_shows_form_errors_on_name_field(client_request, platform_admin_user, fake_uuid):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
-    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename="test.svg")
+    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="test.svg")
 
     client_request.login(platform_admin_user)
     page = client_request.post(
@@ -559,9 +538,6 @@ def test_create_letter_branding_shows_database_errors_on_name_fields(
     platform_admin_user,
     fake_uuid,
 ):
-    with client_request.session_transaction() as session:
-        user_id = session["user_id"]
-
     mocker.patch(
         "app.main.views.letter_branding.letter_branding_client.create_letter_branding",
         side_effect=HTTPError(
@@ -570,7 +546,7 @@ def test_create_letter_branding_shows_database_errors_on_name_fields(
         ),
     )
 
-    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=user_id, unique_id=fake_uuid, filename="test.svg")
+    temp_logo = LETTER_TEMP_LOGO_LOCATION.format(user_id=fake_uuid, unique_id=fake_uuid, filename="test.svg")
 
     client_request.login(platform_admin_user)
     page = client_request.post(


### PR DESCRIPTION
**Use current_user in the branding files**
Some of the old code for email branding and letter branding was getting the id of the current user from the session using `session["user_id"]`. We can use the `current_user` proxy instead, which is more consistent with our code in other places and saves some set up in the tests.

**Remove unused fixtures from branding tests**
And fix one test where the parameterization wasn't being used.