### PR TITLE
Reword ‘contact us’ hint on settings page

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -301,8 +301,8 @@
           <li>{{ current_service.letter_message_limit | message_count('letter') }} per day</li>
         </ul>
         <p class="govuk-body">
-          Problems or comments?
-          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">Give feedback</a>.
+          If you need to discuss these limits,
+          <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.support') }}">contact us</a>.
         </p>
 
       {% endif %}

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -633,6 +633,8 @@ def test_show_limits_for_live_service(
         "2,000 text messages per day",
         "3,000 letters per day",
     ]
+    assert normalize_spaces(page.select_one("main ul + p").text) == "If you need to discuss these limits, contact us."
+    assert page.select_one("main ul + p a")["href"] == url_for("main.support")
 
 
 def test_broadcast_service_in_training_mode_doesnt_show_trial_mode_content(


### PR DESCRIPTION
Now that we’ve included the per-channel rate limits on the settings page we should make this prompt to contact us specific to the limits.

This commit does so, copying the wording from the bulk sending page:
https://github.com/alphagov/notifications-admin/blob/4b7f816cbfae1cf2413097cfb42d67b81e4b9cb9/app/templates/views/guidance/bulk-sending.html#L18

# Before

<img width="746" alt="image" src="https://user-images.githubusercontent.com/355079/217238214-e197fd0b-7ad9-436c-9b09-79e504656d4e.png">

# After 

<img width="746" alt="image" src="https://user-images.githubusercontent.com/355079/217238138-35a99169-a5a0-46be-9eb2-e28a6387e2f6.png">

***

Suggested by @CrystalPea 