### PR TITLE
Add missing content to upload logo page

### DIFF
--- a/app/templates/views/service-settings/branding/new/email-branding-upload-logo.html
+++ b/app/templates/views/service-settings/branding/new/email-branding-upload-logo.html
@@ -19,6 +19,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
+      <p class="govuk-body">
+      Your logo must be:
+      </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>a PNG file</li>
         <li>at least 108 pixels high</li>


### PR DESCRIPTION
We were missing call-out content for a requirements list.