### PR TITLE
Remove unused methods from the user model

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -360,23 +360,6 @@ class User(BaseUser, UserMixin):
     def create_webauthn_credential(self, credential):
         user_api_client.create_webauthn_credential_for_user(self.id, credential)
 
-    def serialize(self):
-        dct = {
-            "id": self.id,
-            "name": self.name,
-            "email_address": self.email_address,
-            "mobile_number": self.mobile_number,
-            "password_changed_at": self.password_changed_at,
-            "state": self.state,
-            "failed_login_count": self.failed_login_count,
-            "permissions": [x for x in self._permissions],
-            "organisations": self.organisation_ids,
-            "current_session_id": self.current_session_id,
-        }
-        if hasattr(self, "_password"):
-            dct["password"] = self._password
-        return dct
-
     @classmethod
     def register(
         cls,
@@ -395,9 +378,6 @@ class User(BaseUser, UserMixin):
                 auth_type,
             )
         )
-
-    def set_password(self, pwd):
-        self._password = pwd
 
     def send_verify_email(self):
         user_api_client.send_verify_email(self.id, self.email_address)
@@ -567,23 +547,6 @@ class InvitedUser(BaseUser):
             other.status,
         )
 
-    def serialize(self, permissions_as_string=False):
-        data = {
-            "id": self.id,
-            "service": self.service,
-            "from_user": self._from_user,
-            "email_address": self.email_address,
-            "status": self.status,
-            "created_at": str(self.created_at),
-            "auth_type": self.auth_type,
-            "folder_permissions": self.folder_permissions,
-        }
-        if permissions_as_string:
-            data["permissions"] = ",".join(self.permissions)
-        else:
-            data["permissions"] = sorted(self.permissions)
-        return data
-
     def template_folders_for_service(self, service=None):
         # only used on the manage users page to display the count, so okay to not be fully fledged for now
         return [{"id": x} for x in self.folder_permissions]
@@ -631,17 +594,6 @@ class InvitedOrgUser(BaseUser):
     @classmethod
     def by_id(cls, invited_user_id):
         return cls(org_invite_api_client.get_invited_user(invited_user_id))
-
-    def serialize(self, permissions_as_string=False):
-        data = {
-            "id": self.id,
-            "organisation": self.organisation,
-            "invited_by": self._invited_by,
-            "email_address": self.email_address,
-            "status": self.status,
-            "created_at": str(self.created_at),
-        }
-        return data
 
     @property
     def invited_by(self):

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -363,17 +363,17 @@ def test_verified_org_user_redirects_to_dashboard(
     mock_login,
 ):
     client_request.logout()
-    invited_org_user = InvitedOrgUser(sample_org_invite).serialize()
+    invited_org_user = InvitedOrgUser(sample_org_invite)
     with client_request.session_transaction() as session:
         session["expiry_date"] = str(datetime.utcnow() + timedelta(hours=1))
-        session["user_details"] = {"email": invited_org_user["email_address"], "id": invited_org_user["id"]}
-        session["organisation_id"] = invited_org_user["organisation"]
+        session["user_details"] = {"email": invited_org_user.email_address, "id": invited_org_user.id}
+        session["organisation_id"] = invited_org_user.organisation
 
     client_request.post(
         "main.verify",
         _data={"sms_code": "12345"},
         _expected_redirect=url_for(
             "main.organisation_dashboard",
-            org_id=invited_org_user["organisation"],
+            org_id=invited_org_user.organisation,
         ),
     )


### PR DESCRIPTION
These were added very early on as part of building the team members page<sup>1</sup> and the invite journey<sup>2</sup>.

They are not used any more. Instead we generally use:
- the user ID only (for example in the session)
- the entire user model directly (for example on the team members page)

This means we can safely delete these serialization methods, and the `pwd` property which they use.

***

1. https://github.com/alphagov/notifications-admin/pull/214
2. https://github.com/alphagov/notifications-admin/pull/219
