### PR TITLE
Make performance page less wonky

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -73,6 +73,7 @@ $govuk-new-link-styles: true;
 @import './views/history';
 @import './views/cookies';
 @import './views/webauthn';
+@import './views/performance';
 
 // TODO: break this up
 @import './app';

--- a/app/assets/stylesheets/views/performance.scss
+++ b/app/assets/stylesheets/views/performance.scss
@@ -1,0 +1,118 @@
+// Styles specific to the performance page
+
+$gutter-with-14px-text: 1.696em;
+$gutter-with-16px-text: 1.484em;
+$gutter-with-19px-text: 1.25em;
+
+.totals__all,
+.totals__set-type {
+  margin: 0; // cancel the vertical margins from using <p> tags
+}
+
+// Separate 'grand total' from others in vertical stack of totals
+.totals__all {
+  padding-bottom: 15px;
+}
+
+.totals__all > .product-page-big-number {
+  display: block; // Put label for number on new line
+}
+
+// Make totals block-level by default
+.totals--2-column > .totals__all,
+.totals--2-column > .totals__set-type,
+.totals--4-column > .totals__all,
+.totals--4-column > .totals__set-type {
+  display: block;
+  width: 100%;
+}
+
+// Dashboard tables apply padding to the right of all table headers and cells except the last
+//
+// We reverse this, so the first table header and cell have no padding that could be considered as
+// part of their width
+.performance .dashboard-table .table-field-headings-visible th,
+.performance .table-font-xsmall td {
+  padding-right: 0;
+}
+
+// Set gutters for table headers on
+.performance .dashboard-table .table-field-headings-visible th {
+  padding-left: $gutter-with-16px-text;
+}
+
+// Set gutters for table cells to match table headers
+.performance .table-font-xsmall td {
+  padding-left: $gutter-with-14px-text;
+}
+
+// Cancel padding for gutters on first table headers and cells
+.performance .dashboard-table .table-field-headings-visible th:first-of-type,
+.performance .table-font-xsmall td:first-of-type {
+  padding-left: 0;
+}
+
+.performance .dashboard-table--4-column .table-field-headings-visible th:first-of-type,
+.performance .dashboard-table--4-column .table-font-xsmall td:first-of-type {
+  width: 40%; // 40% is the lowest width the first column works at with the smaller text
+}
+
+.performance .dashboard-table--2-column .table-field-headings-visible th:first-of-type,
+.performance .dashboard-table--2-column .table-font-xsmall td:first-of-type {
+  width: 52.5%;
+}
+
+// Totals use block-level elements so will fill the width and stack by default
+// Make them display as a table on larger screens, to match the data table below
+@include govuk-media-query($from: tablet) {
+  .totals {
+    display: table;
+    width: 100%;
+  }
+
+  .totals > .totals__all,
+  .totals > .totals__set-type {
+    display: table-cell;
+  }
+
+  .totals__all {
+    padding-bottom: 0;
+    padding-left: 0; // Remove padding-left now applied to all totals
+  }
+
+  .totals > .totals__set-type {
+    width: auto; // reset width, set to 100% by default
+  }
+
+  // Give totals and table headers the same gutters
+  .totals__set-type,
+  .performance .dashboard-table .table-field-headings-visible th {
+    padding-left: $gutter-with-19px-text;
+  }
+
+  // Give table cells the same gutters
+  .performance .table-font-xsmall td {
+    padding-left: $gutter-with-16px-text;
+  }
+}
+
+// Handle other screen sizes from tablet up, making totals match tables as much as possible
+.totals--4-column > .totals__all,
+.performance .dashboard-table--4-column .table-field-headings-visible th:first-of-type,
+.performance .dashboard-table--4-column .table-font-xsmall td:first-of-type {
+  // 640-730px has the larger text but less space so needs a smaller first-column width
+  @include govuk-media-query($from: tablet, $until: 730px) {
+    width: 35%;
+  }
+
+  // 900px upwards works with the default of 52.5%
+  @include govuk-media-query($from: 900px) {
+    width: 52.5%;
+  }
+}
+
+.totals--2-column > .totals__all,
+.performance .dashboard-table--2-column .table-field-headings-visible th:first-of-type,
+.performance .dashboard-table--2-column .table-font-xsmall td:first-of-type {
+  width: 52.5%;
+}

--- a/app/templates/content_template.html
+++ b/app/templates/content_template.html
@@ -14,7 +14,7 @@
       <div class="govuk-grid-column-one-quarter">
         {{ sub_navigation(navigation_links, navigation_label_prefix) }}
       </div>
-      <div class="govuk-grid-column-five-eighths">
+      <div class="govuk-grid-column-{% if content_column_width %}{{ content_column_width }}{% else %}five-eighths{% endif %}">
     {% else %}
       <div class="govuk-grid-column-two-thirds">
     {% endif %}

--- a/app/templates/views/guidance/features/performance.html
+++ b/app/templates/views/guidance/features/performance.html
@@ -4,6 +4,8 @@
 {% from "components/table.html" import field, list_table %}
 
 {% set navigation_label_prefix = 'Features' %}
+{% set content_column_width = 'three-quarters' %}
+{% set bodyClasses = 'performance' %}
 
 {% block per_page_title %}
   Performance data
@@ -21,39 +23,35 @@
     Messages sent since May 2016
   </h2>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+  <div class="totals totals--4-column">
+    <div class="totals__all">
       <div class="product-page-big-number">{{ total_notifications|format_billions }}</div>
       total
     </div>
-    <div class="govuk-grid-column-one-half">
-      <div class="govuk-grid-row govuk-!-padding-top-4">
-        <div class="govuk-grid-column-one-third">
-          {{ big_number(
-            email_notifications|format_billions,
-            label=email_notifications|message_count_noun('email'),
-            smallest=True,
-          ) }}
-        </div>
-        <div class="govuk-grid-column-one-third">
-          {{ big_number(
-            sms_notifications|format_billions,
-            label=sms_notifications|message_count_noun('sms'),
-            smallest=True,
-          ) }}
-        </div>
-        <div class="govuk-grid-column-one-third">
-          {{ big_number(
-            letter_notifications|format_billions,
-            label=letter_notifications|message_count_noun('letter'),
-            smallest=True,
-          ) }}
-        </div>
-      </div>
+    <div class="totals__set-type">
+      {{ big_number(
+        email_notifications|format_billions,
+        label=email_notifications|message_count_noun('email'),
+        smallest=True,
+      ) }}
+    </div>
+    <div class="totals__set-type">
+      {{ big_number(
+        sms_notifications|format_billions,
+        label=sms_notifications|message_count_noun('sms'),
+        smallest=True,
+      ) }}
+    </div>
+    <div class="totals__set-type">
+      {{ big_number(
+        letter_notifications|format_billions,
+        label=letter_notifications|message_count_noun('letter'),
+        smallest=True,
+      ) }}
     </div>
   </div>
 
-  <div class="dashboard-table">
+  <div class="dashboard-table dashboard-table--4-column">
     {% call(item, row_number) list_table(
       notifications_by_type|reverse,
       caption='Messages sent since May 2016',
@@ -95,7 +93,7 @@
       ) }}
     </div>
   </div>
-  <div class="dashboard-table">
+  <div class="dashboard-table dashboard-table--2-column">
     {% call(item, row_number) list_table(
       processing_time | reverse,
       caption='Messages sent within 10 seconds',
@@ -120,20 +118,20 @@
   <h2 class="govuk-heading-m" id='organisations-using-notify'>
     Organisations using Notify
   </h2>
-  <div class="govuk-grid-row bottom-gutter">
-    <div class="govuk-grid-column-one-half">
+  <div class="totals totals--2-column bottom-gutter">
+    <div class="totals__all">
       <span class="govuk-visually-hidden">There are</span>
       <div class="product-page-big-number">{{ count_of_live_services_and_organisations.organisations|format_thousands }}</div>
       organisations
     </div>
-    <div class="govuk-grid-column-one-half">
+    <div class="totals__set-type">
       <span class="govuk-visually-hidden">and</span>
       <div class="product-page-big-number">{{ count_of_live_services_and_organisations.services|format_thousands }}</div>
       services
       <span class="govuk-visually-hidden">using Notify.</span>
     </div>
   </div>
-  <div class="dashboard-table">
+  <div class="dashboard-table dashboard-table--2-column">
     {% call(item, row_number) list_table(
       organisations_using_notify,
       caption='Organisations using Notify',

--- a/app/templates/views/guidance/features/performance.html
+++ b/app/templates/views/guidance/features/performance.html
@@ -24,31 +24,31 @@
   </h2>
 
   <div class="totals totals--4-column">
-    <div class="totals__all">
-      <div class="product-page-big-number">{{ total_notifications|format_billions }}</div>
+    <p class="totals__all">
+      <span class="product-page-big-number">{{ total_notifications|format_billions }}</span>
       total
-    </div>
-    <div class="totals__set-type">
+    </p>
+    <p class="totals__set-type">
       {{ big_number(
         email_notifications|format_billions,
         label=email_notifications|message_count_noun('email'),
         smallest=True,
       ) }}
-    </div>
-    <div class="totals__set-type">
+    </p>
+    <p class="totals__set-type">
       {{ big_number(
         sms_notifications|format_billions,
         label=sms_notifications|message_count_noun('sms'),
         smallest=True,
       ) }}
-    </div>
-    <div class="totals__set-type">
+    </p>
+    <p class="totals__set-type">
       {{ big_number(
         letter_notifications|format_billions,
         label=letter_notifications|message_count_noun('letter'),
         smallest=True,
       ) }}
-    </div>
+    </p>
   </div>
 
   <div class="dashboard-table dashboard-table--4-column">
@@ -118,19 +118,19 @@
   <h2 class="govuk-heading-m" id='organisations-using-notify'>
     Organisations using Notify
   </h2>
-  <div class="totals totals--2-column bottom-gutter">
-    <div class="totals__all">
+  <p class="totals totals--2-column bottom-gutter">
+    <span class="totals__all">
       <span class="govuk-visually-hidden">There are</span>
-      <div class="product-page-big-number">{{ count_of_live_services_and_organisations.organisations|format_thousands }}</div>
+      <span class="product-page-big-number">{{ count_of_live_services_and_organisations.organisations|format_thousands }}</span>
       organisations
-    </div>
-    <div class="totals__set-type">
+    </span>
+    <span class="totals__set-type">
       <span class="govuk-visually-hidden">and</span>
-      <div class="product-page-big-number">{{ count_of_live_services_and_organisations.services|format_thousands }}</div>
+      <span class="product-page-big-number">{{ count_of_live_services_and_organisations.services|format_thousands }}</span>
       services
       <span class="govuk-visually-hidden">using Notify.</span>
-    </div>
-  </div>
+    </span>
+  </p>
   <div class="dashboard-table dashboard-table--2-column">
     {% call(item, row_number) list_table(
       organisations_using_notify,

--- a/tests/app/main/views/test_performance.py
+++ b/tests/app/main/views/test_performance.py
@@ -115,7 +115,7 @@ def test_should_render_performance_page(
         end_date=date(2021, 1, 1),
     )
 
-    assert normalize_spaces(page.select_one(".govuk-grid-column-five-eighths").text) == (
+    assert normalize_spaces(page.select_one(".govuk-grid-column-three-quarters").text) == (
         "Performance data "
         ""
         "Messages sent since May 2016 "


### PR DESCRIPTION
Work to fix visual issues with the performance page.

https://trello.com/c/engQbh1r/282-stop-performance-page-being-wonky

This doesn't make it align exactly across all widths of page but I've been working to the main ones from analytics, which are shown below. Worth noting we can't fix columns overlapping in the first table on the smallest screen but I'm making the assumption that user is on mobile and so can rotate to a wider view (called 'landscape' below).

I'm only showing the top table because the others, and their totals, all work so required much less work and so I'm leaving scrutiny of them to local testing.

## Desktop

### Before

<img width="987" alt="perf_page_desktop_before" src="https://user-images.githubusercontent.com/87140/223704802-736a311a-7830-44a8-9df9-9a728613c3d3.png">

### After

<img width="960" alt="perf_page_desktop_after" src="https://user-images.githubusercontent.com/87140/223704836-e26d4547-b41e-4ac6-8850-642f51d44ef6.png">

## Mobile (portrait - smallest)

### Before

<img width="321" alt="perf_page_mobile_portrait_320px_before" src="https://user-images.githubusercontent.com/87140/223704889-6c326800-b58e-4c08-a8b1-081751ead8d1.png">

### After

<img width="320" alt="perf_page_mobile_portrait_320px_after" src="https://user-images.githubusercontent.com/87140/223705150-7ac13096-aa4b-442b-bacd-89cea3e0de89.png">

## Mobile (portrait - average)

### Before

<img width="377" alt="perf_page_mobile_portrait_390px_before" src="https://user-images.githubusercontent.com/87140/223705186-af3710bd-e821-45b0-9fef-193e3fa3dbd7.png">

### After

<img width="379" alt="perf_page_mobile_portrait_390px_after" src="https://user-images.githubusercontent.com/87140/223705218-453128f1-0dcb-4ba5-a67e-c618d37f55b1.png">

## Mobile (landscape - smallest)

### Before

<img width="566" alt="perf_page_mobile_landscape_568px_before" src="https://user-images.githubusercontent.com/87140/223705299-df94b4b1-5dfb-4e84-bcea-4ef7c2aa72a0.png">

### After

<img width="567" alt="perf_page_mobile_landscape_568px_after" src="https://user-images.githubusercontent.com/87140/223705326-03727d5a-e68d-452d-98c9-c3a50a73aa2c.png">

## Mobile (landscape - average)

### Before

<img width="666" alt="perf_page_mobile_landscape_667px_before" src="https://user-images.githubusercontent.com/87140/223705369-fbf14ce1-2bde-497b-827b-a8d9c31d667d.png">

### After

<img width="668" alt="perf_page_mobile_landscape_667px_after" src="https://user-images.githubusercontent.com/87140/223705395-325a0bf0-f3d6-45cd-a124-2a783da53dea.png">

## The changes

These changes:
- make the main content column as wide as it can be (it was constrained to an 'ideal sentence width')
- add a `performance` class to scope styles to just this page
- style the content blocks that show totals for a table to be 'table-like' and to line each total up with the data it totals below
- change the HTML to wrap content in paragraphs where it was just `<div>`s, to add some semantics
- reduce the first columns on smaller screens to give more space to the other columns

They don't:
- make it line up perfectly on all screen sizes
- stop the content of some table cells overlapping (I've assumed users seeing this can rotate their device for a wider screen if needed)

## Notes for reviewers

There's a ton of detail in the initial commit about reasons for taking the approach I did. It's also worth working through commit-by-commit.

## Testing

I've tested these changes on the [service manual browser matrix](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in-from-june-2022) + IE11 (because we're still working out whether to drop support for it or not).