### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: flake8
     name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 black==22.10.0
-isort==5.10.1
+isort==5.12.0
 pytest==7.2.0
 pytest-env==0.8.1
 pytest-mock==3.10.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,13 +1,13 @@
 -r requirements.txt
-black==22.10.0
-isort==5.12.0
+black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes
+isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
 pytest==7.2.0
 pytest-env==0.8.1
 pytest-mock==3.10.0
 pytest-xdist==3.0.2
 beautifulsoup4==4.11.1
 freezegun==1.2.2
-flake8==5.0.4
+flake8==5.0.4  # Also update `.pre-commit-config.yaml` if this changes
 flake8-bugbear==22.10.27
 flake8-print==5.0.0
 moto==4.0.9


### PR DESCRIPTION
Installing isort from scratch via pre-commit has broken due to a release from Poetry.

https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The solution is to bump to the latest isort version.

---

@tombye can you see if this fixes it for you please?

I'll need to apply this to all repos if it works.