### PR TITLE
Fix ‘Last updated’ date

### DIFF
--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -13,7 +13,7 @@
 
     {{ content_metadata(
       data={
-        "Last updated": "1 October 2021"
+        "Last updated": "11 January 2023"
       }
     ) }}
 


### PR DESCRIPTION
This PR bumps the ‘Last updated’ date.

I forgot to do this as part of https://github.com/alphagov/notifications-admin/pull/4569