### PR TITLE
Standardise how we do `IntegerField`s 

### DIFF
--- a/app/formatters.py
+++ b/app/formatters.py
@@ -479,3 +479,8 @@ def format_auth_type(auth_type, with_indefinite_article=False):
         return f"{indefinite_article} {auth_type.lower()}"
 
     return auth_type
+
+
+def sentence_case(sentence):
+    first_word, rest_of_sentence = (sentence + " ").split(" ", 1)
+    return f"{first_word.title()} {rest_of_sentence}"[:-1]

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -302,8 +302,8 @@ class SMSCode(GovukTextInputField):
 
 class ForgivingIntegerField(GovukTextInputField):
 
-    #  Actual value is 2147483647 but this is a scary looking arbitrary number
-    POSTGRES_MAX_INT = 2000000000
+    #  Actual value is 2,147,483,647 but this is a scary looking arbitrary number
+    POSTGRES_MAX_INT = 2_000_000_000
 
     def __init__(self, label=None, things="items", format_error_suffix="", **kwargs):
         self.things = things
@@ -1141,7 +1141,7 @@ class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
 
 
 class AdminServiceMessageLimitForm(StripWhitespaceForm):
-    message_limit = GovukIntegerField("", validators=[DataRequired(message="Cannot be empty")])
+    message_limit = ForgivingIntegerField("", validators=[DataRequired(message="Cannot be empty")])
 
     def __init__(self, notification_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1157,7 +1157,7 @@ class AdminServiceMessageLimitForm(StripWhitespaceForm):
 
 
 class AdminServiceRateLimitForm(StripWhitespaceForm):
-    rate_limit = GovukIntegerField(
+    rate_limit = ForgivingIntegerField(
         "Number of messages the service can send in a rolling 60 second window",
         validators=[DataRequired(message="Cannot be empty")],
     )

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -58,6 +58,7 @@ from app.formatters import (
     format_thousands,
     guess_name_from_email_address,
     message_count_noun,
+    sentence_case,
 )
 from app.main.validators import (
     BroadcastLength,
@@ -326,10 +327,12 @@ class GovukIntegerField(GovukTextInputField):
         if self.data:
 
             if not isinstance(self.data, int):
-                raise ValidationError(f"{self.things} must be a whole number")
+                raise ValidationError(f"{sentence_case(self.things)} must be a whole number")
 
             if self.data > self.POSTGRES_MAX_INT:
-                raise ValidationError(f"{self.things} must be {format_thousands(self.POSTGRES_MAX_INT)} or less")
+                raise ValidationError(
+                    f"{sentence_case(self.things)} must be {format_thousands(self.POSTGRES_MAX_INT)} or less"
+                )
 
         return super().pre_validate(form)
 
@@ -1136,7 +1139,7 @@ class AdminServiceSMSAllowanceForm(StripWhitespaceForm):
 class AdminServiceMessageLimitForm(StripWhitespaceForm):
     message_limit = GovukIntegerField(
         "",
-        things="Number of messages",
+        things="number of messages",
         validators=[DataRequired(message="Cannot be empty")],
     )
 
@@ -1157,7 +1160,7 @@ class AdminServiceMessageLimitForm(StripWhitespaceForm):
 class AdminServiceRateLimitForm(StripWhitespaceForm):
     rate_limit = GovukIntegerField(
         "Number of messages the service can send in a rolling 60 second window",
-        things="Number of messages",
+        things="number of messages",
         validators=[DataRequired(message="Cannot be empty")],
     )
 
@@ -1471,15 +1474,15 @@ class Triage(StripWhitespaceForm):
 class EstimateUsageForm(StripWhitespaceForm):
     volume_email = GovukIntegerField(
         "How many emails do you expect to send in the next year?",
-        things="Number of emails",
+        things="number of emails",
     )
     volume_sms = GovukIntegerField(
         "How many text messages do you expect to send in the next year?",
-        things="Number of text messages",
+        things="number of text messages",
     )
     volume_letter = GovukIntegerField(
         "How many letters do you expect to send in the next year?",
-        things="Number of letters",
+        things="number of letters",
     )
     consent_to_research = GovukRadiosField(
         "Can we contact you when we’re doing user research?",
@@ -1511,7 +1514,7 @@ class AdminProviderRatioForm(Form):
                 provider["identifier"],
                 GovukIntegerField(
                     f"{provider['display_name']} (%)",
-                    things="Percentage",
+                    things="percentage",
                     validators=[validators.NumberRange(min=0, max=100, message="Must be between 0 and 100")],
                     param_extensions={
                         "classes": "govuk-input--width-3",
@@ -2169,7 +2172,7 @@ class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
     )
     days_of_retention = GovukIntegerField(
         label="Days of retention",
-        things="Days of retention",
+        things="days of retention",
         validators=[validators.NumberRange(min=3, max=90, message="Must be between 3 and 90")],
     )
 
@@ -2177,7 +2180,7 @@ class AdminServiceAddDataRetentionForm(StripWhitespaceForm):
 class AdminServiceEditDataRetentionForm(StripWhitespaceForm):
     days_of_retention = GovukIntegerField(
         label="Days of retention",
-        things="Days of retention",
+        things="days of retention",
         validators=[validators.NumberRange(min=3, max=90, message="Must be between 3 and 90")],
     )
 

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -10,6 +10,7 @@ from app.formatters import (
     format_notification_status_as_url,
     format_number_in_pounds_as_currency,
     round_to_significant_figures,
+    sentence_case,
 )
 
 
@@ -133,3 +134,26 @@ def test_round_to_significant_figures(value, significant_figures, expected_resul
 )
 def test_email_safe_return_dot_separated_email_domain(service_name, safe_email):
     assert email_safe(service_name) == safe_email
+
+
+@pytest.mark.parametrize(
+    "sentence, sentence_case_sentence",
+    [
+        ("", ""),
+        ("a", "A"),
+        ("foo", "Foo"),
+        ("foo bar", "Foo bar"),
+        ("Foo bar", "Foo bar"),
+        ("FOO BAR", "Foo BAR"),
+        ("fOO BAR", "Foo BAR"),
+        ("2numeral", "2Numeral"),
+        (".punctuation", ".Punctuation"),
+        ("üńïçödë wördś", "Üńïçödë wördś"),
+        # Only one sentence per string is supported
+        ("multiple. sentences in one. string", "Multiple. sentences in one. string"),
+        # Naïve around camelcase words
+        ("eMail", "Email"),
+    ],
+)
+def test_sentence_case(sentence, sentence_case_sentence):
+    assert sentence_case(sentence) == sentence_case_sentence

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4683,9 +4683,9 @@ def test_should_show_page_to_set_rate_limit(
     "new_limit, expected_api_argument",
     [
         ("1", 1),
-        ("250000", 250000),
-        ("250,000 ", 250000),
-        (" 250 000", 250000),
+        ("250000", 250_000),
+        ("250,000 ", 250_000),
+        (" 250 000", 250_000),
         pytest.param("foo", "foo", marks=pytest.mark.xfail),
         pytest.param("", "", marks=pytest.mark.xfail),
     ],

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4664,7 +4664,7 @@ def test_should_show_page_to_set_message_limit(
     client_request.login(platform_admin_user)
     page = client_request.get("main.set_message_limit", service_id=SERVICE_ONE_ID, notification_type=notification_type)
     assert normalize_spaces(page.select_one("label").text) == expected_label
-    assert normalize_spaces(page.select_one("input[type=text]")["value"]) == "1000"
+    assert normalize_spaces(page.select_one("input[type=text]")["value"]) == "1,000"
 
 
 def test_should_show_page_to_set_rate_limit(
@@ -4676,7 +4676,7 @@ def test_should_show_page_to_set_rate_limit(
     assert normalize_spaces(page.select_one("label").text) == (
         "Number of messages the service can send in a rolling 60 second window"
     )
-    assert normalize_spaces(page.select_one("input[type=text]")["value"]) == "3000"
+    assert normalize_spaces(page.select_one("input[type=text]")["value"]) == "3,000"
 
 
 @pytest.mark.parametrize(
@@ -4684,7 +4684,10 @@ def test_should_show_page_to_set_rate_limit(
     [
         ("1", 1),
         ("250000", 250000),
+        ("250,000 ", 250000),
+        (" 250 000", 250000),
         pytest.param("foo", "foo", marks=pytest.mark.xfail),
+        pytest.param("", "", marks=pytest.mark.xfail),
     ],
 )
 def test_should_set_message_limit(

--- a/tests/app/main/views/test_providers.py
+++ b/tests/app/main/views/test_providers.py
@@ -385,6 +385,7 @@ def test_edit_sms_provider_ratio_submit(
     [
         ({"sms_provider_1": 90, "sms_provider_2": 20}, "Must add up to 100%"),
         ({"sms_provider_1": 101, "sms_provider_2": 20}, "Must be between 0 and 100"),
+        ({"sms_provider_1": 99.9, "sms_provider_2": 0.1}, "Percentage must be a whole number"),
     ],
 )
 def test_edit_sms_provider_submit_invalid_percentages(


### PR DESCRIPTION
Using `ForgivingIntegerField` meant if you paste a number that contains commas or spaces (common for numbers in the hundreds of thousands) it will still be accepted. But we weren’t using it everywhere. This PR:
- makes it used wherever we ask for integers
- renames it to replace `GovukIntegerField` to make it clear that it’s the one canonical way to ask for integers

Also added thousands separators to some hardcoded numbers to make them easier to read.