### PR TITLE
Redirect from empty page if no other users

### DIFF
--- a/app/main/views/service_settings/index.py
+++ b/app/main/views/service_settings/index.py
@@ -831,6 +831,9 @@ def service_set_auth_type_for_users(service_id):
     ]
     all_service_users.extend(current_service.invited_users)
 
+    if not all_service_users:
+        return redirect(url_for(".service_settings", service_id=service_id))
+
     form = SetEmailAuthForUsersForm(
         all_service_users=all_service_users, users=[user.id for user in all_service_users if user.email_auth]
     )

--- a/tests/app/main/views/service_settings/test_service_settings.py
+++ b/tests/app/main/views/service_settings/test_service_settings.py
@@ -4732,6 +4732,24 @@ class TestSetAuthTypeForUsers:
             _expected_redirect=url_for(".service_set_auth_type", service_id=service_one["id"]),
         )
 
+    def test_redirects_away_if_no_other_users(
+        self,
+        mocker,
+        client_request,
+        service_one,
+        active_user_with_permissions,
+        mock_get_users_by_service,
+    ):
+        mocker.patch("app.models.user.InvitedUsers.client_method", return_value=[])
+
+        service_one["permissions"] += ["email_auth"]
+        client_request.login(active_user_with_permissions)
+        client_request.get(
+            "main.service_set_auth_type_for_users",
+            service_id=SERVICE_ONE_ID,
+            _expected_redirect=url_for(".service_settings", service_id=service_one["id"]),
+        )
+
     def test_page_loads(
         self,
         client_request,
@@ -4745,6 +4763,8 @@ class TestSetAuthTypeForUsers:
         client_request.get(
             "main.service_set_auth_type_for_users",
             service_id=SERVICE_ONE_ID,
+            _follow_redirects=False,
+            _expected_status=200,
         )
 
     def test_page_shows_other_users_on_service(


### PR DESCRIPTION
Address an edge case: If the service is changed from 'sms_auth' to 'email/sms auth' when there are no other users, we show a page that has no team members on it.

Let's not do that and just take them straight back to service settings.

This can happen because we don't show the user who's performing the request (as they can't change their own auth method). We'll probably change that, but for now let's be consistent.

## Before
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/2920760/218532076-579eab0a-af3e-41af-bc17-cba8d6c4c917.png">
