### PR TITLE
Letter branding - enforce unique name and set organisation default

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -1491,7 +1491,7 @@ def email_branding_upload_logo(service_id):
     )
 
 
-def _should_set_default_org_branding(branding_choice):
+def _should_set_default_org_email_branding(branding_choice):
     # 1. the user has chosen ‘[organisation name]’ in the first page of the journey
     user_chose_org_name = branding_choice == "organisation"
     # 2. and the organisation doesn’t have default branding already
@@ -1540,7 +1540,7 @@ def email_branding_set_alt_text(service_id):
             current_service.organisation.id, [new_email_branding.id]
         )
 
-        if _should_set_default_org_branding(branding_choice):
+        if _should_set_default_org_email_branding(branding_choice):
             current_service.organisation.update(email_branding_id=new_email_branding.id, delete_services_cache=True)
 
         flash(

--- a/app/main/views/service_settings/letter_branding.py
+++ b/app/main/views/service_settings/letter_branding.py
@@ -4,7 +4,7 @@ from flask import current_app, flash, redirect, render_template, request, url_fo
 from flask_login import current_user
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket
 
-from app import current_service, organisations_client
+from app import current_service, letter_branding_client, organisations_client
 from app.extensions import zendesk_client
 from app.main import main
 from app.main.forms import (
@@ -166,8 +166,9 @@ def letter_branding_set_name(service_id):
     form = LetterBrandingNameForm()
 
     if form.validate_on_submit():
-        # TODO: Handle name already existing
-        new_letter_branding = LetterBranding.create(name=form.name.data, filename=temp_filename)
+        name = letter_branding_client.get_unique_name_for_letter_branding(form.name.data)
+
+        new_letter_branding = LetterBranding.create(name=name, filename=temp_filename)
 
         # set as service branding
         current_service.update(letter_branding=new_letter_branding.id)

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -10,6 +10,9 @@ class LetterBrandingClient(NotifyAdminAPIClient):
     def get_all_letter_branding(self):
         return self.get(url="/letter-branding")
 
+    def get_unique_name_for_letter_branding(self, name):
+        return self.post(url="/letter-branding/get-unique-name", data={"name": name})["name"]
+
     @cache.delete("letter_branding")
     def create_letter_branding(self, *, filename, name, created_by_id):
         data = {

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -14,7 +14,7 @@ from notifications_python_client.errors import HTTPError
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket
 
 import app
-from app.main.views.service_settings.index import _should_set_default_org_branding
+from app.main.views.service_settings.index import _should_set_default_org_email_branding
 from app.models.service import Service
 from tests import (
     find_element_by_tag_and_partial_text,
@@ -4423,8 +4423,8 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
     expected_name,
 ):
     mock_flash = mocker.patch("app.main.views.service_settings.index.flash")
-    mock_should_set_default_org_branding = mocker.patch(
-        "app.main.views.service_settings.index._should_set_default_org_branding", return_value=False
+    mock_should_set_default_org_email_branding = mocker.patch(
+        "app.main.views.service_settings.index._should_set_default_org_email_branding", return_value=False
     )
     mock_add_to_branding_pool = mocker.patch(
         "app.organisations_client.add_brandings_to_email_branding_pool", return_value=None
@@ -4456,7 +4456,7 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
         "You’ve changed your email branding. Send yourself an email to make sure it looks OK.",
         "default_with_tick",
     )
-    mock_should_set_default_org_branding.assert_called_once_with(None)
+    mock_should_set_default_org_email_branding.assert_called_once_with(None)
 
 
 def test_POST_email_branding_set_alt_text_creates_branding_sets_org_default_if_appropriate(
@@ -4473,8 +4473,8 @@ def test_POST_email_branding_set_alt_text_creates_branding_sets_org_default_if_a
     mocker,
 ):
     service_one["organisation"] = ORGANISATION_ID
-    mock_should_set_default_org_branding = mocker.patch(
-        "app.main.views.service_settings.index._should_set_default_org_branding", return_value=True
+    mock_should_set_default_org_email_branding = mocker.patch(
+        "app.main.views.service_settings.index._should_set_default_org_email_branding", return_value=True
     )
     mock_add_to_branding_pool = mocker.patch(
         "app.organisations_client.add_brandings_to_email_branding_pool", return_value=None
@@ -4499,7 +4499,7 @@ def test_POST_email_branding_set_alt_text_creates_branding_sets_org_default_if_a
         created_by_id=active_user_with_permissions["id"],
     )
     mock_add_to_branding_pool.assert_called_once_with(service_one["organisation"], [fake_uuid])
-    mock_should_set_default_org_branding.assert_called_once_with("organisation")
+    mock_should_set_default_org_email_branding.assert_called_once_with("organisation")
     mock_update_organisation.assert_called_once_with(
         ORGANISATION_ID, cached_service_ids=ANY, email_branding_id=fake_uuid
     )
@@ -6210,7 +6210,9 @@ def test_service_set_broadcast_channel_makes_you_choose(
 
 
 @pytest.mark.parametrize("branding_choice", [None, "govuk_and_org", "something_else"])
-def test_should_set_default_org_branding_fails_if_branding_choice_is_not_org(client_request, mocker, branding_choice):
+def test_should_set_default_org_email_branding_fails_if_branding_choice_is_not_org(
+    client_request, mocker, branding_choice
+):
     organisation = organisation_json(email_branding_id=None, organisation_type="local")
     service = service_json(organisation_id=organisation["id"], organisation_type="local")
     mocker.patch(
@@ -6221,10 +6223,10 @@ def test_should_set_default_org_branding_fails_if_branding_choice_is_not_org(cli
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
     g.current_service = Service(service)
 
-    assert _should_set_default_org_branding(branding_choice) is False
+    assert _should_set_default_org_email_branding(branding_choice) is False
 
 
-def test_should_set_default_org_branding_fails_if_org_already_has_a_default_branding(client_request, mocker):
+def test_should_set_default_org_email_branding_fails_if_org_already_has_a_default_branding(client_request, mocker):
     organisation = organisation_json(email_branding_id="12345", organisation_type="local")
     service = service_json(organisation_id=organisation["id"], organisation_type="local")
     mocker.patch(
@@ -6235,10 +6237,10 @@ def test_should_set_default_org_branding_fails_if_org_already_has_a_default_bran
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
     g.current_service = Service(service)
 
-    assert _should_set_default_org_branding("organisation") is False
+    assert _should_set_default_org_email_branding("organisation") is False
 
 
-def test_should_set_default_org_branding_fails_if_org_is_central(client_request, mocker):
+def test_should_set_default_org_email_branding_fails_if_org_is_central(client_request, mocker):
     organisation = organisation_json(email_branding_id=None, organisation_type="central")
     service = service_json(organisation_id=organisation["id"], organisation_type="central")
     mocker.patch(
@@ -6249,10 +6251,10 @@ def test_should_set_default_org_branding_fails_if_org_is_central(client_request,
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
     g.current_service = Service(service)
 
-    assert _should_set_default_org_branding("organisation") is False
+    assert _should_set_default_org_email_branding("organisation") is False
 
 
-def test_should_set_default_org_branding_fails_if_other_live_services_in_org(client_request, mocker):
+def test_should_set_default_org_email_branding_fails_if_other_live_services_in_org(client_request, mocker):
     organisation = organisation_json(email_branding_id=None, organisation_type="local")
     service = service_json(organisation_id=organisation["id"], organisation_type="local")
     mocker.patch(
@@ -6263,13 +6265,15 @@ def test_should_set_default_org_branding_fails_if_other_live_services_in_org(cli
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
     g.current_service = Service(service)
 
-    assert _should_set_default_org_branding("organisation") is False
+    assert _should_set_default_org_email_branding("organisation") is False
 
 
 # regardless of whether this service is live, we're only interested in other services with
 # different ids when checking for other live services
 @pytest.mark.parametrize("is_service_trial", [True, False])
-def test_should_set_default_org_branding_succeeds_if_all_conditions_are_met(client_request, mocker, is_service_trial):
+def test_should_set_default_org_email_branding_succeeds_if_all_conditions_are_met(
+    client_request, mocker, is_service_trial
+):
     organisation = organisation_json(email_branding_id=None, organisation_type="local")
     service = service_json(organisation_id=organisation["id"], organisation_type="local", restricted=is_service_trial)
     mocker.patch(
@@ -6280,4 +6284,4 @@ def test_should_set_default_org_branding_succeeds_if_all_conditions_are_met(clie
     mocker.patch("app.organisations_client.get_organisation", return_value=organisation)
     g.current_service = Service(service)
 
-    assert _should_set_default_org_branding("organisation") is True
+    assert _should_set_default_org_email_branding("organisation") is True

--- a/tests/app/notify_client/test_letter_branding_client.py
+++ b/tests/app/notify_client/test_letter_branding_client.py
@@ -37,6 +37,17 @@ def test_get_all_letter_branding(mocker):
     )
 
 
+def test_get_unique_name_for_letter_branding(mocker):
+    mock_post = mocker.patch(
+        "app.notify_client.letter_branding_client.LetterBrandingClient.post", return_value={"name": "some unique name"}
+    )
+
+    ret = LetterBrandingClient().get_unique_name_for_letter_branding("some name")
+
+    mock_post.assert_called_once_with(url="/letter-branding/get-unique-name", data={"name": "some name"})
+    assert ret == "some unique name"
+
+
 def test_create_letter_branding(mocker):
     new_branding = {"filename": "uuid-test", "name": "my letters", "created_by_id": "1234"}
 


### PR DESCRIPTION
Bring these in parity with email branding[^1][^2]. There's one slight change in that there's no check to see if the org is central or not. But the rest is the same.

[^1]: #4473
[^2]: #4498