### PR TITLE
Add admin page to view a single letter branding

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -40,6 +40,7 @@ def email_branding():
     methods=["GET"],
     endpoint="platform_admin_confirm_archive_email_branding",
 )
+@user_is_platform_admin
 def platform_admin_view_email_branding(branding_id):
     email_branding = EmailBranding.from_id(branding_id)
 

--- a/app/main/views/letter_branding.py
+++ b/app/main/views/letter_branding.py
@@ -35,6 +35,7 @@ def letter_branding():
 
 
 @main.route("/letter-branding/<uuid:branding_id>", methods=["GET", "POST"])
+@user_is_platform_admin
 def platform_admin_view_letter_branding(branding_id):
     letter_branding = LetterBranding.from_id(branding_id)
 

--- a/app/models/branding.py
+++ b/app/models/branding.py
@@ -125,7 +125,12 @@ class EmailBranding(Branding):
 
 
 class LetterBranding(Branding):
-    ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {"filename"}
+    ALLOWED_PROPERTIES = Branding.ALLOWED_PROPERTIES | {
+        "filename",
+        "created_by",
+        "created_at",
+        "updated_at",
+    }
     NHS_ID = "2cd354bb-6b85-eda3-c0ad-6b613150459f"
 
     @classmethod
@@ -152,6 +157,24 @@ class LetterBranding(Branding):
     @property
     def is_nhs(self):
         return self.name == "NHS"
+
+    @property
+    def organisations(self):
+        orgs_and_services = letter_branding_client.get_orgs_and_services_associated_with_branding(self.id)["data"]
+
+        return orgs_and_services["organisations"]
+
+    @property
+    def services(self):
+        orgs_and_services = letter_branding_client.get_orgs_and_services_associated_with_branding(self.id)["data"]
+
+        return orgs_and_services["services"]
+
+    @property
+    def created_by_user(self):
+        if self.created_by:
+            return user_api_client.get_user(self.created_by)
+        return None
 
 
 class AllBranding(ModelList):

--- a/app/notify_client/letter_branding_client.py
+++ b/app/notify_client/letter_branding_client.py
@@ -33,5 +33,8 @@ class LetterBrandingClient(NotifyAdminAPIClient):
         }
         return self.post(url=f"/letter-branding/{branding_id}", data=data)
 
+    def get_orgs_and_services_associated_with_branding(self, branding_id):
+        return self.get(url=f"/letter-branding/{branding_id}/orgs_and_services")
+
 
 letter_branding_client = LetterBrandingClient()

--- a/app/templates/views/letter-branding/manage-letter-branding.html
+++ b/app/templates/views/letter-branding/manage-letter-branding.html
@@ -10,11 +10,10 @@
 {% endblock %}
 
 {% block backLink %}
-  {{ govukBackLink({ "href": url_for('main.letter_branding') }) }}
+  {{ govukBackLink({ "href": back_link }) }}
 {% endblock %}
 
 {% block platform_admin_content %}
-
   {{ page_header('{} letter branding'.format('Update' if is_update else 'Add')) }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">

--- a/app/templates/views/letter-branding/select-letter-branding.html
+++ b/app/templates/views/letter-branding/select-letter-branding.html
@@ -15,7 +15,7 @@
   <nav>
     {% for brand in letter_brandings %}
       <div class="browse-list-item">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.update_letter_branding', branding_id=brand.id) }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.platform_admin_view_letter_branding', branding_id=brand.id) }}">
           {{ brand.name }}
         </a>
       </div>

--- a/app/templates/views/letter-branding/view-branding.html
+++ b/app/templates/views/letter-branding/view-branding.html
@@ -1,0 +1,91 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-header.html" import page_header %}
+{% from "govuk_frontend_jinja/components/back-link/macro.html" import govukBackLink %}
+
+{% set page_title = letter_branding.name %}
+
+{% block per_page_title %}
+{{ page_title }}
+{% endblock %}
+
+
+{% block backLink %}
+{{ govukBackLink({ "href": url_for('.letter_branding') }) }}
+{% endblock %}
+
+{% block platform_admin_content %}
+
+<div class="govuk-grid-row bottom-gutter">
+    <div class="govuk-grid-column-three-quarters">
+        {{ page_header(letter_branding.name) }}
+
+
+        {% if logo %}
+          <div id="logo-img">
+            <img src="https://{{ cdn_url }}/{{ logo }}"/>
+          </div>
+        {% endif %}
+
+        <h2 class="heading-medium">Organisations using this branding as their default</h2>
+        <nav class="browse-list">
+            {% if branding_orgs %}
+                <ul>
+                    {% for organisation in branding_orgs %}
+                        <li class="browse-list-item">
+                            <a class="govuk-link govuk-link--no-visited-state browse-list-hint"
+                                href="{{ url_for('.organisation_settings', org_id=organisation.id) }}">
+                                {{ organisation.name }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p class="hint">No organisations use this branding as their default.</p>
+            {% endif %}
+        </nav>
+
+        <h2 class="heading-medium">Services using this branding</h2>
+        <nav class="browse-list">
+            {% if branding_services %}
+            <ul>
+                {% for service in branding_services %}
+                <li class="browse-list-item">
+                    <a class="govuk-link govuk-link--no-visited-state browse-list-hint" href="{{ url_for('.service_settings', service_id=service.id) }}">
+                        {{ service.name }}
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="hint">No services use this branding.</p>
+            {% endif %}
+        </nav>
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-4" />
+
+        {% if letter_branding.created_by %}
+            <p class="govuk-body">
+                Created by
+                <a class="govuk-link govuk-link--no-visited-state"
+                   href="{{ url_for('.user_information', user_id=letter_branding.created_by) }}">
+                   {{ letter_branding.created_by_user.name }}
+                </a>
+              {% if letter_branding.created_at %}on {{ letter_branding.created_at | format_date }}{% endif %}
+            </p>
+        {% endif %}
+        {% if letter_branding.updated_at %}
+            <p class="govuk-body">
+                Last updated on {{ letter_branding.updated_at | format_date }}
+            </p>
+        {% endif %}
+
+        <div class="js-stick-at-bottom-when-scrolling">
+            <span class="page-footer-link page-footer-delete-link-without-button bottom-gutter-2-3">
+                <a class="govuk-link govuk-link--no-visited-state"
+                    href="{{ url_for('.update_letter_branding', branding_id=letter_branding.id) }}">
+                    Edit this branding</a>
+            </span>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/views/letter-branding/view-branding.html
+++ b/app/templates/views/letter-branding/view-branding.html
@@ -19,12 +19,9 @@
     <div class="govuk-grid-column-three-quarters">
         {{ page_header(letter_branding.name) }}
 
-
-        {% if logo %}
-          <div id="logo-img">
-            <img src="https://{{ cdn_url }}/{{ logo }}"/>
-          </div>
-        {% endif %}
+        <div id="logo-img">
+          <img src="https://{{ cdn_url }}/{{ logo }}"/>
+        </div>
 
         <h2 class="heading-medium">Organisations using this branding as their default</h2>
         <nav class="browse-list">

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -45,6 +45,22 @@ def test_email_branding_page_shows_full_branding_list(client_request, platform_a
     ]
 
 
+@pytest.mark.parametrize(
+    "user_fixture, expected_response_status", (("api_user_active_email_auth", 403), ("platform_admin_user", 200))
+)
+def test_view_email_branding_requires_platform_admin(
+    mocker, client_request, mock_get_email_branding, user_fixture, expected_response_status, request, fake_uuid
+):
+    mocker.patch(
+        "app.email_branding_client.get_orgs_and_services_associated_with_branding",
+    )
+    user = request.getfixturevalue(user_fixture)
+    client_request.login(user)
+    client_request.get(
+        ".platform_admin_view_email_branding", branding_id=fake_uuid, _expected_status=expected_response_status
+    )
+
+
 def test_view_email_branding_with_services_but_no_orgs(
     client_request,
     platform_admin_user,

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -11,7 +11,7 @@ from app.s3_client.s3_logo_client import (
     LETTER_TEMP_LOGO_LOCATION,
     permanent_letter_logo_name,
 )
-from tests.conftest import normalize_spaces
+from tests.conftest import create_letter_branding, normalize_spaces
 
 
 def test_letter_branding_page_shows_full_branding_list(
@@ -35,10 +35,138 @@ def test_letter_branding_page_shows_full_branding_list(
     ]
 
     assert hrefs == [
-        url_for(".update_letter_branding", branding_id=str(UUID(int=0))),
-        url_for(".update_letter_branding", branding_id=str(UUID(int=1))),
-        url_for(".update_letter_branding", branding_id=str(UUID(int=2))),
+        url_for(".platform_admin_view_letter_branding", branding_id=str(UUID(int=0))),
+        url_for(".platform_admin_view_letter_branding", branding_id=str(UUID(int=1))),
+        url_for(".platform_admin_view_letter_branding", branding_id=str(UUID(int=2))),
     ]
+
+
+def test_view_letter_branding_with_services_but_no_orgs(
+    mocker,
+    client_request,
+    platform_admin_user,
+    mock_get_letter_branding,
+    fake_uuid,
+):
+    mocker.patch(
+        "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
+        side_effect=lambda letter_branding_id: {
+            "data": {
+                "services": [{"name": "service 1", "id": "1234"}, {"name": "service 2", "id": "5678"}],
+                "organisations": [],
+            }
+        },
+    )
+
+    client_request.login(platform_admin_user)
+
+    page = client_request.get(".platform_admin_view_letter_branding", branding_id=fake_uuid)
+
+    assert page.select_one(".hint").text.strip() == "No organisations use this branding as their default."
+
+    list_of_service_links = page.select(".browse-list-item")
+
+    link_1 = list_of_service_links[0].select_one("a")
+    assert link_1.text.strip() == "service 1"
+    assert link_1["href"] == url_for(".service_settings", service_id="1234")
+
+    link_2 = list_of_service_links[1].select_one("a")
+    assert link_2.text.strip() == "service 2"
+    assert link_2["href"] == url_for(".service_settings", service_id="5678")
+
+
+def test_view_letter_branding_with_org_but_no_services(
+    mocker,
+    client_request,
+    platform_admin_user,
+    mock_get_letter_branding,
+    fake_uuid,
+):
+    mocker.patch(
+        "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
+        side_effect=lambda letter_branding_id: {
+            "data": {"services": [], "organisations": [{"name": "organisation 1", "id": "1234"}]}
+        },
+    )
+
+    client_request.login(platform_admin_user)
+
+    page = client_request.get(".platform_admin_view_letter_branding", branding_id=fake_uuid)
+
+    assert page.select_one(".hint").text.strip() == "No services use this branding."
+
+    list_of_organisation_links = page.select(".browse-list-item")
+
+    link_1 = list_of_organisation_links[0].select_one("a")
+    assert link_1.text.strip() == "organisation 1"
+    assert link_1["href"] == url_for(".organisation_settings", org_id="1234")
+
+
+@pytest.mark.parametrize(
+    "created_at, updated_at", [("2022-12-06T09:59:56.000000Z", "2023-01-20T11:59:56.000000Z"), (None, None)]
+)
+def test_view_letter_branding_shows_created_by_and_helpful_dates_if_available(
+    client_request,
+    platform_admin_user,
+    fake_uuid,
+    mocker,
+    created_at,
+    updated_at,
+):
+    mocker.patch(
+        "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
+        side_effect=lambda letter_branding_id: {"data": {"services": [], "organisations": []}},
+    )
+    client_request.login(platform_admin_user)
+
+    def _get_letter_branding(id):
+        return create_letter_branding(
+            id,
+            non_standard_values={
+                "created_by": "1234-5678-abcd-efgh",
+                "created_at": created_at,
+                "updated_at": updated_at,
+            },
+        )["letter_branding"]
+
+    mocker.patch("app.models.branding.letter_branding_client.get_letter_branding", side_effect=_get_letter_branding)
+
+    user = {"id": "1234-5678-abcd-efgh", "name": "Arwa Suren"}
+    mocker.patch("app.models.branding.user_api_client.get_user", return_value=user)
+
+    page = client_request.get(".platform_admin_view_letter_branding", branding_id=fake_uuid)
+
+    created_by_link = page.select("main p > a")[0]
+    assert created_by_link.text.strip() == user["name"]
+    assert created_by_link["href"] == url_for(".user_information", user_id=user["id"])
+
+    if created_at:
+        assert "on Tuesday 06 December 2022" in page.select("p")[-2].text
+
+    if updated_at:
+        assert "on Friday 20 January 2023" in page.select("p")[-1].text
+
+
+def test_view_letter_branding_bottom_links(
+    mocker,
+    client_request,
+    platform_admin_user,
+    mock_get_letter_branding,
+    fake_uuid,
+):
+    mocker.patch(
+        "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
+        side_effect=lambda letter_branding_id: {"data": {"services": [], "organisations": []}},
+    )
+    client_request.login(platform_admin_user)
+
+    page = client_request.get(".platform_admin_view_letter_branding", branding_id=fake_uuid)
+
+    bottom_links = page.select(".page-footer-link")
+
+    edit_link = bottom_links[0].select_one("a")
+    assert edit_link.text.strip() == "Edit this branding"
+    assert edit_link["href"] == url_for(".update_letter_branding", branding_id=fake_uuid)
 
 
 def test_update_letter_branding_shows_the_current_letter_brand(
@@ -143,14 +271,14 @@ def test_update_letter_branding_with_original_file_and_new_details(
     )
 
     client_request.login(platform_admin_user)
-    page = client_request.post(
+    client_request.post(
         ".update_letter_branding",
         branding_id=fake_uuid,
         _data={"name": "Updated name", "operation": "branding-details"},
-        _follow_redirects=True,
+        _follow_redirects=False,
+        _expected_redirect=url_for(".platform_admin_view_letter_branding", branding_id=fake_uuid),
     )
 
-    assert page.select_one("h1").text == "Letter branding"
     assert mock_upload_logos.called is False
 
     mock_client_update.assert_called_once_with(
@@ -233,14 +361,14 @@ def test_update_letter_branding_with_new_file_and_new_details(
     branding_id = str(UUID(int=0))
 
     client_request.login(platform_admin_user)
-    page = client_request.post(
+    client_request.post(
         ".update_letter_branding",
         branding_id=branding_id,
         logo=temp_logo,
         _data={"name": "Updated name", "operation": "branding-details"},
-        _follow_redirects=True,
+        _follow_redirects=False,
+        _expected_redirect=url_for(".platform_admin_view_letter_branding", branding_id=branding_id),
     )
-    assert page.select_one("h1").text == "Letter branding"
 
     mock_client_update.assert_called_once_with(
         branding_id=branding_id, filename=f"{fake_uuid}-new_file", name="Updated name", updated_by_id=fake_uuid
@@ -495,14 +623,13 @@ def test_create_letter_branding_persists_logo_when_all_data_is_valid(
     mock_delete_temp_files = mocker.patch("app.main.views.letter_branding.delete_letter_temp_files_created_by")
 
     client_request.login(platform_admin_user)
-    page = client_request.post(
+    client_request.post(
         ".create_letter_branding",
         logo=temp_logo,
         _data={"name": "Test brand", "operation": "branding-details"},
-        _follow_redirects=True,
+        _follow_redirects=False,
+        _expected_redirect=url_for(".platform_admin_view_letter_branding", branding_id=fake_uuid),
     )
-
-    assert page.select_one("h1").text == "Letter branding"
 
     mock_create_letter_branding.assert_called_once_with(
         filename=f"{fake_uuid}-test", name="Test brand", created_by_id=fake_uuid

--- a/tests/app/main/views/test_letter_branding.py
+++ b/tests/app/main/views/test_letter_branding.py
@@ -41,11 +41,27 @@ def test_letter_branding_page_shows_full_branding_list(
     ]
 
 
+@pytest.mark.parametrize(
+    "user_fixture, expected_response_status", (("api_user_active_email_auth", 403), ("platform_admin_user", 200))
+)
+def test_view_letter_branding_requires_platform_admin(
+    mocker, client_request, mock_get_letter_branding_by_id, user_fixture, expected_response_status, request, fake_uuid
+):
+    mocker.patch(
+        "app.letter_branding_client.get_orgs_and_services_associated_with_branding",
+    )
+    user = request.getfixturevalue(user_fixture)
+    client_request.login(user)
+    client_request.get(
+        ".platform_admin_view_letter_branding", branding_id=fake_uuid, _expected_status=expected_response_status
+    )
+
+
 def test_view_letter_branding_with_services_but_no_orgs(
     mocker,
     client_request,
     platform_admin_user,
-    mock_get_letter_branding,
+    mock_get_letter_branding_by_id,
     fake_uuid,
 ):
     mocker.patch(
@@ -79,7 +95,7 @@ def test_view_letter_branding_with_org_but_no_services(
     mocker,
     client_request,
     platform_admin_user,
-    mock_get_letter_branding,
+    mock_get_letter_branding_by_id,
     fake_uuid,
 ):
     mocker.patch(
@@ -151,7 +167,7 @@ def test_view_letter_branding_bottom_links(
     mocker,
     client_request,
     platform_admin_user,
-    mock_get_letter_branding,
+    mock_get_letter_branding_by_id,
     fake_uuid,
 ):
     mocker.patch(

--- a/tests/app/test_navigation.py
+++ b/tests/app/test_navigation.py
@@ -232,6 +232,7 @@ EXCLUDED_ENDPOINTS = tuple(
             "platform_admin_create_email_branding",
             "platform_admin_update_email_branding",
             "platform_admin_view_email_branding",
+            "platform_admin_view_letter_branding",
             "preview_broadcast_areas",
             "preview_broadcast_message",
             "pricing",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2650,16 +2650,6 @@ def mock_create_letter_branding(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
-def mock_get_letter_branding(mocker, fake_uuid):
-    def _get_letter_branding(id):
-        return create_letter_branding(id)["letter_branding"]
-
-    return mocker.patch(
-        "app.models.branding.letter_branding_client.get_letter_branding", side_effect=_get_letter_branding
-    )
-
-
-@pytest.fixture(scope="function")
 def mock_get_email_branding_name_for_alt_text(mocker):
     def _get_email_branding_name_for_alt_text(alt_text):
         return alt_text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2650,6 +2650,16 @@ def mock_create_letter_branding(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
+def mock_get_letter_branding(mocker, fake_uuid):
+    def _get_letter_branding(id):
+        return create_letter_branding(id)["letter_branding"]
+
+    return mocker.patch(
+        "app.models.branding.letter_branding_client.get_letter_branding", side_effect=_get_letter_branding
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_get_email_branding_name_for_alt_text(mocker):
     def _get_email_branding_name_for_alt_text(alt_text):
         return alt_text

--- a/tests/route-list.json
+++ b/tests/route-list.json
@@ -51,6 +51,7 @@
     "/integration_testing",
     "/invitation/<token>",
     "/letter-branding",
+    "/letter-branding/<uuid:branding_id>",
     "/letter-branding/<uuid:branding_id>/edit",
     "/letter-branding/<uuid:branding_id>/edit/<path:logo>",
     "/letter-branding/create",


### PR DESCRIPTION
Partner PR for https://github.com/alphagov/notifications-api/pull/3715

Duplicates the 'view email branding' view, but for letter brandings.

---

A copy of
https://github.com/alphagov/notifications-admin/commit/b0f61c13372a94e4a1e5c2a1eafe22a9b1382f4b but for letter branding.

This page has:
- branding preview
- list of orgs with the branding as a default
- list of services  using the branding
- edit link


![2023-02-01 11 47 55](https://user-images.githubusercontent.com/2920760/216034487-9f72c57f-5413-4c0a-8c35-233ab53998c7.gif)

---

This doesn't give much thought to de-duplicating/refactoring because we have https://trello.com/c/AazU7YzJ/185-look-through-branding-code-and-see-what-can-be-refactored to do that. This brings us (closer to) feature parity between the two branding types though.

I explicitly don't take archiving letter brandings here and leave that to be handled separately, if we want to.