### PR TITLE
Delete .coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: jenkins


### PR DESCRIPTION
[Coveralls](https://coveralls.io) is a continuous integration service for measuring code coverage. We haven’t used it in years.