### PR TITLE
Rename branding files that have been created by users

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -79,7 +79,7 @@ from app.models.branding import (
     LetterBranding,
 )
 from app.models.organisation import Organisation
-from app.s3_client.s3_logo_client import upload_email_logo
+from app.s3_client.s3_logo_client import permanent_email_logo_name, upload_email_logo
 from app.utils import (
     DELIVERED_STATUSES,
     FAILURE_STATUSES,
@@ -1526,6 +1526,8 @@ def email_branding_set_alt_text(service_id):
     if form.validate_on_submit():
         # we use this key to keep track of user choices through the journey but we don't use it to save the branding
         branding_choice = email_branding_data.pop("branding_choice")
+
+        email_branding_data["logo"] = permanent_email_logo_name(email_branding_data["logo"], current_user.id)
 
         new_email_branding = EmailBranding.create(
             alt_text=form.alt_text.data,

--- a/app/main/views/service_settings/letter_branding.py
+++ b/app/main/views/service_settings/letter_branding.py
@@ -15,6 +15,7 @@ from app.main.forms import (
 from app.models.branding import LetterBranding
 from app.s3_client.s3_logo_client import (
     get_letter_filename_with_no_path_or_extension,
+    letter_filename_for_db,
     upload_letter_temp_logo,
 )
 from app.utils.user import user_has_permissions
@@ -181,7 +182,8 @@ def letter_branding_set_name(service_id):
     if form.validate_on_submit():
         name = letter_branding_client.get_unique_name_for_letter_branding(form.name.data)
 
-        new_letter_branding = LetterBranding.create(name=name, filename=temp_filename)
+        db_filename = letter_filename_for_db(temp_filename, current_user.id)
+        new_letter_branding = LetterBranding.create(name=name, filename=db_filename)
 
         # set as service branding
         current_service.update(letter_branding=new_letter_branding.id)

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -11,6 +11,7 @@ from app.main.views.service_settings.letter_branding import (
 )
 from app.models.branding import LetterBranding
 from app.models.service import Service
+from app.s3_client.s3_logo_client import LETTER_PREFIX
 from tests import organisation_json, sample_uuid, service_json
 from tests.conftest import (
     ORGANISATION_ID,
@@ -597,7 +598,7 @@ def test_POST_letter_branding_set_name_creates_branding_adds_to_pool_and_redirec
     client_request.post(
         "main.letter_branding_set_name",
         service_id=SERVICE_ONE_ID,
-        temp_filename="temp_example",
+        temp_filename=f"{LETTER_PREFIX}temp-{fake_uuid}_{fake_uuid}_example.svg",
         branding_choice="something else",
         _data={"name": "some name"},
         _expected_status=302,
@@ -606,7 +607,7 @@ def test_POST_letter_branding_set_name_creates_branding_adds_to_pool_and_redirec
 
     mock_get_unique_name.assert_called_once_with("some name")
     mock_create_letter_branding.assert_called_once_with(
-        filename="temp_example",
+        filename=f"{fake_uuid}_example",
         name="some unique name",
         created_by_id=fake_uuid,
     )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4433,13 +4433,13 @@ def test_POST_email_branding_set_alt_text_creates_branding_adds_to_pool_and_redi
         "main.email_branding_set_alt_text",
         service_id=service_one["id"],
         brand_type=brand_type,
-        logo="example.png",
+        logo=f"temp-{fake_uuid}_{fake_uuid}-example.png",
         _data={"alt_text": "some alt text"},
         _expected_status=302,
         _expected_redirect=url_for("main.service_settings", service_id=SERVICE_ONE_ID),
     )
     mock_create_email_branding.assert_called_once_with(
-        logo="example.png",
+        logo=f"{fake_uuid}-example.png",
         name=expected_name,
         alt_text="some alt text",
         text=None,
@@ -4483,14 +4483,14 @@ def test_POST_email_branding_set_alt_text_creates_branding_sets_org_default_if_a
         "main.email_branding_set_alt_text",
         service_id=service_one["id"],
         brand_type="org",
-        logo="example.png",
+        logo=f"temp-{fake_uuid}_{fake_uuid}-example.png",
         branding_choice="organisation",
         _data={"alt_text": "some alt text"},
         _expected_status=302,
         _expected_redirect=url_for("main.service_settings", service_id=SERVICE_ONE_ID),
     )
     mock_create_email_branding.assert_called_once_with(
-        logo="example.png",
+        logo=f"{fake_uuid}-example.png",
         name="some alt text",
         alt_text="some alt text",
         text=None,


### PR DESCRIPTION
This renames the logos to remove the temporary prefix from the start to match what we do when a platform admin user uploads a logo. If we don't rename the logos there is a chance that any logos that a platform admin user uploads using the user-facing routes will get deleted. This is because we delete all logos with the temporary prefix that a user has uploaded when they use the platform admin branding routes.

This is a temporary fix to stop us creating any more logos which have a "temporary name" (and are at risk of deletion). The longer term plan is to use S3 tags to indicate which uploaded logos aren't being used for branding and can be deleted.