### PR TITLE
Fix margins on branding

### DIFF
--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -14,12 +14,10 @@
   {{ live_search(target_selector='.email-brand', show=True, form=search_form, autofocus=True) }}
   <nav>
     {% for brand in email_brandings|sort %}
-      <div class="email-brand">
-        <div class="message-name">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.platform_admin_update_email_branding', branding_id=brand.id) }}">
-            {{ brand.name or 'Unnamed' }}
-          </a>
-        </div>
+      <div class="email-brand browse-list-item">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.platform_admin_update_email_branding', branding_id=brand.id) }}">
+          {{ brand.name or 'Unnamed' }}
+        </a>
       </div>
     {% endfor %}
   </nav>

--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -11,10 +11,10 @@
 {% block platform_admin_content %}
 
   <h1 class="heading-medium">{{ page_title }}</h1>
-  {{ live_search(target_selector='.email-brand', show=True, form=search_form, autofocus=True) }}
+  {{ live_search(target_selector='.browse-list-item', show=True, form=search_form, autofocus=True) }}
   <nav>
     {% for brand in email_brandings|sort %}
-      <div class="email-brand browse-list-item">
+      <div class="browse-list-item">
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.platform_admin_update_email_branding', branding_id=brand.id) }}">
           {{ brand.name or 'Unnamed' }}
         </a>

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -14,12 +14,10 @@
   {{ live_search(target_selector='.letter-brand', show=True, form=search_form, autofocus=True) }}
   <nav>
     {% for brand in letter_brandings %}
-      <div class="letter-brand">
-        <div class="message-name">
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_letter_branding', branding_id=brand.id) }}">
-            {{ brand.name }}
-          </a>
-        </div>
+      <div class="letter-brand browse-list-item">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_letter_branding', branding_id=brand.id) }}">
+          {{ brand.name }}
+        </a>
       </div>
     {% endfor %}
   </nav>

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -11,10 +11,10 @@
 {% block platform_admin_content %}
 
   <h1 class="heading-medium">{{ page_title }}</h1>
-  {{ live_search(target_selector='.letter-brand', show=True, form=search_form, autofocus=True) }}
+  {{ live_search(target_selector='.browse-list-item', show=True, form=search_form, autofocus=True) }}
   <nav>
     {% for brand in letter_brandings %}
-      <div class="letter-brand browse-list-item">
+      <div class="browse-list-item">
         <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_letter_branding', branding_id=brand.id) }}">
           {{ brand.name }}
         </a>

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -16,7 +16,7 @@ def test_email_branding_page_shows_full_branding_list(client_request, platform_a
     client_request.login(platform_admin_user)
     page = client_request.get(".email_branding")
 
-    links = page.select(".message-name a")
+    links = page.select(".email-brand a")
     brand_names = [normalize_spaces(link.text) for link in links]
     hrefs = [link["href"] for link in links]
 

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -16,7 +16,7 @@ def test_email_branding_page_shows_full_branding_list(client_request, platform_a
     client_request.login(platform_admin_user)
     page = client_request.get(".email_branding")
 
-    links = page.select(".email-brand a")
+    links = page.select(".browse-list-item a")
     brand_names = [normalize_spaces(link.text) for link in links]
     hrefs = [link["href"] for link in links]
 

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -20,7 +20,7 @@ def test_letter_branding_page_shows_full_branding_list(
     client_request.login(platform_admin_user)
     page = client_request.get(".letter_branding")
 
-    links = page.select(".letter-brand a")
+    links = page.select(".browse-list-item a")
     brand_names = [normalize_spaces(link.text) for link in links]
     hrefs = [link["href"] for link in links]
 

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -20,7 +20,7 @@ def test_letter_branding_page_shows_full_branding_list(
     client_request.login(platform_admin_user)
     page = client_request.get(".letter_branding")
 
-    links = page.select(".message-name a")
+    links = page.select(".letter-brand a")
     brand_names = [normalize_spaces(link.text) for link in links]
     hrefs = [link["href"] for link in links]
 


### PR DESCRIPTION
Before: the sticky bottom nav margin completely overlaps the last item in the list, meaning it's impossible to click that list


After: the items in the list all have more consistent styling with other pages, and crucially, a `margin-bottom: 15px` that prevents them from overlapping with the sticky nav.
| before | after |
|-|-|
| ![image](https://user-images.githubusercontent.com/5020841/214069948-b94f0000-2189-432e-a35c-1e37def4b399.png) | ![image](https://user-images.githubusercontent.com/5020841/214070119-40813eb8-3b10-4597-9be1-b2822fe2dd93.png) |