### PR TITLE
Fix New Relic function path

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -158,7 +158,7 @@ transaction_tracer.explain_threshold = 0.15
 # Space separated list of function or method names in form
 # 'module:function' or 'module:class.function' for which
 # additional function timing instrumentation will be added.
-transaction_tracer.function_trace = app.main.views.organisations:organisation_dashboard
+transaction_tracer.function_trace = app.main.views.organisations.index:organisation_dashboard
 
 # The error collector captures information about uncaught
 # exceptions or logged exceptions and sends them to UI for


### PR DESCRIPTION
The `organisation_dashboard` view function was moved to a new file in e9d8803. The New Relic config needed to be updated too since it still had the old path to the file, and the error this gave was stopping the app from starting up.