### PR TITLE
Move ‘Sign out’ link to user profile page and rename link to ‘Your profile’

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -60,14 +60,14 @@
           "active": header_navigation.is_selected('documentation')
         },
         {
-          "href": url_for('main.user_profile'),
-          "text": current_user.name,
-          "active": header_navigation.is_selected('user-profile')
-        },
-        {
           "href": url_for('main.platform_admin_splash_page'),
           "text": "Platform admin",
           "active": header_navigation.is_selected('platform-admin')
+        },
+        {
+          "href": url_for('main.user_profile'),
+          "text": current_user.name,
+          "active": header_navigation.is_selected('user-profile')
         },
         {
           "href": url_for('main.sign_out'),

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -69,10 +69,6 @@
           "text": current_user.name,
           "active": header_navigation.is_selected('user-profile')
         },
-        {
-          "href": url_for('main.sign_out'),
-          "text": "Sign out"
-        }
       ] %}
     {% else %}
       {% set navigation = [
@@ -91,10 +87,6 @@
           "text": current_user.name,
           "active": header_navigation.is_selected('user-profile')
         },
-        {
-          "href": url_for('main.sign_out'),
-          "text": "Sign out"
-        }
       ] %}
     {% endif %}
   {% else %}

--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -66,7 +66,7 @@
         },
         {
           "href": url_for('main.user_profile'),
-          "text": current_user.name,
+          "text": "Your profile",
           "active": header_navigation.is_selected('user-profile')
         },
       ] %}
@@ -84,7 +84,7 @@
         },
         {
           "href": url_for('main.user_profile'),
-          "text": current_user.name,
+          "text": "Your profile",
           "active": header_navigation.is_selected('user-profile')
         },
       ] %}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -161,4 +161,8 @@
   "rows": rows
 }) }}
 
+<p class="govuk-body">
+  <a href="{{ url_for('main.sign_out') }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Sign out</a>
+</p>
+
 {% endblock %}

--- a/tests/app/main/views/test_header_navigation.py
+++ b/tests/app/main/views/test_header_navigation.py
@@ -1,0 +1,59 @@
+import pytest
+from flask import url_for
+
+from tests.conftest import normalize_spaces
+
+
+@pytest.mark.parametrize(
+    "signed_in, platform_admin, expected_navigation_items",
+    (
+        (
+            False,
+            False,
+            (
+                ("Support", ".support"),
+                ("Features", ".features"),
+                ("Pricing", ".pricing"),
+                ("Documentation", ".documentation"),
+                ("Sign in", ".sign_in"),
+            ),
+        ),
+        (
+            True,
+            False,
+            (
+                ("Support", ".support"),
+                ("Documentation", ".documentation"),
+                ("Test User", ".user_profile"),
+                ("Sign out", ".sign_out"),
+            ),
+        ),
+        (
+            True,
+            True,
+            (
+                ("Support", ".support"),
+                ("Documentation", ".documentation"),
+                ("Test User", ".user_profile"),
+                ("Platform admin", ".platform_admin_splash_page"),
+                ("Sign out", ".sign_out"),
+            ),
+        ),
+    ),
+)
+def test_header_navigation(
+    client_request,
+    signed_in,
+    platform_admin,
+    expected_navigation_items,
+    active_user_with_permissions,
+):
+    active_user_with_permissions["platform_admin"] = platform_admin
+    client_request.login(active_user_with_permissions)
+    if not signed_in:
+        client_request.logout()
+    page = client_request.get("main.features")
+    assert [
+        (normalize_spaces(link.text), link["href"])
+        for link in page.select(".govuk-header__navigation-list .govuk-header__navigation-item a")
+    ] == [(label, url_for(endpoint)) for label, endpoint in expected_navigation_items]

--- a/tests/app/main/views/test_header_navigation.py
+++ b/tests/app/main/views/test_header_navigation.py
@@ -25,7 +25,6 @@ from tests.conftest import normalize_spaces
                 ("Support", ".support"),
                 ("Documentation", ".documentation"),
                 ("Test User", ".user_profile"),
-                ("Sign out", ".sign_out"),
             ),
         ),
         (
@@ -36,7 +35,6 @@ from tests.conftest import normalize_spaces
                 ("Documentation", ".documentation"),
                 ("Platform admin", ".platform_admin_splash_page"),
                 ("Test User", ".user_profile"),
-                ("Sign out", ".sign_out"),
             ),
         ),
     ),

--- a/tests/app/main/views/test_header_navigation.py
+++ b/tests/app/main/views/test_header_navigation.py
@@ -34,8 +34,8 @@ from tests.conftest import normalize_spaces
             (
                 ("Support", ".support"),
                 ("Documentation", ".documentation"),
-                ("Test User", ".user_profile"),
                 ("Platform admin", ".platform_admin_splash_page"),
+                ("Test User", ".user_profile"),
                 ("Sign out", ".sign_out"),
             ),
         ),

--- a/tests/app/main/views/test_header_navigation.py
+++ b/tests/app/main/views/test_header_navigation.py
@@ -24,7 +24,7 @@ from tests.conftest import normalize_spaces
             (
                 ("Support", ".support"),
                 ("Documentation", ".documentation"),
-                ("Test User", ".user_profile"),
+                ("Your profile", ".user_profile"),
             ),
         ),
         (
@@ -34,7 +34,7 @@ from tests.conftest import normalize_spaces
                 ("Support", ".support"),
                 ("Documentation", ".documentation"),
                 ("Platform admin", ".platform_admin_splash_page"),
-                ("Test User", ".user_profile"),
+                ("Your profile", ".user_profile"),
             ),
         ),
     ),

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -25,6 +25,11 @@ def test_should_show_overview_page(
     assert "Use platform admin view" not in page
     assert "Security keys" not in page
 
+    sign_out_link = page.select("main a")[-1]
+    assert normalize_spaces(sign_out_link.text) == "Sign out"
+    assert sign_out_link["href"] == url_for("main.sign_out")
+    assert "govuk-!-font-weight-bold" in sign_out_link["class"]
+
 
 def test_overview_page_shows_disable_for_platform_admin(client_request, platform_admin_user, mocker):
     mocker.patch("app.models.webauthn_credential.WebAuthnCredentials.client_method")


### PR DESCRIPTION
# Remove sign out links

We think that most users don’t use the sign out* link so it doesn’t need to be so prominent.

We’ve already added it to the profile page, so there is still a way for users who manually want to sign out to do so.

We can better use the space to link to guidance in future PRs.

# Rename link from ‘Firstname Lastname’ to ‘Your profile’

Instead of calling it by the user’s name, let’s name it the same as the page you go to.

Discussion with KC:

> Given what we’ve seen with user generated content for pages named after templates, folders, etc – I’m wary of playing back actual names in such a key part of the UI. Things can get ugly fast.
>
> When sending emails to our users in the last few months I’ve spotted:
> - some very long names
> - users entering their org or service as their user name
>
> Using ‘Your profile’ (or, even better, ‘Your account’†) is descriptive and gives us a degree of control over how the header nav looks.
>

# Before 

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/355079/215462084-4f4a18c8-741c-44e3-9f1c-ee072ad2d25b.png">

# After

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/355079/215462304-83c1be13-1e98-43f2-9816-f127da9b2309.png">

<img width="1036" alt="Screenshot 2023-01-30 at 10 12 59" src="https://user-images.githubusercontent.com/355079/215461880-1b1eba2e-56c7-463f-8fc8-9fd25c56d3cc.png">

# Long term ambition

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/355079/215462718-773d21e4-c9c2-4657-a0c5-6e1b86824ed8.png">

***

\* ~13,000 Kibana hits to `/sign-in*` versus ~500 to `/sign-out`

†I’ve got 1 eye on the ongoing issue of clarifying the difference between account and service.
