### PR TITLE
preview current letter branding when changing it

### DIFF
--- a/app/templates/views/service-settings/branding/letter-branding-options.html
+++ b/app/templates/views/service-settings/branding/letter-branding-options.html
@@ -6,6 +6,7 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+{% from "components/branding-preview.html" import letter_branding_preview %}
 
 {% block service_page_title %}
   Change letter branding
@@ -24,6 +25,10 @@
   <p class="govuk-body">
     Your letters currently have {{ current_service.letter_branding.name or 'no' }} branding.
   </p>
+
+  {% if current_service.letter_branding %}
+    {{ letter_branding_preview(current_service.letter_branding_id) }}
+  {% endif %}
 
   {% call form_wrapper() %}
     {% if form.something_else_is_only_option %}

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -82,6 +82,9 @@ def test_letter_branding_request_page_when_no_branding_is_set(
 
     assert normalize_spaces(page.select_one("main p").text) == "Your letters currently have no branding."
 
+    # no preview if no existing branding
+    assert not page.select_one("iframe")
+
     button_text = normalize_spaces(page.select_one(".page-footer button").text)
     assert button_text == "Continue"
 
@@ -105,6 +108,11 @@ def test_letter_branding_request_page_when_branding_is_set_already(
     service_one["letter_branding"] = fake_uuid
     page = client_request.get(".letter_branding_request", service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one("main p").text) == "Your letters currently have HM Government branding."
+
+    letter_preview = page.select_one("iframe")
+    letter_preview_url = letter_preview.get("src")
+    letter_preview_query_args = parse_qs(urlparse(letter_preview_url).query)
+    assert letter_preview_query_args == {"branding_style": [fake_uuid]}
 
 
 @pytest.mark.parametrize(
@@ -546,7 +554,6 @@ def test_GET_letter_branding_set_name_renders(client_request, service_one):
     letter_preview = page.select_one("iframe")
     letter_preview_url = letter_preview.get("src")
     letter_preview_query_args = parse_qs(urlparse(letter_preview_url).query)
-
     assert letter_preview_query_args == {"filename": ["temp_something"]}
 
     assert normalize_spaces(page.select_one("h1").text) == "Preview your letter branding"

--- a/tests/app/main/views/service_settings/test_letter_branding_requests.py
+++ b/tests/app/main/views/service_settings/test_letter_branding_requests.py
@@ -1,6 +1,5 @@
 from io import BytesIO
 from unittest.mock import ANY, PropertyMock
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from flask import g, url_for
@@ -109,10 +108,7 @@ def test_letter_branding_request_page_when_branding_is_set_already(
     page = client_request.get(".letter_branding_request", service_id=SERVICE_ONE_ID)
     assert normalize_spaces(page.select_one("main p").text) == "Your letters currently have HM Government branding."
 
-    letter_preview = page.select_one("iframe")
-    letter_preview_url = letter_preview.get("src")
-    letter_preview_query_args = parse_qs(urlparse(letter_preview_url).query)
-    assert letter_preview_query_args == {"branding_style": [fake_uuid]}
+    assert page.select_one("iframe")["src"] == url_for("main.letter_template", branding_style=fake_uuid)
 
 
 @pytest.mark.parametrize(
@@ -551,10 +547,7 @@ def test_GET_letter_branding_set_name_renders(client_request, service_one):
         temp_filename="temp_something",
     )
 
-    letter_preview = page.select_one("iframe")
-    letter_preview_url = letter_preview.get("src")
-    letter_preview_query_args = parse_qs(urlparse(letter_preview_url).query)
-    assert letter_preview_query_args == {"filename": ["temp_something"]}
+    assert page.select_one("iframe")["src"] == url_for("main.letter_template", filename="temp_something")
 
     assert normalize_spaces(page.select_one("h1").text) == "Preview your letter branding"
     assert normalize_spaces(page.select_one("label[for=name]").text) == "Enter the name of your branding"


### PR DESCRIPTION
only shows if you have existing letter branding

<img width="737" alt="image" src="https://user-images.githubusercontent.com/5020841/212894419-4d9004a2-c0fe-4b00-8ab8-201385c8c434.png">

Note that this is separate to the other letter branding work, and can go in before OR after the other stuff