### PR TITLE
Update pricing content

### DIFF
--- a/app/templates/views/pricing/how-to-pay.html
+++ b/app/templates/views/pricing/how-to-pay.html
@@ -31,7 +31,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>exceed the <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('.pricing_text_messages') }}">free text message allowance</a></li>
-      <li>send letters</li>
+      <li>send <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.pricing_letters') }}">letters</a></li>
     </ul>
 
     <p class="govuk-body">

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -26,6 +26,12 @@
     <li>send <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.pricing_letters') }}">letters</a></li>
   </ul>
 
+  <p class="govuk-body">Find out <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
+
+  <h2 class="heading-medium">Try Notify for free</p>  
+
+  <p class="govuk-body">When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode') }}">trial mode</a>.</p>
+
   <p class="govuk-body">
     {% if not current_user.is_authenticated %}
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.register') }}">Create an account</a> then add as many unique services as you need to.
@@ -33,9 +39,5 @@
       You can add as many unique services as you need to.
     {% endif %}
   </p>
-
-  <p class="govuk-body">When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode') }}">trial mode</a>.</p>
-  
-  <p class="govuk-body">Find out <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
 {% endblock %}

--- a/app/templates/views/pricing/index.html
+++ b/app/templates/views/pricing/index.html
@@ -28,7 +28,7 @@
 
   <p class="govuk-body">Find out <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.how_to_pay') }}">how to pay</a>.
 
-  <h2 class="heading-medium">Try Notify for free</p>  
+  <h2 class="heading-medium">Try Notify for free</h2>  
 
   <p class="govuk-body">When you add a new service it will start in <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.trial_mode') }}">trial mode</a>.</p>
 

--- a/app/templates/views/pricing/text-message-pricing.html
+++ b/app/templates/views/pricing/text-message-pricing.html
@@ -23,9 +23,9 @@ Text message pricing
 
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
-  <p class="govuk-body">You’ll use more free messages, or pay more for each message, if you send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">text messages longer than 160 characters</a>.</p>
-  <p class="govuk-body">You may also use more free messages, or pay more for each message, if you:</p>
+  <p class="govuk-body">You may use more free messages, or pay more for each message, if you:</p>
   <ul class="govuk-list govuk-list--bullet">
+    <li>send <a class="govuk-link govuk-link--no-visited-state" href="#long-text-messages">text messages longer than 160 characters</a></li>
     <li>use certain <a class="govuk-link govuk-link--no-visited-state" href="#symbols">signs and symbols</a></li>
     <li>use <a class="govuk-link govuk-link--no-visited-state" href="#accents">accents and accented letters</a></li>
     <li>send text messages to <a class="govuk-link govuk-link--no-visited-state" href="#international-numbers">international numbers</a></li>

--- a/app/templates/views/trial-mode.html
+++ b/app/templates/views/trial-mode.html
@@ -11,7 +11,7 @@
 
   <h1 class="heading-large">Trial mode</h1>
 
-  <p class="govuk-body">When you add a new service it will start in trial mode. This lets you try out GOV.UK Notify, with a few restrictions.</p>
+  <p class="govuk-body">When you add a new service it will start in trial mode. This lets you try out GOV.UK Notify for free, with a few restrictions.</p>
   <p class="govuk-body">While your service is in trial mode you can only:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>send messages to yourself and other people in your team</li>


### PR DESCRIPTION
This PR makes a few small changes to the updated Pricing pages.

**Changes**

* Add a link to the ‘How to pay’ page for consistency 
* Reorder the information on the ‘Pricing’ page so payment information and trial mode information are separate
* Make the introduction to the ‘Text message pricing’ page shorter, less repetitive and (hopefully) clearer
* Add a reference to pricing/cost to the ‘Trial mode’ page