### PR TITLE
Correct the date of the price increase

### DIFF
--- a/app/templates/views/guidance/pricing/text-message-pricing.html
+++ b/app/templates/views/guidance/pricing/text-message-pricing.html
@@ -24,7 +24,7 @@ Text message pricing
   <p class="govuk-body">Each unique service you add has an annual allowance of free text messages.</p>
   <p class="govuk-body">When a service has used its annual allowance, it costs {{ sms_rate }} pence (plus VAT) for each text message you send.</p>
   <div class="govuk-inset-text">  
-    <p class="govuk-body">On 1 May 2023 the cost of sending a text message will go up to 1.97 pence (plus VAT).</p>
+    <p class="govuk-body">On 1 April 2023 the cost of sending a text message will go up to 1.97 pence (plus VAT).</p>
   </div>
   <p class="govuk-body">You may use more free messages, or pay more for each message, if you:</p>
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
This PR corrects the date of the text message price increase from May to April.

This error was down to copy/pasting content from last year.