### PR TITLE
Remove columes from go-live zendesk tickets

### DIFF
--- a/app/templates/support-tickets/go-live-request.txt
+++ b/app/templates/support-tickets/go-live-request.txt
@@ -20,10 +20,6 @@ Agreement signed by: {{ organisation.agreement_signed_by.email_address }}
 Agreement signed on behalf of: {{ organisation.agreement_signed_on_behalf_of_email_address }}
 {%- endif %}
 
-Emails in next year: {{ service.volume_email|format_thousands }}
-Text messages in next year: {{ service.volume_sms|format_thousands }}
-Letters in next year: {{ service.volume_letter|format_thousands }}
-
 Consent to research: {{ service.consent_to_research|format_yes_no }}
 Other live services for that user: {{ user.live_services|format_yes_no }}
 


### PR DESCRIPTION
We will still collect this information so that it's available for organisation-level approvers, but as platform admins we don't take this information into account when approving services.