### PR TITLE
Archive email branding

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -99,6 +99,12 @@ def platform_admin_update_email_branding(branding_id, logo=None):
     )
 
 
+@main.route("/email-branding/<uuid:branding_id>/archive", methods=["GET", "POST"])
+@user_is_platform_admin
+def platform_admin_archive_email_branding():
+    pass
+
+
 @main.route("/email-branding/create-government-identity/logo", methods=["GET", "POST"])
 @user_is_platform_admin
 def create_email_branding_government_identity_logo():

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -1,7 +1,7 @@
 import os
 from io import BytesIO
 
-from flask import abort, current_app, redirect, render_template, request, url_for
+from flask import abort, current_app, flash, redirect, render_template, request, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
@@ -32,8 +32,19 @@ def email_branding():
     )
 
 
-@main.route("/email-branding/<uuid:branding_id>/edit", methods=["GET", "POST"])
-@main.route("/email-branding/<uuid:branding_id>/edit/<logo>", methods=["GET", "POST"])
+@main.route(
+    "/email-branding/<uuid:branding_id>/edit", methods=["GET", "POST"], endpoint="platform_admin_update_email_branding"
+)
+@main.route(
+    "/email-branding/<uuid:branding_id>/edit/<logo>",
+    methods=["GET", "POST"],
+    endpoint="platform_admin_update_email_branding",
+)
+@main.route(
+    "/email-branding/<uuid:branding_id>/archive",
+    methods=["GET"],
+    endpoint="platform_admin_confirm_archive_email_branding",
+)
 @user_is_platform_admin
 def platform_admin_update_email_branding(branding_id, logo=None):
     email_branding = EmailBranding.from_id(branding_id)
@@ -87,6 +98,9 @@ def platform_admin_update_email_branding(branding_id, logo=None):
         if not form.errors:
             return redirect(url_for(".email_branding", branding_id=branding_id))
 
+    if request.endpoint == "main.platform_admin_confirm_archive_email_branding":
+        flash("Are you sure you want to archive this email branding?", "archive")
+
     return (
         render_template(
             "views/email-branding/manage-branding.html",
@@ -99,7 +113,7 @@ def platform_admin_update_email_branding(branding_id, logo=None):
     )
 
 
-@main.route("/email-branding/<uuid:branding_id>/archive", methods=["GET", "POST"])
+@main.route("/email-branding/<uuid:branding_id>/archive", methods=["POST"])
 @user_is_platform_admin
 def platform_admin_archive_email_branding():
     pass

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -115,8 +115,11 @@ def platform_admin_update_email_branding(branding_id, logo=None):
 
 @main.route("/email-branding/<uuid:branding_id>/archive", methods=["POST"])
 @user_is_platform_admin
-def platform_admin_archive_email_branding():
-    pass
+def platform_admin_archive_email_branding(branding_id):
+    # TODO: if branding used by active services, don't archive it.
+
+    email_branding_client.archive_email_branding(branding_id=branding_id)
+    return redirect(url_for(".email_branding"))
 
 
 @main.route("/email-branding/create-government-identity/logo", methods=["GET", "POST"])

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -99,7 +99,10 @@ def platform_admin_update_email_branding(branding_id, logo=None):
             return redirect(url_for(".email_branding", branding_id=branding_id))
 
     if request.endpoint == "main.platform_admin_confirm_archive_email_branding":
-        flash("Are you sure you want to archive this email branding?", "archive")
+        if email_branding.is_used_by_orgs_or_services:
+            flash("This branding is used and so it can't be archived.")
+        else:
+            flash("Are you sure you want to archive this email branding?", "archive")
 
     return (
         render_template(
@@ -116,8 +119,6 @@ def platform_admin_update_email_branding(branding_id, logo=None):
 @main.route("/email-branding/<uuid:branding_id>/archive", methods=["POST"])
 @user_is_platform_admin
 def platform_admin_archive_email_branding(branding_id):
-    # TODO: if branding used by active services, don't archive it.
-
     email_branding_client.archive_email_branding(branding_id=branding_id)
     return redirect(url_for(".email_branding"))
 

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -111,7 +111,7 @@ def platform_admin_update_email_branding(branding_id, logo=None):
                 raise e
 
         if not form.errors:
-            return redirect(url_for(".email_branding", branding_id=branding_id))
+            return redirect(url_for(".platform_admin_view_email_branding", branding_id=branding_id))
 
     return (
         render_template(

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -9,6 +9,7 @@ from app.models import JSONModel, ModelList
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.letter_branding_client import letter_branding_client
 from app.notify_client.organisations_api_client import organisations_client
+from app.notify_client.user_api_client import user_api_client
 
 
 class Branding(JSONModel):
@@ -36,6 +37,9 @@ class EmailBranding(Branding):
         "alt_text",
         "text",
         "brand_type",
+        "created_by",
+        "created_at",
+        "updated_at",
     }
 
     NHS_ID = "a7dc4e56-660b-4db7-8cff-12c37b12b5ea"
@@ -112,6 +116,12 @@ class EmailBranding(Branding):
         orgs_and_services = email_branding_client.get_orgs_and_services_associated_with_branding(self.id)["data"]
 
         return orgs_and_services["services"]
+
+    @property
+    def created_by_user(self):
+        if self.created_by:
+            return user_api_client.get_user(self.created_by)
+        return None
 
 
 class LetterBranding(Branding):

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -95,6 +95,12 @@ class EmailBranding(Branding):
         if self.logo:
             return f"https://{current_app.config['LOGO_CDN_DOMAIN']}/{self.logo}"
 
+    @property
+    def is_used_by_orgs_or_services(self):
+        orgs_and_services = email_branding_client.get_orgs_and_services_associated_with_branding(self.id)["data"]
+
+        return len(orgs_and_services["services"]) > 0 or len(orgs_and_services["organisations"]) > 0
+
 
 class LetterBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {"filename"}

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -101,6 +101,18 @@ class EmailBranding(Branding):
 
         return len(orgs_and_services["services"]) > 0 or len(orgs_and_services["organisations"]) > 0
 
+    @property
+    def organisations(self):
+        orgs_and_services = email_branding_client.get_orgs_and_services_associated_with_branding(self.id)["data"]
+
+        return orgs_and_services["organisations"]
+
+    @property
+    def services(self):
+        orgs_and_services = email_branding_client.get_orgs_and_services_associated_with_branding(self.id)["data"]
+
+        return orgs_and_services["services"]
+
 
 class LetterBranding(Branding):
     ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {"filename"}

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -105,6 +105,7 @@ class HeaderNavigation(Navigation):
             "platform_admin_confirm_archive_email_branding",
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
+            "platform_admin_view_email_branding",
             "trial_services",
             "update_letter_branding",
             "user_information",

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -102,6 +102,7 @@ class HeaderNavigation(Navigation):
             "platform_admin_returned_letters",
             "platform_admin_splash_page",
             "platform_admin_archive_email_branding",
+            "platform_admin_confirm_archive_email_branding",
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
             "trial_services",

--- a/app/navigation.py
+++ b/app/navigation.py
@@ -101,6 +101,7 @@ class HeaderNavigation(Navigation):
             "platform_admin_reports",
             "platform_admin_returned_letters",
             "platform_admin_splash_page",
+            "platform_admin_archive_email_branding",
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
             "trial_services",

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -50,5 +50,8 @@ class EmailBrandingClient(NotifyAdminAPIClient):
     def archive_email_branding(self, branding_id):
         return self.post(url=f"/email-branding/{branding_id}/delete", data=None)
 
+    def get_orgs_and_services_associated_with_branding(self, branding_id):
+        return self.get(url=f"/email-branding/{branding_id}/orgs_and_services")
+
 
 email_branding_client = EmailBrandingClient()

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -4,7 +4,7 @@ from app.notify_client import NotifyAdminAPIClient, cache
 class EmailBrandingClient(NotifyAdminAPIClient):
     @cache.set("email_branding-{branding_id}")
     def get_email_branding(self, branding_id):
-        return self.get(url="/email-branding/{}".format(branding_id))
+        return self.get(url=f"/email-branding/{branding_id}")
 
     @cache.set("email_branding")
     def get_all_email_branding(self):
@@ -42,7 +42,13 @@ class EmailBrandingClient(NotifyAdminAPIClient):
             "brand_type": brand_type,
             "updated_by": updated_by_id,
         }
-        return self.post(url="/email-branding/{}".format(branding_id), data=data)
+        return self.post(url=f"/email-branding/{branding_id}", data=data)
+
+    @cache.delete("email_branding")
+    @cache.delete("email_branding-{branding_id}")
+    @cache.delete_by_pattern("organisation-*-email-branding-pool")
+    def archive_email_branding(self, branding_id):
+        return self.post(url=f"/email-branding/{branding_id}/delete", data=None)
 
 
 email_branding_client = EmailBrandingClient()

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -48,7 +48,7 @@ class EmailBrandingClient(NotifyAdminAPIClient):
     @cache.delete("email_branding-{branding_id}")
     @cache.delete_by_pattern("organisation-*-email-branding-pool")
     def archive_email_branding(self, branding_id):
-        return self.post(url=f"/email-branding/{branding_id}/delete", data=None)
+        return self.post(url=f"/email-branding/{branding_id}/archive", data=None)
 
     def get_orgs_and_services_associated_with_branding(self, branding_id):
         return self.get(url=f"/email-branding/{branding_id}/orgs_and_services")

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -3,7 +3,6 @@
   {% if messages %}
     {% for category, message in messages %}
       {% if category in [
-        'archive',
         'cancel',
         'delete',
         'suspend',

--- a/app/templates/flash_messages.html
+++ b/app/templates/flash_messages.html
@@ -3,6 +3,7 @@
   {% if messages %}
     {% for category, message in messages %}
       {% if category in [
+        'archive',
         'cancel',
         'delete',
         'suspend',

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -46,15 +46,6 @@
         </div>
       {% endcall %}
 
-      <!-- Should not be shown if email branding already archived -->
-      {% if email_branding %}
-        <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
-          <a class="govuk-link govuk-link--destructive"
-            href="{{ url_for('.platform_admin_confirm_archive_email_branding', branding_id=email_branding.id) }}">
-            Archive this branding</a>
-        </span>
-      {% endif %}
-      &emsp;
     </div>
   </div>
 

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -50,7 +50,7 @@
       {% if email_branding %}
         <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
           <a class="govuk-link govuk-link--destructive"
-            href="{{ url_for('.platform_admin_archive_email_branding', branding_id=email_branding.id) }}">
+            href="{{ url_for('.platform_admin_confirm_archive_email_branding', branding_id=email_branding.id) }}">
             Archive this branding</a>
         </span>
       {% endif %}

--- a/app/templates/views/email-branding/manage-branding.html
+++ b/app/templates/views/email-branding/manage-branding.html
@@ -45,6 +45,16 @@
           ) }}
         </div>
       {% endcall %}
+
+      <!-- Should not be shown if email branding already archived -->
+      {% if email_branding %}
+        <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
+          <a class="govuk-link govuk-link--destructive"
+            href="{{ url_for('.platform_admin_archive_email_branding', branding_id=email_branding.id) }}">
+            Archive this branding</a>
+        </span>
+      {% endif %}
+      &emsp;
     </div>
   </div>
 

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -15,7 +15,7 @@
   <nav>
     {% for brand in email_brandings|sort %}
       <div class="browse-list-item">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.platform_admin_update_email_branding', branding_id=brand.id) }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.platform_admin_view_email_branding', branding_id=brand.id) }}">
           {{ brand.name or 'Unnamed' }}
         </a>
       </div>

--- a/app/templates/views/email-branding/view-branding.html
+++ b/app/templates/views/email-branding/view-branding.html
@@ -57,6 +57,24 @@
             {% endif %}
         </nav>
 
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />
+
+        {% if email_branding.created_by %}
+            <p class="govuk-body">
+                Created by <a class="govuk-link govuk-link--no-visited-state"
+                    href="{{ url_for('.user_information', user_id=email_branding.created_by) }}">
+                    {{ email_branding.created_by_user.name }}
+                </a> {% if email_branding.created_at %}on {{ email_branding.created_at | format_date }}{% endif %}
+            </p>
+        {% endif %}
+        {% if email_branding.updated_at %}
+            <p class="govuk-body">
+                Last updated on {{ email_branding.updated_at | format_date }}
+            </p>
+        {% endif %}
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />
+
         <div class="js-stick-at-bottom-when-scrolling">
             <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
                 <a class="govuk-link"

--- a/app/templates/views/email-branding/view-branding.html
+++ b/app/templates/views/email-branding/view-branding.html
@@ -1,0 +1,77 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/branding-preview.html" import email_branding_preview %}
+
+{% set page_title = email_branding.name %}
+
+{% block per_page_title %}
+{{ page_title }}
+{% endblock %}
+
+
+{% block backLink %}
+{{ govukBackLink({ "href": url_for('.email_branding') }) }}
+{% endblock %}
+
+{% block platform_admin_content %}
+
+<div class="govuk-grid-row bottom-gutter">
+    <div class="govuk-grid-column-full">
+        {{ page_header(email_branding.name) }}
+
+        {{ email_branding_preview(email_branding.id) }}
+
+        <h2 class="heading-medium">Organisations using this branding as their default</h2>
+        <nav class="browse-list">
+            {% if branding_orgs %}
+                <ul>
+                    {% for organisation in branding_orgs %}
+                        <li class="browse-list-item">
+                            <a class="govuk-link govuk-link--no-visited-state browse-list-hint"
+                                href="{{ url_for('.organisation_settings', org_id=organisation.id) }}">
+                                {{ organisation.name }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p class="hint">No organisations use this branding as their default.</p>
+            {% endif %}
+        </nav>
+
+        <h2 class="heading-medium">Services using this branding</h2>
+        <nav class="browse-list">
+            {% if branding_services %}
+            <ul>
+                {% for service in branding_services %}
+                <li class="browse-list-item">
+                    <a class="govuk-link govuk-link--no-visited-state browse-list-hint" href="{{ url_for('.service_settings', service_id=service.id) }}">
+                        {{ service.name }}
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="hint">No services use this branding.</p>
+            {% endif %}
+        </nav>
+
+        <div class="js-stick-at-bottom-when-scrolling">
+            <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
+                <a class="govuk-link"
+                    href="{{ url_for('.platform_admin_update_email_branding', branding_id=email_branding.id) }}">
+                    Edit this branding</a>
+            </span>
+            &emsp;
+            <!-- Should not be shown if email branding already archived -->
+            <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
+                <a class="govuk-link govuk-link--destructive"
+                    href="{{ url_for('.platform_admin_confirm_archive_email_branding', branding_id=email_branding.id) }}">
+                    Delete this branding</a>
+            </span>
+            &emsp;
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -59,7 +59,25 @@ def test_edit_email_branding_shows_the_correct_branding_info(
     assert page.select_one("#colour").attrs.get("value") == "f00"
 
 
-def test_create_email_branding_does_not_show_any_branding_info(client_request, platform_admin_user):
+def test_edit_email_branding_shows_the_archive_button(
+    client_request, platform_admin_user, mock_get_email_branding, fake_uuid
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get(
+        ".platform_admin_update_email_branding",
+        branding_id=fake_uuid,
+        _test_page_title=False,  # TODO: Fix page titles
+    )
+
+    archive_link = page.select_one(".govuk-link--destructive")
+
+    assert archive_link.text.strip() == "Archive this branding"
+    assert archive_link["href"] == url_for(".platform_admin_archive_email_branding", branding_id=fake_uuid)
+
+
+def test_create_email_branding_does_not_show_any_branding_info(
+    client_request, platform_admin_user
+):
     client_request.login(platform_admin_user)
     page = client_request.get(
         "main.platform_admin_create_email_branding",

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -72,12 +72,10 @@ def test_edit_email_branding_shows_the_archive_button(
     archive_link = page.select_one(".govuk-link--destructive")
 
     assert archive_link.text.strip() == "Archive this branding"
-    assert archive_link["href"] == url_for(".platform_admin_archive_email_branding", branding_id=fake_uuid)
+    assert archive_link["href"] == url_for(".platform_admin_confirm_archive_email_branding", branding_id=fake_uuid)
 
 
-def test_create_email_branding_does_not_show_any_branding_info(
-    client_request, platform_admin_user
-):
+def test_create_email_branding_does_not_show_any_branding_info(client_request, platform_admin_user):
     client_request.login(platform_admin_user)
     page = client_request.get(
         "main.platform_admin_create_email_branding",
@@ -559,6 +557,23 @@ def test_update_email_branding_with_unique_name_conflict(
         normalize_spaces(resp.select_one("#name-error").text)
         == "Error: An email branding with that name already exists."
     )
+
+
+def test_platform_admin_confirm_archive_email_branding(
+    client_request, platform_admin_user, mock_get_email_branding, fake_uuid
+):
+    client_request.login(platform_admin_user)
+    page = client_request.get(
+        ".platform_admin_confirm_archive_email_branding",
+        branding_id=fake_uuid,
+        _test_page_title=False,  # TODO: Fix page titles
+    )
+
+    assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
+        "Are you sure you want to delete this email branding? Yes, delete"
+    )
+    assert "action" not in page.select_one(".banner-dangerous form")
+    assert page.select_one(".banner-dangerous form")["method"] == "post"
 
 
 def test_temp_logo_is_shown_after_uploading_logo(

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -576,6 +576,25 @@ def test_platform_admin_confirm_archive_email_branding(
     assert page.select_one(".banner-dangerous form")["method"] == "post"
 
 
+def test_platform_admin_archive_email_branding_happy_path(
+    client_request,
+    platform_admin_user,
+    mocker,
+    fake_uuid,
+    mock_get_email_branding,
+):
+    mock_archive = mocker.patch("app.email_branding_client.archive_email_branding")
+
+    client_request.login(platform_admin_user)
+
+    client_request.post(
+        ".platform_admin_archive_email_branding",
+        branding_id=fake_uuid,
+        _expected_redirect=url_for(".email_branding"),
+    )
+    mock_archive.assert_called_once_with(branding_id=fake_uuid)
+
+
 def test_temp_logo_is_shown_after_uploading_logo(
     client_request,
     platform_admin_user,

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -441,6 +441,10 @@ def test_update_existing_branding(
             "cdn_url": "https://static-logos.cdn.com",
             "brand_type": data["brand_type"],
         },
+        _expected_redirect=url_for(
+            ".platform_admin_view_email_branding",
+            branding_id=fake_uuid,
+        ),
     )
 
     assert mock_update_email_branding.called

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -226,6 +226,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "platform_admin_returned_letters",
             "platform_admin_splash_page",
             "platform_admin_archive_email_branding",
+            "platform_admin_confirm_archive_email_branding",
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
             "preview_broadcast_areas",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -229,6 +229,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "platform_admin_confirm_archive_email_branding",
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
+            "platform_admin_view_email_branding",
             "preview_broadcast_areas",
             "preview_broadcast_message",
             "pricing",

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -225,6 +225,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "platform_admin_reports",
             "platform_admin_returned_letters",
             "platform_admin_splash_page",
+            "platform_admin_archive_email_branding",
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
             "preview_broadcast_areas",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3035,6 +3035,35 @@ def valid_token(notify_admin, fake_uuid):
 
 
 @pytest.fixture(scope="function")
+def mock_get_orgs_and_services_associated_with_branding_empty(mocker):
+    def _get(email_branding_id):
+        return {"data": {"services": [], "organisations": []}}
+
+    return mocker.patch("app.email_branding_client.get_orgs_and_services_associated_with_branding", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
+def mock_get_orgs_and_services_associated_with_branding_no_orgs(mocker):
+    def _get(email_branding_id):
+        return {
+            "data": {
+                "services": [{"name": "service 1", "id": "1234"}, {"name": "service 2", "id": "5678"}],
+                "organisations": [],
+            }
+        }
+
+    return mocker.patch("app.email_branding_client.get_orgs_and_services_associated_with_branding", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
+def mock_get_orgs_and_services_associated_with_branding_no_services(mocker):
+    def _get(email_branding_id):
+        return {"data": {"services": [], "organisations": [{"name": "organisation 1", "id": "1234"}]}}
+
+    return mocker.patch("app.email_branding_client.get_orgs_and_services_associated_with_branding", side_effect=_get)
+
+
+@pytest.fixture(scope="function")
 def mock_get_valid_service_inbound_api(mocker):
     def _get(service_id, inbound_api_id):
         return {

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -18,6 +18,7 @@
     "/documentation",
     "/email-auth/<token>",
     "/email-branding",
+    "/email-branding/<uuid:branding_id>",
     "/email-branding/<uuid:branding_id>/archive",
     "/email-branding/<uuid:branding_id>/edit",
     "/email-branding/<uuid:branding_id>/edit/<logo>",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -18,6 +18,7 @@
     "/documentation",
     "/email-auth/<token>",
     "/email-branding",
+    "/email-branding/<uuid:branding_id>/archive",
     "/email-branding/<uuid:branding_id>/edit",
     "/email-branding/<uuid:branding_id>/edit/<logo>",
     "/email-branding/create",


### PR DESCRIPTION
In this PR:
- new page for viewing an email branding (more detail in the commit)
- let admin users archive a branding

TODO:
- don't show archive link when branding already archived

Screenshots:

![Screenshot 2023-01-13 at 17 32 34](https://user-images.githubusercontent.com/20957548/212382940-b8df98f6-8af9-4761-a4a9-b9f3921ac810.png)


![Screenshot 2023-01-13 at 17 32 50](https://user-images.githubusercontent.com/20957548/212382945-88c83ab5-c6e7-4f4a-8226-0a8efb416ce8.png)


![Screenshot 2023-01-13 at 17 33 07](https://user-images.githubusercontent.com/20957548/212382947-bd7c1cc1-7f6d-4900-9da7-9fc53aea16a8.png)
