### PR TITLE
Update back link for email branding edit view

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -120,7 +120,7 @@ def platform_admin_update_email_branding(branding_id, logo=None):
             email_branding=email_branding,
             cdn_url=current_app.config["LOGO_CDN_DOMAIN"],
             logo=logo_key,
-            back_link=url_for("main.email_branding"),
+            back_link=url_for("main.platform_admin_view_email_branding", branding_id=email_branding.id),
         ),
         400 if form.errors else 200,
     )


### PR DESCRIPTION
When users are on the 'edit email branding' view, the backlink takes the user to the 'list all email brandings' view. The correct (and more useful) page is probably 'view email branding'.