### PR TITLE
Update footer links

### DIFF
--- a/app/templates/admin_template.html
+++ b/app/templates/admin_template.html
@@ -154,48 +154,21 @@
     "classes": "js-footer",
     "navigation": [
       {
-        "title": "Support",
-        "columns": 1,
-        "width": "one-quarter",
-        "items": [
-          {
-            "href": url_for('main.support'),
-            "text": "Contact support"
-          },
-          {
-            "href": "https://status.notifications.service.gov.uk",
-            "text": "System status"
-          },
-          {
-            "href": url_for('main.performance'),
-            "text": "Performance data"
-          },
-          {
-            "href": "https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC",
-            "text": "Chat to us on Slack"
-          }
-        ]
-      },
-      {
         "title": "About Notify",
         "columns": 1,
-        "width": "one-quarter",
+        "width": "one-half",
         "items": [
           {
             "href": url_for("main.guidance_features"),
             "text": "Features"
           },
           {
-            "href": url_for("main.guidance_roadmap"),
-            "text": "Roadmap"
+            "href": url_for("main.guidance_pricing"),
+            "text": "Pricing"
           },
           {
-            "href": url_for("main.guidance_who_can_use_notify"),
-            "text": "Who can use Notify",
-          },
-          {
-            "href": url_for("main.guidance_security"),
-            "text": "Security"
+            "href": url_for("main.guidance_using_notify"),
+            "text": "Using Notify"
           },
           {
             "href": "https://gds.blog.gov.uk/category/gov-uk-notify/",
@@ -204,47 +177,28 @@
         ]
       },
       {
-        "title": "Pricing and payment",
+        "title": "Support",
         "columns": 1,
-        "width": "one-quarter",
+        "width": "one-half",
         "items": [
           {
-            "href": url_for("main.guidance_pricing"),
-            "text": "Pricing"
+            "href": url_for('main.support'),
+            "text": "Contact support"
           },
           {
-            "href": url_for("main.guidance_how_to_pay"),
-            "text": "How to pay"
+            "href": "https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC",
+            "text": "Chat to us on Slack"
           },
           {
-            "href": url_for("main.guidance_billing_details"),
-            "text": "Billing details"
-          }
-        ]
-      },
-      {
-        "title": "Using Notify",
-        "columns": 1,
-        "width": "one-quarter",
-        "items": [
-          {
-            "href": url_for("main.guidance_trial_mode"),
-            "text": "Trial mode"
-          },
-          {
-            "href": url_for("main.guidance_message_status"),
-            "text": "Delivery status"
-          },
-          {
-            "href": url_for("main.guidance_using_notify"),
-            "text": "Using Notify"
+            "href": "https://status.notifications.service.gov.uk",
+            "text": "System status"
           },
           {
             "href": url_for("main.guidance_api_documentation"),
             "text": "API documentation"
           }
         ]
-      }
+      },
     ],
     "meta": {
       "items": meta_items,


### PR DESCRIPTION
Our updated header and left-hand navigation menus reduce the pressure on our footer to signpost all of Notify’s content.

This PR reduces the number of links in the footer to a few key pages, plus things like the blog, status page and Slack, which aren’t part of the Notify domain.

Later we may want to remove ‘Features’, ‘Pricing’ and ‘Using Notify’ from the footer, as they already appear in the header and (if you’re in the `guidance` pages) the left-hand navigation.

We’ve left ‘API documentation’ in the footer because:
* we’ve removed it from the header
* some users might be used to seeing it in the footer

| before | after |
|-------|------|
| ![image](https://user-images.githubusercontent.com/5020841/220897011-fa3ab162-70b9-437c-b225-9bc32328dc2a.png) |  ![image](https://user-images.githubusercontent.com/5020841/220896968-6eb403dc-ac02-48c6-8e94-81aefdc45785.png) |