### PR TITLE
Update sending limits on trial mode page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -248,6 +248,7 @@ def trial_mode_new():
     return render_template(
         "views/trial-mode.html",
         navigation_links=using_notify_nav(),
+        email_and_sms_daily_limit=current_app.config["DEFAULT_SERVICE_LIMIT"],
     )
 
 

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -13,11 +13,12 @@
 
   <p class="govuk-body">When you add a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
   <p class="govuk-body">While your service is in trial mode you can only:</p>
-    <ul class="govuk-list govuk-list--bullet">
-     <li>send 50 text messages and emails per day</li>
-      <li>send messages to yourself and other people in your team</li>
-     <li>create letter templates, but not send them</li>
-   </ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>send messages to yourself and other people in your team</li>
+    <li>send {{ email_and_sms_daily_limit | message_count('email') }} per day</li>
+    <li>send {{ email_and_sms_daily_limit | message_count('sms') }} per day</li>
+    <li>create letter templates, but not send them</li>
+  </ul>
 
     {% if current_service and current_service.trial_mode %}
   <p class="govuk-body">

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -449,3 +449,14 @@ def test_bulk_sending_limits(client_request):
         "There’s a maximum daily limit of 250,000 emails, 250,000 text messages and 20,000 letters. "
         "If you need to discuss these limits, contact us."
     )
+
+
+def test_trial_mode_sending_limits(client_request):
+    page = client_request.get("main.trial_mode_new")
+
+    assert [normalize_spaces(li.text) for li in page.select_one("main ul").select("li")] == [
+        "send messages to yourself and other people in your team",
+        "send 50 emails per day",
+        "send 50 text messages per day",
+        "create letter templates, but not send them",
+    ]


### PR DESCRIPTION
The limits are per channel now, not a single overall limit.

The bullet points match those added to the settings page in https://github.com/alphagov/notifications-admin/pull/4562/files#diff-664a9d9eb8f139a1234539f2d3dc39d1dd4454ef97b04d5829864bef984fbb93R277-R282