### PR TITLE
Allow services to enable email auth

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -85,6 +85,7 @@ from app.models.branding import (
 from app.models.feedback import PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE
 from app.models.organisation import Organisation
 from app.utils import branding
+from app.utils.constants import SIGN_IN_METHOD_TEXT, SIGN_IN_METHOD_TEXT_OR_EMAIL
 from app.utils.govuk_frontend_field import (
     GovukFrontendWidgetMixin,
     render_govuk_frontend_macro,
@@ -2583,4 +2584,14 @@ class GovernmentIdentityColour(StripWhitespaceForm):
     colour = GovukRadiosField(
         "Colour for stripe",
         thing="a colour for the stripe",
+    )
+
+
+class SetAuthTypeForm(StripWhitespaceForm):
+    sign_in_method = GovukRadiosField(
+        "Sign in method",
+        choices=(
+            (SIGN_IN_METHOD_TEXT, "Text message code"),
+            (SIGN_IN_METHOD_TEXT_OR_EMAIL, "Email link or text message code"),
+        ),
     )

--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -789,6 +789,7 @@ def service_set_auth_type(service_id):
 
 
 @main.route("/services/<uuid:service_id>/service-settings/set-auth-type/confirm", methods=["GET", "POST"])
+@user_has_permissions("manage_service")
 def service_confirm_disable_email_auth(service_id):
     if current_service.sign_in_method != SIGN_IN_METHOD_TEXT_OR_EMAIL:
         return redirect(url_for(".service_set_auth_type", service_id=service_id))

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -17,6 +17,7 @@ from app.notify_client.organisations_api_client import organisations_client
 from app.notify_client.service_api_client import service_api_client
 from app.notify_client.template_folder_api_client import template_folder_api_client
 from app.utils import get_default_sms_sender
+from app.utils.constants import SIGN_IN_METHOD_TEXT, SIGN_IN_METHOD_TEXT_OR_EMAIL
 
 
 class Service(JSONModel):
@@ -600,6 +601,13 @@ class Service(JSONModel):
 
     def get_message_limit(self, notification_type):
         return getattr(self, f"{notification_type}_message_limit")
+
+    @property
+    def sign_in_method(self) -> str:
+        if "email_auth" in self.permissions:
+            return SIGN_IN_METHOD_TEXT_OR_EMAIL
+
+        return SIGN_IN_METHOD_TEXT
 
 
 class Services(SerialisedModelCollection):

--- a/app/templates/views/service-settings/confirm-disable-email-auth.html
+++ b/app/templates/views/service-settings/confirm-disable-email-auth.html
@@ -4,14 +4,14 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
-{% set heading = 'Sign-in method' %}
+{% set heading = 'Are you sure you want to switch off the email link sign-in method?' %}
 
 {% block service_page_title %}
   {{ heading }}
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.service_settings', service_id=current_service.id) }) }}
+  {{ govukBackLink({ "href": url_for('main.service_set_auth_type', service_id=current_service.id) }) }}
 {% endblock %}
 
 {% block maincolumn_content %}
@@ -20,21 +20,14 @@
     <div class="govuk-grid-column-five-sixths">
       {{ page_header(heading) }}
       <p class="govuk-body">
-        The most secure way to sign in to Notify is with a text message code.
+        All team members will sign in to Notify using a text message code.
       </p>
       <p class="govuk-body">
-        Team members can also sign in using a link that’s sent in an email.
-        For security, you should only do this if they access their email accounts using:
+        This change will affect any other services they belong to.
       </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>a work-issued device</li>
-        <li>an office network or VPN</li>
-        <li>another type of two-factor authentication</li>
-      </ul>
 
       {% call form_wrapper() %}
-        {{ form.sign_in_method }}
-        {{ page_footer('Continue') }}
+        {{ page_footer('Save') }}
       {% endcall %}
     </div>
   </div>

--- a/app/templates/views/service-settings/disable-email-auth-blocked.html
+++ b/app/templates/views/service-settings/disable-email-auth-blocked.html
@@ -30,7 +30,7 @@
       </ul>
       <p class="govuk-body">
         If you need to change an individual’s sign-in method, go to the
-        <a class="govuk-link" href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a>
         page.
       </p>
     </div>

--- a/app/templates/views/service-settings/disable-email-auth-blocked.html
+++ b/app/templates/views/service-settings/disable-email-auth-blocked.html
@@ -1,7 +1,5 @@
 {% extends "withnav_template.html" %}
 {% from "components/page-header.html" import page_header %}
-{% from "components/page-footer.html" import page_footer %}
-{% from "components/form.html" import form_wrapper %}
 {% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
 
 {% set heading = 'Sign-in method' %}
@@ -15,30 +13,26 @@
 {% endblock %}
 
 {% block maincolumn_content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-five-sixths">
       {{ page_header(heading) }}
 
       <p class="govuk-body">
-        The most secure way to sign in to Notify is with a text message code.
+        Your team members can sign in with an email link or text message code.
       </p>
       <p class="govuk-body">
-        Team members can also sign in using a link that’s sent in an email.
-        For security, you should only do this if they access their email accounts using:
+        You cannot switch off the email link sign-in method for the whole team until these members add a mobile phone number:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>a work-issued device</li>
-        <li>an office network or VPN</li>
-        <li>another type of two-factor authentication</li>
+      {% for user in users_without_phone_numbers %}
+        <li>{{ user.name }}</li>
+      {% endfor %}
       </ul>
-
-      {% call form_wrapper() %}
-        {{ form.sign_in_method }}
-        {{ page_footer('Continue') }}
-      {% endcall %}
-
+      <p class="govuk-body">
+        If you need to change an individual’s sign-in method, go to the
+        <a class="govuk-link" href="{{ url_for('.manage_users', service_id=current_service.id) }}">team members</a>
+        page.
+      </p>
     </div>
   </div>
-
 {% endblock %}

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -1,0 +1,2 @@
+SIGN_IN_METHOD_TEXT = "text"
+SIGN_IN_METHOD_TEXT_OR_EMAIL = "text-or-email"

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4558,10 +4558,9 @@ class TestSetAuthType:
         self,
         client_request,
         service_one,
-        active_user_with_permissions,
+        active_user_view_permissions,
     ):
-        active_user_with_permissions["permissions"][service_one["id"]].remove("manage_settings")
-        client_request.login(active_user_with_permissions)
+        client_request.login(active_user_view_permissions)
         client_request.get(
             "main.service_set_auth_type",
             service_id=SERVICE_ONE_ID,
@@ -4638,6 +4637,19 @@ class TestSetAuthType:
 
 
 class TestConfirmDisableEmailAuth:
+    def test_page_requires_manage_settings_permission(
+        self,
+        client_request,
+        service_one,
+        active_user_view_permissions,
+    ):
+        client_request.login(active_user_view_permissions)
+        client_request.get(
+            "main.service_confirm_disable_email_auth",
+            service_id=SERVICE_ONE_ID,
+            _expected_status=403,
+        )
+
     def test_page_loads(self, mocker, client_request, service_one, active_user_with_permissions):
         service_one["permissions"] += ["email_auth"]
         mocker.patch("app.models.user.Users.client_method", return_value=[active_user_with_permissions])

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -278,6 +278,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "service_confirm_delete_email_reply_to",
             "service_confirm_delete_letter_contact",
             "service_confirm_delete_sms_sender",
+            "service_confirm_disable_email_auth",
             "service_dashboard",
             "service_dashboard_updates",
             "service_delete_email_reply_to",

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -261,6 +261,7 @@
     "/services/<uuid:service_id>/service-settings/set-<notification_type>-branding",
     "/services/<uuid:service_id>/service-settings/set-<notification_type>-branding/add-to-branding-pool-step",
     "/services/<uuid:service_id>/service-settings/set-auth-type",
+    "/services/<uuid:service_id>/service-settings/set-auth-type/confirm",
     "/services/<uuid:service_id>/service-settings/set-free-sms-allowance",
     "/services/<uuid:service_id>/service-settings/set-inbound-number",
     "/services/<uuid:service_id>/service-settings/set-international-letters",


### PR DESCRIPTION
Content/design doc: https://docs.google.com/document/d/1PTZD3nwaj1H9ijMaYVrEkChP_sZ1iyAsCv5rQzCo2FE/edit#heading=h.akt2c46d6o07

Service managers can request to allow their users to login via a magic email link instead of a text message as a form of 2FA. At the moment this goes through Zendesk, requiring support action from us, but we believe this should be able to be self-served.

This changes the `set-auth-type` change to a form which allows managers to decide between text message and magic link auth.

Enabling email auth does not change users' sign in to actually use email links - so service managers will still need to go to the team members page and update permissions individually from there. A future patch will provide an immediate page where the manager can update permissions in bulk.

Disabling email auth _does_ automatically change any users of the service who sign-in with emails to sign in with text messages instead. Anyone signing in with webauthn is unaffected.

![2023-01-30 10 11 01](https://user-images.githubusercontent.com/2920760/215448619-e9beaae6-6f01-46b4-b7b8-20cf08bb446d.gif)

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/2920760/215747866-a8145751-2f40-4a00-b2e5-46f504053610.png">
