### PR TITLE
Remove unexpected argument when calling `create_service_template`

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -289,7 +289,7 @@ def _add_template_by_type(template_type, template_folder_id):
 
     if template_type == "letter":
         blank_letter = service_api_client.create_service_template(
-            "New letter template", "letter", "Body", current_service.id, "Main heading", "normal", template_folder_id
+            "New letter template", "letter", "Body", current_service.id, "Main heading", template_folder_id
         )
         return redirect(
             url_for(


### PR DESCRIPTION
This function no longer takes queue type.