### PR TITLE
Refactor branding logo handling and temporary (email) logos

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -115,6 +115,7 @@ from app.notify_client.template_folder_api_client import template_folder_api_cli
 from app.notify_client.template_statistics_api_client import template_statistics_client
 from app.notify_client.upload_api_client import upload_api_client
 from app.notify_client.user_api_client import user_api_client
+from app.s3_client.logo_client import logo_client
 from app.url_converters import (
     LetterFileExtensionConverter,
     SimpleDateTypeConverter,
@@ -193,6 +194,7 @@ def create_app(application):
         antivirus_client,
         redis_client,
         zendesk_client,
+        logo_client,
     ):
         client.init_app(application)
 

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import abort, current_app, redirect, render_template, request, url_for
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
@@ -18,6 +20,7 @@ from app.models.branding import (
     AllEmailBranding,
     EmailBranding,
 )
+from app.s3_client.logo_client import logo_client
 from app.s3_client.s3_logo_client import (
     TEMP_TAG,
     delete_email_temp_file,
@@ -150,7 +153,7 @@ def create_email_branding_government_identity_colour():
                 name=request.args.get("text"),
                 text=request.args.get("text"),
                 colour=form.colour.data,
-                logo=upload_filename,
+                logo_key=upload_filename,
                 brand_type=request.args.get("brand_type"),
             )
         )
@@ -172,22 +175,26 @@ def platform_admin_create_email_branding(logo=None):
         brand_type=request.args.get("brand_type", "org"),
     )
 
+    # TODO: remove the `logo`-based URL path
+    temporary_logo_key = request.args.get("logo_key", logo)
+
     if form.validate_on_submit():
         if form.file.data:
-            upload_filename = upload_email_logo(
-                form.file.data.filename, form.file.data, current_app.config["AWS_REGION"], user_id=current_user.id
+            file_extension = os.path.splitext(form.file.data.filename)[1]
+            temporary_logo_key = logo_client.save_temporary_logo(
+                form.file.data, "email", file_extension=file_extension, content_type=form.file.data.content_type
             )
+            return redirect(url_for("main.platform_admin_create_email_branding", logo_key=temporary_logo_key))
 
-            if logo and logo.startswith(TEMP_TAG.format(user_id=current_user.id)):
-                delete_email_temp_file(logo)
-
-            return redirect(url_for("main.platform_admin_create_email_branding", logo=upload_filename))
-
-        updated_logo_name = permanent_email_logo_name(logo, current_user.id) if logo else None
+        permanent_logo_key = None
+        if temporary_logo_key:
+            permanent_logo_key = logo_client.save_permanent_logo(
+                temporary_logo_key, logo_type="email", logo_key_extra=form.name.data
+            )
 
         try:
             email_branding_client.create_email_branding(
-                logo=updated_logo_name,
+                logo=permanent_logo_key,
                 name=form.name.data,
                 alt_text=form.alt_text.data,
                 text=form.text.data,
@@ -201,11 +208,6 @@ def platform_admin_create_email_branding(logo=None):
             else:
                 raise e
 
-        if logo:
-            persist_logo(logo, updated_logo_name)
-
-        delete_email_temp_files_created_by(current_user.id)
-
         if not form.errors:
             return redirect(url_for(".email_branding"))
 
@@ -214,7 +216,7 @@ def platform_admin_create_email_branding(logo=None):
             "views/email-branding/manage-branding.html",
             form=form,
             cdn_url=current_app.config["LOGO_CDN_DOMAIN"],
-            logo=logo,
+            logo=temporary_logo_key,
         ),
         400 if form.errors else 200,
     )

--- a/app/s3_client/logo_client.py
+++ b/app/s3_client/logo_client.py
@@ -1,0 +1,112 @@
+import os
+import re
+import typing
+import uuid
+
+from boto3 import resource
+from notifications_utils.s3 import s3upload as utils_s3upload
+
+LOGO_TYPES = typing.Literal["email", "letter"]
+
+
+class LogoClient:
+    TEMPORARY_LOGO_PATHS = {
+        "email": "temporary/email/{filename}",
+        "letter": "temporary/letter/{filename}",
+    }
+    PERMANENT_LOGO_PATHS = {
+        "email": "email/{filename}",
+        "letter": "letters/static/images/letter-template/{filename}",
+    }
+
+    def __init__(self):
+        # Make sure to call `init_app` to configure the client properly.
+        self.region = None
+        self.bucket_name = None
+        self.client = None
+
+    def init_app(self, application):
+        self.region = application.config["AWS_REGION"]
+        self.bucket_name = application.config["LOGO_UPLOAD_BUCKET_NAME"]
+        self.client = resource("s3")
+
+    def _get_object(self, key_):
+        return self.client.Object(self.bucket_name, key_)
+
+    def _slugify(self, text: str) -> str:
+        text = text.lower()
+        text = re.sub(r"\s+", "-", text)
+        text = re.sub(r"[^A-Za-z\d\-]", "", text)
+        text = re.sub(r"\-{2,}", "-", text)
+        text = text.strip("-")
+        return text.lower()
+
+    def _get_temporary_logo_key(self, logo_file_name: str, logo_type: LOGO_TYPES) -> str:
+        return self.TEMPORARY_LOGO_PATHS[logo_type].format(filename=logo_file_name)
+
+    def _get_permanent_logo_key(
+        self, logo_file_name: str, logo_type: LOGO_TYPES, logo_key_extra: typing.Optional[str] = None
+    ) -> str:
+        """Returns the s3 object key for a permanent logo
+
+        Pass some arbitrary extra context to `logo_key_extra` - this will be normalised and appended to the
+        filename.
+        """
+        if logo_key_extra:
+            _file_name, _file_ext = os.path.splitext(logo_file_name)
+            logo_key_extra = self._slugify(logo_key_extra)
+            logo_file_name = f"{_file_name}-{logo_key_extra}{_file_ext}"
+
+        return self.PERMANENT_LOGO_PATHS[logo_type].format(filename=logo_file_name)
+
+    def save_temporary_logo(
+        self, file_data: typing.IO, logo_type: LOGO_TYPES, file_extension: str, content_type: str
+    ) -> str:
+        """Returns the S3 object key of the uploaded temporary logo.
+
+        args:
+            file_data: file-like object
+            logo_type: one of: 'email' or 'letter'
+            file_extension: eg `.png` - notably should include the full-stop
+            content_type: eg 'image/png'
+
+        returns:
+            S3 object key (excluding bucket name)
+        """
+        unique_id = str(uuid.uuid4())
+        logo_file_name = f"{unique_id}{file_extension}"
+        temporary_logo_key = self._get_temporary_logo_key(logo_file_name=logo_file_name, logo_type=logo_type)
+        utils_s3upload(
+            filedata=file_data,
+            region=self.region,
+            bucket_name=self.bucket_name,
+            file_location=temporary_logo_key,
+            content_type=content_type,
+        )
+        return temporary_logo_key
+
+    def save_permanent_logo(
+        self, temporary_logo_key: str, logo_type: LOGO_TYPES, logo_key_extra: typing.Optional[str] = None
+    ) -> str:
+        """Takes a temporary logo S3 object key and copies it to an immutable, must-never-be-deleted final location.
+
+        args:
+            temporary_logo_key: s3 object key to existing temporary logo
+            logo_type: one of: 'email' or 'letter'
+            logo_key_extra: some extra context to include in the s3 object key/absolute path. will be normalised.
+
+        returns:
+            S3 object key (excluding bucket name)
+        """
+        logo_key = os.path.basename(temporary_logo_key)
+
+        permanent_logo_key = self._get_permanent_logo_key(
+            logo_file_name=logo_key, logo_type=logo_type, logo_key_extra=logo_key_extra
+        )
+
+        self._get_object(permanent_logo_key).copy_from(CopySource="{}/{}".format(self.bucket_name, temporary_logo_key))
+
+        return permanent_logo_key
+
+
+logo_client = LogoClient()

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -750,9 +750,9 @@ def test_create_email_branding_government_identity_colour_400_if_no_filename_or_
 
 
 def test_post_create_email_branding_government_identity_form_colour(mocker, client_request, platform_admin_user):
-    mock_upload = mocker.patch(
-        "app.main.views.email_branding.upload_email_logo",
-        return_value="example.png",
+    mock_save_temporary = mocker.patch(
+        "app.main.views.email_branding.logo_client.save_temporary_logo",
+        return_value="temporary/email/example.png",
     )
     client_request.login(platform_admin_user)
 
@@ -765,13 +765,15 @@ def test_post_create_email_branding_government_identity_form_colour(mocker, clie
         },
         _expected_redirect=url_for(
             "main.platform_admin_create_email_branding",
-            logo_key="example.png",
+            logo_key="temporary/email/example.png",
             colour="#005abb",
             name="Department of Social Affairs and Citizenship",
             text="Department of Social Affairs and Citizenship",
         ),
     )
 
-    assert mock_upload.call_args[0][0] == "hm.government.png"
-    assert mock_upload.call_args[0][1][:4] == b"\x89PNG"
-    assert mock_upload.call_args[0][1] == (INSIGNIA_ASSETS_PATH / "HM Government.png").resolve().read_bytes()
+    assert mock_save_temporary.call_args_list == [
+        mocker.call(file_data=mocker.ANY, logo_type="email", file_extension=".png", content_type="image/png")
+    ]
+    logo_bytes_io = mock_save_temporary.call_args_list[0][1]["file_data"]
+    assert logo_bytes_io.read() == (INSIGNIA_ASSETS_PATH / "HM Government.png").resolve().read_bytes()

--- a/tests/app/s3_client/test_logo_client.py
+++ b/tests/app/s3_client/test_logo_client.py
@@ -1,0 +1,133 @@
+from io import BytesIO
+
+import boto3
+import pytest
+
+LOGO_TYPES = ["email", "letter"]
+
+
+class TestLogoClientSlugify:
+    @pytest.mark.parametrize(
+        "text, expected_slug",
+        (
+            ("blah", "blah"),
+            ("replace stuff", "replace-stuff"),
+            ("replace [] stuff", "replace-stuff"),
+            ("a110w numb3r5", "a110w-numb3r5"),
+            ("only \x03😈alphanumeric\t\nstuff", "only-alphanumeric-stuff"),
+            ("LOWERCASE", "lowercase"),
+            ("remove----many------dashes", "remove-many-dashes"),
+            ("[] (no leading or trailing dashes))] ][", "no-leading-or-trailing-dashes"),
+        ),
+    )
+    def test_expected_slugs(self, logo_client, text, expected_slug):
+        assert logo_client._slugify(text) == expected_slug
+
+
+class TestLogoClientGetTemporaryLogoAbsolutePath:
+    @pytest.mark.parametrize(
+        "file_name, logo_type, expected_path",
+        (
+            ("my-logo.png", "email", "temporary/email/my-logo.png"),
+            ("my-logo.svg", "letter", "temporary/letter/my-logo.svg"),
+        ),
+    )
+    def test_expected_path(self, logo_client, file_name, logo_type, expected_path):
+        assert logo_client._get_temporary_logo_key(file_name, logo_type=logo_type) == expected_path
+
+
+class TestLogoClientGetPermanentLogoAbsolutePath:
+    @pytest.mark.parametrize(
+        "file_name, logo_type, file_name_extra, expected_path",
+        (
+            ("my-logo.png", "email", None, "email/my-logo.png"),
+            ("my-logo.png", "email", "extra-stuff", "email/my-logo-extra-stuff.png"),
+            ("my-logo.png", "email", "NON standard *&^%$£ extras", "email/my-logo-non-standard-extras.png"),
+            ("my-logo.svg", "letter", None, "letters/static/images/letter-template/my-logo.svg"),
+            ("my-logo.svg", "letter", "extra-stuff", "letters/static/images/letter-template/my-logo-extra-stuff.svg"),
+            (
+                "my-logo.png",
+                "letter",
+                "NON standard *&^%$£ extras",
+                "letters/static/images/letter-template/my-logo-non-standard-extras.png",
+            ),
+        ),
+    )
+    def test_expected_path(self, logo_client, file_name, logo_type, file_name_extra, expected_path):
+        assert (
+            logo_client._get_permanent_logo_key(file_name, logo_type=logo_type, logo_key_extra=file_name_extra)
+            == expected_path
+        )
+
+
+class TestLogoClientSaveTemporaryLogo:
+    @pytest.mark.parametrize(
+        "logo_type, file_extension, content_type, expected_location",
+        (
+            ("email", ".png", "image/png", "temporary/email/uuid.png"),
+            ("letter", ".svg", "image/svg+xml", "temporary/letter/uuid.svg"),
+        ),
+    )
+    def test_expected_s3upload_call(
+        self, mocker, logo_client, logo_type, file_extension, content_type, expected_location
+    ):
+        mock_utils_s3upload = mocker.patch("app.s3_client.logo_client.utils_s3upload")
+        mock_uui4 = mocker.patch("app.s3_client.logo_client.uuid.uuid4")
+        mock_uui4.return_value = "uuid"
+
+        file_data = BytesIO()
+
+        retval = logo_client.save_temporary_logo(
+            file_data, logo_type=logo_type, file_extension=file_extension, content_type=content_type
+        )
+
+        assert mock_utils_s3upload.call_args_list == [
+            mocker.call(
+                filedata=file_data,
+                region="eu-west-1",
+                bucket_name="public-logos-test",
+                file_location=expected_location,
+                content_type=content_type,
+            )
+        ]
+        assert retval == expected_location
+
+
+class TestLogoClientSavePermanentLogo:
+    def s3_setup(self, app):
+        s3 = boto3.client("s3", region_name=app.config["AWS_REGION"])
+        s3.create_bucket(Bucket=app.config["LOGO_UPLOAD_BUCKET_NAME"])
+
+    @pytest.mark.parametrize(
+        "temporary_logo_key, logo_type, logo_key_extra, expected_location",
+        (
+            ("temporary/email/uuid.png", "email", None, "email/uuid.png"),
+            ("temporary/email/uuid.png", "email", "some extra", "email/uuid-some-extra.png"),
+            ("temporary/letter/uuid.png", "letter", None, "letters/static/images/letter-template/uuid.png"),
+            (
+                "temporary/letter/uuid.png",
+                "letter",
+                "some extra",
+                "letters/static/images/letter-template/uuid-some-extra.png",
+            ),
+        ),
+    )
+    def test_copies_object(
+        self,
+        mocker,
+        notify_admin,
+        logo_client,
+        temporary_logo_key,
+        logo_type,
+        logo_key_extra,
+        expected_location,
+    ):
+        mock_s3_resource = mocker.patch.object(logo_client, "client")
+        mock_s3_object = mock_s3_resource.Object()
+
+        retval = logo_client.save_permanent_logo(temporary_logo_key, logo_type=logo_type, logo_key_extra=logo_key_extra)
+
+        assert mock_s3_object.copy_from.call_args_list == [
+            mocker.call(CopySource=f"public-logos-test/{temporary_logo_key}")
+        ]
+        assert retval == expected_location

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4235,3 +4235,10 @@ def webauthn_credential_2():
         "created_at": "2021-05-14T16:57:14.154185Z",
         "logged_in_at": None,
     }
+
+
+@pytest.fixture
+def logo_client(notify_admin):
+    from app import logo_client
+
+    yield logo_client


### PR DESCRIPTION
The interface to `s3_logo_client` has become a little bit fractured, so this does a quick rewrite to create a client class that we can use in a more similar way to other API clients.

We update all of the platform admin email branding routes to use the new client, which will store branding logos in a consistent, clear place depending on whether they're temporary or permanent. Logos are uploaded to the temporary directory when they aren't attached to any EmailBranding records in the DB (ie the user is still completing the form to create/update an email brand).

Once they go to commit those changes, we save (copy) the brand to a 'permanent' place in S3 and update the DB record with the new location. Email brands in the DB should never reference a temporary logo after this.

We remove all of the "delete temporary logo" attempts during the email branding flow, as this will be handed off to an S3 bucket lifecycle (deleting old objects with the temporary path prefix).

---

Todo in the future:
- migrate user email branding flows
- Migrate the letter branding views; slightly more complex
- Optional/undecided: look into cleaning up the S3 bucket using object redirect rules.
- Delete `s3_logo_client.py`