### PR TITLE
Fix link colour for new service

### DIFF
--- a/app/templates/partials/tour.html
+++ b/app/templates/partials/tour.html
@@ -31,7 +31,7 @@
           Notify delivers the message
         </p>
         {% if help == '3' %}
-          <a class="govuk-link govuk-link--no-visited-state" href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
+          <a class="govuk-link govuk-link--inverse" href='{{ url_for(".go_to_dashboard_after_tour", service_id=current_service.id, example_template_id=template.id) }}'>
             Now go to your dashboard
           </a>
         {% endif %}


### PR DESCRIPTION
We've had a link styling regression where the 'Now go to your dashboard' link when creating a new service is in blue on a blue background (ie basically not visible).

Let's invert the link colour so it's visible again.

## Before
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/2920760/223675251-47493746-ab06-4cf1-9e3e-a751f7b1f769.png">


## After
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/2920760/223675173-a1f7c8b5-e78c-4b14-a197-17887346a222.png">
