### PR TITLE
Remove Python 2 compatible way of defining classes

### DIFF
--- a/app/asset_fingerprinter.py
+++ b/app/asset_fingerprinter.py
@@ -1,7 +1,7 @@
 import hashlib
 
 
-class AssetFingerprinter(object):
+class AssetFingerprinter:
     """
     Get a unique hash for an asset file, so that it doesn't stay cached
     when it changes

--- a/app/broadcast_areas/repo.py
+++ b/app/broadcast_areas/repo.py
@@ -8,7 +8,7 @@ rtree_index_path = Path(__file__).parent / "rtree.pickle"
 rtree_index = pickle.loads(rtree_index_path.read_bytes())
 
 
-class BroadcastAreasRepository(object):
+class BroadcastAreasRepository:
     def __init__(self):
         self.database = Path(__file__).resolve().parent / "broadcast-areas.sqlite3"
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ if os.environ.get("VCAP_APPLICATION"):
     extract_cloudfoundry_config()
 
 
-class Config(object):
+class Config:
     ADMIN_CLIENT_SECRET = os.environ.get("ADMIN_CLIENT_SECRET")
     API_HOST_NAME = os.environ.get("API_HOST_NAME")
     SECRET_KEY = os.environ.get("SECRET_KEY")

--- a/app/proxy_fix.py
+++ b/app/proxy_fix.py
@@ -1,7 +1,7 @@
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 
-class CustomProxyFix(object):
+class CustomProxyFix:
     def __init__(self, app, forwarded_proto):
         self.app = ProxyFix(app, x_for=1, x_proto=1, x_host=1, x_port=0, x_prefix=0)
         self.forwarded_proto = forwarded_proto

--- a/tests/app/main/test_asset_fingerprinter.py
+++ b/tests/app/main/test_asset_fingerprinter.py
@@ -3,7 +3,7 @@
 from app.asset_fingerprinter import AssetFingerprinter
 
 
-class TestAssetFingerprint(object):
+class TestAssetFingerprint:
     def test_url_format(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
         get_file_content_mock.return_value = """
@@ -94,7 +94,7 @@ class TestAssetFingerprint(object):
         assert fingerprinter._cache == {}
 
 
-class TestAssetFingerprintWithUnicode(object):
+class TestAssetFingerprintWithUnicode:
     def test_can_read_self(self):
         "Ralph’s apostrophe is a string containing a unicode character"
         AssetFingerprinter(filesystem_path="tests/app/main/").get_url("test_asset_fingerprinter.py")


### PR DESCRIPTION
To make classes work the same in Python 2 and Python 3 they need to inherit from `object`.

In Python 3 classes work the same whether or not they inherit from `object`. Therefore doing so is redundant.

***

Some of these go back to when Notify was forked from the Digital Marketplace codebase, which did maintain Python 2 compatibility for a while.