### PR TITLE
remove second hr from view branding page

### DIFF
--- a/app/templates/views/email-branding/view-branding.html
+++ b/app/templates/views/email-branding/view-branding.html
@@ -73,8 +73,6 @@
             </p>
         {% endif %}
 
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />
-
         <div class="js-stick-at-bottom-when-scrolling">
             <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
                 <a class="govuk-link"


### PR DESCRIPTION
when a branding doesn't have created_by or updated_at set, it would show two horizontal rules, which looks strange. And there isn't as much a need to draw a clear line between the updated at text and the edit/delete buttons, as they look very dissimilar. It's useful to still have an hr if the last line of the main body is a link to a service that uses it, as we want to clearly separate that link from the edit/delete links

| | has created at/updated at | has no content |
|-|-|-|
| before | ![image](https://user-images.githubusercontent.com/5020841/214114014-e7e634a4-e65e-4909-b4dc-1e253170fc5a.png) | ![image](https://user-images.githubusercontent.com/5020841/214113870-f61da713-9805-4ad4-9f36-4c2189e09950.png) |
| after |  ![image](https://user-images.githubusercontent.com/5020841/214113456-2f62afd5-0c4a-4213-955a-7a94f3bf299b.png) |  ![image](https://user-images.githubusercontent.com/5020841/214114191-476c2fc1-a273-4617-8978-c4fc01a405cb.png) |