### PR TITLE
Clarify personalisation and bulk sending

### DIFF
--- a/app/templates/views/guidance/using-notify/bulk-sending.html
+++ b/app/templates/views/guidance/using-notify/bulk-sending.html
@@ -13,7 +13,7 @@
 
   <h1 class="heading-large">Bulk sending</h1>
 
-  <p class="govuk-body">You can send a batch of up to {{ max_spreadsheet_rows|format_thousands }} messages at once.</p>
+  <p class="govuk-body">You can send a batch of up to {{ max_spreadsheet_rows|format_thousands }} personalised messages at once.</p>
 
   <p class="govuk-body">There’s a maximum daily limit of {{ rate_limits|formatted_list(before_each="", after_each="") }}. If you need to discuss these limits, <a class="govuk-link govuk-link--no-visited-state" href={{ url_for("main.support") }}>contact us</a>.</p>
 
@@ -24,6 +24,8 @@
     <li>Add a new template or choose an existing template and select <b class="govuk-!-font-weight-bold">Get ready to send</b>.</li>
     <li>Select <b class="govuk-!-font-weight-bold">Upload a list of email addresses</b>, <b class="govuk-!-font-weight-bold">Upload a list of phone numbers</b>, or <b class="govuk-!-font-weight-bold">Upload a list of addresses</b>.</li>
   </ol>
+
+  <p class="govuk-body">Find out <a class="govuk-link govuk-link--no-visited-state" href={{ url_for("main.guidance_personalisation" )}}>how to personalise your messages</a>.</p>
 
   <p class="govuk-body">You can also <a class="govuk-link govuk-link--no-visited-state" href={{ url_for("main.guidance_schedule_messages" )}}>schedule a batch of emails and text messages</a>.</p>
 

--- a/app/templates/views/guidance/using-notify/personalisation.html
+++ b/app/templates/views/guidance/using-notify/personalisation.html
@@ -30,7 +30,7 @@
     <li>upload a list of personal details and let Notify do it for you</li>
   </ul>
 
-  <p class="govuk-body">If you upload a list of personal details, the column names need to match the placeholders in your template.</p>
+  <p class="govuk-body">If you upload a list of personal details, the column names in your spreadsheet need to match the placeholders in the template.</p>
 
   <h2 class="heading-medium" id="hide-personalised-content">Hide personalised content after sending</h2>
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -425,7 +425,9 @@ def test_bulk_sending_limits(client_request):
     page = client_request.get("main.guidance_bulk_sending")
     paragraphs = page.select("main p")
 
-    assert normalize_spaces(paragraphs[0].text) == "You can send a batch of up to 100,000 messages at once."
+    assert normalize_spaces(paragraphs[0].text) == (
+        "You can send a batch of up to 100,000" " personalised messages at once."
+    )
     assert normalize_spaces(paragraphs[1].text) == (
         "There’s a maximum daily limit of 250,000 emails, 250,000 text messages and 20,000 letters. "
         "If you need to discuss these limits, contact us."


### PR DESCRIPTION
This PR updates the ‘Bulk sending’ and ‘Personalisation’ pages to make clear that you can personalise bulk messages.

We’re making this small change based on an enquiry from a user.