### PR TITLE
Visually hint which pages of a letter are on the same sheet

### DIFF
--- a/app/assets/stylesheets/components/letter.scss
+++ b/app/assets/stylesheets/components/letter.scss
@@ -38,6 +38,10 @@ $iso-paper-ratio: 141.42135624%;
     box-shadow: inset 0 0 0 1px $govuk-border-colour;
   }
 
+  &:nth-of-type(even) {
+    margin-top: -1 * (govuk-spacing(6) + 1px);
+  }
+
   &-postage {
 
     $art-width: 97.83;


### PR DESCRIPTION
Because our letters are double sided, pages 1 and 2; 3 and 4; etc. will appear on the same sheets of paper.

This commit adds some styling to remove the space between these adjacent pages. This is a visual cue often used by desktop publishing programs to show pages which are on the same spread.

Hopefully this will help a little bit once we start supporting attachments in letters, where it might not be obvious that an attachment could be printed on the reverse side of a page of the letter.

The `:nth-of-type` CSS selector has good support in all browsers, including IE11: https://caniuse.com/?search=nth-of-type

I used negative margins so as not to disrupt the spacing after an odd page of the letter, where it also appears as the last page of the letter.

Before | After
---|---
![localhost_6012_services_fd8d189f-4caf-4420-b9a4-11a45b5b2c7c_templates_4e31d8c1-cff7-4a66-93c6-f3782d15da8e(iPad Mini) (2)](https://user-images.githubusercontent.com/355079/223730183-c04256e8-b592-4de4-8581-1ac72b27ecdf.png) | ![localhost_6012_services_fd8d189f-4caf-4420-b9a4-11a45b5b2c7c_templates_4e31d8c1-cff7-4a66-93c6-f3782d15da8e(iPad Mini)](https://user-images.githubusercontent.com/355079/223729942-10b2b653-bbc1-4b8b-851e-f9a6952defbc.png)



